### PR TITLE
[BP] Used nv-i18n library to add better support for iso639-2/T iso639-2/B support #5982

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -520,6 +520,10 @@
     </dependency>
     <!-- end language detection -->
     <dependency>
+      <groupId>com.neovisionaries</groupId>
+      <artifactId>nv-i18n</artifactId>
+    </dependency>
+    <dependency>
       <groupId>opendap</groupId>
       <artifactId>opendap</artifactId>
       <version>2.1</version>

--- a/core/src/main/java/org/fao/geonet/languages/IsoLanguagesMapper.java
+++ b/core/src/main/java/org/fao/geonet/languages/IsoLanguagesMapper.java
@@ -27,6 +27,7 @@ import org.fao.geonet.repository.IsoLanguageRepository;
 
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
+import com.neovisionaries.i18n.LanguageCode;
 
 import org.fao.geonet.utils.Log;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -133,6 +134,32 @@ public class IsoLanguagesMapper {
             return defaultLang.toLowerCase();
         } else {
             return result;
+        }
+    }
+
+    /**
+     * Convert the iso639_2B to iso639_2T
+     */
+    public static String iso639_2B_to_iso639_2T(String iso639_2B) {
+        LanguageCode code = LanguageCode.getByCode(iso639_2B);
+        if (code == null) {
+            // If we could not find the code then just return the original code.
+            return iso639_2B;
+        } else {
+            return code.getAlpha3().getAlpha3T().name();
+        }
+    }
+
+    /**
+     * Convert the iso639_2T to iso639_2B
+     */
+    public static String iso639_2T_to_iso639_2B(String iso639_2T) {
+        LanguageCode code = LanguageCode.getByCode(iso639_2T);
+        if (code == null) {
+            // If we could not find the code then just return the original code.
+            return iso639_2T;
+        } else {
+            return code.getAlpha3().getAlpha3B().name();
         }
     }
 

--- a/core/src/main/java/org/fao/geonet/util/XslUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/XslUtil.java
@@ -27,6 +27,7 @@ package org.fao.geonet.util;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import com.neovisionaries.i18n.LanguageCode;
 
 import org.fao.geonet.api.records.attachments.FilesystemStoreResourceContainer;
 import org.fao.geonet.api.records.attachments.Store;
@@ -662,6 +663,30 @@ public final class XslUtil {
     }
 
     /**
+     * Convert the iso639_2B to iso639_2T
+     *
+     * @param iso639_2B The 3 iso lang code B
+     * @return The iso639_2T lang code
+     */
+    public static
+    @Nonnull
+    String iso639_2B_to_iso639_2T(String iso639_2B) {
+        return IsoLanguagesMapper.iso639_2B_to_iso639_2T(iso639_2B);
+    }
+
+    /**
+     * Convert the iso639_2T to iso639_2B
+     *
+     * @param iso639_2T The 3 iso lang code T
+     * @return The iso639_2B lang code
+     */
+    public static
+    @Nonnull
+    String iso639_2T_to_iso639_2B(String iso639_2T) {
+        return IsoLanguagesMapper.iso639_2T_to_iso639_2B(iso639_2T);
+    }
+
+    /**
      * Return 2 iso lang code from a 3 iso lang code. If any error occurs return "".
      *
      * @param iso3LangCode The 2 iso lang code
@@ -674,7 +699,7 @@ public final class XslUtil {
     }
 
     /**
-     * Return 2 iso lang code from a 3 iso lang code. If any error occurs return "".
+     * Return 2 char iso lang code from a 3 iso lang code.
      *
      * @param iso3LangCode The 2 iso lang code
      * @return The related 3 iso lang code
@@ -686,38 +711,24 @@ public final class XslUtil {
             if (defaultValue != null) {
                 return defaultValue;
             } else {
-                return twoCharLangCode(Geonet.DEFAULT_LANGUAGE);
+                iso3LangCode = Geonet.DEFAULT_LANGUAGE;
             }
-        } else {
-            if (iso3LangCode.equalsIgnoreCase("FRA")) {
-                return "FR";
+            }
+        String iso2LangCode = null;
+
+        // Catch language entries longer than 3 characters with a semicolon
+        if (iso3LangCode.length() > 3 && (iso3LangCode.indexOf(';') != -1)) {
+            //This will extract text similar to the following "fr;CAN", "fra;CAN", "fr ;CAN"
+            //In the case of "fr;CAN",  fr would be extracted even though it is not a 3 char code - but that is ok because LanguageCode.getByCode supports 2 and 3 char codes.
+            iso3LangCode = iso3LangCode.split(";")[0].trim();
             }
 
-            if (iso3LangCode.equalsIgnoreCase("DEU")) {
-                return "DE";
-            }
-            String iso2LangCode = null;
-
-            try {
-                final IsoLanguagesMapper mapper = ApplicationContextHolder.get().getBean(IsoLanguagesMapper.class);
-                /*if the language  is 2 characters long...*/
-                if (iso3LangCode.length() == 2) {
-                    iso2LangCode = iso3LangCode;
-                    /*Catch language entries longer than 3 characters with a semicolon*/
-                } else if (iso3LangCode.length() > 3 && (iso3LangCode.indexOf(';') != -1)) {
-                    iso2LangCode = mapper.iso639_2_to_iso639_1(iso3LangCode.substring(0, 3));
-                    /** This final else works properly for languages with exactly three characters, so
-                     * an exception will occur if gmd:language has more than 3 characters but
-                     * does not have a semicolon.
-                     */
-                } else {
-                    iso2LangCode = mapper.iso639_2_to_iso639_1(iso3LangCode);
+        LanguageCode languageCode = LanguageCode.getByCode(iso3LangCode.toLowerCase());
+        if (languageCode != null) {
+            iso2LangCode = languageCode.name();
                 }
-            } catch (Exception ex) {
-                Log.error(Geonet.GEONETWORK, "Failed to get iso 2 language code for " + iso3LangCode + " caused by " + ex.getMessage());
 
-            }
-            /* Triggers when the language can't be matched to a code */
+        // Triggers when the language can't be matched to a code
             if (iso2LangCode == null) {
                 Log.error(Geonet.GEONETWORK, "Cannot convert " + iso3LangCode + " to 2 char iso lang code", new Error());
                 return iso3LangCode.substring(0, 2);
@@ -725,7 +736,6 @@ public final class XslUtil {
                 return iso2LangCode;
             }
         }
-    }
 
     /**
      * Returns the HTTP code  or error message if error occurs during URL connection.

--- a/pom.xml
+++ b/pom.xml
@@ -984,6 +984,11 @@
         <version>1.1-20120112</version>
       </dependency>
       <dependency>
+        <groupId>com.neovisionaries</groupId>
+        <artifactId>nv-i18n</artifactId>
+        <version>1.29</version>
+      </dependency>
+      <dependency>
         <groupId>net.arnx.jsonic</groupId>
         <artifactId>jsonic</artifactId>
         <version>1.2.0</version>

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterApi.java
@@ -145,6 +145,9 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
     @Autowired
     LanguageUtils languageUtils;
 
+    @Autowired
+    IsoLanguagesMapper isoLanguagesMapper;
+
     /**
      * Map (canonical path to formatter dir -> Element containing all xml files in Formatter
      * bundle's loc directory)
@@ -277,9 +280,10 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
         if (formatType == null) {
             formatType = FormatType.xml;
         }
-        String language = LanguageUtils.iso3code(locale);
+
+        String language = isoLanguagesMapper.iso639_2T_to_iso639_2B(locale.getISO3Language());
         if (StringUtils.isNotEmpty(iso3lang)) {
-            language = LanguageUtils.locale2gnCode(iso3lang);
+            language = isoLanguagesMapper.iso639_2T_to_iso639_2B(iso3lang);
         }
 
         AbstractMetadata metadata = ApiUtils.canViewRecord(metadataUuid, servletRequest);
@@ -339,7 +343,7 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
                 context.getBean(DataManager.class).increasePopularity(context, String.valueOf(metadata.getId()));
             }
             writeOutResponse(context, metadataUuid,
-                LanguageUtils.iso3code(locale),
+                isoLanguagesMapper.iso639_2T_to_iso639_2B(locale.getISO3Language()),
                 request.getNativeResponse(HttpServletResponse.class), formatType, bytes);
         }
       }

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/SchemaLocalizations.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/SchemaLocalizations.java
@@ -317,9 +317,9 @@ public class SchemaLocalizations {
             return null;
         }
         List<IsoLanguage> lang;
-        if (value.equals("deu")) {
-            value = "ger";
-        }
+
+        // ensure the code is in iso-639-2/B
+        value = IsoLanguagesMapper.iso639_2T_to_iso639_2B(value);
 
         if (value.length() == 2) {
             lang = this.languageRepo.findAllByShortCode(value.toLowerCase());

--- a/services/src/main/java/org/fao/geonet/api/tools/i18n/LanguageUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/tools/i18n/LanguageUtils.java
@@ -25,6 +25,8 @@ package org.fao.geonet.api.tools.i18n;
 
 import java.util.*;
 
+import org.fao.geonet.languages.IsoLanguagesMapper;
+
 /**
  * Created by francois on 05/02/16.
  */
@@ -84,22 +86,6 @@ public class LanguageUtils {
     }
 
     /**
-     * Converts from {@link Locale#getISO3Language()} 639-2/T langauge code into GeoNetwork ISO Language 639-2/B representation.
-     *
-     * @param isoLanguage_638_2_T_code Java {@link Locale#getISO3Language()} 639-2/T language code
-     * @return Geonetwork ISO 639-2/B language code
-     */
-    public static String locale2gnCode(String isoLanguage_638_2_T_code){
-        if (isoLanguage_638_2_T_code.equals("fra")) {
-            return "fre";
-        } else if (isoLanguage_638_2_T_code.equals("slk")) { // transforms ISO 639-2/T into ISO 639-2/B
-            return "slo";
-        } else {
-            return isoLanguage_638_2_T_code;
-        }
-    }
-
-    /**
      * Obtain into GeoNetwork ISO Language 639-2/B representation for locale.
      *
      * Translate locale three-letter abbreviation to language code (providing a special case for 'fra' and 'slk' locales.
@@ -111,7 +97,7 @@ public class LanguageUtils {
         if (locale == null){
             return null;
         }
-        return locale2gnCode(locale.getISO3Language());
+        return IsoLanguagesMapper.iso639_2T_to_iso639_2B(locale.getISO3Language());
     }
 
     /**


### PR DESCRIPTION
* Used nv-i18n library to add better support for `iso639-2/T` `iso639-2/B` support
* Fixed bug where `getAlpha3T` and `isoLanguagesMapper.iso639_2T_to_iso639_2B` should have been used.
* 
Updated language parsing to support `fr:can`
