### PR TITLE
Admin / better handle harvester types translation

### DIFF
--- a/web-ui/src/main/resources/catalog/js/admin/HarvestSettingsController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/HarvestSettingsController.js
@@ -191,11 +191,9 @@
             .success(function(data) {
               angular.forEach(data[0], function(value) {
                 $scope.harvesterTypes[value] = {
-                  label: value
+                  type: value,
+                  label: 'harvester-' + value
                 };
-                $translate('harvester-' + value).then(function(translated) {
-                  $scope.harvesterTypes[value].text = translated;
-                });
 
                 $.getScript('../../catalog/templates/admin/harvest/type/' +
                     value + '.js')

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/harvest-settings.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/harvest-settings.html
@@ -70,11 +70,12 @@
           <ul id="gn-harvest-select-available-list"
               class="dropdown-menu"
               role="menu">
-            <li data-ng-repeat="h in getHarvesterTypes() | orderBy:'text'"
+            <li data-ng-repeat="h in getHarvesterTypes() | orderBy:'label'"
                 data-ng-class="h.loaded ? '' : 'disabled'">
-              <a href="" data-ng-click="addHarvester(h.label)"
-                 title="{{'harvester-' + h.label + 'Help' | translate}}">{{h.text}}
-                <span data-ng-hide="h.loaded" data-translate="">notYetSupported</span>
+              <a href="" data-ng-click="addHarvester(h.type)"
+                 title="{{'harvester-' + h.type + 'Help' | translate}}">
+                <span translate>{{h.label}}</span>
+                <span data-ng-hide="h.loaded" translate>notYetSupported</span>
               </a>
             </li>
           </ul>


### PR DESCRIPTION
Without this change, harvester types without translation would simply not appear in the list (actually they'd be there but as an empty button and as such, almost invisible).

See example below (notice the `harvester-simpleurl` untranslated key, which appears as it should):

![image](https://user-images.githubusercontent.com/10629150/139077630-cb26d7ff-27a2-43f0-a2ba-03f92a1885fd.png)
