### PR TITLE
Fix for the print bug with annotations on map.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/print/PrintMapDirective.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/print/PrintMapDirective.js
@@ -60,7 +60,7 @@
         overlayCanvas.width = width;
         overlayCanvas.height = height;
         var ctx = overlayCanvas.getContext('2d');
-        
+
 
         var minx, miny, maxx, maxy;
         minx = printRectangle[0], miny = printRectangle[1],
@@ -316,11 +316,7 @@
           } else if (src instanceof ol.source.XYZ) {
             encLayer = gnPrint.encoders.layers['XYZ'].call(this,
                 layer, layerConfig, proj);
-          } else if (src instanceof ol.source.Vector ||
-              src instanceof ol.source.ImageVector) {
-            if (src instanceof ol.source.ImageVector) {
-              src = src.getSource();
-            }
+          } else if (src instanceof ol.source.Vector) {
             var features = [];
             src.forEachFeatureInExtent(ext, function(feat) {
               features.push(feat);
@@ -371,17 +367,17 @@
             scope.defaultLayout = attrs.layout;
             scope.auto = true;
             scope.activatedOnce = false;
-            
+
             scope.layersWithWhiteSpaces = false;
-            
+
             scope.$watchCollection(
                 function() {
                   return scope.map.getLayers().getArray();
-                }, 
+                },
                 function(layers) {
                   scope.layersWithWhiteSpaces = false;
                   layers.forEach(function(layer) {
-                    if(layer.getSource() 
+                    if(layer.getSource()
                         && layer.getSource() instanceof ol.source.TileWMS
                         && layer.getSource().getParams()
                         && layer.getSource().getParams().LAYERS


### PR DESCRIPTION
It was not possible to print a map with annotations on it. This bug was fixed for `3.12` and higher, but never made it to `3.10.x`

Related to: https://github.com/geonetwork/core-geonetwork/pull/5044