### PR TITLE
Metadata status migration - add FK for relatedMetadataStatusId

### DIFF
--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v3110/UpdateMetadataStatus.java
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v3110/UpdateMetadataStatus.java
@@ -350,7 +350,9 @@ public class UpdateMetadataStatus extends DatabaseMigrationTask {
             String[] fkColumns = new String[] {"relatedMetadataStatusId"};
             String[] pkColumns = new String[] {MetadataStatus_.id.getName()};
 
-            statement.execute("ALTER TABLE " + MetadataStatus.TABLE_NAME + " " +  dialect.getAddForeignKeyConstraintString(MetadataStatus.TABLE_NAME + "relatedMetadataStatusIdFk", fkColumns, MetadataStatus.TABLE_NAME, pkColumns, true));
+            statement.execute("ALTER TABLE " + MetadataStatus.TABLE_NAME + " " +
+                dialect.getAddForeignKeyConstraintString(MetadataStatus.TABLE_NAME + "RelMdStatusIdFk",
+                    fkColumns, MetadataStatus.TABLE_NAME, pkColumns, true));
         } catch (Exception e) {
             connection.rollback();
             // If there was an error then we will log the error and continue.

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v3110/UpdateMetadataStatus.java
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v3110/UpdateMetadataStatus.java
@@ -344,6 +344,21 @@ public class UpdateMetadataStatus extends DatabaseMigrationTask {
         }
 
         connection.commit();
+
+        // lets add the FK relatedMetadataStatusId
+        try (Statement statement = connection.createStatement()) {
+            String[] fkColumns = new String[] {"relatedMetadataStatusId"};
+            String[] pkColumns = new String[] {MetadataStatus_.id.getName()};
+
+            statement.execute("ALTER TABLE " + MetadataStatus.TABLE_NAME + " " +  dialect.getAddForeignKeyConstraintString(MetadataStatus.TABLE_NAME + "relatedMetadataStatusIdFk", fkColumns, MetadataStatus.TABLE_NAME, pkColumns, true));
+        } catch (Exception e) {
+            connection.rollback();
+            // If there was an error then we will log the error and continue.
+            // Most likely cause is that the column already exists which should be fine.
+            Log.error(Geonet.DB, "  Exception while adding foreign key on relatedMetadataStatusId column of " + MetadataStatus.TABLE_NAME + ". " +
+                "Error is: " + e.getMessage());
+            Log.debug(Geonet.DB, e);
+        }
     }
 
     private String getDatabaseObjectName(final Connection connection, String objectName) throws SQLException {

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v3110/UpdateMetadataStatus.java
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v3110/UpdateMetadataStatus.java
@@ -353,6 +353,7 @@ public class UpdateMetadataStatus extends DatabaseMigrationTask {
             statement.execute("ALTER TABLE " + MetadataStatus.TABLE_NAME + " " +
                 dialect.getAddForeignKeyConstraintString(MetadataStatus.TABLE_NAME + "RelMdStatusIdFk",
                     fkColumns, MetadataStatus.TABLE_NAME, pkColumns, true));
+            connection.commit();
         } catch (Exception e) {
             connection.rollback();
             // If there was an error then we will log the error and continue.


### PR DESCRIPTION
The FK for the column `relatedMetadataStatusId` is not added when migrating from a 3.10 database. Hibernate tries to create it, but fails due to the key changes.