### PR TITLE
Fix credentials autocomplete in harvesters

### DIFF
--- a/web-ui/src/main/resources/catalog/components/admin/harvester/partials/account.html
+++ b/web-ui/src/main/resources/catalog/components/admin/harvester/partials/account.html
@@ -20,7 +20,7 @@
         <input id="gn-harvest-settings-gn-advanced-remote-password-input"
               type="password"
               class="form-control"
-              autocomplete="off"
+              autocomplete="new-password"
               data-ng-model="harvester.site.account.password"/>
       </div>
     </div>


### PR DESCRIPTION
Chrome autocompletes the harvester credentials, seem as the username field is hidden by default, the heuristic used, autocompletes the previous field: **XPath Filter**.  The main problem with this, apart of the wrong value in the field, is that when the harvested is edited again and saved, causes an error.

![autocomplete-harvesters](https://user-images.githubusercontent.com/1695003/139396491-ab1dc11a-3b5d-4a78-a162-8a1d50a357b2.png)

This change prevents the autocomplete in the harvester credentials.