### PR TITLE
Fix the list of elements to process in CSW ElementSet strategy 'context'

### DIFF
--- a/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/SearchController.java
+++ b/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/SearchController.java
@@ -347,7 +347,7 @@ public class SearchController {
                         }
 
                         List<Element> elementsInContextMatching = new ArrayList<Element>();
-                        for (Element match : elementsInContextMatching) {
+                        for (Element match : elementsMatching) {
                             Element parent = match.getParentElement();
                             while (parent != null) {
                                 parent.removeContent();


### PR DESCRIPTION
The ElementSet strategy 'context' was using an invalid variable with the name of elements to filter from the metadata for the CSW response, causing that all the metadata elements were returned.