### PR TITLE
Fix gn-fn-index:is-isoDate - invalid dates like 2021-04-207 match, causing indexing errors

### DIFF
--- a/web/src/main/webapp/xslt/common/index-utils.xsl
+++ b/web/src/main/webapp/xslt/common/index-utils.xsl
@@ -60,7 +60,7 @@
     <xsl:param name="value" as="xs:string?"/>
     <xsl:value-of select="if ($value castable as xs:date
                           or $value castable as xs:dateTime
-                          or matches($value, '^[0-9]{4}$|^[0-9]{4}-[0-9]{2}$'))
+                          or matches($value, '^[0-9]{4}$|^[0-9]{4}-(0[1-9]|1[012])$'))
                           then true() else false()"/>
   </xsl:function>
 

--- a/web/src/main/webapp/xslt/common/index-utils.xsl
+++ b/web/src/main/webapp/xslt/common/index-utils.xsl
@@ -60,7 +60,7 @@
     <xsl:param name="value" as="xs:string?"/>
     <xsl:value-of select="if ($value castable as xs:date
                           or $value castable as xs:dateTime
-                          or matches($value, '[0-9]{4}(-[0-9]{2})?'))
+                          or matches($value, '^[0-9]{4}$|^[0-9]{4}-[0-9]{2}$'))
                           then true() else false()"/>
   </xsl:function>
 


### PR DESCRIPTION
The original regular expression matched invalid values like `2021-04-207`, causing the metadata indexing to fail, not being searchable.

@fxprunayre in the function comments indicates `epoch_millis`, can you confirm if that is matched with the expression `$value castable as xs:dateTime`?