### PR TITLE
Convert iso639_2T to iso639_2B in form-builder

### DIFF
--- a/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
@@ -211,7 +211,7 @@
             <xsl:if test="$isMultilingual">
               <xsl:attribute name="data-gn-multilingual-field"
                              select="$metadataOtherLanguagesAsJson"/>
-              <xsl:attribute name="data-main-language" select="$metadataLanguage"/>
+              <xsl:attribute name="data-main-language" select="java-xsl-util:iso639_2T_to_iso639_2B($metadataLanguage)"/>
               <xsl:attribute name="data-expanded" select="$toggleLang"/>
             </xsl:if>
 


### PR DESCRIPTION
Original issue:

https://github.com/metadata101/iso19139.ca.HNAP/pull/240

Issue brief description:

Some metadata template uses ISO_639_2T language code which is not supported in Geonetwork. For example:

https://github.com/metadata101/iso19139.ca.HNAP/blob/b37d4f95091af69974c0036d05f5100a28a6db92/src/main/plugin/iso19139.ca.HNAP/templates/hnaplevel1-french.xml#L15-L17

https://github.com/metadata101/iso19139.ca.HNAP/blob/b37d4f95091af69974c0036d05f5100a28a6db92/src/main/plugin/iso19139.ca.HNAP/templates/hnaplevel1-english.xml#L121-L125


The consequence is multilingual field is not recognized and its correct language tab cannot be rendered. Here is the example in French profile, but English tab is always showing to the user.
![image](https://user-images.githubusercontent.com/74916635/140801142-5a620b21-e987-40f6-9b30-3e77c4fb2394.png)
 

In order to eliminate such language inconsistent issue, this pull request is to enforce all metadata language code to be converted as pass ISO 639_2B standard only. Based on the fixed of https://github.com/geonetwork/core-geonetwork/pull/5982, this is extended enforcement rule in XSLT form-builder.