### PR TITLE
Fix the display of the service metadata title for CSW and portals

### DIFF
--- a/web-ui/src/main/resources/catalog/js/admin/CSWSettingsController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/CSWSettingsController.js
@@ -57,8 +57,10 @@
    *
    */
   module.controller('GnCSWSettingsController', [
-    '$scope', '$http', '$rootScope', '$translate', 'gnUtilityService',
-    function($scope, $http, $rootScope, $translate, gnUtilityService) {
+    '$scope', '$http', '$rootScope', '$translate',
+    'gnUtilityService', 'gnESClient', 'Metadata',
+    function($scope, $http, $rootScope, $translate, gnUtilityService,
+             gnESClient, Metadata) {
       /**
        * CSW properties
        */
@@ -107,17 +109,20 @@
       function loadServiceRecords() {
         var id = $scope.cswSettings['system/csw/capabilityRecordUuid'];
         if (angular.isDefined(id) && id != -1){
-          $http.post('../api/search/records/_search', {"query": {
-              "term": {
-                "uuid": {
-                  "value": "\"" + id + "\""
+          var query =
+            {"query": {
+                "term": {
+                  "uuid": {
+                    "value": id
+                  }
                 }
-              }
-            }, "from": 0, "size": 1}, {cache: true})
-            .then(function(r) {
-              if (r.data.hits.hits > 0) {
-                $scope.cswServiceRecord = new Metadata(r.data.hits.hits[0]);
-              }
+              }, "from": 0, "size": 1};
+
+          gnESClient.search(query).then(function(data) {
+            angular.forEach(data.hits.hits, function(record) {
+              var md = new Metadata(record);
+              $scope.cswServiceRecord = md;
+            });
           });
         }
       }

--- a/web-ui/src/main/resources/catalog/js/admin/SourcesController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/SourcesController.js
@@ -30,8 +30,8 @@
 
 
   module.controller('GnSourcesController', [
-    '$scope', '$http', '$rootScope', '$translate',
-    function($scope, $http, $rootScope, $translate) {
+    '$scope', '$http', '$rootScope', '$translate', 'gnESClient', 'Metadata',
+    function($scope, $http, $rootScope, $translate, gnESClient, Metadata) {
       $scope.sources = [];
       $scope.uiConfigurations = [];
       $scope.source = null;
@@ -104,10 +104,22 @@
       };
       function loadServiceRecords() {
         var id = $scope.source.serviceRecord;
+
         if (angular.isDefined(id) && id != -1){
-          $http.get('qi?_content_type=json&fast=index&_uuid=' + id,
-            {cache: true}).then(function(r) {
-            $scope.cswServiceRecord = r.data.metadata;
+          var query =
+            {"query": {
+                "term": {
+                  "uuid": {
+                    "value": id
+                  }
+                }
+            }, "from": 0, "size": 1};
+
+          gnESClient.search(query).then(function(data) {
+            angular.forEach(data.hits.hits, function(record) {
+              var md = new Metadata(record);
+              $scope.cswServiceRecord = md;
+            });
           });
         }
       }


### PR DESCRIPTION
The code to retrieve the service metadata title was using the old query API, causing the title not being displayed:

![service-metadata-title-missing](https://user-images.githubusercontent.com/1695003/140769801-c5534704-eae9-45f3-bf97-e7395699d2cc.png)

With the change: 

![service-metadata-title-fixed](https://user-images.githubusercontent.com/1695003/140769922-1aae81c8-dd37-42f1-9f6f-884126a5c269.png)

