### PR TITLE
Allow to configure the map context files for maps (viewer / search / editor) from map context files defined in the metadata online resources

### DIFF
--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/mapconfig.html
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/mapconfig.html
@@ -1,6 +1,43 @@
 <label class="control-label" translate>mapConfigContext</label>
-<input type="text" class="form-control"
-  data-ng-model="mCfg[key]['context']"/>
+
+<div data-ng-controller="GnSearchController">
+  <div data-ng-search-form=""
+       data-ng-controller="GnMapContextRecordController">
+    <div class="input-group dropdown"
+         id="serviceList">
+      <input type="text" class="form-control"
+             data-ng-model="mCfg[key]['context']"/>
+
+      <div class="input-group-btn">
+        <button type="button" class="btn btn-default dropdown-toggle"
+                data-toggle="dropdown" aria-haspopup="true" aria-expanded="false"
+                data-ng-click="updateParams();triggerSearch();" type="text">
+          <i class="fa fa-search"/>
+          <span class="caret"></span>
+        </button>
+        <ul class="dropdown-menu dropdown-menu-right">
+          <li>
+            <input class="form-control"
+                   onClick="window.event.stopPropagation()"
+                   data-ng-change="updateParams();triggerSearch();" type="text"
+                   data-toggle="dropdown"
+                   data-ng-model="searchObj.any"
+                   data-ng-model-options="{debounce: 200}"
+                   placeholder="{{'search' | translate}}"/>
+          </li>
+          <li data-ng-repeat="md in searchResults.records">
+            <a href=""
+               data-ng-click="mCfg[key]['context'] = md.linkUrlProtocolOGCOWSC">
+              {{md.resourceTitleObject.default}}
+            </a>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </div>
+</div>
+
+
 <label class="control-label" translate>mapConfigExtent</label>
 <div class="input-group">
   <span class="input-group-addon">MinX</span>

--- a/web-ui/src/main/resources/catalog/js/admin/SystemSettingsController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/SystemSettingsController.js
@@ -503,4 +503,31 @@
       loadSettings();
     }]);
 
+  /**
+   * GnMapContextRecordController provides de search object to query
+   * metadata with public (download privilege to group ALL)
+   * map context resources (OGC:OWS-C protocol).
+   */
+  module.controller('GnMapContextRecordController', [
+    '$scope', 'gnGlobalSettings',
+    function($scope, gnGlobalSettings) {
+      $scope.searchObj = {
+        internal: true,
+        any: '',
+        defaultParams: {
+          any: '',
+          from: 1,
+          to: 50,
+          op1: 1,
+          linkProtocol: 'OGC:OWS-C',
+          sortBy: 'resourceTitleObject.default.keyword',
+          sortOrder: 'asc'
+        }
+      };
+      $scope.searchObj.params = angular.extend({},
+        $scope.searchObj.defaultParams);
+      $scope.updateParams = function() {
+        $scope.searchObj.params.any = $scope.searchObj.any;
+      };
+    }]);
 })();


### PR DESCRIPTION
This PR allows to select the map context files for the maps in the viewer / search and editor defined in metadata records.

To create these records:

1) In the map viewer, customise the background layers and and extent.

2) In the Maps option select `Save` and configure the metadata title and abstract, click `Save as public record`

![maps-1](https://user-images.githubusercontent.com/1695003/140772603-b3bb09d9-1f6b-4448-904b-9954127d3619.png)

2) Go to the UI settings and select the metadata with the map context file to use.

![select-mapcontext-from-metadata-1](https://user-images.githubusercontent.com/1695003/140771875-fe26ad57-8352-43e2-971c-bfd21bd82b3c.png)

![select-mapcontext-from-metadata-2](https://user-images.githubusercontent.com/1695003/140771888-04c2448f-d046-47b3-9f91-7c4b63442bde.png)

@fxprunayre please check if the protocol filter is ok or should be supported additional values, thanks.
