### PR TITLE
Error message JSON path fixes in Editor Angular Controllers

### DIFF
--- a/web-ui/src/main/resources/catalog/js/edit/EditorBoardController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/EditorBoardController.js
@@ -119,7 +119,7 @@
               deferred.resolve(data);
             }, function(reason) {
               $rootScope.$broadcast('StatusUpdated', {
-                title: reason.data.description,
+                title: reason.data.description, //returned error JSON obj
                 timeout: 0,
                 type: 'danger'
               });

--- a/web-ui/src/main/resources/catalog/js/edit/EditorController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/EditorController.js
@@ -570,8 +570,8 @@
                 closeEditor();
               }, function(reason) {
                 $rootScope.$broadcast('StatusUpdated', {
-                  title: $translate.instant(reason.data.error.message),
-                  error: reason.data.error.description,
+                  title: reason.data.message, //returned error JSON obj
+                  error: reason.data.description,
                   timeout: 0,
                   type: 'danger'
                 });


### PR DESCRIPTION
Issue Description:

The exception thrown in metadata editor/editorBoard was not captured the correct returned JSON path. The example JSON looks like. It should be reason.data->{code, description, message}. There is an unknown "error" object in the controller.

![image](https://user-images.githubusercontent.com/74916635/140828628-3e203966-1c61-4241-8338-da805f86f4f1.png)

There is no specific way to reproduce such exception. The exception can happens randomly for example, the backend store throws timeout or service not available. But there is some workaround to reproduce such issue. Go to this line of code

https://github.com/geonetwork/core-geonetwork/blob/695c20e34b54b5760ce80c68c84cff0a26a1abc1/services/src/main/java/org/fao/geonet/api/records/MetadataInsertDeleteApi.java#L192-L196

Place manual exception throwing code:
![image](https://user-images.githubusercontent.com/74916635/140829240-c946e635-ec61-4d63-bbb5-5574a8fff696.png)


Build your project and go to editor board and delete any records:
![image](https://user-images.githubusercontent.com/74916635/140829348-fe9235ec-a0f9-4eef-8c3d-057e1bdd1892.png)

Since there is forced exception throwing in the API, so an error response will be returned to the browser.

![image](https://user-images.githubusercontent.com/74916635/140829458-1253a402-de13-44e6-9fa9-8997a4a60cfd.png)


But the delete icon will keep spinning and no error message returned.

After the fix, the error message should be look like this:
![image](https://user-images.githubusercontent.com/74916635/140829536-7f22a7f1-7406-4cea-bb3e-96351f72cc09.png)



There was a fix in one of the previous PR https://github.com/geonetwork/core-geonetwork/pull/5079 but this PR is not meant for backporting to 3.12 as there are problems when doing cherry pick. So I created this PR in order to backport partial of its solution into 3.12.


As this PR changed EditorController.js which will fix another place for unrecognized returned JSON in newly created record when exception happens:

![image](https://user-images.githubusercontent.com/74916635/140836712-fe03823b-e1c8-4f44-894a-f68cca3717ab.png)

After the fix:
![image](https://user-images.githubusercontent.com/74916635/140836864-364e233b-b71d-47f3-b98f-abb79a517889.png)
