### PR TITLE
Fixed token refresh issue with keycloakSecurityContextRequestFilter

### DIFF
--- a/web/src/main/webapp/WEB-INF/config-security/config-security-keycloak.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-keycloak.xml
@@ -82,6 +82,8 @@
   <bean id="keycloakAuthenticationProcessingFilter" class="org.fao.geonet.kernel.security.keycloak.KeycloakAuthenticationProcessingFilter" depends-on="keycloakUtil">
     <constructor-arg name="authenticationManager" ref="authenticationManager" />
   </bean>
+  <bean id="keycloakSecurityContextRequestFilter"
+        class="org.keycloak.adapters.springsecurity.filter.KeycloakSecurityContextRequestFilter" />
 
   <bean id="keycloakLogoutHandler" class="org.fao.geonet.kernel.security.keycloak.KeycloakLogoutHandler">
     <constructor-arg ref="adapterDeploymentContext" />
@@ -124,6 +126,7 @@
     <ref bean="logoutFilter" />
     <ref bean="keycloakPreAuthActionsLoginFilter" />
     <ref bean="keycloakAuthenticationProcessingFilter" />
+    <ref bean="keycloakSecurityContextRequestFilter" />
     <ref bean="requestCacheFilter" />
     <ref bean="anonymousFilter" />
     <ref bean="sessionMgmtFilter" />
@@ -139,6 +142,7 @@
     <ref bean="logoutFilter" />
     <ref bean="keycloakPreAuthActionsFilter" />
     <ref bean="keycloakAuthenticationProcessingFilter" />
+    <ref bean="keycloakSecurityContextRequestFilter" />
     <ref bean="requestCacheFilter" />
     <ref bean="anonymousFilter" />
     <ref bean="sessionMgmtFilter" />
@@ -155,6 +159,7 @@
 		<ref bean="logoutFilter" />
 		<ref bean="keycloakPreAuthActionsFilter"/>
 		<ref bean="keycloakAuthenticationProcessingFilter"/>
+		<ref bean="keycloakSecurityContextRequestFilter" />
 		<ref bean="basicAuthenticationFilter" />
 		<ref bean="formLoginFilter" />
 		<ref bean="requestCacheFilter" />


### PR DESCRIPTION
Fixed issue with missing keycloakSecurityContextRequestFilter that was causing keycloak not to refresh the keycloak session  correctly.

Before this fix, if a user logged in via keycloak and browsed for a while, the keycloak session would be removed but the geonetwork session would still be active.  So it would loose the SSO capabilities.

Oddly the documentation on keycloak 11 does not include adding the bean and that is why it was previously missed.
https://www.keycloak.org/docs/11.0/securing_apps/#xml-configuration

The newer documentation include the addition of the bean.
https://www.keycloak.org/docs/latest/securing_apps/#xml-configuration

Please backport this to 3.12.x