### PR TITLE
Change the links to buttons so ngClickAndSpin is actually disabled in DOI widget html template

### DIFF
--- a/web-ui/src/main/resources/catalog/components/doi/partials/doiwidget.html
+++ b/web-ui/src/main/resources/catalog/components/doi/partials/doiwidget.html
@@ -7,7 +7,7 @@
   <div class="btn-group"
        data-ng-class="{'btn-group-xs': xsMode}"
        role="group">
-    <a class="btn btn-default"
+    <button class="btn btn-default"
        data-gn-click-and-spin="check()"
        data-ng-class="{
           'btn-default': response.check == null,
@@ -21,9 +21,9 @@
           'fa-thumbs-up': response.check.data.code === 'resource_already_exist',
           'fa-thumbs-down': response.check.status === 400 && response.check.data.code !== 'resource_already_exist'}"></i>
       <span data-translate="">doiCreationTaskCheckAction</span>
-    </a>
+    </button>
 
-    <a class="btn btn-primary"
+    <button class="btn btn-primary"
        data-ng-disabled="response.check.status !== 200 && response.check.data.code !== 'resource_already_exist'"
        data-gn-click-and-spin="create()">
       <i class="fa fa-fw fa-play"></i>
@@ -31,7 +31,7 @@
             data-translate="">doiCreationTaskCreateAction</span>
       <span data-ng-if="isUpdate"
             data-translate="">doiCreationTaskUpdateAction</span>
-    </a>
+    </button>
 
     <a class="btn btn-default"
        data-ng-if="doiUrl"


### PR DESCRIPTION
Change the links by actual buttons so `ngClickAndSpin` directive is not executed when
the user clicks a disabled button. With the links the action was triggered even when
the component is `disabled`.