### PR TITLE
Datacite formatter - process for creators only point of contacts with roles pointOfContact and custodian

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/datacite/view.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/datacite/view.xsl
@@ -344,14 +344,12 @@
     multiple creators, repeat this
     property.
    -->
-  <xsl:variable name="creatorRoles"
-                select="'pointOfContact', 'custodian'"/>
   <xsl:template mode="toDatacite"
                 match="mdb:MD_Metadata/mdb:identificationInfo/*/
                           mri:pointOfContact[1]">
     <datacite:creators>
       <!-- [cit:role/*/@codeListValue = $roles] TODO: Restrict on roles ?-->
-      <xsl:for-each select="../mri:pointOfContact/*">
+      <xsl:for-each select="../mri:pointOfContact/*[cit:role/*/@codeListValue = ('pointOfContact', 'custodian')]">
         <datacite:creator>
           <!--
           Expect the entry point to be CI_Organisation

--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/datacite/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/datacite/view.xsl
@@ -334,14 +334,11 @@
     multiple creators, repeat this
     property.
    -->
-  <xsl:variable name="creatorRoles"
-                select="'pointOfContact', 'custodian'"/>
   <xsl:template mode="toDatacite"
                 match="gmd:MD_Metadata/gmd:identificationInfo/*/
                           gmd:pointOfContact[1]">
     <datacite:creators>
-      <!-- [gmd:role/*/@codeListValue = $roles] TODO: Restrict on roles ?-->
-      <xsl:for-each select="../gmd:pointOfContact/*">
+      <xsl:for-each select="../gmd:pointOfContact/*[gmd:role/gmd:CI_RoleCode/@codeListValue = ('pointOfContact', 'custodian')]">
         <datacite:creator>
           <!-- The full name of the creator. -->
           <datacite:creatorName nameType="Personal">


### PR DESCRIPTION
This will align the formatter with the fields that the schematron considers as valid creators.