### PR TITLE
Add mimetype in WWW:DOWNLOAD protocol on opendatasoft harveting

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/fromJsonLdEsri.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/fromJsonLdEsri.xsl
@@ -424,13 +424,7 @@
                       </cit:linkage>
                       <cit:protocol>
                         <gco:CharacterString>
-                          <xsl:choose>
-                            <xsl:when test="format = 'Web Page'">WWW:LINK-1.0-http--link</xsl:when>
-                            <xsl:when test="format = 'ArcGIS GeoServices REST API'">ESRI:REST</xsl:when>
-                            <xsl:otherwise>
-                              <xsl:value-of select="concat($format-mimetype-mapping/entry[format=lower-case(format)]/protocol,':', mediaType)"/>
-                            </xsl:otherwise>
-                          </xsl:choose>
+                          <xsl:value-of select="$format-protocol-mapping/entry[format=lower-case(format)]/protocol"/>
                         </gco:CharacterString>
                       </cit:protocol>
                       <cit:name>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/fromJsonLdEsri.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/fromJsonLdEsri.xsl
@@ -44,9 +44,10 @@
                 xmlns:xd="http://www.oxygenxml.com/ns/doc/xsl"
                 exclude-result-prefixes="#all">
 
+    <xsl:import href="protocol-mapping.xsl"></xsl:import>
+
     <xsl:output method="xml" indent="yes"/>
     <xsl:strip-space elements="*"/>
-    <xsl:import href="protocol-mapping.xsl"></xsl:import>
 
     <xsl:template match="/record">
       <xsl:variable name="cataloglang" select="'fr'"></xsl:variable>
@@ -415,6 +416,7 @@
             <mrd:transferOptions>
               <mrd:MD_DigitalTransferOptions>
                 <xsl:for-each select="distribution">
+                  <xsl:variable name="format" select="format"/>
                   <mrd:onLine>
                     <cit:CI_OnlineResource>
                       <cit:linkage>
@@ -434,7 +436,7 @@
                       </cit:name>
                       <cit:description>
                         <gco:CharacterString>
-                          <xsl:value-of select="format"/>
+                          <xsl:value-of select="$format"/>
                         </gco:CharacterString>
                       </cit:description>
                     </cit:CI_OnlineResource>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/fromJsonLdEsri.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/fromJsonLdEsri.xsl
@@ -424,7 +424,7 @@
                       </cit:linkage>
                       <cit:protocol>
                         <gco:CharacterString>
-                          <xsl:value-of select="$format-protocol-mapping/entry[format=lower-case(format)]/protocol"/>
+                          <xsl:value-of select="$format-protocol-mapping/entry[format=lower-case($format)]/protocol"/>
                         </gco:CharacterString>
                       </cit:protocol>
                       <cit:name>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/fromJsonLdEsri.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/fromJsonLdEsri.xsl
@@ -46,6 +46,7 @@
 
     <xsl:output method="xml" indent="yes"/>
     <xsl:strip-space elements="*"/>
+    <xsl:import href="protocol-mapping.xsl"></xsl:import>
 
     <xsl:template match="/record">
       <xsl:variable name="cataloglang" select="'fr'"></xsl:variable>
@@ -426,7 +427,9 @@
                           <xsl:choose>
                             <xsl:when test="format = 'Web Page'">WWW:LINK-1.0-http--link</xsl:when>
                             <xsl:when test="format = 'ArcGIS GeoServices REST API'">ESRI:REST</xsl:when>
-                            <xsl:otherwise>WWW:DOWNLOAD</xsl:otherwise>
+                            <xsl:otherwise>
+                              <xsl:value-of select="concat($format-mimetype-mapping/entry[format=lower-case(format)]/protocol,':', mediaType)"/>
+                            </xsl:otherwise>
                           </xsl:choose>
                         </gco:CharacterString>
                       </cit:protocol>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/fromJsonOpenDataSoft.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/fromJsonOpenDataSoft.xsl
@@ -556,7 +556,7 @@
           </cit:linkage>
           <cit:protocol>
             <gco:CharacterString>
-              <xsl:value-of select="$format-protocol-mapping/entry[format=lower-case(format)]/protocol"/>
+              <xsl:value-of select="$format-protocol-mapping/entry[format=lower-case($format)]/protocol"/>
             </gco:CharacterString>
           </cit:protocol>
           <cit:name>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/fromJsonOpenDataSoft.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/fromJsonOpenDataSoft.xsl
@@ -44,7 +44,9 @@
                 xmlns:xd="http://www.oxygenxml.com/ns/doc/xsl"
                 exclude-result-prefixes="#all">
 
-    <xsl:output method="xml" indent="yes"/>
+  <xsl:import href="protocol-mapping.xsl"></xsl:import>
+
+  <xsl:output method="xml" indent="yes"/>
 
     <xsl:strip-space elements="*"/>
 
@@ -504,17 +506,21 @@
                 <xsl:if test="metas/records_count > 0">
                   <xsl:call-template name="dataLink">
                     <xsl:with-param name="format">csv</xsl:with-param>
+                    <xsl:with-param name="fields"><xsl:copy-of select="fields"></xsl:copy-of></xsl:with-param>
                   </xsl:call-template>
                   <xsl:call-template name="dataLink">
                     <xsl:with-param name="format">json</xsl:with-param>
+                    <xsl:with-param name="fields"><xsl:copy-of select="fields"></xsl:copy-of></xsl:with-param>
                   </xsl:call-template>
                   <xsl:if test="count(features[. = 'geo']) > 0">
                     <xsl:call-template name="dataLink">
                       <xsl:with-param name="format">geojson</xsl:with-param>
+                      <xsl:with-param name="fields"><xsl:copy-of select="fields"></xsl:copy-of></xsl:with-param>
                     </xsl:call-template>
                     <xsl:if test="metas/records_count &lt; 5000">
                       <xsl:call-template name="dataLink">
                         <xsl:with-param name="format">shapefile</xsl:with-param>
+                        <xsl:with-param name="fields"><xsl:copy-of select="fields"></xsl:copy-of></xsl:with-param>
                       </xsl:call-template>
                     </xsl:if>
                   </xsl:if>
@@ -524,8 +530,6 @@
             </mrd:transferOptions>
           </mrd:MD_Distribution>
         </mdb:distributionInfo>
-
-
 
         <mdb:resourceLineage>
           <mrl:LI_Lineage>
@@ -546,6 +550,12 @@
 
     <xsl:template name="dataLink">
       <xsl:param name="format" />
+      <xsl:param name="fields" />
+      <xsl:variable name="description">
+        <xsl:for-each select="$fields/fields">
+          <xsl:value-of select="concat('- *', label, '* : ', name, '[', type, ']\n')" />
+        </xsl:for-each>
+      </xsl:variable>
 
       <mrd:onLine>
         <cit:CI_OnlineResource>
@@ -555,16 +565,18 @@
             </gco:CharacterString>
           </cit:linkage>
           <cit:protocol>
-            <gco:CharacterString>WWW:DOWNLOAD-1.0-http--download</gco:CharacterString>
+            <gco:CharacterString>
+              <xsl:value-of select="concat($format-mimetype-mapping/entry[format=lower-case($format)]/protocol,':', $format-mimetype-mapping/entry[format=lower-case($format)]/mimetype)"/>
+            </gco:CharacterString>
           </cit:protocol>
           <cit:name>
             <gco:CharacterString>
-              <xsl:value-of select="concat('Download as ', upper-case($format))"/>
+              <xsl:value-of select="$format"/>
             </gco:CharacterString>
           </cit:name>
           <cit:description>
             <gco:CharacterString>
-              <xsl:value-of select="concat('Download this dataset in the ', upper-case($format), ' format.')"/>
+              <xsl:value-of select="$description"/>
             </gco:CharacterString>
           </cit:description>
           <cit:function>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/fromJsonOpenDataSoft.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/fromJsonOpenDataSoft.xsl
@@ -506,21 +506,17 @@
                 <xsl:if test="metas/records_count > 0">
                   <xsl:call-template name="dataLink">
                     <xsl:with-param name="format">csv</xsl:with-param>
-                    <xsl:with-param name="fields"><xsl:copy-of select="fields"></xsl:copy-of></xsl:with-param>
                   </xsl:call-template>
                   <xsl:call-template name="dataLink">
                     <xsl:with-param name="format">json</xsl:with-param>
-                    <xsl:with-param name="fields"><xsl:copy-of select="fields"></xsl:copy-of></xsl:with-param>
                   </xsl:call-template>
                   <xsl:if test="count(features[. = 'geo']) > 0">
                     <xsl:call-template name="dataLink">
                       <xsl:with-param name="format">geojson</xsl:with-param>
-                      <xsl:with-param name="fields"><xsl:copy-of select="fields"></xsl:copy-of></xsl:with-param>
                     </xsl:call-template>
                     <xsl:if test="metas/records_count &lt; 5000">
                       <xsl:call-template name="dataLink">
                         <xsl:with-param name="format">shapefile</xsl:with-param>
-                        <xsl:with-param name="fields"><xsl:copy-of select="fields"></xsl:copy-of></xsl:with-param>
                       </xsl:call-template>
                     </xsl:if>
                   </xsl:if>
@@ -550,12 +546,6 @@
 
     <xsl:template name="dataLink">
       <xsl:param name="format" />
-      <xsl:param name="fields" />
-      <xsl:variable name="description">
-        <xsl:for-each select="$fields/fields">
-          <xsl:value-of select="concat('- *', label, '* : ', name, '[', type, ']\n')" />
-        </xsl:for-each>
-      </xsl:variable>
 
       <mrd:onLine>
         <cit:CI_OnlineResource>
@@ -566,7 +556,7 @@
           </cit:linkage>
           <cit:protocol>
             <gco:CharacterString>
-              <xsl:value-of select="concat($format-mimetype-mapping/entry[format=lower-case($format)]/protocol,':', $format-mimetype-mapping/entry[format=lower-case($format)]/mimetype)"/>
+              <xsl:value-of select="$format-protocol-mapping/entry[format=lower-case(format)]/protocol"/>
             </gco:CharacterString>
           </cit:protocol>
           <cit:name>
@@ -576,7 +566,7 @@
           </cit:name>
           <cit:description>
             <gco:CharacterString>
-              <xsl:value-of select="$description"/>
+              <xsl:value-of select="$format"/>
             </gco:CharacterString>
           </cit:description>
           <cit:function>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/protocol-mapping.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/protocol-mapping.xsl
@@ -9,45 +9,37 @@
     <xsl:output method="xml" indent="yes"/>
     <xsl:strip-space elements="*"/>
 
-    <xsl:variable name="format-mimetype-mapping">
+    <xsl:variable name="format-protocol-mapping">
         <entry>
             <format>csv</format>
-            <mimetype>text/csv</mimetype>
-            <protocol>WWW:DOWNLOAD</protocol>
+            <protocol>WWW:DOWNLOAD:text/csv</protocol>
         </entry>
         <entry>
             <format>geojson</format>
-            <mimetype>application/vnd.geo+json</mimetype>
-            <protocol>WWW:DOWNLOAD</protocol>
+            <protocol>WWW:DOWNLOAD:application/vnd.geo+json</protocol>
         </entry>
         <entry>
             <format>kml</format>
-            <mimetype>application/vnd.google-earth.kml+xml</mimetype>
-            <protocol>WWW:DOWNLOAD</protocol>
+            <protocol>WWW:DOWNLOAD:application/vnd.google-earth.kml+xml</protocol>
         </entry>
         <entry>
             <format>zip</format>
-            <mimetype>application/zip</mimetype>
-            <protocol>WWW:DOWNLOAD</protocol>
+            <protocol>WWW:DOWNLOAD:application/zip</protocol>
         </entry>
         <entry>
             <format>shapefile</format>
-            <mimetype>x-gis/x-shapefile</mimetype>
-            <protocol>WWW:DOWNLOAD</protocol>
+            <protocol>WWW:DOWNLOAD:x-gis/x-shapefile</protocol>
         </entry>
         <entry>
             <format>json</format>
-            <mimetype>application/json</mimetype>
-            <protocol>WWW:DOWNLOAD</protocol>
+            <protocol>WWW:DOWNLOAD:application/json</protocol>
         </entry>
         <entry>
             <format>web page</format>
-            <mimetype>text/html</mimetype>
-            <protocol>WWW:LINK</protocol>
+            <protocol>WWW:LINK-1.0-http--link</protocol>
         </entry>
         <entry>
             <format>arcgis geoservices rest api</format>
-            <mimetype>application/json</mimetype>
             <protocol>ESRI:REST</protocol>
         </entry>
     </xsl:variable>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/protocol-mapping.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/protocol-mapping.xsl
@@ -1,0 +1,55 @@
+<xsl:stylesheet version="2.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xmlns:dct="http://purl.org/dc/terms/"
+                xmlns:dcat="http://www.w3.org/ns/dcat#"
+                xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                exclude-result-prefixes="#all">
+
+    <xsl:output method="xml" indent="yes"/>
+    <xsl:strip-space elements="*"/>
+
+    <xsl:variable name="format-mimetype-mapping">
+        <entry>
+            <format>csv</format>
+            <mimetype>text/csv</mimetype>
+            <protocol>WWW:DOWNLOAD</protocol>
+        </entry>
+        <entry>
+            <format>geojson</format>
+            <mimetype>application/vnd.geo+json</mimetype>
+            <protocol>WWW:DOWNLOAD</protocol>
+        </entry>
+        <entry>
+            <format>kml</format>
+            <mimetype>application/vnd.google-earth.kml+xml</mimetype>
+            <protocol>WWW:DOWNLOAD</protocol>
+        </entry>
+        <entry>
+            <format>zip</format>
+            <mimetype>application/zip</mimetype>
+            <protocol>WWW:DOWNLOAD</protocol>
+        </entry>
+        <entry>
+            <format>shapefile</format>
+            <mimetype>x-gis/x-shapefile</mimetype>
+            <protocol>WWW:DOWNLOAD</protocol>
+        </entry>
+        <entry>
+            <format>json</format>
+            <mimetype>application/json</mimetype>
+            <protocol>WWW:DOWNLOAD</protocol>
+        </entry>
+        <entry>
+            <format>web page</format>
+            <mimetype>text/html</mimetype>
+            <protocol>WWW:LINK</protocol>
+        </entry>
+        <entry>
+            <format>arcgis geoservices rest api</format>
+            <mimetype>application/json</mimetype>
+            <protocol>ESRI:REST</protocol>
+        </entry>
+    </xsl:variable>
+
+</xsl:stylesheet>


### PR DESCRIPTION
In the `ISO19115-3` schema, the PR improves the transformation from Opendatasoft API.

- add the mimetype in the protocol, so it can be used in the UI eg `WWW:DOWNLOAD:application/json`
- add the fields if available in the description 
