### PR TITLE
Configuration option to restrict the map services supported in map extent API (geom.png) the usage of non-predefined map services. 

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/regions/RegionsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/regions/RegionsApi.java
@@ -42,6 +42,7 @@ import org.fao.geonet.kernel.region.Region;
 import org.fao.geonet.kernel.region.RegionsDAO;
 import org.fao.geonet.kernel.region.Request;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.ApplicationContext;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
@@ -78,6 +79,9 @@ public class RegionsApi {
 
     @Autowired
     LanguageUtils languageUtils;
+
+    @Value("${metadata.extentApi.disableFullUrlBackgroundMapServices:true}")
+    private boolean disableFullUrlBackgroundMapServices;
 
     public static Request createRequest(String label, String categoryId,
                                         int maxRecords, ServiceContext context,
@@ -239,6 +243,11 @@ public class RegionsApi {
             throw new BadParameterEx(WIDTH_PARAM, "One of " + WIDTH_PARAM + " or " + HEIGHT_PARAM
                 + " parameters must be included in the request");
 
+        }
+
+        if ((background != null) && (background.startsWith("http")) && (disableFullUrlBackgroundMapServices)) {
+            throw new BadParameterEx(BACKGROUND_PARAM, "Background layers from provided are not supported, " +
+                "use a preconfigured background layers map service.");
         }
 
         String outputFileName = "geom.png";


### PR DESCRIPTION
Related to #5166