### PR TITLE
Fix the registration of the `surname` and `country` for the 'self' registration process

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/users/RegisterApi.java
+++ b/services/src/main/java/org/fao/geonet/api/users/RegisterApi.java
@@ -173,6 +173,7 @@ public class RegisterApi {
 
         // user.setUsername(userRegisterDto.getUsername());
         user.setName(userRegisterDto.getName());
+        user.setSurname(userRegisterDto.getSurname());
         user.setOrganisation(userRegisterDto.getOrganisation());
         user.setProfile(Profile.findProfileIgnoreCase(userRegisterDto.getProfile()));
         user.getAddresses().add(userRegisterDto.getAddress());

--- a/web-ui/src/main/resources/catalog/templates/new-account.html
+++ b/web-ui/src/main/resources/catalog/templates/new-account.html
@@ -79,11 +79,11 @@
                       data-ng-model="userInfo.address.city"/>
             </div>
             <div class="form-group">
-              <label data-translate=""
-                     data-ng-model="userInfo.address.country">country</label>
+              <label data-translate="">country</label>
               <!-- TODO : Add country list -->
               <input type="text" name="country" class="form-control"
-                      aria-label="{{'country' | translate}}"/>
+                      aria-label="{{'country' | translate}}"
+                      data-ng-model="userInfo.address.country"/>
             </div>
           </fieldset>
 


### PR DESCRIPTION
When a (future) user was using the 'self' registration option, the `surname` and `country` were not stored. This PR fixes this so `surname` and `country` are correctly registered and saved.

**The register (new account) page**

![gn-register](https://user-images.githubusercontent.com/19608667/143026454-4cb41169-88e1-4ed0-8a24-80a4504190d6.png)


