### PR TITLE
Update user feedback API to create a ServiceContext, otherwise the metadata titles retrieved from the Lucene index are not retrieved

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/userfeedback/UserFeedbackAPI.java
+++ b/services/src/main/java/org/fao/geonet/api/userfeedback/UserFeedbackAPI.java
@@ -337,10 +337,13 @@ public class UserFeedbackAPI {
             required = false
         )
         int size,
+        @ApiIgnore final HttpServletRequest request,
         @ApiIgnore final HttpServletResponse response,
         @ApiIgnore final HttpSession httpSession) throws Exception {
 
-        return getUserFeedback(metadataUuid, size, response, httpSession);
+        try (ServiceContext context = ApiUtils.createServiceContext(request)) {
+            return getUserFeedback(metadataUuid, size, response, httpSession);
+        }
     }
 
     /**
@@ -380,10 +383,13 @@ public class UserFeedbackAPI {
             required = false
         )
         int size,
+        @ApiIgnore final HttpServletRequest request,
         @ApiIgnore final HttpServletResponse response,
         @ApiIgnore final HttpSession httpSession) throws Exception {
 
-        return getUserFeedback(metadataUuid, size, response, httpSession);
+        try (ServiceContext context = ApiUtils.createServiceContext(request)) {
+            return getUserFeedback(metadataUuid, size, response, httpSession);
+        }
     }
 
     private List<UserFeedbackDTO> getUserFeedback(


### PR DESCRIPTION
Related to #5260

Test case:

1) Enable user feedback in the settings
2) Add comments to a metadata
3) Go to the home page and select the `Comments` panel: without the fix, metadata titles are not displayed.