### PR TITLE
Add styles and classes to fix the button bars not really fitting inside the headers on admin pages

### DIFF
--- a/web-ui/src/main/resources/catalog/templates/admin/report/report-filedownload-metadata.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/report/report-filedownload-metadata.html
@@ -3,7 +3,7 @@
   <!--  metadata file downloads report -->
   <div class="col-lg-7">
     <div class="panel panel-default">
-      <div class="panel-heading">
+      <div class="panel-heading clearfix">
         <strong data-translate="">reportFileDownloadMetadata-title</strong>
 
         <p data-translate="">reportFileDownloadMetadata-description</p>

--- a/web-ui/src/main/resources/catalog/templates/admin/report/report-fileupload-metadata.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/report/report-fileupload-metadata.html
@@ -3,7 +3,7 @@
   <!--  metadata file uploads report -->
   <div class="col-lg-7">
     <div class="panel panel-default">
-      <div class="panel-heading">
+      <div class="panel-heading clearfix">
         <strong data-translate="">reportFileUploadMetadata-title</strong>
 
         <p data-translate="">reportFileUploadMetadata-description</p>

--- a/web-ui/src/main/resources/catalog/templates/admin/report/report-internal-metadata.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/report/report-internal-metadata.html
@@ -3,7 +3,7 @@
   <!--  metadata internal report -->
   <div class="col-lg-7">
     <div class="panel panel-default">
-      <div class="panel-heading">
+      <div class="panel-heading clearfix">
         <strong data-translate="">reportInternalMetadata-title</strong>
 
         <p data-translate="">reportInternalMetadata-description</p>

--- a/web-ui/src/main/resources/catalog/templates/admin/report/report-updated-metadata.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/report/report-updated-metadata.html
@@ -3,7 +3,7 @@
   <!--  metadata updated report -->
   <div class="col-lg-7">
     <div class="panel panel-default">
-      <div class="panel-heading">
+      <div class="panel-heading clearfix">
         <strong data-translate="">reportUpdatedMetadata-title</strong>
 
         <p data-translate="">reportUpdatedMetadata-description</p>

--- a/web-ui/src/main/resources/catalog/templates/admin/report/report-users.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/report/report-users.html
@@ -3,7 +3,7 @@
   <!--  users report -->
   <div class="col-lg-7">
     <div class="panel panel-default">
-      <div class="panel-heading">
+      <div class="panel-heading clearfix">
         <strong data-translate="">reportUsers-title</strong>
 
         <p data-translate="">reportUsers-description</p>

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_admin_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_admin_default.less
@@ -318,6 +318,12 @@ ul.gn-resultview li.list-group-item {
       }
       .panel {
         .panel-heading {
+          line-height: 34px !important;
+          padding: 6px 15px;
+          height: auto !important;
+          p {
+            line-height: 1.5;
+          }
           .btn-toolbar {
             float: right;
           }


### PR DESCRIPTION
This PR fixes UI problems with buttons not fitting inside panel headers on different admin pages.

**Category before**

![gn-category-button-before](https://user-images.githubusercontent.com/19608667/143428194-5f009565-8d6e-442a-a1a9-c66f9dc84a6d.png)

**and after**

![gn-category-button-after](https://user-images.githubusercontent.com/19608667/143428219-5e3c3892-d783-4cd9-9723-d178cc0d429e.png)

**A report page before**

![gn-report-button-before](https://user-images.githubusercontent.com/19608667/143428259-54e4bb2b-817f-42d7-8614-0762ad49177b.png)

**and after**

![gn-report-button-after](https://user-images.githubusercontent.com/19608667/143428284-5c4d4f57-3f5b-4013-a23a-4cbb87b9c0a8.png)


