### PR TITLE
Opendata harvesting: add a resource for the landing page

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/fromJsonLdEsri.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/fromJsonLdEsri.xsl
@@ -444,6 +444,33 @@
                 </xsl:for-each>
               </mrd:MD_DigitalTransferOptions>
             </mrd:transferOptions>
+            <mrd:transferOptions>
+              <mrd:MD_DigitalTransferOptions>
+                  <mrd:onLine>
+                    <cit:CI_OnlineResource>
+                      <cit:linkage>
+                        <gco:CharacterString>
+                          <xsl:value-of select="landingPage"/>
+                        </gco:CharacterString>
+                      </cit:linkage>
+                      <cit:protocol>
+                        <gco:CharacterString>
+                          WWW:LINK:LANDING_PAGE
+                        </gco:CharacterString>
+                      </cit:protocol>
+                      <cit:name>
+                        <gco:CharacterString>
+                          Landing Page
+                        </gco:CharacterString>
+                      </cit:name>
+                      <cit:description>
+                        <gco:CharacterString>
+                        </gco:CharacterString>
+                      </cit:description>
+                    </cit:CI_OnlineResource>
+                  </mrd:onLine>
+              </mrd:MD_DigitalTransferOptions>
+            </mrd:transferOptions>
           </mrd:MD_Distribution>
         </mdb:distributionInfo>
 

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/fromJsonOpenDataSoft.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/fromJsonOpenDataSoft.xsl
@@ -524,6 +524,33 @@
 
               </mrd:MD_DigitalTransferOptions>
             </mrd:transferOptions>
+            <mrd:transferOptions>
+              <mrd:MD_DigitalTransferOptions>
+                <mrd:onLine>
+                  <cit:CI_OnlineResource>
+                    <cit:linkage>
+                      <gco:CharacterString>
+                        <xsl:value-of select="concat(nodeUrl, '/explore/dataset/', datasetid, '/information/')" />
+                      </gco:CharacterString>
+                    </cit:linkage>
+                    <cit:protocol>
+                      <gco:CharacterString>
+                        WWW:LINK:LANDING_PAGE
+                      </gco:CharacterString>
+                    </cit:protocol>
+                    <cit:name>
+                      <gco:CharacterString>
+                        Landing Page
+                      </gco:CharacterString>
+                    </cit:name>
+                    <cit:description>
+                      <gco:CharacterString>
+                      </gco:CharacterString>
+                    </cit:description>
+                  </cit:CI_OnlineResource>
+                </mrd:onLine>
+              </mrd:MD_DigitalTransferOptions>
+            </mrd:transferOptions>
           </mrd:MD_Distribution>
         </mdb:distributionInfo>
 


### PR DESCRIPTION
Add a link to the landing page of the source metadata for ESRI and Opendatasoft harvesting.
The protocol used to distinguish the resource is `WWW:LINK:LANDING_PAGE`

```xml
<mrd:onLine>
<cit:CI_OnlineResource xmlns:cit="http://standards.iso.org/iso/19115/-3/cit/2.0">
<cit:linkage>
<gco:CharacterString xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0">https://metropole-europeenne-de-lille.opendatasoft.com/explore/dataset/bornes-dateliers-velos-a-lille/information/</gco:CharacterString>
</cit:linkage>
<cit:protocol>
<gco:CharacterString xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0">WWW:LINK:LANDING_PAGE</gco:CharacterString>
</cit:protocol>
<cit:name>
<gco:CharacterString xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0">Landing Page</gco:CharacterString>
</cit:name>
<cit:description>
<gco:CharacterString xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0"/>
</cit:description>
</cit:CI_OnlineResource>
</mrd:onLine>
```