### PR TITLE
Fix MetadataServiceApiTest tests

### DIFF
--- a/services/src/test/java/org/fao/geonet/api/records/extent/MetadataExtentApiTest.java
+++ b/services/src/test/java/org/fao/geonet/api/records/extent/MetadataExtentApiTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2021 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -46,7 +46,6 @@ import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-import org.springframework.util.DigestUtils;
 import org.springframework.web.context.WebApplicationContext;
 
 import javax.imageio.ImageIO;
@@ -55,17 +54,13 @@ import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
-import java.util.Arrays;
 import java.util.Calendar;
 import java.util.GregorianCalendar;
 import java.util.TimeZone;
 import java.util.UUID;
 
-import static org.fao.geonet.schema.iso19139.ISO19139Namespaces.GCO;
-import static org.fao.geonet.schema.iso19139.ISO19139Namespaces.GMD;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertEquals;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -73,12 +68,13 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 public class MetadataExtentApiTest extends AbstractServiceIntegrationTest {
 
     /**
-     * Use <code>-DMetadataExtentApiTest.save.png=true</code> to save geneated images for visual reference.
+     * Use <code>-DMetadataExtentApiTest.save.png=true</code> to save generated images for visual reference.
      */
-    private static boolean SAVE_IMAGE_TO_DISK = Boolean.getBoolean("MetadataExtentApiTest.save.png" );
+    private static boolean SAVE_IMAGE_TO_DISK = Boolean.getBoolean("MetadataExtentApiTest.save.png");
 
     private static String REFERENCE = "./src/test/resources/org/fao/geonet/api/records/extent/";
-
+    @Rule
+    public TestName name = new TestName();
     @Autowired
     private DataManager dataManager;
     @Autowired
@@ -87,11 +83,7 @@ public class MetadataExtentApiTest extends AbstractServiceIntegrationTest {
     private SchemaManager schemaManager;
     @Autowired
     private WebApplicationContext wac;
-
     private ServiceContext context;
-
-    @Rule
-    public TestName name = new TestName();
 
     @Before
     public void setUp() throws Exception {
@@ -105,8 +97,8 @@ public class MetadataExtentApiTest extends AbstractServiceIntegrationTest {
         String uuid = createTestData();
 
         mockMvc.perform(get(String.format("/srv/api/records/%s/extents.json", uuid))
-            .session(mockHttpSession)
-            .accept(MediaType.APPLICATION_JSON_VALUE))
+                .session(mockHttpSession)
+                .accept(MediaType.APPLICATION_JSON_VALUE))
             .andExpect(status().is2xxSuccessful())
             .andExpect(content().contentType(API_JSON_EXPECTED_ENCODING))
             .andExpect(jsonPath("$", hasSize(3)))
@@ -124,17 +116,17 @@ public class MetadataExtentApiTest extends AbstractServiceIntegrationTest {
         MockHttpSession mockHttpSession = loginAsAdmin();
         String uuid = createTestData();
 
-        byte[] reponseBuffer = mockMvc.perform(get(String.format("/srv/api/records/%s/extents.png", uuid))
-            .session(mockHttpSession)
-            .accept(MediaType.IMAGE_PNG_VALUE))
+        byte[] responseBuffer = mockMvc.perform(get(String.format("/srv/api/records/%s/extents.png?mapsrs=EPSG:4326", uuid))
+                .session(mockHttpSession)
+                .accept(MediaType.IMAGE_PNG_VALUE))
             .andExpect(status().is2xxSuccessful())
             .andExpect(content().contentType(API_PNG_EXPECTED_ENCODING))
             .andReturn().getResponse().getContentAsByteArray();
 
-        saveImageToDiskIfConfiguredToDoSo(reponseBuffer, name.getMethodName());
+        saveImageToDiskIfConfiguredToDoSo(responseBuffer, name.getMethodName());
         assertImage(
-            REFERENCE+"getOneRecordExtentAsImage.png",
-            reponseBuffer,
+            REFERENCE + "getOneRecordExtentAsImage.png",
+            responseBuffer,
             550);
     }
 
@@ -144,18 +136,18 @@ public class MetadataExtentApiTest extends AbstractServiceIntegrationTest {
         MockHttpSession mockHttpSession = loginAsAdmin();
         String uuid = createTestData();
 
-        byte[] reponseBuffer = mockMvc.perform(get(String.format("/srv/api/records/%s/extents.png", uuid))
-            .header("If-Modified-Since", "Wed, 21 Oct 2015 07:29:00 UTC")
-            .session(mockHttpSession)
-            .accept(MediaType.IMAGE_PNG_VALUE))
+        byte[] responseBuffer = mockMvc.perform(get(String.format("/srv/api/records/%s/extents.png?mapsrs=EPSG:4326", uuid))
+                .header("If-Modified-Since", "Wed, 21 Oct 2015 07:29:00 UTC")
+                .session(mockHttpSession)
+                .accept(MediaType.IMAGE_PNG_VALUE))
             .andExpect(status().is2xxSuccessful())
             .andExpect(content().contentType(API_PNG_EXPECTED_ENCODING))
             .andReturn().getResponse().getContentAsByteArray();
 
-        saveImageToDiskIfConfiguredToDoSo(reponseBuffer, name.getMethodName());
+        saveImageToDiskIfConfiguredToDoSo(responseBuffer, name.getMethodName());
         assertImage(
-            REFERENCE+"lastModifiedNotModified.png",
-            reponseBuffer,
+            REFERENCE + "lastModifiedNotModified.png",
+            responseBuffer,
             550);
     }
 
@@ -165,17 +157,17 @@ public class MetadataExtentApiTest extends AbstractServiceIntegrationTest {
         MockHttpSession mockHttpSession = loginAsAdmin();
         String uuid = createTestData();
 
-        byte[] reponseBuffer = mockMvc.perform(get(String.format("/srv/api/records/%s/extents.png", uuid))
-            .header("If-Modified-Since", "Wed, 21 Oct 2015 07:27:00 UTC")
-            .session(mockHttpSession)
-            .accept(MediaType.IMAGE_PNG_VALUE))
+        byte[] responseBuffer = mockMvc.perform(get(String.format("/srv/api/records/%s/extents.png?mapsrs=EPSG:4326", uuid))
+                .header("If-Modified-Since", "Wed, 21 Oct 2015 07:27:00 UTC")
+                .session(mockHttpSession)
+                .accept(MediaType.IMAGE_PNG_VALUE))
             .andExpect(status().is2xxSuccessful())
             .andExpect(content().contentType(API_PNG_EXPECTED_ENCODING))
             .andReturn().getResponse().getContentAsByteArray();
 
         assertImage(
-            REFERENCE+"lastModifiedModified.png",
-            reponseBuffer,
+            REFERENCE + "lastModifiedModified.png",
+            responseBuffer,
             550);
     }
 
@@ -185,17 +177,17 @@ public class MetadataExtentApiTest extends AbstractServiceIntegrationTest {
         MockHttpSession mockHttpSession = loginAsAdmin();
         String uuid = createTestDataTwoExtent();
 
-        byte[] reponseBuffer = mockMvc.perform(get(String.format("/srv/api/records/%s/extents.png", uuid))
-            .session(mockHttpSession)
-            .accept(MediaType.IMAGE_PNG_VALUE))
+        byte[] responseBuffer = mockMvc.perform(get(String.format("/srv/api/records/%s/extents.png?mapsrs=EPSG:4326", uuid))
+                .session(mockHttpSession)
+                .accept(MediaType.IMAGE_PNG_VALUE))
             .andExpect(status().is2xxSuccessful())
             .andExpect(content().contentType(API_PNG_EXPECTED_ENCODING))
             .andReturn().getResponse().getContentAsByteArray();
 
-        saveImageToDiskIfConfiguredToDoSo(reponseBuffer, name.getMethodName());
+        saveImageToDiskIfConfiguredToDoSo(responseBuffer, name.getMethodName());
         assertImage(
-            REFERENCE+"aggregatedWithTwoExtent.png",
-            reponseBuffer,
+            REFERENCE + "aggregatedWithTwoExtent.png",
+            responseBuffer,
             550);
     }
 
@@ -205,52 +197,52 @@ public class MetadataExtentApiTest extends AbstractServiceIntegrationTest {
         MockHttpSession mockHttpSession = loginAsAdmin();
         String uuid = createTestDataTwoExtent();
 
-        byte[] reponseBuffer = mockMvc.perform(get(String.format("/srv/api/records/%s/extents.png", uuid))
-            .session(mockHttpSession)
-            .accept(MediaType.IMAGE_PNG_VALUE))
+        byte[] responseBuffer = mockMvc.perform(get(String.format("/srv/api/records/%s/extents.png?mapsrs=EPSG:4326", uuid))
+                .session(mockHttpSession)
+                .accept(MediaType.IMAGE_PNG_VALUE))
             .andExpect(status().is2xxSuccessful())
             .andExpect(content().contentType(API_PNG_EXPECTED_ENCODING))
             .andReturn().getResponse().getContentAsByteArray();
-        saveImageToDiskIfConfiguredToDoSo(reponseBuffer, name.getMethodName() + "-overview");
+        saveImageToDiskIfConfiguredToDoSo(responseBuffer, name.getMethodName() + "-overview");
         assertImage(
-            REFERENCE+"twoExtentFirstOneWithBothBoundingBoxAndPolygon-overview.png",
-            reponseBuffer,
+            REFERENCE + "twoExtentFirstOneWithBothBoundingBoxAndPolygon-overview.png",
+            responseBuffer,
             550);
 
-        reponseBuffer = mockMvc.perform(get(String.format("/srv/api/records/%s/extents/1.png", uuid))
-            .session(mockHttpSession)
-            .accept(MediaType.IMAGE_PNG_VALUE))
+        responseBuffer = mockMvc.perform(get(String.format("/srv/api/records/%s/extents/1.png?mapsrs=EPSG:4326", uuid))
+                .session(mockHttpSession)
+                .accept(MediaType.IMAGE_PNG_VALUE))
             .andExpect(status().is2xxSuccessful())
             .andExpect(content().contentType(API_PNG_EXPECTED_ENCODING))
             .andReturn().getResponse().getContentAsByteArray();
-        saveImageToDiskIfConfiguredToDoSo(reponseBuffer, name.getMethodName() + "-1");
+        saveImageToDiskIfConfiguredToDoSo(responseBuffer, name.getMethodName() + "-1");
         assertImage(
-            REFERENCE+"twoExtentFirstOneWithBothBoundingBoxAndPolygon-1.png",
-            reponseBuffer,
+            REFERENCE + "twoExtentFirstOneWithBothBoundingBoxAndPolygon-1.png",
+            responseBuffer,
             550);
 
-        reponseBuffer = mockMvc.perform(get(String.format("/srv/api/records/%s/extents/2.png", uuid))
-            .session(mockHttpSession)
-            .accept(MediaType.IMAGE_PNG_VALUE))
+        responseBuffer = mockMvc.perform(get(String.format("/srv/api/records/%s/extents/2.png?mapsrs=EPSG:4326", uuid))
+                .session(mockHttpSession)
+                .accept(MediaType.IMAGE_PNG_VALUE))
             .andExpect(status().is2xxSuccessful())
             .andExpect(content().contentType(API_PNG_EXPECTED_ENCODING))
             .andReturn().getResponse().getContentAsByteArray();
-        saveImageToDiskIfConfiguredToDoSo(reponseBuffer, name.getMethodName() + "-2");
+        saveImageToDiskIfConfiguredToDoSo(responseBuffer, name.getMethodName() + "-2");
         assertImage(
-            REFERENCE+"twoExtentFirstOneWithBothBoundingBoxAndPolygon-2.png",
-            reponseBuffer,
+            REFERENCE + "twoExtentFirstOneWithBothBoundingBoxAndPolygon-2.png",
+            responseBuffer,
             550);
 
-        reponseBuffer = mockMvc.perform(get(String.format("/srv/api/records/%s/extents/3.png", uuid))
-            .session(mockHttpSession)
-            .accept(MediaType.IMAGE_PNG_VALUE))
+        responseBuffer = mockMvc.perform(get(String.format("/srv/api/records/%s/extents/3.png?mapsrs=EPSG:4326", uuid))
+                .session(mockHttpSession)
+                .accept(MediaType.IMAGE_PNG_VALUE))
             .andExpect(status().is2xxSuccessful())
             .andExpect(content().contentType(API_PNG_EXPECTED_ENCODING))
             .andReturn().getResponse().getContentAsByteArray();
-        saveImageToDiskIfConfiguredToDoSo(reponseBuffer, name.getMethodName() + "-3");
+        saveImageToDiskIfConfiguredToDoSo(responseBuffer, name.getMethodName() + "-3");
         assertImage(
-            REFERENCE+"twoExtentFirstOneWithBothBoundingBoxAndPolygon-3.png",
-            reponseBuffer,
+            REFERENCE + "twoExtentFirstOneWithBothBoundingBoxAndPolygon-3.png",
+            responseBuffer,
             550);
     }
 
@@ -261,29 +253,29 @@ public class MetadataExtentApiTest extends AbstractServiceIntegrationTest {
         MockHttpSession mockHttpSession = loginAsAdmin();
         String uuid = createTestDataThreeExtent();
 
-        byte[] reponseBuffer = mockMvc.perform(get(String.format("/srv/api/records/%s/extents.png", uuid))
-            .session(mockHttpSession)
-            .accept(MediaType.IMAGE_PNG_VALUE))
+        byte[] responseBuffer = mockMvc.perform(get(String.format("/srv/api/records/%s/extents.png?mapsrs=EPSG:4326", uuid))
+                .session(mockHttpSession)
+                .accept(MediaType.IMAGE_PNG_VALUE))
             .andExpect(status().is2xxSuccessful())
             .andExpect(content().contentType(API_PNG_EXPECTED_ENCODING))
             .andReturn().getResponse().getContentAsByteArray();
-        saveImageToDiskIfConfiguredToDoSo(reponseBuffer, name.getMethodName() + "-overview");
+        saveImageToDiskIfConfiguredToDoSo(responseBuffer, name.getMethodName() + "-overview");
         assertImage(
-            REFERENCE+"threeExtentThirdOne-overview.png",
-            reponseBuffer,
+            REFERENCE + "threeExtentThirdOne-overview.png",
+            responseBuffer,
             550);
 
-        reponseBuffer = mockMvc.perform(get(String.format("/srv/api/records/%s/extents/4.png", uuid))
-            .session(mockHttpSession)
-            .accept(MediaType.IMAGE_PNG_VALUE))
+        responseBuffer = mockMvc.perform(get(String.format("/srv/api/records/%s/extents/4.png?mapsrs=EPSG:4326", uuid))
+                .session(mockHttpSession)
+                .accept(MediaType.IMAGE_PNG_VALUE))
             .andExpect(status().is2xxSuccessful())
             .andExpect(content().contentType(API_PNG_EXPECTED_ENCODING))
             .andReturn().getResponse().getContentAsByteArray();
 
-        saveImageToDiskIfConfiguredToDoSo(reponseBuffer, name.getMethodName());
+        saveImageToDiskIfConfiguredToDoSo(responseBuffer, name.getMethodName());
         assertImage(
             "./src/test/resources/org/fao/geonet/api/records/extent/threeExtentThirdOne.png",
-            reponseBuffer,
+            responseBuffer,
             550);
     }
 
@@ -293,29 +285,29 @@ public class MetadataExtentApiTest extends AbstractServiceIntegrationTest {
         MockHttpSession mockHttpSession = loginAsAdmin();
         String uuid = createTestDataIso191153ThreeExtent();
 
-        byte[] reponseBuffer = mockMvc.perform(get(String.format("/srv/api/records/%s/extents.png", uuid))
-            .session(mockHttpSession)
-            .accept(MediaType.IMAGE_PNG_VALUE))
+        byte[] responseBuffer = mockMvc.perform(get(String.format("/srv/api/records/%s/extents.png?mapsrs=EPSG:4326", uuid))
+                .session(mockHttpSession)
+                .accept(MediaType.IMAGE_PNG_VALUE))
             .andExpect(status().is2xxSuccessful())
             .andExpect(content().contentType(API_PNG_EXPECTED_ENCODING))
             .andReturn().getResponse().getContentAsByteArray();
-        saveImageToDiskIfConfiguredToDoSo(reponseBuffer, name.getMethodName() + "-overview");
+        saveImageToDiskIfConfiguredToDoSo(responseBuffer, name.getMethodName() + "-overview");
         assertImage(
-            REFERENCE+"threeExtentThirdOne115_3-overview.png",
-            reponseBuffer,
+            REFERENCE + "threeExtentThirdOne115_3-overview.png",
+            responseBuffer,
             550);
 
-        reponseBuffer = mockMvc.perform(get(String.format("/srv/api/records/%s/extents/3.png", uuid))
-            .session(mockHttpSession)
-            .accept(MediaType.IMAGE_PNG_VALUE))
+        responseBuffer = mockMvc.perform(get(String.format("/srv/api/records/%s/extents/3.png?mapsrs=EPSG:4326", uuid))
+                .session(mockHttpSession)
+                .accept(MediaType.IMAGE_PNG_VALUE))
             .andExpect(status().is2xxSuccessful())
             .andExpect(content().contentType(API_PNG_EXPECTED_ENCODING))
             .andReturn().getResponse().getContentAsByteArray();
 
-        saveImageToDiskIfConfiguredToDoSo(reponseBuffer, name.getMethodName());
+        saveImageToDiskIfConfiguredToDoSo(responseBuffer, name.getMethodName());
         assertImage(
-            REFERENCE+"threeExtentThirdOne115_3.png",
-            reponseBuffer,
+            REFERENCE + "threeExtentThirdOne115_3.png",
+            responseBuffer,
             550);
     }
 
@@ -325,17 +317,17 @@ public class MetadataExtentApiTest extends AbstractServiceIntegrationTest {
         MockHttpSession mockHttpSession = loginAsAdmin();
         String uuid = createTestDataThreeExtent();
 
-        byte[] reponseBuffer = mockMvc.perform(get(String.format("/srv/api/records/%s/extents/3.png", uuid))
-            .session(mockHttpSession)
-            .accept(MediaType.IMAGE_PNG_VALUE))
+        byte[] responseBuffer = mockMvc.perform(get(String.format("/srv/api/records/%s/extents/3.png?mapsrs=EPSG:4326", uuid))
+                .session(mockHttpSession)
+                .accept(MediaType.IMAGE_PNG_VALUE))
             .andExpect(status().is2xxSuccessful())
             .andExpect(content().contentType(API_PNG_EXPECTED_ENCODING))
             .andReturn().getResponse().getContentAsByteArray();
 
-        saveImageToDiskIfConfiguredToDoSo(reponseBuffer, name.getMethodName());
+        saveImageToDiskIfConfiguredToDoSo(responseBuffer, name.getMethodName());
         assertImage(
-            REFERENCE+"threeExtentThirdOneIsABoundingBox.png",
-            reponseBuffer,
+            REFERENCE + "threeExtentThirdOneIsABoundingBox.png",
+            responseBuffer,
             550);
     }
 
@@ -404,36 +396,35 @@ public class MetadataExtentApiTest extends AbstractServiceIntegrationTest {
      * </ul>
      * </p>
      *
-     * @param expected filepath to expected image
-     * @param reponseBuffer image content
-     * @param threshold visual threadshold for match, often a small percentage is acceptable for font changes
+     * @param expected      filepath to expected image
+     * @param responseBuffer image content
+     * @param threshold     visual threadshold for match, often a small percentage is acceptable for font changes
      */
-    private void assertImage( String expected, byte[] reponseBuffer, int threshold ) throws IOException {
-        BufferedImage imag = ImageIO.read(new ByteArrayInputStream(reponseBuffer));
-        File file = new File( expected );
+    private void assertImage(String expected, byte[] responseBuffer, int threshold) throws IOException {
+        BufferedImage imag = ImageIO.read(new ByteArrayInputStream(responseBuffer));
+        File file = new File(expected);
         ImageAssert.assertEquals(file, imag, threshold);
     }
 
     /**
      * Use {@link #SAVE_IMAGE_TO_DISK} to save generated image to disk for visual comparison.
      *
-     * @param reponseBuffer png image
-     *
-     * @param methodName method being tested, used for generated filename
+     * @param responseBuffer png image
+     * @param methodName    method being tested, used for generated filename
      * @throws IOException
      */
-    private void saveImageToDiskIfConfiguredToDoSo(byte[] reponseBuffer, String methodName) throws IOException {
+    private void saveImageToDiskIfConfiguredToDoSo(byte[] responseBuffer, String methodName) throws IOException {
         if (SAVE_IMAGE_TO_DISK) {
-            BufferedImage imag = ImageIO.read(new ByteArrayInputStream(reponseBuffer));
+            BufferedImage imag = ImageIO.read(new ByteArrayInputStream(responseBuffer));
 
             File testResults = new File("./target/test-results");
-            if( !testResults.isDirectory() ){
+            if (!testResults.isDirectory()) {
                 testResults.mkdirs();
             }
             File file = new File(testResults, String.format("%s.png", methodName));
 
-            ImageIO.write(imag, "png", file );
-            System.out.println( "Generated image to: "+file );
+            ImageIO.write(imag, "png", file);
+            System.out.println("Generated image to: " + file);
         }
     }
 }


### PR DESCRIPTION
Since the settings for regions API map projection is used now if no `mapsrs` is passed
in the request and because the default value of the setting is EPSG:3857 the tests were failing.
This fix the test passing the `mapsrs=EPSG:4326` parameter that is the projection used
in the pre-generated test images.
