### PR TITLE
Add the doi-get query for ISO19115-3.2018 standard

### DIFF
--- a/schemas/iso19115-3.2018/src/main/resources/config-spring-geonetwork.xml
+++ b/schemas/iso19115-3.2018/src/main/resources/config-spring-geonetwork.xml
@@ -45,6 +45,10 @@
                       cit:name/gco:CharacterString = '{{name}}']
                     /cit:applicationProfile/gco:CharacterString/text())"/>
         </bean>
+        <bean class="org.fao.geonet.kernel.schema.SavedQuery">
+			    <property name="id" value="doi-get"/>
+			    <property name="xpath" value="//cit:CI_OnlineResource[cit:protocol/gco:CharacterString = 'DOI']/cit:linkage/cit:URL/text()"/>
+		    </bean>
       </list>
     </property>
   </bean>


### PR DESCRIPTION
The section for the DOI-get query was missing for this standard. Inserting these lines, it will be possible to create DOI.