### PR TITLE
Add missing translations for the doiCreationTask status

### DIFF
--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v406/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v406/migrate-default.sql
@@ -5,3 +5,23 @@ DELETE FROM Settings WHERE name = 'system/server/securePort';
 
 UPDATE Settings SET value='4.0.6' WHERE name='system/platform/version';
 UPDATE Settings SET value='SNAPSHOT' WHERE name='system/platform/subVersion';
+
+-- Add missing translation for StatusValue 100 - doiCreationTask
+INSERT INTO StatusValuesDes  (iddes, langid, label) VALUES (100,'tur','DOI creation request');
+INSERT INTO StatusValuesDes  (iddes, langid, label) VALUES (100,'ara','DOI creation request');
+INSERT INTO StatusValuesDes  (iddes, langid, label) VALUES (100,'ger','DOI-Erstellungsanfrage');
+INSERT INTO StatusValuesDes  (iddes, langid, label) VALUES (100,'pol','DOI creation request');
+INSERT INTO StatusValuesDes  (iddes, langid, label) VALUES (100,'rus','DOI creation request');
+INSERT INTO StatusValuesDes  (iddes, langid, label) VALUES (100,'nor','DOI creation request');
+INSERT INTO StatusValuesDes  (iddes, langid, label) VALUES (100,'swe','Begäran att skapa DOI');
+INSERT INTO StatusValuesDes  (iddes, langid, label) VALUES (100,'fre','Demande de création de DOI');
+INSERT INTO StatusValuesDes  (iddes, langid, label) VALUES (100,'fin','DOI creation request');
+INSERT INTO StatusValuesDes  (iddes, langid, label) VALUES (100,'vie','DOI creation request');
+INSERT INTO StatusValuesDes  (iddes, langid, label) VALUES (100,'eng','DOI creation request');
+INSERT INTO StatusValuesDes  (iddes, langid, label) VALUES (100,'chi','DOI creation request');
+INSERT INTO StatusValuesDes  (iddes, langid, label) VALUES (100,'dut','DOI aanvragen');
+INSERT INTO StatusValuesDes  (iddes, langid, label) VALUES (100,'ita','DOI creation request');
+INSERT INTO StatusValuesDes  (iddes, langid, label) VALUES (100,'slo','DOI creation request');
+INSERT INTO StatusValuesDes  (iddes, langid, label) VALUES (100,'cat','DOI creation request');
+INSERT INTO StatusValuesDes  (iddes, langid, label) VALUES (100,'spa','Solicitud de creación de DOI');
+INSERT INTO StatusValuesDes  (iddes, langid, label) VALUES (100,'por','DOI creation request');


### PR DESCRIPTION
The statusvalue 100 - doiCreationTask doesn't have a translation in the DB if the database has
been created before GeoNetwork [v3.5.0](https://github.com/geonetwork/core-geonetwork/blob/main/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v350/migrate-default.sql#L18) This migration add the missing translation fixing an
option without label in the Manage Records menu in the record view.
![image](https://user-images.githubusercontent.com/826920/144597490-f566046f-9748-46f7-bb33-fad2371923aa.png)


