### PR TITLE
[3.12.x] Add a confirm popup when deleting a logo

### DIFF
--- a/web-ui/src/main/resources/catalog/js/admin/LogoSettingsController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/LogoSettingsController.js
@@ -103,25 +103,33 @@
       };
 
       /**
-       * Remove the logo and refresh the list when done.
+       * Ask for confirmation to delete a logo
        */
       $scope.removeLogo = function(logoName) {
-        $http.delete('../api/logos/' + logoName)
-            .success(function(data) {
-              $rootScope.$broadcast('StatusUpdated', {
-                msg: $translate.instant('logoRemoved'),
-                timeout: 2,
-                type: 'success'});
-              loadLogo();
-            })
-            .error(function(data) {
-              $rootScope.$broadcast('StatusUpdated', {
-                title: $translate.instant('logoRemoveError'),
-                error: data,
-                timeout: 0,
-                type: 'danger'});
-              loadLogo();
-            });
+        $scope.remLogoName = logoName;
+        $('#gn-confirm-remove-logo').modal('show');
+      }
+
+      /**
+       * Remove the logo and refresh the list when done.
+       */
+      $scope.confirmRemoveLogo = function(logoName) {
+        $http.delete('../api/logos/' + $scope.remLogoName)
+          .success(function(data) {
+            $rootScope.$broadcast('StatusUpdated', {
+              msg: $translate.instant('logoRemoved'),
+              timeout: 2,
+              type: 'success'});
+            loadLogo();
+          })
+          .error(function(data) {
+            $rootScope.$broadcast('StatusUpdated', {
+              title: $translate.instant('logoRemoveError'),
+              error: data,
+              timeout: 0,
+              type: 'danger'});
+            loadLogo();
+          });
       };
 
       loadLogo();

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1478,5 +1478,6 @@
     "confirmDeletecategory": "Are you sure you want to delete this category?",
     "ui-addWMSLayersToMap": "Add WMS layers from metadata to the map viewer",
     "ui-addWMSLayersToMap-urlLayerParam": "URL parameter with the layer name",
-    "ui-addWMSLayersToMap-urlLayerParam-help": "If the WMS layer name is configured in the metadata resource url, configure the url parameter that contains the layer name."
+    "ui-addWMSLayersToMap-urlLayerParam-help": "If the WMS layer name is configured in the metadata resource url, configure the url parameter that contains the layer name.",
+    "confirmRemoveLogo": "Are you sure you want to delete this logo?"
 }

--- a/web-ui/src/main/resources/catalog/style/gn_admin.less
+++ b/web-ui/src/main/resources/catalog/style/gn_admin.less
@@ -155,7 +155,7 @@ ul.pager {
   margin-bottom: 0px;
 }
 
-#gn-thesaurus-container, #gn-categories-container {
+#gn-thesaurus-container, #gn-categories-container, #gn-logo-container {
   // Fixes gn-modal windows; TODO: fix this globally in gn-popup style
   [gn-modal] {
     max-width: none;

--- a/web-ui/src/main/resources/catalog/templates/admin/settings/logo.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/settings/logo.html
@@ -1,4 +1,5 @@
-<span data-ng-controller="GnLogoSettingsController">
+<div data-ng-controller="GnLogoSettingsController"
+      id="gn-logo-container">
   <div class="row">
     <div class="col-lg-3 gn-logo-list">
       <div class="panel panel-default">
@@ -75,4 +76,10 @@
       </div>
     </div>
   </div>
-</span>
+
+  <div gn-modal class="gn-confirm-delete"
+       gn-popup-options="{title: 'confirmDialogTitle', confirmCallback: confirmRemoveLogo}"
+       id="gn-confirm-remove-logo">
+    <p translate>confirmRemoveLogo</p>
+  </div>
+</div>


### PR DESCRIPTION
`3.12.x` version of https://github.com/geonetwork/core-geonetwork/pull/6067

When you click on the delete logo button in the logo page in the settings, it immediately deletes the logo. You get no second changes.

This PR adds a confirm popup in between, to ask if you really want to delete the logo.

![gn-logo-confirm-delete](https://user-images.githubusercontent.com/19608667/144859869-3d5f9a8e-8912-4c0a-86e6-ae0be07fbc51.png)