### PR TITLE
User custom dialog to ask for users / groups delete confirmation

### DIFF
--- a/web-ui/src/main/resources/catalog/js/admin/UserGroupController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/UserGroupController.js
@@ -566,12 +566,24 @@
       };
 
       /**
-       * Delete a user.
+       * Ask for confirmation to delete an user.
        */
-      $scope.deleteUser = function(formId) {
+      $scope.removeUser = function(logoName) {
+        $('#gn-confirm-remove-user').modal('show');
+      }
+
+      /**
+       * Remove the user and refresh the list when done.
+       */
+      $scope.confirmRemoveUser = function() {
         $http.delete('../api/users/' +
             $scope.userSelected.id)
             .success(function(data) {
+              $rootScope.$broadcast('StatusUpdated', {
+                msg: $translate.instant('userRemoved'),
+                timeout: 2,
+                type: 'success'});
+
               $scope.unselectUser();
               loadUsers();
             })
@@ -698,10 +710,25 @@
         }
       };
 
-      $scope.deleteGroup = function(formId) {
+      /**
+       * Ask for confirmation to delete a group.
+       */
+      $scope.removeGroup = function(logoName) {
+        $('#gn-confirm-remove-group').modal('show');
+      }
+
+      /**
+       * Remove the group and refresh the list when done.
+       */
+      $scope.confirmRemoveGroup = function() {
         $http.delete('../api/groups/' +
                 $scope.groupSelected.id + '?force=true')
             .success(function(data) {
+              $rootScope.$broadcast('StatusUpdated', {
+                msg: $translate.instant('groupRemoved'),
+                timeout: 2,
+                type: 'success'});
+
               $scope.unselectGroup();
               loadGroups();
             })

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1491,6 +1491,8 @@
     "ui-addWMSLayersToMap": "Add WMS layers from metadata to the map viewer",
     "ui-addWMSLayersToMap-urlLayerParam": "URL parameter with the layer name",
     "ui-addWMSLayersToMap-urlLayerParam-help": "If the WMS layer name is configured in the metadata resource url, configure the url parameter that contains the layer name.",
-    "confirmRemoveLogo": "Are you sure you want to delete this logo?"
+    "confirmRemoveLogo": "Are you sure you want to delete this logo?",
+    "groupRemoved": "Group removed",
+    "userRemoved": "User removed"
 }
 

--- a/web-ui/src/main/resources/catalog/style/gn_admin.less
+++ b/web-ui/src/main/resources/catalog/style/gn_admin.less
@@ -190,7 +190,8 @@ ul.pager {
   margin-bottom: 0px;
 }
 
-#gn-thesaurus-container, #gn-categories-container, #gn-logo-container {
+#gn-thesaurus-container, #gn-categories-container,
+#gn-logo-container, #gn-group-container, #gn-user-container {
   // Fixes gn-modal windows; TODO: fix this globally in gn-popup style
   [gn-modal] {
     max-width: none;

--- a/web-ui/src/main/resources/catalog/templates/admin/usergroup/groups.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/usergroup/groups.html
@@ -1,4 +1,5 @@
-<div class="row" data-ng-controller="GnUserGroupController">
+<div class="row" data-ng-controller="GnUserGroupController"
+     id="gn-group-container">
   <div class="col-lg-4">
     <div class="panel panel-default">
       <div class="panel-heading">
@@ -65,8 +66,7 @@
           <button type="button" class="btn pull-right btn-danger"
                   data-ng-hide="!user.isAdministratorOrMore() || !groupSelected.id || groupSelected.id<0"
                   data-ng-disabled="searchResults.count > 0"
-                  data-gn-confirm-click="{{'groupDeleteConfirm' | translate}}"
-                  data-ng-click="deleteGroup(groupSelected.id)" id="gn-btn-group-delete">
+                  data-ng-click="removeGroup()" id="gn-btn-group-delete">
             <i class="fa fa-times"></i>&nbsp;
             <span data-translate="">deleteGroup</span>
           </button>
@@ -254,5 +254,11 @@
         </div>
       </div>
     </div>
+  </div>
+
+  <div gn-modal class="gn-confirm-delete"
+       gn-popup-options="{title: 'confirmDialogTitle', confirmCallback: confirmRemoveGroup}"
+       id="gn-confirm-remove-group">
+    <p translate>groupDeleteConfirm</p>
   </div>
 </div>

--- a/web-ui/src/main/resources/catalog/templates/admin/usergroup/users.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/usergroup/users.html
@@ -1,4 +1,5 @@
-<div class="row" data-ng-controller="GnUserGroupController">
+<div class="row" data-ng-controller="GnUserGroupController"
+     id="gn-user-container">
   <div class="col-lg-4">
     <div class="panel panel-default">
       <div class="panel-heading">
@@ -70,8 +71,7 @@
           <button type="button" class="btn pull-right btn-danger"
                   data-ng-disabled="searchResults.count > 0"
                   data-ng-show="user.isUserAdminOrMore() && (userSelected.id && userSelected.id >= 0)"
-                  data-gn-confirm-click="{{'userDeleteConfirm' | translate}}"
-                  data-ng-click="deleteUser(userSelected.id)" id="gn-btn-user-delete">
+                  data-ng-click="removeUser()" id="gn-btn-user-delete">
             <i class="fa fa-times"></i> <span data-translate=""
           >deleteUser</span></button>
         </div>
@@ -441,4 +441,9 @@
     </div>
   </div>
 
+  <div gn-modal class="gn-confirm-delete"
+       gn-popup-options="{title: 'confirmDialogTitle', confirmCallback: confirmRemoveUser}"
+       id="gn-confirm-remove-user">
+    <p translate>userDeleteConfirm</p>
+  </div>
 </div>


### PR DESCRIPTION
Use a custom dialog to ask for users / groups delete instead of the browser confirm dialog to unify the behaviour with other pages in the application.

<img width="681" alt="ask-confirmation-remove-group" src="https://user-images.githubusercontent.com/1695003/145082242-96a940c1-8a6b-495d-bd33-15604591e6cf.png">


