### PR TITLE
Fix coordinate order in jsonld GeoShape element

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/jsonld/iso19115-3.2018-to-jsonld.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/jsonld/iso19115-3.2018-to-jsonld.xsl
@@ -341,9 +341,9 @@
           <xsl:for-each select="gex:geographicElement/gex:EX_GeographicBoundingBox">
               {"@type":"GeoShape",
               "box": "<xsl:value-of select="string-join((
-                                              gex:southBoundLatitude/gco:Decimal|
-                                              gex:westBoundLongitude/gco:Decimal|
-                                              gex:northBoundLatitude/gco:Decimal|
+                                              gex:southBoundLatitude/gco:Decimal,
+                                              gex:westBoundLongitude/gco:Decimal,
+                                              gex:northBoundLatitude/gco:Decimal,
                                               gex:eastBoundLongitude/gco:Decimal
                                               ), ' ')"/>"
               }<xsl:if test="position() != last()">,</xsl:if>

--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/jsonld/iso19139-to-jsonld.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/jsonld/iso19139-to-jsonld.xsl
@@ -282,9 +282,9 @@
           <xsl:for-each select="gmd:geographicElement/gmd:EX_GeographicBoundingBox">
               {"@type":"GeoShape",
               "box": "<xsl:value-of select="string-join((
-                                              gmd:southBoundLatitude/gco:Decimal|
-                                              gmd:westBoundLongitude/gco:Decimal|
-                                              gmd:northBoundLatitude/gco:Decimal|
+                                              gmd:southBoundLatitude/gco:Decimal,
+                                              gmd:westBoundLongitude/gco:Decimal,
+                                              gmd:northBoundLatitude/gco:Decimal,
                                               gmd:eastBoundLongitude/gco:Decimal
                                               ), ' ')"/>"
               }<xsl:if test="position() != last()">,</xsl:if>


### PR DESCRIPTION
For these values:

```
WestBoundLongitude: -8.8
NorthBoundLatitude: 60.87
EastBoundLongitude: -0.71
SouthBoundLatitude: 54.63
```

The previous code for jsonld formatter was outputting:

```
"spatialCoverage": {
      "@type":"Place"
     
        ,"geo": {
          "@type":"GeoShape",
          "box": "-8.80 -0.71 54.63 60.87"
        }
     
    }
```

With the fix, the correct order (S,W,N,E) is output:

```
"spatialCoverage": {
      "@type":"Place"
     
        ,"geo": {
          "@type":"GeoShape",
          "box": "54.63,-8.8,60.87,-0.71"
        }
     
    }
```
