### PR TITLE
Don't allow to delete a group if owns metadata

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/groups/GroupsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/groups/GroupsApi.java
@@ -48,6 +48,7 @@ import org.fao.geonet.domain.*;
 import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.repository.*;
 import org.fao.geonet.repository.specification.GroupSpecs;
+import org.fao.geonet.repository.specification.MetadataSpecs;
 import org.fao.geonet.repository.specification.OperationAllowedSpecs;
 import org.fao.geonet.repository.specification.UserGroupSpecs;
 import org.fao.geonet.resources.Resources;
@@ -144,6 +145,9 @@ public class GroupsApi {
 
     @Autowired
     private TranslationPackBuilder translationPackBuilder;
+
+    @Autowired
+    private MetadataRepository metadataRepository;
 
     private static Resources.ResourceHolder getImage(Resources resources, ServiceContext serviceContext, Group group) throws IOException {
         final Path logosDir = resources.locateLogosDir(serviceContext);
@@ -502,6 +506,15 @@ public class GroupsApi {
         Optional<Group> group = groupRepository.findById(groupIdentifier);
 
         if (group.isPresent()) {
+            final long metadataCount = metadataRepository.count(where((Specification<Metadata>)
+                MetadataSpecs.isOwnedByOneOfFollowingGroups(Arrays.asList(group.get().getId()))));
+            if (metadataCount > 0) {
+                throw new NotAllowedException(String.format(
+                    "Group %s owns metadata. To remove the group you should transfer first the metadata to another group.",
+                    group.get().getName()
+                ));
+            }
+
             List<Integer> reindex = operationAllowedRepo.findAllIds(OperationAllowedSpecs.hasGroupId(groupIdentifier),
                 OperationAllowedId_.metadataId);
 


### PR DESCRIPTION
Test case:

1) Create a new group
2) Create a user and assign it as `editor` in the previous group
3) Login as the previous user and create a metadata
4) Login as an `administrator` user and try to delete the group. An error message should be displayed to indicate the user to transfer the metadata ownership