### PR TITLE
Metadata get status service - return the status change date for all types of statuses

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java
@@ -682,11 +682,12 @@ public class MetadataWorkflowApi {
                 }
             }
 
+            status.setDateChange(s.getChangeDate().getDateAndTime());
+
             if (s.getStatusValue().getType().equals(StatusValueType.event)) {
                 status.setCurrentStatus(extractCurrentStatus(s));
                 status.setPreviousStatus(extractPreviousStatus(s));
             } else if (s.getStatusValue().getType().equals(StatusValueType.task)) {
-                status.setDateChange(s.getChangeDate().getDateAndTime());
                 if (s.getDueDate() != null) {
                     status.setDateDue(s.getDueDate().getDateAndTime());
                 }


### PR DESCRIPTION
The status change date is filled for all type of statuses, but it was returned only for `task` statuses.

@fxprunayre is there any reason for that? Otherwise, please check the proposed change, thanks.