### PR TITLE
Bump log4j-core and log4j-api from 2.15.0 to 2.16.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1556,7 +1556,7 @@
     <flying-saucer>9.0.7</flying-saucer>
     <camel.version>2.25.1</camel.version>
     <log4j.version>1.2.17</log4j.version>
-    <log4j2.version>2.15.0</log4j2.version>
+    <log4j2.version>2.16.0</log4j2.version>
     <slf4j.version>1.8.0-beta2</slf4j.version>
     <xbean.version>3.18</xbean.version>
     <jolokia.version>1.6.0</jolokia.version>


### PR DESCRIPTION
It was found that the fix to address CVE-2021-44228 in Apache Log4j `2.15.0` was incomplete
in certain non-default configurations.

As far as we know GeoNetwork doesn't use any of these pattern layouts but anyway this
commit updates log4j to `2.16.0` that fixes the new CVE-2021-45046 disabling access to
JNDI by default and removing the message lookups feature.
