### PR TITLE
Enable to display map in left column of search UI

### DIFF
--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
@@ -658,6 +658,17 @@
            data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
           {{('ui-' + key + '-help') | translate}} </p>
       </div>
+      <div data-ng-switch-when="showMapInFacet">
+        <input type="checkbox"
+               id="{{key}}-checkbox"
+               data-ng-model="mCfg[key]"/>&nbsp;
+        <label class="control-label"
+               for="{{key}}-checkbox">{{('ui-' + key) | translate}}</label>
+
+        <p class="help-block"
+           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+          {{('ui-' + key + '-help') | translate}} </p>
+      </div>
 
       <div data-ng-switch-when="disabledTools">
         <h3>{{('ui-' + key) | translate}}</h3>

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -573,6 +573,7 @@ goog.require('gn_alert');
             'maps': ['ows']
           },
           'isFilterTagsDisplayedInSearch': true,
+          'showMapInFacet': false,
           'showStatusFooterFor': 'historicalArchive,obsolete,superseded',
           'usersearches': {
             'enabled': false,

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1230,6 +1230,8 @@
     "ui-isFilterTagsDisplayed-help": "If enabled, display the list of filters applied in the dashboard and the batch editor dashboard",
     "ui-isFilterTagsDisplayedInSearch": "Display filter tags in the search results",
     "ui-isFilterTagsDisplayedInSearch-help": "If enabled, display the list of filters applied in the search results page",
+    "ui-showMapInFacet": "Display map in left column over search filter",
+    "ui-showMapInFacet-help": "If enabled, display the map in the left column and not in default position of lower right corner",
     "ui-showStatusFooterFor": "Highlight status in the record footer",
     "ui-showStatusFooterFor-help": "List of codelist values (eg. completed,historicalArchive,obsolete,superseded) for which the footer has the status background color.",
     "map/isMapViewerEnabled": "Enable Map Viewer",

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_map_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_map_default.less
@@ -3,16 +3,21 @@
 @btn-link-disabled-color: #707070;
 @dropdown-link-disabled-color: #707070;
 
-[data-gn-map-field] > [ol-map] {
-  border: 1px solid #ccc;
-  border-radius: 3px;
-  right: 0;
-  bottom: 0;
-  position: fixed !important;
-  z-index: 99;
-  width: 250px !important;
-  height: 250px !important;
-  margin: 5px;
+.gn-map-fixed { 
+  [ol-map] {
+    border: 1px solid #ccc;
+    border-radius: 3px;
+    right: 0;
+    bottom: 0;
+    position: fixed !important;
+    z-index: 99;
+    width: 250px !important;
+    height: 250px !important;
+    margin: 5px;
+  }
+}
+.gn-map-relative {
+  position: relative;
 }
 
 // map viewer

--- a/web-ui/src/main/resources/catalog/views/default/module.js
+++ b/web-ui/src/main/resources/catalog/views/default/module.js
@@ -148,6 +148,7 @@
       $scope.modelOptions = angular.copy(gnGlobalSettings.modelOptions);
       $scope.modelOptionsForm = angular.copy(gnGlobalSettings.modelOptions);
       $scope.isFilterTagsDisplayedInSearch = gnGlobalSettings.gnCfg.mods.search.isFilterTagsDisplayedInSearch;
+      $scope.showMapInFacet = gnGlobalSettings.gnCfg.mods.search.showMapInFacet;
       $scope.showStatusFooterFor = gnGlobalSettings.gnCfg.mods.search.showStatusFooterFor;
       $scope.exactMatchToggle = gnGlobalSettings.gnCfg.mods.search.exactMatchToggle;
       $scope.exactTitleToggle = gnGlobalSettings.gnCfg.mods.search.exactTitleToggle;

--- a/web-ui/src/main/resources/catalog/views/default/templates/results.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/results.html
@@ -5,6 +5,20 @@
   <div class="row gn-row-results">
     <div data-ng-class="fluidLayout ? 'container-fluid' : 'container'">
       <div class="col-md-3 gn-search-facet">
+        <div ng-if="showMapInFacet">
+          <div class="panel panel-default">
+            <div class="panel-heading"
+              data-gn-slide-toggle="">
+              <span translate="" class="ng-scope">map</span>
+            </div>
+            <div
+              data-gn-map-field="searchObj.searchMap"
+              data-gn-map-field-geom="searchObj.params.geometry"
+              data-gn-map-field-opt="searchObj.mapfieldOption"
+              class="gn-search-map gn-map-relative">
+            </div>
+          </div>
+        </div>
         <div data-search-filter-tags
              data-dimensions="searchResults.facets"
              data-use-location-parameters="true"
@@ -76,16 +90,18 @@
     </div>
   </div>
 
-  <div data-gn-map-field="searchObj.searchMap"
-       data-gn-map-field-geom="searchObj.params.geometry"
-       data-gn-map-field-opt="searchObj.mapfieldOption"
-       class="gn-search-map hidden-xs">
-  </div>
+  <div ng-if="!showMapInFacet">
+    <div data-gn-map-field="searchObj.searchMap"
+      data-gn-map-field-geom="searchObj.params.geometry"
+      data-gn-map-field-opt="searchObj.mapfieldOption"
+      class="gn-search-map gn-map-fixed hidden-xs">
+    </div>
 
-  <button data-ng-click="toggleMap()"
+    <button data-ng-click="toggleMap()"
           title="{{'toggleMiniMap' | translate}}"
           class="gn-toggle gn-minimap-toggle btn btn-primary gn-minimap-button hidden-xs">
     <i class="fa fa-angle-double-right" ></i>
     <strong class="gn-minimap-toggle gn-minimap-text" data-translate="">map</strong>
-  </button>
+    </button>
+  </div>
 </div>


### PR DESCRIPTION
The PR allows displaying the map in the left column of the search UI via a setting `showMapInFacet`.

![gn-map](https://user-images.githubusercontent.com/6329425/146757501-9a9eb611-c95b-41b8-98a3-0319140ad838.png)

