### PR TITLE
Fix removal of sort by and hits per page elements in the UI configuration

### DIFF
--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -862,6 +862,8 @@ goog.require('gn_alert');
         var copy = angular.copy(defaultConfig);
         copy.mods.header.languages = {};
         copy.mods.search.grid.related = [];
+        copy.mods.search.sortbyValues = [];
+        copy.mods.search.hitsperpageValues = [];
         copy.mods.home.facetConfig = {};
         copy.mods.search.facetConfig = {};
         copy.mods.search.scoreConfig = {};

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -836,6 +836,14 @@ goog.require('gn_alert');
             }
           }, config).mods.header.languages;
 
+          this.gnCfg.mods.search.sortbyValues = angular.extend({
+            mods: {
+              search: {
+                sortbyValues: {}
+              }
+            }
+          }, config).mods.search.sortbyValues;
+
           this.gnCfg.mods.search.scoreConfig = config.mods.search.scoreConfig;
           this.gnCfg.mods.search.facetConfig = config.mods.search.facetConfig;
           this.gnCfg.mods.home.facetConfig = config.mods.home.facetConfig;


### PR DESCRIPTION
Removing items in sort by or hits per page in the UI configuration doesn't work. 

Instead of removing the item, it's replaced with the last element in the default UI configuration. For example for sort b , replaces by the "removed" element with the entry `popularity`.

https://github.com/geonetwork/core-geonetwork/blob/829a6f691097a32f5f3685e4a01e6205fa1481ef/web-ui/src/main/resources/catalog/js/CatController.js#L509-L512

<img width="540" alt="sort-by-removal" src="https://user-images.githubusercontent.com/1695003/147330413-93e37f36-9ea7-47df-8ca2-b5ec939ee427.png">