### PR TITLE
Sort groups and users in transfer ownership

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionsDirective.js
@@ -443,21 +443,6 @@
           scope.userGroupDefined = false;
           scope.userGroups = null;
 
-          scope.selectUser = function(user) {
-            scope.selectedUser = user;
-            scope.editorSelectedId = user.id;
-            $http.get('../api/users/' + id + '/groups')
-                .success(function(data) {
-                  var uniqueGroup = {};
-                  angular.forEach(data, function(g) {
-                    if (!uniqueGroup[g.group.id]) {
-                      uniqueGroup[g.group.id] = g.group;
-                    }
-                  });
-                  $scope.editorGroups = uniqueGroup;
-                });
-          };
-
           scope.selectGroup = function(group) {
             scope.selectedGroup = group;
           };
@@ -473,7 +458,20 @@
                         $translate.instant('group-' + g.groupId);
                   }
                 });
-                scope.userGroups = uniqueUserGroups;
+
+                // Sort by group name and user name
+                var sortedKeys = Object.keys(uniqueUserGroups).sort(function (a, b) {
+                  var ka = uniqueUserGroups[a].groupNameTranslated + '|' + uniqueUserGroups[a].userName;
+                  var kb = uniqueUserGroups[b].groupNameTranslated + '|' + uniqueUserGroups[b].userName;
+
+                  return ka.localeCompare(kb);
+                })
+
+                scope.userGroups = {};
+                angular.forEach(sortedKeys, function(g) {
+                  scope.userGroups[g] = uniqueUserGroups[g];
+                });
+
                 if (scope.userGroups && Object.keys(scope.userGroups).length > 0) {
                   scope.userGroupDefined = true;
                 } else {

--- a/web-ui/src/main/resources/catalog/js/admin/AdminToolsController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/AdminToolsController.js
@@ -204,7 +204,19 @@
                     $translate.instant('group-' + g.groupId);
                 }
               });
-              $scope.userGroups = uniqueUserGroups;
+
+              // Sort by group name and user name
+              var sortedKeys = Object.keys(uniqueUserGroups).sort(function (a, b) {
+                var ka = uniqueUserGroups[a].groupNameTranslated + '|' + uniqueUserGroups[a].userName;
+                var kb = uniqueUserGroups[b].groupNameTranslated + '|' + uniqueUserGroups[b].userName;
+
+                return ka.localeCompare(kb);
+              })
+
+              $scope.userGroups = {};
+              angular.forEach(sortedKeys, function(g) {
+                $scope.userGroups[g] = uniqueUserGroups[g];
+              });
             });
       }
       $scope.selectUser = function(id) {
@@ -217,7 +229,11 @@
                   uniqueGroup[g.group.id] = g.group;
                 }
               });
-              $scope.editorGroups = uniqueGroup;
+
+              // Sort the groups by group name translation
+              $scope.editorGroups = Object.values(uniqueGroup).sort(function(a, b) {
+                return a.label[$scope.lang].localeCompare(b.label[$scope.lang]);
+              });
             });
       };
       $scope.transfertList = {};

--- a/web-ui/src/main/resources/catalog/templates/admin/tools/transferownership.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/tools/transferownership.html
@@ -15,7 +15,7 @@
             <th data-translate="">sourceGroup</th>
             <th data-translate="">targetGroup</th>
           </tr>
-          <tr data-ng-repeat="(key, g) in editorGroups"
+          <tr data-ng-repeat="g in editorGroups"
               data-ng-init="transfertList[g.id] = {sourceGroup: g.id};">
             <td>{{g.label[lang]|empty:g.name}}</td>
             <!--TODO: Only list group with records. -->


### PR DESCRIPTION
Currently the transfer ownership page doesn't sort the `Source group` and `Target group & editor' fields` This is a bit problematic in catalogues with a huger number of groups / users as difficult the selection of the user/group to transfer the ownership.

With this change, the values are displayed sorted.

<img width="612" alt="transfer-ownership" src="https://user-images.githubusercontent.com/1695003/147351310-315ce150-4b02-4f8f-9a4f-7916a5f8b730.png">

Updated also the angular directive `gnTransferOwnership` used in the Editor board.
  