### PR TITLE
Update UI configuration selected by default: 

### DIFF
--- a/web-ui/src/main/resources/catalog/js/admin/SystemSettingsController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/SystemSettingsController.js
@@ -226,10 +226,19 @@
             }
             $scope.uiConfigurations = data;
 
-            // Select the first
+            // Select the current node if defined in the configuration, otherwise the first one
             if ($scope.uiConfigurations.length > 0 &&
                 angular.isUndefined($scope.uiConfiguration)) {
-              $scope.uiConfiguration = $scope.uiConfigurations[0];
+
+              var defaultUiIndex = _.findIndex($scope.uiConfigurations, function(ui){
+                return ui.id === gnGlobalSettings.nodeId;
+              });
+
+              if (defaultUiIndex > -1) {
+                $scope.uiConfiguration = $scope.uiConfigurations[defaultUiIndex];
+              } else {
+                $scope.uiConfiguration = $scope.uiConfigurations[0];
+              }
             }
           });
       };


### PR DESCRIPTION
Select the current node if defined in the configuration, otherwise the first one.

To test:

1) Create an UI configuration: `internaldata`

2) Reload the page with the node `srv` : http://localhost:8080/geonetwork/srv/eng/admin.console?debug#/settings/ui --> `srv` UI should be selected

<img width="327" alt="nodeselection" src="https://user-images.githubusercontent.com/1695003/147353733-57cdf448-91bc-4182-8e4e-1ba0df20cf9f.png">

3) Change the node in the url to use `internaldata`: http://localhost:8080/geonetwork/internaldata/eng/admin.console?debug#/settings/ui --> `internaldata` UI should be selected

