### PR TITLE
Metadata view / correctly escape quotes in links title to avoid runtime error

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/related.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/related.html
@@ -43,28 +43,28 @@
           <div data-ng-switch-when="WMS">
             <p class="text-muted">
               <span data-translate=""
-                    data-translate-values="{url:'{{r.url | gnLocalized: lang}}', layer:'{{(r.title | gnLocalized: lang).replace('\'', '\\\'')}}'}">
+                    data-translate-values="{url:{{r.url | gnLocalized: lang | toJson}}, layer:{{r.title | gnLocalized: lang | toJson}}}">
                 wmsLinkDetails</span>
             </p>
           </div>
           <div data-ng-switch-when="WMTS">
             <p class="text-muted">
               <span data-translate=""
-                    data-translate-values="{url:'{{r.url | gnLocalized: lang}}', layer:'{{(r.title | gnLocalized: lang).replace('\'', '\\\'')}}'}">
+                    data-translate-values="{url:{{r.url | gnLocalized: lang | toJson}}, layer:{{r.title | gnLocalized: lang | toJson}}}">
                 wmtsLinkDetails</span>
             </p>
           </div>
           <div data-ng-switch-when="WMSSERVICE">
             <p class="text-muted">
               <span data-translate=""
-                    data-translate-values="{url:'{{r.url | gnLocalized: lang}}'}">
+                    data-translate-values="{url:{{r.url | gnLocalized: lang | toJson}}}">
                 wmsServiceLinkDetails</span>
             </p>
           </div>
           <div data-ng-switch-when="WMTSSERVICE">
             <p class="text-muted">
               <span data-translate=""
-                    data-translate-values="{url:'{{r.url | gnLocalized: lang}}'}">
+                    data-translate-values="{url:{{r.url | gnLocalized: lang | toJson}}}">
                 wmtsServiceLinkDetails</span>
             </p>
           </div>
@@ -72,7 +72,7 @@
             <p class="text-muted"
                data-ng-if="isLayerProtocol(r)">
               <span data-translate=""
-                    data-translate-values="{url:'{{r.url | gnLocalized: lang}}', layer:'{{r.title | gnLocalized: lang}}'}">
+                    data-translate-values="{url:{{r.url | gnLocalized: lang | toJson}}, layer:{{r.title | gnLocalized: lang | toJson}}}">
                 wfsLinkDetails</span>
             </p>
             <div data-ng-if="isLayerProtocol(r)"
@@ -84,7 +84,7 @@
             <p class="text-muted"
                data-ng-if="!isLayerProtocol(r)">
               <span data-translate=""
-                    data-translate-values="{url:'{{r.url | gnLocalized: lang}}'}">
+                    data-translate-values="{url:{{r.url | gnLocalized: lang | toJson}}}">
                 wfsServiceLinkDetails</span>
             </p>
             <div data-ng-if="!isLayerProtocol(r)"
@@ -96,33 +96,33 @@
 
           <div data-ng-switch-when="TMS">
             <span data-translate=""
-                  data-translate-values="{url:'{{r.url | gnLocalized: lang}}', layer:'{{r.title | gnLocalized: lang}}'}">
+                  data-translate-values="{url:{{r.url | gnLocalized: lang | toJson}}, layer:{{r.title | gnLocalized: lang | toJson}}}">
               tmsLinkDetails</span>
           </div>
 
           <div data-ng-switch-when="SOS">
             <span data-translate=""
-                  data-translate-values="{url:'{{r.url | gnLocalized: lang}}', layer:'{{r.title | gnLocalized: lang}}'}">
+                  data-translate-values="{url:{{r.url | gnLocalized: lang | toJson}}, layer:{{r.title | gnLocalized: lang | toJson}}}">
               sosLinkDetails</span>
           </div>
 
           <div data-ng-switch-when="ESRI:REST">
             <span data-translate=""
-                  data-translate-values="{url:'{{r.url | gnLocalized: lang}}', layer:'{{r.title | gnLocalized: lang}}'}">
+                  data-translate-values="{url:{{r.url | gnLocalized: lang | toJson}}, layer:{{r.title | gnLocalized: lang | toJson}}}">
               esriRestLinkDetails</span>
           </div>
 
           <div data-ng-switch-when="WCS">
             <p class="text-muted">
             <span data-translate=""
-                  data-translate-values="{url:'{{r.url | gnLocalized: lang}}', layer:'{{r.title | gnLocalized: lang}}'}">
+                  data-translate-values="{url:{{r.url | gnLocalized: lang | toJson}}, layer:{{r.title | gnLocalized: lang | toJson}}}">
               wcsLinkDetails</span>
             </p>
           </div>
 
           <div data-ng-switch-when="ATOM">
             <p class="text-muted" data-translate=""
-               data-translate-values="{url:'{{r.url | gnLocalized: lang}}', layer:'{{r.title | gnLocalized: lang}}'}">
+               data-translate-values="{url:{{r.url | gnLocalized: lang | toJson}}, layer:{{r.title | gnLocalized: lang | toJson}}}">
               atomLinkDetails
             </p>
             <div
@@ -136,7 +136,7 @@
           <div data-ng-switch-when="DB">
             <p class="text-muted">
             <span data-translate=""
-                  data-translate-values="{url:'{{r.url | gnLocalized: lang}}', layer:'{{r.title | gnLocalized: lang}}'}">
+                  data-translate-values="{url:{{r.url | gnLocalized: lang | toJson}}, layer:{{r.title | gnLocalized: lang | toJson}}}">
               databaseLayerDetails</span>
             </p>
           </div>
@@ -144,7 +144,7 @@
           <div data-ng-switch-when="FILE">
             <p class="text-muted">
               <span data-translate=""
-                    data-translate-values="{url:'{{r.url | gnLocalized: lang}}', name:'{{r.title | gnLocalized: lang}}'}">
+                    data-translate-values="{url:{{r.url | gnLocalized: lang | toJson}}, name:'{{r.title | gnLocalized: lang | toJson}}'}">
                 fileLayerDetails</span>
               <input class="form-control"
                      type="text"

--- a/web-ui/src/main/resources/catalog/components/utility/UtilityService.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityService.js
@@ -590,4 +590,10 @@
       return $sanitize(input);
     }
   }]);
+
+  module.filter('toJson', [function() {
+    return function(input) {
+      return JSON.stringify(input);
+    }
+  }]);
 })();


### PR DESCRIPTION
This is a follow up of https://github.com/geonetwork/core-geonetwork/pull/4611 which only partially fixed the issue (only for WMS and WMTS).

This PR introduces a new `escapeQuote` filter and uses it on all types of links displayed in the metadata view:

![image](https://user-images.githubusercontent.com/10629150/147673155-8fb5259c-323c-4e89-9556-a662ea13450e.png)

This fix has been done against 3.12.x for easier backporting in the customer project and will be ported to the `main` branch afterwards.