### PR TITLE
Fix for the height of a Modal popup in the Editor

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/linkServiceToDataset.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/linkServiceToDataset.html
@@ -5,7 +5,7 @@
     <div class="onlinesrc-container">
       <div class="form-group">
         <div class="col-sm-12">
-          <div class="input-group">
+          <div class="input-group gn-margin-bottom">
             <span class="input-group-addon"><i
               class="fa fa-search"/></span>
             <input class="form-control"

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/linkToMd.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/linkToMd.html
@@ -5,7 +5,7 @@
     <div class="onlinesrc-container">
       <div class="form-group">
         <div class="col-sm-12">
-          <div class="input-group">
+          <div class="input-group gn-margin-bottom">
             <span class="input-group-addon"><i
               class="fa fa-search"/></span>
             <input class="form-control"

--- a/web-ui/src/main/resources/catalog/style/gn_editor.less
+++ b/web-ui/src/main/resources/catalog/style/gn_editor.less
@@ -608,6 +608,12 @@ form.gn-tab-inspire {
     to be higher than view port
     as the modal does not have overflow. */
     max-height: 50vh;
+    @media (max-height: 786px) {
+      max-height: 35vh;
+    }
+    @media (max-height: 550px) {
+      max-height: 23vh;
+    }
   }
 
   .gn-record {


### PR DESCRIPTION
In the editor the contents of a Modal popup can be too high, which results in the buttons 'falling' off the popup.

This PR fixes this, by decreasing the height of the contents based on the height of the browser window. When browser window is less then 460px high it doesn't help anymore, because the height is just not enough.

**Before**
![gn-modal-height-before](https://user-images.githubusercontent.com/19608667/148025032-cebf1d1a-4a5f-465d-aa85-fc264d2ad4d7.png)

**and after**
![gn-modal-height-after](https://user-images.githubusercontent.com/19608667/148025058-4fbd8c80-95cc-400d-be8a-a9b4f721f85d.png)

