### PR TITLE
Additional Icons and Labels based on Protocol

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/RelatedDirective.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/RelatedDirective.js
@@ -281,6 +281,8 @@
                   return r.protocol.replace('WWW:DOWNLOAD:', '');
                 } else if (mainType.match(/W([MCF]|MT)S.*|ESRI:REST/)) {
                   return mainType.replace('SERVICE', '');
+                } else if (mainType.indexOf('KML') >= 0) {
+                  return mainType;
                 } else {
                   return '';
                 }

--- a/web-ui/src/main/resources/catalog/components/metadataactions/RelatedResourcesService.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/RelatedResourcesService.js
@@ -345,6 +345,10 @@
                 this.map['DEFAULT'].iconClass;
           };
 
+          this.getProtocolClassIcon = function (type) {
+            return type.replace(':','-').replace(' ','-').toLowerCase();
+          };
+
           this.getLabel = function(mainType, type) {
             // Old key before the move to API
             var oldKey = {

--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/related.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/related.html
@@ -7,20 +7,25 @@
        data-ng-if="type && type !== 'thumbnails'">
     <div data-ng-init="mainType = config.getType(r, type);
                        badge = getBadgeLabel(mainType, r);
-                       icon = config.getClassIcon(mainType);"
+                       icon = config.getClassIcon(mainType);
+                       protocolIcon = config.getProtocolClassIcon(r.protocol);"
          class="row list-group-item gn-related-item gn-related-{{type}} gn-relation-type-{{mainType}}"
          data-ng-repeat="r in items track by $index">
       <div class="gn-related-icon-col col-xs-2 col-sm-2 text-center">
         <strong>
           <div class="clearfix">
             <i class="fa"
-               data-ng-class="icon"/>
+               data-ng-class="mainType.indexOf('DEFAULT') === 0 ? 'fa-question-circle gn-icon-' + protocolIcon : icon"/>
           </div>
           <span data-ng-if="badge != ''"
                 class="label label-default"
                 data-ng-class="{
                   'label-primary': icon === 'fa-download' || icon === 'fa-file-pdf-o',
                   'label-success': icon === 'fa-globe'}">{{badge}}</span>
+          <span data-ng-if="mainType.indexOf('DEFAULT') === 0"
+                class="label label-default">
+            {{r.protocol}}
+          </span>
         </strong>
       </div>
       <div data-ng-class="mainType === 'MDFCATS' ? 'col-xs-11' : 'col-xs-7 col-sm-7'">
@@ -73,12 +78,6 @@
                     data-translate-values="{url:'{{r.url | gnLocalized: lang}}', layer:'{{r.title | gnLocalized: lang}}'}">
                 wfsLinkDetails</span>
             </p>
-            <div data-ng-if="isLayerProtocol(r)"
-                 data-gn-no-map-wfs-download=""
-                 data-typename="{{r.title | gnLocalized: lang}}"
-                 data-url="{{r.url | gnLocalized: lang}}">
-            </div>
-
             <p class="text-muted"
                data-ng-if="!isLayerProtocol(r)">
               <span data-translate=""
@@ -158,6 +157,10 @@
             </div>
           </div>
 
+          <div data-ng-switch-when="LINKDOWNLOAD-ZIP">
+            <span ng-bind-html="r.url | gnLocalized: lang | linky:'_blank'"></span>
+          </div>
+
           <div data-ng-switch-default>
             <p class="text-muted"
                data-ng-if="mainType.indexOf('MD') == 0 && r.id
@@ -198,6 +201,12 @@
             ({{::r.associationType | translate}}{{::(r.initiativeType != '' ? ' / ' + (r.initiativeType | translate) : '')}})
           </span>
         </button>
+
+        <div data-ng-if="mainType === 'WFS'"
+             data-gn-no-map-wfs-download=""
+             data-typename="{{r.title | gnLocalized: lang}}"
+             data-url="{{r.url | gnLocalized: lang}}">
+        </div>
 
 
         <button type="button"

--- a/web-ui/src/main/resources/catalog/style/gn_icons.less
+++ b/web-ui/src/main/resources/catalog/style/gn_icons.less
@@ -74,3 +74,11 @@
 
 .gn-icon-MyFrequentlyUsedRecords:before { content: @fa-var-star }
 .gn-icon-WatchingRecords:before { content: @fa-var-bell }
+/* protocol icons */
+.gn-icon-arcgis-mapservice:before { content: @fa-var-map-o }
+.gn-icon-arcgis-featureservice:before { content: @fa-var-cloud }
+.gn-icon-csv:before { content: @fa-var-table }
+.gn-icon-ogc-gml:before { content: @fa-var-file-code-o }
+.gn-icon-json:before { content: @fa-var-file-text-o }
+.gn-icon-zip-shape:before { content: @fa-var-file-zip-o }
+.gn-icon-doi:before { content: @fa-var-info-circle }

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_result_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_result_default.less
@@ -51,7 +51,7 @@
       padding-left: 0px;
       padding-right: 0px;
       .fa {
-        font-size: 2em;
+        font-size: 1.7em;
       }
     }
     h3 {
@@ -60,12 +60,29 @@
       padding-left: 0;
       margin-bottom: 10px;
     }
+    a {
+      line-break: anywhere;
+    }
     .table-striped td {
       padding-left: 8px;
     }
     .gn-atom {
       max-height: 250px;
       overflow: auto;
+    }
+    .label {
+      display: inline-block;
+      padding: 0.4em 0.6em;
+      white-space: normal;
+      margin-top: 5px;
+    }
+    .col-xs-12.col-sm-3 {
+      .btn-group {
+        width: 100%;
+        .btn {
+          width: 100%;
+        }
+      }
     }
   }
   .gn-md-side {


### PR DESCRIPTION
This PR adds additional Icons and Labels in the detail (metadata record) view that are based on Protocol. Before icons and labels where only shown for a main type (WMS, WFS, etc) and all the others got a question mark.

Further changes:
- labels on more than 1 line
- WFS download option now in the right columns (in stead of middle column)

**Screenshot after the changes**

![gn-additional-icons](https://user-images.githubusercontent.com/19608667/148220681-500b9669-a2ad-4519-ab9c-a63a2ce16b7c.png)

