### PR TITLE
Harvester results - filter by harvester uuid instead of site id. Fixes #5530

### DIFF
--- a/core/src/main/java/org/fao/geonet/constants/Geonet.java
+++ b/core/src/main/java/org/fao/geonet/constants/Geonet.java
@@ -1,5 +1,5 @@
 //=============================================================================
-//===	Copyright (C) 2001-2021 Food and Agriculture Organization of the
+//===	Copyright (C) 2001-2022 Food and Agriculture Organization of the
 //===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
 //===	and United Nations Environment Programme (UNEP)
 //===
@@ -664,6 +664,7 @@ public final class Geonet {
         public static final String DATABASE_CREATE_DATE = "_createDate";
         public static final String DATABASE_CHANGE_DATE = "_changeDate";
         public static final String SOURCE = "_source";
+        public static final String HARVESTUUID = "_harvesterUuid";
         public static final String IS_TEMPLATE = "_isTemplate";
         public static final String UUID = "_uuid";
         public static final String IS_HARVESTED = "_isHarvested";

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataIndexer.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataIndexer.java
@@ -1,5 +1,5 @@
 //=============================================================================
-//===	Copyright (C) 2001-2011 Food and Agriculture Organization of the
+//===	Copyright (C) 2001-2022 Food and Agriculture Organization of the
 //===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
 //===	and United Nations Environment Programme (UNEP)
 //===
@@ -483,6 +483,11 @@ public class BaseMetadataIndexer implements IMetadataIndexer, ApplicationEventPu
                 SearchManager.makeField(Geonet.IndexFieldNames.IS_TEMPLATE, metadataType.codeString, true, true));
             moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.UUID, uuid, true, true));
             moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.IS_HARVESTED, isHarvested, true, true));
+
+            if (fullMd.getHarvestInfo().isHarvested()) {
+                moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.HARVESTUUID, fullMd.getHarvestInfo().getUuid(), true, true));
+            }
+
             moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.OWNER, owner, true, true));
             moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.DUMMY, "0", false, true));
             moreFields.add(SearchManager.makeField(Geonet.IndexFieldNames.POPULARITY, popularity, true, true));

--- a/web-ui/src/main/resources/catalog/js/admin/HarvestSettingsController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/HarvestSettingsController.js
@@ -344,7 +344,7 @@
 
           // Retrieve records in that harvester
           angular.extend($scope.searchObj.params, {
-            siteId: $scope.harvesterSelected.site.uuid
+            _harvesterUuid: $scope.harvesterSelected.site.uuid
           });
           $scope.$broadcast('resetSearch', $scope.searchObj.params);
         });


### PR DESCRIPTION
In the Harvester admin page show the harvester records filtering by `_harvesterUuid` instead of `_siteId`.