### PR TITLE
New utility function for copying text to the clipboard

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/related.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/related.html
@@ -174,6 +174,7 @@
                 {{ (r.description | gnLocalized: lang | striptags)}}</a>
               </span>
               <span ng-bind-html="r.url | gnLocalized: lang | linky:'_blank'"></span>
+              <span gn-copy-to-clipboard="{{r.url | gnLocalized: lang}}" gn-copy-button-only="false"></span>
             </p>
           </div>
         </div>

--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -562,6 +562,80 @@
 
   /**
    * @ngdoc directive
+   * @name gn_utility.directive:gnCopyToClipboard
+   * @function
+   *
+   * @description
+   * Put a string in a input field with copy to clipboard functions attached to it.
+   *
+   * The code to be used in a HTML page:
+   * 
+   * <span gn-copy-to-clipboard="{{r.url | gnLocalized: lang}}"></span>
+   *
+   * or
+   *
+   * <span gn-copy-to-clipboard="{{r.url | gnLocalized: lang}}" gn-copy-button-only="true"></span>
+   *
+   * The first option displays an input and copy button. Copying the text to the clipboard is triggered by
+   * clicking on the button or in the input.
+   *
+   * The second option only displays the copy button (in case the input is not needed). The input is
+   * moved out of sight, because for copying you need an input (or textarea)
+   */
+  module.directive('gnCopyToClipboard', ['gnAlertService','$translate',
+    function (gnAlertService,$translate) {
+      return {
+        restrict: 'A',
+        scope: {
+          copytext: '@gnCopyToClipboard',
+          buttononly: '@gnCopyButtonOnly'
+        },
+        templateUrl: '../../catalog/components/utility/' +
+          'partials/copytoclipboard.html',
+        link: function(scope, element, attr) {
+
+          var target = element.find('input:first');
+          scope.moveinput = (scope.buttononly === 'true');
+
+          scope.copyToClipboard = function() {
+            // select the current focus
+            var currentFocus = document.activeElement;
+
+            // set focus on the text input
+            target.focus();
+            target[0].setSelectionRange(0, target.val().length);
+
+            // copy the selection
+            var succeed;
+
+            try {
+              succeed = document.execCommand("copy");
+            } catch (e) {
+              console.warn(e);
+              succeed = false;
+            }
+
+            // Restore original focus
+            if (currentFocus && typeof currentFocus.focus === "function") {
+              currentFocus.focus();
+            }
+
+            if (succeed) {
+              gnAlertService.addAlert({
+                msg: $translate.instant('textCopied'),
+                delay: 5000,
+                type: 'success'});
+            }
+
+            return succeed;
+          };
+        }
+      };
+    }
+  ]);
+
+  /**
+   * @ngdoc directive
    * @name gn_utility.directive:gnMetadataPicker
    * @function
    *

--- a/web-ui/src/main/resources/catalog/components/utility/UtilityService.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityService.js
@@ -322,7 +322,7 @@
         function getPermalink(title, url) {
           gnPopup.createModal({
             title: $translate.instant('permalinkTo', {title: title}),
-            content: '<div gn-permalink-input="' + url + '"></div>'
+            content: '<span gn-copy-to-clipboard="' + url + '"></span>'
           });
         };
 

--- a/web-ui/src/main/resources/catalog/components/utility/partials/copytoclipboard.html
+++ b/web-ui/src/main/resources/catalog/components/utility/partials/copytoclipboard.html
@@ -1,0 +1,13 @@
+<div class="input-group gn-copy-clipboard"
+     data-ng-class="moveinput ? 'gn-hide-input' : 'gn-show-input'">
+  <input type="text"
+         data-ng-click="copyToClipboard()"
+         class="form-control"
+         value="{{copytext}}">
+  <span class="input-group-addon btn"
+        data-ng-click="copyToClipboard()"
+        title="{{'copyToClipboard' | translate}}">
+    <i class="fa fa-clipboard" aria-hidden="true"></i>
+  </span>
+</div>
+

--- a/web-ui/src/main/resources/catalog/locales/en-core.json
+++ b/web-ui/src/main/resources/catalog/locales/en-core.json
@@ -559,5 +559,7 @@
     "unselectChoiceNotAllowedTitle": "Unselect choices",
     "unselectChoiceNotAllowed": "Some choices can't be removed: {{notAllowedChoices}}",
     "searchOptions": "Search options",
-    "options": "Options"
+    "options": "Options",
+    "copyToClipboard": "Copy the text to the clipboard",
+    "textCopied": "Text has been copied to the clipboard."
 }

--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -917,6 +917,21 @@ input.ng-invalid {
   }
 }
 
+.gn-copy-clipboard {
+  &.gn-hide-input {
+    display: inline-block;
+    // old trick to not hide the input but position it out of sight
+    input[type=text] {
+      position: absolute;
+      top: -9999px;
+    }
+    .btn {
+      border-radius: @border-radius-base !important;
+      border: 1px solid @btn-default-border;
+    }
+  }
+}
+
 /* Highlight updated checkboxes in sharing form */
 .gn-sharing-batch {
   // remove


### PR DESCRIPTION
New utility function for copying text to the clipboard. The new utility is already implemented for related links and the permalink for the metadata record.

An example of the code to be used in a HTML page:
```
<span gn-copy-to-clipboard="{{r.url | gnLocalized: lang}}"></span>
```
or
```
<span gn-copy-to-clipboard="{{r.url | gnLocalized: lang}}" gn-copy-button-only="true"></span>
```
The first option displays an input and copy button. Copying the text to the clipboard is triggered by clicking on the button or in the input. 

The second option only displays the copy button (in case the input is not needed). The input is moved out of sight, because for copying you need an `input` (or `textarea`).

When the text is copied and a message is shown.

**Screenshot for the related records**

![gn-related](https://user-images.githubusercontent.com/19608667/148386627-018e4adc-76ae-451d-b08f-7fc612e20d67.png)

**Screenshot for the permalink**

![gn-permalink](https://user-images.githubusercontent.com/19608667/148386651-848c8f95-694f-4e4b-8b45-1ff3ffc15eee.png)