### PR TITLE
FIX: Display the alert message within the online resource popup

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -376,6 +376,14 @@ div.gn-scroll-spy {
           max-height: 250px;
         }
       }
+      // error message
+      .alert {
+        position: fixed;
+        bottom: 0;
+        width: calc(~"100% - 100px");
+        margin-left: 200px;
+        margin-right: 200px;
+      }
     }
   }
   .modal-dialog {


### PR DESCRIPTION
The alert message in the online resource popup is displayed below the popup on smaller, less higher screens, this PR has a fix to display the alert message on top of the popup.

**Before**

![gn-alert-below](https://user-images.githubusercontent.com/19608667/148958365-e28551f7-df35-4120-8331-8f03261d1196.png)

**After**

![gn-alert-within](https://user-images.githubusercontent.com/19608667/148958562-37a40b04-0e23-4ada-9791-2a58b3d9c3c3.png)