### PR TITLE
Ignore the portal filter when executed from a scheduled AtomHarvester

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/search/LuceneSearcher.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/LuceneSearcher.java
@@ -1,5 +1,5 @@
 //==============================================================================
-//===	Copyright (C) 2001-2007 Food and Agriculture Organization of the
+//===	Copyright (C) 2001-2022 Food and Agriculture Organization of the
 //===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
 //===	and United Nations Environment Programme (UNEP)
 //===
@@ -116,6 +116,7 @@ import org.jdom.Element;
 import org.jdom.JDOMException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.BeanCreationException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.jpa.domain.Specification;
 
@@ -1622,6 +1623,17 @@ public class LuceneSearcher extends MetaSearcher implements MetadataRecordSelect
         // If the requested portal define a filter
         // Add it to the request.
         NodeInfo node = ApplicationContextHolder.get().getBean(NodeInfo.class);
+        try {
+            // This method can be called from the Atom Harvester that doesn't have a
+            // WebApplicationContext. In that case accessing to any property of the
+            // NodeInfo class throws an exception. We ignore the portalFilter query part
+            // in that case
+            node.getId();
+        } catch (BeanCreationException ex) {
+            LOGGER.debug("appendPortalFilter called from a non http request thread. Ignoring the node in the search");
+            return q;
+
+        }
         SourceRepository sourceRepository = ApplicationContextHolder.get().getBean(SourceRepository.class);
         if (node != null && !NodeInfo.DEFAULT_NODE.equals(node.getId())) {
             final Source portal = sourceRepository.findOne(node.getId());

--- a/inspire-atom/src/main/java/org/fao/geonet/inspireatom/harvester/InspireAtomHarvester.java
+++ b/inspire-atom/src/main/java/org/fao/geonet/inspireatom/harvester/InspireAtomHarvester.java
@@ -1,5 +1,5 @@
 //=============================================================================
-//===	Copyright (C) 2001-2010 Food and Agriculture Organization of the
+//===	Copyright (C) 2001-2022 Food and Agriculture Organization of the
 //===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
 //===	and United Nations Environment Programme (UNEP)
 //===
@@ -223,7 +223,7 @@ public class InspireAtomHarvester {
             String metadataUuid = dataMan.getMetadataUuid(metadataId);
 
             try {
-                logger.info("Processing feed (" + i++ + "/"+ total + ") for service metadata with uuid:" + metadataUuid);
+                logger.info("Processing feed (" + i++ + "/"+ total + ") for service metadata with uuid: " + metadataUuid);
 
                 String atomUrl = entry.getValue();
                 logger.debug("Atom feed Url for service metadata (" + metadataUuid + "): " + atomUrl);


### PR DESCRIPTION
This fix the aborted Atom Harvester scheduled executions that end immediately after start.

The `LuceneSearcher.appendPortalFilter` can be called from the Atom Harvester  when it doesn't have a `WebApplicationContext` (a scheduled execution, not when called from the UI using the button in the _Admin Console -> Settings_). In that case accessing to any property of the `NodeInfo` class throws an exception. We ignore the `portalFilter` query part in that case.