### PR TITLE
Metadata view / correctly escape quotes for file resources as well

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/related.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/related.html
@@ -144,7 +144,7 @@
           <div data-ng-switch-when="FILE">
             <p class="text-muted">
               <span data-translate=""
-                    data-translate-values="{url:{{r.url | gnLocalized: lang | toJson}}, name:'{{r.title | gnLocalized: lang | toJson}}'}">
+                    data-translate-values="{url:{{r.url | gnLocalized: lang | toJson}}, name:{{r.title | gnLocalized: lang | toJson}}}">
                 fileLayerDetails</span>
               <input class="form-control"
                      type="text"


### PR DESCRIPTION
Followup of https://github.com/geonetwork/core-geonetwork/pull/6095

This PR fixes an overlook on my side which would cause FILE resources names to not be displayed correctly if they contain single quotes.

To clarify: the `toJson` filter will actually output the string value enclosed by double quotes.