### PR TITLE
Fix to display the role translation instead of the role code in the iso19139 full view formatter

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
@@ -652,7 +652,7 @@
         <div class="gn-contact">
           <strong>
             <xsl:comment select="'email'"/>
-            <xsl:apply-templates mode="render-value-no-breaklines"
+            <xsl:apply-templates mode="render-value"
                                  select="*/gmd:role/*/@codeListValue"/>
           </strong>
           <address>


### PR DESCRIPTION
Without the fix, the full view formatter displays the role code instead of the translation:

<img width="259" alt="role-code" src="https://user-images.githubusercontent.com/1695003/150091147-c7dba9e9-3be8-472a-97b8-6d13856be02d.png">

After the change:

<img width="254" alt="role-code-fix" src="https://user-images.githubusercontent.com/1695003/150091762-e539c2ee-53da-4647-b2ab-3d77301f0086.png">

