### PR TITLE
DOI - add identifier / online resource url using the DOI proxy url

### DIFF
--- a/doi/src/main/java/org/fao/geonet/doi/client/DoiClient.java
+++ b/doi/src/main/java/org/fao/geonet/doi/client/DoiClient.java
@@ -36,7 +36,6 @@ import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.utils.GeonetHttpRequestFactory;
 import org.fao.geonet.utils.Log;
 import org.apache.commons.httpclient.HttpStatus;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.client.ClientHttpResponse;
 
 import java.io.InputStreamReader;
@@ -57,7 +56,8 @@ public class DoiClient {
     public static final String ALL_DOI_ENTITY = "All DOI";
     public static final String DOI_METADATA_ENTITY = "DOI metadata";
 
-    private String serverUrl;
+    private String apiUrl;
+    private String doiPublicUrl;
     private String username;
     private String password;
 
@@ -65,12 +65,13 @@ public class DoiClient {
 
     protected GeonetHttpRequestFactory requestFactory;
 
-    public DoiClient(String serverUrl, String username, String password) {
-        this(serverUrl, username, password, true);
+    public DoiClient(String apiUrl, String username, String password, String doiPublicUrl) {
+        this(apiUrl, username, password, doiPublicUrl, true);
     }
 
-    public DoiClient(String serverUrl, String username, String password, boolean testMode) {
-        this.serverUrl = serverUrl.endsWith("/") ? serverUrl : serverUrl + "/";
+    public DoiClient(String apiUrl, String username, String password, String doiPublicUrl, boolean testMode) {
+        this.apiUrl = apiUrl.endsWith("/") ? apiUrl : apiUrl + "/";
+        this.doiPublicUrl = doiPublicUrl.endsWith("/") ? doiPublicUrl : doiPublicUrl + "/";
         this.username = username;
         this.password = password;
         this.testMode = testMode;
@@ -177,7 +178,7 @@ public class DoiClient {
         HttpDelete deleteMethod = null;
 
         try {
-            Log.debug(LOGGER_NAME, "   -- URL: " + this.serverUrl + "/metadata");
+            Log.debug(LOGGER_NAME, "   -- URL: " + this.apiUrl + "/metadata");
 
             deleteMethod = new HttpDelete(createUrl("metadata/" + doi));
 
@@ -217,7 +218,7 @@ public class DoiClient {
         HttpDelete deleteMethod = null;
 
         try {
-            Log.debug(LOGGER_NAME, "   -- URL: " + this.serverUrl + "/metadata");
+            Log.debug(LOGGER_NAME, "   -- URL: " + this.apiUrl + "/metadata");
 
             deleteMethod = new HttpDelete(createUrl("doi/" + doi));
 
@@ -351,14 +352,21 @@ public class DoiClient {
     }
 
     /**
-     * Builds service url with server url.
+     * Builds API endpoint url based on server URL configured in settings.
      *
-     * @param service
-     * @return
+     * eg. https://mds.datacite.org/doi/10.12770/38e00808-ffca-4266-943f-b691d3ca0bec
      */
     public String createUrl(String service) {
-        return this.serverUrl +
-            (this.serverUrl.endsWith("/") ? "" : "/") +
-            service;
+        return this.apiUrl + service;
+    }
+
+    /**
+     * Builds final DOI url based on public URL configured in settings.
+     * Default is https://doi.org.
+     *
+     * eg. https://doi.org/10.17882/80771
+     */
+    public String createPublicUrl(String doi) {
+        return this.doiPublicUrl + doi;
     }
 }

--- a/doi/src/main/java/org/fao/geonet/doi/client/DoiManager.java
+++ b/doi/src/main/java/org/fao/geonet/doi/client/DoiManager.java
@@ -63,6 +63,7 @@ import java.util.Map;
  * @author Francois Prunayre
  */
 public class DoiManager {
+    private static final String DOI_PROXY_URL = "https://doi.org/";
     private static final String DOI_ADD_XSL_PROCESS = "process/doi-add.xsl";
     private static final String DOI_REMOVE_XSL_PROCESS = "process/doi-remove.xsl";
     public static final String DATACITE_XSL_CONVERSION_FILE = "formatter/datacite/view.xsl";
@@ -229,7 +230,7 @@ public class DoiManager {
             String currentDoi = schema.queryString(DOI_GET_SAVED_QUERY, xml);
             if (StringUtils.isNotEmpty(currentDoi)) {
                 // Current doi does not match the one going to be inserted. This is odd
-                if (!currentDoi.equals(client.createUrl("doi") + "/" + doi)) {
+                if (!currentDoi.equals(DOI_PROXY_URL + doi)) {
                     throw new DoiClientException(String.format(
                         "Record '%s' already contains a DOI <a href='%s'>%s</a> which is not equal " +
                             "to the DOI about to be created (ie. '%s'). " +
@@ -371,13 +372,11 @@ public class DoiManager {
         String landingPage = landingPageTemplate.replace(
                         "{{uuid}}", metadata.getUuid());
         doiInfo.put("doiLandingPage", landingPage);
-        doiInfo.put("doiUrl",
-            client.createUrl("doi") + "/" + doiInfo.get("doi"));
         client.createDoi(doiInfo.get("doi"), landingPage);
 
 
         // Add the DOI in the record
-        Element recordWithDoi = setDOIValue(doiInfo.get("doiUrl"), metadata.getDataInfo().getSchemaId(), metadata.getXmlData(false));
+        Element recordWithDoi = setDOIValue(doiInfo.get("doi"), metadata.getDataInfo().getSchemaId(), metadata.getXmlData(false));
         // Update the published copy
         //--- needed to detach md from the document
 //        md.detach();
@@ -443,6 +442,7 @@ public class DoiManager {
 
         Map<String, Object> params = new HashMap<>(1);
         params.put("doi", doi);
+        params.put("doiProxy", DOI_PROXY_URL);
         return Xml.transform(md, styleSheet, params);
     }
 

--- a/doi/src/main/java/org/fao/geonet/doi/client/DoiSettings.java
+++ b/doi/src/main/java/org/fao/geonet/doi/client/DoiSettings.java
@@ -28,6 +28,8 @@ package org.fao.geonet.doi.client;
 public class DoiSettings {
     public static final String SETTING_PUBLICATION_DOI_DOIURL =
         "system/publication/doi/doiurl";
+    public static final String SETTING_PUBLICATION_DOI_DOIPUBLICURL =
+        "system/publication/doi/doipublicurl";
     public static final String SETTING_PUBLICATION_DOI_DOIUSERNAME =
         "system/publication/doi/doiusername";
     public static final String SETTING_PUBLICATION_DOI_DOIPASSWORD =

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/process/doi-add.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/process/doi-add.xsl
@@ -16,6 +16,8 @@
 
   <xsl:param name="doi"
              select="''"/>
+  <xsl:param name="doiProxy"
+             select="'https://www.doi.org/'"/>
   <xsl:variable name="doiProtocol"
                 select="'DOI'"/>
   <xsl:variable name="doiName"
@@ -49,7 +51,7 @@
       <cit:identifier>
         <mcc:MD_Identifier>
           <mcc:code>
-            <gcx:Anchor xlink:href="{$doi}">
+            <gcx:Anchor xlink:href="{concat($doiProxy, $doi)}">
               <xsl:value-of select="$doi"/>
             </gcx:Anchor>
           </mcc:code>
@@ -89,7 +91,7 @@
             <mrd:onLine>
               <cit:CI_OnlineResource>
                 <cit:linkage>
-                  <gco:CharacterString><xsl:value-of select="$doi"/></gco:CharacterString>
+                  <gco:CharacterString><xsl:value-of select="concat($doiProxy, $doi)"/></gco:CharacterString>
                 </cit:linkage>
                 <cit:protocol>
                   <gco:CharacterString><xsl:value-of select="$doiProtocol"/></gco:CharacterString>

--- a/schemas/iso19139/src/main/plugin/iso19139/process/doi-add.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/process/doi-add.xsl
@@ -17,6 +17,8 @@
 
   <xsl:param name="doi"
              select="''"/>
+  <xsl:param name="doiProxy"
+             select="'https://www.doi.org/'"/>
   <xsl:param name="doiProtocolRegex"
              select="'(DOI|WWW:LINK-1.0-http--metadata-URL)'"/>
 
@@ -52,7 +54,7 @@
       <gmd:identifier>
         <gmd:MD_Identifier>
           <gmd:code>
-            <gmx:Anchor xlink:href="{$doi}">
+            <gmx:Anchor xlink:href="{concat($doiProxy, $doi)}">
               <xsl:value-of select="$doi"/>
             </gmx:Anchor>
 <!--            <gco:CharacterString><xsl:value-of select="$doi"/></gco:CharacterString>-->
@@ -92,7 +94,7 @@
             <gmd:onLine>
               <gmd:CI_OnlineResource>
                 <gmd:linkage>
-                  <gmd:URL><xsl:value-of select="$doi"/></gmd:URL>
+                  <gmd:URL><xsl:value-of select="concat($doiProxy, $doi)"/></gmd:URL>
                 </gmd:linkage>
                 <gmd:protocol>
                   <gco:CharacterString><xsl:value-of select="$doiProtocol"/></gco:CharacterString>

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -767,6 +767,8 @@
     "system/publication": "Publication",
     "system/publication/doi/doienabled": "Allow creation of Digital Object Identifier (DOI)",
     "system/publication/doi/doienabled-help": "A Digital Object Identifier (DOI) is an alphanumeric string assigned to uniquely identify an object. It is tied to a metadata description of the object as well as to a digital location, such as a URL, where all the details about the object are accessible. More information available on <a href='https://www.datacite.org/dois.html'>DataCite website</a>.",
+    "system/publication/doi/doipublicurl": "The final DOI URL prefix",
+    "system/publication/doi/doipublicurl-help": "Keep it empty to use the default https://doi.org prefix. Use https://mds.test.datacite.org/doi when using the test API.",
     "system/publication/doi/doiurl": "The DataCite API endpoint",
     "system/publication/doi/doiurl-help": "Usually https://mds.datacite.org or https://mds.test.datacite.org for testing.",
     "system/publication/doi/doiusername": "Your DataCite username",

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
@@ -700,6 +700,7 @@ INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system
 INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALUES ('system/publication/doi/doipassword', '', 0, 100194, 'y', 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/publication/doi/doikey', '', 0, 110095, 'n');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/publication/doi/doilandingpagetemplate', 'http://localhost:8080/geonetwork/srv/resources/records/{{uuid}}', 0, 100195, 'n');
+INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/publication/doi/doipublicurl', '', 0, 100196, 'n');
 
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/security/passwordEnforcement/minLength', '6', 1, 12000, 'n');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/security/passwordEnforcement/maxLength', '20', 1, 12001, 'n');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v406/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v406/migrate-default.sql
@@ -1,5 +1,6 @@
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/inspire/remotevalidation/nodeid', '', 0, 7212, 'n');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/inspire/remotevalidation/apikey', '', 0, 7213, 'y');
+INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/publication/doi/doipublicurl', '', 0, 100196, 'n');
 
 DELETE FROM Settings WHERE name = 'system/server/securePort';
 


### PR DESCRIPTION
Update the code to use the DOI proxy url (https://doi.org/) or the value of new `system/publication/doi/doipublicurl` setting if defined for the DOI resource in the metadata:

```
<gmd:identifier>
  <gmd:MD_Identifier>
    <gmd:code>
      <gmx:Anchor xlink:href="ValueOf('system/publication/doi/doipublicurl'|https:/doi.org)/DOI-PREFIX/DOI">
        DOI-PREFIX/DOI
      </gmx:Anchor>
    </gmd:code>
  </gmd:MD_Identifier>
</gmd:identifier>
...
<gmd:onLine>
  <gmd:CI_OnlineResource>
    <gmd:linkage>
      <gmd:URL>ValueOf('system/publication/doi/doipublicurl'|https:/doi.org)/DOI-PREFIX/DOI</gmd:URL>
    </gmd:linkage>
    <gmd:protocol>
```