### PR TITLE
Fix the metadata full view formatter url

### DIFF
--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -546,7 +546,7 @@ goog.require('gn_alert');
               'url' : ''
             }, {
               'label': 'full',
-              'url' : '/formatters/xsl-view?root=div&view=xml'
+              'url' : '/formatters/xsl-view?root=div&view=advanced'
             }]
           },
           'downloadFormatter': [{


### PR DESCRIPTION
The code added in https://github.com/geonetwork/core-geonetwork/pull/5820 uses the xml formatter for the full view, this seem not correct as the UI doesn't show correctly the metadata information when selecting the Full view in the metadata detail page.