### PR TITLE
Fix bug with Keycloak backchannel logout not working due to CSRF issue.

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/security/keycloak/keycloakPreAuthActionsLoginFilter.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/keycloak/keycloakPreAuthActionsLoginFilter.java
@@ -25,6 +25,7 @@ package org.fao.geonet.kernel.security.keycloak;
 
 import org.fao.geonet.Constants;
 import org.keycloak.adapters.spi.UserSessionManagement;
+import org.keycloak.adapters.springsecurity.filter.KeycloakCsrfRequestMatcher;
 import org.keycloak.adapters.springsecurity.filter.KeycloakPreAuthActionsFilter;
 import org.keycloak.constants.AdapterConstants;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -32,6 +33,7 @@ import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.web.authentication.LoginUrlAuthenticationEntryPoint;
+import org.springframework.security.web.csrf.CsrfFilter;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
@@ -50,6 +52,13 @@ public class keycloakPreAuthActionsLoginFilter extends KeycloakPreAuthActionsFil
 
     public keycloakPreAuthActionsLoginFilter(UserSessionManagement userSessionManagement) {
         super(userSessionManagement);
+    }
+
+    public keycloakPreAuthActionsLoginFilter(UserSessionManagement userSessionManagement, CsrfFilter csrfFilter) {
+        super(userSessionManagement);
+        // Set the csrf filter request matcher for Keycloak so that it allows k_* endpoints to be reached without CSRF.
+        // Without this fix, the backchannel logout was not working due to CSRF failures.
+        csrfFilter.setRequireCsrfProtectionMatcher(new KeycloakCsrfRequestMatcher());
     }
 
     @Override

--- a/web/src/main/webapp/WEB-INF/config-security/config-security-keycloak.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-keycloak.xml
@@ -78,6 +78,7 @@
   </bean>
   <bean id="keycloakPreAuthActionsLoginFilter" class="org.fao.geonet.kernel.security.keycloak.keycloakPreAuthActionsLoginFilter" >
       <constructor-arg ref="userSessionManagement" />
+      <constructor-arg ref="csrfFilter" />
   </bean>
   <bean id="keycloakAuthenticationProcessingFilter" class="org.fao.geonet.kernel.security.keycloak.KeycloakAuthenticationProcessingFilter" depends-on="keycloakUtil">
     <constructor-arg name="authenticationManager" ref="authenticationManager" />


### PR DESCRIPTION
Keycloak backchannel logout was not working due CSRF issue.

This PR fixes the issue by registering the keycloak endpoints to the CSRF bean.

Please backport to 3.12.x