### PR TITLE
URL rewrite / Make "/geonetwork?uuid=..." links work again

### DIFF
--- a/web/src/main/webResources/WEB-INF/urlrewrite.xml
+++ b/web/src/main/webResources/WEB-INF/urlrewrite.xml
@@ -132,7 +132,14 @@
     <to type="permanent-redirect">%{context-path}/#/page/$2?page=$2</to>
   </rule>
 
-
+  <rule>
+    <note>
+      Redirects to hash with metadata
+      Example URL: http://localhost:8080/geonetwork?uuid=da165110-88fd-11da-a88f-000d939bc5d8
+    </note>
+    <from>^/(.*)/catalog.search\?.*uuid=(.*)</from>
+    <to type="permanent-redirect">%{context-path}/#/metadata/$2</to>
+  </rule>
 
   <rule>
     <note>


### PR DESCRIPTION
Links such as http://localhost:8080/geonetwork?uuid=aaa-bbb-ccc were not redirecting anymore to http://localhost:8080/geonetwork/srv/fre/catalog.search#/metadata/aaa-bbb-ccc. This is fixed by this PR.