### PR TITLE
Users form - add button to toggle password fields visibility

### DIFF
--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -1738,4 +1738,43 @@
       }
     };
   });
+
+  /**
+   * @ngdoc directive
+   * @name gn_utility.directive:gnHideShowPassword
+   *
+   * @description
+   * Toggles the visibility of a  related input password field.
+   * To be used in input type=password fields and display a button
+   * to toggle the visibility of the password field.
+   *
+   */
+  module.directive('gnHideShowPassword', function() {
+    return {
+      restrict: 'E',
+      replace: true,
+      scope: {
+        inputId: '@'
+      },
+      templateUrl: '../../catalog/components/utility/' +
+        'partials/hideshowpassword.html',
+      link: function (scope) {
+        scope.showHideClass = 'fa fa-eye-slash';
+
+        scope.hideShowPassword = function(){
+          var target = $('#' + scope.inputId)[0];
+
+          if(target != null) {
+            if(target.type == 'password') {
+              target.type = 'text';
+              scope.showHideClass = 'fa fa-eye-slash';
+            } else {
+              target.type = 'password';
+              scope.showHideClass = 'fa fa-eye';
+            }
+          }
+        };
+      }
+    };
+  });
 })();

--- a/web-ui/src/main/resources/catalog/components/utility/partials/hideshowpassword.html
+++ b/web-ui/src/main/resources/catalog/components/utility/partials/hideshowpassword.html
@@ -1,0 +1,5 @@
+<span class="input-group-addon">
+  <span class="{{showHideClass}}"
+        style="cursor:pointer"
+        data-ng-click="hideShowPassword()"></span>
+</span>

--- a/web-ui/src/main/resources/catalog/components/utility/partials/hideshowpassword.html
+++ b/web-ui/src/main/resources/catalog/components/utility/partials/hideshowpassword.html
@@ -1,5 +1,4 @@
-<span class="input-group-addon">
-  <span class="{{showHideClass}}"
-        style="cursor:pointer"
-        data-ng-click="hideShowPassword()"></span>
+<span class="input-group-btn">
+  <button type="button" class="btn btn-default {{showHideClass}}"
+        data-ng-click="hideShowPassword()"></button>
 </span>

--- a/web-ui/src/main/resources/catalog/templates/admin/usergroup/users.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/usergroup/users.html
@@ -124,14 +124,19 @@
                 class="form-group">
                 <label class="control-label col-sm-3" data-translate="">password</label>
                 <div class="col-sm-9">
-                  <input type="password" id="gn-user-password" name="password"
-                         class="form-control"
-                         data-ng-minlength="{{passwordMinLength}}"
-                         data-ng-maxlength="{{passwordMaxLength}}"
-                         data-ng-required="true"
-                         data-ng-pattern="passwordPattern"
-                         data-ng-model="userSelected.password"
-                         autocomplete="off"/>
+                  <div class="input-group">
+                    <input type="password" id="gn-user-password" name="password"
+                           class="form-control"
+                           data-ng-minlength="{{passwordMinLength}}"
+                           data-ng-maxlength="{{passwordMaxLength}}"
+                           data-ng-required="true"
+                           data-ng-pattern="passwordPattern"
+                           data-ng-model="userSelected.password"
+                           autocomplete="off"/>
+
+                    <gn-hide-show-password input-id="gn-user-password"></gn-hide-show-password>
+                  </div>
+
                   <p class="help-block">
                     <div class="error" data-ng-show="gnUserEdit.password.$error.minlength && !gnUserInfo.password.$pristine"
                          data-translate="passwordMinlength" data-translate-value-length="{{passwordMinLength}}"></div>
@@ -149,10 +154,14 @@
                   (passwordCheck !== userSelected.password) ? 'has-error' : ''" class="form-group">
                 <label class="control-label col-sm-3" data-translate="">passwordRepeat</label>
                 <div class="col-sm-9">
-                  <input type="password" id="gn-user-password2" name="password2"
-                         class="form-control"
-                         autocomplete="off"
-                         data-ng-model="passwordCheck"/>
+                  <div class="input-group">
+                    <input type="password" id="gn-user-password2" name="password2"
+                           class="form-control"
+                           autocomplete="off"
+                           data-ng-model="passwordCheck"/>
+
+                    <gn-hide-show-password input-id="gn-user-password2"></gn-hide-show-password>
+                  </div>
                   <p class="help-block">
                     <span class="error"
                           data-ng-show="gnUserEdit.password.$valid
@@ -376,23 +385,33 @@
                  data-ng-class="gnPasswordReset.passwordOld.$error.required ? 'has-error' : ''">
               <label class="control-label col-sm-3" data-translate="">passwordOld</label>
               <div class="col-sm-9">
-                <input type="password" id="gn-user-password-old" name="passwordOld"
-                       class="form-control" autocomplete="off"
-                       data-ng-required="true"
-                       data-ng-model="resetPasswordOld"/>
+                <div class="input-group">
+                  <input type="password" id="gn-user-password-old" name="passwordOld"
+                         class="form-control" autocomplete="off"
+                         data-ng-required="true"
+                         data-ng-model="resetPasswordOld"/>
+
+                  <gn-hide-show-password input-id="gn-user-password-old"></gn-hide-show-password>
+                </div>
+
               </div>
             </div>
             <div class="form-group"
                  data-ng-class="gnPasswordReset.password.$error.required || gnPasswordReset.password.$error.minlength ? 'has-error' : ''">
               <label class="control-label col-sm-3" data-translate="">password</label>
               <div class="col-sm-9">
-                <input type="password" id="gn-user-password" name="password"
-                       class="form-control" autocomplete="off"
-                       data-ng-minlength="{{passwordMinLength}}"
-                       data-ng-maxlength="{{passwordMaxLength}}"
-                       data-ng-required="true"
-                       data-ng-model="resetPassword1"
-                       data-ng-pattern="passwordPattern" />
+                <div class="input-group">
+                  <input type="password" id="gn-user-password" name="password"
+                         class="form-control" autocomplete="off"
+                         data-ng-minlength="{{passwordMinLength}}"
+                         data-ng-maxlength="{{passwordMaxLength}}"
+                         data-ng-required="true"
+                         data-ng-model="resetPassword1"
+                         data-ng-pattern="passwordPattern" />
+
+                  <gn-hide-show-password input-id="gn-user-password"></gn-hide-show-password>
+                </div>
+
                 <p class="help-block">
                   <div class="error" data-ng-show="gnPasswordReset.password.$error.minlength && !gnPasswordReset.password.$pristine"
                        data-translate="passwordMinlength" data-translate-value-length="{{passwordMinLength}}"></div>
@@ -410,10 +429,16 @@
                       (resetPassword2 !== resetPassword1) ? 'has-error' : ''">
               <label class="control-label col-sm-3" data-translate="">passwordRepeat</label>
               <div class="col-sm-9">
-                <input type="password" id="gn-user-password2"
-                       name="password2" class="form-control"
-                       autocomplete="off"
-                       data-ng-model="resetPassword2"/>
+                <div class="input-group">
+                  <input type="password" id="gn-user-password2"
+                         name="password2" class="form-control"
+                         autocomplete="off"
+                         data-ng-model="resetPassword2"/>
+
+                  <gn-hide-show-password input-id="gn-user-password2"></gn-hide-show-password>
+                </div>
+
+
                 <p class="help-block">
                   <span class="error"
                         data-ng-show="gnPasswordReset.password.$valid


### PR DESCRIPTION
Add a button to toggle the visibility of the user password in the users create and reset password forms, to facilitate the configuration of the user password.

![users-password](https://user-images.githubusercontent.com/1695003/151715899-142e235d-d015-4dca-8004-4d87f5fe3f8a.png)
