### PR TITLE
Metadata publish - check if the metadata owner group has the workflow enabled

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/MetadataSharingApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataSharingApi.java
@@ -413,7 +413,8 @@ public class MetadataSharingApi {
 
                 if (isGroupWithEnabledWorkflow) {
                     MetadataStatus mdStatus = metadataStatus.getStatus(metadata.getId());
-                    if (mdStatus.getStatusValue().getId() == Integer.parseInt(StatusValue.Status.RETIRED)) {
+                    if ((mdStatus != null) &&
+                        (mdStatus.getStatusValue().getId() == Integer.parseInt(StatusValue.Status.RETIRED))) {
                         List<GroupOperations> allGroupOps =
                             privileges.stream().filter(p -> p.getGroup() == ReservedGroup.all.getId()).collect(Collectors.toList());
 

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataSharingApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataSharingApi.java
@@ -55,6 +55,7 @@ import org.fao.geonet.kernel.setting.Settings;
 import org.fao.geonet.repository.*;
 import org.fao.geonet.repository.specification.MetadataValidationSpecs;
 import org.fao.geonet.repository.specification.UserGroupSpecs;
+import org.fao.geonet.util.WorkflowUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationContext;
@@ -403,19 +404,26 @@ public class MetadataSharingApi {
 
             boolean isMdWorkflowEnable = sm.getValueAsBool(Settings.METADATA_WORKFLOW_ENABLE);
 
+            Integer groupOwnerId = metadata.getSourceInfo().getGroupOwner();
+
             // Check not trying to publish a retired metadata
-            if (isMdWorkflowEnable) {
-                MetadataStatus mdStatus = metadataStatus.getStatus(metadata.getId());
-                if (mdStatus.getStatusValue().getId() == Integer.parseInt(StatusValue.Status.RETIRED)) {
-                    List<GroupOperations> allGroupOps =
-                        privileges.stream().filter(p -> p.getGroup() == ReservedGroup.all.getId()).collect(Collectors.toList());
+            if (isMdWorkflowEnable && (groupOwnerId != null)) {
+                java.util.Optional<Group> groupOwner = groupRepository.findById(groupOwnerId);
+                boolean isGroupWithEnabledWorkflow = WorkflowUtil.isGroupWithEnabledWorkflow(groupOwner.get().getName());
 
-                    for (GroupOperations p : allGroupOps) {
-                        if (p.getOperations().containsValue(true)) {
-                            throw new Exception(String.format("Retired metadata %s can't be published.",
-                                metadata.getUuid()));
+                if (isGroupWithEnabledWorkflow) {
+                    MetadataStatus mdStatus = metadataStatus.getStatus(metadata.getId());
+                    if (mdStatus.getStatusValue().getId() == Integer.parseInt(StatusValue.Status.RETIRED)) {
+                        List<GroupOperations> allGroupOps =
+                            privileges.stream().filter(p -> p.getGroup() == ReservedGroup.all.getId()).collect(Collectors.toList());
+
+                        for (GroupOperations p : allGroupOps) {
+                            if (p.getOperations().containsValue(true)) {
+                                throw new Exception(String.format("Retired metadata %s can't be published.",
+                                    metadata.getUuid()));
+                            }
+
                         }
-
                     }
                 }
             }


### PR DESCRIPTION
With the workflow enabled for certain groups, when trying to publish a metadata that is in a group that doesn't have the workflow enabled a `NullPointerException` is thrown when the publication code tries to check if the metadata status is `Retired`. Related to https://github.com/geonetwork/core-geonetwork/pull/5943.

Test case:

1) Enable the workflow for certain groups
2) Create a metadata in a group that doesn't have the workflow enabled
3) Publish the metadata --> An error is displayed with the message  `NullPointerException`.