### PR TITLE
Metadata detail page - fix trigger metadata tab selection

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/RelatedObserverDirective.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/RelatedObserverDirective.js
@@ -78,6 +78,11 @@
           this.scope.gnRelatedLoadFinished = true;
           if (!this.scope.relatedsFound) {
             this.rootScope.$broadcast('tabChangeRequested', 'general');
+          } else {
+            // Issue the event to update the proper tab if the user requested
+            // a different tab in the url, for example:
+            // /metadata/UUID?tab=contact
+            this.rootScope.$broadcast('tabChangeRequested', 'relations');
           }
         }
       };


### PR DESCRIPTION
A test case:

1) Use a custom view that uses tabs in the metadata detail page, like: https://github.com/osgeonl/geonetwork-dutch-skin
2) Create a metadata with online resources
3) Request the metadata detail page:

http://localhost:8080/geonetwork/srv/eng/catalog.search?#/metadata/UUID?tab=contact

With the previous code, the tab for downloads was selected by default, ignoring the parameter `tab` to select the tab with the contact details.