### PR TITLE
Use typeNames in the WFS URL when version is >= "2.0.0"

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -1300,15 +1300,24 @@
 
                   var parts = url.split('?');
 
+                  var parametersMap = {
+                    service: 'WFS',
+                    request: 'GetFeature',
+                    version: getCapLayer.version,
+                    srsName: map.getView().getProjection().getCode(),
+                    bbox: extent.join(',')
+                  };
+
+                  if (parametersMap.version < "2.0.0") {
+                    parametersMap.typeName = getCapLayer.name.prefix + ':' +
+                      getCapLayer.name.localPart;
+                  } else {
+                    parametersMap.typeNames = getCapLayer.name.prefix + ':' +
+                      getCapLayer.name.localPart;
+                  }
+
                   var urlGetFeature = gnUrlUtils.append(parts[0],
-                      gnUrlUtils.toKeyValue({
-                        service: 'WFS',
-                        request: 'GetFeature',
-                        version: getCapLayer.version,
-                        srsName: map.getView().getProjection().getCode(),
-                        bbox: extent.join(','),
-                        typename: getCapLayer.name.prefix + ':' +
-                                   getCapLayer.name.localPart}));
+                      gnUrlUtils.toKeyValue(parametersMap));
 
                   //Fix, ArcGIS fails if there is a bbox:
                   if(getCapLayer.version == '1.1.0') {
@@ -1318,7 +1327,7 @@
                           request: 'GetFeature',
                           version: getCapLayer.version,
                           srsName: map.getView().getProjection().getCode(),
-                          typename: getCapLayer.name.prefix + ':' +
+                          typeName: getCapLayer.name.prefix + ':' +
                                      getCapLayer.name.localPart}));
                   }
 

--- a/web-ui/src/main/resources/catalog/components/viewer/wfs/WfsService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wfs/WfsService.js
@@ -127,9 +127,15 @@
             request: 'GetFeature',
             service: 'WFS',
             version: version || defaultVersion,
-            typeName: typename,
             outputFormat: format
           };
+
+          if (params.version < "2.0.0") {
+            params.typeName = typename;
+          } else {
+            params.typeNames = typename;
+          }
+
           if (extent) {
             params.bbox = extent;
           }


### PR DESCRIPTION
* In the Related resources Download button for WFS online resources use `typeNames`
instead of `typeName` if the service version is >= "2.0.0"
* Apply this fix to the WFS layer loader in the map too.

Fixes #6087 (https://github.com/geonetwork/core-geonetwork/issues/6087).
