### PR TITLE
Update transfer ownership to handle when the metadata workflow is enabled the approved version of the metadata with a working copy

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/MetadataSharingApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataSharingApi.java
@@ -53,6 +53,7 @@ import org.fao.geonet.kernel.datamanager.*;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.kernel.setting.Settings;
 import org.fao.geonet.repository.*;
+import org.fao.geonet.repository.specification.MetadataSpecs;
 import org.fao.geonet.repository.specification.MetadataValidationSpecs;
 import org.fao.geonet.repository.specification.UserGroupSpecs;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -743,8 +744,8 @@ public class MetadataSharingApi {
             List<String> listOfUpdatedRecords = new ArrayList<>();
             for (String uuid : records) {
                 updateOwnership(groupIdentifier, userIdentifier,
-                    report, dataManager, accessManager, metadataRepository,
-                    serviceContext, listOfUpdatedRecords, uuid, session, approved);
+                    report, dataManager, accessManager,
+                    serviceContext, listOfUpdatedRecords, uuid, session);
             }
             dataManager.flush();
             dataManager.indexMetadata(listOfUpdatedRecords);
@@ -808,13 +809,11 @@ public class MetadataSharingApi {
         try {
             report.setTotalRecords(1);
 
-            final ApplicationContext context = ApplicationContextHolder.get();
-
             ServiceContext serviceContext = ApiUtils.createServiceContext(request);
             List<String> listOfUpdatedRecords = new ArrayList<>();
             updateOwnership(groupIdentifier, userIdentifier,
-                report, dataManager, accessManager, metadataRepository,
-                serviceContext, listOfUpdatedRecords, metadataUuid, session, approved);
+                report, dataManager, accessManager,
+                serviceContext, listOfUpdatedRecords, metadataUuid, session);
             dataManager.flush();
             dataManager.indexMetadata(String.valueOf(metadata.getId()), true);
 
@@ -831,10 +830,9 @@ public class MetadataSharingApi {
                                  MetadataProcessingReport report,
                                  DataManager dataManager,
                                  AccessManager accessMan,
-                                 MetadataRepository metadataRepository,
                                  ServiceContext serviceContext,
                                  List<String> listOfUpdatedRecords, String uuid,
-                                 HttpSession session, Boolean approved) throws Exception {
+                                 HttpSession session) throws Exception {
         AbstractMetadata metadata = metadataUtils.findOneByUuid(uuid);
         if (metadata == null) {
             report.incrementNullRecords();
@@ -842,63 +840,79 @@ public class MetadataSharingApi {
             serviceContext, String.valueOf(metadata.getId()))) {
             report.addNotEditableMetadataId(metadata.getId());
         } else {
-            //-- Get existing owner and privileges for that owner - note that
-            //-- owners don't actually have explicit permissions - only their
-            //-- group does which is why we have an ownerGroup (parameter groupid)
-            Integer sourceUsr = metadata.getSourceInfo().getOwner();
-            Integer sourceGrp = metadata.getSourceInfo().getGroupOwner();
-            Vector<OperationAllowedId> sourcePriv =
-                retrievePrivileges(serviceContext, String.valueOf(metadata.getId()), sourceUsr, sourceGrp);
+            // Retrieve the identifiers associated with the metadata uuid.
+            // When the workflow is enabled, the metadata can have an approved and a working copy version.
+            List<Integer> idList = metadataUtils.findAllIdsBy(MetadataSpecs.hasMetadataUuid(uuid));
 
-            // -- Set new privileges for new owner from privileges of the old
-            // -- owner, if none then set defaults
-            if (sourcePriv.size() == 0) {
-                dataManager.copyDefaultPrivForGroup(
-                    serviceContext,
-                    String.valueOf(metadata.getId()),
-                    String.valueOf(groupIdentifier),
-                    false);
-                report.addMetadataInfos(metadata, String.format(
-                    "No privileges for user '%s' on metadata '%s', so setting default privileges",
-                    sourceUsr, metadata.getUuid()
-                ));
-            } else {
-                for (OperationAllowedId priv : sourcePriv) {
-                    if (sourceGrp != null) {
-                        dataManager.unsetOperation(serviceContext,
+            // Increase the total records counter when processing a metadata with approved and working copies
+            // as the initial counter doesn't take in account this case
+            if (idList.size() > 1) {
+                report.setTotalRecords(report.getNumberOfRecords() + 1);
+            }
+
+            for(Integer mdId : idList) {
+                if (mdId != metadata.getId()) {
+                    metadata = metadataUtils.findOne(mdId);
+                }
+
+                //-- Get existing owner and privileges for that owner - note that
+                //-- owners don't actually have explicit permissions - only their
+                //-- group does which is why we have an ownerGroup (parameter groupid)
+                Integer sourceUsr = metadata.getSourceInfo().getOwner();
+                Integer sourceGrp = metadata.getSourceInfo().getGroupOwner();
+                Vector<OperationAllowedId> sourcePriv =
+                    retrievePrivileges(serviceContext, String.valueOf(metadata.getId()), sourceUsr, sourceGrp);
+
+                // -- Set new privileges for new owner from privileges of the old
+                // -- owner, if none then set defaults
+                if (sourcePriv.size() == 0) {
+                    dataManager.copyDefaultPrivForGroup(
+                        serviceContext,
+                        String.valueOf(metadata.getId()),
+                        String.valueOf(groupIdentifier),
+                        false);
+                    report.addMetadataInfos(metadata, String.format(
+                        "No privileges for user '%s' on metadata '%s', so setting default privileges",
+                        sourceUsr, metadata.getUuid()
+                    ));
+                } else {
+                    for (OperationAllowedId priv : sourcePriv) {
+                        if (sourceGrp != null) {
+                            dataManager.unsetOperation(serviceContext,
+                                metadata.getId(),
+                                sourceGrp,
+                                priv.getOperationId());
+                        }
+                        dataManager.setOperation(serviceContext,
                             metadata.getId(),
-                            sourceGrp,
+                            groupIdentifier,
                             priv.getOperationId());
                     }
-                    dataManager.setOperation(serviceContext,
-                        metadata.getId(),
-                        groupIdentifier,
-                        priv.getOperationId());
                 }
-            }
 
-            Long metadataId = Long.parseLong(ApiUtils.getInternalId(uuid, approved));
-            ApplicationContext context = ApplicationContextHolder.get();
-            if (!Objects.equals(groupIdentifier, sourceGrp)) {
-                Group newGroup = groupRepository.findById(groupIdentifier).get();
-                Group oldGroup = sourceGrp == null ? null : groupRepository.findById(sourceGrp).get();
-                new RecordGroupOwnerChangeEvent(metadataId,
-                    ApiUtils.getUserSession(session).getUserIdAsInt(),
-                    sourceGrp == null ? null : ObjectJSONUtils.convertObjectInJsonObject(oldGroup, RecordGroupOwnerChangeEvent.FIELD),
-                    ObjectJSONUtils.convertObjectInJsonObject(newGroup, RecordGroupOwnerChangeEvent.FIELD)).publish(context);
+                Long metadataId = Long.valueOf(metadata.getId());
+                ApplicationContext context = ApplicationContextHolder.get();
+                if (!Objects.equals(groupIdentifier, sourceGrp)) {
+                    Group newGroup = groupRepository.findById(groupIdentifier).get();
+                    Group oldGroup = sourceGrp == null ? null : groupRepository.findById(sourceGrp).get();
+                    new RecordGroupOwnerChangeEvent(metadataId,
+                        ApiUtils.getUserSession(session).getUserIdAsInt(),
+                        sourceGrp == null ? null : ObjectJSONUtils.convertObjectInJsonObject(oldGroup, RecordGroupOwnerChangeEvent.FIELD),
+                        ObjectJSONUtils.convertObjectInJsonObject(newGroup, RecordGroupOwnerChangeEvent.FIELD)).publish(context);
+                }
+                if (!Objects.equals(userIdentifier, sourceUsr)) {
+                    User newOwner = userRepository.findById(userIdentifier).get();
+                    User oldOwner = userRepository.findById(sourceUsr).get();
+                    new RecordOwnerChangeEvent(metadataId, ApiUtils.getUserSession(session).getUserIdAsInt(), ObjectJSONUtils.convertObjectInJsonObject(oldOwner, RecordOwnerChangeEvent.FIELD), ObjectJSONUtils.convertObjectInJsonObject(newOwner, RecordOwnerChangeEvent.FIELD)).publish(context);
+                }
+                // -- set the new owner into the metadata record
+                dataManager.updateMetadataOwner(metadata.getId(),
+                    String.valueOf(userIdentifier),
+                    String.valueOf(groupIdentifier));
+                report.addMetadataId(metadata.getId());
+                report.incrementProcessedRecords();
+                listOfUpdatedRecords.add(metadata.getId() + "");
             }
-            if (!Objects.equals(userIdentifier, sourceUsr)) {
-                User newOwner = userRepository.findById(userIdentifier).get();
-                User oldOwner = userRepository.findById(sourceUsr).get();
-                new RecordOwnerChangeEvent(metadataId, ApiUtils.getUserSession(session).getUserIdAsInt(), ObjectJSONUtils.convertObjectInJsonObject(oldOwner, RecordOwnerChangeEvent.FIELD), ObjectJSONUtils.convertObjectInJsonObject(newOwner, RecordOwnerChangeEvent.FIELD)).publish(context);
-            }
-            // -- set the new owner into the metadata record
-            dataManager.updateMetadataOwner(metadata.getId(),
-                String.valueOf(userIdentifier),
-                String.valueOf(groupIdentifier));
-            report.addMetadataId(metadata.getId());
-            report.incrementProcessedRecords();
-            listOfUpdatedRecords.add(metadata.getId() + "");
         }
     }
 


### PR DESCRIPTION
Similar to the changes done in https://github.com/geonetwork/core-geonetwork/pull/5811, but for transfer ownership.

When the workflow is enabled the transfer ownership works fine in these cases:

- records are in draft
- records approved without working copy

But it's not working fine If the metadata is approved and has a working copy. In this case it's processing all the records, but updating only the working copy version, not the approved version.

This PR updates the transfer ownership API to handle both versions of the metadata. For now, in the total number of records are counted the approved and draft versions. This is something to improve in the report, but will require some refactor of the current report.

---

Test case:

1. On a published record, create and save a working copy.
2. in the editor board, select the record
3. Hit the Selected Button and choose Transfer Ownership
4. Choose any user to transfer ownership to

Without the change the UI displayed the old ownership.

With the changes the ownership is updated for the approved and working copy.