### PR TITLE
Editor / Avoid conflicts between ID and UUID when editing records

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadatamanager/EditorService.js
+++ b/web-ui/src/main/resources/catalog/components/metadatamanager/EditorService.js
@@ -139,7 +139,7 @@
          return {
            buildEditUrlPrefix: function(service) {
              var params = ['../api/records/',
-               gnCurrentEdit.id, '/', service, '?'];
+               gnCurrentEdit.metadata.uuid, '/', service, '?'];
              gnCurrentEdit.tab ?
              params.push('&currTab=', gnCurrentEdit.tab) :
              params.push('&currTab=', 'default');

--- a/web-ui/src/main/resources/catalog/js/edit/EditorController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/EditorController.js
@@ -161,9 +161,12 @@
             $http.post('../api/search/records/_search', {"query": {
                 "bool" : {
                   "must": [
-                    {"multi_match": {
+                    {
+                      "multi_match": {
                         "query": $routeParams.id,
-                        "fields": ['id', 'uuid']}},
+                        "fields": ['id^2', 'uuid']
+                      }
+                    },
                     {"terms": {"draft": ["n", "y", "e"]}},
                     {"terms": {"isTemplate": ["n", "y", "s"]}}
                   ]


### PR DESCRIPTION
This PR intends to fix conflicts in catalogs which contain records with integer UUIDs.

### Example
* record A has UUID `ABC-DEF` and ID `123`
* record B has UUID `123` and ID `6789`
* when opening the editor for record A with the URL `/geonetwork/srv/fre/catalog.edit#/metadata/123`, the editor form will actually contain record B's fields.

Granted, `123` does not really feel _unique_ (as in UUID), but it is a valid use case nonetheless.

What this PR does:
* boot the ES query on the `id` field to preferably match records based on ID instead of UUID (for retrocompatibility reasons)
* use the fact that `00000123` will be cast to `123` when comparing IDs, but will stay as `00000123` when comparing UUIDs.