### PR TITLE
doi prefix with slash

### DIFF
--- a/doi/src/main/java/org/fao/geonet/doi/client/DoiBuilder.java
+++ b/doi/src/main/java/org/fao/geonet/doi/client/DoiBuilder.java
@@ -34,6 +34,7 @@ public class DoiBuilder {
      * @return
      */
     public static String create(String prefix, String metadataUuid) {
-        return prefix + "/" + metadataUuid;
+        String sep = prefix.indexOf("/") > -1 ? "" : "/";
+        return prefix + sep + metadataUuid;
     }
 }


### PR DESCRIPTION
this proposal is made to verify if the doi prefix has a slash, if so do not add another one

our organization wants to have doi like: doi.org/10.1000/example.{uuid}

so our prefix in settings is 10.1000/example.

this patch prevents another slash to be added (not allowed by doi)