### PR TITLE
Metadata status dialog - disable button until receiving the current metadata status value

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionsDirective.js
@@ -63,7 +63,7 @@
           scope.statusType = scope.statusType || defaultType;
           scope.lang = scope.$parent.lang;
           scope.task = angular.isDefined(scope.task) ? scope.task : scope.$parent.task;
-          scope.newStatus = {status: scope.task ? scope.task.id : 0, owner: null, dueDate: null, changeMessage: ''};
+          scope.newStatus = {status: scope.task ? scope.task.id : -1, owner: null, dueDate: null, changeMessage: ''};
 
 
           // Retrieve last status to set it in the form

--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/statusupdater.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/statusupdater.html
@@ -16,7 +16,7 @@
           data-icon-only="true"
           class="pull-left"></div>
       <div class="btn-toolbar pull-right">
-        <button class="btn btn-default" data-ng-disabled="newStatus.status == 0"
+        <button class="btn btn-default" data-ng-disabled="newStatus.status == -1"
                 data-gn-click-and-spin="updateStatus()">
           {{"mdStatusButton-" + statusToSelect | translate}}
         </button>
@@ -61,7 +61,7 @@
                   data-ng-model="newStatus.changeMessage"></textarea>
       </div>
 
-      <button class="btn btn-default" data-ng-disabled="newStatus.status == 0"
+      <button class="btn btn-default" data-ng-disabled="newStatus.status == -1"
               data-gn-click-and-spin="updateStatus()">
         <i class="fa fa-mail-forward"></i>&nbsp;
         <span data-translate="">triggerTask</span>

--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/statusupdater.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/statusupdater.html
@@ -16,7 +16,7 @@
           data-icon-only="true"
           class="pull-left"></div>
       <div class="btn-toolbar pull-right">
-        <button class="btn btn-default"
+        <button class="btn btn-default" data-ng-disabled="newStatus.status == 0"
                 data-gn-click-and-spin="updateStatus()">
           {{"mdStatusButton-" + statusToSelect | translate}}
         </button>
@@ -61,7 +61,7 @@
                   data-ng-model="newStatus.changeMessage"></textarea>
       </div>
 
-      <button class="btn btn-default"
+      <button class="btn btn-default" data-ng-disabled="newStatus.status == 0"
               data-gn-click-and-spin="updateStatus()">
         <i class="fa fa-mail-forward"></i>&nbsp;
         <span data-translate="">triggerTask</span>


### PR DESCRIPTION
The dialog assigns a default status of `0` that is replaced when the current metadata status is received, but if this request takes a bit, the user can click the button to change the status, setting an invalid status to the metadata.

This pull request, disables the button until a valid value is received.