### PR TITLE
Export metadata as csv to download (not in browsing mode)

### DIFF
--- a/core/src/main/java/jeeves/server/dispatchers/ServiceManager.java
+++ b/core/src/main/java/jeeves/server/dispatchers/ServiceManager.java
@@ -1063,6 +1063,12 @@ public class ServiceManager {
                     guiServicesTimerContext.stop();
                 }
 
+                String documentName = guiElem.getChildText("documentFileName");
+                if (StringUtils.isNotBlank(documentName)) {
+                    SimpleDateFormat datetimeFormat = new SimpleDateFormat("yyyyMMddHHmmss");
+                    documentName = documentName.replace("{datetime}", datetimeFormat.format(Calendar.getInstance().getTime()));
+                }
+
                 addPrefixes(guiElem, context.getLanguage(), req.getService(), nodeInfo.getId());
 
                 Element rootElem = new Element(Jeeves.Elem.ROOT)
@@ -1117,10 +1123,15 @@ public class ServiceManager {
 
                                 if (outPage.getContentType() != null
                                     && outPage.getContentType().startsWith("text/plain")) {
-                                    req.beginStream(outPage.getContentType(), -1L, "attachment;", cache);
+                                    String contentDisposition = "";
+                                    if (StringUtils.isNotBlank(documentName)) {
+                                        contentDisposition = "filename="+documentName;
+                                    }
+                                    req.beginStream(outPage.getContentType(), -1L, "attachment;"+contentDisposition, cache);
                                 } else {
                                     req.beginStream(outPage.getContentType(), cache);
                                 }
+
                                 req.getOutputStream().write(baos.toByteArray());
                                 req.endStream();
                             }

--- a/services/src/main/java/org/fao/geonet/guiservices/util/GetCsvFileName.java
+++ b/services/src/main/java/org/fao/geonet/guiservices/util/GetCsvFileName.java
@@ -1,0 +1,20 @@
+package org.fao.geonet.guiservices.util;
+
+import jeeves.interfaces.Service;
+import jeeves.server.ServiceConfig;
+import jeeves.server.context.ServiceContext;
+import org.jdom.Element;
+
+import java.nio.file.Path;
+
+public class GetCsvFileName implements Service {
+    @Override
+    public void init(Path appPath, ServiceConfig params) throws Exception {
+
+    }
+
+    @Override
+    public Element exec(Element params, ServiceContext context) throws Exception {
+        return new Element("a").setText("metadata_{datetime}.csv");
+    }
+}

--- a/web/src/main/webapp/WEB-INF/config/config-service-csv.xml
+++ b/web/src/main/webapp/WEB-INF/config/config-service-csv.xml
@@ -28,7 +28,7 @@
     <service name="csv.search">
       <documentation><![CDATA[
         Search service returning results in CSV format.
-        
+
         Parameters:
         * Any search criteria supported by Lucene search service.
         ]]></documentation>
@@ -45,7 +45,9 @@
       <class name=".services.main.Result">
         <param name="range" value="all"/>
       </class>
-      <output sheet="../xslt/services/csv/csv-search.xsl" contentType="text/plain; charset=UTF-8"/>
+      <output sheet="../xslt/services/csv/csv-search.xsl" contentType="text/plain; charset=UTF-8">
+        <call name="documentFileName" class=".guiservices.util.GetCsvFileName"/>
+      </output>
       <error id="search-error" sheet="../xslt/common/error/error-xml.xsl" statusCode="500"/>
     </service>
 


### PR DESCRIPTION
The issue when export as csv

![image](https://user-images.githubusercontent.com/74916635/152576000-52da047b-f871-4d82-b4d7-4bb6311f3bb6.png)

The exported file was in browsing mode:
![image](https://user-images.githubusercontent.com/74916635/152576114-88dbc033-d047-4c89-8b13-9e8b2c13a2e9.png)

The user has to use browser's feature to download the file which defeats the purpose of "export". The fix is limited within 3.12 because main branch 4.0 contains different csv service module https://github.com/geonetwork/core-geonetwork/blob/368661c023a3c2648f709dfe284f3185c3bc661b/services/src/main/java/org/fao/geonet/api/records/CatalogApi.java#L465-L533 This feature is relative big and it's not backportable into 3.12. So this short quick fix applies to 3.12 only.