### PR TITLE
[FP] Support for non-editable settings

### DIFF
--- a/domain/src/main/java/org/fao/geonet/domain/Setting.java
+++ b/domain/src/main/java/org/fao/geonet/domain/Setting.java
@@ -67,6 +67,7 @@ public class Setting extends GeonetEntity {
     private int position = 0;
     private char internal = Constants.YN_TRUE;
     private char encrypted  = Constants.YN_FALSE;
+    private char editable = Constants.YN_TRUE;
 
     @Id
     @Column(name = "name", nullable = false, length = 255/* mysql cannot accept it any bigger if it is to be the id */)
@@ -202,6 +203,46 @@ public class Setting extends GeonetEntity {
         // Required to trigger PreUpdate event in  {@link org.fao.geonet.entitylistener.SettingEntityListenerManager},
         // otherwise doesn't work with transient properties
         this.setStoredValue(value);
+        return this;
+    }
+
+    /**
+     * For backwards compatibility we need the activated column to be either 'n' or 'y'. This is a
+     * workaround to allow this until future versions of JPA that allow different ways of
+     * controlling how types are mapped to the database.
+     */
+    @Column(name = "editable", nullable = false, length = 1, columnDefinition = "char default 'y'")
+    protected char getEditable_JpaWorkaround() {
+        return editable;
+    }
+
+    /**
+     * Set the column value. Constants.YN_ENABLED for true Constants.YN_DISABLED for false.
+     *
+     * @param editableValue the column value. Constants.YN_ENABLED for true Constants.YN_DISABLED
+     *                      for false.
+     */
+    protected void setEditable_JpaWorkaround(char editableValue) {
+        editable = editableValue;
+    }
+
+    /**
+     * Return true if the setting is editable in the administration UI.
+     *
+     * @return true if the setting is editable.
+     */
+    @Transient
+    public boolean isEditable() {
+        return Constants.toBoolean_fromYNChar(getEditable_JpaWorkaround());
+    }
+
+    /**
+     * Set true if the setting is private.
+     *
+     * @param editable true if the setting is private.
+     */
+    public Setting setEditable(boolean editable) {
+        setInternal_JpaWorkaround(Constants.toYN_EnabledChar(editable));
         return this;
     }
 

--- a/domain/src/main/java/org/fao/geonet/domain/SettingToObjectSerializer.java
+++ b/domain/src/main/java/org/fao/geonet/domain/SettingToObjectSerializer.java
@@ -45,6 +45,8 @@ public class SettingToObjectSerializer extends JsonSerializer<Setting> {
         jsonGenerator.writeStringField("name", s.getName());
         jsonGenerator.writeStringField("dataType", s.getDataType() == null ? null : s.getDataType().name());
         jsonGenerator.writeNumberField("position", s.getPosition());
+        jsonGenerator.writeBooleanField("internal", s.isInternal());
+        jsonGenerator.writeBooleanField("editable", s.isEditable());
         jsonGenerator.writeFieldName("value");
         writeSettingValue(s, jsonGenerator);
         jsonGenerator.writeEndObject();

--- a/web-ui/src/main/resources/catalog/js/admin/SystemSettingsController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/SystemSettingsController.js
@@ -44,16 +44,14 @@
   });
 
   /**
-   * Filters internal settings used by GeoNetwork,
+   * Filters non-editable settings used by GeoNetwork,
    * not intended to be configured by the user.
    */
-  module.filter('hideGeoNetworkInternalSettings', function() {
+  module.filter('hideGeoNetworkNonEditableSettings', function() {
     return function(input) {
       var filtered = [];
-      var internal = ['system/userFeedback/lastNotificationDate',
-        'system/security/passwordEnforcement/pattern'];
       angular.forEach(input, function(el) {
-        if (internal.indexOf(el.name) === -1) {
+        if (el.editable === true) {
           filtered.push(el);
         }
       });

--- a/web-ui/src/main/resources/catalog/templates/admin/settings/system.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/settings/system.html
@@ -83,7 +83,7 @@
                      class="pull-right"></div>
               </legend>
               <!-- According to data type -->
-              <div data-ng-repeat="s in section2.children | hideLanguages | hideGeoNetworkInternalSettings | orderObjectBy:'position'"
+              <div data-ng-repeat="s in section2.children | hideLanguages | hideGeoNetworkNonEditableSettings | orderObjectBy:'position'"
                   data-ng-switch="s.dataType"
                   data-ng-if="s.name != ''">
 

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
@@ -609,7 +609,7 @@ INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/csw/transactionUpdateCreateXPath', 'true', 2, 1320, 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/userSelfRegistration/enable', 'false', 2, 1910, 'n');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/userFeedback/enable', 'false', 2, 1911, 'n');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/userFeedback/lastNotificationDate', '', 0, 1912, 'y');
+INSERT INTO Settings (name, value, datatype, position, internal, editable) VALUES ('system/userFeedback/lastNotificationDate', '', 0, 1912, 'y', 'n');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/clickablehyperlinks/enable', 'true', 2, 2010, 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/localrating/enable', 'advanced', 0, 2110, 'n');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/downloadservice/leave', 'false', 0, 2210, 'y');
@@ -705,7 +705,7 @@ INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/security/passwordEnforcement/minLength', '6', 1, 12000, 'n');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/security/passwordEnforcement/maxLength', '20', 1, 12001, 'n');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/security/passwordEnforcement/usePattern', 'true', 2, 12002, 'n');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/security/passwordEnforcement/pattern', '^((?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*(_|[^\w])).*)$', 0, 12003, 'n');
+INSERT INTO Settings (name, value, datatype, position, internal, editable) VALUES ('system/security/passwordEnforcement/pattern', '^((?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*(_|[^\w])).*)$', 0, 12003, 'n', 'n');
 
 
 INSERT INTO HarvesterSettings (id, parentid, name, value) VALUES  (1,NULL,'harvesting',NULL);

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v407/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v407/migrate-default.sql
@@ -1,2 +1,5 @@
 UPDATE Settings SET value='4.0.7' WHERE name='system/platform/version';
 UPDATE Settings SET value='SNAPSHOT' WHERE name='system/platform/subVersion';
+
+UPDATE Settings SET editable = 'n' WHERE name = 'system/userFeedback/lastNotificationDate';
+UPDATE Settings SET editable = 'n' WHERE name = 'system/security/passwordEnforcement/pattern';


### PR DESCRIPTION
See #5565

A test case:

- Settings > Security panel, **should not** display the setting to define the password pattern. It should be similar to this panel:
 
![password-security](https://user-images.githubusercontent.com/1695003/153817044-31294409-aa77-471f-a2b2-50ab19926a53.png)

