### PR TITLE
Users form - add button to toggle password fields visibility - fix initial button icon

### DIFF
--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -569,7 +569,7 @@
    * Put a string in a input field with copy to clipboard functions attached to it.
    *
    * The code to be used in a HTML page:
-   * 
+   *
    * <span gn-copy-to-clipboard="{{r.url | gnLocalized: lang}}"></span>
    *
    * or
@@ -1833,21 +1833,35 @@
       templateUrl: '../../catalog/components/utility/' +
         'partials/hideshowpassword.html',
       link: function (scope) {
-        scope.showHideClass = 'fa fa-eye-slash';
+        var cssInputPasswordType = 'fa fa-eye';
+        var cssInputTextType = 'fa fa-eye-slash';
+
+        var target = $('#' + scope.inputId)[0];
+
+        var updateInputCss = function() {
+          if(target != null) {
+            if(target.type == 'password') {
+              scope.showHideClass = cssInputPasswordType;
+            } else {
+              scope.showHideClass =  cssInputTextType;
+            }
+          }
+        }
 
         scope.hideShowPassword = function(){
-          var target = $('#' + scope.inputId)[0];
-
+          // Toggle the control type and button icon
           if(target != null) {
             if(target.type == 'password') {
               target.type = 'text';
-              scope.showHideClass = 'fa fa-eye-slash';
             } else {
               target.type = 'password';
-              scope.showHideClass = 'fa fa-eye';
             }
+
+            updateInputCss();
           }
         };
+
+        updateInputCss();
       }
     };
   });


### PR DESCRIPTION
The default icon if the control is of type `password` should have the style `fa fa-eye`:

![correct-initial-icon](https://user-images.githubusercontent.com/1695003/158122252-5ea279ec-03ea-45d4-8683-057628fb66bb.png)

, but instead it was `fa fa-eye-slash`.

![incorrect-initial-icon](https://user-images.githubusercontent.com/1695003/158122396-a2ee7e19-cf59-4900-94da-d8dc4bc782d5.png)

Related to https://github.com/geonetwork/core-geonetwork/pull/6140/, this PR sets the initial button icon depending on the related control type.