### PR TITLE
Backports from Sextant

### DIFF
--- a/web-ui/src/main/resources/catalog/components/catalog/CatalogService.js
+++ b/web-ui/src/main/resources/catalog/components/catalog/CatalogService.js
@@ -701,14 +701,14 @@
               if (type.substr(0, 1) == '#') {
                 var protocolMatch = link.protocol == type.substr(1, type.length - 1);
                 if ((protocolMatch && groupId === undefined) ||
-                    (protocolMatch && groupId != undefined && groupId == link.group)) {
+                    (protocolMatch && groupId != undefined && groupId === link.group)) {
                   ret.push(link);
                 }
               }
               else {
                 if (link.protocol.toLowerCase().indexOf(
                     type.toLowerCase()) >= 0 &&
-                    (!groupId || groupId == link.group)) {
+                    (groupId === undefined || groupId === link.group)) {
                   ret.push(link);
                 }
               }

--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -1560,7 +1560,7 @@
                   };
 
                   var feedMdPromise =
-                    typeof md === 'object' ?
+                    md && typeof md === 'object' ?
                     $q.resolve(md).then(function(md) {
                       olL.set('md', md);
                     }) : (

--- a/web-ui/src/main/resources/catalog/components/common/map/print/PrintMapDirective.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/print/PrintMapDirective.js
@@ -250,15 +250,6 @@
         return parseInt(scale.value);
       });
 
-      // encode url to remove accents
-      encLegends.map(function(url) {
-        try {
-          return new URL(url).toString();
-        } catch (e) {
-          return url;
-        }
-      });
-
       var spec = {
         layout: $scope.config.layout.name,
         srs: proj.getCode(),

--- a/web-ui/src/main/resources/catalog/components/common/map/print/PrintMapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/print/PrintMapService.js
@@ -386,7 +386,7 @@
             name: layer.get('title') || layer.get('label'),
             classes: [{
               name: '',
-              icon: layer.get('legend')
+              icon: new URL(layer.get('legend')).toString()
             }]
           };
         }

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/EsService.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/EsService.js
@@ -350,6 +350,10 @@
           var queryHook = params.query.function_score.query.bool;
           var luceneQueryString = currentSearch.state && currentSearch.state.filters ? gnEsLuceneQueryParser.facetsToLuceneQuery(currentSearch.state.filters) : undefined;
 
+          if (angular.isArray(currentSearch.filters)) {
+            params.query.function_score.query.bool.filter = currentSearch.filters;
+          }
+
           this.buildQueryClauses(queryHook, currentSearch.params, luceneQueryString);
 
           return params;

--- a/web-ui/src/main/resources/catalog/components/search/searchmanager/LocationService.js
+++ b/web-ui/src/main/resources/catalog/components/search/searchmanager/LocationService.js
@@ -139,7 +139,7 @@
           $location.path(this.SEARCH);
         }
         var params = angular.copy(searchObjParam, {}), urlParams = {};
-        if (angular.isObject(params)) {
+        if (angular.isObject(searchObjParam)) {
           var keys = Object.keys(params);
           keys.map(function(k) {
             if (k != 'query_string' && angular.isObject(params[k])) {

--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -1200,7 +1200,14 @@
             }
           };
 
-          init();
+          // init once we have a config
+          var initDone = false;
+          var unwatchInit = scope.$watch('config', function(n, o) {
+            if (!n) { return; }
+            init();
+            initDone = true;
+            unwatchInit();
+          });
 
           // model -> view
           if (!isRange) {
@@ -1216,9 +1223,6 @@
             });
           }
           else {
-            scope.$watch('config', function(n, o) {
-              init();
-            });
             scope.$watchCollection('date', function(newValue, oldValue) {
               if (!scope.date) {
                 scope.date = {};

--- a/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
@@ -667,7 +667,9 @@
               olL.set('title', layer.title);
               olL.set('label', layer.title);
             }
-            olL.set('metadataUuid', layer.metadataUuid || '');
+            if (layer.metadataUuid) {
+              olL.set('metadataUuid', layer.metadataUuid);
+            }
             if (bgIdx) {
               olL.set('bgIdx', bgIdx);
             } else if (index) {

--- a/web-ui/src/main/resources/catalog/components/viewer/wps/WpsService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wps/WpsService.js
@@ -239,7 +239,8 @@
               }
             });
           }
-          if (input.boundingBoxData && data) {
+          // when bbox is cleared value is still set to ',,,'
+          if (input.boundingBoxData && data && data != ',,,') {
             var bbox = data.split(',');
             request.value.dataInputs.input.push({
               identifier: {
@@ -249,8 +250,8 @@
                 boundingBoxData: {
                   dimensions: 2,
                   crs: 'EPSG:4326',
-                  lowerCorner: [bbox[0], bbox[1]],
-                  upperCorner: [bbox[2], bbox[3]]
+                  lowerCorner: [bbox[1], bbox[0]],
+                  upperCorner: [bbox[3], bbox[2]]
                 }
               }
             });


### PR DESCRIPTION
* Print / fix legend URL sanitizing

* Date picker / avoid running init multiple times

  The init function cannot be called more than once and is only called when a config is available

  This could result in infinite loops when the date picker is provided with invalid dates

* WPS / invert lat/lon values in bbox data since we're using EPSG:4326

* Switch to Fontawesome v4.7.0

* Search / avoid reloading search when coming from elsewhere if not needed

  Previously the search request was always sent again even though parameters
did not change.

* Map / correctly identify WPS processes linked to a layer

* Map / call feedLayerMd when only a md uuid is present

  This fixes a regression in https://github.com/geonetwork/core-geonetwork/pull/5307 where a layer with a metadata uuid (i.e. whose metadata was found in the catalog) was not going through feedLayerMd and as such did not have a link to the
md record

* Map / avoid race condition where metadata uuid of a layer was reset

  In some cases the `metadataUuid` property of a layer was set by MapService and then immediately reset by OwsContextService if the layer was created from an OWS context with no md uuid specified.