### PR TITLE
Bump hibernate deps from 5.4.24.Final to 5.4.33.Final

### DIFF
--- a/inspire-atom/pom.xml
+++ b/inspire-atom/pom.xml
@@ -58,7 +58,6 @@
     <dependency>
       <groupId>org.hibernate</groupId>
       <artifactId>hibernate-jpamodelgen</artifactId>
-      <version>1.2.0.Final</version>
     </dependency>
     <dependency>
       <groupId>org.hibernate</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1057,17 +1057,17 @@
       <dependency>
         <groupId>org.hibernate</groupId>
         <artifactId>hibernate-core</artifactId>
-        <version>5.4.24.Final</version>
+        <version>${hibernate.version}</version>
       </dependency>
       <dependency>
         <groupId>org.hibernate</groupId>
         <artifactId>hibernate-ehcache</artifactId>
-        <version>5.4.17.Final</version>
+        <version>${hibernate.version}</version>
       </dependency>
       <dependency>
         <groupId>org.hibernate</groupId>
         <artifactId>hibernate-jpamodelgen</artifactId>
-        <version>5.4.17.Final</version>
+        <version>${hibernate.version}</version>
       </dependency>
       <dependency>
         <groupId>org.springframework.data</groupId>
@@ -1563,6 +1563,7 @@
     <httpcomponents.version>4.5.9</httpcomponents.version>
     <jasypt.version>1.9.3</jasypt.version>
     <jupiter.version>5.7.0</jupiter.version>
+    <hibernate.version>5.4.33.Final</hibernate.version>
 
     <skipIT>true</skipIT> <!-- disable integration tests by default, use the "it" profile to run them which enables them -->
   </properties>


### PR DESCRIPTION
Refactor hibernate version to a property:
* Use `5.4.33.Final` in all the hibernate components.
* Remove specific hibernate-core from inspire-atom project.