### PR TITLE
Point jcs DiskPath to a dir where java can write

### DIFF
--- a/web/src/main/webapp/WEB-INF/classes/cache.ccf
+++ b/web/src/main/webapp/WEB-INF/classes/cache.ccf
@@ -14,7 +14,7 @@ jcs.default.elementattributes.IsEternal=false
 
 jcs.auxiliary.DC=org.apache.jcs.auxiliary.disk.indexed.IndexedDiskCacheFactory
 jcs.auxiliary.DC.attributes=org.apache.jcs.auxiliary.disk.indexed.IndexedDiskCacheAttributes
-jcs.auxiliary.DC.attributes.DiskPath=jcs_caching
+jcs.auxiliary.DC.attributes.DiskPath=${java.io.tmpdir}/jcs_caching
 
 # XLink cache
 jcs.region.xlink=DC


### PR DESCRIPTION
cf georchestra/geonetwork#87, we've been carrying this as a local patch since some years.

otherwise at startup this assumes / is writable which probably works on windows..
```
08:37:24.793 [Catalina-utility-1] ERROR org.apache.jcs.auxiliary.disk.indexed.IndexedDiskCache - Region [xlink] Failure initializing for fileName: xlink and root directory: jcs_caching
java.io.FileNotFoundException: /jcs_caching/xlink.data (No such file or directory)
08:37:24.819 [Catalina-utility-1] ERROR org.apache.jcs.auxiliary.disk.indexed.IndexedDiskCache - Region [SpatialFilterCache] Failure initializing for fileName: SpatialFilterCache and root directory: jcs_caching
java.io.FileNotFoundException: /jcs_caching/SpatialFilterCache.data (No such file or directory)
08:37:24.820 [Catalina-utility-1] ERROR org.apache.jcs.auxiliary.disk.indexed.IndexedDiskCache - Region [JeevesCacheManagerTenSeconds] Failure initializing for fileName: JeevesCacheManagerTenSeconds and root directory: jcs_caching
java.io.FileNotFoundException: /jcs_caching/JeevesCacheManagerTenSeconds.data (No such file or directory)
08:37:24.821 [Catalina-utility-1] ERROR org.apache.jcs.auxiliary.disk.indexed.IndexedDiskCache - Region [JeevesCacheManagerETERNAL] Failure initializing for fileName: JeevesCacheManagerETERNAL and root directory: jcs_caching
java.io.FileNotFoundException: /jcs_caching/JeevesCacheManagerETERNAL.data (No such file or directory)
08:37:24.830 [Catalina-utility-1] ERROR org.apache.jcs.auxiliary.disk.indexed.IndexedDiskCache - Region [XmlResolver] Failure initializing for fileName: XmlResolver and root directory: jcs_caching
java.io.FileNotFoundException: /jcs_caching/XmlResolver.data (No such file or directory)

```

might want to backport it to 4.0.x ?