### PR TITLE
wfs-harvesters - properly shutdown quartz

### DIFF
--- a/workers/camelPeriodicProducer/src/main/java/org/fao/geonet/camelPeriodicProducer/MessageProducerFactory.java
+++ b/workers/camelPeriodicProducer/src/main/java/org/fao/geonet/camelPeriodicProducer/MessageProducerFactory.java
@@ -30,6 +30,8 @@ import org.apache.camel.model.RouteDefinition;
 import org.quartz.CronScheduleBuilder;
 import org.quartz.CronTrigger;
 import org.quartz.TriggerBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import javax.annotation.PostConstruct;
@@ -41,7 +43,7 @@ public class MessageProducerFactory {
     protected RouteBuilder routeBuilder;
     @Autowired
     protected QuartzComponent quartzComponent;
-
+    private static Logger LOGGER = LoggerFactory.getLogger("geonetwork.harvest.wfs.camel");
     @PostConstruct
     public void init() throws Exception {
         quartzComponent.start();
@@ -73,6 +75,15 @@ public class MessageProducerFactory {
     public void destroy(Long id) throws Exception {
         routeBuilder.getContext().removeRouteDefinition(findRoute(id));
         routeBuilder.getContext().removeEndpoints("quartz2://" + id);
+
+    }
+
+    public void shutdown() {
+        try {
+            quartzComponent.shutdown();
+        } catch (Exception e) {
+            LOGGER.error("Error while trying to shutdown quartz", e);
+        }
     }
 
     private void writeRoute(MessageProducer messageProducer) throws Exception {

--- a/workers/camelPeriodicProducer/src/main/resources/config-spring-geonetwork.xml
+++ b/workers/camelPeriodicProducer/src/main/resources/config-spring-geonetwork.xml
@@ -28,7 +28,7 @@
         http://www.springframework.org/schema/beans
         http://www.springframework.org/schema/beans/spring-beans.xsd">
 
-  <bean class="org.fao.geonet.camelPeriodicProducer.MessageProducerFactory"/>
+  <bean class="org.fao.geonet.camelPeriodicProducer.MessageProducerFactory" destroy-method="shutdown"/>
   <bean class="org.apache.camel.component.quartz2.QuartzComponent"/>
   <bean class="org.fao.geonet.camelPeriodicProducer.MessageProducerService"/>"
 


### PR DESCRIPTION
See https://github.com/georchestra/georchestra/issues/3629 for the
motivation behind this change.

Tests: runtime into a tomcat servlet container, touch'ing web.xml from
GN do not produce the stacktrace about jmx mbeans anymore, and the
webapp successfully redeploys itself.