### PR TITLE
[Fix] Fix for the copy2clipboard function

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -931,7 +931,7 @@ input.ng-invalid {
     // old trick to not hide the input but position it out of sight
     input[type=text] {
       position: absolute;
-      top: -9999px;
+      left: -99999px;
     }
     .btn {
       border-radius: @border-radius-base !important;


### PR DESCRIPTION
When the function is used with the input box 'hidden' the input box is not really hidden (this prevents copying) but the input is moved outside the view(port). However, it turned out it wasn't moved far enough in case the recordview page was too high (over 10000px high)

This PR fixes the problem by moving the input very far to the left.