### PR TITLE
Configure HttpOnly for language cookie and fix the cookie path. Fixes #6151

### DIFF
--- a/core/src/main/java/jeeves/server/sources/http/JeevesServlet.java
+++ b/core/src/main/java/jeeves/server/sources/http/JeevesServlet.java
@@ -206,7 +206,10 @@ public class JeevesServlet extends HttpServlet {
         langCookie.setMaxAge((int) TimeUnit.DAYS.toSeconds(7));
         langCookie.setComment("Keeps the last language chosen to be the preferred language");
         langCookie.setVersion(1);
-        langCookie.setPath("/");
+        langCookie.setPath(req.getContextPath());
+        langCookie.setHttpOnly(req.getServletContext().getSessionCookieConfig().isHttpOnly());
+        langCookie.setSecure(req.getServletContext().getSessionCookieConfig().isSecure());
+
         res.addCookie(langCookie);
 
         //--- execute request


### PR DESCRIPTION
It seems `JeevesServlet` is only used to initialise the old Jeeves services, there is no servlet mapping defined in `web.xml` for this servlet, so probably the `execute` method could be even removed.

For now, fixing the language cookie configuration, although doesn't seem used that code