### PR TITLE
Fix the thumbnail generator using the metadata view services for metadata working copies

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsActionsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsActionsApi.java
@@ -31,14 +31,12 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jeeves.server.context.ServiceContext;
 import org.fao.geonet.ApplicationContextHolder;
-import org.fao.geonet.api.API;
 import org.fao.geonet.api.ApiParams;
 import org.fao.geonet.api.ApiUtils;
 import org.fao.geonet.domain.MetadataResource;
 import org.fao.geonet.domain.MetadataResourceVisibility;
 import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.thumbnail.ThumbnailMaker;
-import org.fao.geonet.lib.Lib;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.http.HttpStatus;
@@ -122,13 +120,12 @@ public class AttachmentsActionsApi {
         throws Exception {
         ServiceContext context = ApiUtils.createServiceContext(request);
 
-        String metadataId = dataMan.getMetadataId(metadataUuid);
-        Lib.resource.checkEditPrivilege(context, metadataId);
+        ApiUtils.canEditRecord(metadataUuid, request);
 
         Path thumbnailFile = thumbnailMaker.generateThumbnail(
             jsonConfig,
             rotationAngle);
 
-        return store.putResource(context, metadataUuid, thumbnailFile, MetadataResourceVisibility.PUBLIC);
+        return store.putResource(context, metadataUuid, thumbnailFile, MetadataResourceVisibility.PUBLIC, false);
     }
 }


### PR DESCRIPTION
With the metadata workflow enabled, generating a thumbnail with a map doesn't work for metadata working copies.

---

Test case:

1) Enable the workflow
2) Create a metadata (optionally add a WMS service layer)
3) Save & Close it
4) Approve the metadata
5) Edit the metadata to create a working copy
3) In the metadata editor, select **Associated resources** > **Link an online resource** > **Add a thumbnail** > **Generate thumbnail using the view service**,  and select the map extent for the image, clicking **Generate thumbnail**

**Result NOT OK**: the thumbnail image is not generated and not displayed in the metadata file store 

---

Expected result, fixed in the pull request: the thumbnail image is generated and displayed in the metadata file store.

![thumbnail-for-working-copy](https://user-images.githubusercontent.com/1695003/155562571-764d49e9-adeb-40f2-a787-1026ecf22cda.png)

---

The code had a bug that was using the approved version of the metadata instead of the working copy.

