### PR TITLE
Fix list filtering (ex. users / groups lists) to reset the paginationto the first page when the filtered results have less results than the ones needed to be displayed the current page

### DIFF
--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -569,7 +569,7 @@
    * Put a string in a input field with copy to clipboard functions attached to it.
    *
    * The code to be used in a HTML page:
-   * 
+   *
    * <span gn-copy-to-clipboard="{{r.url | gnLocalized: lang}}"></span>
    *
    * or
@@ -1339,6 +1339,13 @@
               // to use in ng-repeat
               scope.$parent[getItemsFunctionName] = function() {
                 if (angular.isArray(scope.items())) {
+                  // Reset pagination to the first page when the filtered results have less results
+                  // than the ones needed to be displayed in the current page
+                  if (scope.items().length < ((scope.paginator.currentPage *
+                    scope.paginator.pageSize)+1)) {
+                    scope.paginator.currentPage = 0;
+                  }
+
                   var start = scope.paginator.currentPage *
                       scope.paginator.pageSize;
                   var limit = scope.paginator.pageSize;


### PR DESCRIPTION
This issue happens in the list that have filters like users, groups, categories or harvesters.

Test case:

1) Create 12 groups with names `B1`-`B8`, `A1`-`A4`.
2) In the first page type `B` --> the results are filtered properly.
3) Clear the filter and go to the 2on page,  type `B`.
  - **without the fix:** No results are displayed. The number of results are less than the page size (10), but the pagination control is displaying the 2on page results.
  - **with the fix:** the filtered results are displayed properly. With this code change, if the number of results filtered are lower than the ones needed to be displayed the current page, the pagination is reset to the 1st page.