### PR TITLE
[a11y] Make search and footer a11y compliant on the homepage

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/templates/home.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/home.html
@@ -12,6 +12,7 @@
 
       <div class="input-group gn-form-any">
         <input type="text"
+              role="combobox"
               class="form-control input-lg"
               autofocus=""
               autocomplete="off"

--- a/web-ui/src/main/resources/catalog/views/default/templates/index.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/index.html
@@ -46,7 +46,7 @@
 </div>
 
 
-<footer class="navbar navbar-default gn-bottom-bar" role="navigation"
+<footer class="navbar navbar-default gn-bottom-bar"
      data-ng-show="gnCfg.mods.footer.enabled"
      data-ng-include="'../../catalog/views/default/templates/footer.html'">
 </footer>


### PR DESCRIPTION
Make the search box on the homepage and the footer `a11y` compliant on the homepage.