### PR TITLE
Reindex the working copy when transferred the ownership of a single metadata. Related to #6144

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/MetadataSharingApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataSharingApi.java
@@ -824,7 +824,7 @@ public class MetadataSharingApi {
                 report, dataManager, accessManager,
                 serviceContext, listOfUpdatedRecords, metadataUuid, session);
             dataManager.flush();
-            dataManager.indexMetadata(String.valueOf(metadata.getId()), true);
+            dataManager.indexMetadata(listOfUpdatedRecords);
 
         } catch (Exception exception) {
             report.addError(exception);


### PR DESCRIPTION
Related to #6144

---

Test case:

1. On a published record, create and save a working copy. 
2. In the metadata detail page, in the Manage record menu choose Transfer Ownership
4. Choose any user to transfer ownership to
5. In the editor board --> it's displayed the old owner (wrong)

The ownership it is transferred, but the Lucene index is not refreshed properly.

With the PR the new owner is displayed.



