### PR TITLE
UserId param in {metadata}/status update API.

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java
@@ -252,7 +252,7 @@ public class MetadataWorkflowApi {
 
         boolean isMdWorkflowEnable = settingManager.getValueAsBool(Settings.METADATA_WORKFLOW_ENABLE);
 
-        int author = context.getUserSession().getUserIdAsInt();
+        int author = status.getUserId() == null? context.getUserSession().getUserIdAsInt() : status.getUserId();
         MetadataStatus metadataStatus = convertParameter(metadata.getId(), metadata.getUuid(), status, author);
 
         if (metadataStatus.getStatusValue().getType() == StatusValueType.workflow

--- a/services/src/main/java/org/fao/geonet/api/records/model/MetadataStatusParameter.java
+++ b/services/src/main/java/org/fao/geonet/api/records/model/MetadataStatusParameter.java
@@ -32,6 +32,7 @@ public class MetadataStatusParameter {
     private String dueDate;
     private String closeDate;
     private Integer owner;
+    private Integer userId;
 
     public StatusValueType getType() {
         return type;
@@ -80,4 +81,8 @@ public class MetadataStatusParameter {
     public void setOwner(Integer owner) {
         this.owner = owner;
     }
+
+    public Integer getUserId() { return userId; }
+
+    public void setUserId(Integer userId) { this.userId = userId; }
 }


### PR DESCRIPTION
This API gives option for inter-system migration of status history. Right now, if we call set status API, there is no such option to specify what user did this operation.

![image](https://user-images.githubusercontent.com/74916635/157104815-b4e5a09b-2135-40ab-a6dd-f140d0e0f20a.png)


If we want to get status from Geonetwork 1 to Geonetwork 2, the user information will get lost. For example:
Geonetwork 1 consists of this history:
![image](https://user-images.githubusercontent.com/74916635/157105000-1223b4db-47b3-4a27-93c0-a921191ba448.png)


But it will end up in Geonetwork 2 as:
![image](https://user-images.githubusercontent.com/74916635/157105037-68818dde-d4fd-46c8-b370-575fa012baaa.png)

because admin was the login session where we execute the set status API.