### PR TITLE
Metadata editor - allow to add WMS layer names in the URL

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/config/associated-panel/default.json
+++ b/schemas/iso19139/src/main/plugin/iso19139/config/associated-panel/default.json
@@ -49,6 +49,9 @@
         "name": {"param": "thumbnail_desc"}
       }
     }],
-    "multilingualFields": ["name", "desc"]
+    "multilingualFields": ["name", "desc"],
+    "wmsResources": {
+      "addLayerNamesMode": "url"
+    }
   }
 }

--- a/schemas/iso19139/src/main/plugin/iso19139/config/associated-panel/default.json
+++ b/schemas/iso19139/src/main/plugin/iso19139/config/associated-panel/default.json
@@ -51,7 +51,7 @@
     }],
     "multilingualFields": ["name", "desc"],
     "wmsResources": {
-      "addLayerNamesMode": "url"
+      "addLayerNamesMode": "resourcename"
     }
   }
 }

--- a/web-ui/src/main/resources/catalog/components/common/ows/OWSDirective.js
+++ b/web-ui/src/main/resources/catalog/components/common/ows/OWSDirective.js
@@ -55,7 +55,9 @@
                };
                scope.select = function(layer) {
                  if (scope.selectionMode.indexOf('multiple') >= 0) {
-                   if (scope.selection.indexOf(layer) < 0) {
+                   var layerInSelection = _.find(scope.selection,  {'Name': layer.Name});
+
+                   if (layerInSelection == undefined) {
                      scope.selection.push(layer);
                    }
                    else {

--- a/web-ui/src/main/resources/catalog/components/common/ows/OWSDirective.js
+++ b/web-ui/src/main/resources/catalog/components/common/ows/OWSDirective.js
@@ -85,7 +85,8 @@
               'partials/layersTree.html',
             scope: {
               selection: '=',
-              layers: '='
+              layers: '=',
+              selectionMode: '='
             },
             controller: ['$scope', function($scope) {
               this.isSelected = function(layer) {
@@ -98,6 +99,10 @@
                 var layerInSelection = _.find($scope.selection,  {'Name': layer.Name});
 
                 if (layerInSelection == undefined) {
+                  if ($scope.selectionMode == 'single') {
+                    $scope.selection = [];
+                  }
+
                   $scope.selection.push(layer);
                 }
                 else {

--- a/web-ui/src/main/resources/catalog/components/common/ows/OWSDirective.js
+++ b/web-ui/src/main/resources/catalog/components/common/ows/OWSDirective.js
@@ -72,5 +72,116 @@
              }
            }
          };
-       }]);
+       }])
+
+    .directive(
+      'gnLayersTree',
+      [
+        'gnOwsCapabilities',
+        function(gnOwsCapabilities) {
+          return {
+            restrict: 'A',
+            templateUrl: '../../catalog/components/common/ows/' +
+              'partials/layersTree.html',
+            scope: {
+              selection: '=',
+              layers: '='
+            },
+            controller: ['$scope', function($scope) {
+              this.isSelected = function(layer) {
+                var layerInSelection = _.find($scope.selection,  {'Name': layer.Name});
+
+                return (layerInSelection != undefined);
+              };
+
+              this.addLayer = function(layer) {
+                var layerInSelection = _.find($scope.selection,  {'Name': layer.Name});
+
+                if (layerInSelection == undefined) {
+                  $scope.selection.push(layer);
+                }
+                else {
+                  $scope.selection.splice($scope.selection.indexOf(layer), 1);
+                }
+              };
+            }],
+            link: function(scope, element, attrs) {
+              scope.removeLayer = function(layer) {
+                scope.selection.splice(scope.selection.indexOf(layer), 1);
+              };
+            }
+          };
+        }])
+
+    .directive('gnCapTreeColEditor', [
+      '$translate',
+      function($translate) {
+
+        var label= $translate.instant('filter');
+
+        return {
+          restrict: 'E',
+          replace: true,
+          scope: {
+            collection: '='
+          },
+          template: '<ul class="gn-layer-tree" style="list-style: none; margin-left: 0px;"><li data-ng-show="collection.length > 10" >' +
+            "<div class='input-group input-group-sm'><span class='input-group-addon'><i class='fa fa-filter'></i></span>" +
+            "<input class='form-control' aria-label='" + label + "' data-ng-model-options='{debounce: 200}' data-ng-model='layerSearchText'/></div>" +
+            "</li>" +
+            '<gn-cap-tree-elt-editor ng-repeat="member in collection | filter:layerSearchText | orderBy: \'Title\'" member="member">' +
+            '</gn-cap-tree-elt-editor></ul>'
+        };
+      }])
+
+
+  .directive('gnCapTreeEltEditor', [
+    '$compile',
+    '$translate',
+    function($compile, $translate) {
+      return {
+        restrict: 'E',
+        replace: true,
+        require: '^gnLayersTree',
+        scope: {
+          member: '='
+        },
+        templateUrl: '../../catalog/components/common/ows/' +
+          'partials/layer.html',
+        link: function(scope, element, attrs, controller) {
+          var el = element;
+
+          scope.toggleNode = function(evt) {
+            el.find('.fa').first().toggleClass('fa-folder-open-o')
+              .toggleClass('fa-folder-o');
+            el.children('ul').toggle();
+            evt.stopPropagation();
+          };
+
+          scope.addLayer = function(c) {
+            controller.addLayer(scope.member, c ? c : null);
+          };
+
+          scope.isSelected = function(layer) {
+            var sel = controller.isSelected(layer);
+
+            return sel;
+          };
+
+          scope.isParentNode = angular.isDefined(scope.member.Layer);
+
+          // Add all subchildren
+          if (angular.isArray(scope.member.Layer)) {
+            element.append("<gn-cap-tree-col-editor " +
+              "collection='member.Layer'></gn-cap-tree-col-editor>");
+            $compile(element.find('gn-cap-tree-col-editor'))(scope);
+          }
+        }
+      };
+    }]);
+
+
+
+
+
 })();

--- a/web-ui/src/main/resources/catalog/components/common/ows/OWSService.js
+++ b/web-ui/src/main/resources/catalog/components/common/ows/OWSService.js
@@ -99,7 +99,7 @@
             var parser = new ol.format.WMSCapabilities();
             cachedGetCapabilitiesUrls[getCapabilitiesUrl] = parser.read(data);
           }
-          
+
            // do a deep copy of the capabilities obj
           var result = JSON.parse(JSON.stringify(cachedGetCapabilitiesUrls[getCapabilitiesUrl]));
 

--- a/web-ui/src/main/resources/catalog/components/common/ows/partials/layer.html
+++ b/web-ui/src/main/resources/catalog/components/common/ows/partials/layer.html
@@ -8,7 +8,7 @@
            title="{{member.Title || member.title}}">
           <i class='fa fa-fw'
              data-ng-class='::isParentNode ? "fa-folder-open-o" : "fa-map-o"'></i>
-          {{member.Title || member.title}}
+          {{member.Title || member.title}} <span data-ng-if="member.Name || member.name">({{member.Name || member.name}})</span>
         </a>
       </div>
       <div class="gn-layer-toolbar btn-group btn-group-xs">

--- a/web-ui/src/main/resources/catalog/components/common/ows/partials/layer.html
+++ b/web-ui/src/main/resources/catalog/components/common/ows/partials/layer.html
@@ -1,0 +1,25 @@
+<li data-ng-class='::!isParentNode ? "leaf" : ""' style="margin-left: 0px;">
+  <div class="flex-col">
+    <div class="flex-row width-100 flex-align-stretch">
+      <div class="flex-col flex-grow">
+        <a href=""
+           class="truncate"
+           data-ng-click="isParentNode ? toggleNode($event) : addLayer(null, $event)"
+           title="{{member.Title || member.title}}">
+          <i class='fa fa-fw'
+             data-ng-class='::isParentNode ? "fa-folder-open-o" : "fa-map-o"'></i>
+          {{member.Title || member.title}}
+        </a>
+      </div>
+      <div class="gn-layer-toolbar btn-group btn-group-xs">
+        <a href=""
+          class="btn btn-link btn-xs"
+          data-ng-click="addLayer(null, $event)"
+          data-ng-if="member.Name || member.name"
+          class="btn btn-default btn-xs">
+          <i class="fa fa-fw" data-ng-class="isSelected(member)?'fa-minus':'fa-plus'"></i>
+        </a>
+      </div>
+    </div>
+  </div>
+</li>

--- a/web-ui/src/main/resources/catalog/components/common/ows/partials/layersTree.html
+++ b/web-ui/src/main/resources/catalog/components/common/ows/partials/layersTree.html
@@ -5,6 +5,7 @@
   <ul>
     <li data-ng-repeat="layer in selection">
       {{layer.Title || layer.title}}
+      <span data-ng-if="layer.Name || layer.name">({{layer.Name || layer.name}})</span>
 
       <a
          class="btn btn-link btn-xs"

--- a/web-ui/src/main/resources/catalog/components/common/ows/partials/layersTree.html
+++ b/web-ui/src/main/resources/catalog/components/common/ows/partials/layersTree.html
@@ -1,8 +1,9 @@
 <div class="table-content-container gn-layers-grid-container">
 
-  <h5 translate="">wmsSelectedLayers</h5>
+  <h5 data-ng-if="selection.length > 0" data-translate="">wmsSelectedLayers</h5>
+  <h5 data-ng-if="selection.length == 0" data-translate="">wmsSelectedLayersNone</h5>
 
-  <ul>
+  <ul data-ng-if="selection.length > 0">
     <li data-ng-repeat="layer in selection">
       {{layer.Title || layer.title}}
       <span data-ng-if="layer.Name || layer.name">({{layer.Name || layer.name}})</span>

--- a/web-ui/src/main/resources/catalog/components/common/ows/partials/layersTree.html
+++ b/web-ui/src/main/resources/catalog/components/common/ows/partials/layersTree.html
@@ -1,0 +1,21 @@
+<div class="table-content-container gn-layers-grid-container">
+
+  <h5 translate="">wmsSelectedLayers</h5>
+
+  <ul>
+    <li data-ng-repeat="layer in selection">
+      {{layer.Title || layer.title}}
+
+      <a
+         class="btn btn-link btn-xs"
+         data-ng-click="removeLayer(layer)"
+         class="btn btn-default btn-xs">
+        <i class="fa fa-times text-danger"></i>
+      </a>
+    </li>
+  </ul>
+
+  <hr/>
+
+  <gn-cap-tree-col-editor collection='layers.Layer'></gn-cap-tree-col-editor>
+</div>

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -1180,6 +1180,7 @@
                     var params = gnUrlUtils.parseKeyValue(scope.params.url.split('?')[1]);
 
                     if (params[scope.addLayersInUrl]) {
+                      scope.params.selectedLayers = [];
                       selectedLayersNames = params[scope.addLayersInUrl].split(',');
                     }
 
@@ -1190,6 +1191,14 @@
                     });
 
                     scope.params.url = gnUrlUtils.remove(scope.params.url, [scope.addLayersInUrl], true);
+                  } else {
+                    var selectedLayersNames = scope.params.name.split(',');
+                    scope.params.selectedLayers = [];
+                    scope.layers.forEach(function(l) {
+                      if (selectedLayersNames.indexOf(l.Name) != -1) {
+                        scope.params.selectedLayers.push(l);
+                      }
+                    });
                   }
                 };
 

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcService.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcService.js
@@ -1,4 +1,4 @@
-/*
+ /*
  * Copyright (C) 2001-2016 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
@@ -54,8 +54,11 @@
     '$translate',
     '$filter',
     'Metadata',
+    'gnUrlUtils',
+    'gnGlobalSettings',
     function(gnBatchProcessing, gnHttp, gnEditor, gnCurrentEdit,
-             $q, $http, $window, $rootScope, $translate, $filter, Metadata) {
+             $q, $http, $window, $rootScope, $translate, $filter, Metadata,
+             gnUrlUtils, gnGlobalSettings) {
 
       var reload = false;
       var openCb = {};
@@ -112,17 +115,29 @@
         if (angular.isArray(params.selectedLayers) &&
             params.selectedLayers.length > 0) {
           var names = [],
-              descs = [];
+            descs = [];
 
           angular.forEach(params.selectedLayers, function(layer) {
             names.push(layer.Name || layer.name);
             descs.push(layer.Title || layer.title);
           });
 
-          angular.extend(params, {
-            name: names.join(','),
-            desc: descs.join(',')
-          });
+          var addLayersInUrl = gnGlobalSettings.gnCfg.mods.search.addWMSLayersToMap.urlLayerParam;
+
+          if (angular.isDefined(addLayersInUrl)) {
+            params.url = gnUrlUtils.remove(params.url, [addLayersInUrl], true);
+            params.url = gnUrlUtils.append(params.url, addLayersInUrl + '=' + names.join(','));
+
+            angular.extend(params, {
+              desc: descs.join(',')
+            });
+          } else {
+            angular.extend(params, {
+              name: names.join(','),
+              desc: descs.join(',')
+            });
+          }
+
         }
         delete params.layers;
         delete params.selectedLayers;

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcService.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcService.js
@@ -122,25 +122,25 @@
             descs.push(layer.Title || layer.title);
           });
 
-          var addLayersInUrl = gnGlobalSettings.gnCfg.mods.search.addWMSLayersToMap.urlLayerParam || '';
+          var addLayersInUrl = params.addLayersInUrl;
 
           if ((addLayersInUrl != '') && (params.protocol.indexOf('OGC:WMS') >= 0)) {
             params.url = gnUrlUtils.remove(params.url, [addLayersInUrl], true);
             params.url = gnUrlUtils.append(params.url, addLayersInUrl + '=' + names.join(','));
+          }
 
-            angular.extend(params, {
-              desc: descs.join(',')
-            });
-          } else {
+          if (params.wmsResources.addLayerNamesMode == "resourcename") {
             angular.extend(params, {
               name: names.join(','),
               desc: descs.join(',')
             });
           }
-
         }
+
         delete params.layers;
         delete params.selectedLayers;
+        delete params.wmsResources;
+        delete params.addLayersInUrl;
         return params;
       };
 

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcService.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcService.js
@@ -122,9 +122,9 @@
             descs.push(layer.Title || layer.title);
           });
 
-          var addLayersInUrl = gnGlobalSettings.gnCfg.mods.search.addWMSLayersToMap.urlLayerParam;
+          var addLayersInUrl = gnGlobalSettings.gnCfg.mods.search.addWMSLayersToMap.urlLayerParam || '';
 
-          if (angular.isDefined(addLayersInUrl)) {
+          if ((addLayersInUrl != '') && (params.protocol.indexOf('OGC:WMS') >= 0)) {
             params.url = gnUrlUtils.remove(params.url, [addLayersInUrl], true);
             params.url = gnUrlUtils.append(params.url, addLayersInUrl + '=' + names.join(','));
 

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
@@ -168,12 +168,21 @@
                 </div>
               </div>
 
-              <!-- Layers grid directive -->
+              <!-- Layers tree directive -->
               <div class="form-group">
+                <div data-gn-layers-tree
+                     id="gn-addonlinesrc-layers-row"
+                     class="col-sm-9 col-md-offset-2"
+                     data-ng-if="OGCProtocol != null  && isWMSProtocolWithLayersInUrl()"
+                     data-layers="capabilitiesLayers"
+                     data-selection="params.selectedLayers">
+                </div>
+
+                <!-- Layers grid directive -->
                 <div data-gn-layers-grid
                      id="gn-addonlinesrc-layers-row"
                      class="col-sm-9 col-md-offset-2"
-                     data-ng-show="OGCProtocol != null"
+                     data-ng-if="OGCProtocol != null && !isWMSProtocolWithLayersInUrl()"
                      data-gn-selection-mode="!isMultipleLayerSelection ? 'single' : 'multiple'"
                      data-layers="layers"
                      data-selection="params.selectedLayers">

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
@@ -173,7 +173,8 @@
                 <div data-gn-layers-tree
                      id="gn-addonlinesrc-layers-row"
                      class="col-sm-9 col-md-offset-2"
-                     data-ng-if="OGCProtocol != null  && isWMSProtocolWithLayersInUrl()"
+                     data-ng-if="OGCProtocol != null  && isWMSProtocol()"
+                     data-selection-mode="(!isWMSProtocolWithLayersInUrl() && isEditing) ? 'single' : 'multiple'"
                      data-layers="capabilitiesLayers"
                      data-selection="params.selectedLayers">
                 </div>
@@ -182,7 +183,7 @@
                 <div data-gn-layers-grid
                      id="gn-addonlinesrc-layers-row"
                      class="col-sm-9 col-md-offset-2"
-                     data-ng-if="OGCProtocol != null && !isWMSProtocolWithLayersInUrl()"
+                     data-ng-if="OGCProtocol != null && !isWMSProtocol()"
                      data-gn-selection-mode="isEditing ? 'single' : 'multiple'"
                      data-layers="layers"
                      data-selection="params.selectedLayers">

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
@@ -174,7 +174,7 @@
                      id="gn-addonlinesrc-layers-row"
                      class="col-sm-9 col-md-offset-2"
                      data-ng-show="OGCProtocol != null"
-                     data-gn-selection-mode="isEditing ? 'single' : 'multiple'"
+                     data-gn-selection-mode="!isMultipleLayerSelection ? 'single' : 'multiple'"
                      data-layers="layers"
                      data-selection="params.selectedLayers">
                 </div>

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
@@ -183,7 +183,7 @@
                      id="gn-addonlinesrc-layers-row"
                      class="col-sm-9 col-md-offset-2"
                      data-ng-if="OGCProtocol != null && !isWMSProtocolWithLayersInUrl()"
-                     data-gn-selection-mode="!isMultipleLayerSelection ? 'single' : 'multiple'"
+                     data-gn-selection-mode="isEditing ? 'single' : 'multiple'"
                      data-layers="layers"
                      data-selection="params.selectedLayers">
                 </div>

--- a/web-ui/src/main/resources/catalog/locales/en-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/en-editor.json
@@ -421,5 +421,6 @@
     "link-text": "Link text",
     "confirmCancelEdit": "Do you want to cancel all changes and close the editor?",
     "allowEditGroupMembers": "Allow group editors to edit",
-    "wmsSelectedLayers": "Selected layers"
+    "wmsSelectedLayers": "Selected layers",
+    "wmsSelectedLayersNone": "No layers selected"
 }

--- a/web-ui/src/main/resources/catalog/locales/en-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/en-editor.json
@@ -420,5 +420,6 @@
     "link": "Link",
     "link-text": "Link text",
     "confirmCancelEdit": "Do you want to cancel all changes and close the editor?",
-    "allowEditGroupMembers": "Allow group editors to edit"
+    "allowEditGroupMembers": "Allow group editors to edit",
+    "wmsSelectedLayers": "Selected layers"
 }

--- a/web-ui/src/main/resources/catalog/style/gn_editor.less
+++ b/web-ui/src/main/resources/catalog/style/gn_editor.less
@@ -623,6 +623,22 @@ form.gn-tab-inspire {
   }
 
 }
+.onlinesrc-container {
+  .gn-layers-grid-container {
+    hr {
+      display: none;
+    }
+    .gn-layer-tree {
+      padding-left: 0;
+      .gn-layer-tree {
+        padding-left: 20px;
+        li {
+          padding: 5px 0;
+        }
+      }
+    }
+  }
+}
 
 table.gn-data-store {
   td {


### PR DESCRIPTION
A metadata schema configuration setting has been added to configure how to add the WMS layer names to the online resources:

   - `resourcename`: (Default value) adds the layer names to the name and description fields of the online resources.
   - `url`: adds the layer names to url parameter defined in the following UI setting

<img width="805" alt="wms-url-layers-param-config" src="https://user-images.githubusercontent.com/1695003/157217671-58a466a1-3798-48b5-b8c4-ac989ee246c3.png">


See the metadata schema configuration setting:

https://github.com/geonetwork/core-geonetwork/pull/6195/files#diff-0cf19d65aac74977b4f108e7dc593e3cf403af32b212e4595fc2bdee132f1c3a


Additionally has been updated the WMS layer widget to display the layer structure:

<img width="502" alt="layer-tree" src="https://user-images.githubusercontent.com/1695003/157219200-b32515e7-edfd-48da-9410-0d7dcd1f4d2b.png">


For example, in the `url` mode for the previous screenshot the following URL is generated using the layer name:

https://maps-cartes.ec.gc.ca/arcgis/services/BC_CriticalHabitat_CB_HabitatEssentiel/MapServer/WMSServer?layers=71
