### PR TITLE
Add Accept-Language header in login controller requests, to set the correct language in the requests done in the login page

### DIFF
--- a/web-ui/src/main/resources/catalog/js/GnLoginModule.js
+++ b/web-ui/src/main/resources/catalog/js/GnLoginModule.js
@@ -30,11 +30,13 @@
   goog.require('gn');
   goog.require('gn_cat_controller');
   goog.require('gn_login_controller');
+  goog.require('gn_cors_interceptor');
 
   var module = angular.module('gn_login', [
     'gn',
     'gn_login_controller',
-    'gn_cat_controller'
+    'gn_cat_controller',
+    'gn_cors_interceptor'
   ]);
 
   module.config(['$LOCALES', function($LOCALES) {

--- a/web-ui/src/main/resources/catalog/js/GnLoginModule.js
+++ b/web-ui/src/main/resources/catalog/js/GnLoginModule.js
@@ -30,13 +30,11 @@
   goog.require('gn');
   goog.require('gn_cat_controller');
   goog.require('gn_login_controller');
-  goog.require('gn_cors_interceptor');
 
   var module = angular.module('gn_login', [
     'gn',
     'gn_login_controller',
-    'gn_cat_controller',
-    'gn_cors_interceptor'
+    'gn_cat_controller'
   ]);
 
   module.config(['$LOCALES', function($LOCALES) {

--- a/web-ui/src/main/resources/catalog/js/LoginController.js
+++ b/web-ui/src/main/resources/catalog/js/LoginController.js
@@ -42,11 +42,11 @@
       ['$scope', '$http', '$rootScope', '$translate',
        '$location', '$window', '$timeout',
        'gnUtilityService', 'gnConfig', 'gnGlobalSettings',
-       'vcRecaptchaService', '$q',
+       'vcRecaptchaService', '$q', 'gnLangs',
        function($scope, $http, $rootScope, $translate,
            $location, $window, $timeout,
                gnUtilityService, gnConfig, gnGlobalSettings,
-               vcRecaptchaService, $q) {
+               vcRecaptchaService, $q, gnLangs) {
           $scope.formAction = '../../signin#' + $location.url();
           $scope.registrationStatus = null;
           $scope.sendPassword = false;
@@ -141,7 +141,11 @@
 
            $scope.userInfo.email = $scope.userInfo.username;
 
-           return $http.put('../api/user/actions/register', $scope.userInfo)
+           return $http.put('../api/user/actions/register', $scope.userInfo, {
+               headers: {
+                 'Accept-Language': gnLangs.current
+               }
+             })
            .success(function(data) {
              $rootScope.$broadcast('StatusUpdated', {
                title: data,
@@ -159,8 +163,13 @@
           * Remind user password.
           */
          $scope.remindMyPassword = function() {
-
-           $http.put('../api/user/actions/forgot-password?username=' + $scope.usernameToRemind)
+           //config.headers['Accept-Language'] = gnLangs.current;
+           $http.put('../api/user/actions/forgot-password?username=' + $scope.usernameToRemind, null,
+             {
+               headers: {
+                'Accept-Language': gnLangs.current
+               }
+             })
             .success(function(data) {
              $scope.sendPassword = false;
              $rootScope.$broadcast('StatusUpdated', {
@@ -184,6 +193,10 @@
            $http.patch('../api/user/' + $scope.userToRemind, {
              password: $scope.password,
              changeKey: $scope.changeKey
+           }, {
+             headers: {
+               'Accept-Language': gnLangs.current
+             }
            })
             .success(function(data) {
              $rootScope.$broadcast('StatusUpdated', {


### PR DESCRIPTION
Test case related to https://github.com/geonetwork/core-geonetwork/pull/6191

Switch to French UI and send a forgot request password request, the message was displayed in English