### PR TITLE
Fix for the `View Previous Version` button for viewing Metadata history

### DIFF
--- a/web-ui/src/main/resources/catalog/components/history/partials/historyStep.html
+++ b/web-ui/src/main/resources/catalog/components/history/partials/historyStep.html
@@ -58,7 +58,7 @@
 
           <a class="btn btn-default"
              target="_blank"
-             data-ng-href="../api/records/{{h.uuid}}/status/{{h.statusId}}.{{h.userId}}.{{h.changeDate.dateAndTime}}/before"
+             data-ng-href="../api/records/{{h.uuid}}/status/{{h.statusId}}.{{h.userId}}.{{h.dateChange}}/before"
              data-ng-if="!h.previousStateEmpty"
              data-ng-hide="noSourceViewOption">
             <i class="fa fa-fw fa-search"


### PR DESCRIPTION
Fix for the `View Previous Version` button for viewing Metadata history.

The link was still using the old formatting which resulted in a malformed url, resulting in an `XML` file with an error, not a file with the history.

<img width="659" alt="gn-history-step" src="https://user-images.githubusercontent.com/19608667/158407829-5c306757-db6e-4196-bc22-7cc792c19f6b.png">

