### PR TITLE
Fixed issue with getting keycloak token for mapserver proxy from security context.

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/security/keycloak/KeycloakUtil.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/keycloak/KeycloakUtil.java
@@ -82,9 +82,9 @@ public class KeycloakUtil implements SecurityProviderUtil {
      */
     @Override
     public String getSSOAuthenticationHeaderValue() {
-        if (SecurityContextHolder.getContext().getAuthentication().getDetails() instanceof RefreshableKeycloakSecurityContext) {
+        if (SecurityContextHolder.getContext().getAuthentication().getPrincipal() instanceof KeycloakPrincipal) {
             RefreshableKeycloakSecurityContext refreshableKeycloakSecurityContext =
-                (RefreshableKeycloakSecurityContext) SecurityContextHolder.getContext().getAuthentication().getDetails();
+                (RefreshableKeycloakSecurityContext) ((KeycloakPrincipal)SecurityContextHolder.getContext().getAuthentication().getPrincipal()).getKeycloakSecurityContext();
             return "Bearer " + refreshableKeycloakSecurityContext.getTokenString();
         }
         return null;


### PR DESCRIPTION
Fixed issue with getting keycloak token from upgraded security context that was implemented in  PR 6134

It was using the old security context which failed to get the token.