### PR TITLE
[a11y] Small fix to make the copy button from the copy2clipboard option accessible

### DIFF
--- a/web-ui/src/main/resources/catalog/components/utility/partials/copytoclipboard.html
+++ b/web-ui/src/main/resources/catalog/components/utility/partials/copytoclipboard.html
@@ -4,10 +4,13 @@
          data-ng-click="copyToClipboard()"
          class="form-control"
          value="{{copytext}}">
-  <span class="input-group-addon btn"
-        data-ng-click="copyToClipboard()"
-        title="{{'copyToClipboard' | translate}}">
-    <i class="fa fa-clipboard" aria-hidden="true"></i>
+  <span class="input-group-btn">
+    <button type="button"
+            class="btn btn-default"
+            data-ng-click="copyToClipboard()"
+            title="{{'copyToClipboard' | translate}}">
+      <i class="fa fa-clipboard" aria-hidden="true"></i>
+    </button>
   </span>
 </div>
 


### PR DESCRIPTION
Small fix to make the copy button from the copy2clipboard option accessible

Change: make an actual `<button>` and add the 'click' action to it, rather than have the 'click' attached to a `<span>` element