### PR TITLE
Fix for the alert info message displayed in footer and sometimes outside the popup

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -396,11 +396,13 @@ div.gn-scroll-spy {
       }
       // error message
       .alert {
-        position: fixed;
-        bottom: 0;
-        width: calc(~"100% - 100px");
-        margin-left: 200px;
-        margin-right: 200px;
+        &.alert-warning {
+          position: fixed;
+          bottom: 0;
+          width: calc(~"100% - 100px");
+          margin-left: 200px;
+          margin-right: 200px;
+        }
       }
     }
   }


### PR DESCRIPTION
Fix for the alert info message displayed in the footer and sometimes accidentally falling partly outside the popup (smaller screens). This error happens with the info alert for the thumbnail upload tab.

Introduced by https://github.com/geonetwork/core-geonetwork/pull/6109

The PR above causing this should have targeted the warning messages only, not all messages

**Screenshot of the error:**

![gn-onlineresource-error](https://user-images.githubusercontent.com/19608667/161050026-52c63eb5-e513-428c-983c-a329f6ebd83a.png)

