### PR TITLE
XSLT / Utility to parse HTML

### DIFF
--- a/core/src/main/java/org/fao/geonet/util/XslUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/XslUtil.java
@@ -64,7 +64,6 @@ import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.NodeInfo;
 import org.fao.geonet.SystemInfo;
 import org.fao.geonet.api.records.attachments.FilesystemStore;
-import org.fao.geonet.api.records.attachments.Store;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.*;
 import org.fao.geonet.index.es.EsRestClient;
@@ -647,7 +646,24 @@ public final class XslUtil {
         return "";
     }
 
+    /**
+     * Try to preserve some HTML layout to text layout.
+     *
+     * Replace br tag by new line, li by new line with leading *.
+     */
+    public static String htmlElement2textReplacer(String html) {
+        return html
+            .replaceAll("<br */?>", System.getProperty("line.separator"))
+            .replaceAll("<li>(.*)</li>", System.getProperty("line.separator") + "* $1");
+    }
     public static String html2text(String html) {
+        return Jsoup.parse(html).wholeText();
+    }
+    public static String html2text(String html, boolean substituteHtmlToTextLayoutElement) {
+        return html2text(
+            substituteHtmlToTextLayoutElement ? htmlElement2textReplacer(html) : html);
+    }
+    public static String html2textNormalized(String html) {
         return Jsoup.parse(html).text();
     }
 

--- a/core/src/test/java/org/fao/geonet/util/XslUtilTest.java
+++ b/core/src/test/java/org/fao/geonet/util/XslUtilTest.java
@@ -1,0 +1,59 @@
+/*
+ * Copyright (C) 2001-2022 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+package org.fao.geonet.util;
+
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+
+public class XslUtilTest {
+
+    @Test
+    public void testHtml2text() {
+        String html = "<div><span>Sample text</span><br/><span>Sample text 2</span><br/><span>Sample text 3</span></div>";
+        String expectedText = "Sample textSample text 2Sample text 3";
+        String text = XslUtil.html2text(html);
+
+        assertEquals(expectedText, text);
+    }
+
+    @Test
+    public void testHtml2textSubstituteHtmlToTextLayoutElement() {
+        String html = "<div><span>Sample text</span><br/><span>Sample text 2</span><br/><span>Sample text 3</span></div>";
+        String expectedText = "Sample text\nSample text 2\nSample text 3";
+        String text = XslUtil.html2text(html, true);
+
+        assertEquals(expectedText, text);
+    }
+
+    @Test
+    public void testHtml2textNormalized() {
+        String html = "<div><span>Sample text</span><br/><span>Sample text 2</span></div>";
+        String expectedText = "Sample text Sample text 2";
+        String text = XslUtil.html2textNormalized(html);
+
+        assertEquals(expectedText, text);
+    }
+
+}


### PR DESCRIPTION
Follow up of https://github.com/titellus/core-geonetwork/pull/80.

eg. while moving content from CMS (which quite often allow HTML content in articles) to the catalogue we can build XSL conversions. It can be useful to preserve some basic layout (at least new lines) in text.