### PR TITLE
Admin / Password reset by admin.

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/setting/Settings.java
+++ b/core/src/main/java/org/fao/geonet/kernel/setting/Settings.java
@@ -134,6 +134,7 @@ public class Settings {
     public static final String SYSTEM_SECURITY_PASSWORDENFORCEMENT_MAXLENGH = "system/security/passwordEnforcement/maxLength";
     public static final String SYSTEM_SECURITY_PASSWORDENFORCEMENT_USEPATTERN = "system/security/passwordEnforcement/usePattern";
     public static final String SYSTEM_SECURITY_PASSWORDENFORCEMENT_PATTERN = "system/security/passwordEnforcement/pattern";
+    public static final String SYSTEM_SECURITY_PASSWORD_ALLOWADMINRESET = "system/security/password/allowAdminReset";
 
     public static class GNSetting {
         private String name;

--- a/services/src/main/java/org/fao/geonet/api/users/UsersApi.java
+++ b/services/src/main/java/org/fao/geonet/api/users/UsersApi.java
@@ -73,6 +73,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.*;
 
+import static org.fao.geonet.kernel.setting.Settings.SYSTEM_SECURITY_PASSWORD_ALLOWADMINRESET;
 import static org.fao.geonet.kernel.setting.Settings.SYSTEM_USERS_IDENTICON;
 import static org.fao.geonet.repository.specification.UserGroupSpecs.hasProfile;
 import static org.fao.geonet.repository.specification.UserGroupSpecs.hasUserId;
@@ -586,6 +587,11 @@ public class UsersApi {
         return new ResponseEntity(HttpStatus.NO_CONTENT);
     }
 
+    private boolean isUserAllowedToResetWithoutOldPassword(Profile myProfile) {
+        boolean isAdminAllowed = settingManager.getValueAsBool(SYSTEM_SECURITY_PASSWORD_ALLOWADMINRESET, false);
+        return isAdminAllowed && myProfile == Profile.Administrator;
+    }
+
     @io.swagger.v3.oas.annotations.Operation(
         summary = "Resets user password",
         description = "Resets the user password.")
@@ -630,7 +636,9 @@ public class UsersApi {
         Profile myProfile = session.getProfile();
         String myUserId = session.getUserId();
 
-        if (myProfile != Profile.Administrator && myProfile != Profile.UserAdmin && !myUserId.equals(Integer.toString(userIdentifier))) {
+        if (myProfile != Profile.Administrator
+            && myProfile != Profile.UserAdmin
+            && !myUserId.equals(Integer.toString(userIdentifier))) {
             throw new IllegalArgumentException("You don't have rights to do this");
         }
 
@@ -641,8 +649,12 @@ public class UsersApi {
 
         PasswordEncoder encoder = PasswordUtil.encoder(ApplicationContextHolder.get());
 
-        if (!encoder.matches(passwordResetDto.getPasswordOld(), user.get().getPassword())) {
-            throw new IllegalArgumentException("The old password is not valid");
+        if (isUserAllowedToResetWithoutOldPassword(myProfile) == false
+            && (passwordResetDto.getPasswordOld() == null
+            || !encoder.matches(
+            passwordResetDto.getPasswordOld(),
+            user.get().getPassword()))) {
+            throw new IllegalArgumentException("The old password is not valid.");
         }
 
         String passwordHash = PasswordUtil.encoder(ApplicationContextHolder.get()).encode(

--- a/services/src/test/java/org/fao/geonet/api/site/SiteApiTest.java
+++ b/services/src/test/java/org/fao/geonet/api/site/SiteApiTest.java
@@ -3,6 +3,7 @@ package org.fao.geonet.api.site;
 import junit.framework.Assert;
 import org.fao.geonet.SystemInfo;
 import org.fao.geonet.services.AbstractServiceIntegrationTest;
+import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
@@ -12,17 +13,9 @@ import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
-
-import static org.hamcrest.Matchers.greaterThan;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.isEmptyOrNullString;
-import static org.hamcrest.Matchers.not;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.hamcrest.Matchers.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 /**
  * Created by francois on 19/06/16.
@@ -35,15 +28,19 @@ public class SiteApiTest extends AbstractServiceIntegrationTest {
     @Autowired
     private SystemInfo systemInfo;
 
+    @Autowired
+    StandardPBEStringEncryptor encryptor;
+
     private MockMvc mockMvc;
 
     private MockHttpSession mockHttpSession;
+
 
     @Test
     public void getSite() throws Exception {
         this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
         this.mockMvc.perform(get("/srv/api/site")
-            .accept(MediaType.parseMediaType("application/json")))
+                .accept(MediaType.parseMediaType("application/json")))
             .andExpect(status().isOk())
             .andExpect(content().contentType(API_JSON_EXPECTED_ENCODING))
             .andExpect(jsonPath("$['system/site/name']", is("My GeoNetwork catalogue")));
@@ -56,11 +53,42 @@ public class SiteApiTest extends AbstractServiceIntegrationTest {
         this.mockHttpSession = loginAsAdmin();
 
         this.mockMvc.perform(get("/srv/api/site/settings")
-            .session(this.mockHttpSession)
-            .accept(MediaType.parseMediaType("application/json")))
+                .session(this.mockHttpSession)
+                .accept(MediaType.parseMediaType("application/json")))
             .andExpect(status().isOk())
             .andExpect(content().contentType(API_JSON_EXPECTED_ENCODING))
             .andExpect(jsonPath("$['system/site/name']", is("My GeoNetwork catalogue")));
+    }
+
+
+    @Test
+    public void updateSettings() throws Exception {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
+
+        this.mockHttpSession = loginAsAdmin();
+
+        encryptor.initialize();
+
+        this.mockMvc.perform(get("/srv/api/site/settings")
+                .session(this.mockHttpSession)
+                .accept(MediaType.parseMediaType("application/json")))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(API_JSON_EXPECTED_ENCODING))
+            .andExpect(jsonPath("$['system/site/name']", is("My GeoNetwork catalogue")));
+
+        String newName = "DataHub";
+        this.mockMvc.perform(post("/srv/api/site/settings")
+                .param("system/site/name", newName)
+                .session(this.mockHttpSession)
+                .accept(MediaType.parseMediaType("application/json")))
+            .andExpect(status().is(204));
+
+        this.mockMvc.perform(get("/srv/api/site/settings")
+                .session(this.mockHttpSession)
+                .accept(MediaType.parseMediaType("application/json")))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(API_JSON_EXPECTED_ENCODING))
+            .andExpect(jsonPath("$['system/site/name']", is(newName)));
     }
 
     @Test
@@ -70,8 +98,8 @@ public class SiteApiTest extends AbstractServiceIntegrationTest {
         this.mockHttpSession = loginAsAdmin();
 
         this.mockMvc.perform(get("/srv/api/site/info")
-            .accept(MediaType.parseMediaType("application/json"))
-            .session(this.mockHttpSession))
+                .accept(MediaType.parseMediaType("application/json"))
+                .session(this.mockHttpSession))
             .andExpect(status().isOk())
             .andExpect(content().contentType(API_JSON_EXPECTED_ENCODING))
             .andExpect(jsonPath("$.catalogue['data.dataDir']", is(not(isEmptyOrNullString()))))
@@ -87,8 +115,8 @@ public class SiteApiTest extends AbstractServiceIntegrationTest {
 
         // This service returns a boolean, not encapsulated in json, can't use jsonPath
         MvcResult result = this.mockMvc.perform(get("/srv/api/site/info/isCasEnabled")
-            .session(this.mockHttpSession)
-            .accept(MediaType.parseMediaType("application/json")))
+                .session(this.mockHttpSession)
+                .accept(MediaType.parseMediaType("application/json")))
             .andExpect(status().isOk())
             .andExpect(content().contentType(API_JSON_EXPECTED_ENCODING))
             .andReturn();
@@ -105,8 +133,8 @@ public class SiteApiTest extends AbstractServiceIntegrationTest {
         Assert.assertTrue(systemInfo.getStagingProfile().equals(SystemInfo.Staging.development.toString()));
 
         this.mockMvc.perform(put("/srv/api/site/info/staging/" + SystemInfo.Staging.production.toString())
-            .session(this.mockHttpSession)
-            .accept(MediaType.parseMediaType("application/json")))
+                .session(this.mockHttpSession)
+                .accept(MediaType.parseMediaType("application/json")))
             .andExpect(status().is(204));
 
         Assert.assertTrue(systemInfo.getStagingProfile().equals(SystemInfo.Staging.production.toString()));
@@ -120,8 +148,8 @@ public class SiteApiTest extends AbstractServiceIntegrationTest {
 
         // This service returns a boolean, not encapsulated in json, can't use jsonPath
         MvcResult result = this.mockMvc.perform(get("/srv/api/site/info/readonly")
-            .session(this.mockHttpSession)
-            .accept(MediaType.parseMediaType("application/json")))
+                .session(this.mockHttpSession)
+                .accept(MediaType.parseMediaType("application/json")))
             .andExpect(status().isOk())
             .andExpect(content().contentType(API_JSON_EXPECTED_ENCODING))
             .andReturn();
@@ -137,8 +165,8 @@ public class SiteApiTest extends AbstractServiceIntegrationTest {
 
         // This service returns a boolean, not encapsulated in json, can't use jsonPath
         MvcResult result = this.mockMvc.perform(get("/srv/api/site/indexing")
-            .session(this.mockHttpSession)
-            .accept(MediaType.parseMediaType("application/json")))
+                .session(this.mockHttpSession)
+                .accept(MediaType.parseMediaType("application/json")))
             .andExpect(status().isOk())
             .andExpect(content().contentType(API_JSON_EXPECTED_ENCODING))
             .andReturn();
@@ -150,7 +178,7 @@ public class SiteApiTest extends AbstractServiceIntegrationTest {
     public void getSystemInfo() throws Exception {
         this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
         this.mockMvc.perform(get("/srv/api/site/info/build")
-            .accept(MediaType.parseMediaType("application/json")))
+                .accept(MediaType.parseMediaType("application/json")))
             .andExpect(status().isOk())
             .andExpect(content().contentType(API_JSON_EXPECTED_ENCODING))
             .andExpect(jsonPath("$.stagingProfile", is(not(isEmptyOrNullString()))))
@@ -163,7 +191,7 @@ public class SiteApiTest extends AbstractServiceIntegrationTest {
     public void getXslTransformations() throws Exception {
         this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
         this.mockMvc.perform(get("/srv/api/site/info/transforms")
-            .accept(MediaType.parseMediaType("application/json")))
+                .accept(MediaType.parseMediaType("application/json")))
             .andExpect(status().isOk())
             .andExpect(content().contentType(API_JSON_EXPECTED_ENCODING))
             .andExpect(jsonPath("$", hasSize(greaterThan(0))));

--- a/services/src/test/java/org/fao/geonet/api/users/UsersApiTest.java
+++ b/services/src/test/java/org/fao/geonet/api/users/UsersApiTest.java
@@ -345,7 +345,6 @@ public class UsersApiTest extends AbstractServiceIntegrationTest {
 
         Gson gson = new Gson();
         PasswordResetDto passwordReset = new PasswordResetDto();
-        passwordReset.setPasswordOld("testuser-editor-password");
         passwordReset.setPassword("NewPassword1$");
         passwordReset.setPassword2("NewPassword1$");
 
@@ -356,6 +355,18 @@ public class UsersApiTest extends AbstractServiceIntegrationTest {
             .contentType(API_JSON_EXPECTED_ENCODING)
             .session(this.mockHttpSession)
             .accept(MediaType.parseMediaType("application/json")))
+            .andExpect(status().is(400))
+            .andExpect(jsonPath("$.description", is("The old password is not valid.")));
+
+
+        passwordReset.setPasswordOld("testuser-editor-password");
+        json = gson.toJson(passwordReset);
+
+        this.mockMvc.perform(post("/srv/api/users/" + user.getId() + "/actions/forget-password")
+                .content(json)
+                .contentType(API_JSON_EXPECTED_ENCODING)
+                .session(this.mockHttpSession)
+                .accept(MediaType.parseMediaType("application/json")))
             .andExpect(status().is(204));
     }
 

--- a/services/src/test/resources/services-web-test-context.xml
+++ b/services/src/test/resources/services-web-test-context.xml
@@ -54,5 +54,4 @@
       <bean class="org.springframework.data.web.SortHandlerMethodArgumentResolver"/>
     </mvc:argument-resolvers>
   </mvc:annotation-driven>
-
 </beans>

--- a/web-ui/src/main/resources/catalog/js/admin/UserGroupController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/UserGroupController.js
@@ -107,6 +107,7 @@
       $scope.passwordMaxLength =
         Math.max(gnConfig['system.security.passwordEnforcement.maxLength'], 6);
       $scope.usePattern = gnConfig['system.security.passwordEnforcement.usePattern'];
+      $scope.allowAdminReset = gnConfig['system.security.password.allowAdminReset'];
 
       if ($scope.usePattern) {
         $scope.passwordPattern = new RegExp(
@@ -339,13 +340,17 @@
        * @returns {boolean}
        */
       $scope.hideResetPassword = function() {
-        if ((!$scope.userSelected) ||
-            (!$scope.userSelected.security)) {
+        if ((!$scope.userSelected)
+            || (!$scope.userSelected.security)) {
+          return true;
+        } else if ($scope.userSelected.security.authType == 'LDAP') {
+          return true;
+        } else if ($scope.allowAdminReset && $scope.user.isAdministratorOrMore()) {
+          return false;
+        } else if ($scope.userSelected.username !== $scope.user.username) {
           return true;
         }
-
-        return (($scope.userSelected.security.authType == 'LDAP') ||
-            ($scope.userSelected.username !== $scope.user.username));
+        return false;
       };
 
       /**

--- a/web-ui/src/main/resources/catalog/locales/en-v4.json
+++ b/web-ui/src/main/resources/catalog/locales/en-v4.json
@@ -227,6 +227,8 @@
   "system/inspire/remotevalidation/apikey-help": "Users and organisations interested in receiving an API key will need to contact the Validator team by sending an e-mail to JRC-INSPIRE-SUPPORT AT ec.europa.eu and provide the following information: name of the organisation, responsible contact point and intended use of the API key.",
   "system/inspire/remotevalidation/nodeid": "Portal identifier to use for the validation",
   "system/inspire/remotevalidation/nodeid-help": "If null, the record is uploaded to the validator, if a node is defined, then the CSW url of this node is used, the validator will make a GetRecordById request to retrieve the record.",
+  "system/security/password/allowAdminReset": "Allow password reset by administrator",
+  "system/security/password/allowAdminReset-help": "If a mail server is configured, then users can reset password directly. For security reason, enable this option only if there is no mail server configured.",
   "chooseOptionsToCustomize": "Choose an option to customize",
   "ui/chooseAnOption-help": "Current user configuration is empty. Choose one or more option above or create a full configuration.",
   "uiConfigForm": "Configuration form",

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
@@ -714,6 +714,11 @@ INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/security/passwordEnforcement/usePattern', 'true', 2, 12002, 'n');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/security/passwordEnforcement/pattern', '^((?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*(_|[^\w])).*)$', 0, 12003, 'n');
 
+-- WARNING: Security / Add this settings only if you need to allow admin
+-- users to be able to reset user password. If you have mail server configured
+-- user can reset password directly. If not, then you may want to add that settings
+-- if you don't have access to the database.
+-- INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/security/password/allowAdminReset', 'false', 2, 12004, 'n');
 
 INSERT INTO HarvesterSettings (id, parentid, name, value) VALUES  (1,NULL,'harvesting',NULL);
 

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v407/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v407/migrate-default.sql
@@ -8,6 +8,11 @@ INSERT INTO Users (id, username, password, name, surname, profile, kind, organis
 INSERT INTO Address (id, address, city, country, state, zip) VALUES  (0, '', '', '', '', '');
 INSERT INTO UserAddress (userid, addressid) VALUES  (0, 0);
 
+-- WARNING: Security / Add this settings only if you need to allow admin
+-- users to be able to reset user password. If you have mail server configured
+-- user can reset password directly. If not, then you may want to add that settings
+-- if you don't have access to the database.
+-- INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/security/password/allowAdminReset', 'false', 2, 12004, 'n');
 
 UPDATE Settings SET value='4.0.7' WHERE name='system/platform/version';
 UPDATE Settings SET value='SNAPSHOT' WHERE name='system/platform/subVersion';


### PR DESCRIPTION
A new settings allows administrator to reset local user password (feature which was removed in https://github.com/geonetwork/core-geonetwork/pull/5550). Therefor some catalogue setup not having mail server available (and users who don't have access to the database) can't reset password anymore (the only workaround is to drop the user and recreate it). 

This setting is not added to the database by default (for security
reason - see https://github.com/geonetwork/core-geonetwork/pull/5550).

Add it, only if you don't have mail server or if it is difficult to
access to the database.