### PR TITLE
Security / Libraries update.

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -488,7 +488,6 @@
     <dependency>
       <groupId>edu.ucar</groupId>
       <artifactId>netcdf</artifactId>
-      <version>4.3.23</version>
     </dependency>
     <dependency>
       <groupId>com.neovisionaries</groupId>

--- a/core/src/main/java/org/fao/geonet/kernel/thumbnail/ThumbnailMaker.java
+++ b/core/src/main/java/org/fao/geonet/kernel/thumbnail/ThumbnailMaker.java
@@ -25,7 +25,6 @@ package org.fao.geonet.kernel.thumbnail;
 
 import jeeves.server.context.ServiceContext;
 
-import org.dom4j.DocumentException;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.utils.IO;
 import org.fao.geonet.utils.Log;
@@ -150,7 +149,7 @@ public class ThumbnailMaker {
     }
 
     public Path generateThumbnail(String jsonConfig, Integer rotationAngle)
-        throws IOException, DocumentException, com.itextpdf.text.DocumentException {
+        throws IOException, com.itextpdf.text.DocumentException {
 
         PJsonObject specJson = MapPrinter.parseSpec(jsonConfig);
         if (Log.isDebugEnabled(LOGGER_NAME)) {

--- a/domain/src/test/java/org/fao/geonet/GeonetworkH2TestEmbeddedDatabaseConfigurer.java
+++ b/domain/src/test/java/org/fao/geonet/GeonetworkH2TestEmbeddedDatabaseConfigurer.java
@@ -67,12 +67,12 @@ public class GeonetworkH2TestEmbeddedDatabaseConfigurer implements EmbeddedDatab
 //        properties.setUrl(String.format("jdbc:h2:mem:%s;DB_CLOSE_DELAY=-1;DATABASE_TO_UPPER=FALSE", databaseName));
         if (_dbPathLocator.isPresent()) {
             try {
-                properties.setUrl(String.format("jdbc:h2:%s;DB_CLOSE_DELAY=-1%s", _dbPathLocator.get().call(), _mode));
+                properties.setUrl(String.format("jdbc:h2:%s;NON_KEYWORDS=VALUE;DB_CLOSE_DELAY=-1%s", _dbPathLocator.get().call(), _mode));
             } catch (Exception e) {
                 throw new RuntimeException(e);
             }
         } else {
-            properties.setUrl(String.format("jdbc:h2:mem:%s;DB_CLOSE_DELAY=-1%s", databaseName, _mode));
+            properties.setUrl(String.format("jdbc:h2:mem:%s;NON_KEYWORDS=VALUE;DB_CLOSE_DELAY=-1%s", databaseName, _mode));
         }
         properties.setUsername(_username);
         properties.setPassword(_password);

--- a/pom.xml
+++ b/pom.xml
@@ -1080,6 +1080,17 @@
         <version>${jackson.version}</version>
       </dependency>
       <dependency>
+        <groupId>edu.ucar</groupId>
+        <artifactId>netcdf</artifactId>
+        <version>4.3.23</version>
+        <exclusions>
+          <exclusion>
+            <groupId>net.sf.ehcache</groupId>
+            <artifactId>ehcache-core</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
+      <dependency>
         <groupId>com.google.code.findbugs</groupId>
         <artifactId>jsr305</artifactId>
         <version>2.0.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -889,7 +889,7 @@
       <dependency>
         <groupId>com.h2database</groupId>
         <artifactId>h2</artifactId>
-        <version>1.4.200</version>
+        <version>2.1.212</version>
       </dependency>
       <dependency>
         <groupId>org.postgis</groupId>
@@ -1535,18 +1535,18 @@
      request the list of hosts (but JPA cache db queries). -->
     <cors.allowedHosts>*</cors.allowedHosts>
 
-    <jetty.version>9.4.44.v20210927</jetty.version>
+    <jetty.version>9.4.46.v20220331</jetty.version>
     <jetty.file>jetty-distribution-${jetty.version}</jetty.file>
     <jetty.download>https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/${jetty.version}/${jetty.file}.tar.gz</jetty.download>
 
     <!-- NOTE: When updating GeoTools, check which version
     of Postgres is used and update pg.version if needed. -->
     <geotools.version>23.0</geotools.version>
-    <pg.version>42.2.5</pg.version>
+    <pg.version>42.3.3</pg.version>
 
-    <spring.version>5.2.6.RELEASE</spring.version>
-    <spring.security.version>5.2.5.RELEASE</spring.security.version>
-    <spring.jpa.version>2.2.8.RELEASE</spring.jpa.version>
+    <spring.version>5.2.20.RELEASE</spring.version>
+    <spring.security.version>5.2.15.RELEASE</spring.security.version>
+    <spring.jpa.version>2.2.13.RELEASE</spring.jpa.version>
     <springboot.version>2.2.2.RELEASE</springboot.version>
     <springdoc.version>1.5.9</springdoc.version>
 
@@ -1571,7 +1571,7 @@
     <httpcomponents.version>4.5.9</httpcomponents.version>
     <jasypt.version>1.9.3</jasypt.version>
     <jupiter.version>5.7.0</jupiter.version>
-    <hibernate.version>5.4.33.Final</hibernate.version>
+    <hibernate.version>5.6.7.Final</hibernate.version>
 
     <skipIT>true</skipIT> <!-- disable integration tests by default, use the "it" profile to run them which enables them -->
   </properties>

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/cache/FilesystemStore.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/cache/FilesystemStore.java
@@ -67,7 +67,7 @@ public class FilesystemStore implements PersistentStore {
     private static final String STATS_TABLE = "stats";
     private static final String NAME = "name";
     private static final String CURRENT_SIZE = "currentsize";
-    private static final String VALUE = "value";
+    private static final String VALUE = "statvalue";
     public static final String QUERY_SETCURRENT_SIZE = "MERGE INTO " + STATS_TABLE + " (" + NAME + ", " + VALUE + ") VALUES ('" + CURRENT_SIZE + "', ?)";
     public static final String QUERY_GETCURRENT_SIZE = "SELECT " + VALUE + " FROM " + STATS_TABLE + " WHERE " + NAME + " = '" + CURRENT_SIZE + "'";
     private static final String QUERY_GET_INFO = "SELECT * FROM " + INFO_TABLE + " WHERE " + KEY + "=?";

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -436,7 +436,6 @@
     <dependency>
       <groupId>edu.ucar</groupId>
       <artifactId>netcdf</artifactId>
-      <version>4.3.23</version>
     </dependency>
 
     <!-- Monitoring libraries -->

--- a/web/src/main/webResources/WEB-INF/config-db/h2.xml
+++ b/web/src/main/webResources/WEB-INF/config-db/h2.xml
@@ -40,7 +40,7 @@
 
   <bean id="jdbcURL" class="java.lang.String">
     <constructor-arg
-      value="jdbc:h2:${jdbc.database};${jdbc.connectionProperties:LOCK_TIMEOUT=20000;DB_CLOSE_ON_EXIT=FALSE}"/>
+      value="jdbc:h2:${jdbc.database};NON_KEYWORDS=VALUE;${jdbc.connectionProperties:LOCK_TIMEOUT=20000;DB_CLOSE_ON_EXIT=FALSE}"/>
   </bean>
 
 </beans>

--- a/web/src/main/webResources/WEB-INF/config-db/jndiExamples_tomcat/h2_JNDI_Example.xml
+++ b/web/src/main/webResources/WEB-INF/config-db/jndiExamples_tomcat/h2_JNDI_Example.xml
@@ -28,7 +28,7 @@
   <Resource name="jdbc/geonetwork" auth="Container"
             factory="org.apache.tomcat.jdbc.pool.DataSourceFactory"
             type="javax.sql.DataSource" driverClassName="org.h2.Driver"
-            url="jdbc:h2:gn;LOCK_TIMEOUT=20000;DB_CLOSE_ON_EXIT=FALSE"
+            url="jdbc:h2:gn;NON_KEYWORDS=VALUE;LOCK_TIMEOUT=20000;DB_CLOSE_ON_EXIT=FALSE"
             username="www-data" password="www-data"
             maxActive="20" maxIdle="10"
             defaultAutoCommit="false" maxWait="-1"/>

--- a/web/src/main/webapp/WEB-INF/classes/log4j.xml
+++ b/web/src/main/webapp/WEB-INF/classes/log4j.xml
@@ -137,7 +137,7 @@
     <level value="ERROR"/>
   </logger>
   <logger name="geonetwork.harvest.wfs.features">
-    <level value="ERROR"/>
+    <level value="DEBUG"/>
   </logger>
   <logger name="geonetwork.backup">
     <level value="ERROR"/>
@@ -221,6 +221,8 @@
     <appender-ref ref="allConsoleAppender"/>
     <appender-ref ref="fileAppender"/>
   </logger>
+  <!-- Check also domain/src/main/resources/config-spring-geonetwork.xml
+  show_sql properties. -->
   <logger name="org.hibernate.SQL" additivity="false">
     <level value="ERROR"/>
     <appender-ref ref="consoleAppender"/>

--- a/web/src/main/webapp/WEB-INF/classes/log4j.xml
+++ b/web/src/main/webapp/WEB-INF/classes/log4j.xml
@@ -137,7 +137,7 @@
     <level value="ERROR"/>
   </logger>
   <logger name="geonetwork.harvest.wfs.features">
-    <level value="DEBUG"/>
+    <level value="ERROR"/>
   </logger>
   <logger name="geonetwork.backup">
     <level value="ERROR"/>

--- a/web/src/main/webapp/WEB-INF/jetty-env.xml
+++ b/web/src/main/webapp/WEB-INF/jetty-env.xml
@@ -21,7 +21,7 @@
         <!--<Set name="driverClassName">org.postgis.DriverWrapper</Set>
         <Set name="url">jdbc:postgresql_postGIS://localhost:5432/gndb</Set>-->
         <Set name="driverClassName">org.h2.Driver</Set>
-        <Set name="url">jdbc:h2:gn;LOCK_TIMEOUT=20000;DB_CLOSE_ON_EXIT=FALSE</Set>
+        <Set name="url">jdbc:h2:gn;NON_KEYWORDS=VALUE;LOCK_TIMEOUT=20000;DB_CLOSE_ON_EXIT=FALSE</Set>
         <Set name="username">www-data</Set>
         <Set name="password">www-data</Set>
         <Set name="validationQuery">SELECT 1</Set>


### PR DESCRIPTION
Library reported as having security alerts have been updated and this is a follow up of https://github.com/geonetwork/core-geonetwork/pull/6104.

H2 version 2 can't read a version 1 database.

> Between version `1.4.200` and version `2.0.202` there have been considerable changes, such that a simple update is not possible. The official way to upgrade is to do a BACKUP of your existing database USING YOUR CURRENT VERSION OF H2. Then create a fresh database USING THE NEW VERSION OF H2, then perform a SCRIPT to load your data.

If the catalogue is not using H2 as the main database (as recommended in https://geonetwork-opensource.org/manuals/4.0.x/en/maintainer-guide/production-use/index.html#database), before starting the application remove:
* JS/CSS cache database in $DATA_DIR/wro4j-cache.mv.db
* Formatter cache database in $DATA_DIR/data/resources/htmlcache/formatter-cache/info-store.mv.db
Then start the application.

If the catalogue is using H2, no migration is provided so GeoNetwork users needs to:
* backup your database content
* Start the new version which will create a new database
* Reload your backup
or as it is recommended switch to another database type.



As suggested by @juanluisrp this change could be a good reason to make a 4.2.x as it will affect users during migration. At least by removing the caches or taking care of migrating H2 database if used as the main one. Any opinions?