### PR TITLE
Reordering elements on search page and editor board

### DIFF
--- a/web-ui/src/main/resources/catalog/components/usersearches/partials/usersearchespanel.html
+++ b/web-ui/src/main/resources/catalog/components/usersearches/partials/usersearchespanel.html
@@ -31,7 +31,7 @@
     <ul class="list-group">
       <li class="list-group-item clearfix" data-ng-repeat="search in userSearchesPageItems()">
         <div class="pull-left">
-          <span class="fa fa-star fa-fw"
+          <span class="fa fa-star fa-fw text-warning"
                 data-ng-show="canManageUserSearches() && search.featuredType !== ''"
                 title="{{ 'featuredsearch' | translate }}"></span>
           <span class="fa fa-fw"

--- a/web-ui/src/main/resources/catalog/templates/editor/editorboard.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/editorboard.html
@@ -6,18 +6,12 @@
       <div class="col-sm-12"
           data-ng-search-form=""
           data-runSearch="true"
-          data-wait-for-user="true" >
-
-
+          data-wait-for-user="true">
         <form class="form-horizontal"
                 role="form">
             <input type="hidden" name="_csrf" value="{{csrf}}"/>
             <div class="row gn-top-search">
-              <div class="col-md-3 gn-search-facet">
-                <div data-gn-user-searches-panel="user"
-                     data-ng-if="isUserSearchesEnabled && user.isConnected()"></div>
-              </div>
-              <div class="col-md-4">
+              <div class="col-md-offset-3 col-md-6">
                 <div class="input-group gn-form-any">
                   <div data-gn-user-searches-list=""
                        data-ng-cloak=""
@@ -72,26 +66,6 @@
                   <div data-ng-include="advancedSearchTemplate"></div>
                 </div>
               </div>
-              <div class="col-xs-5 col-sm-5 col-md-5 col-lg-5 text-right">
-                <a href="#/create" class="btn btn-primary btn-truncate" title="{{'addRecord' | translate}}">
-                  <i class="fa fa-fw fa-plus"/><span class=" hidden-sm" data-translate="">addRecord</span>
-                </a>
-                <a href="#/import" class="btn btn-default btn-truncate" title="{{'ImportRecord' | translate}}">
-                  <i class="fa fa-fw fa-upload"/><span class="hidden-xs hidden-sm" data-translate="">ImportRecord</span>
-                </a>
-                <a href="#/directory" class="btn btn-default btn-truncate" title="{{'directoryManager' | translate}}"
-                  ng-if="user.isEditorOrMore()">
-                  <i class="fa fa-fw fa-bookmark"/><span class="hidden-xs hidden-sm hidden-md btn-truncate-lg" data-translate="">directoryManager</span>
-                </a>
-                <a href="#/batchedit" class="btn btn-default btn-truncate" title="{{'batchEditing' | translate}}"
-                  ng-if="user.isEditorOrMore()">
-                  <i class="fa fa-fw fa-pencil"/><span class="hidden-xs hidden-sm hidden-md" data-translate="">batchEditing</span>
-                </a>
-                <a href="#/accessManager" class="btn btn-default" title="{{'accessManager' | translate}}"
-                  ng-if="user.isAdministratorOrMore() && healthCheck.IndexHealthCheck === true">
-                  <i class="fa fa-fw fa-lock"/><span class="hidden-xs hidden-sm hidden-md" data-translate="">accessManager</span>
-                </a>
-              </div>
             </div>
           </form>
 
@@ -106,18 +80,20 @@
         </div>
 
         <div class="row">
-          <div class="col-sm-3 col-md-3 gn-search-facet">
+          <div class="col-sm-3 col-md-3 col-lg-3 gn-search-facet">
             <div data-search-filter-tags
                  data-dimensions="searchResults.facets"
                  data-use-location-parameters="true"
                  ng-if="searchResults.facets">
             </div>
 
+            <div data-gn-user-searches-panel="user"
+                 data-ng-if="isUserSearchesEnabled && user.isConnected()"></div>
             <div
               ng-if="searchResults.facets"
               data-es-facets="searchResults.facets"/>
           </div>
-          <div class="col-sm-9 col-md-9">
+          <div class="col-sm-8 col-md-8 col-lg-7">
 
             <span class="loading fa fa-spinner fa-spin"
                   data-ng-show="searching"></span>
@@ -159,6 +135,26 @@
                   data-search-results="searchResults"
                   data-template-url="resultTemplate"></div>
             </div>
+          </div>
+          <div class="col-sm-1 col-md-1 col-lg-2 gn-sm-nopadding-left">
+            <a href="#/create" class="btn btn-primary btn-block gn-margin-bottom" title="{{'addRecord' | translate}}">
+              <i class="fa fa-fw fa-plus"/><span class="hidden-xs hidden-sm hidden-md" data-translate="">addRecord</span>
+            </a>
+            <a href="#/import" class="btn btn-default btn-block gn-margin-bottom" title="{{'ImportRecord' | translate}}">
+              <i class="fa fa-fw fa-upload"/><span class="hidden-xs hidden-sm hidden-md" data-translate="">ImportRecord</span>
+            </a>
+            <a href="#/directory" class="btn btn-default btn-block gn-margin-bottom" title="{{'directoryManager' | translate}}"
+               ng-if="user.isEditorOrMore()">
+              <i class="fa fa-fw fa-bookmark"/><span class="hidden-xs hidden-sm hidden-md" data-translate="">directoryManager</span>
+            </a>
+            <a href="#/batchedit" class="btn btn-default btn-block gn-margin-bottom" title="{{'batchEditing' | translate}}"
+               ng-if="user.isEditorOrMore()">
+              <i class="fa fa-fw fa-pencil"/><span class="hidden-xs hidden-sm hidden-md" data-translate="">batchEditing</span>
+            </a>
+            <a href="#/accessManager" class="btn btn-default btn-block gn-margin-bottom" title="{{'accessManager' | translate}}"
+               ng-if="user.isAdministratorOrMore() && healthCheck.IndexHealthCheck === true">
+              <i class="fa fa-fw fa-lock"/><span class="hidden-xs hidden-sm hidden-md" data-translate="">accessManager</span>
+            </a>
           </div>
         </div>
       </div>

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
@@ -81,9 +81,8 @@
     }
   }
   .gn-editor-board {
+    padding-top: @gn-header-height;
     .gn-top-search {
-      padding-top: 0;
-      padding-bottom: 0;
       background-color: #fff;
     }
   }

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_facets_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_facets_default.less
@@ -36,6 +36,9 @@ facetsConfigService ? */
       padding-right: 0;
     }
   }
+  .text-warning {
+    color: #ffc107;
+  }
 }
 
 // nojs styles
@@ -59,7 +62,7 @@ facetsConfigService ? */
       overflow: hidden;
       text-overflow: ellipsis;
     }
-    details { 
+    details {
       ul {
         padding-left: 2.5em;
       }

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_view.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_view.less
@@ -1,3 +1,5 @@
+@import "../../../lib/style/bootstrap/less/variables.less";
+
 /* Defined here any custom style for the view
    which has to be applied for all apps
    (ie. admin, search, login, editor). */
@@ -26,6 +28,26 @@
 .gn-nopadding-right { padding-right: 0 !important; }
 .gn-nopadding-bottom { padding-bottom: 0 !important; }
 .gn-nopadding-left { padding-left: 0 !important; }
+.gn-sm-nopadding-top {
+  @media (max-width: @screen-sm-max) {
+    padding-top: 0 !important;
+  }
+}
+.gn-sm-nopadding-right {
+  @media (max-width: @screen-sm-max) {
+    padding-right: 0 !important;
+  }
+}
+.gn-sm-nopadding-bottom {
+  @media (max-width: @screen-sm-max) {
+    padding-bottom: 0 !important;
+  }
+}
+.gn-sm-nopadding-left {
+  @media (max-width: @screen-sm-max) {
+    padding-left: 0 !important;
+  }
+}
 
 // margin
 .gn-margin-top { margin-top: @gn-spacing !important; }

--- a/web-ui/src/main/resources/catalog/views/default/templates/results.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/results.html
@@ -27,6 +27,8 @@
              ng-if="isFilterTagsDisplayedInSearch && searchResults.facets">
         </div>
 
+        <div data-gn-user-searches-panel="user"
+             data-ng-if="isUserSearchesEnabled && user.isConnected()"></div>
 
             <div data-ng-show="searchResults.records.length > 0"
                  data-es-facets="searchResults.facets"></div>

--- a/web-ui/src/main/resources/catalog/views/default/templates/searchForm.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/searchForm.html
@@ -4,11 +4,7 @@
   <!--ANY full text search input-->
   <div class="row gn-top-search">
     <div data-ng-class="fluidLayout ? 'container-fluid' : 'container'">
-      <div class="col-md-3 gn-search-facet">
-        <div data-gn-user-searches-panel="user"
-             data-ng-if="isUserSearchesEnabled && user.isConnected()"></div>
-      </div>
-      <div class="col-md-6">
+      <div class="col-md-offset-3 col-md-6">
         <div class="input-group gn-form-any">
           <div data-gn-user-searches-list=""
                data-ng-cloak=""


### PR DESCRIPTION
Replaces: https://github.com/geonetwork/core-geonetwork/pull/6107

When all options are selected in the admin pages, the top of the search page and editor board can be become a little cluttered. This PR reorders the different elements a bit to get a cleaner, more minimal look.

Placing the buttons in the right column enables them to be more responsive and look the same on all screen sizes

Reordered elements:
- user search list to left column
- contribute buttons in (new) right column
- only search input left on top

Small changes:
- color the 'favourite' icon

**2 screenshot for 2 screen sizes**

![gn-reorder-large](https://user-images.githubusercontent.com/19608667/148941811-8d1934b6-b63b-4a1b-83c7-89bac9f7f619.png)

![gn-reorder-small](https://user-images.githubusercontent.com/19608667/148941991-a6b3667b-be1f-441f-991d-4f92b7d3d19b.png)

