### PR TITLE
Create hierarchy in the language elements on the advanced search options

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/searchoptions/partials/searchoptions.html
+++ b/web-ui/src/main/resources/catalog/components/search/searchoptions/partials/searchoptions.html
@@ -1,4 +1,5 @@
-<div title="{{'exactMatch-help' | translate}}"
+<div class="checkbox"
+     title="{{'exactMatch-help' | translate}}"
      data-ng-show="optionsConfig.exactMatch">
   <label>
     <input type="checkbox"
@@ -7,7 +8,8 @@
     <span data-translate="">exactMatch</span>
   </label>
 </div>
-<div title="{{'titleOnly-help' | translate}}"
+<div class="checkbox"
+     title="{{'titleOnly-help' | translate}}"
      data-ng-show="optionsConfig.titleOnly">
   <label>
     <input type="checkbox"
@@ -16,13 +18,20 @@
     <span data-translate="">titleOnly</span>
   </label>
 </div>
+<div class="checkbox"
+     data-ng-show="user.isConnected()">
+  <label>
+    <input type="checkbox"
+           data-ng-model="onlyMyRecord"
+           aria-label="{{'onlyMyRecord' | translate}}">
+    <span data-translate="">onlyMyRecord</span>
+  </label>
+</div>
 <div title="{{'searchAllLanguages-help' | translate}}"
      data-ng-show="optionsConfig.language"
-     class="row">
-  <div class="col-md-2">
-    <span data-translate="">searchWithLang</span>
-  </div>
-  <div class="col-md-10">
+     class="gn-margin-top">
+  <label data-translate="">searchWithLang</label>
+  <div class="radio">
     <label>
       <input type="radio"
              name="languageStrategy"
@@ -31,6 +40,8 @@
              aria-label="{{'searchInAllLanguages' | translate}}">
       <span data-translate="">searchInAllLanguages</span>
     </label>
+  </div>
+  <div class="radio">
     <label>
       <input type="radio"
              name="languageStrategy"
@@ -42,6 +53,8 @@
         ({{$parent.searchObj.state.detectedLanguage | translate}})
       </span>
     </label>
+  </div>
+  <div class="radio">
     <label>
       <input type="radio"
              name="languageStrategy"
@@ -50,8 +63,9 @@
              aria-label="{{'searchInUILanguage' | translate}}">
       <span data-translate="">searchInUILanguage</span>
     </label>
-    <br/>
-    <div data-ng-show="languagesAvailable.length > 1">
+  </div>
+  <div data-ng-show="languagesAvailable.length > 1">
+    <div class="radio">
       <label>
         <input type="radio"
                name="languageStrategy"
@@ -60,8 +74,9 @@
                aria-label="{{'forceALanguage' | translate}}">
         <span data-translate="">forceALanguage</span>
       </label>
-      <label data-ng-repeat="l in languagesAvailable"
-             title="{{l}}">
+    </div>
+    <div data-ng-repeat="l in languagesAvailable" class="radio gn-margin-left-lg">
+      <label title="{{l}}">
         <input type="radio"
                name="forcedLanguage"
                value="{{l}}"
@@ -71,12 +86,4 @@
       </label>
     </div>
   </div>
-</div>
-<div data-ng-show="user.isConnected()">
-  <label>
-    <input type="checkbox"
-           data-ng-model="onlyMyRecord"
-           aria-label="{{'onlyMyRecord' | translate}}">
-    <span data-translate="">onlyMyRecord</span>
-  </label>
 </div>

--- a/web-ui/src/main/resources/catalog/locales/en-v4.json
+++ b/web-ui/src/main/resources/catalog/locales/en-v4.json
@@ -249,7 +249,7 @@
   "ui-detectors": "Detectors",
   "uiRestorePrevious": "Restore last saved",
   "onlyMyRecord": "Only my records",
-  "searchWithLang": "Search ",
+  "searchWithLang": "Languages",
   "searchAllLanguages-help": "Define which language is giving priorities to some records.",
   "searchInAllLanguages": "in all languages",
   "searchInUILanguage": "in UI language",

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_search_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_search_default.less
@@ -200,7 +200,7 @@ a {
 // advanced search
 .gn-search-filter {
   position: absolute;
-  z-index: 10;
+  z-index: 110;
   padding: 15px;
   background-color: @panel-default-heading-bg;
   width: calc(~"100% - 30px");
@@ -211,11 +211,6 @@ a {
   }
   .col-md-2 {
     padding-left: 0;
-  }
-  .search-options {
-    label {
-      font-weight: normal;
-    }
   }
   .btn-link {
     padding-left: 0;


### PR DESCRIPTION
The advanced search options have all the radios in 1 big row, but they are in fact 2 lists of options.

This PR re-orders the list of language radio options to create a visual hierarchy.

**Before**:
<img width="803" alt="gn-lang-before" src="https://user-images.githubusercontent.com/19608667/163181945-0e4a7763-fdfa-4f67-9a8e-2bff2a90f4b9.png">

**After**:
<img width="815" alt="gn-lang-after" src="https://user-images.githubusercontent.com/19608667/163181904-a3757515-476c-4ff0-9d80-5e2df65d8084.png">

