### PR TITLE
Harvester / WFS features / Improvements

### DIFF
--- a/web-ui/src/main/resources/catalog/js/admin/DashboardWfsIndexingController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/DashboardWfsIndexingController.js
@@ -335,6 +335,9 @@
               field: 'endDate',
               title: $translate.instant('wfsIndexingEndDate'),
               sortable: true,
+              sorter: function(a, b) {
+                return a && a.localeCompare(b);
+              },
               formatter: function(value, row) {
                 if (value) {
                   var date = gnHumanizeTimeService(value, null, true);

--- a/web-ui/src/main/resources/catalog/js/admin/DashboardWfsIndexingController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/DashboardWfsIndexingController.js
@@ -35,13 +35,15 @@
     '$translate',
     '$element',
     '$timeout',
-    'gnMetadataManager',
     'gnHttp',
     'gnAlertService',
     'gnLangs',
     'wfsFilterService',
-    function($q, $scope, $location, $http, $translate, $element, $timeout, gnMetadataManager, gnHttp, gnAlertService, gnLangs,
-             wfsFilterService) {
+    'gnHumanizeTimeService',
+    'Metadata',
+    function($q, $scope, $location, $http, $translate,
+             $element, $timeout, gnHttp, gnAlertService, gnLangs,
+             wfsFilterService, gnHumanizeTimeService, Metadata) {
       // this returns a valid xx_XX language code based on available locales in bootstrap-table
       // if none found, return 'en'
       // FIXME: use a global service
@@ -57,6 +59,8 @@
         });
         return lang;
       }
+
+      var defaultStrategy = '';
 
       $scope.url = decodeURIComponent($location.search()['wfs-indexing']);
 
@@ -144,8 +148,6 @@
           });
           event.preventDefault();
         });
-
-        // bind md title
         $element.find('div[data-md-uuid]').each(function() {
           updateMdTitle(this);
         });
@@ -194,6 +196,7 @@
 
       $scope.refreshJobList = function() {
         $scope.jobs = {};
+        $scope.uuids = {};
         $scope.error = null;
         $scope.loading = true;
 
@@ -218,12 +221,14 @@
               var featureType = producer.wfsHarvesterParam.typeName;
               var key = url + '#' + featureType;
 
+              $scope.uuids[producer.wfsHarvesterParam.metadataUuid] = null;
+
               $scope.jobs[key] = {
                 url: url,
                 featureType: featureType,
                 status: 'not started',
                 mdUuid: producer.wfsHarvesterParam.metadataUuid,
-                strategy: producer.wfsHarvesterParam.strategy || '',
+                strategy: producer.wfsHarvesterParam.strategy || defaultStrategy,
                 cronScheduleExpression: producer.cronExpression,
                 cronScheduleProducerId: producer.id
               };
@@ -244,29 +249,22 @@
                 });
               }
             });
-
-            angular.forEach($scope.jobs, function(job) {
-              if (!job.mdUuid) return;
-              if ($scope.mdCache[job.mdUuid]) {
-                job.md = $scope.mdCache[job.mdUuid];
-                return;
-              }
-
-              gnMetadataManager.getMdObjByUuid(job.mdUuid).then(function(md) {
-                if (!md) {
-                  job.md = {
-                    error: 'wfsIndexingMetadataNotFound'
-                  };
-                } else {
-                  job.md = md;
-                }
-                $scope.mdCache[job.mdUuid] = job.md;
-
-                $element.find('div[data-md-uuid=' + job.mdUuid + ']').each(function() {
-                  updateMdTitle(this);
-                });
-              })
-            });
+            $http.post('../api/search/records/_search', {"query": {
+                "bool" : {
+                  "must": [
+                    {"terms": {"uuid": Object.keys($scope.uuids)}}
+                  ]
+                }},
+              "size": Object.keys($scope.uuids).length,
+              "_source": ["resourceTitleObject"]
+            }, {cache: true}).then(
+              function (r) {
+                r.data.hits.hits.forEach(function (hit) {
+                  $scope.mdCache[hit._id] = new Metadata(hit);
+                  $element.find('div[data-md-uuid=' + hit._id + ']').each(function() {
+                    updateMdTitle(this);
+                  });
+              })});
 
             $scope.jobsArray = Object.keys($scope.jobs).sort().map(function (key) {
               return $scope.jobs[key];
@@ -296,8 +294,8 @@
             paginationHAlign: 'right',
             paginationVAlign: 'bottom',
             paginationDetailHAlign: 'left',
-            paginationPreText: 'previous',
-            paginationNextText: 'Next page',
+            paginationPreText: $translate.instant('previous'),
+            paginationNextText: $translate.instant('next'),
             style: 'min-height:100',
             classes: 'table table-responsive full-width',
             sortName: 'endDate',
@@ -338,7 +336,12 @@
               title: $translate.instant('wfsIndexingEndDate'),
               sortable: true,
               formatter: function(value, row) {
-                return value ? moment(value).format('LLLL') : null;
+                if (value) {
+                  var date = gnHumanizeTimeService(value, null, true);
+                  return '<div title="' + date.title + '">' + date.value + '</div>'
+                } else {
+                  return null;
+                }
               }
             }, {
               field: 'status',
@@ -371,8 +374,9 @@
                 var labelDelete = $translate.instant('wfsDeleteWfsIndexing');
 
                 return '<a class="btn btn-xs btn-block btn-default" data-job-key="' + key + '"><icon class="fa fa-fw fa-calendar"/>' + labelEdit + '</a>' +
-                  '<a class="btn btn-xs btn-block btn-primary" data-trigger-job-key="' + key + '"><icon class="fa fa-fw fa-play"/>' + labelNow + '</a>' +
-                  '<a class="btn btn-xs btn-block btn-danger" data-delete-key="' + key + '"><icon class="fa fa-fw fa-times"/>' + labelDelete + '</a>';
+                  '<a class="btn btn-xs btn-block btn-default" data-trigger-job-key="' + key + '"><icon class="fa fa-fw fa-play text-primary"/>' + labelNow + '</a>' +
+                  '<a class="btn btn-xs btn-block btn-default" ' +
+                  '   data-delete-key="' + key + '"><icon class="fa fa-fw fa-times text-danger"/>' + labelDelete + '</a>';
               }
             }],
             locale: getBsTableLang()
@@ -450,7 +454,7 @@
         var params = {
           typeName: job.featureType,
           url: job.url,
-          strategy: job.strategy,
+          strategy: job.strategy || defaultStrategy,
           metadataUuid: job.mdUuid,
           tokenizedFields: null,
           treeFields : null

--- a/workers/wfsfeature-harvester/src/main/java/org/fao/geonet/harvester/wfsfeatures/worker/EsWFSFeatureIndexer.java
+++ b/workers/wfsfeature-harvester/src/main/java/org/fao/geonet/harvester/wfsfeatures/worker/EsWFSFeatureIndexer.java
@@ -42,6 +42,7 @@ import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.rest.RestStatus;
 import org.fao.geonet.harvester.wfsfeatures.model.WFSHarvesterParameter;
 import org.fao.geonet.index.es.EsRestClient;
+import org.geotools.data.DataSourceException;
 import org.geotools.data.simple.SimpleFeatureCollection;
 import org.geotools.data.store.ReprojectingFeatureCollection;
 import org.geotools.data.wfs.WFSDataStore;
@@ -63,6 +64,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
@@ -284,6 +286,17 @@ public class EsWFSFeatureIndexer {
                             feature = features.next();
                             featurePointer = String.format("%s/id:%s", featurePointer, feature.getID());
                         } catch (Exception e) {
+                            if (e.getCause() instanceof IOException
+                                || e.getCause() instanceof DataSourceException) {
+                                String msg = String.format(
+                                    "Error while getting feature %s. Exception is: %s. Harvesting task will be stopped. This is probably a problem with the data source or some network related issues. Try to relaunch it later.",
+                                    featurePointer,
+                                    e.getMessage()
+                                );
+                                LOGGER.warn(msg);
+                                report.put("error_ss", msg);
+                                break;
+                            }
                             String msg = String.format(
                                 "Error on reading %s. Exception is: %s",
                                 featurePointer, e.getMessage()

--- a/workers/wfsfeature-harvester/src/main/java/org/fao/geonet/harvester/wfsfeatures/worker/EsWFSFeatureIndexer.java
+++ b/workers/wfsfeature-harvester/src/main/java/org/fao/geonet/harvester/wfsfeatures/worker/EsWFSFeatureIndexer.java
@@ -70,13 +70,14 @@ import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.temporal.ChronoUnit;
-import java.util.HashMap;
-import java.util.LinkedHashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 import java.util.concurrent.Phaser;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.elasticsearch.rest.RestStatus.CREATED;
+import static org.elasticsearch.rest.RestStatus.OK;
 
 
 // TODO: GeoServer WFS 1.0.0 in some case return
@@ -88,7 +89,8 @@ public class EsWFSFeatureIndexer {
     public static final String CDATA_START = "<![CDATA[";
     public static final String CDATA_START_REGEX = "<!\\[CDATA\\[";
     public static final String CDATA_END = "]]>";
-    private static Logger LOGGER =  LoggerFactory.getLogger(WFSHarvesterRouteBuilder.LOGGER_NAME);
+    private static Logger LOGGER = LoggerFactory.getLogger(WFSHarvesterRouteBuilder.LOGGER_NAME);
+
     static {
         try {
             Logging.ALL.setLoggerFactory("org.geotools.util.logging.Log4JLoggerFactory");
@@ -157,13 +159,13 @@ public class EsWFSFeatureIndexer {
 
     /**
      * Create exchange states for this feature type.
-     *
+     * <p>
      * Load configuration from exchange properties.
      * Could be a {@link WFSHarvesterParameter} or url and typeName
      * exchange properties.
      *
      * @param exchange
-     * @param connect   Init datastore ie. connect to WFS, retrieve schema
+     * @param connect  Init datastore ie. connect to WFS, retrieve schema
      */
     public void initialize(Exchange exchange, boolean connect) throws InvalidArgumentException {
         WFSHarvesterParameter configuration = (WFSHarvesterParameter) exchange.getProperty("configuration");
@@ -172,7 +174,7 @@ public class EsWFSFeatureIndexer {
         }
 
         LOGGER.info("Initializing harvester configuration for uuid '{}', url '{}'," +
-            "feature type '{}'. treefields are {}, tokenizedFields are {} Exchange id is '{}'.", new Object[] {
+            "feature type '{}'. treefields are {}, tokenizedFields are {} Exchange id is '{}'.", new Object[]{
             configuration.getMetadataUuid(),
             configuration.getUrl(),
             configuration.getTypeName(),
@@ -221,7 +223,7 @@ public class EsWFSFeatureIndexer {
 
         } catch (Exception e) {
             e.printStackTrace();
-            LOGGER.error( "Error connecting to ES at '{}'. Error is {}.", index, e.getMessage());
+            LOGGER.error("Error connecting to ES at '{}'. Error is {}.", index, e.getMessage());
         }
     }
 
@@ -232,16 +234,16 @@ public class EsWFSFeatureIndexer {
     public void indexFeatures(Exchange exchange) throws Exception {
         WFSHarvesterExchangeState state = (WFSHarvesterExchangeState) exchange.getProperty("featureTypeConfig");
 
-        String url                              = state.getParameters().getUrl();
-        String typeName                         = state.getParameters().getTypeName();
-        String resolvedTypeName                 = state.getResolvedTypeName();
-        Map<String, String> tokenizedFields     = state.getParameters().getTokenizedFields();
-        WFSDataStore wfs                        = state.getWfsDatastore();
-        Map<String, String> featureAttributes   = state.getFields();
+        String url = state.getParameters().getUrl();
+        String typeName = state.getParameters().getTypeName();
+        String resolvedTypeName = state.getResolvedTypeName();
+        Map<String, String> tokenizedFields = state.getParameters().getTokenizedFields();
+        WFSDataStore wfs = state.getWfsDatastore();
+        Map<String, String> featureAttributes = state.getFields();
         TitleResolver titleResolver = getTitleResolver(state);
 
         LOGGER.info("Indexing WFS features from service '{}' and feature type '{}'. Precision model applied: '{}', number of decimals: '{}'", url, typeName, applyPrecisionModel, numberOfDecimals);
-        Report report= new Report(url, typeName);
+        Report report = new Report(url, typeName);
         ObjectNode protoNode = createProtoNode(url, typeName);
         if (state.getParameters().getMetadataUuid() != null) {
             report.put("parent", state.getParameters().getMetadataUuid());
@@ -254,8 +256,9 @@ public class EsWFSFeatureIndexer {
         initFeatureAttributeToDocumentFieldNamesMapping(featureAttributes, state.getParameters().getTreeFields(), report);
         boolean initializeESReportSucceeded = report.saveHarvesterReport();
         if (!initializeESReportSucceeded) {
-            LOGGER.error("couldn't initialize es report, don't even try to go further querying wfs.");
-            throw new RuntimeException("couldn't initialize es report, don't even try to go further querying wfs.");
+            String msg = "Couldn't initialize harvesting report, don't even try to go further querying wfs.";
+            LOGGER.error(msg);
+            throw new RuntimeException(msg);
         }
 
         try {
@@ -269,22 +272,24 @@ public class EsWFSFeatureIndexer {
 
             SimpleFeatureCollection fc = wfs.getFeatureSource(resolvedTypeName).getFeatures();
             ReprojectingFeatureCollection rfc = new ReprojectingFeatureCollection(fc, CRS.decode("urn:ogc:def:crs:OGC:1.3:CRS84"));
+
             FeatureIterator<SimpleFeature> features = rfc.features();
 
             try {
                 while (features.hasNext()) {
-
+                    String featurePointer = String.format("%s#%s", typeName, nbOfFeatures);
                     try {
                         SimpleFeature feature = null;
                         try {
                             feature = features.next();
+                            featurePointer = String.format("%s/id:%s", featurePointer, feature.getID());
                         } catch (Exception e) {
-                            LOGGER.warn("Error while getting feature for {}#{}. Exception is: {}", new Object[] {
-                                typeName, nbOfFeatures, e.getMessage()});
-                            report.put("error_ss", String.format(
-                                "Error while getting feature for %s#%s. Exception is: %s",
-                                typeName, nbOfFeatures, e.getMessage()
-                            ));
+                            String msg = String.format(
+                                "Error on reading %s. Exception is: %s",
+                                featurePointer, e.getMessage()
+                            );
+                            LOGGER.warn(msg);
+                            report.put("error_ss", msg);
                             continue;
                         }
                         ObjectNode rootNode = protoNode.deepCopy();
@@ -311,10 +316,19 @@ public class EsWFSFeatureIndexer {
                                 Geometry geom = (Geometry) feature.getDefaultGeometry();
 
                                 if (applyPrecisionModel) {
-                                    PrecisionModel precisionModel = new PrecisionModel(Math.pow(10, numberOfDecimals - 1));
-                                    geom = GeometryPrecisionReducer.reduce(geom, precisionModel);
-                                    // numberOfDecimals is equal to
-                                    // precisionModel.getMaximumSignificantDigits()
+                                    if (geom.isValid()) {
+                                        PrecisionModel precisionModel = new PrecisionModel(Math.pow(10, numberOfDecimals - 1));
+                                        geom = GeometryPrecisionReducer.reduce(geom, precisionModel);
+                                        // numberOfDecimals is equal to
+                                        // precisionModel.getMaximumSignificantDigits()
+                                    } else {
+                                        String msg = String.format(
+                                            "Feature %s: Cannot apply precision reducer on invalid geometry. Check the geometry validity. The feature will be indexed but with no geometry.",
+                                            featurePointer);
+                                        LOGGER.warn(msg);
+                                        report.put("error_ss", msg);
+                                        break;
+                                    }
                                 }
 
                                 // An issue here is that GeometryJSON conversion may over simplify
@@ -336,7 +350,7 @@ public class EsWFSFeatureIndexer {
                                 boolean isPoint = geom instanceof Point;
                                 if (isPoint) {
                                     Coordinate point = geom.getCoordinate();
-                                    rootNode.put("location", String.format("%s,%s", point.y , point.x));
+                                    rootNode.put("location", String.format("%s,%s", point.y, point.x));
                                 } else {
                                     report.setPointOnlyForGeomsFalse();
                                 }
@@ -353,11 +367,11 @@ public class EsWFSFeatureIndexer {
                                     rootNode.put(getDocumentFieldName(attributeName),
                                         ((DefaultInstant) attributeValue).getPosition().getDate().toInstant().toString());
                                 } catch (Exception instantException) {
-                                    LOGGER.warn("Error while getting attribute feature for {}#{} attribute {}, value {}. Exception is: {}", new Object[] {
-                                        typeName, nbOfFeatures, attributeName, attributeValue, instantException.getMessage()});
-                                    report.put("error_ss", String.format(
-                                        "Error while getting attribute feature for %s#%s attribute %s, value %s. Exception is: %s",
-                                            typeName, nbOfFeatures, attributeName, attributeValue, instantException.getMessage()));
+                                    String msg = String.format(
+                                        "Feature %s: Cannot read attribute %s, value %s. Exception is: %s",
+                                        featurePointer, attributeName, attributeValue, instantException.getMessage());
+                                    LOGGER.warn(msg);
+                                    report.put("error_ss", msg);
                                 }
                             } else {
                                 String value = attributeValue.toString();
@@ -370,16 +384,16 @@ public class EsWFSFeatureIndexer {
                             }
                         }
 
-                        nbOfFeatures ++;
+                        nbOfFeatures++;
                         brh.addAction(rootNode, feature);
 
                     } catch (Exception ex) {
-                        LOGGER.warn("Error while creating document for {} feature {}. Exception is: {}", new Object[] {
-                            typeName, nbOfFeatures, ex.getMessage()});
-                        report.put("error_ss", String.format(
-                            "Error while creating document for %s feature %d. Exception is: %s",
-                            typeName, nbOfFeatures, ex.getMessage()
-                        ));
+                        String msg = String.format(
+                            "Feature %s: Error is: %s",
+                            featurePointer, ex.getMessage()
+                        );
+                        LOGGER.warn(msg);
+                        report.put("error_ss", msg);
                     }
 
                     if (brh.getBulkSize() >= featureCommitInterval) {
@@ -402,9 +416,10 @@ public class EsWFSFeatureIndexer {
             } catch (TimeoutException e) {
                 throw new Exception("Timeout when awaiting all bulks to be processed.");
             }
-            LOGGER.info("Total number of {} features indexed is {} in {} ms.", new Object[]{
+            LOGGER.info("{}: {} features processed in {} ms.", new Object[]{
                 typeName, nbOfFeatures,
-                System.currentTimeMillis() - begin});
+                System.currentTimeMillis() - begin
+            });
             report.success(nbOfFeatures);
         } catch (Exception e) {
             report.put("status_s", "error");
@@ -428,14 +443,11 @@ public class EsWFSFeatureIndexer {
                         WFSFeatureUtils.buildFeatureTitle(simpleFeature, state.getFields(), titleExpression));
                 }
             };
-        } else if (defaultTitleAttribute !=null) {
+        } else if (defaultTitleAttribute != null) {
             titleResolver = new TitleResolver() {
                 @Override
                 public void setTitle(ObjectNode objectNode, SimpleFeature simpleFeature) {
-                    Object titleAttribute = simpleFeature.getAttribute(defaultTitleAttribute);
-                    if (titleAttribute != null) {
-                        objectNode.put("resourceTitle", titleAttribute.toString());
-                    }
+                    objectNode.put("resourceTitle", simpleFeature.getAttribute(defaultTitleAttribute).toString());
                 }
             };
         } else {
@@ -480,7 +492,7 @@ public class EsWFSFeatureIndexer {
         }
 
         public void success(int nbOfFeatures) {
-            report.put("status_s","success");
+            report.put("status_s", "success");
             report.put("totalRecords_i", nbOfFeatures);
             OffsetDateTime dateTime = OffsetDateTime.now(ZoneOffset.UTC).truncatedTo(ChronoUnit.SECONDS);
             report.put("endDate_dt", dateTime.format(DateTimeFormatter.ISO_LOCAL_DATE_TIME));
@@ -498,7 +510,7 @@ public class EsWFSFeatureIndexer {
                     LOGGER.info("Report saved for service {} and typename {}. Report id is {}",
                         url, typeName, report.get("id"));
                 } else {
-                    LOGGER.info("Failed to save report for {}. Error message when saving report was '{}'.",
+                    LOGGER.info("Failed to save report for {}. Error was '{}'.",
                         typeName,
                         response.getResult());
                 }
@@ -531,6 +543,7 @@ public class EsWFSFeatureIndexer {
         protected long begin;
         protected BulkRequest bulk;
         protected int bulkSize;
+        protected int failuresCount;
         ActionListener<BulkResponse> listener;
 
         public BulkResutHandler(Phaser phaser, String typeName, String url, int firstFeatureIndex, Report report, String metadataUuid) {
@@ -541,26 +554,48 @@ public class EsWFSFeatureIndexer {
             this.report = report;
 
             this.metadataUuid = metadataUuid;
-            this.bulk =  new BulkRequest(index);
+            this.bulk = new BulkRequest(index);
             this.bulkSize = 0;
-            LOGGER.debug("  {} - from {}, {} features to index, preparing bulk.", typeName, firstFeatureIndex, featureCommitInterval);
+            this.failuresCount = 0;
+            LOGGER.debug("  {} - Indexing bulk (size {}) starting at {} ...",
+                typeName, featureCommitInterval, firstFeatureIndex);
 
             listener = new ActionListener<BulkResponse>() {
                 @Override
                 public void onResponse(BulkResponse bulkResponse) {
-                    LOGGER.debug("  {} - from {}, {}/{} features, indexed in {} ms.", new Object[]{
-                        typeName, firstFeatureIndex, bulkSize, featureCommitInterval, System.currentTimeMillis() - begin});
+                    AtomicInteger bulkFailures = new AtomicInteger();
+                    if (bulkResponse.hasFailures()) {
+                        Arrays.stream(bulkResponse.getItems()).forEach(e -> {
+                            if (e.status() != OK
+                                && e.status() != CREATED) {
+                                String msg = String.format(
+                                    "Feature %s: Indexing error. Error is: %s", e.getId(), e.getFailure().toString());
+                                report.put("error_ss", msg);
+                                LOGGER.warn(msg);
+                                bulkFailures.getAndIncrement();
+                            }
+                        });
+                    }
+                    LOGGER.debug("  {} - Features [{}-{}] indexed in {} ms{}.", new Object[]{
+                        typeName, firstFeatureIndex, firstFeatureIndex + bulkSize,
+                        System.currentTimeMillis() - begin,
+                        bulkResponse.hasFailures() ?
+                            " but with " + bulkFailures + " errors" : ""
+                    });
+                    failuresCount = bulkFailures.get();
                     phaser.arriveAndDeregister();
                 }
 
                 @Override
                 public void onFailure(Exception e) {
-                    report.put("error_ss", String.format(
-                        "Error while indexing %s block of documents [%d-%d]. Exception is: %s",
-                        typeName, firstFeatureIndex, firstFeatureIndex + featureCommitInterval, e.getMessage()
-                    ));
-                    LOGGER.error("  {} - from {}, {}/{} features, NOT indexed in {} ms. ({}).", new Object[]{
-                        typeName, firstFeatureIndex, bulkSize, featureCommitInterval, System.currentTimeMillis() - begin, e.getMessage()});
+                    String msg = String.format(
+                        "Features [%s-%s] indexed in %s ms but with errors. Exception: %s",
+                        typeName, firstFeatureIndex, bulkSize,
+                        System.currentTimeMillis() - begin,
+                        e.getMessage()
+                    );
+                    report.put("error_ss", msg);
+                    LOGGER.error(msg);
                     phaser.arriveAndDeregister();
                 }
             };
@@ -568,6 +603,10 @@ public class EsWFSFeatureIndexer {
 
         public int getBulkSize() {
             return bulkSize;
+        }
+
+        public int getNumberOfIndexedFeatures() {
+            return bulkSize - failuresCount;
         }
 
         public void addAction(ObjectNode rootNode, SimpleFeature feature) throws JsonProcessingException {
@@ -587,9 +626,8 @@ public class EsWFSFeatureIndexer {
         protected void prepareLaunch() {
             phaser.register();
             this.begin = System.currentTimeMillis();
-            LOGGER.debug("  {} - from {}, {}/{} features, launching bulk.", new Object[]{
-                typeName, firstFeatureIndex, bulkSize, featureCommitInterval,});
         }
+
         abstract public void launchBulk(EsRestClient client) throws Exception;
     }
 
@@ -613,14 +651,16 @@ public class EsWFSFeatureIndexer {
     private static final String TREE_FIELD_SUFFIX = "_tree";
     private static final String FEATURE_FIELD_PREFIX = "ft_";
     private static final Map<String, String> XSDTYPES_TO_FIELD_NAME_SUFFIX;
-    static { XSDTYPES_TO_FIELD_NAME_SUFFIX = ImmutableMap.<String, String>builder()
-        .put("integer", "_ti")
-        .put("string", DEFAULT_FIELDSUFFIX)
-        .put("double", "_d")
-        .put("boolean", "_b")
-        .put("date", "_dt")
-        .put("dateTime", "_dt")
-        .build();
+
+    static {
+        XSDTYPES_TO_FIELD_NAME_SUFFIX = ImmutableMap.<String, String>builder()
+            .put("integer", "_ti")
+            .put("string", DEFAULT_FIELDSUFFIX)
+            .put("double", "_d")
+            .put("boolean", "_b")
+            .put("date", "_dt")
+            .put("dateTime", "_dt")
+            .build();
     }
 
     private Map<String, String> featureAttributeToDocumentFieldNames = new LinkedHashMap<String, String>();

--- a/workers/wfsfeature-harvester/src/main/java/org/fao/geonet/harvester/wfsfeatures/worker/EsWFSFeatureIndexer.java
+++ b/workers/wfsfeature-harvester/src/main/java/org/fao/geonet/harvester/wfsfeatures/worker/EsWFSFeatureIndexer.java
@@ -447,7 +447,10 @@ public class EsWFSFeatureIndexer {
             titleResolver = new TitleResolver() {
                 @Override
                 public void setTitle(ObjectNode objectNode, SimpleFeature simpleFeature) {
-                    objectNode.put("resourceTitle", simpleFeature.getAttribute(defaultTitleAttribute).toString());
+                    Object titleAttribute = simpleFeature.getAttribute(defaultTitleAttribute);
+                    if (titleAttribute != null) {
+                        objectNode.put("resourceTitle", titleAttribute.toString());
+                    }
                 }
             };
         } else {


### PR DESCRIPTION
* Improve logging message (and cleanup)
* Validate geometry before applying precision model (which will fails) and report the error. The feature will be indexed with no geometry
* Handle error on bulk response. Sometimes Elasticsearch fails to index geometry and user can only find the cause in Elasticsearch logs.


Testing can be done with https://sextant.ifremer.fr/Donnees/Catalogue#/metadata/08d2834a-28ed-43d5-8f2c-4bcafdbc445d. The polygon layer contains one invalid geometry.