### PR TITLE
Reorder the elements for the `series` and `dataset` pages.

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -1432,7 +1432,18 @@ gn-indexing-task-status {
 .width-100 { width: 100%; } .width-75 { width: 75%; } .width-50 { width: 50%; }
 .width-25 { width: 25%; } .width-33 { width: 33%; } .width-66 { width: 66%; }
 .height-auto { height: auto !important; max-height: none !important; }
-
+.col-2 {
+  column-count: 2;
+  div {
+    break-inside: avoid;
+  }
+}
+.col-3 {
+  column-count: 3;
+  div {
+    break-inside: avoid;
+  }
+}
 
 html {
   // As a side-effect of setting the @viewport in bootstrap,

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_result_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_result_default.less
@@ -87,6 +87,14 @@
     background-color: #efefef !important;
     flex: none;
     display: none;
+    &.bg-success {
+      color: #fff;
+      background-color: @brand-success !important;
+    }
+    &.bg-danger {
+      color: #fff;
+      background-color: @brand-danger !important;
+    }
   }
   // card
   .gn-card-view-header {

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/categories.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/categories.html
@@ -1,69 +1,66 @@
-<div>
-  <div data-ng-if="mdView.current.record.cat.length > 0 ||
-                   mdView.current.record.cl_topic.length > 0"
-       class="gn-margin-bottom flex-row">
-    <span class="badge badge-rounded"
-          title="{{'listOfCategories' | translate}}">
-      <i class="fa fa-fw fa-tags"></i>
-    </span>
-    <div>
+<div data-ng-if="mdView.current.record.cat.length > 0 ||
+                 mdView.current.record.cl_topic.length > 0"
+     class="gn-margin-bottom flex-row">
+  <span class="badge badge-rounded"
+        title="{{'listOfCategories' | translate}}">
+    <i class="fa fa-fw fa-tags"></i>
+  </span>
+  <div>
 
-      <h3 data-translate="">listOfCategories</h3>
+    <h3 data-translate="">listOfCategories</h3>
 
-      <div class="gn-label-list">
-        <button data-ng-repeat="cat in mdView.current.record.cat"
-                data-ng-click="filterBy('cat', cat)"
-                data-ng-if="!sortKeywordsAlphabetically"
-                class="btn btn-xs btn-default"
-                title="{{'clickToFilterOn' | translate}} {{('cat-' + cat) | translate}}">
-          <span class="fa gn-icon-{{cat}} resource-color"></span>&nbsp;
-          {{('cat-' + cat) | translate}}
+    <div class="gn-label-list">
+      <button data-ng-repeat="cat in mdView.current.record.cat"
+              data-ng-click="filterBy('cat', cat)"
+              data-ng-if="!sortKeywordsAlphabetically"
+              class="btn btn-xs btn-default"
+              title="{{'clickToFilterOn' | translate}} {{('cat-' + cat) | translate}}">
+        <span class="fa gn-icon-{{cat}} resource-color"></span>&nbsp;
+        {{('cat-' + cat) | translate}}
+      </button>
+
+      <button data-ng-repeat="cat in mdView.current.record.cat  | orderBy:sortByCategory"
+              data-ng-click="filterBy('cat', cat)"
+              data-ng-if="sortKeywordsAlphabetically"
+              class="btn btn-xs btn-default"
+              title="{{'clickToFilterOn' | translate}} {{('cat-' + cat) | translate}}">
+        <span class="fa gn-icon-{{cat}} resource-color"></span>&nbsp;
+        {{('cat-' + cat) | translate}}
+      </button>
+    </div>
+    <hr data-ng-if="mdView.current.record.cat.length > 0 &&
+                      mdView.current.record.cl_topic.length > 0" />
+
+    <div class="gn-label-list">
+      <div data-ng-repeat="cat in mdView.current.record.cl_topic track by $index"
+           data-ng-if="(cat != '') && !sortKeywordsAlphabetically"
+           gn-popover=""
+           gn-popover-placement="bottom">
+        <button class="btn btn-xs btn-default"
+                gn-popover-anchor="">
+          <span class="fa gn-icon-{{cat.key}} topic-color"></span>&nbsp;
+          {{cat.key | translate}}
         </button>
-
-        <button data-ng-repeat="cat in mdView.current.record.cat  | orderBy:sortByCategory"
-                data-ng-click="filterBy('cat', cat)"
-                data-ng-if="sortKeywordsAlphabetically"
-                class="btn btn-xs btn-default"
-                title="{{'clickToFilterOn' | translate}} {{('cat-' + cat) | translate}}">
-          <span class="fa gn-icon-{{cat}} resource-color"></span>&nbsp;
-          {{('cat-' + cat) | translate}}
-        </button>
-      </div>
-      <hr data-ng-if="mdView.current.record.cat.length > 0 &&
-                        mdView.current.record.cl_topic.length > 0" />
-
-      <div class="gn-label-list">
-        <div data-ng-repeat="cat in mdView.current.record.cl_topic track by $index"
-             data-ng-if="(cat != '') && !sortKeywordsAlphabetically"
-             gn-popover=""
-             gn-popover-placement="bottom">
-          <button class="btn btn-xs btn-default"
-                  gn-popover-anchor="">
-            <span class="fa gn-icon-{{cat.key}} topic-color"></span>&nbsp;
-            {{cat.key | translate}}
-          </button>
-          <div gn-popover-content="">
-            <div data-gn-search-filter-link="cl_topic.key"
-                 data-filter="cat.key">{{cat.key}}</div>
-          </div>
+        <div gn-popover-content="">
+          <div data-gn-search-filter-link="cl_topic.key"
+               data-filter="cat.key">{{cat.key}}</div>
         </div>
+      </div>
 
-        <div data-ng-repeat="cat in mdView.current.record.cl_topic | orderBy: 'key | translate'"
-             data-ng-if="(cat != '') && sortKeywordsAlphabetically"
-             gn-popover=""
-             gn-popover-placement="bottom">
-          <button class="btn btn-xs btn-default"
-                  gn-popover-anchor="">
-            <span class="fa gn-icon-{{cat.key}} topic-color"></span>&nbsp;
-            {{cat.key | translate}}
-          </button>
-          <div gn-popover-content="">
-            <div data-gn-search-filter-link="cl_topic.key"
-                 data-filter="cat.key">{{cat.key}}</div>
-          </div>
+      <div data-ng-repeat="cat in mdView.current.record.cl_topic | orderBy: 'key | translate'"
+           data-ng-if="(cat != '') && sortKeywordsAlphabetically"
+           gn-popover=""
+           gn-popover-placement="bottom">
+        <button class="btn btn-xs btn-default"
+                gn-popover-anchor="">
+          <span class="fa gn-icon-{{cat.key}} topic-color"></span>&nbsp;
+          {{cat.key | translate}}
+        </button>
+        <div gn-popover-content="">
+          <div data-gn-search-filter-link="cl_topic.key"
+               data-filter="cat.key">{{cat.key}}</div>
         </div>
       </div>
     </div>
   </div>
-
 </div>

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/featurecatalogue.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/featurecatalogue.html
@@ -1,51 +1,45 @@
-<div class="row gn-section"
-     data-ng-if="mdView.current.record.featureTypes
-                 || mdView.current.record.relatedRecords.fcats.length > 0">
-  <div class="col-md-12 gn-record">
-    <div data-ng-repeat="featureType in mdView.current.record.featureTypes">
+<div data-ng-repeat="featureType in mdView.current.record.featureTypes">
 
-      <h3 data-translate="">featureAttributeTable</h3>
+  <h3 data-translate="">featureAttributeTable</h3>
 
-      <table class="table table-striped">
-        <tbody>
-        <tr data-ng-if="featureType.typeName">
-          <th></th>
-          <td>{{featureType.typeName}}</td>
-        </tr>
-        <tr data-ng-if="featureType.definition">
-          <th data-translate="">featureDefinition</th>
-          <td>{{featureType.definition}}</td>
-        </tr>
-        <tr data-ng-if="featureType.code">
-          <th data-translate="">featureCode</th>
-          <td>{{featureType.code}}</td>
-        </tr>
-        <tr data-ng-if="featureType.isAbstract">
-          <th data-translate="">featureIsAbstract</th>
-          <td>{{featureType.isAbstract}}</td>
-        </tr>
-        <tr data-ng-if="featureType.aliases">
-          <th data-translate="">featureAliases</th>
-          <td>{{featureType.aliases}}</td>
-        </tr>
-        <tr data-ng-if="featureType.attributeTable">
-          <td colspan="2" class="gn-noborder-top gn-nopadding-top gn-nopadding-bottom"/>
-        </tr>
-        <tr data-ng-if="featureType.attributeTable">
-          <td colspan="2" class="gn-noborder-top gn-table-attribute">
-            <div data-ng-if="featureType.attributeTable"
-                 data-gn-attribute-table-renderer="featureType.attributeTable">
-            </div>
-          </td>
-        </tr>
-        </tbody>
-      </table>
-    </div>
-    <div data-ng-if="mdView.current.record.relatedRecords"
-         data-gn-related="mdView.current.record"
-         data-user="user"
-         data-types="fcats|related"
-         data-title="{{'featureCatalog' | translate}}">
-    </div>
-  </div>
+  <table class="table table-striped">
+    <tbody>
+    <tr data-ng-if="featureType.typeName">
+      <th></th>
+      <td>{{featureType.typeName}}</td>
+    </tr>
+    <tr data-ng-if="featureType.definition">
+      <th data-translate="">featureDefinition</th>
+      <td>{{featureType.definition}}</td>
+    </tr>
+    <tr data-ng-if="featureType.code">
+      <th data-translate="">featureCode</th>
+      <td>{{featureType.code}}</td>
+    </tr>
+    <tr data-ng-if="featureType.isAbstract">
+      <th data-translate="">featureIsAbstract</th>
+      <td>{{featureType.isAbstract}}</td>
+    </tr>
+    <tr data-ng-if="featureType.aliases">
+      <th data-translate="">featureAliases</th>
+      <td>{{featureType.aliases}}</td>
+    </tr>
+    <tr data-ng-if="featureType.attributeTable">
+      <td colspan="2" class="gn-noborder-top gn-nopadding-top gn-nopadding-bottom"/>
+    </tr>
+    <tr data-ng-if="featureType.attributeTable">
+      <td colspan="2" class="gn-noborder-top gn-table-attribute">
+        <div data-ng-if="featureType.attributeTable"
+             data-gn-attribute-table-renderer="featureType.attributeTable">
+        </div>
+      </td>
+    </tr>
+    </tbody>
+  </table>
+</div>
+<div data-ng-if="mdView.current.record.relatedRecords"
+     data-gn-related="mdView.current.record"
+     data-user="user"
+     data-types="fcats|related"
+     data-title="{{'featureCatalog' | translate}}">
 </div>

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/lineage.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/lineage.html
@@ -1,45 +1,14 @@
-<div class="row"
-     data-ng-if="mdView.current.record.lineage
-                 || mdView.current.record.sourceDescription
-                 || mdView.current.record.supplementalInformation">
-  <div class="col-md-8 gn-record">
-    <div data-ng-if="mdView.current.record.lineage">
-      <h2 data-translate="">lineage</h2>
-      <p data-ng-bind-html="mdView.current.record.lineage | linky | newlines"/>
-    </div>
-
-    <div data-ng-if="mdView.current.record.sourceDescription">
-      <h2 data-translate="">sourceDescription</h2>
-      <p data-ng-bind-html="mdView.current.record.sourceDescription | linky | newlines"/>
-    </div>
-
-    <div data-ng-if="mdView.current.record.supplementalInformation">
-      <h2 data-translate="">supplementalInformation</h2>
-      <p data-ng-bind-html="mdView.current.record.supplementalInformation | linky | newlines"/>
-    </div>
-
-  </div>
-  <!-- /.col-md-8 gn-record -->
-  <div class="gn-md-side"
-       data-ng-class="[].concat(mdView.current.record.relatedRecords.sources, mdView.current.record.relatedRecords.hassources).length > 3 ? 'col-md-12' : 'col-md-4'">
-    <div data-ng-if="mdView.current.record.relatedRecords"
-         data-gn-related="mdView.current.record"
-         data-user="user"
-         data-types="sources"
-         data-layout="card"
-         data-has-results="hasRelations.sources"
-         data-title="{{'sourceDatasets' | translate}}">
-    </div>
-    <div data-ng-if="mdView.current.record.relatedRecords"
-         data-gn-related="mdView.current.record"
-         data-user="user"
-         data-types="hassources"
-         data-layout="card"
-         data-has-results="hasRelations.hassources"
-         data-title="{{'isSourceOfDatasets' | translate}}">
-    </div>
-  </div>
+<div data-ng-if="mdView.current.record.lineage">
+  <h2 data-translate="">lineage</h2>
+  <p data-ng-bind-html="mdView.current.record.lineage | linky | newlines"/>
 </div>
 
-<div ng-include="'../../catalog/views/default/templates/recordView/quality.html'"/>
+<div data-ng-if="mdView.current.record.sourceDescription">
+  <h2 data-translate="">sourceDescription</h2>
+  <p data-ng-bind-html="mdView.current.record.sourceDescription | linky | newlines"/>
+</div>
 
+<div data-ng-if="mdView.current.record.supplementalInformation">
+  <h2 data-translate="">supplementalInformation</h2>
+  <p data-ng-bind-html="mdView.current.record.supplementalInformation | linky | newlines"/>
+</div>

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/metadata.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/metadata.html
@@ -1,83 +1,60 @@
-<div class="row">
-  <div class="col-md-12">
-    <h2>
-      <span data-translate="">metadataInformation</span>
-    </h2>
+<div class="gn-margin-bottom">
+  <span class="badge badge-rounded" title="{{'updatedOn' | translate}}">
+    <i class="fa fa-fw fa-file-code-o"></i>
+  </span>
+  <a class="btn btn-default btn-sm"
+     data-ng-href="../api/records/{{mdView.current.record.uuid}}/formatters/xml">
+    <span data-translate="">metadataInXML</span>
+  </a>
+</div>
+
+<div class="gn-md-side-calendar gn-margin-bottom">
+    <span class="badge badge-rounded" title="{{'updatedOn' | translate}}">
+      <i class="fa fa-fw fa-calendar"></i>
+    </span>
+  <h3 data-translate="">updatedOn</h3>
+  <span data-gn-humanize-time="{{mdView.current.record.changeDate}}"
+        data-from-now=""></span>
+</div>
+
+<div data-ng-init="mdLanguages = [mdView.current.record.mainLanguage].concat(mdView.current.record.otherLanguage || [])"
+     data-aang-if="mdLanguages.length > 0"
+     class="gn-margin-bottom flex-row">
+  <span class="badge badge-rounded" title="{{'language' | translate}}">
+    <i class="fa fa-fw fa-language"></i>
+  </span>
+  <div>
+    <h3 data-translate="">metadataLanguage</h3>
+    <ul class="gn-comma-list">
+      <li data-ng-repeat="l in mdLanguages">
+        {{l | translate}}
+      </li>
+    </ul>
   </div>
 </div>
-<div class="row">
-  <div class="col-md-8">
 
-    <div data-ng-if="mdView.current.record.contact">
-      <div data-gn-metadata-contacts="mdView.current.record.contact"
-             data-gn-mode="role"
-             data-layout="icon"/>
-    </div>
-    <div data-ng-if="showCitation"
-         data-gn-metadata-citation="mdView.current.record"/>
+<div class="gn-margin-bottom">
+  <span class="badge badge-rounded" title="{{'sourceCatalog' | translate}}">
+    <i class="fa fa-fw fa-cloud"></i>
+  </span>
+  <span data-translate="">sourceCatalog</span>:
+  <span data-gn-record-origin-logo="mdView.current.record"/>
+</div>
 
-  </div>
-  <div class="col-md-4 gn-md-side gn-nopadding-top">
-
-    <div class="gn-margin-bottom">
-      <span class="badge badge-rounded" title="{{'updatedOn' | translate}}">
-        <i class="fa fa-fw fa-file-code-o"></i>
+<div data-ng-if="mdView.current.record.uuid"
+     class="gn-margin-bottom flex-row">
+  <span class="badge badge-rounded" title="{{'uuid' | translate}}">
+    <i class="fa fa-fw fa-info"></i>
+  </span>
+  <div>
+    <h3 data-translate="">uuid</h3>
+    <div class="input-group">
+      <input type="text" class="form-control"
+             value="{{::mdView.current.record.uuid}}">
+      <span gn-copy-to-clipboard-button=""
+            data-btn-class="input-group-addon"
+            data-text="{{::mdView.current.record.uuid}}">
       </span>
-      <a class="btn btn-default btn-sm"
-         data-ng-href="../api/records/{{mdView.current.record.uuid}}/formatters/xml">
-        <span data-translate="">metadataInXML</span>
-      </a>
-    </div>
-
-    <div class="gn-md-side-calendar gn-margin-bottom">
-        <span class="badge badge-rounded" title="{{'updatedOn' | translate}}">
-          <i class="fa fa-fw fa-calendar"></i>
-        </span>
-      <h3 data-translate="">updatedOn</h3>
-      <span data-gn-humanize-time="{{mdView.current.record.changeDate}}"
-            data-from-now=""></span>
-    </div>
-
-    <div data-ng-init="mdLanguages = [mdView.current.record.mainLanguage].concat(mdView.current.record.otherLanguage || [])"
-         data-aang-if="mdLanguages.length > 0"
-         class="gn-margin-bottom flex-row">
-      <span class="badge badge-rounded" title="{{'language' | translate}}">
-        <i class="fa fa-fw fa-language"></i>
-      </span>
-      <div>
-        <h3 data-translate="">metadataLanguage</h3>
-        <ul class="gn-comma-list">
-          <li data-ng-repeat="l in mdLanguages">
-            {{l | translate}}
-          </li>
-        </ul>
-      </div>
-    </div>
-
-    <div class="gn-margin-bottom">
-      <span class="badge badge-rounded" title="{{'sourceCatalog' | translate}}">
-        <i class="fa fa-fw fa-cloud"></i>
-      </span>
-      <span data-translate="">sourceCatalog</span>:
-      <span data-gn-record-origin-logo="mdView.current.record"/>
-    </div>
-
-    <div data-ng-if="mdView.current.record.uuid"
-         class="gn-margin-bottom flex-row">
-      <span class="badge badge-rounded" title="{{'uuid' | translate}}">
-        <i class="fa fa-fw fa-info"></i>
-      </span>
-      <div>
-        <h3 data-translate="">uuid</h3>
-        <div class="input-group">
-          <input type="text" class="form-control"
-                 value="{{::mdView.current.record.uuid}}">
-          <span gn-copy-to-clipboard-button=""
-                data-btn-class="input-group-addon"
-                data-text="{{::mdView.current.record.uuid}}">
-          </span>
-        </div>
-      </div>
     </div>
   </div>
 </div>

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/metadatacontact.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/metadatacontact.html
@@ -1,0 +1,7 @@
+<div data-ng-if="mdView.current.record.contact">
+  <div data-gn-metadata-contacts="mdView.current.record.contact"
+       data-gn-mode="role"
+       data-layout="icon"/>
+</div>
+<div data-ng-if="showCitation"
+     data-gn-metadata-citation="mdView.current.record"/>

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/quality.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/quality.html
@@ -1,22 +1,31 @@
-<div class="row"
-     data-ng-if="mdView.current.record.specificationConformance">
-  <div class="col-md-8 gn-record">
-    <div>
-      <h2 data-translate="">specificationConformance</h2>
-      <ul class="list-group">
-        <li class="list-group-item"
-            data-ng-repeat="c in mdView.current.record.specificationConformance"
-            title="{{c.explanation}}">
-          <i class="fa fa-fw"
-             data-ng-class="{
-               'fa-check text-success': c.pass == 'true',
-               '': c.pass == '',
-               'fa-times text-danger': c.pass == 'false'
-               }"></i>
-          <a data-ng-if="::c.link" data-ng-href="{{c.link}}">{{c.title}}</a>
-          <span data-ng-if="::!c.link">{{c.title}}</span>
-        </li>
-      </ul>
-    </div>
-  </div>
-</div>
+<h2 data-translate="">specificationConformance</h2>
+
+<!--<div data-ng-if="mdView.current.record.cat.length > 0 ||-->
+<!--                 mdView.current.record.cl_topic.length > 0"-->
+<!--     class="gn-margin-bottom flex-row">-->
+<!--  <span class="badge badge-rounded"-->
+<!--        title="{{'listOfCategories' | translate}}">-->
+<!--    <i class="fa fa-fw fa-tags"></i>-->
+<!--  </span>-->
+<!--  <div>-->
+<ul class="gn-md-side gn-comma-list">
+  <li class="list-group-ite1m flex-row"
+      data-ng-repeat="c in mdView.current.record.specificationConformance"
+      title="{{c.explanation}}">
+    <span class="badge badge-rounded"
+          data-ng-class="{
+           'bg-success': c.pass == 'true',
+           '': c.pass == '',
+           'bg-danger': c.pass == 'false'
+           }">
+      <i class="fa fa-fw"
+         data-ng-class="{
+           'fa-check': c.pass == 'true',
+           '': c.pass == '',
+           'fa-times': c.pass == 'false'
+           }"></i>
+    </span>
+    <a data-ng-if="::c.link" data-ng-href="{{c.link}}">{{c.title}}</a>
+    <span data-ng-if="::!c.link">{{c.title}}</span>
+  </li>
+

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/share.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/share.html
@@ -1,5 +1,4 @@
-<div class="row">
-  <div class="col-md-8">
+
     <div ng-include="'../../catalog/views/default/templates/recordView/social.html'"/>
 
     <div data-ng-show="isRatingEnabled"
@@ -16,5 +15,4 @@
          data-ng-if="isUserFeedbackEnabled && mdView.current.record.draft != 'y'">
     </div>
     <div data-gn-md-feedback="mdView.current.record"></div>
-  </div>
-</div>
+

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/sources.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/sources.html
@@ -1,0 +1,18 @@
+<div data-ng-class="[].concat(mdView.current.record.relatedRecords.sources, mdView.current.record.relatedRecords.hassources).length > 3 ? 'col-md-12' : 'col-md-4'">
+  <div data-ng-if="mdView.current.record.relatedRecords"
+       data-gn-related="mdView.current.record"
+       data-user="user"
+       data-types="sources"
+       data-layout="card"
+       data-has-results="hasRelations.sources"
+       data-title="{{'sourceDatasets' | translate}}">
+  </div>
+  <div data-ng-if="mdView.current.record.relatedRecords"
+       data-gn-related="mdView.current.record"
+       data-user="user"
+       data-types="hassources"
+       data-layout="card"
+       data-has-results="hasRelations.hassources"
+       data-title="{{'isSourceOfDatasets' | translate}}">
+  </div>
+</div>

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/spatial.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/spatial.html
@@ -1,0 +1,58 @@
+<div data-ng-if="mdView.current.record.cl_spatialRepresentationType.length > 0"
+     class="gn-margin-bottom flex-row">
+      <span class="badge badge-rounded">
+        <i class="fa fa-fw fa-globe"></i>
+      </span>
+  <div>
+    <h3 data-translate="">spatialRepresentationType</h3>
+    <ul class="gn-label-list"
+        data-ng-repeat="c in mdView.current.record.cl_spatialRepresentationType">
+      <li data-gn-search-filter-popup-link="cl_spatialRepresentationType.key"
+          data-filter="c.key">{{c.default}}</li>
+    </ul>
+  </div>
+</div>
+
+<div data-ng-if="mdView.current.record.resolutionScaleDenominator"
+     class="gn-margin-bottom flex-row">
+      <span class="badge badge-rounded ">
+        <i class="fa fa-fw fa-globe"></i>
+      </span>
+  <div>
+    <h3 data-translate="">scale</h3>
+    <ul class="gn-comma-list">
+      <li data-ng-repeat="d in mdView.current.record.resolutionScaleDenominator"
+          class="gn-scale">{{d}}
+      </li>
+    </ul>
+  </div>
+</div>
+
+<div data-ng-if="mdView.current.record.resolutionDistance"
+     class="gn-margin-bottom flex-row">
+      <span class="badge badge-rounded">
+        <i class="fa fa-fw fa-globe"></i>
+      </span>
+  <div>
+    <h3 data-translate="">resolution</h3>
+    <ul class="gn-comma-list">
+      <li data-ng-repeat="r in mdView.current.record.resolutionDistance">{{r}}</li>
+    </ul>
+  </div>
+</div>
+
+<div data-ng-if="mdView.current.record.crsDetails"
+     class="gn-margin-bottom flex-row">
+      <span class="badge badge-rounded">
+        <i class="fa fa-fw fa-compass"></i>
+      </span>
+  <div>
+    <h3 data-translate="">crs</h3>
+    <ul class="gn-comma-list">
+      <li data-ng-repeat="r in mdView.current.record.crsDetails">
+        <a ng-show="r.url" href="{{r.url}}">{{r.name || r.code}}</a>
+        <span ng-hide="r.url">{{r.name || r.code}}</span>
+      </li>
+    </ul>
+  </div>
+</div>

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/technical.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/technical.html
@@ -1,110 +1,95 @@
-<div class="row gn-section">
-  <div class="col-md-12 gn-record">
-    <h2 data-translate="">technicalInformation</h2>
-
-    <div class="row">
-      <div class="col-md-4 gn-md-side">
-        <section class="gn-md-side-dates"
-                 data-ng-if="mdView.current.record.resourceDate.length > 0">
-          <ul>
-            <li data-ng-repeat="date in mdView.current.record.resourceDate">
-              <div class="badge badge-rounded"
-                   data-ng-class="{'danger': date.type === 'deprecated'}">
-                <i class="fa fa-fw"
-                   data-ng-class="{'fa-chevron-right': date.type === 'creation', 'fa-code-fork': date.type === 'superseded','fa-ban': date.type === 'deprecated', 'fa-retweet': date.type === 'revision', 'fa-check': date.type === 'publication', 'fa-calendar': date.type === 'nextUpdate'}" />
-              </div>
-              <span>
-                <h3 data-translate>{{date.type | translate}}</h3>
-                <span data-gn-humanize-time="{{date.date}}"></span>
-              </span>
-            </li>
-          </ul>
-        </section>
-
-
-        <div data-ng-if="mdView.current.record.cl_maintenanceAndUpdateFrequency.length > 0"
-             class="gn-margin-bottom flex-row">
-          <span class="badge badge-rounded" title="{{'updateFrequency' | translate}}">
-            <i class="fa fa-fw fa-language"></i>
-          </span>
-          <div>
-            <h3 data-translate="">updateFrequency</h3>
-            <p data-ng-repeat="c in mdView.current.record.cl_maintenanceAndUpdateFrequency">
-              {{c.default}}
-            </p>
-          </div>
-        </div>
+<section class="gn-md-side-dates"
+         data-ng-if="mdView.current.record.resourceDate.length > 0">
+  <ul>
+    <li data-ng-repeat="date in mdView.current.record.resourceDate">
+      <div class="badge badge-rounded"
+           data-ng-class="{'danger': date.type === 'deprecated'}">
+        <i class="fa fa-fw"
+           data-ng-class="{'fa-chevron-right': date.type === 'creation', 'fa-code-fork': date.type === 'superseded','fa-ban': date.type === 'deprecated', 'fa-retweet': date.type === 'revision', 'fa-check': date.type === 'publication', 'fa-calendar': date.type === 'nextUpdate'}" />
       </div>
-
-
-      <div class="col-md-4 gn-md-side">
-        <div data-ng-repeat="(key, t) in mdView.current.record.allKeywords"
-             data-ng-if="(user.canEditRecord(mdView.current.record)
-                       && viewConfig.internalThesaurus
-                       && viewConfig.internalThesaurus.indexOf(key) !== -1)
-                      || highlightedThesaurus.indexOf(key) === -1"
-             class="gn-margin-bottom flex-row">
-      <span class="badge badge-rounded">
-        <i class="fa fa-fw fa-tags"></i>
+      <span>
+        <h3 data-translate>{{date.type | translate}}</h3>
+        <span data-gn-humanize-time="{{date.date}}"></span>
       </span>
-          <div>
-            <h3 data-translate="">{{(t.title || key) | translate}}</h3>
+    </li>
+  </ul>
+</section>
 
-            <div data-gn-keyword-badges="mdView.current.record"
-                 data-thesaurus="key" />
-          </div>
-        </div>
-      </div>
-
-      <div class="col-md-4 gn-md-side">
-        <!-- Resource identifier-->
-        <div data-ng-if="mdView.current.record.resourceIdentifier"
-             class="gn-margin-bottom flex-row">
-        <span class="badge badge-rounded" title="{{identifier | translate}}">
-          <i class="fa fa-fw fa-info"></i>
-        </span>
-          <div>
-            <h3 data-translate="">identifier</h3>
-            <ul class="gn-comma-list">
-              <li data-ng-repeat="i in mdView.current.record.resourceIdentifier">
-                <span data-ng-bind-html="i.code | linky" />
-              </li>
-            </ul>
-          </div>
-        </div>
-
-        <!-- Language-->
-        <div data-ng-if="mdView.current.record.resourceLanguage.length > 0"
-             class="gn-margin-bottom flex-row">
-        <span class="badge badge-rounded" title="{{'language' | translate}}">
-          <i class="fa fa-fw fa-language"></i>
-        </span>
-          <div>
-            <h3 data-translate="">language</h3>
-            <ul class="gn-comma-list">
-              <li data-ng-repeat="l in mdView.current.record.resourceLanguage">
-                {{l | translate}}
-              </li>
-            </ul>
-          </div>
-        </div>
-
-        <div ng-include="'../../catalog/views/default/templates/recordView/categories.html'" />
-
-        <div data-ng-if="mdView.current.record.cl_classification > 0"
-             class="gn-margin-bottom flex-row">
-        <span class="badge badge-rounded" title="{{'classification' | translate}}">
-          <i class="fa fa-fw fa-tags"></i>
-        </span>
-          <div>
-            <h3 data-translate="">classification</h3>
-            <ul>
-              <li data-ng-repeat="c in mdView.current.record.cl_classification">{{c.default}}</li>
-            </ul>
-          </div>
-          ß
-        </div>
-      </div>
-    </div>
+<div data-ng-if="mdView.current.record.cl_maintenanceAndUpdateFrequency.length > 0"
+     class="gn-margin-bottom flex-row">
+  <span class="badge badge-rounded" title="{{'updateFrequency' | translate}}">
+    <i class="fa fa-fw fa-language"></i>
+  </span>
+  <div>
+    <h3 data-translate="">updateFrequency</h3>
+    <p data-ng-repeat="c in mdView.current.record.cl_maintenanceAndUpdateFrequency">
+      {{c.default}}
+    </p>
   </div>
 </div>
+
+<div data-ng-repeat="(key, t) in mdView.current.record.allKeywords"
+     data-ng-if="(user.canEditRecord(mdView.current.record)
+               && viewConfig.internalThesaurus
+               && viewConfig.internalThesaurus.indexOf(key) !== -1)
+              || highlightedThesaurus.indexOf(key) === -1"
+     class="gn-margin-bottom flex-row">
+  <span class="badge badge-rounded">
+    <i class="fa fa-fw fa-tags"></i>
+  </span>
+  <div>
+    <h3 data-translate="">{{(t.title || key) | translate}}</h3>
+
+    <div data-gn-keyword-badges="mdView.current.record"
+         data-thesaurus="key" />
+  </div>
+</div>
+
+<!-- Resource identifier-->
+<div data-ng-if="mdView.current.record.resourceIdentifier"
+     class="gn-margin-bottom flex-row">
+  <span class="badge badge-rounded" title="{{identifier | translate}}">
+    <i class="fa fa-fw fa-info"></i>
+  </span>
+  <div>
+    <h3 data-translate="">identifier</h3>
+    <ul class="gn-comma-list">
+      <li data-ng-repeat="i in mdView.current.record.resourceIdentifier">
+        <span data-ng-bind-html="i.code | linky" />
+      </li>
+    </ul>
+  </div>
+</div>
+
+<!-- Language-->
+<div data-ng-if="mdView.current.record.resourceLanguage.length > 0"
+     class="gn-margin-bottom flex-row">
+  <span class="badge badge-rounded" title="{{'language' | translate}}">
+    <i class="fa fa-fw fa-language"></i>
+  </span>
+  <div>
+    <h3 data-translate="">language</h3>
+    <ul class="gn-comma-list">
+      <li data-ng-repeat="l in mdView.current.record.resourceLanguage">
+        {{l | translate}}
+      </li>
+    </ul>
+  </div>
+</div>
+
+<div ng-include="'../../catalog/views/default/templates/recordView/categories.html'" />
+
+<div data-ng-if="mdView.current.record.cl_classification > 0"
+     class="gn-margin-bottom flex-row">
+  <span class="badge badge-rounded" title="{{'classification' | translate}}">
+    <i class="fa fa-fw fa-tags"></i>
+  </span>
+  <div>
+    <h3 data-translate="">classification</h3>
+    <ul>
+      <li data-ng-repeat="c in mdView.current.record.cl_classification">{{c.default}}</li>
+    </ul>
+  </div>
+
+</div>
+

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/type-dataset.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/type-dataset.html
@@ -1,5 +1,5 @@
 <!-- title & summary -->
-<div class="row gn-card gn-card-{{mdView.current.record.resourceType[0]}} gn-margin-top gn-margin-bottom gn-padding-bottom">
+<div class="row gn-card gn-card-{{mdView.current.record.resourceType[0]}} gn-margin-top gn-margin-bottom gn-padding-top gn-padding-bottom">
   <div ng-include="'../../catalog/views/default/templates/recordView/status.html'"/>
 
   <div class="col-md-8 gn-record">
@@ -14,8 +14,9 @@
 
 <!-- map & extent -->
 <div class="row gn-section gn-padding-top">
+  <h2 data-translate="">spatialExtent</h2>
   <div class="col-md-8 gn-record">
-    <h2 data-translate="">spatialExtent</h2>
+
     <div data-gn-data-preview="mdView.current.record"/>
 
     <br/>
@@ -24,64 +25,7 @@
   </div>
   <!-- /.col-md-8 gn-record -->
   <div class="col-md-4 gn-md-side gn-nopadding-top">
-    <div data-ng-if="mdView.current.record.cl_spatialRepresentationType.length > 0"
-         class="gn-margin-bottom flex-row">
-      <span class="badge badge-rounded">
-        <i class="fa fa-fw fa-globe"></i>
-      </span>
-      <div>
-        <h3 data-translate="">spatialRepresentationType</h3>
-        <ul class="gn-label-list"
-            data-ng-repeat="c in mdView.current.record.cl_spatialRepresentationType">
-          <li data-gn-search-filter-popup-link="cl_spatialRepresentationType.key"
-             data-filter="c.key">{{c.default}}</li>
-        </ul>
-      </div>
-    </div>
-
-    <div data-ng-if="mdView.current.record.resolutionScaleDenominator"
-         class="gn-margin-bottom flex-row">
-      <span class="badge badge-rounded ">
-        <i class="fa fa-fw fa-globe"></i>
-      </span>
-      <div>
-        <h3 data-translate="">scale</h3>
-        <ul class="gn-comma-list">
-          <li data-ng-repeat="d in mdView.current.record.resolutionScaleDenominator"
-              class="gn-scale">{{d}}
-          </li>
-        </ul>
-      </div>
-    </div>
-
-    <div data-ng-if="mdView.current.record.resolutionDistance"
-         class="gn-margin-bottom flex-row">
-      <span class="badge badge-rounded">
-        <i class="fa fa-fw fa-globe"></i>
-      </span>
-      <div>
-        <h3 data-translate="">resolution</h3>
-        <ul class="gn-comma-list">
-          <li data-ng-repeat="r in mdView.current.record.resolutionDistance">{{r}}</li>
-        </ul>
-      </div>
-    </div>
-
-    <div data-ng-if="mdView.current.record.crsDetails"
-         class="gn-margin-bottom flex-row">
-      <span class="badge badge-rounded">
-        <i class="fa fa-fw fa-compass"></i>
-      </span>
-      <div>
-        <h3 data-translate="">crs</h3>
-        <ul class="gn-comma-list">
-          <li data-ng-repeat="r in mdView.current.record.crsDetails">
-            <a ng-show="r.url" href="{{r.url}}">{{r.name || r.code}}</a>
-            <span ng-hide="r.url">{{r.name || r.code}}</span>
-          </li>
-        </ul>
-      </div>
-    </div>
+    <div ng-include="'../../catalog/views/default/templates/recordView/spatial.html'"/>
   </div>
   <!-- /.col-md-4 gn-md-side -->
 </div>
@@ -95,6 +39,7 @@
   <!-- /.col-md-8 gn-record -->
   <div class="gn-md-side"
        data-ng-class="[].concat(mdView.current.record.relatedRecords.datasets, mdView.current.record.relatedRecords.services).length > 3 ? 'col-md-12' : 'col-md-4'">
+    <!-- format -->
     <div data-ng-if="mdView.current.record.format"
          class="gn-margin-bottom flex-row">
       <span class="badge badge-rounded">
@@ -129,16 +74,44 @@
   </div>
 </div>
 
+<div class="row gn-section">
+  <div class="col-md-12 gn-record">
+    <h2 data-translate="">technicalInformation</h2>
+  </div>
+  <div class="col-md-12 gn-md-side gn-nopadding-top">
+    <div class="col-3" ng-include="'../../catalog/views/default/templates/recordView/technical.html'"/>
+  </div>
+</div>
 
-<div ng-include="'../../catalog/views/default/templates/recordView/technical.html'"/>
+<div class="row gn-section"
+     data-ng-if="mdView.current.record.featureTypes
+                 || mdView.current.record.relatedRecords.fcats.length > 0">
+  <div class="col-md-12 gn-record">
+    <div ng-include="'../../catalog/views/default/templates/recordView/featurecatalogue.html'"/>
+  </div>
+</div>
 
-<div ng-include="'../../catalog/views/default/templates/recordView/featurecatalogue.html'"/>
+<div class="row"
+     data-ng-if="mdView.current.record.lineage
+                 || mdView.current.record.sourceDescription
+                 || mdView.current.record.supplementalInformation">
+  <div class="col-md-8 gn-record">
+    <div ng-include="'../../catalog/views/default/templates/recordView/lineage.html'"/>
+  </div>
+  <!-- /.col-md-8 gn-record -->
+  <div class="gn-md-side">
+    <div ng-include="'../../catalog/views/default/templates/recordView/sources.html'"/>
+  </div>
+</div>
 
+<div class="row"
+     data-ng-if="mdView.current.record.specificationConformance">
+  <div class="col-md-8 gn-record">
+    <div ng-include="'../../catalog/views/default/templates/recordView/quality.html'"/>
+  </div>
+</div>
 
-<div class="gn-section"
-     ng-include="'../../catalog/views/default/templates/recordView/lineage.html'"/>
-
-
+<!-- contact -->
 <div class="row gn-section">
   <div class="col-md-8 gn-record gn-break">
     <div ng-include="'../../catalog/views/default/templates/recordView/contact.html'"/>
@@ -151,9 +124,21 @@
   </div>
 </div>
 
-<div class="gn-section"
-     ng-include="'../../catalog/views/default/templates/recordView/metadata.html'"/>
+<!-- metadata -->
+<div class="gn-section row">
+  <h2 class="col-md-12" data-translate="">metadataInformation</h2>
+  <div class="col-md-8">
+    <div ng-include="'../../catalog/views/default/templates/recordView/metadatacontact.html'"/>
+  </div>
+  <div class="col-md-4 gn-md-side">
+    <div ng-include="'../../catalog/views/default/templates/recordView/metadata.html'"/>
+  </div>
+</div>
 
-<div ng-include="'../../catalog/views/default/templates/recordView/share.html'"/>
+<div class="row">
+  <div class="col-md-8">
+    <div ng-include="'../../catalog/views/default/templates/recordView/share.html'"/>
+  </div>
+</div>
 
 <div ng-include="'../../catalog/views/default/templates/recordView/footer.html'"/>

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/type-series.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/type-series.html
@@ -64,27 +64,56 @@
   </div>
 </div>
 
-<div ng-include="'../../catalog/views/default/templates/recordView/featurecatalogue.html'"/>
+<div class="row gn-section"
+     data-ng-if="mdView.current.record.featureTypes
+                 || mdView.current.record.relatedRecords.fcats.length > 0">
+  <div class="col-md-12 gn-record">
+    <div ng-include="'../../catalog/views/default/templates/recordView/featurecatalogue.html'"/>
+  </div>
+</div>
 
-
+<!-- constraints -->
 <div class="row gn-section">
   <div class="col-md-8 gn-record">
     <div ng-include="'../../catalog/views/default/templates/recordView/constraints.html'"/>
   </div>
 </div>
 
+<!-- lineage -->
 <div class="gn-section"
-     ng-include="'../../catalog/views/default/templates/recordView/lineage.html'"/>
+     data-ng-if="mdView.current.record.lineage
+                 || mdView.current.record.sourceDescription
+                 || mdView.current.record.supplementalInformation">
+  <div class="col-md-8 gn-record">
+    <div ng-include="'../../catalog/views/default/templates/recordView/lineage.html'"/>
+  </div>
+  <div class="gn-md-side">
+    <div ng-include="'../../catalog/views/default/templates/recordView/sources.html'"/>
+  </div>
+</div>
 
+<!-- contact -->
 <div class="row gn-section">
   <div class="col-md-8 gn-record gn-break">
     <div ng-include="'../../catalog/views/default/templates/recordView/contact.html'"/>
   </div>
 </div>
 
-<div class="gn-section"
-     ng-include="'../../catalog/views/default/templates/recordView/metadata.html'"/>
+<!-- metadata -->
+<div class="gn-section row">
+  <h2 class="col-md-12" data-translate="">metadataInformation</h2>
+  <div class="col-md-8">
+    <div ng-include="'../../catalog/views/default/templates/recordView/metadatacontact.html'"/>
+  </div>
+  <div class="col-md-4 gn-md-side">
+    <div ng-include="'../../catalog/views/default/templates/recordView/metadata.html'"/>
+  </div>
+</div>
 
-<div ng-include="'../../catalog/views/default/templates/recordView/share.html'"/>
+<div class="row">
+  <div class="col-md-8">
+    <div ng-include="'../../catalog/views/default/templates/recordView/share.html'"/>
+  </div>
+</div>
 
 <div ng-include="'../../catalog/views/default/templates/recordView/footer.html'"/>


### PR DESCRIPTION
All layout related elements (the columns) are moved to the `series` and `dataset` template. All other templates have elements without layout info, so they can be moved freely without breaking the layout and columns.

Extra: Added 2 general classes for 'css' columns: `col-2` and `col-3`. These are used for the technical information, so when you place this information in a `col-md-12` you can add the class `col-3` to display all the list elements in 3 columns