### PR TITLE
Editor / Associated resource / Don't allow removal of siblings relation.

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/MetadataUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataUtils.java
@@ -214,7 +214,13 @@ public class MetadataUtils {
                     }
                 }
             }
-            relatedRecords.addContent(new Element("siblings").addContent(response));
+            // May have been added by brothersAndSisters step above.
+            Element container = relatedRecords.getChild("siblings");
+            if (container == null) {
+                container = new Element("siblings");
+                relatedRecords.addContent(container);
+            }
+            container.addContent(response);
             appendRemoteRecord("siblings", mdIndexFields, relatedRecords.getChild("siblings"));
         }
 
@@ -369,6 +375,9 @@ public class MetadataUtils {
                 final Map<String, Object> source = e.getSourceAsMap();
                 record.addContent(new Element("id").setText((String) source.get(Geonet.IndexFieldNames.ID)));
                 record.addContent(new Element("uuid").setText((String) source.get(Geonet.IndexFieldNames.UUID)));
+                if (type.equals("brothersAndSisters")) {
+                    record.setAttribute("association", "brothersAndSisters");
+                }
 
                 setFieldFromIndexDocument(record, source, Geonet.IndexFieldNames.RESOURCETITLE, "title");
                 setFieldFromIndexDocument(record, source, Geonet.IndexFieldNames.RESOURCEABSTRACT, "abstract");

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/onlinesrcList.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/onlinesrcList.html
@@ -477,7 +477,7 @@
             </div>
             <div class="col-md-1 text-right">
               <a href="" class="onlinesrc-remove"
-                 data-ng-if="readonly !== true"
+                 data-ng-if="readonly !== true && resource.associationType != 'brothersAndSisters'"
                  title="{{'remove' | translate}} {{resource.title | gnLocalized: lang}}"
                  aria-label="{{'remove' | translate}} {{resource.title | gnLocalized: lang}}"
                  data-ng-click="onlinesrcService.removeSibling(resource)">

--- a/web-ui/src/main/resources/catalog/locales/en-v4.json
+++ b/web-ui/src/main/resources/catalog/locales/en-v4.json
@@ -13,6 +13,7 @@
   "otherKeywords-": "Keywords",
   "link-datasets": "Service",
   "link-services": "Service",
+  "brothersAndSisters": "Siblings",
   "languagesAndTranslations.manage": "Languages & translations",
   "languages.manage": "Registered languages in database",
   "languages.manage.help": "Language stored in database are used to store translations for database entity like group names, portal titles, ... Limiting the list of languages to the minimum simplify admin console entry forms.",


### PR DESCRIPTION
When 2 records A and B points to the same parent C. The associated panel will list A and B as siblings.
Therefore when editing A or B, user has no privilege to remove the relation in the siblings to the parent.

![image](https://user-images.githubusercontent.com/1701393/164428987-b6073f87-36ed-44c0-a12b-6e38822c5eb6.png)



Also fix list of related records when a record has both siblings and aggregatedResource (only the last category was listed).