### PR TITLE
Update DraftValidationWidget to use an ElasticSearch query

### DIFF
--- a/web-ui/src/main/resources/catalog/components/utility/partials/draftvalidationwidget.html
+++ b/web-ui/src/main/resources/catalog/components/utility/partials/draftvalidationwidget.html
@@ -10,7 +10,7 @@
 	  <i class="fa fa-fw fa-bookmark" ng-switch-when="s" />
 	  <i class="fa fa-fw fa-bookmark-o" ng-switch-when="t" />
 	  <i class="fa fa-fw fa-question" ng-switch-default />
-	</small> 
+	</small>
 	<label title="{{'seeDraft' | translate}}">{{(('draft') | translate)}}</label>
 </small>
 </a>


### PR DESCRIPTION
The code to retrieve the metadata draft copy information was using the old query service from GeoNetwork 3.x versions.

To test:

1) Enable the workflow
2) Create a metadata, approve it and edit it again to create a working copy
3) Access to the editor board.

Previously in the application log an error like the following was displayed:

```
06:24:50,883 ERROR [jeeves.service] - (C) Exc : java.lang.UnsupportedOperationException: Use ES search instead. metadatakatalogen | 2022-04-12 06:24:50,845 ERROR [jeeves.service] - Exception when executing service metadatakatalogen | 2022-04-12 06:24:50,883 ERROR [jeeves.service] - (C) Exc : java.lang.UnsupportedOperationException: Use ES search instead.
```

With the fix, no error should be displayed.