### PR TITLE
CSW / Bbox is always WGS84. Adapt & fix coordinate order. (#5545)

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/present/csw/csw-brief.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/present/csw/csw-brief.xsl
@@ -66,24 +66,13 @@
       <xsl:for-each
         select="$identification/mri:extent/gex:EX_Extent/gex:geographicElement/gex:EX_GeographicBoundingBox|
         $identification/srv:extent/gex:EX_Extent/gex:geographicElement/gex:EX_GeographicBoundingBox">
-        <xsl:variable name="rsi"
-          select="/mdb:MD_Metadata/mdb:referenceSystemInfo/mrs:MD_ReferenceSystem/
-          mrs:referenceSystemIdentifier/mcc:MD_Identifier|/mdb:MD_Metadata/mdb:referenceSystemInfo/
-          *[contains(@gco:isoType, 'MD_ReferenceSystem')]/mrs:referenceSystemIdentifier/mcc:MD_Identifier"/>
-        <xsl:variable name="auth" select="$rsi/mcc:codeSpace/gco:CharacterString"/>
-        <xsl:variable name="id" select="$rsi/mcc:code/gco:CharacterString"/>
-
-        <ows:BoundingBox crs="{$auth}::{$id}">
+        <ows:BoundingBox crs="urn:ogc:def:crs:EPSG:6.6:4326">
           <ows:LowerCorner>
-            <xsl:value-of
-              select="concat(gex:eastBoundLongitude/gco:Decimal, ' ', gex:southBoundLatitude/gco:Decimal)"
-            />
+            <xsl:value-of select="concat(gex:southBoundLatitude/gco:Decimal, ' ', gex:westBoundLongitude/gco:Decimal)"/>
           </ows:LowerCorner>
 
           <ows:UpperCorner>
-            <xsl:value-of
-              select="concat(gex:westBoundLongitude/gco:Decimal, ' ', gex:northBoundLatitude/gco:Decimal)"
-            />
+            <xsl:value-of select="concat(gex:northBoundLatitude/gco:Decimal, ' ', gex:eastBoundLongitude/gco:Decimal)"/>
           </ows:UpperCorner>
         </ows:BoundingBox>
       </xsl:for-each>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/present/csw/csw-full.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/present/csw/csw-full.xsl
@@ -188,11 +188,11 @@
       <xsl:for-each select="$identification/mri:extent/gex:EX_Extent/gex:geographicElement/gex:EX_GeographicBoundingBox">
         <ows:BoundingBox crs="urn:ogc:def:crs:EPSG:6.6:4326">
           <ows:LowerCorner>
-            <xsl:value-of select="concat(gex:eastBoundLongitude/gco:Decimal, ' ', gex:southBoundLatitude/gco:Decimal)"/>
+            <xsl:value-of select="concat(gex:southBoundLatitude/gco:Decimal, ' ', gex:westBoundLongitude/gco:Decimal)"/>
           </ows:LowerCorner>
 
           <ows:UpperCorner>
-            <xsl:value-of select="concat(gex:westBoundLongitude/gco:Decimal, ' ', gex:northBoundLatitude/gco:Decimal)"/>
+            <xsl:value-of select="concat(gex:northBoundLatitude/gco:Decimal, ' ', gex:eastBoundLongitude/gco:Decimal)"/>
           </ows:UpperCorner>
         </ows:BoundingBox>
       </xsl:for-each>

--- a/schemas/iso19139/src/main/plugin/iso19139/present/csw/csw-brief.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/present/csw/csw-brief.xsl
@@ -84,21 +84,16 @@
       <!-- bounding box -->
       <xsl:for-each select="$identification/gmd:extent/gmd:EX_Extent/gmd:geographicElement/gmd:EX_GeographicBoundingBox|
         $identification/srv:extent/gmd:EX_Extent/gmd:geographicElement/gmd:EX_GeographicBoundingBox">
-        <xsl:variable name="rsi" select="/gmd:MD_Metadata/gmd:referenceSystemInfo/gmd:MD_ReferenceSystem/
-          gmd:referenceSystemIdentifier/gmd:RS_Identifier|/gmd:MD_Metadata/gmd:referenceSystemInfo/
-          *[contains(@gco:isoType, 'MD_ReferenceSystem')]/gmd:referenceSystemIdentifier/gmd:RS_Identifier"/>
-        <xsl:variable name="auth" select="$rsi/gmd:codeSpace/gco:CharacterString"/>
-        <xsl:variable name="id" select="$rsi/gmd:code/gco:CharacterString"/>
 
-        <ows:BoundingBox crs="{$auth}::{$id}">
+        <ows:BoundingBox crs="urn:ogc:def:crs:EPSG:6.6:4326">
           <ows:LowerCorner>
             <xsl:value-of
-              select="concat(gmd:eastBoundLongitude/gco:Decimal, ' ', gmd:southBoundLatitude/gco:Decimal)"/>
+              select="concat(gmd:southBoundLatitude/gco:Decimal, ' ', gmd:westBoundLongitude/gco:Decimal)"/>
           </ows:LowerCorner>
 
           <ows:UpperCorner>
             <xsl:value-of
-              select="concat(gmd:westBoundLongitude/gco:Decimal, ' ', gmd:northBoundLatitude/gco:Decimal)"/>
+              select="concat(gmd:northBoundLatitude/gco:Decimal, ' ', gmd:eastBoundLongitude/gco:Decimal)"/>
           </ows:UpperCorner>
         </ows:BoundingBox>
       </xsl:for-each>

--- a/schemas/iso19139/src/main/plugin/iso19139/present/csw/csw-full.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/present/csw/csw-full.xsl
@@ -211,31 +211,16 @@
 
       <xsl:for-each
         select="$identification/gmd:extent/gmd:EX_Extent/gmd:geographicElement/gmd:EX_GeographicBoundingBox">
-        <xsl:variable name="rsi" select="/gmd:MD_Metadata/gmd:referenceSystemInfo/gmd:MD_ReferenceSystem/
-          gmd:referenceSystemIdentifier/gmd:RS_Identifier|/gmd:MD_Metadata/gmd:referenceSystemInfo/
-          *[@gco:isoType='MD_ReferenceSystem']/gmd:referenceSystemIdentifier/gmd:RS_Identifier"/>
-        <xsl:variable name="auth" select="$rsi/gmd:codeSpace/gco:CharacterString"/>
-        <xsl:variable name="id" select="$rsi/gmd:code/gco:CharacterString"/>
-        <xsl:variable name="crs" select="concat('urn:ogc:def:crs:', $auth, '::', $id)"/>
-
-        <ows:BoundingBox>
-          <xsl:attribute name="crs">
-            <xsl:choose>
-              <xsl:when test="$crs = 'urn:ogc:def:crs:::'">urn:ogc:def:crs:EPSG:6.6:4326</xsl:when>
-              <xsl:otherwise>
-                <xsl:value-of select="$crs"/>
-              </xsl:otherwise>
-            </xsl:choose>
-          </xsl:attribute>
-
+          <ows:BoundingBox crs="urn:ogc:def:crs:EPSG:6.6:4326">
+          
           <ows:LowerCorner>
             <xsl:value-of
-              select="concat(gmd:eastBoundLongitude/gco:Decimal, ' ', gmd:southBoundLatitude/gco:Decimal)"/>
+              select="concat(gmd:southBoundLatitude/gco:Decimal, ' ', gmd:westBoundLongitude/gco:Decimal)"/>
           </ows:LowerCorner>
 
           <ows:UpperCorner>
             <xsl:value-of
-              select="concat(gmd:westBoundLongitude/gco:Decimal, ' ', gmd:northBoundLatitude/gco:Decimal)"/>
+              select="concat(gmd:northBoundLatitude/gco:Decimal, ' ', gmd:eastBoundLongitude/gco:Decimal)"/>
           </ows:UpperCorner>
         </ows:BoundingBox>
       </xsl:for-each>


### PR DESCRIPTION
Cherrypicked the previous fix from @pvgenuchten:

* crs in record does not influence bbox, it is an indicator of the crs used in the dataset, bbox is 'always'(?) expressed in 4326.
mind that urn:ogc:def:crs:EPSG:6.6:4326 indicates yx axis order
fixes #5545

* apply the fixed crs also on brief and iso19115-3