### PR TITLE
Metadata editor / Fix initialise the default configuration to handle WMS resources, when it's not defined in the schema configuration. 

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -904,6 +904,7 @@
                        *    - url: Add layer names to url parameter defined in gnGlobalSettings.gnCfg.mods.search.addWMSLayersToMap.urlLayerParam
                        */
                       if (!scope.config.wmsResources) {
+                        scope.config.wmsResources = {};
                         scope.config.wmsResources.addLayerNamesMode = "resourcename";
                       }
 


### PR DESCRIPTION
Fixes adding online resources to iso19115-3 and dublin core metadata.

Related to #6195
