### PR TITLE
Add Heritrix to the list of bots that shouldn't create a session

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/AllRequestsInterceptor.java
+++ b/services/src/main/java/org/fao/geonet/api/AllRequestsInterceptor.java
@@ -48,7 +48,7 @@ public class AllRequestsInterceptor extends HandlerInterceptorAdapter {
      * List of bots to avoid.
      */
     private final String BOT_REGEXP_FILTER_DEFAULT =
-        ".*(bot|crawler|baiduspider|80legs|ia_archiver|voyager|yahoo! slurp|mediapartners-google|Linguee Bot|SemrushBot).*";
+        ".*(bot|crawler|baiduspider|80legs|ia_archiver|voyager|yahoo! slurp|mediapartners-google|Linguee Bot|SemrushBot|heritrix).*";
 
     @Value("${bot.regexpFilter}")
     public String botRegexpFilter = null;


### PR DESCRIPTION
Heritrix is the Internet Archive's open-source, extensible, web-scale, archival-quality web crawler project.
Add this crawler to the list of bots that shouldn't create a session.

Heritrix user-agent string is like this:
```
Mozilla/5.0 (compatible; heritrix/0.11.0 +PROJECT_URL_HERE)
```

Ref: https://github.com/internetarchive/heritrix3