### PR TITLE
Fix search suggestions output when a suggestion contains the character \

### DIFF
--- a/web/src/main/webapp/xslt/services/suggestions.xsl
+++ b/web/src/main/webapp/xslt/services/suggestions.xsl
@@ -37,9 +37,17 @@
     [
     <xsl:for-each
       select="/root/items/item">
-      <xsl:variable name="value">
+      <xsl:variable name="valueAux">
         <xsl:call-template name="replaceString">
           <xsl:with-param name="expr" select="@term"/>
+          <xsl:with-param name="pattern" select="'\'"/>
+          <xsl:with-param name="replacement" select="'\\'"/>
+        </xsl:call-template>
+      </xsl:variable>
+
+      <xsl:variable name="value">
+        <xsl:call-template name="replaceString">
+          <xsl:with-param name="expr" select="$valueAux"/>
           <xsl:with-param name="pattern" select="'&quot;'"/>
           <xsl:with-param name="replacement" select="'\&quot;'"/>
         </xsl:call-template>


### PR DESCRIPTION
Affects GeoNetwork 3.X versions, the xslt was not encoding the character `\` creating an invalid json output.

Potentially, there are other characters that can have a similar issue.