### PR TITLE
check content type for runtime exception

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/GlobalExceptionController.java
+++ b/services/src/main/java/org/fao/geonet/api/GlobalExceptionController.java
@@ -164,10 +164,15 @@ public class GlobalExceptionController {
         Exception.class,
         RuntimeException.class
     })
-    public ApiError runtimeExceptionHandler(final Exception exception) {
+    public ApiError runtimeExceptionHandler(final Exception exception, final HttpServletRequest request) {
         storeApiErrorCause(exception);
 
-        return new ApiError("runtime_exception", exception);
+        if (contentTypeNeedsBody(request)) {
+            return new ApiError("runtime_exception", exception);
+        } else {
+            return null;
+        }
+
     }
 
     @ResponseBody


### PR DESCRIPTION
The runtime error will always throw 500 with stack trace instead of 400 BAD_REQUEST

![image](https://user-images.githubusercontent.com/74916635/165135436-5513f394-eb81-45ec-bbb7-79d3afe8de6d.png)


The issue is related to https://github.com/geonetwork/core-geonetwork/blob/cb92fe7fc08aad84e9cceea4d861bed4e1265365/services/src/main/java/org/fao/geonet/api/GlobalExceptionController.java#L170

The exception handler should check the content like this method https://github.com/geonetwork/core-geonetwork/blob/cb92fe7fc08aad84e9cceea4d861bed4e1265365/services/src/main/java/org/fao/geonet/api/GlobalExceptionController.java#L182

The way I attempt to reproduce the issue is to manually throw some RuntimeException in https://github.com/geonetwork/core-geonetwork/blob/cb92fe7fc08aad84e9cceea4d861bed4e1265365/services/src/main/java/org/fao/geonet/api/records/CatalogApi.java#L603
and insert the code like:
![image](https://user-images.githubusercontent.com/74916635/165136064-07cec067-8cb5-4c96-9cdd-9e6970078f62.png)

Then invoke this API:
http://localhost:8080/geonetwork/srv/api/0.1/records?from=1&hitsPerPage=10&similarity=0.8

Then we will get this page instead of stack trace:

![image](https://user-images.githubusercontent.com/74916635/165136181-ec5e93a5-e3bb-4658-8ce2-4a3ed67edd76.png)
