### PR TITLE
Ensure that keycloak login redirects only go the the current server.

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/security/keycloak/keycloakPreAuthActionsLoginFilter.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/keycloak/keycloakPreAuthActionsLoginFilter.java
@@ -82,12 +82,9 @@ public class keycloakPreAuthActionsLoginFilter extends KeycloakPreAuthActionsFil
             !servletRequest.getRequestURI().endsWith(AdapterConstants.K_TEST_AVAILABLE) &&
             !servletRequest.getRequestURI().endsWith(AdapterConstants.K_JWKS)) {
 
-            String returningUrl = servletRequest.getRequestURL().toString();
-
-            // Append query string
-            if (servletRequest.getQueryString() != null) {
-                returningUrl = returningUrl + "?" + servletRequest.getQueryString();
-            }
+            // Get request uri which is a relative path. Absolute paths will be ignored if they are received as returning url.
+            String returningUrl = servletRequest.getRequestURI() +
+                (servletRequest.getQueryString() == null ? "" : "?" + servletRequest.getQueryString());
 
             String encodedRedirectURL = ((HttpServletResponse) response).encodeRedirectURL(
                 servletRequest.getContextPath() + KeycloakUtil.getSigninPath() + "?redirectUrl=" + URLEncoder.encode(returningUrl, Constants.ENCODING));


### PR DESCRIPTION
Harden keycloak redirect url after login so that it will only perform redirects to the existing server.  Login redirects should always go back to the server.