### PR TITLE
Cancelling from import or add new record results in a blank editor board

### DIFF
--- a/web-ui/src/main/resources/catalog/components/utility/UtilityService.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityService.js
@@ -72,8 +72,8 @@
   }]);
 
   module.factory('gnUtilityService',
-      ['gnPopup', '$translate', '$location', '$rootScope', '$timeout',
-        function(gnPopup, $translate, $location, $rootScope, $timeout) {
+      ['gnPopup', '$translate', '$location', '$rootScope', '$timeout', '$window',
+        function(gnPopup, $translate, $location, $rootScope, $timeout, $window) {
         /**
        * Scroll page to element.
        */
@@ -376,6 +376,24 @@
             }
           };
 
+          var goBack = function (fallback) {
+            if ($window.history.length > 0) {
+              var referrer = $window.document.referrer;
+
+              // Check if previous page was not the login page
+              if ((!referrer) || (referrer.indexOf("catalog.signin") == -1)) {
+                $window.history.back();
+                return;
+              }
+            }
+
+            if (fallback) {
+              $location.path(fallback);
+            } else {
+              $window.history.back();
+            }
+          };
+
         return {
           scrollTo: scrollTo,
           isInView: isInView,
@@ -390,7 +408,8 @@
           getUrlParameter: getUrlParameter,
           randomUuid: randomUuid,
           getPermalink: getPermalink,
-          openModal: openModal
+          openModal: openModal,
+          goBack: goBack
         };
       }]);
 

--- a/web-ui/src/main/resources/catalog/js/edit/ImportController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/ImportController.js
@@ -49,8 +49,9 @@
     'gnConfigService',
     'gnConfig',
     '$window',
+    '$location',
     function($scope,  $rootScope, gnMetadataManager,
-             gnConfigService, gnConfig, $window) {
+             gnConfigService, gnConfig, $window, $location) {
       $scope.importMode = 'uploadFile';
       $scope.file_type = 'single';
       $scope.queue = [];
@@ -140,6 +141,21 @@
         }
         $scope.unsupportedFile = false;
       });
+
+      $scope.cancelImportRecords = function (){
+        if ($window.history.length > 0) {
+          var referrer = $window.document.referrer;
+
+          // Check if previous page was not the login page
+          if ((!referrer) || (referrer.indexOf("catalog.signin") == -1)) {
+            $window.history.back();
+            return;
+          }
+        }
+
+        $location.path("/board");
+      };
+
       $scope.importRecords = function(formId) {
         $scope.reports = [];
         $scope.error = null;

--- a/web-ui/src/main/resources/catalog/js/edit/ImportController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/ImportController.js
@@ -48,10 +48,10 @@
     'gnMetadataManager',
     'gnConfigService',
     'gnConfig',
+    'gnUtilityService',
     '$window',
-    '$location',
     function($scope,  $rootScope, gnMetadataManager,
-             gnConfigService, gnConfig, $window, $location) {
+             gnConfigService, gnConfig, gnUtilityService, $window) {
       $scope.importMode = 'uploadFile';
       $scope.file_type = 'single';
       $scope.queue = [];
@@ -143,17 +143,7 @@
       });
 
       $scope.cancelImportRecords = function (){
-        if ($window.history.length > 0) {
-          var referrer = $window.document.referrer;
-
-          // Check if previous page was not the login page
-          if ((!referrer) || (referrer.indexOf("catalog.signin") == -1)) {
-            $window.history.back();
-            return;
-          }
-        }
-
-        $location.path("/board");
+        gnUtilityService.goBack("/board");
       };
 
       $scope.importRecords = function(formId) {

--- a/web-ui/src/main/resources/catalog/js/edit/NewMetadataController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/NewMetadataController.js
@@ -40,15 +40,12 @@
     'gnConfigService',
     'gnConfig',
     'Metadata',
-    '$window',
-    '$location',
     function($scope, $routeParams, $http, $rootScope, $translate, $compile,
             gnSearchManagerService,
             gnUtilityService,
             gnMetadataManager,
             gnConfigService,
-            gnConfig, Metadata,
-             $window, $location) {
+            gnConfig, Metadata) {
 
       $scope.isTemplate = false;
       $scope.hasTemplates = true;
@@ -224,17 +221,7 @@
       }
 
       $scope.cancelCreateMetadata = function (){
-        if ($window.history.length > 0) {
-          var referrer = $window.document.referrer;
-
-          // Check if previous page was not the login page
-          if ((!referrer) || (referrer.indexOf("catalog.signin") == -1)) {
-            $window.history.back();
-            return;
-          }
-        }
-
-        $location.path("/board");
+        gnUtilityService.goBack("/board");
       };
 
       $scope.createNewMetadata = function(isPublic) {

--- a/web-ui/src/main/resources/catalog/js/edit/NewMetadataController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/NewMetadataController.js
@@ -40,12 +40,15 @@
     'gnConfigService',
     'gnConfig',
     'Metadata',
+    '$window',
+    '$location',
     function($scope, $routeParams, $http, $rootScope, $translate, $compile,
             gnSearchManagerService,
             gnUtilityService,
             gnMetadataManager,
             gnConfigService,
-            gnConfig, Metadata) {
+            gnConfig, Metadata,
+             $window, $location) {
 
       $scope.isTemplate = false;
       $scope.hasTemplates = true;
@@ -219,6 +222,20 @@
       } else {
         $scope.resourceTitle = 'createA';
       }
+
+      $scope.cancelCreateMetadata = function (){
+        if ($window.history.length > 0) {
+          var referrer = $window.document.referrer;
+
+          // Check if previous page was not the login page
+          if ((!referrer) || (referrer.indexOf("catalog.signin") == -1)) {
+            $window.history.back();
+            return;
+          }
+        }
+
+        $location.path("/board");
+      };
 
       $scope.createNewMetadata = function(isPublic) {
         var metadataUuid = '';

--- a/web-ui/src/main/resources/catalog/templates/editor/import.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/import.html
@@ -332,7 +332,7 @@
                 <span data-translate="">importRecords</span>
               </button>
               <a id="gn-import-buttons-cancel"
-                 href="#/board"
+                 data-ng-click="cancelImportRecords()"
                  class="btn btn-default">
                 <i class="fa fa-close"/>&nbsp;
                 <span data-translate="">cancel</span>

--- a/web-ui/src/main/resources/catalog/templates/editor/new-metadata-horizontal.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/new-metadata-horizontal.html
@@ -130,7 +130,7 @@
             createMetadataForGroup</a></li>
         </ul>
       </div>
-      <a href="#/board" class="btn btn-default">
+      <a data-ng-click="cancelCreateMetadata()" class="btn btn-default">
         <i class="fa fa-close"/>&nbsp;
         <span data-translate="">cancel</span>
       </a>

--- a/web-ui/src/main/resources/catalog/templates/editor/new-metadata-vertical.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/new-metadata-vertical.html
@@ -130,7 +130,7 @@
               createMetadataForGroup</a></li>
           </ul>
         </div>
-        <a href="#/board" class="btn btn-default">
+        <a data-ng-click="cancelCreateMetadata()" class="btn btn-default">
           <i class="fa fa-close"/>&nbsp;
           <span data-translate="">cancel</span>
         </a>


### PR DESCRIPTION
With the original code, the cancel button in the create or import metadata pages displayed the Editor board page, but the search is not executed, causing an empty results page.

This change returns to the previous page in the navigation history. When returning to the editor board the search is preserved, displaying the results.

