### PR TITLE
NumberFormatException handling

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/GlobalExceptionController.java
+++ b/services/src/main/java/org/fao/geonet/api/GlobalExceptionController.java
@@ -160,7 +160,6 @@ public class GlobalExceptionController {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ApiResponse(content = {@Content(mediaType = APPLICATION_JSON_VALUE)})
     @ExceptionHandler({
-        NumberFormatException.class,
         HttpMessageNotReadableException.class,
         Exception.class,
         RuntimeException.class
@@ -350,10 +349,13 @@ public class GlobalExceptionController {
         MultipartException.class,
         DoiClientException.class
     })
-    public ApiError unsatisfiedParameterHandler(final Exception exception) {
+    public ApiError unsatisfiedParameterHandler(final Exception exception, final HttpServletRequest request) {
         storeApiErrorCause(exception);
 
-        return new ApiError("unsatisfied_request_parameter", exception);
+        if (contentTypeNeedsBody(request)) {
+            return new ApiError("unsatisfied_request_parameter", exception);
+        }
+        return null;
     }
 
     @ResponseBody

--- a/services/src/main/java/org/fao/geonet/api/GlobalExceptionController.java
+++ b/services/src/main/java/org/fao/geonet/api/GlobalExceptionController.java
@@ -160,6 +160,7 @@ public class GlobalExceptionController {
     @ResponseStatus(HttpStatus.BAD_REQUEST)
     @ApiResponse(content = {@Content(mediaType = APPLICATION_JSON_VALUE)})
     @ExceptionHandler({
+        NumberFormatException.class,
         HttpMessageNotReadableException.class,
         Exception.class,
         RuntimeException.class


### PR DESCRIPTION
In theory, NumberFormatException is type of RuntimeException and should be caught by this handler
https://github.com/geonetwork/core-geonetwork/blob/e58ee2b7a64760239cd816f2f71748d33f5822ba/services/src/main/java/org/fao/geonet/api/GlobalExceptionController.java#L164-L165

It should be either caught with Exception or RuntimeException. However it isn't the case for this API call:
![image](https://user-images.githubusercontent.com/74916635/165983447-1a7bbbe3-1cec-4ef6-b9ec-51e6d72d7a92.png)


This pull request can fix this issue but it doesn't tell the root cause of it. The issue is also reported: https://github.com/geonetwork/core-geonetwork/pull/6279