### PR TITLE
Standards / ISO19115-3 / Validation / Avoid exception on geographicIdentifier

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/schematron/schematron-rules-iso.sch
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/schematron/schematron-rules-iso.sch
@@ -226,7 +226,7 @@
       <sch:let name="description" value="gex:description[text() != '']"/>
 
       <sch:let name="geographicId"
-               value="gex:geographicElement/gex:EX_GeographicDescription/                          gex:geographicIdentifier[normalize-space(*) != '']"/>
+               value="gex:geographicElement/gex:EX_GeographicDescription/                          gex:geographicIdentifier[normalize-space(mcc:*) != '']"/>
 
       <sch:let name="geographicBox"
                value="gex:geographicElement/                          gex:EX_GeographicBoundingBox[                          normalize-space(gex:westBoundLongitude/gco:Decimal) != '' and                          normalize-space(gex:eastBoundLongitude/gco:Decimal) != '' and                          normalize-space(gex:southBoundLatitude/gco:Decimal) != '' and                          normalize-space(gex:northBoundLatitude/gco:Decimal) != ''                          ]"/>


### PR DESCRIPTION
Fixes https://github.com/geonetwork/core-geonetwork/issues/6281

During validation, the metadocument contains geonet:info. Be sure to select the identifier only for the check.