### PR TITLE
docker - missing mentioned kibana configuration

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -4,7 +4,7 @@ volumes:
 
 services:
   geonetwork:
-    image: geonetwork:3.99.0
+    image: geonetwork:latest
     restart: always
     ports:
       - 8080:8080

--- a/docker/kibana/kibana.yml
+++ b/docker/kibana/kibana.yml
@@ -1,0 +1,4 @@
+server.basePath: "/geonetwork/dashboards"
+server.rewriteBasePath: false
+kibana.index: ".dashboards"
+

--- a/docker/kibana/kibana.yml
+++ b/docker/kibana/kibana.yml
@@ -1,4 +1,5 @@
 server.basePath: "/geonetwork/dashboards"
 server.rewriteBasePath: false
 kibana.index: ".dashboards"
+elasticsearch.hosts: ["http://elasticsearch:9200"]
 


### PR DESCRIPTION
The file mentioned here:
https://github.com/geonetwork/core-geonetwork/blob/main/docker/docker-compose.yml#L42

does not exist in the `docker/` subdirectory. This PR aims to fix this (somehow I got the file locally but never added it to git).

Also the `3.99.0` tag does not exist on docker-hub, but the composition works fine with `latest`.
