### PR TITLE
XSL / Utility / Get source name by UUID

### DIFF
--- a/core/src/main/java/org/fao/geonet/util/XslUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/XslUtil.java
@@ -434,7 +434,7 @@ public final class XslUtil {
      * If the main one, then get the name on the source table with the site id.
      * If a sub portal, use the sub portal key.
      *
-     * @param key   Sub portal key
+     * @param key   Sub portal key or UUID
      * @return
      */
     public static String getNodeName(String key, String lang, boolean withOrganization) {
@@ -447,6 +447,10 @@ public final class XslUtil {
         }
         SourceRepository sourceRepository = ApplicationContextHolder.get().getBean(SourceRepository.class);
         Optional<Source> source = sourceRepository.findById(key);
+
+        if (!source.isPresent()) {
+            source = Optional.ofNullable(sourceRepository.findOneByUuid(key));
+        }
 
         return source.isPresent() ? source.get().getLabel(lang) : settingsMan.getSiteName()
             + (withOrganization ? " - " + settingsMan.getValue(SYSTEM_SITE_ORGANIZATION) : "");


### PR DESCRIPTION
This can be useful in formatter where we only have UUID in sourceinfo

```xsl
<xsl:variable name="sourceName"
                     select="utils:getNodeName(/root/info/record/sourceinfo/sourceid, $language, false())"/>
```