### PR TITLE
Update the harvester setting repository to remove the hierarchical delete of the harvester settings.

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/setting/HarvesterSettingsManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/setting/HarvesterSettingsManager.java
@@ -254,11 +254,12 @@ public class HarvesterSettingsManager {
         HarvesterSetting s = settingsRepo.findOneByPath(path);
         if (s == null)
             return false;
-        
+
         //First we have to remove all children
         removeChildren(s.getId());
 
         settingsRepo.delete(s);
+        settingsRepo.flush();
         return true;
     }
 

--- a/domain/src/main/java/org/fao/geonet/repository/GeonetRepositoryFactoryBean.java
+++ b/domain/src/main/java/org/fao/geonet/repository/GeonetRepositoryFactoryBean.java
@@ -69,8 +69,6 @@ public class GeonetRepositoryFactoryBean<R extends JpaRepository<T, I>, T, I ext
 
             if (isQueryDslExecutor(repositoryInterface)) {
                 return super.getTargetRepository(metadata);
-            } else if (metadata.getDomainType().equals(HarvesterSetting.class)) {
-                return new HarvesterSettingRepositoryOverridesImpl((Class<HarvesterSetting>) metadata.getDomainType(), entityManager);
             } else {
                 return new GeonetRepositoryImpl((Class<T>) metadata.getDomainType(), entityManager);
             }
@@ -80,8 +78,6 @@ public class GeonetRepositoryFactoryBean<R extends JpaRepository<T, I>, T, I ext
 
             if (isQueryDslExecutor(metadata.getRepositoryInterface())) {
                 return super.getRepositoryBaseClass(metadata);
-            } else if (metadata.getDomainType().equals(HarvesterSetting.class)) {
-                return HarvesterSettingRepositoryOverridesImpl.class;
             } else {
                 return GeonetRepositoryImpl.class;
             }


### PR DESCRIPTION
This causes an error when configuring the harvester password in the credentials section and the harvester is updated. 

Error:

```
<?xml version="1.0" encoding="UTF-8"?>
<error id="error">
  <message>Batch update returned unexpected row count from update [0]; actual row count: 0; expected: 1; nested exception is org.hibernate.StaleStateException: Batch update returned unexpected row count from update [0]; actual row count: 0; expected: 1</message>
  <class>ObjectOptimisticLockingFailureException</class>
  <stack>
    <at class="org.springframework.orm.jpa.vendor.HibernateJpaDialect" file="HibernateJpaDialect.java" line="320" method="convertHibernateAccessException" />
    <at class="org.springframework.orm.jpa.vendor.HibernateJpaDialect" file="HibernateJpaDialect.java" line="244" method="translateExceptionIfPossible" />
    <at class="org.springframework.orm.jpa.AbstractEntityManagerFactoryBean" file="AbstractEntityManagerFactoryBean.java" line="491" method="translateExceptionIfPossible" />
    <at class="org.springframework.dao.support.ChainedPersistenceExceptionTranslator" file="ChainedPersistenceExceptionTranslator.java" line="59" method="translateExceptionIfPossible" />
    <at class="org.springframework.dao.support.DataAccessUtils" file="DataAccessUtils.java" line="213" method="translateIfNecessary" />
    <at class="org.springframework.dao.support.PersistenceExceptionTranslationInterceptor" file="PersistenceExceptionTranslationInterceptor.java" line="147" method="invoke" />
    <at class="org.springframework.aop.framework.ReflectiveMethodInvocation" file="ReflectiveMethodInvocation.java" line="179" method="proceed" />
    <at class="org.springframework.data.jpa.repository.support.LockModeRepositoryPostProcessor$LockModePopulatingMethodIntercceptor" file="LockModeRepositoryPostProcessor.java" line="92" method="invoke" />
    <at class="org.springframework.aop.framework.ReflectiveMethodInvocation" file="ReflectiveMethodInvocation.java" line="179" method="proceed" />
    <at class="org.springframework.aop.interceptor.ExposeInvocationInterceptor" file="ExposeInvocationInterceptor.java" line="92" method="invoke" />
    <skip>...</skip>
    <at class="org.fao.geonet.kernel.setting.HarvesterSettingsManager" file="HarvesterSettingsManager.java" line="421" method="remove" />
    <at class="org.fao.geonet.kernel.setting.HarvesterSettingsManager" file="HarvesterSettingsManager.java" line="294" method="removeChildren" />
    <at class="org.fao.geonet.kernel.setting.HarvesterSettingsManager" file="HarvesterSettingsManager.java" line="292" method="removeChildren" />
    <at class="org.fao.geonet.kernel.setting.HarvesterSettingsManager" file="HarvesterSettingsManager.java" line="278" method="removeChildren" />
    <at class="org.fao.geonet.kernel.harvest.harvester.AbstractHarvester" file="AbstractHarvester.java" line="937" method="doUpdate" />
    <at class="org.fao.geonet.kernel.harvest.harvester.AbstractHarvester" file="AbstractHarvester.java" line="572" method="update" />
    <at class="org.fao.geonet.kernel.harvest.HarvestManagerImpl" file="HarvestManagerImpl.java" line="419" method="update" />
    <at class="org.fao.geonet.services.harvesting.Update" file="Update.java" line="65" method="exec" />
    <at class="jeeves.server.dispatchers.ServiceInfo" file="ServiceInfo.java" line="227" method="execService" />
 ...
```

Test case:

1) Run Geonetwork 3.12.x in jetty, against a clean postgresql database.
2) Sign in, and create a geonetwork harvester with remote authentication, with everything else left as default, and save it.
3) Try to make a change to the harvester settings (such as changing the behaviour from skip records to override).

Without the change an error is reported and in the Chrome Network tab (Developer tools), the previous error is displayed.

With the fix, the harvester is updated properly.


---

That code updated, seems to remove the children of a harvester setting, and for an unclear reason causes some side effects with the encrypted field. But the delete method of the `HarvesterSettingsManager` class is already deleting all the harvester settings hierarchically, so the code removed doesn't seem to be required:

https://github.com/geonetwork/core-geonetwork/blob/44966a98a20eeb0c547a0bf653f95f7ffea9bc0e/core/src/main/java/org/fao/geonet/kernel/setting/HarvesterSettingsManager.java#L251-L279

---

In GeoNetwork 4, the issue doesn't happen, the code was updated in the upgrade to JPA 2, in a similar way, but needs to be cleanup as the delete methods are still defined in the class, but not used.

See:

https://github.com/geonetwork/core-geonetwork/blob/7c700728d74a308ff2352703b3f9b2b6813aeaf4/domain/src/main/java/org/fao/geonet/repository/HarvesterSettingRepositoryCustomImpl.java#L72

https://github.com/geonetwork/core-geonetwork/blob/7c700728d74a308ff2352703b3f9b2b6813aeaf4/domain/src/main/java/org/fao/geonet/repository/HarvesterSettingRepositoryCustomImpl.java#L93-L121