### PR TITLE
Harvester / OGC / SOS / Do not add version parameter and improve error reporting

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/ogcwxs/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/ogcwxs/Harvester.java
@@ -216,9 +216,12 @@ class Harvester extends BaseAligner<OgcWxSParams> implements IHarvester<HarvestR
 
 
         // Try to load capabilities document
+        String serviceType = params.ogctype.substring(0, 3);
+        String version = params.ogctype.substring(3);
+        boolean isSos = "SOS".equals(serviceType);
         this.capabilitiesUrl = getBaseUrl(params.url) +
-            "SERVICE=" + params.ogctype.substring(0, 3) +
-            "&VERSION=" + params.ogctype.substring(3) +
+            "SERVICE=" +  serviceType +
+            (isSos ? "" : ("&VERSION=" + version)) +
             "&REQUEST=" + GETCAPABILITIES
         ;
 
@@ -458,7 +461,7 @@ class Harvester extends BaseAligner<OgcWxSParams> implements IHarvester<HarvestR
 
         try {
             md = Xml.transform(capa, styleSheet, xsltParams);
-        } catch (IllegalStateException e) {
+        } catch (Exception e) {
             String message = String.format(
                 "Failed to convert GetCapabilities '%s' to metadata record. Error is: '%s'. Service response is: %s.",
                 this.capabilitiesUrl, e.getMessage(), Xml.getString(capa));


### PR DESCRIPTION

Fixes https://github.com/geonetwork/core-geonetwork/issues/6273

In that case a NPE was reported in the log with no clear explanation about the issue.
Report error properly so user can try to understand why the capabilities document can't be converted.

eg. a rejected parameter

![image](https://user-images.githubusercontent.com/1701393/166879123-5e0f6b2f-5ee8-4a0e-9a85-2f9f33278aad.png)

a version 2.0.0 capabilities (not supported)
![image](https://user-images.githubusercontent.com/1701393/166879206-d3cf464e-f1e0-4739-89d9-bc8d9ce740c9.png)

