### PR TITLE
Remote ATOM feeds: fix atom describe output to remove a wrong empty namespace in some elements.

### DIFF
--- a/web/src/main/webapp/xslt/services/inspire-atom/describe.xsl
+++ b/web/src/main/webapp/xslt/services/inspire-atom/describe.xsl
@@ -27,9 +27,39 @@
                 xmlns:georss="http://www.georss.org/georss"
                 xmlns:geo="http://www.w3.org/2003/01/geo/wgs84_pos#"
                 xmlns:inspire_dls="http://inspire.ec.europa.eu/schemas/inspire_dls/1.0"
-                exclude-result-prefixes="#all" version="1.0">
+                exclude-result-prefixes="#all" version="2.0">
 
   <xsl:template match="/root">
-    <xsl:copy-of select="atom:feed" />
+    <xsl:apply-templates select="atom:feed|@*" />
   </xsl:template>
+
+
+  <xsl:template match="atom:*">
+    <xsl:call-template name="correct_ns_prefix">
+      <xsl:with-param name="element" select="."/>
+      <xsl:with-param name="prefix" select="''"/>
+    </xsl:call-template>
+  </xsl:template>
+
+  <xsl:template name="correct_ns_prefix">
+    <xsl:param name="element"/>
+    <xsl:param name="prefix"/>
+    <xsl:choose>
+      <xsl:when test="local-name($element)=name($element) and $prefix != '' ">
+        <xsl:element name="{$prefix}:{local-name($element)}">
+          <xsl:apply-templates select="@*|node()"/>
+        </xsl:element>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:copy>
+          <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
+  <xsl:template match="@*">
+    <xsl:copy-of select="."></xsl:copy-of>
+  </xsl:template>
+
 </xsl:stylesheet>


### PR DESCRIPTION
Some elements like `link` or `category` were getting an empty (invalid) namespace declaration inline:

```
<link xmlns=""  href=https://...
```

This change fixes the issue.