### PR TITLE
Update INSPIRE Validation API to return JSON format.

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/InspireValidationApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/InspireValidationApi.java
@@ -23,6 +23,7 @@
 
 package org.fao.geonet.api.records;
 
+import com.google.gson.JsonObject;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
@@ -159,7 +160,7 @@ public class InspireValidationApi {
     @RequestMapping(value = "/{metadataUuid}/validate/inspire",
         method = RequestMethod.PUT,
         produces = {
-            MediaType.TEXT_PLAIN_VALUE
+            MediaType.APPLICATION_JSON_VALUE
         })
     @PreAuthorize("hasRole('Editor')")
     @ApiResponses(value = {
@@ -274,7 +275,10 @@ public class InspireValidationApi {
 
             threadPool.runTask(new InspireValidationRunnable(context, URL, testId, metadata.getId()));
 
-            return testId;
+            JsonObject testIdResponse = new JsonObject();
+            testIdResponse.addProperty("testId", testId);
+
+            return testIdResponse.toString();
         } finally {
             context.clearAsThreadLocal();
             // context clear is handled scheduled InspireValidationRunnable above

--- a/web-ui/src/main/resources/catalog/components/validationtools/GnmdInspireValidationDirective.js
+++ b/web-ui/src/main/resources/catalog/components/validationtools/GnmdInspireValidationDirective.js
@@ -86,7 +86,7 @@
                     '/validate/inspire?testsuite=' + test
                   }).then(function mySucces(response) {
                     if (angular.isDefined(response.data) && response.data != null) {
-                      scope.checkInBackgroud(response.data);
+                      scope.checkInBackgroud(response.data.testId);
                     } else {
                       scope.isDownloadingRecord = false;
                       scope.isDownloadedRecord = false;


### PR DESCRIPTION
Returning text if an exception occurred, for example no quotas available in the INSPIRE Validator, the `ApiError` returned can not be converted to text format, throwing an additional exception that hides the original exception.

Without the change:

<img width="301" alt="error-1" src="https://user-images.githubusercontent.com/1695003/167408205-91feeecd-3be3-4a56-801f-74a05a1223a6.png">

With the change:

<img width="1317" alt="error-2" src="https://user-images.githubusercontent.com/1695003/167408211-1c1f028f-1e94-4cff-8053-dc728a5c4619.png">

----

A way to test, without requiring that the INSPIRE validator quotas are exceeeded is to modify this method:

https://github.com/geonetwork/core-geonetwork/blob/3851ea69eb33fc4f9b5bdb5dad0872de5ede0dd8/services/src/main/java/org/fao/geonet/api/records/InspireValidationApi.java#L195

To thrown an exception:

```
if (true) {
    throw new Exception("Test custom INSPIRE validator error");
}
```
----

Identified in the back port  https://github.com/geonetwork/core-geonetwork/pull/5995, happens  only in `3.12.x` branch, `main` branch looks ok, probably due to the Spring MVC different version, as the code looks the same.

In any case, the API change to return JSON, would be good to unify in `main` branch as seem better in the API to return JSON instead of text.
