### PR TITLE
Adjust side bar thickness to 12px

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -894,7 +894,7 @@ button, .btn, .btn:active, a {
   }
 }
 ::-webkit-scrollbar {
-  width: 6px;
+  width: 12px;
   height: 6px;
   background-color: transparent;
 }


### PR DESCRIPTION
This is based on previous pull request https://github.com/geonetwork/core-geonetwork/pull/4642

The side bar thickness is still very thin and not very user friendly 

It is currently set as 6px and looks like:

![image](https://user-images.githubusercontent.com/74916635/167690913-1aed75f3-e054-4733-82c8-5ca07737d682.png)


Here is what 12px looks like:

![image](https://user-images.githubusercontent.com/74916635/167690810-50491f03-6284-49cd-ac9f-7db5c93c8aec.png)

The 12px looks more like what typical web page scroll bar. For example, GitHub's
![image](https://user-images.githubusercontent.com/74916635/167691049-94000c2c-10ec-4233-a024-f0143638c084.png)
