### PR TITLE
Metadata workflow: cancelling the metadata editor when editing a working copy always removes the working copy

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/draft/DraftMetadataUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/draft/DraftMetadataUtils.java
@@ -643,6 +643,9 @@ public class DraftMetadataUtils extends BaseMetadataUtils {
                 // --- remove metadata
                 xmlSerializer.delete(id, ServiceContext.get());
                 searchManager.delete(id);
+
+                // Unset METADATA_EDITING_CREATED_DRAFT flag
+                context.getUserSession().removeProperty(Geonet.Session.METADATA_EDITING_CREATED_DRAFT);
             } catch (Exception e) {
                 Log.error(Geonet.DATA_MANAGER, "Couldn't cleanup draft " + id, e);
             }

--- a/services/src/main/java/org/fao/geonet/api/records/editing/MetadataEditingApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/editing/MetadataEditingApi.java
@@ -52,6 +52,7 @@ import org.fao.geonet.kernel.metadata.StatusActions;
 import org.fao.geonet.kernel.metadata.StatusActionsFactory;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.kernel.setting.Settings;
+import org.fao.geonet.repository.MetadataDraftRepository;
 import org.fao.geonet.repository.MetadataValidationRepository;
 import org.fao.geonet.repository.OperationAllowedRepository;
 import org.fao.geonet.repository.specification.MetadataValidationSpecs;
@@ -95,6 +96,9 @@ public class MetadataEditingApi {
     @Autowired
     SchemaManager schemaManager;
 
+    @Autowired
+    MetadataDraftRepository metadataDraftRepository;
+
     @io.swagger.v3.oas.annotations.Operation(summary = "Edit a record", description = "Return HTML form for editing.")
     @RequestMapping(value = "/{metadataUuid}/editor", method = RequestMethod.GET, consumes = {
         MediaType.ALL_VALUE}, produces = {MediaType.APPLICATION_XML_VALUE})
@@ -115,6 +119,21 @@ public class MetadataEditingApi {
 
         ServiceContext context = ApiUtils.createServiceContext(request);
         ApplicationContext applicationContext = ApplicationContextHolder.get();
+
+        SettingManager sm = context.getBean(SettingManager.class);
+
+        // Code to handle the flag METADATA_EDITING_CREATED_DRAFT:
+        //   1) Editing an approved metadata, without a working copy creates the working copy and should set
+        //      METADATA_EDITING_CREATED_DRAFT = true, to remove the working copy if the user cancel the editor form.
+        //
+        //   2) Editing an approved metadata, with a working copy should NOT set
+        //      METADATA_EDITING_CREATED_DRAFT = true, in this case should NOT be removed the working copy
+        //      if the user cancel the editor form.
+        boolean isEnabledWorkflow = sm.getValueAsBool(Settings.METADATA_WORKFLOW_ENABLE);
+        boolean flagCreateDraftFromApprovedMetadata = false;
+        if (isEnabledWorkflow) {
+            flagCreateDraftFromApprovedMetadata = (metadataDraftRepository.findOneByUuid(metadata.getUuid()) == null);
+        }
 
         // Start editing session
         IMetadataUtils dm = applicationContext.getBean(IMetadataUtils.class);
@@ -143,7 +162,7 @@ public class MetadataEditingApi {
                 sb.append("redirectUrl=catalog.edit");
             }
 
-            context.getUserSession().setProperty(Geonet.Session.METADATA_EDITING_CREATED_DRAFT, true);
+            context.getUserSession().setProperty(Geonet.Session.METADATA_EDITING_CREATED_DRAFT, flagCreateDraftFromApprovedMetadata);
 
             Element el = new Element("script");
             el.setText("window.location.hash = decodeURIComponent(\"#/metadata/" + id2 + sb.toString() + "\")");


### PR DESCRIPTION
Fixes #6294