### PR TITLE
Update multicombiner directive to allow to configure the number of suggestions for the elements that use the thesaurus keyWord picker component

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/multientrycombiner/MultiEntryCombiner.js
+++ b/web-ui/src/main/resources/catalog/components/edit/multientrycombiner/MultiEntryCombiner.js
@@ -61,6 +61,7 @@
  * 2. thesaurus
  *      This represents a Thesaurus KeyWord Picker.
  *           + thesaurus is the name of the thesaurus
+ *           + numberOfSuggestions is the number of suggestions to display (if not set, defaults to 20)
  *
  * 3. freeText
  *      This represents a field the user can type into.
@@ -110,7 +111,8 @@
      *           "eng": "Government of Canada Organization",
      *           "fra": "Organisation du Gouvernement du Canada"
      *         },
-     *         "thesaurus": "external.theme.EC_Government_Titles"
+     *         "thesaurus": "external.theme.EC_Government_Titles",
+     *         "numberOfSuggestions: 200,
      *       },
      *       {
      *         "type": "freeText",

--- a/web-ui/src/main/resources/catalog/components/edit/multientrycombiner/partials/multientrycombiner.html
+++ b/web-ui/src/main/resources/catalog/components/edit/multientrycombiner/partials/multientrycombiner.html
@@ -15,6 +15,7 @@
       <input class="form-control hidden"
              data-gn-keyword-picker=""
              data-thesaurus-key="{{c.thesaurus}}"
+             data-number-of-suggestions="{{c.numberOfSuggestions || 20}}"
              data-faux-multilingual="true"
              data-focus-to-input="false"
              lang="{{lang}}"


### PR DESCRIPTION
The thesaurus picker directive supports an attribute to configure the number of suggestions to display. 

This change updates the  multicombiner directive allowing to configure the number of suggestions to display for  the elements of type `thesaurus`, that are rendered with the thesaurus picker directive.