### PR TITLE
Metadata workflow: metadata save and submit was displaying the metadata in a wrong status.

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/editing/MetadataEditingApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/editing/MetadataEditingApi.java
@@ -45,6 +45,7 @@ import org.fao.geonet.constants.Params;
 import org.fao.geonet.domain.*;
 import org.fao.geonet.events.history.RecordUpdatedEvent;
 import org.fao.geonet.kernel.*;
+import org.fao.geonet.kernel.datamanager.IMetadataIndexer;
 import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.kernel.datamanager.IMetadataValidator;
 import org.fao.geonet.kernel.datamanager.base.BaseMetadataStatus;
@@ -52,6 +53,7 @@ import org.fao.geonet.kernel.metadata.StatusActions;
 import org.fao.geonet.kernel.metadata.StatusActionsFactory;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.kernel.setting.Settings;
+import org.fao.geonet.repository.MetadataRepository;
 import org.fao.geonet.repository.MetadataValidationRepository;
 import org.fao.geonet.repository.OperationAllowedRepository;
 import org.fao.geonet.repository.specification.MetadataValidationSpecs;
@@ -92,8 +94,15 @@ public class MetadataEditingApi {
 
     @Autowired
     LanguageUtils languageUtils;
+
     @Autowired
     SchemaManager schemaManager;
+
+    @Autowired
+    MetadataRepository metadataRepository;
+
+    @Autowired
+    IMetadataIndexer metadataIndexer;
 
     @io.swagger.v3.oas.annotations.Operation(summary = "Edit a record", description = "Return HTML form for editing.")
     @RequestMapping(value = "/{metadataUuid}/editor", method = RequestMethod.GET, consumes = {
@@ -405,6 +414,16 @@ public class MetadataEditingApi {
             if (reindex) {
                 Log.trace(Geonet.DATA_MANAGER, " > Reindexing record");
                 dataMan.indexMetadata(id, true);
+            }
+
+            // Reindex the metadata table record to update the field _statusWorkflow that contains the composite
+            // status of the published and draft versions
+            if (metadata instanceof MetadataDraft) {
+                Metadata metadataApproved = metadataRepository.findOneByUuid(metadata.getUuid());
+
+                if (metadataApproved != null) {
+                    metadataIndexer.indexMetadata(String.valueOf(metadataApproved.getId()), true);
+                }
             }
 
             ajaxEditUtils.removeMetadataEmbedded(session, id);


### PR DESCRIPTION
The metadata approved version requires to be reindexed to display the metadata status as Approved with working copy submitted, otherwise it was displayed as Approved with working copy.

Test case:

1. Go to an approved record and edit it. Save your edits
2. Record shows as "Approved with working copy" in the contribute facet
3. In Working copy edit view, make changes, choose Save and submit
4. In the contribute tab the record should be visible as "Approved with working copy submitted" but it just says "Approved with working copy", although the status shows as submitted when you view the working copy