### PR TITLE
Remote ATOM feeds: fix atom describe output to remove a wrong empty namespace in some elements - handle additional namespaces. 

### DIFF
--- a/web/src/main/webapp/xslt/services/inspire-atom/describe.xsl
+++ b/web/src/main/webapp/xslt/services/inspire-atom/describe.xsl
@@ -34,7 +34,7 @@
   </xsl:template>
 
 
-  <xsl:template match="atom:*">
+  <xsl:template match="atom:*|georss:*|geo:*|inspire_dls:*">
     <xsl:call-template name="correct_ns_prefix">
       <xsl:with-param name="element" select="."/>
       <xsl:with-param name="prefix" select="''"/>


### PR DESCRIPTION
Related to #6288

With the fix some namespaces were not handled, rendering in the output only the element content, without the element tag:

```
    <updated>2020-07-29T01:00:00Z</updated>
    50.73 3.3 50.73 7.24 53.6 7.24 53.6 3.3 50.73 3.3
    <category term="https://www.opengis.net/def/crs/EPSG/0/3035" label="ETRS89-extended / LAEA Europe"/>
```

With the fix:

```
    <updated>2020-07-29T01:00:00Z</updated>
    <georss:polygon>50.73 3.3 50.73 7.24 53.6 7.24 53.6 3.3 50.73 3.3</georss:polygon>
    <category term="https://www.opengis.net/def/crs/EPSG/0/3035" label="ETRS89-extended / LAEA Europe"/>
```