### PR TITLE
Standard / ISO19115-3 / Suggestion / Add WMS and legend when ESRI-REST service defined

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/process/add-wms-and-legend-from-esrirest.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/process/add-wms-and-legend-from-esrirest.xsl
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0"
+  xmlns:mdb="http://standards.iso.org/iso/19115/-3/mdb/2.0"
+  xmlns:mrd="http://standards.iso.org/iso/19115/-3/mrd/1.0"
+  xmlns:mrc="http://standards.iso.org/iso/19115/-3/mrc/2.0"
+  xmlns:mpc="http://standards.iso.org/iso/19115/-3/mpc/1.0"
+  xmlns:cit="http://standards.iso.org/iso/19115/-3/cit/2.0"
+  xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0"
+  xmlns:lan="http://standards.iso.org/iso/19115/-3/lan/1.0"
+  xmlns:geonet="http://www.fao.org/geonetwork"
+  exclude-result-prefixes="#all">
+
+
+  <xsl:import href="process-utility.xsl"/>
+
+  <xsl:param name="esriRestServiceUrl" select="''"/>
+
+  <xsl:variable name="wmsUrl"
+                select="concat($esriRestServiceUrl, '/WMSServer?request=GetCapabilities&amp;service=WMS')"/>
+  <xsl:variable name="isWmsDefined"
+                select="count(//mrd:online
+                                [cit:protocol/*/text() = 'OGC:WMS'
+                                and */cit:linkage/*/text() = $wmsUrl]) > 0"/>
+
+
+  <xsl:variable name="legendUrl"
+                select="concat($esriRestServiceUrl, '/legend')"/>
+  <xsl:variable name="isLegendDefined"
+                select="count(//mdb:portrayalCatalogueInfo/*/
+                                mpc:portrayalCatalogueCitation/*/cit:onlineResource/*
+                                  [cit:protocol/*/text() = 'WWW:LINK'
+                                  and cit:linkage/*/text() = $legendUrl]) > 0"/>
+
+
+
+  <!-- i18n information -->
+  <xsl:variable name="add-wms-and-legend-from-esrirest-loc">
+    <msg id="a" xml:lang="eng">Add WMS and legend links for ESRI REST service:</msg>
+    <msg id="a" xml:lang="fre">Ajouter les liens vers le WMS et la légende pour le service ESRI REST :</msg>
+    <msg id="legendLabel" xml:lang="eng">Layer legend</msg>
+    <msg id="legendLabel" xml:lang="fre">Légende des couches de données</msg>
+  </xsl:variable>
+
+  <xsl:template name="list-add-wms-and-legend-from-esrirest">
+    <suggestion process="add-wms-and-legend-from-esrirest"/>
+  </xsl:template>
+
+
+  <xsl:template name="analyze-add-wms-and-legend-from-esrirest">
+    <xsl:param name="root"/>
+
+    <xsl:variable name="esriRestUrls"
+                  select="$root//mrd:onLine/*[cit:protocol/*/text() = 'ESRI:REST']/cit:linkage/*"/>
+
+    <xsl:for-each select="$esriRestUrls">
+      <suggestion process="add-wms-and-legend-from-esrirest"
+                  id="{generate-id()}"
+                  category="online" target="onLine">
+        <name>
+          <xsl:value-of select="geonet:i18n($add-wms-and-legend-from-esrirest-loc, 'a', $guiLang)"/><xsl:value-of
+          select="."/>
+        </name>
+        <operational>true</operational>
+        <params>{"esriRestServiceUrl":{"type":"string", "defaultValue":"<xsl:value-of select="."/>"}}
+        </params>
+      </suggestion>
+    </xsl:for-each>
+  </xsl:template>
+
+
+  <!-- Do a copy of every nodes and attributes -->
+  <xsl:template match="@*|node()">
+    <xsl:copy>
+      <xsl:apply-templates select="@*|node()"/>
+    </xsl:copy>
+  </xsl:template>
+
+  <!-- Remove geonet:* elements. -->
+  <xsl:template match="geonet:*" priority="2">
+  </xsl:template>
+
+  <xsl:template match="mrd:onLine[not($isWmsDefined)
+                                  and */cit:linkage/*/text() = $esriRestServiceUrl]"
+                priority="99">
+    <xsl:copy-of select="."/>
+    <mrd:onLine>
+      <cit:CI_OnlineResource>
+        <cit:linkage>
+          <gco:CharacterString><xsl:value-of select="$wmsUrl"/></gco:CharacterString>
+        </cit:linkage>
+        <cit:protocol>
+          <gco:CharacterString>OGC:WMS</gco:CharacterString>
+        </cit:protocol>
+        <cit:name>
+          <gco:CharacterString>
+            <xsl:value-of select="replace(*/cit:name/gco:CharacterString, 'ESRI-REST', 'WMS')"/>
+          </gco:CharacterString>
+        </cit:name>
+        <cit:description>
+          <gco:CharacterString>
+            <xsl:value-of select="replace(*/cit:description/gco:CharacterString, 'ESRI-REST', 'WMS')"/>
+          </gco:CharacterString>
+        </cit:description>
+        <cit:function>
+          <cit:CI_OnLineFunctionCode
+            codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_OnLineFunctionCode"
+            codeListValue="information"/>
+        </cit:function>
+      </cit:CI_OnlineResource>
+    </mrd:onLine>
+  </xsl:template>
+
+
+  <xsl:template
+    match="mdb:MD_Metadata[not($isLegendDefined)]"
+    priority="2">
+
+    <xsl:variable name="metadataLanguage"
+                  select="//mdb:MD_Metadata/mdb:defaultLocale/
+                              lan:PT_Locale/lan:language/lan:LanguageCode/@codeListValue"/>
+    <xsl:copy>
+      <xsl:apply-templates select="@*"/>
+      <xsl:apply-templates
+        select="mdb:metadataIdentifier|
+                mdb:defaultLocale|
+                mdb:parentMetadata|
+                mdb:metadataScope|
+                mdb:dateInfo|
+                mdb:metadataStandard|
+                mdb:metadataProfile|
+                mdb:alternativeMetadataReference|
+                mdb:otherLocale|
+                mdb:metadataLinkage|
+                mdb:spatialRepresentationInfo|
+                mdb:referenceSystemInfo|
+                mdb:metadataExtensionInfo|
+                mdb:identificationInfo|
+                mdb:contentInfo|
+                mdb:distributionInfo|
+                mdb:dataQualityInfo|
+                mdb:resourceLineage|
+                mdb:portrayalCatalogueInfo"/>
+
+      <mdb:portrayalCatalogueInfo>
+        <mpc:MD_PortrayalCatalogueReference>
+          <mpc:portrayalCatalogueCitation>
+            <cit:CI_Citation>
+              <cit:title>
+                <gco:CharacterString><xsl:value-of select="geonet:i18n($add-wms-and-legend-from-esrirest-loc, 'legendLabel', $metadataLanguage)"/></gco:CharacterString>
+              </cit:title>
+              <cit:onlineResource>
+                <cit:CI_OnlineResource>
+                  <cit:linkage>
+                    <gco:CharacterString>
+                      <xsl:value-of select="$legendUrl"/>
+                    </gco:CharacterString>
+                  </cit:linkage>
+                  <cit:protocol>
+                    <gco:CharacterString>WWW:LINK</gco:CharacterString>
+                  </cit:protocol>
+                  <cit:function>
+                    <cit:CI_OnLineFunctionCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_OnLineFunctionCode"
+                                               codeListValue="information.portrayal"/>
+                  </cit:function>
+                </cit:CI_OnlineResource>
+              </cit:onlineResource>
+            </cit:CI_Citation>
+          </mpc:portrayalCatalogueCitation>
+        </mpc:MD_PortrayalCatalogueReference>
+      </mdb:portrayalCatalogueInfo>
+
+      <xsl:apply-templates
+        select="
+                mdb:metadataConstraints|
+                mdb:applicationSchemaInfo|
+                mdb:metadataMaintenance|
+                mdb:acquisitionInformation"/>
+
+    </xsl:copy>
+  </xsl:template>
+
+</xsl:stylesheet>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/process/add-wms-and-legend-from-esrirest.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/process/add-wms-and-legend-from-esrirest.xsl
@@ -105,7 +105,7 @@
         <cit:function>
           <cit:CI_OnLineFunctionCode
             codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_OnLineFunctionCode"
-            codeListValue="information"/>
+            codeListValue="browsing"/>
         </cit:function>
       </cit:CI_OnlineResource>
     </mrd:onLine>
@@ -161,7 +161,7 @@
                   </cit:protocol>
                   <cit:function>
                     <cit:CI_OnLineFunctionCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_OnLineFunctionCode"
-                                               codeListValue="information.portrayal"/>
+                                               codeListValue="information"/>
                   </cit:function>
                 </cit:CI_OnlineResource>
               </cit:onlineResource>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/process/add-wms-and-legend-from-esrirest.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/process/add-wms-and-legend-from-esrirest.xsl
@@ -17,7 +17,7 @@
   <xsl:param name="esriRestServiceUrl" select="''"/>
 
   <xsl:variable name="wmsUrl"
-                select="concat($esriRestServiceUrl, '/WMSServer?request=GetCapabilities&amp;service=WMS')"/>
+                select="concat(replace($esriRestServiceUrl, '/rest/', ''), '/WMSServer?request=GetCapabilities&amp;service=WMS')"/>
   <xsl:variable name="isWmsDefined"
                 select="count(//mrd:online
                                 [cit:protocol/*/text() = 'OGC:WMS'

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/suggest.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/suggest.xsl
@@ -7,6 +7,7 @@
 
   <!-- Register here the list of process for the schema-->
   <xsl:include href="process/add-extent-from-geokeywords.xsl"/>
+  <xsl:include href="process/add-wms-and-legend-from-esrirest.xsl"/>
   <xsl:include href="process/add-resource-id.xsl"/>
   <xsl:include href="process/add-contact.xsl"/>
   <xsl:include href="process/add-columns-from-csv.xsl"/>
@@ -19,6 +20,7 @@
     <p>add-resource-id</p>
     <p>add-contact</p>
     <p>create-featurecatalogue-from-wfs</p>
+    <p>add-wms-and-legend-from-esrirest</p>
     <p>add-columns-from-csv</p>
     <p>add-values-from-csv</p>
     <!--<p>inspire-add-conformity</p>-->

--- a/web-ui/src/main/resources/catalog/locales/en-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/en-editor.json
@@ -129,6 +129,7 @@
     "file": "File",
     "fileType": "Type of file",
     "fromTemplate": "From ",
+    "esriRestServiceUrl": "ESRI REST URL",
     "generateUUID": "Generate UUID for inserted metadata",
     "geopublisher": "Publish as WMS, WFS, WCS",
     "gmd:CI_ResponsibleParty": "Organizations & contacts",


### PR DESCRIPTION

When using ESRI to distribute data over geoservices, most of the time the metadata record also reference a WMS endpoint and a link to the legend. Add a simple suggestion to add those links easily.

![image](https://user-images.githubusercontent.com/1701393/168065990-192799d3-395d-4437-9ea6-b45a3fd6cd49.png)

In one click, 
![image](https://user-images.githubusercontent.com/1701393/168066023-1db15967-42e9-4f01-b673-767d07f6b49a.png)
is updated with
![image](https://user-images.githubusercontent.com/1701393/168066044-de8d39e7-ea01-4525-8197-65eb2b4d3b37.png)

