### PR TITLE
Standard / ISO19115-3 / Mapping ISO19139 / Datestamp is revision date

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ISO19139/mapping/core.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ISO19139/mapping/core.xsl
@@ -222,7 +222,7 @@
             <xsl:call-template name="writeCodelistElement">
               <xsl:with-param name="elementName" select="'cit:dateType'"/>
               <xsl:with-param name="codeListName" select="'cit:CI_DateTypeCode'"/>
-              <xsl:with-param name="codeListValue" select="'creation'"/>
+              <xsl:with-param name="codeListValue" select="'revision'"/>
             </xsl:call-template>
           </cit:CI_Date>
         </mdb:dateInfo>


### PR DESCRIPTION
Even if the ISO19115 defintion of dateStamp is "Date that the metadata was created", it is used mainly as revision date (at least by GeoNetwork). Fix the ISO19139 to ISO19115-3 mapping to set the revision date (instead of creation date).