### PR TITLE
Editor / New metadata / Allow closing the tab once finalized.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/catalog/CatalogService.js
+++ b/web-ui/src/main/resources/catalog/components/catalog/CatalogService.js
@@ -200,7 +200,7 @@
            * @return {HttpPromise} Future object
            */
         create: function(id, groupId, withFullPrivileges,
-            isTemplate, isChild, tab, metadataUuid, hasCategoryOfSource) {
+            isTemplate, isChild, tab, metadataUuid, hasCategoryOfSource, redirectUrl) {
 
           return this.copy(id, groupId, withFullPrivileges,
               isTemplate, isChild, metadataUuid, hasCategoryOfSource)
@@ -211,7 +211,7 @@
                 }
                 $location.path(path)
                 .search('justcreated')
-                .search('redirectUrl', 'catalog.edit');
+                .search('redirectUrl', redirectUrl || 'catalog.edit');
               });
         },
 

--- a/web-ui/src/main/resources/catalog/js/edit/EditorController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/EditorController.js
@@ -540,9 +540,9 @@
         window.onbeforeunload = null;
 
         // if there is no history, attempt to close tab
-        if ($scope.redirectUrl != null) {
+        if ($scope.redirectUrl != null && $scope.redirectUrl != 'close') {
           window.location.replace($scope.redirectUrl);
-        } else if (window.history.length == 1) {
+        } else if (window.history.length == 1 || $scope.redirectUrl == 'close') {
           window.close();
           // This last point may trigger
           // "Scripts may close only the windows that were opened by it."

--- a/web-ui/src/main/resources/catalog/js/edit/NewMetadataController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/NewMetadataController.js
@@ -33,14 +33,14 @@
    * Controller to create new metadata record.
    */
   module.controller('GnNewMetadataController', [
-    '$scope', '$routeParams', '$http', '$rootScope', '$translate', '$compile',
+    '$scope', '$routeParams', '$http', '$rootScope', '$translate', '$compile', '$location',
     'gnSearchManagerService',
     'gnUtilityService',
     'gnMetadataManager',
     'gnConfigService',
     'gnConfig',
     'Metadata',
-    function($scope, $routeParams, $http, $rootScope, $translate, $compile,
+    function($scope, $routeParams, $http, $rootScope, $translate, $compile, $location,
             gnSearchManagerService,
             gnUtilityService,
             gnMetadataManager,
@@ -93,7 +93,8 @@
               $routeParams.template,
               false,
               $routeParams.tab,
-              true);
+              true,
+              $location.search()['redirectUrl']);
         } else {
 
           // Metadata creation could be on a template
@@ -256,7 +257,8 @@
             $routeParams.childOf ? true : false,
             undefined,
             metadataUuid,
-            true
+            true,
+            $location.search()['redirectUrl']
         ).error(function(data) {
           $rootScope.$broadcast('StatusUpdated', {
             title: $translate.instant('createMetadataError'),


### PR DESCRIPTION
When creating direct link to create new metadata, application opening the link in a new window may want to have the window closed at the end of the editing session instead of returning to the editor board. Add a specific redirect URL flag to trigger that.


Example of a custom app opening the editor in a new tab when creating a new record
![image](https://user-images.githubusercontent.com/1701393/168239959-48129f1e-1c98-432a-b6f7-8598d15b3b9b.png)
At the end of the session, the `redirectUrl=close` parameter will close the tab and user ends up in the main app.

