### PR TITLE
Dublin core / Do not propose associations not supported

### DIFF
--- a/schemas/dublin-core/src/main/java/org/fao/geonet/schema/dublincore/DublinCoreSchemaPlugin.java
+++ b/schemas/dublin-core/src/main/java/org/fao/geonet/schema/dublincore/DublinCoreSchemaPlugin.java
@@ -70,7 +70,7 @@ public class DublinCoreSchemaPlugin
      * Always return null. Not implemented for dublin core records.
      */
     public Set<AssociatedResource> getAssociatedResourcesUUIDs(Element metadata) {
-        return null;
+        return new HashSet<>();
     }
 
     @Override
@@ -82,19 +82,19 @@ public class DublinCoreSchemaPlugin
     }
 
     public Set<String> getAssociatedDatasetUUIDs(Element metadata) {
-        return null;
+        return new HashSet<>();
     }
 
     ;
 
     public Set<String> getAssociatedFeatureCatalogueUUIDs(Element metadata) {
-        return null;
+        return new HashSet<>();
     }
 
     ;
 
     public Set<String> getAssociatedSourceUUIDs(Element metadata) {
-        return null;
+        return new HashSet<>();
     }
 
     @Override

--- a/schemas/dublin-core/src/main/plugin/dublin-core/layout/config-editor.xml
+++ b/schemas/dublin-core/src/main/plugin/dublin-core/layout/config-editor.xml
@@ -53,7 +53,8 @@
     <view name="default" upAndDownControlHidden="true">
       <sidePanel>
         <directive data-gn-validation-report=""/>
-        <directive data-gn-onlinesrc-list=""/>
+        <directive data-gn-onlinesrc-list=""
+                   data-types="onlinesrc|thumbnail|parent"/>
         <directive data-gn-need-help="user-guide/describing-information/creating-metadata.html"/>
       </sidePanel>
       <tab id="default" default="true" mode="flat">
@@ -66,7 +67,8 @@
     <view name="advanced" upAndDownControlHidden="true">
       <sidePanel>
         <directive data-gn-validation-report=""/>
-        <directive data-gn-onlinesrc-list=""/>
+        <directive data-gn-onlinesrc-list=""
+                   data-types="onlinesrc|thumbnail|parent"/>
         <directive data-gn-need-help="user-guide/describing-information/creating-metadata.html"/>
       </sidePanel>
       <tab id="advanced" default="true">
@@ -76,7 +78,8 @@
     <view name="xml">
       <sidePanel>
         <directive data-gn-validation-report=""/>
-        <directive data-gn-onlinesrc-list=""/>
+        <directive data-gn-onlinesrc-list=""
+                   data-types="onlinesrc|thumbnail|parent"/>
         <directive data-gn-need-help="user-guide/describing-information/creating-metadata.html"/>
       </sidePanel>
       <tab id="xml" default="true"/>


### PR DESCRIPTION
In the editor, only parent (isPartOf) is currently supported for Dublin Core records.


![image](https://user-images.githubusercontent.com/1701393/168590970-121e3feb-d603-4ba6-b7ac-23550bd970c5.png)
