### PR TITLE
Use SAXBuilder in XslUtil method to retrieve the xml content from an URL

### DIFF
--- a/core/src/main/java/org/fao/geonet/util/XslUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/XslUtil.java
@@ -34,6 +34,7 @@ import com.neovisionaries.i18n.LanguageCode;
 import org.fao.geonet.api.records.attachments.FilesystemStoreResourceContainer;
 import org.fao.geonet.api.records.attachments.Store;
 import org.fao.geonet.domain.MetadataResourceContainer;
+import org.jdom.input.SAXBuilder;
 import org.jsoup.Jsoup;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.MultiPolygon;
@@ -1241,11 +1242,13 @@ public final class XslUtil {
             URL url = new URL(surl);
             URLConnection conn = Lib.net.setupProxy(context, url);
 
-            DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
-            DocumentBuilder db = dbf.newDocumentBuilder();
-
             is = conn.getInputStream();
-            res = db.parse(is);
+
+            SAXBuilder builder = Xml.getSAXBuilder(false);
+            Document jdoc = builder.build(is);
+
+            DOMOutputter outputter = new DOMOutputter();
+            return outputter.output(jdoc);
 
         } catch (Throwable e) {
             Log.error(Geonet.GEONETWORK, "Failed fetching url: " + surl, e);


### PR DESCRIPTION
Test case:

1) Create a service metadata
2) In Contains operations section add a WMS service URL 

<img width="1118" alt="issue-1" src="https://user-images.githubusercontent.com/1695003/168780180-ee2a7008-7665-4a0b-b119-8ffe177dffc9.png">


3) Click in the suggestions panel, selecting the following one to add the operations from the WMS service

<img width="543" alt="issue-2" src="https://user-images.githubusercontent.com/1695003/168780221-c4ff1a10-6aaf-46f7-b68a-84f5fefdcf42.png">


4) Expected: The metadata is updated with the operations from the WMS service. 

The method to retrieve the WMS service capabilities is the one updated in this code change.