### PR TITLE
Metadata workflow: cancelling the metadata editor when editing a working copy always removes the working copy - related issue when the working copy was saved clicking 'Save & close' only. 

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/editing/MetadataEditingApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/editing/MetadataEditingApi.java
@@ -469,6 +469,12 @@ public class MetadataEditingApi {
 
             ajaxEditUtils.removeMetadataEmbedded(session, id);
             dataMan.endEditingSession(id, session);
+
+            if (isEnabledWorkflow) {
+                // After saving & close remove the information to remove the draft copy if the user cancels the editor
+                context.getUserSession().removeProperty(Geonet.Session.METADATA_EDITING_CREATED_DRAFT);
+            }
+
             if (isUnpublished) {
                 throw new IllegalStateException(String.format("Record saved but as it was invalid at the end of "
                     + "the editing session. The public record '%s' was unpublished.", metadata.getUuid()));


### PR DESCRIPTION
Related to #6295

The test case from https://github.com/geonetwork/core-geonetwork/issues/6294 only worked if in step 4, the user used `Save draft` and after `Save & Close`. When using only `Save & Close` was not working properly.

1. Enable the metadata workflow.
2. Create a record and directly approve it
3. Edit the record and cancel the metadata editor --> No working copy is created (ok)
4. Edit the record and save and close the editor --> A working copy is created (ok)
5. Edit the record record again and cancel without making any changes --> The working copy is removed (no ok)
