### PR TITLE
Make consistent the date set in metadata status change date.

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataStatus.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataStatus.java
@@ -226,7 +226,7 @@ public class BaseMetadataStatus implements IMetadataStatus {
         metatatStatus.setChangeMessage("");
         metatatStatus.setStatusValue(statusValue.get());
         metatatStatus.setMetadataId(metadataId);
-        metatatStatus.setChangeDate(new ISODate(System.currentTimeMillis()));
+        metatatStatus.setChangeDate(new ISODate());
         metatatStatus.setUserId(userId);
         metatatStatus.setUuid(metadataUtils.getMetadataUuid(Integer.toString(metadataId)));
         metatatStatus.setTitles(metadataUtils.extractTitles(Integer.toString(metadataId)));


### PR DESCRIPTION
Previously the updated method call was using the date in UTC, while other places setting the date were using the system date.

This was causing when a working copy is created and later used the Save and submit option in the metadata editor, the submitted status had a previous date than the draft status, if GeoNetwork uses a different timezone than UTC. For example:

- draft status --> change date: 12:32:01
- submitted status --> change date: 10:33:10 (should be 12:33:10)

The metadata status is reported wrongly as draft instead of submitted.