### PR TITLE
Metadata workflow: update edit button to use in the link the metadata identifier of the working copy when a metadata has a working copy

### DIFF
--- a/core/src/main/java/org/fao/geonet/constants/Geonet.java
+++ b/core/src/main/java/org/fao/geonet/constants/Geonet.java
@@ -660,6 +660,7 @@ public final class Geonet {
         public static final String IS_PUBLISHED_TO_ALL = "isPublishedToAll";
         public static final String FEEDBACKCOUNT = "feedbackCount";
         public static final String DRAFT = "draft";
+        public static final String DRAFT_ID = "draftId";
         public static final String RESOURCETITLE = "resourceTitle";
         public static final String RESOURCEABSTRACT = "resourceAbstract";
         public static final String PARENTUUID = "parentUuid";

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/draft/DraftMetadataIndexer.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/draft/DraftMetadataIndexer.java
@@ -75,6 +75,7 @@ public class DraftMetadataIndexer extends BaseMetadataIndexer implements IMetada
                 Log.trace(Geonet.DATA_MANAGER,
                     "We are indexing a record with a draft associated with uuid " + fullMd.getUuid());
                 extraFields.put(Geonet.IndexFieldNames.DRAFT, "e");
+                extraFields.put(Geonet.IndexFieldNames.DRAFT_ID, metadataDraft.getId());
 
                 String status = "";
                 String statusDraft = "";

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/EsFacet.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/EsFacet.js
@@ -42,7 +42,7 @@
       'topic*',
       'inspire*',
       'resource*',
-      'draft',
+      'draft*',
       'overview.*',
       'owner*',
       'link*',

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/EsFacet.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/EsFacet.js
@@ -95,7 +95,7 @@
             'creat*',
             'group*',
             'resource*',
-            'draft',
+            'draft*',
             'owner*',
             'recordOwner',
             'status*',

--- a/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionService.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionService.js
@@ -260,6 +260,8 @@
       };
 
       this.getMetadataIdToEdit = function(md) {
+        if (!md) return;
+
         if (md.draftId) {
           return md.draftId;
         } else {

--- a/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionService.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionService.js
@@ -259,7 +259,14 @@
         return deferred.promise;
       };
 
+      this.getMetadataIdToEdit = function(md) {
+        if (md.draftId) {
+          return md.draftId;
+        } else {
+          return md.id;
+        }
 
+      };
       this.openPrivilegesPanel = function(md, scope) {
         gnUtilityService.openModal({
           title: $translate.instant('privileges') + ' - ' +

--- a/web-ui/src/main/resources/catalog/components/search/mdview/mdviewService.js
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/mdviewService.js
@@ -49,12 +49,13 @@
     'gnESClient',
     'gnESFacet',
     'gnGlobalSettings',
+    'gnMetadataActions',
     '$http',
     '$filter',
     function(gnSearchLocation, $rootScope, gnMdFormatter, Metadata,
              gnMdViewObj, gnSearchManagerService, gnSearchSettings,
              gnUrlUtils, gnUtilityService, gnESService, gnESClient,
-             gnESFacet, gnGlobalSettings, $http, $filter) {
+             gnESFacet, gnGlobalSettings, gnMetadataActions, $http, $filter) {
 
       // Keep where the metadataview come from to get back on close
       var initFromConfig = function() {
@@ -281,7 +282,6 @@
 
                       //If returned more than one, maybe we are looking for the draft
                       var i = 0;
-                      var idToEdit;
 
                       r.data.hits.hits.forEach(function (md, index) {
                         if(getDraft
@@ -289,14 +289,11 @@
                           //This will only happen if the draft exists
                           //and the user can see it
                           i = index;
-                        } else if(md._source.draft == 'y') {
-                          idToEdit = md._source.id;
                         }
                       });
 
                       var metadata = [];
                       metadata.push(new Metadata(r.data.hits.hits[i]));
-                      metadata[0].idToEdit = (idToEdit ? idToEdit: metadata[0].id) ;
 
                       data = {metadata: metadata};
                       //Keep the search results (gnMdViewObj.records)

--- a/web-ui/src/main/resources/catalog/components/search/mdview/mdviewService.js
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/mdviewService.js
@@ -281,17 +281,23 @@
 
                       //If returned more than one, maybe we are looking for the draft
                       var i = 0;
+                      var idToEdit;
+
                       r.data.hits.hits.forEach(function (md, index) {
                         if(getDraft
                             && md._source.draft == 'y') {
                           //This will only happen if the draft exists
                           //and the user can see it
                           i = index;
+                        } else if(md._source.draft == 'y') {
+                          idToEdit = md._source.id;
                         }
                       });
 
                       var metadata = [];
                       metadata.push(new Metadata(r.data.hits.hits[i]));
+                      metadata[0].idToEdit = (idToEdit ? idToEdit: metadata[0].id) ;
+
                       data = {metadata: metadata};
                       //Keep the search results (gnMdViewObj.records)
                       // that.feedMd(0, undefined, data.metadata);

--- a/web-ui/src/main/resources/catalog/components/search/mdview/mdviewService.js
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/mdviewService.js
@@ -284,10 +284,15 @@
                       var i = 0;
 
                       r.data.hits.hits.forEach(function (md, index) {
-                        if(getDraft
+                        if (getDraft
                             && md._source.draft == 'y') {
                           //This will only happen if the draft exists
                           //and the user can see it
+                          i = index;
+                        } else if (!getDraft
+                          && md._source.draft != 'y') {
+                          // This use the non-draft version when the  results include the
+                          // approved and the working copy (draft) versions
                           i = index;
                         }
                       });

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/editor.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/editor.html
@@ -61,7 +61,7 @@
             <a class="btn btn-default"
                data-ng-show="user.canEditRecord(md) && md.isTemplate != 's'
                              && (user.isReviewerOrMore() || md.mdStatus != 4 || !isMdWorkflowEnable)"
-               data-ng-href="#/metadata/{{md.id}}?redirectUrl=catalog.edit"
+               data-ng-href="#/metadata/{{mdService.getMetadataIdToEdit(md)}}?redirectUrl=catalog.edit"
                title="{{'edit' | translate}}">
               <i class="fa fa-pencil"></i>
             </a>

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/recordView.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/recordView.html
@@ -76,7 +76,7 @@
           <div class="btn-group pull-left" role="group">
             <a class="btn btn-default gn-md-edit-btn"
                data-ng-show="user.canEditRecord(mdView.current.record) && (user.isReviewerOrMore() || mdView.current.record.mdStatus != 4 || !isMdWorkflowEnable)"
-               data-ng-href="catalog.edit#/metadata/{{mdView.current.record.idToEdit}}?redirectUrl=catalog.search%23%2Fmetadata%2F{{mdView.current.record.uuid}}"
+               data-ng-href="catalog.edit#/metadata/{{gnMetadataActions.getMetadataIdToEdit(mdView.current.record)}}?redirectUrl=catalog.search%23%2Fmetadata%2F{{mdView.current.record.uuid}}"
                title="{{'edit' | translate}}">
               <span class="fa fa-fw fa-pencil"></span>
               <span data-translate="" class="hidden-sm hidden-xs">edit</span>

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/recordView.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/recordView.html
@@ -76,7 +76,7 @@
           <div class="btn-group pull-left" role="group">
             <a class="btn btn-default gn-md-edit-btn"
                data-ng-show="user.canEditRecord(mdView.current.record) && (user.isReviewerOrMore() || mdView.current.record.mdStatus != 4 || !isMdWorkflowEnable)"
-               data-ng-href="catalog.edit#/metadata/{{mdView.current.record.id}}?redirectUrl=catalog.search%23%2Fmetadata%2F{{mdView.current.record.uuid}}"
+               data-ng-href="catalog.edit#/metadata/{{mdView.current.record.idToEdit}}?redirectUrl=catalog.search%23%2Fmetadata%2F{{mdView.current.record.uuid}}"
                title="{{'edit' | translate}}">
               <span class="fa fa-fw fa-pencil"></span>
               <span data-translate="" class="hidden-sm hidden-xs">edit</span>


### PR DESCRIPTION
The backend code always edits the working copy (independently of receiving the identifier of the approved or working copy), but the UI stores the information of the approved version and causes the following error:

```
angular.js?v=0340653132a9d5190768df9193cb149c80f92e7e:14199 SyntaxError: Unexpected token u in JSON at position 0
    at JSON.parse (<anonymous>)
    at Object.onFormLoad (EditorService.js:415:37)
    at refreshForm (EditorService.js:319:24)
    at Object.refreshEditorForm (EditorService.js:331:16)
    at EditorService.js:163:22
    at angular.js?v=0340653132a9d5190768df9193cb149c80f92e7e:11728:13
    at processQueue (angular.js?v=0340653132a9d5190768df9193cb149c80f92e7e:16696:28)
    at angular.js?v=0340653132a9d5190768df9193cb149c80f92e7e:16712:27
    at Scope.$eval (angular.js?v=0340653132a9d5190768df9193cb149c80f92e7e:17994:28)
```

This has been identified to fail only in `main` branch, but requires to be check if required also for `3.12.x`