### PR TITLE
Fix ESAPI Logger configuration

### DIFF
--- a/web/src/main/webapp/WEB-INF/classes/ESAPI.properties
+++ b/web/src/main/webapp/WEB-INF/classes/ESAPI.properties
@@ -3,7 +3,7 @@
 #
 # This file is part of the Open Web Application Security Project (OWASP)
 # Enterprise Security API (ESAPI) project. For details, please see
-# http://www.owasp.org/index.php/ESAPI.
+# https://owasp.org/www-project-enterprise-security-api/
 #
 # Copyright (c) 2008,2009 - The OWASP Foundation
 #
@@ -31,14 +31,6 @@
 # way up to the root directory of the file system.  Note that if you are using
 # file-based implementations, that some files may need to be read-write as they
 # get updated dynamically.
-#
-# Before using, be sure to update the MasterKey and MasterSalt as described below.
-# N.B.: If you had stored data that you have previously encrypted with ESAPI 1.4,
-#		you *must* FIRST decrypt it using ESAPI 1.4 and then (if so desired)
-#		re-encrypt it with ESAPI 2.0. If you fail to do this, you will NOT be
-#		able to decrypt your data with ESAPI 2.0.
-#
-#		YOU HAVE BEEN WARNED!!! More details are in the ESAPI 2.0 Release Notes.
 #
 #===========================================================================
 # ESAPI Configuration
@@ -75,8 +67,12 @@ ESAPI.Executor=org.owasp.esapi.reference.DefaultExecutor
 ESAPI.HTTPUtilities=org.owasp.esapi.reference.DefaultHTTPUtilities
 ESAPI.IntrusionDetector=org.owasp.esapi.reference.DefaultIntrusionDetector
 # Log4JFactory Requires log4j.xml or log4j.properties in classpath - http://www.laliluna.de/log4j-tutorial.html
+# Note that this is now considered deprecated!
 ESAPI.Logger=org.owasp.esapi.logging.log4j.Log4JLogFactory
 #ESAPI.Logger=org.owasp.esapi.logging.java.JavaLogFactory
+# To use the new SLF4J logger in ESAPI (see GitHub issue #129), set
+#    ESAPI.Logger=org.owasp.esapi.logging.slf4j.Slf4JLogFactory
+# and do whatever other normal SLF4J configuration that you normally would do for your application.
 ESAPI.Randomizer=org.owasp.esapi.reference.DefaultRandomizer
 ESAPI.Validator=org.owasp.esapi.reference.DefaultValidator
 
@@ -130,21 +126,6 @@ Encoder.DefaultCodecList=HTMLEntityCodec,PercentCodec,JavaScriptCodec
 # unlimited strength policy files and install in the lib directory of your JRE/JDK.
 # See http://java.sun.com/javase/downloads/index.jsp for more information.
 #
-# Backward compatibility with ESAPI Java 1.4 is supported by the two deprecated API
-# methods, Encryptor.encrypt(String) and Encryptor.decrypt(String). However, whenever
-# possible, these methods should be avoided as they use ECB cipher mode, which in almost
-# all circumstances a poor choice because of it's weakness. CBC cipher mode is the default
-# for the new Encryptor encrypt / decrypt methods for ESAPI Java 2.0.  In general, you
-# should only use this compatibility setting if you have persistent data encrypted with
-# version 1.4 and even then, you should ONLY set this compatibility mode UNTIL
-# you have decrypted all of your old encrypted data and then re-encrypted it with
-# ESAPI 2.0 using CBC mode. If you have some reason to mix the deprecated 1.4 mode
-# with the new 2.0 methods, make sure that you use the same cipher algorithm for both
-# (256-bit AES was the default for 1.4; 128-bit is the default for 2.0; see below for
-# more details.) Otherwise, you will have to use the new 2.0 encrypt / decrypt methods
-# where you can specify a SecretKey. (Note that if you are using the 256-bit AES,
-# that requires downloading the special jurisdiction policy files mentioned above.)
-#
 #		***** IMPORTANT: Do NOT forget to replace these with your own values! *****
 # To calculate these values, you can run:
 #		java -classpath esapi.jar org.owasp.esapi.reference.crypto.JavaEncryptor
@@ -182,12 +163,6 @@ Encryptor.PreferredJCEProvider=
 
 # AES is the most widely used and strongest encryption algorithm. This
 # should agree with your Encryptor.CipherTransformation property.
-# By default, ESAPI Java 1.4 uses "PBEWithMD5AndDES" and which is
-# very weak. It is essentially a password-based encryption key, hashed
-# with MD5 around 1K times and then encrypted with the weak DES algorithm
-# (56-bits) using ECB mode and an unspecified padding (it is
-# JCE provider specific, but most likely "NoPadding"). However, 2.0 uses
-# "AES/CBC/PKCSPadding". If you want to change these, change them here.
 # Warning: This property does not control the default reference implementation for
 #		   ESAPI 2.0 using JavaEncryptor. Also, this property will be dropped
 #		   in the future.
@@ -219,45 +194,52 @@ Encryptor.cipher_modes.combined_modes=GCM,CCM,IAPM,EAX,OCB,CWC
 # Additional cipher modes allowed for ESAPI 2.0 encryption. These
 # cipher modes are in _addition_ to those specified by the property
 # 'Encryptor.cipher_modes.combined_modes'.
-# Note: We will add support for streaming modes like CFB & OFB once
-# we add support for 'specified' to the property 'Encryptor.ChooseIVMethod'
-# (probably in ESAPI 2.1).
 # DISCUSS: Better name?
 Encryptor.cipher_modes.additional_allowed=CBC
 
-# 128-bit is almost always sufficient and appears to be more resistant to
-# related key attacks than is 256-bit AES. Use '_' to use default key size
-# for cipher algorithms (where it makes sense because the algorithm supports
-# a variable key size). Key length must agree to what's provided as the
-# cipher transformation, otherwise this will be ignored after logging a
-# warning.
+# Default key size to use for cipher specified by Encryptor.EncryptionAlgorithm.
+# Note that this MUST be a valid key size for the algorithm being used
+# (as specified by Encryptor.EncryptionAlgorithm). So for example, if AES is used,
+# it must be 128, 192, or 256. If DESede is chosen, then it must be either 112 or 168.
 #
-# NOTE: This is what applies BOTH ESAPI 1.4 and 2.0. See warning above about mixing!
+# Note that 128-bits is almost always sufficient and for AES it appears to be more
+# somewhat more resistant to related key attacks than is 256-bit AES.)
+#
+# Defaults to 128-bits if left blank.
+#
+# NOTE: If you use a key size > 128-bits, then you MUST have the JCE Unlimited
+#       Strength Jurisdiction Policy files installed!!!
+#
 Encryptor.EncryptionKeyLength=128
 
-# Because 2.0 uses CBC mode by default, it requires an initialization vector (IV).
-# (All cipher modes except ECB require an IV.) There are two choices: we can either
-# use a fixed IV known to both parties or allow ESAPI to choose a random IV. While
-# the IV does not need to be hidden from adversaries, it is important that the
-# adversary not be allowed to choose it. Also, random IVs are generally much more
-# secure than fixed IVs. (In fact, it is essential that feed-back cipher modes
-# such as CFB and OFB use a different IV for each encryption with a given key so
-# in such cases, random IVs are much preferred. By default, ESAPI 2.0 uses random
-# IVs. If you wish to use 'fixed' IVs, set 'Encryptor.ChooseIVMethod=fixed' and
-# uncomment the Encryptor.fixedIV.
+# This is the _minimum_ key size (in bits) that we allow with ANY symmetric
+# cipher for doing encryption. (There is no minimum for decryption.)
 #
-# Valid values:		random|fixed|specified		'specified' not yet implemented; planned for 2.1
+# Generally, if you only use one algorithm, this should be set the same as
+# the Encryptor.EncryptionKeyLength property.
+Encryptor.MinEncryptionKeyLength=128
+
+# Because 2.x uses CBC mode by default, it requires an initialization vector (IV).
+# (All cipher modes except ECB require an IV.) Previously there were two choices: we can either
+# use a fixed IV known to both parties or allow ESAPI to choose a random IV. The
+# former was deprecated in ESAPI 2.2 and removed in ESAPI 2.3. It was not secure
+# because the Encryptor (as are all the other major ESAPI components) is a
+# singleton and thus the same IV would get reused each time. It was not a
+# well-thought out plan. (To do it correctly means we need to add a setIV() method
+# and get rid of the Encryptor singleton, thus it will not happen until 3.0.)
+# However, while the IV does not need to be hidden from adversaries, it is important that the
+# adversary not be allowed to choose it. Thus for now, ESAPI just chooses a random IV.
+# Originally there was plans to allow a developer to provide a class and method
+# name to define a custom static method to generate an IV, but that is just
+# trouble waiting to happen. Thus in effect, the ONLY acceptable property value
+# for this property is "random". In the not too distant future (possibly the
+# next release), I will be removing it, but for now I am leaving this and
+# checking for it so a ConfigurationException can be thrown if anyone using
+# ESAPI ignored the deprecation warning message and still has it set to "fixed".
+#
+# Valid values:		random
 Encryptor.ChooseIVMethod=random
-# If you choose to use a fixed IV, then you must place a fixed IV here that
-# is known to all others who are sharing your secret key. The format should
-# be a hex string that is the same length as the cipher block size for the
-# cipher algorithm that you are using. The following is an *example* for AES
-# from an AES test vector for AES-128/CBC as described in:
-# NIST Special Publication 800-38A (2001 Edition)
-# "Recommendation for Block Cipher Modes of Operation".
-# (Note that the block size for AES is 16 bytes == 128 bits.)
-#
-Encryptor.fixedIV=0x000102030405060708090a0b0c0d0e0f
+
 
 # Whether or not CipherText should use a message authentication code (MAC) with it.
 # This prevents an adversary from altering the IV as well as allowing a more
@@ -267,7 +249,15 @@ Encryptor.fixedIV=0x000102030405060708090a0b0c0d0e0f
 # "combined mode" cipher mode.
 #
 # If you are using ESAPI with a FIPS 140-2 cryptographic module, you *must* also
-# set this property to false.
+# set this property to false. That is because ESAPI takes the master key and
+# derives 2 keys from it--a key for the MAC and a key for encryption--and
+# because ESAPI is not itself FIPS 140-2 verified such intermediary aterations
+# to keys from FIPS approved sources would have the effect of making your FIPS
+# approved key generation and thus your FIPS approved JCE provider unapproved!
+# More details in
+#       documentation/esapi4java-core-2.0-readme-crypto-changes.html
+#       documentation/esapi4java-core-2.0-symmetric-crypto-user-guide.html
+# You have been warned.
 Encryptor.CipherText.useMAC=true
 
 # Whether or not the PlainText object may be overwritten and then marked
@@ -276,12 +266,14 @@ Encryptor.PlainText.overwrite=true
 
 # Do not use DES except in a legacy situations. 56-bit is way too small key size.
 #Encryptor.EncryptionKeyLength=56
+#Encryptor.MinEncryptionKeyLength=56
 #Encryptor.EncryptionAlgorithm=DES
 
 # TripleDES is considered strong enough for most purposes.
 #	Note:	There is also a 112-bit version of DESede. Using the 168-bit version
 #			requires downloading the special jurisdiction policy from Sun.
 #Encryptor.EncryptionKeyLength=168
+#Encryptor.MinEncryptionKeyLength=112
 #Encryptor.EncryptionAlgorithm=DESede
 
 Encryptor.HashAlgorithm=SHA-512
@@ -319,10 +311,32 @@ HttpUtilities.ForceHttpOnlySession=false
 HttpUtilities.ForceSecureSession=false
 HttpUtilities.ForceHttpOnlyCookies=true
 HttpUtilities.ForceSecureCookies=true
-# Maximum size of HTTP headers
-HttpUtilities.MaxHeaderSize=4096
+# Maximum size of HTTP header key--the validator regex may have additional values.
+HttpUtilities.MaxHeaderNameSize=256
+# Maximum size of HTTP header value--the validator regex may have additional values.
+HttpUtilities.MaxHeaderValueSize=4096
+# Maximum size of JSESSIONID for the application--the validator regex may have additional values.
+HttpUtilities.HTTPJSESSIONIDLENGTH=50
+# Maximum length of a URL (see https://stackoverflow.com/questions/417142/what-is-the-maximum-length-of-a-url-in-different-browsers)
+HttpUtilities.URILENGTH=2000
+# Maximum length of a redirect
+HttpUtilities.maxRedirectLength=512
+# Maximum length for an http scheme
+HttpUtilities.HTTPSCHEMELENGTH=10
+# Maximum length for an http host
+HttpUtilities.HTTPHOSTLENGTH=100
+# Maximum length for an http path
+HttpUtilities.HTTPPATHLENGTH=150
+#Maximum length for a context path
+HttpUtilities.contextPathLength=150
+#Maximum length for an httpServletPath
+HttpUtilities.HTTPSERVLETPATHLENGTH=100
+#Maximum length for an http query parameter name
+HttpUtilities.httpQueryParamNameLength=100
+#Maximum length for an http query parameter -- old default was 2000, but that's the max length for a URL...
+HttpUtilities.httpQueryParamValueLength=500
 # File upload configuration
-HttpUtilities.ApprovedUploadExtensions=.zip,.pdf,.doc,.docx,.ppt,.pptx,.tar,.gz,.tgz,.rar,.war,.jar,.ear,.xls,.rtf,.properties,.java,.class,.txt,.xml,.jsp,.jsf,.exe,.dll
+HttpUtilities.ApprovedUploadExtensions=.zip,.pdf,.doc,.docx,.ppt,.pptx,.xls,.xlsx,.rtf,.txt,.xml
 HttpUtilities.MaxUploadFileBytes=500000000
 # Using UTF-8 throughout your stack is highly recommended. That includes your database driver,
 # container, and any other technologies you may be using. Failure to do this may expose you
@@ -331,14 +345,23 @@ HttpUtilities.ResponseContentType=text/html; charset=UTF-8
 # This is the name of the cookie used to represent the HTTP session
 # Typically this will be the default "JSESSIONID"
 HttpUtilities.HttpSessionIdName=JSESSIONID
-
-
+#Sets whether or not we will overwrite http status codes to 200.
+HttpUtilities.OverwriteStatusCodes=true
+#Sets the application's base character encoding.  This is forked from the Java Encryptor property.
+HttpUtilities.CharacterEncoding=UTF-8
 
 #===========================================================================
 # ESAPI Executor
-# CHECKME - Not sure what this is used for, but surely it should be made OS independent.
-Executor.WorkingDirectory=C:\\Windows\\Temp
-Executor.ApprovedExecutables=C:\\Windows\\System32\\cmd.exe,C:\\Windows\\System32\\runas.exe
+# CHECKME - This should be made OS independent. Don't use unsafe defaults.
+# # Examples only -- do NOT blindly copy!
+#   For Windows:
+#     Executor.WorkingDirectory=C:\\Windows\\Temp
+#     Executor.ApprovedExecutables=C:\\Windows\\System32\\cmd.exe,C:\\Windows\\System32\\runas.exe
+#   For *nux, MacOS:
+#     Executor.WorkingDirectory=/tmp
+#     Executor.ApprovedExecutables=/bin/bash
+Executor.WorkingDirectory=
+Executor.ApprovedExecutables=
 
 
 #===========================================================================
@@ -351,12 +374,10 @@ Logger.LogEncodingRequired=false
 Logger.LogApplicationName=true
 # Determines whether ESAPI should log the server IP and port. This might be clutter in some single-server environments.
 Logger.LogServerIP=true
-# LogFileName, the name of the logging file. Provide a full directory path (e.g., C:\\ESAPI\\ESAPI_logging_file) if you
-# want to place it in a specific directory.
-Logger.LogFileName=ESAPI_logging_file
-# MaxLogFileSize, the max size (in bytes) of a single log file before it cuts over to a new one (default is 10,000,000)
-Logger.MaxLogFileSize=10000000
-
+# Determines whether ESAPI should log the user info.
+Logger.UserInfo=true
+# Determines whether ESAPI should log the session id and client IP.
+Logger.ClientInfo=true
 
 #===========================================================================
 # ESAPI Intrusion Detection
@@ -414,6 +435,11 @@ IntrusionDetector.org.owasp.esapi.errors.AuthenticationHostException.actions=log
 # This allows enterprises to specify both organizational standards as well as application specific
 # validation rules.
 #
+# Use '\p{L}' (without the quotes) within the character class to match
+# any Unicode LETTER. You can also use a range, like:  \u00C0-\u017F
+# You can also use any of the regex flags as documented at
+# https://docs.oracle.com/javase/tutorial/essential/regex/pattern.html, e.g. (?u)
+#
 Validator.ConfigurationFile=validation.properties
 
 # Validators used by ESAPI
@@ -429,19 +455,25 @@ Validator.Redirect=^\\/test.*$
 # Values with Base64 encoded data (e.g. encrypted state) will need at least [a-zA-Z0-9\/+=]
 Validator.HTTPScheme=^(http|https)$
 Validator.HTTPServerName=^[a-zA-Z0-9_.\\-]*$
-Validator.HTTPParameterName=^[a-zA-Z0-9_]{1,32}$
-Validator.HTTPParameterValue=^[a-zA-Z0-9.\\-\\/+=@_ ]*$
 Validator.HTTPCookieName=^[a-zA-Z0-9\\-_]{1,32}$
-Validator.HTTPCookieValue=^[a-zA-Z0-9\\-\\/+=_ ]*$
-Validator.HTTPHeaderName=^[a-zA-Z0-9\\-_]{1,32}$
+Validator.HTTPCookieValue=^[a-zA-Z0-9\\-\\/+=_ ]{0,1024}$
+# Note that headerName and Value length is also configured in the HTTPUtilities section
+Validator.HTTPHeaderName=^[a-zA-Z0-9\\-_]{1,256}$
 Validator.HTTPHeaderValue=^[a-zA-Z0-9()\\-=\\*\\.\\?;,+\\/:&_ ]*$
-Validator.HTTPContextPath=^\\/?[a-zA-Z0-9.\\-\\/_]*$
 Validator.HTTPServletPath=^[a-zA-Z0-9.\\-\\/_]*$
 Validator.HTTPPath=^[a-zA-Z0-9.\\-_]*$
-Validator.HTTPQueryString=^[a-zA-Z0-9()\\-=\\*\\.\\?;,+\\/:&_ %]*$
-Validator.HTTPURI=^[a-zA-Z0-9()\\-=\\*\\.\\?;,+\\/:&_ ]*$
 Validator.HTTPURL=^.*$
-Validator.HTTPJSESSIONID=^[A-Z0-9]{10,30}$
+Validator.HTTPJSESSIONID=^[A-Z0-9]{10,32}$
+
+
+# Contributed by Fraenku@gmx.ch
+# Github Issue 126 https://github.com/ESAPI/esapi-java-legacy/issues/126
+Validator.HTTPParameterName=^[a-zA-Z0-9_\\-]{1,32}$
+Validator.HTTPParameterValue=^[-\\p{L}\\p{N}./+=_ !$*?@]{0,1000}$
+Validator.HTTPContextPath=^/[a-zA-Z0-9.\\-_]*$
+Validator.HTTPQueryString=^([a-zA-Z0-9_\\-]{1,32}=[\\p{L}\\p{N}.\\-/+=_ !$*?@%]*&?)*$
+Validator.HTTPURI=^/([a-zA-Z0-9.\\-_]*/?)*$
+
 
 # Validation of file related input
 Validator.FileName=^[a-zA-Z0-9!@#$%^&{}\\[\\]()_+\\-=,.~'` ]{1,255}$
@@ -450,3 +482,45 @@ Validator.DirectoryName=^[a-zA-Z0-9:/\\\\!@#$%^&{}\\[\\]()_+\\-=,.~'` ]{1,255}$
 # Validation of dates. Controls whether or not 'lenient' dates are accepted.
 # See DataFormat.setLenient(boolean flag) for further details.
 Validator.AcceptLenientDates=false
+
+#                       ~~~~~ Important Note ~~~~~
+# This is a workaround to make sure that a commit to address GitHub issue #509
+# doesn't accidentally break someone's production code. So essentially what we
+# are doing is to reverting back to the previous possibly buggy (by
+# documentation intent at least), but, by now, expected legacy behavior.
+# Prior to the code changes for issue #509, if invalid / malicious HTML input was
+# observed, AntiSamy would simply attempt to sanitize (cleanse) it and it would
+# only be logged. However, the code change made ESAPI comply with its
+# documentation, which stated that a ValidationException should be thrown in
+# such cases. Unfortunately, changing this behavior--especially when no one is
+# 100% certain that the documentation was correct--could break existing code
+# using ESAPI so after a lot of debate, issue #521 was created to restore the
+# previous behavior, but still allow the documented behavior. (We did this
+# because it wasn't really causing an security issues since AntiSamy would clean
+# it up anyway and we value backward compatibility as long as it doesn't clearly
+# present security vulnerabilities.)
+# More defaults about this are written up under GitHub issue #521 and
+# the pull request it references. Future major releases of ESAPI (e.g., ESAPI 3.x)
+# will not support this previous behavior, but it will remain for ESAPI 2.x.
+# Set this to 'throw' if you want the originally intended behavior of throwing
+# that was fixed via issue #509. Set to 'clean' if you want want the HTML input
+# sanitized instead.
+#
+# Possible values:
+#   clean -- Use the legacy behavior where unsafe HTML input is logged and the
+#            sanitized (i.e., clean) input as determined by AntiSamy and your
+#            AntiSamy rules is returned. This is the default behavior if this
+#            new property is not found.
+#   throw -- The new, presumably correct and originally intended behavior where
+#            a ValidationException is thrown when unsafe HTML input is
+#            encountered.
+#
+#Validator.HtmlValidationAction=clean
+Validator.HtmlValidationAction=throw
+
+# With the fix for #310 to enable loading antisamy-esapi.xml from the classpath
+# also an enhancement was made to be able to use a different filename for the configuration.
+# You don't have to configure the filename here, but in that case the code will keep looking for antisamy-esapi.xml.
+# This is the default behaviour of ESAPI.
+#
+#Validator.HtmlValidationConfigurationFile=antisamy-esapi.xml

--- a/web/src/main/webapp/WEB-INF/classes/ESAPI.properties
+++ b/web/src/main/webapp/WEB-INF/classes/ESAPI.properties
@@ -1,6 +1,6 @@
 #
 # OWASP Enterprise Security API (ESAPI) Properties file -- PRODUCTION Version
-# 
+#
 # This file is part of the Open Web Application Security Project (OWASP)
 # Enterprise Security API (ESAPI) project. For details, please see
 # http://www.owasp.org/index.php/ESAPI.
@@ -75,8 +75,8 @@ ESAPI.Executor=org.owasp.esapi.reference.DefaultExecutor
 ESAPI.HTTPUtilities=org.owasp.esapi.reference.DefaultHTTPUtilities
 ESAPI.IntrusionDetector=org.owasp.esapi.reference.DefaultIntrusionDetector
 # Log4JFactory Requires log4j.xml or log4j.properties in classpath - http://www.laliluna.de/log4j-tutorial.html
-ESAPI.Logger=org.owasp.esapi.reference.Log4JLogFactory
-#ESAPI.Logger=org.owasp.esapi.reference.JavaLogFactory
+ESAPI.Logger=org.owasp.esapi.logging.log4j.Log4JLogFactory
+#ESAPI.Logger=org.owasp.esapi.logging.java.JavaLogFactory
 ESAPI.Randomizer=org.owasp.esapi.reference.DefaultRandomizer
 ESAPI.Validator=org.owasp.esapi.reference.DefaultValidator
 
@@ -102,12 +102,12 @@ Authenticator.AbsoluteTimeoutDuration=120
 # following code to canonicalize data.
 #
 #      ESAPI.Encoder().canonicalize( "%22hello world&#x22;" );
-#  
+#
 # Multiple encoding is when a single encoding format is applied multiple times. Allowing
 # multiple encoding is strongly discouraged.
 Encoder.AllowMultipleEncoding=false
 
-# Mixed encoding is when multiple different encoding formats are applied, or when 
+# Mixed encoding is when multiple different encoding formats are applied, or when
 # multiple formats are nested. Allowing multiple encoding is strongly discouraged.
 Encoder.AllowMixedEncoding=false
 
@@ -306,7 +306,7 @@ Encryptor.KDF.PRF=HmacSHA256
 #===========================================================================
 # ESAPI HttpUtilties
 #
-# The HttpUtilities provide basic protections to HTTP requests and responses. Primarily these methods 
+# The HttpUtilities provide basic protections to HTTP requests and responses. Primarily these methods
 # protect against malicious data from attackers, such as unprintable characters, escaped characters,
 # and other simple attacks. The HttpUtilities also provides utility methods for dealing with cookies,
 # headers, and CSRF tokens.
@@ -329,7 +329,7 @@ HttpUtilities.MaxUploadFileBytes=500000000
 # to Unicode transcoding injection attacks. Use of UTF-8 does not hinder internationalization.
 HttpUtilities.ResponseContentType=text/html; charset=UTF-8
 # This is the name of the cookie used to represent the HTTP session
-# Typically this will be the default "JSESSIONID" 
+# Typically this will be the default "JSESSIONID"
 HttpUtilities.HttpSessionIdName=JSESSIONID
 
 
@@ -421,7 +421,7 @@ Validator.AccountName=^[a-zA-Z0-9]{3,20}$
 Validator.SystemCommand=^[a-zA-Z\\-\\/]{1,64}$
 Validator.RoleName=^[a-z]{1,20}$
 
-#the word TEST below should be changed to your application 
+#the word TEST below should be changed to your application
 #name - only relative URL's are supported
 Validator.Redirect=^\\/test.*$
 


### PR DESCRIPTION
ESAPI Logger configuration has changed in 2.2.1.0 (and later).

This fixes this error:
```
ESAPI: Attempting to load validation.properties via the classpath.
ESAPI: validation.properties could not be loaded by any means. fail..
 Caught java.lang.IllegalArgumentException;
  exception message was: java.lang.IllegalArgumentException: Failed to load ESAPI.properties as a classloader resource.
Error at xsl:value-of on line 52 of error.xsl:
  Exception in extension function org.owasp.esapi.errors.ConfigurationException:
  java.lang.ClassNotFoundException: org.owasp.esapi.reference.Log4JLogFactory LogFactory
  class (org.owasp.esapi.reference.Log4JLogFactory) must be in class path.
2022-05-17 17:36:18,578 ERROR [jeeves] - Exception in extension function
  org.owasp.esapi.errors.ConfigurationException: java.lang.ClassNotFoundException:
   org.owasp.esapi.reference.Log4JLogFactory LogFactory class (org.owasp.esapi.reference.Log4JLogFactory) must be in class path.
```

From the release notes:

> However, if you try to juse the new ESAPI 2.2.1.0 or later logging you will notice that you need to change ESAPI.Logger and also possibly provide some other properties as well to get the logging behavior that you desire.
> 
> To use ESAPI logging in ESAPI 2.2.1.0 (and later), you will need to set the ESAPI.Logger property to
> 
>     org.owasp.esapi.logging.java.JavaLogFactory     - To use the new default, java.util.logging (JUL)
>     org.owasp.esapi.logging.log4j.Log4JLogFactory   - To use the end-of-life Log4J 1.x logger
>     org.owasp.esapi.logging.slf4j.Slf4JLogFactory   - To use the new (to release 2.2.0.0) SLF4J logger
> 
> In addition, if you wish to use JUL for logging, you *MUST* supply an "esapi-java-logging.properties" file in your classpath. This file is included in the 'esapi-2.2.2.0-configuration.jar' file provided under the 'Assets' section of the GitHub Release at
    https://github.com/ESAPI/esapi-java-legacy/releases/esapi-2.2.2.0
