### PR TITLE
Indexing / Keyword expansion.

### DIFF
--- a/core/src/main/java/org/fao/geonet/util/XslUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/XslUtil.java
@@ -1397,6 +1397,32 @@ public final class XslUtil {
         return res;
     }
 
+
+    public static List<String> getNarrowerKeywords(String keyword,
+                                                   String thesaurusId,
+                                                   String langCode,
+                                                   int depth) {
+        List<String> res = new ArrayList<String>();
+        if (StringUtils.isEmpty(thesaurusId)) {
+            return res;
+        }
+
+        try {
+            ApplicationContext applicationContext = ApplicationContextHolder.get();
+            ThesaurusManager thesaurusManager = applicationContext.getBean(ThesaurusManager.class);
+
+            thesaurusId = thesaurusId.replaceAll("geonetwork.thesaurus.", "");
+            Thesaurus thesaurus = thesaurusManager.getThesaurusByName(thesaurusId);
+
+            if (thesaurus != null) {
+                res = thesaurus.getNarrowerKeywords(keyword, langCode, depth);
+            }
+            return res;
+        } catch (Exception ex) {
+        }
+        return res;
+    }
+
     public static String getKeywordValueByUri(String uri, String thesaurusId, String langCode) {
         if (StringUtils.isEmpty(thesaurusId)) {
             return "";

--- a/core/src/test/java/org/fao/geonet/kernel/ThesaurusTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/ThesaurusTest.java
@@ -498,4 +498,16 @@ public class ThesaurusTest extends AbstractThesaurusBasedTest {
         assertEquals(1, hierarchy.size());
         assertEquals("140_testValue_eng", hierarchy.get(0));
     }
+
+    @Test
+    public void getNarrowerKeywords() {
+        List<String> list = thesaurus.getNarrowerKeywords("20_testValue_eng", "eng", 1);
+        assertEquals(1, list.size());
+        assertEquals("15_testValue_eng", list.get(0));
+
+        list = thesaurus.getNarrowerKeywords("20_testValue_eng", "eng", 2);
+        assertEquals(2, list.size());
+        assertTrue(list.contains("15_testValue_eng"));
+        assertTrue(list.contains("150_testValue_eng"));
+    }
 }

--- a/core/src/test/resources/org/fao/geonet/kernel/testThesaurus.rdf
+++ b/core/src/test/resources/org/fao/geonet/kernel/testThesaurus.rdf
@@ -456,6 +456,14 @@
 	<ns2:broader rdf:resource="http://abstract.thesaurus.test#20"/>
 </rdf:Description>
 
+<rdf:Description rdf:about="http://abstract.thesaurus.test#15">
+	<ns2:narrower rdf:resource="http://abstract.thesaurus.test#150"/>
+</rdf:Description>
+
+<rdf:Description rdf:about="http://abstract.thesaurus.test#150">
+	<ns2:broader rdf:resource="http://abstract.thesaurus.test#15"/>
+</rdf:Description>
+
 <rdf:Description rdf:about="http://abstract.thesaurus.test#21">
 	<rdf:type rdf:resource="http://www.w3.org/2004/02/skos/core#Concept"/>
 	<ns2:prefLabel xml:lang="en">21_testValue_eng</ns2:prefLabel>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
@@ -579,6 +579,20 @@
                       </errors>
                     </xsl:if>
 
+                    <xsl:variable name="expansionConfig"
+                                  select="$keywordExpansion[ends-with($thesaurusId, @id)]"/>
+                    <xsl:if test="$expansionConfig">
+                      <narrowers>
+                        <xsl:for-each select="util:getNarrowerKeywords(
+                                                   (*/text())[1],
+                                                   $thesaurusId,
+                                                   $allLanguages/lang[@id = 'default']/@value,
+                                                   $expansionConfig/@depth)">
+                          <value><xsl:value-of select="."/></value>
+                        </xsl:for-each>
+                      </narrowers>
+                    </xsl:if>
+
                     <tree>
                       <defaults>
                         <xsl:call-template name="get-keyword-tree-values">

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
@@ -547,6 +547,21 @@
                       </errors>
                     </xsl:if>
 
+
+                    <xsl:variable name="expansionConfig"
+                                  select="$keywordExpansion[ends-with($thesaurusId, @id)]"/>
+                    <xsl:if test="$expansionConfig">
+                      <narrowers>
+                        <xsl:for-each select="util:getNarrowerKeywords(
+                                                   (*/text())[1],
+                                                   $thesaurusId,
+                                                   $allLanguages/lang[@id = 'default']/@value,
+                                                   $expansionConfig/@depth)">
+                          <value><xsl:value-of select="."/></value>
+                        </xsl:for-each>
+                      </narrowers>
+                    </xsl:if>
+
                     <tree>
                       <defaults>
                         <xsl:call-template name="get-keyword-tree-values">

--- a/web/src/main/webapp/xslt/common/index-utils.xsl
+++ b/web/src/main/webapp/xslt/common/index-utils.xsl
@@ -385,7 +385,6 @@
       </xsl:element>
 
 
-      <xsl:message>$$<xsl:copy-of select="count(keywords//narrowers/*) > 0"/></xsl:message>
       <xsl:if test="count(keywords//narrowers/*) > 0">
         <xsl:element name="{info/@field}_expanded">
           <xsl:attribute name="type" select="'object'"/>

--- a/web/src/main/webapp/xslt/common/index-utils.xsl
+++ b/web/src/main/webapp/xslt/common/index-utils.xsl
@@ -385,31 +385,17 @@
       </xsl:element>
 
 
-      <xsl:variable name="thesaurusId"
-                    select="info/@id"/>
-      <xsl:variable name="expansionConfig"
-                    select="$keywordExpansion[ends-with($thesaurusId, @id)]"/>
-      <xsl:if test="$expansionConfig">
-        <xsl:variable name="narrowerKeywords" as="xs:string*">
-          <xsl:for-each select="keywords/keyword">
-            <xsl:copy-of select="util:getNarrowerKeywords(
-                                                 tree/defaults/value,
-                                                 $thesaurusId,
-                                                 'eng',
-                                                 $expansionConfig/@depth)"/>
-          </xsl:for-each>
-        </xsl:variable>
-        <xsl:if test="count($narrowerKeywords) > 0">
-          <xsl:element name="{info/@field}_expanded">
-            <xsl:attribute name="type" select="'object'"/>
-            [<xsl:for-each select="$narrowerKeywords">
-            {
-              "default": "<xsl:value-of select="gn-fn-index:json-escape(.)"/>"
-            }
-            <xsl:if test="position() != last()">,</xsl:if>
-          </xsl:for-each>]
-          </xsl:element>
-        </xsl:if>
+      <xsl:message>$$<xsl:copy-of select="count(keywords//narrowers/*) > 0"/></xsl:message>
+      <xsl:if test="count(keywords//narrowers/*) > 0">
+        <xsl:element name="{info/@field}_expanded">
+          <xsl:attribute name="type" select="'object'"/>
+          [<xsl:for-each select="keywords//narrowers/*">
+          {
+            "default": "<xsl:value-of select="gn-fn-index:json-escape(.)"/>"
+          }
+          <xsl:if test="position() != last()">,</xsl:if>
+        </xsl:for-each>]
+        </xsl:element>
       </xsl:if>
     </xsl:for-each>
 


### PR DESCRIPTION
> So example, if a record contains EU25, a search for Greece should return that record.

Indexing time keywords expansion is done when a thesaurus contains relations.
For each keywords, narrower terms are identified and added to an index field named `th_{thesaurusid}_expanded`. This field is also copied to full text search fields.

So for example, a record is tagged with `Asia` from the regions thesaurus, then `th_regions_expanded` contains all countries in Asia. A full text search for `Azerbaijan` match the record. The keyword aggregation on `tag` or  on `th_regions` only display keywords encoded in the record (expanded terms are not displayed). 

![image](https://user-images.githubusercontent.com/1701393/169263319-c752e934-9404-4ce1-9607-a4a50a12af31.png)

Same works with SeaVox relations:

![image](https://user-images.githubusercontent.com/1701393/169267260-9572aa9d-e512-422a-b54c-fc307e2a2b97.png)


TODO & questions:

* Multilingual support ?
* GeoNames support ?
