### PR TITLE
Fix the metadata detail page code to display the non-draft version when the results include the approved and the working copy (draft) versions, and it is requested the non-draft version

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/mdview/mdviewService.js
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/mdviewService.js
@@ -198,6 +198,11 @@
                           //This will only happen if the draft exists
                           //and the user can see it
                           i = index;
+                        } else if (!getDraft
+                          &&  md.draft != 'y') {
+                          // This use the non-draft version when the results include the
+                          // approved and the working copy (draft) versions
+                          i = index;
                         }
                       });
 


### PR DESCRIPTION
When the metadata workflow is enabled, the original code to display the metadata page, retrieves the approved and the working copy versions, but was assuming that the first result is always the approved version. This assumption is not correct.

For `main` and `4.0.x` branches, this fix is part of https://github.com/geonetwork/core-geonetwork/pull/6321