### PR TITLE
Search results / Draft / Improve edit action layout.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid.html
@@ -72,13 +72,6 @@
         <!--<div data-gn-related-dropdown="md"
              class="pull-right"></div>
         </div>-->
-
-        <div data-ng-if="(md.draft == 'e') && (md.edit == true)"
-             title="{{'workingCopy' | translate}}"
-             class="gn-workingcopy-status pull-right">
-          <i class="fa fa-pencil"></i>
-          <span>{{'workingCopy' | translate}}</span>
-        </div>
       </div>
     </div>
     <!-- /.gn-card-footer -->

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/list.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/list.html
@@ -119,12 +119,6 @@
         </div>
 
         <gn-links-btn class="pull-right"></gn-links-btn>
-        <div data-ng-if="(md.draft == 'e') && (md.edit == true)"
-             title="{{'workingCopy' | translate}}"
-             class="gn-workingcopy-status">
-          <i class="fa fa-pencil"></i>
-          <span>{{'workingCopy' | translate}}</span>
-        </div>
       </div>
     </div>
     <!-- /.gn-card-footer -->

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/table.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/table.html
@@ -66,12 +66,6 @@
         </div>
 
         <gn-links-btn class="pull-left"></gn-links-btn>
-        <div data-ng-if="(md.draft == 'e') && (md.edit == true)"
-             title="{{'workingCopy' | translate}}"
-             class="gn-workingcopy-status pull-left">
-          <i class="fa fa-pencil"></i>
-          <span>{{'workingCopy' | translate}}</span>
-        </div>
       </div>
     </td>
   </tr>

--- a/web-ui/src/main/resources/catalog/views/default/directives/partials/linksbtn.html
+++ b/web-ui/src/main/resources/catalog/views/default/directives/partials/linksbtn.html
@@ -6,6 +6,10 @@
      title="{{'edit' | translate}}"
      aria-label="{{'edit' | translate}}">
     <i class="fa fa-pencil"></i>
+
+    <span data-ng-if="(md.draft == 'e')" data-translate="">
+      workingCopy
+    </span>
   </a>
 
   <div class="btn-group"


### PR DESCRIPTION
When the record is draft, simply add the label to the edit button. The layout is overlapping quite often in list and grid mode

Before

![image](https://user-images.githubusercontent.com/1701393/169282000-fcac2652-394f-4340-9aa3-1c5de5f242d2.png)

After

![image](https://user-images.githubusercontent.com/1701393/169282013-b539420b-cfdf-4cd7-93f2-9625ba73affa.png)

