### PR TITLE
Record view / Associated resources / Group by type.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/RelatedDirective.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/RelatedDirective.js
@@ -415,7 +415,7 @@
                       });
                       scope.relations.siblings = [];
                     } else {
-                      siblingsCount = scope.relations.siblings.length;
+                      siblingsCount = scope.relations[idx].length;
                     }
                   }
 

--- a/web-ui/src/main/resources/catalog/components/metadataactions/RelatedDirective.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/RelatedDirective.js
@@ -323,7 +323,8 @@
               hasResults: '=?',
               layout: '@',
               // Only apply to card layout
-              size: '@'
+              size: '@',
+              groupSiblingsByType: '=?'
             },
             require: '?^gnRelatedObserver',
             link: function(scope, element, attrs, controller) {
@@ -382,6 +383,7 @@
                   // are preserved
                   // * Exclude children and parent from associated and siblings,
                   // and also filter siblings from associated to avoid duplicates
+                  var siblingsCount = 0;
                   if (idx === 'associated' || idx === 'siblings') {
                     var indexToRemove = [];
                     for (var i = 0; i < scope.relations[idx].length; i++) {
@@ -397,9 +399,28 @@
                     indexToRemove.reverse().forEach(function(value) {
                       scope.relations[idx].splice(value, 1);
                     });
+
+                    if (scope.relations.siblings
+                      && scope.relations.siblings.map
+                      && scope.groupSiblingsByType) {
+                      scope.relations.siblings.map(function(r) {
+                        return r.properties && r.properties.initiativeType || '';
+                      }).filter(function(value, index, self) {
+                        return self.indexOf(value) === index;
+                      }).forEach(function(type) {
+                        scope.relations['siblings' + type] = scope.relations.siblings.filter(function (r) {
+                          return r.properties && r.properties.initiativeType === type;
+                        });
+                        siblingsCount += scope.relations['siblings' + type].length;
+                      });
+                      scope.relations.siblings = [];
+                    } else {
+                      siblingsCount = scope.relations.siblings.length;
+                    }
                   }
 
-                  relationCount += scope.relations[idx].length;
+                  relationCount += idx === 'siblings'
+                    ? siblingsCount : scope.relations[idx].length;
                 });
                 scope.relationFound = relationCount > 0;
               };
@@ -435,8 +456,8 @@
               };
 
               scope.getOrderBy = function(link) {
-                return link.record && link.record.resourceTitle
-                        ? link.record.resourceTitle
+                return link && link.resourceTitle
+                        ? link.resourceTitle
                         : link.locTitle
               };
 

--- a/web-ui/src/main/resources/catalog/components/metadataactions/RelatedResourcesService.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/RelatedResourcesService.js
@@ -502,7 +502,7 @@
               (type === 'children')) {
               return 'MDCHILDREN';
             } else if (type &&
-               (type === 'siblings')) {
+               (type.indexOf('siblings') === 0)) {
               return 'MDSIBLING';
             } else if (type &&
                (type === 'services')) {

--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/related.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/related.html
@@ -135,47 +135,56 @@
     </div>
   </div>
 
-  <ul class="gn-related-list"
-      data-ng-repeat="(type, items) in relations track by $index"
-      data-ng-if="layout === 'title'
+  <div data-ng-repeat="(type, items) in relations track by $index"
+       data-ng-if="layout === 'title'
                   && type && type !== 'thumbnails' && type !== 'onlines'"
-      data-ng-init="mainType = config.getType(md, type);
+       data-ng-init="mainType = config.getType(md, type);
                     badge = config.getBadgeLabel(mainType, md);
-                    icon = config.getClassIcon(mainType);" >
-    <li data-ng-repeat="md in items | orderBy:getOrderBy">
-      <a data-ng-hide="md.remoteUrl"
-         href=""
-         title="{{md.resourceTitle}}"
-         gn-metadata-open="md"
-         gn-formatter="formatter.defaultUrl">
-        <i class="fa {{icon}}"/>
-        {{md.resourceTitle}}
-      </a>
-      <a data-ng-show="md.remoteUrl"
-         data-ng-href="{{md.remoteUrl}}"
-         rel="noopener noreferrer"
-         target="_blank"
-         title="{{md.resourceTitle}}">
-        <i class="fa {{icon}}"/>
-        {{md.resourceTitle}}
-        <i data-ng-if="md.origin === 'remote'"
-           class="fa fa-external-link"
-           title="{{'remoteRecord' | translate}}"></i>
-      </a>
-    </li>
-  </ul>
+                    icon = config.getClassIcon(mainType);">
+    <h3 data-ng-if="groupSiblingsByType && items.length > 0" >
+      {{type.replace('siblings', '') | translate}}
+    </h3>
 
-  <ul class="row list-group gn-info-list"
-      data-ng-repeat="(type, items) in relations track by $index"
-      data-ng-if="layout === 'card'
+    <ul class="gn-related-list">
+      <li data-ng-repeat="md in items | orderBy:getOrderBy">
+        <a data-ng-hide="md.remoteUrl"
+           href=""
+           title="{{md.resourceTitle}}"
+           gn-metadata-open="md"
+           gn-formatter="formatter.defaultUrl">
+          <i class="fa {{icon}}"/>
+          {{md.resourceTitle}}
+        </a>
+        <a data-ng-show="md.remoteUrl"
+           data-ng-href="{{md.remoteUrl}}"
+           rel="noopener noreferrer"
+           target="_blank"
+           title="{{md.resourceTitle}}">
+          <i class="fa {{icon}}"/>
+          {{md.resourceTitle}}
+          <i data-ng-if="md.origin === 'remote'"
+             class="fa fa-external-link"
+             title="{{'remoteRecord' | translate}}"></i>
+        </a>
+      </li>
+    </ul>
+  </div>
+
+  <div data-ng-repeat="(type, items) in relations track by $index"
+       data-ng-if="layout === 'card'
                   && type && type !== 'thumbnails' && type !== 'onlines'"
-      data-ng-init="mainType = config.getType(md, type);
+       data-ng-init="mainType = config.getType(md, type);
                     badge = config.getBadgeLabel(mainType, md);
-                    icon = config.getClassIcon(mainType);" >
-    <gn-metadata-card data-ng-repeat="md in items | orderBy:getOrderBy"
-                      data-ng-if="!size || $index < sizeConfig[type]"
-                      md="md"
-                      formatter-url="formatter.defaultUrl">
+                    icon = config.getClassIcon(mainType);">
+    <h3 data-ng-if="groupSiblingsByType && items.length > 0" >
+      {{type.replace('siblings', '') | translate}}
+    </h3>
+    <ul class="row list-group gn-info-list">
+
+      <gn-metadata-card data-ng-repeat="md in items | orderBy:getOrderBy"
+                        data-ng-if="!size || $index < sizeConfig[type]"
+                        md="md"
+                        formatter-url="formatter.defaultUrl">
       <span class="label label-default gn-card-badge"
             data-ng-class="{
             'gn-card-series': type === 'parent',
@@ -197,14 +206,16 @@
            class="fa fa-external-link"
            title="{{'remoteRecord' | translate}}"></i>
       </span>
-    </gn-metadata-card>
-    <button class="btn btn-link"
-            data-ng-if="size && items.length > sizeConfig[type]"
-            data-ng-click="showAllItems(type)">
+      </gn-metadata-card>
+      <button class="btn btn-link"
+              data-ng-if="size && items.length > sizeConfig[type]"
+              data-ng-click="showAllItems(type)">
       <span data-ng-if="items.length !== sizeConfig[type]">
         {{items.length - sizeConfig[type]}} more</span>
-      <span data-ng-if="items.length === sizeConfig[type]"
-            data-translate="">showLess</span>
-    </button>
-  </ul>
+        <span data-ng-if="items.length === sizeConfig[type]"
+              data-translate="">showLess</span>
+      </button>
+    </ul>
+  </div>
+
 </div>

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/related.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/related.html
@@ -23,6 +23,7 @@
        data-user="user"
        data-layout="card"
        data-types="siblings|associated"
+       data-group-siblings-by-type="true"
        data-title="{{'siblings' | translate}}">
   </div>
 </div>


### PR DESCRIPTION
More and more record are linking to remote resources (eg. documents, datasets, oceanographic cruises, sensors). This adds the possibility to group associated resources by types.

Before:
![image](https://user-images.githubusercontent.com/1701393/169807457-6e73ad75-f9c6-4760-be13-53c5bfaa7a45.png)

After:
![image](https://user-images.githubusercontent.com/1701393/169807483-90d04cb4-b796-498a-a24b-2e8cb720cbc7.png)

or in title mode
![image](https://user-images.githubusercontent.com/1701393/169807502-eba6ad92-f608-4095-a668-261ea67f35d6.png)


