### PR TITLE
JSON Harvesters: Fix ODS and DKAN issues

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/fromJsonDkan.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/fromJsonDkan.xsl
@@ -222,7 +222,7 @@
               <xsl:for-each select="tags">
                 <mri:keyword>
                   <gco:CharacterString>
-                    <xsl:value-of select="name" disable-output-escaping="yes"/> <!-- this can contain HTML entities -->
+                    <xsl:value-of select="java-xsl-util:html2textNormalized(name)" /> <!-- this can contain HTML entities -->
                   </gco:CharacterString>
                 </mri:keyword>
               </xsl:for-each>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/fromJsonOpenDataSoft.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/fromJsonOpenDataSoft.xsl
@@ -42,6 +42,7 @@
                 xmlns:gml="http://www.opengis.net/gml/3.2"
                 xmlns:xlink="http://www.w3.org/1999/xlink"
                 xmlns:xd="http://www.oxygenxml.com/ns/doc/xsl"
+                xmlns:java-xsl-util="java:org.fao.geonet.util.XslUtil"
                 exclude-result-prefixes="#all">
 
   <xsl:import href="protocol-mapping.xsl"></xsl:import>
@@ -80,7 +81,7 @@
         <mdb:defaultLocale>
           <lan:PT_Locale>
             <lan:language>
-              <lan:LanguageCode codeList="codeListLocation#LanguageCode" codeListValue="{metas/language}"/>
+              <lan:LanguageCode codeList="codeListLocation#LanguageCode" codeListValue="{java-xsl-util:threeCharLangCode(metas/language)}"/>
             </lan:language>
             <lan:characterEncoding>
               <lan:MD_CharacterSetCode codeList="codeListLocation#MD_CharacterSetCode"
@@ -378,7 +379,7 @@
             <mri:defaultLocale>
               <lan:PT_Locale>
                 <lan:language>
-                  <lan:LanguageCode codeList="codeListLocation#LanguageCode" codeListValue="{metas/language}"/>
+                  <lan:LanguageCode codeList="codeListLocation#LanguageCode" codeListValue="{java-xsl-util:threeCharLangCode(metas/language)}"/>
                 </lan:language>
                 <lan:characterEncoding>
                   <lan:MD_CharacterSetCode codeList="codeListLocation#MD_CharacterSetCode"


### PR DESCRIPTION
- Opendatasoft
ensure languages are iso3 code (was indexing in langfr instead of langfre)

- DKAN
Trim extra space on keywords (was disturbing the indexing).