### PR TITLE
Fix DOI publication task enabling after publishing the metadata

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/directives/partials/mdactionmenu.html
+++ b/web-ui/src/main/resources/catalog/views/default/directives/partials/mdactionmenu.html
@@ -189,7 +189,7 @@
 
       <li data-ng-repeat="t in tasks"
           data-ng-show="taskConfiguration[t.name] && taskConfiguration[t.name].isVisible && taskConfiguration[t.name].isVisible(md)"
-          data-ng-class="::{'disabled': !taskConfiguration[t.name].isApplicable(md)}">
+          data-ng-class="{'disabled': !taskConfiguration[t.name].isApplicable(md)}">
         <a href="" data-ng-click="mdService.openUpdateStatusPanel(getScope(md), 'task', t)">
           <span class="fa fa-fw"></span>&nbsp;
           <span>{{t.label | gnLocalized}}</span>


### PR DESCRIPTION
Test case:

1) Login as administrator and configure in the settings page the DOI publication.
2) Create an iso19139 metadata.
3) In the metadata detail page, open the Manage record menu --> DOI publication option is disabled (OK)
4) Select the Publish option --> DOI publication option is disabled (NO OK)

With the fix, after selecting the Publish option, the DOI publication option is enabled.