### PR TITLE
Sharing / Who can publish?

### DIFF
--- a/core/src/main/java/org/fao/geonet/constants/Edit.java
+++ b/core/src/main/java/org/fao/geonet/constants/Edit.java
@@ -89,6 +89,7 @@ public final class Edit {
 
             public static final String ADMIN = "admin";
             public static final String EDIT = "edit";
+            public static final String REVIEW = "canReview";
             public static final String NOTIFY = "notify";
             public static final String DOWNLOAD = "download";
             public static final String DYNAMIC = "dynamic";

--- a/core/src/main/java/org/fao/geonet/kernel/AccessManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/AccessManager.java
@@ -23,6 +23,7 @@
 
 package org.fao.geonet.kernel;
 
+import static org.fao.geonet.kernel.setting.Settings.SYSTEM_METADATAPRIVS_PUBLICATIONBYGROUPOWNERONLY;
 import static org.fao.geonet.repository.specification.OperationAllowedSpecs.hasMetadataId;
 import static org.fao.geonet.repository.specification.OperationAllowedSpecs.hasOperation;
 import static org.springframework.data.jpa.domain.Specification.where;
@@ -47,6 +48,7 @@ import org.fao.geonet.domain.User;
 import org.fao.geonet.domain.UserGroup;
 import org.fao.geonet.domain.User_;
 import org.fao.geonet.kernel.datamanager.IMetadataUtils;
+import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.kernel.setting.Settings;
 import org.fao.geonet.repository.GroupRepository;
 import org.fao.geonet.repository.GroupRepositoryCustom;
@@ -72,6 +74,9 @@ import jeeves.server.context.ServiceContext;
  * Handles the access to a metadata depending on the metadata/group.
  */
 public class AccessManager {
+
+    @Autowired
+    SettingManager settingManager;
 
     @Autowired
     SettingRepository settingRepository;
@@ -252,8 +257,11 @@ public class AccessManager {
     }
 
     /**
-     * Returns true if, and only if, at least one of these conditions is satisfied: <ul> <li>the
-     * user is owner (@see #isOwner)</li> <li>the user has edit rights over the metadata</li> </ul>
+     * Returns true if, and only if, at least one of these conditions is satisfied:
+     * <ul>
+     *     <li>the user is owner (@see #isOwner)</li>
+     *     <li>the user has edit rights over the metadata</li>
+     * </ul>
      *
      * @param id The metadata internal identifier
      */
@@ -262,34 +270,12 @@ public class AccessManager {
     }
 
     /**
-     * Returns true if, and only if, at least one of these conditions is satisfied: <ul> <li>the
-     * user is owner (@see #isOwner)</li> <li>the user has reviewing rights over the metadata</li> </ul>
-     *
-     * @param id The metadata internal identifier
-     */
-    public boolean canReview(final ServiceContext context, final String id) throws Exception {
-        if (!isUserAuthenticated(context.getUserSession())) {
-            return false;
-        }
-
-        //--- retrieve metadata info
-        AbstractMetadata info = context.getBean(IMetadataUtils.class).findOne(id);
-
-        if (info == null)
-            return false;
-        final MetadataSourceInfo sourceInfo = info.getSourceInfo();
-
-        return isOwner(context, sourceInfo) || hasReviewPermission(context, info);
-    }
-
-    /**
-     * Returns true if, and only if, at least one of these conditions is satisfied: <ul> <li>the
-     * user is owner (@see #isOwner)</li> <li>the user has reviewing rights over owning group of the metadata</li> </ul>
+     * Returns true if user is reviewer
      *
      * @param id The metadata internal identifier
      */
     public boolean canChangeStatus(final ServiceContext context, final String id) throws Exception {
-        return hasOnwershipReviewPermission(context, id) || hasReviewPermission(context, id);
+        return hasReviewPermission(context, id);
     }
 
     /**
@@ -357,20 +343,6 @@ public class AccessManager {
                 return true;
         }
         return false;
-    }
-
-    /**
-     * TODO javadoc.
-     */
-    private String join(Set<Integer> set, String delim) {
-        StringBuilder sb = new StringBuilder();
-        String loopDelim = "";
-        for (Integer s : set) {
-            sb.append(loopDelim);
-            sb.append(s + "");
-            loopDelim = delim;
-        }
-        return sb.toString();
     }
 
     /**
@@ -464,28 +436,37 @@ public class AccessManager {
     }
 
     /**
-     * Check if current user can review the metadata if
-     * the user is a reviewer in the metadata owners group.
-     *
-     * @param id The metadata internal identifier
+     * See {@link #hasReviewPermission(ServiceContext, AbstractMetadata)}
      */
     public boolean hasReviewPermission(final ServiceContext context, final String id) throws Exception {
         if (!isUserAuthenticated(context.getUserSession())) {
             return false;
         }
-
-        //--- retrieve metadata info
         AbstractMetadata info = context.getBean(IMetadataUtils.class).findOne(id);
-
-        if (info == null)
+        if (info == null) {
             return false;
-
+        }
         return hasReviewPermission(context, info);
+    }
+
+    private String GROUPOWNERONLY_STRATEGY =
+        "You need to be administrator, or reviewer of the metadata group.";
+    private String REVIEWERINGROUP_STRATEGY =
+        "You need to be administrator, or reviewer of the metadata group " +
+            "or reviewer with edit privilege on the metadata.";
+
+    public String getReviewerRule() {
+        return settingManager.getValueAsBool(
+            SYSTEM_METADATAPRIVS_PUBLICATIONBYGROUPOWNERONLY, true) ?
+            GROUPOWNERONLY_STRATEGY :
+            REVIEWERINGROUP_STRATEGY;
     }
 
     /**
      * Check if current user can review the metadata if
-     * the user is a reviewer in the metadata owners group.
+     * the user is a reviewer in the metadata owners group if
+     * SYSTEM_METADATAPRIVS_PUBLICATIONBYGROUPOWNERONLY is true
+     * otherwise, check also if user can edit in a group with a reviewer profile.
      *
      * @param context Service context.
      * @param metadata The metadata info.
@@ -495,6 +476,9 @@ public class AccessManager {
         if (!isUserAuthenticated(us)) {
             return false;
         }
+        if (Profile.Administrator == us.getProfile()) {
+            return true;
+        }
 
         // Check if the user is a reviewer in the metadata owners group.
         Specification<UserGroup> hasUserIdAndGroupAndProfile = where(UserGroupSpecs.hasProfile(Profile.Reviewer))
@@ -502,9 +486,17 @@ public class AccessManager {
             .and(UserGroupSpecs.hasUserId(us.getUserIdAsInt()));
 
         UserGroupRepository userGroupRepo = context.getBean(UserGroupRepository.class);
-        long count = userGroupRepo.count(hasUserIdAndGroupAndProfile);
+        boolean userIsReviewerOfOwnerGroup =
+            !userGroupRepo.findAll(hasUserIdAndGroupAndProfile).isEmpty();
 
-        return  (count > 0);
+        if (settingManager.getValueAsBool(
+                SYSTEM_METADATAPRIVS_PUBLICATIONBYGROUPOWNERONLY, true)) {
+            return userIsReviewerOfOwnerGroup;
+        } else {
+            return userIsReviewerOfOwnerGroup
+                || hasEditingPermissionWithProfile(
+                    context, String.valueOf(metadata.getId()), Profile.Reviewer);
+        }
     }
 
     /**
@@ -536,30 +528,6 @@ public class AccessManager {
 
         return (!userGroupRepository.findAll(spec).isEmpty());
 
-    }
-
-    /**
-     * Check if current user is reviewer of the owner group for this metadata
-     *
-     * @param id The metadata internal identifier
-     */
-    public boolean hasOnwershipReviewPermission(final ServiceContext context, final String id) throws Exception {
-        UserSession us = context.getUserSession();
-        if (!isUserAuthenticated(us)) {
-            return false;
-        }
-
-        UserGroupRepository userGroupRepository = context.getBean(UserGroupRepository.class);
-        IMetadataUtils metadataUtils = context.getBean(IMetadataUtils.class);
-
-        Specification spec = where(UserGroupSpecs.hasProfile(Profile.Reviewer)).and(UserGroupSpecs.hasUserId(us.getUserIdAsInt()));
-
-        List<Integer> opAlloweds = new ArrayList<Integer>();
-        opAlloweds.add(metadataUtils.findOne(id).getSourceInfo().getGroupOwner());
-
-        spec = spec.and(UserGroupSpecs.hasGroupIds(opAlloweds));
-
-        return (!userGroupRepository.findAll(spec).isEmpty());
     }
 
     public int getPrivilegeId(final String name) {

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataOperations.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataOperations.java
@@ -299,7 +299,7 @@ public class BaseMetadataOperations implements IMetadataOperations, ApplicationE
 
     /**
      * Unset operation without checking if user privileges allows the operation. This may be useful when a user is an editor and internal
-     * operations needs to update privilages for reserved group. eg. {@link org.fao.geonet.kernel.metadata.DefaultStatusActions}
+     * operations needs to update privileges for reserved group. eg. {@link org.fao.geonet.kernel.metadata.DefaultStatusActions}
      */
     @Override
     public void forceUnsetOperation(ServiceContext context, int mdId, int groupId, int operId) throws Exception {

--- a/core/src/main/java/org/fao/geonet/kernel/metadata/DefaultStatusActions.java
+++ b/core/src/main/java/org/fao/geonet/kernel/metadata/DefaultStatusActions.java
@@ -196,32 +196,6 @@ public class DefaultStatusActions implements StatusActions {
         return unchanged;
     }
 
-    /**
-     * This apply specific rules depending on status change.
-     * The default rules are:
-     * <ul>
-     * <li>DISABLED When approved, the record is automatically published.</li>
-     * <li>When draft or rejected, unpublish the record.</li>
-     * </ul>
-     *
-     * @param status
-     * @throws Exception
-     */
-    private void applyRulesForStatusChange(MetadataStatus status) throws Exception {
-        String statusId = status.getStatusValue().getId() + "";
-        if (statusId.equals(StatusValue.Status.APPROVED)) {
-            //            AccessManager accessManager = context.getBean(AccessManager.class);
-            //            if (!accessManager.hasReviewPermission(context, String.valueOf(status.getMetadataId()))) {
-            //                throw new SecurityException(String.format(
-            //                    "You can't edit record with ID %s",
-            //                    String.valueOf(status.getMetadataId())));
-            //            }
-            // setAllOperations(mid); - this is a short cut that could be enabled
-        } else if (statusId.equals(StatusValue.Status.DRAFT)) {
-            unsetAllOperations(status.getMetadataId());
-        }
-    }
-
 
     /**
      * Send email to a list of users. The list of users is defined based on the

--- a/core/src/main/java/org/fao/geonet/kernel/metadata/DefaultStatusActions.java
+++ b/core/src/main/java/org/fao/geonet/kernel/metadata/DefaultStatusActions.java
@@ -210,13 +210,13 @@ public class DefaultStatusActions implements StatusActions {
     private void applyRulesForStatusChange(MetadataStatus status) throws Exception {
         String statusId = status.getStatusValue().getId() + "";
         if (statusId.equals(StatusValue.Status.APPROVED)) {
+            //            AccessManager accessManager = context.getBean(AccessManager.class);
+            //            if (!accessManager.hasReviewPermission(context, String.valueOf(status.getMetadataId()))) {
+            //                throw new SecurityException(String.format(
+            //                    "You can't edit record with ID %s",
+            //                    String.valueOf(status.getMetadataId())));
+            //            }
             // setAllOperations(mid); - this is a short cut that could be enabled
-            AccessManager accessManager = context.getBean(AccessManager.class);
-            if (!accessManager.canReview(context, String.valueOf(status.getMetadataId()))) {
-                throw new SecurityException(String.format(
-                    "You can't edit record with ID %s",
-                    String.valueOf(status.getMetadataId())));
-            }
         } else if (statusId.equals(StatusValue.Status.DRAFT)) {
             unsetAllOperations(status.getMetadataId());
         }

--- a/core/src/main/java/org/fao/geonet/kernel/setting/Settings.java
+++ b/core/src/main/java/org/fao/geonet/kernel/setting/Settings.java
@@ -96,6 +96,7 @@ public class Settings {
     public static final String SYSTEM_HARVESTER_ENABLE_PRIVILEGES_MANAGEMENT = "system/harvester/enablePrivilegesManagement";
     public static final String SYSTEM_HARVESTER_DISABLED_HARVESTER_TYPES = "system/harvester/disabledHarvesterTypes";
     public static final String SYSTEM_METADATAPRIVS_USERGROUPONLY = "system/metadataprivs/usergrouponly";
+    public static final String SYSTEM_METADATAPRIVS_PUBLICATIONBYGROUPOWNERONLY = "system/metadataprivs/publicationbyrevieweringroupowneronly";
     public static final String SYSTEM_INSPIRE_ATOM_PROTOCOL = "system/inspire/atomProtocol";
     public static final String SYSTEM_HARVESTING_MAIL_RECIPIENT = "system/harvesting/mail/recipient";
     public static final String SYSTEM_HARVESTING_MAIL_LEVEL3 = "system/harvesting/mail/level3";

--- a/services/src/main/java/org/fao/geonet/api/ApiUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/ApiUtils.java
@@ -271,20 +271,6 @@ public class ApiUtils {
     }
 
     /**
-     * Check if the current user can review this record.
-     */
-    static public AbstractMetadata canReviewRecord(String metadataUuid, HttpServletRequest request) throws Exception {
-        ApplicationContext appContext = ApplicationContextHolder.get();
-        AbstractMetadata metadata = getRecord(metadataUuid);
-        AccessManager accessManager = appContext.getBean(AccessManager.class);
-        if (!accessManager.canReview(createServiceContext(request), String.valueOf(metadata.getId()))) {
-            throw new SecurityException(String.format(
-                "You can't review or edit record with UUID %s", metadataUuid));
-        }
-        return metadata;
-    }
-
-    /**
      * Check if the current user can change status of this record.
      */
     static public AbstractMetadata canChangeStatusRecord(String metadataUuid, HttpServletRequest request) throws Exception {

--- a/services/src/main/java/org/fao/geonet/api/es/EsHTTPProxy.java
+++ b/services/src/main/java/org/fao/geonet/api/es/EsHTTPProxy.java
@@ -225,7 +225,8 @@ public class EsHTTPProxy {
             }
         }
         doc.put(Edit.Info.Elem.EDIT, isOwner || canEdit);
-        doc.put(Edit.Info.Elem.REVIEW, accessManager.hasReviewPermission(context, id));
+        doc.put(Edit.Info.Elem.REVIEW,
+            id != null ? accessManager.hasReviewPermission(context, id) : false);
         doc.put(Edit.Info.Elem.OWNER, isOwner);
         doc.put(Edit.Info.Elem.IS_PUBLISHED_TO_ALL, hasOperation(doc, ReservedGroup.all, ReservedOperation.view));
         addReservedOperation(doc, operations, ReservedOperation.view);
@@ -392,9 +393,13 @@ public class EsHTTPProxy {
                     }
                     final JsonNode sourceNode = node.get("_source");
                     if (sourceNode != null) {
-                        final JsonNode sourceIncludes = sourceNode.get("includes");
-                        if (sourceIncludes != null && sourceIncludes.isArray()) {
-                            ((ArrayNode) sourceIncludes).add("op*");
+                        if (sourceNode.isArray()) {
+                            addRequiredField((ArrayNode) sourceNode);
+                        } else {
+                            final JsonNode sourceIncludes = sourceNode.get("includes");
+                            if (sourceIncludes != null && sourceIncludes.isArray()) {
+                                addRequiredField((ArrayNode) sourceIncludes);
+                            }
                         }
                     }
                 }
@@ -406,6 +411,17 @@ public class EsHTTPProxy {
             handleRequest(context, httpSession, request, response, url, endPoint,
                 body, true, selectionBucket, relatedTypes);
         }
+    }
+
+    /**
+     * {@link #addUserInfo(ObjectNode, ServiceContext)}
+     * rely on fields from the index. Add them to the source.
+     */
+    private void addRequiredField(ArrayNode source) {
+        source.add("op*");
+        source.add(Geonet.IndexFieldNames.GROUP_OWNER);
+        source.add(Geonet.IndexFieldNames.OWNER);
+        source.add(Geonet.IndexFieldNames.ID);
     }
 
     private void addFilterToQuery(ServiceContext context,

--- a/services/src/main/java/org/fao/geonet/api/es/EsHTTPProxy.java
+++ b/services/src/main/java/org/fao/geonet/api/es/EsHTTPProxy.java
@@ -179,6 +179,7 @@ public class EsHTTPProxy {
     public static void addUserInfo(ObjectNode doc, ServiceContext context) throws Exception {
         final Integer owner = getSourceInteger(doc, Geonet.IndexFieldNames.OWNER);
         final Integer groupOwner = getSourceInteger(doc, Geonet.IndexFieldNames.GROUP_OWNER);
+        final String id = getSourceString(doc, Geonet.IndexFieldNames.ID);
 
         ObjectMapper objectMapper = new ObjectMapper();
 
@@ -224,6 +225,7 @@ public class EsHTTPProxy {
             }
         }
         doc.put(Edit.Info.Elem.EDIT, isOwner || canEdit);
+        doc.put(Edit.Info.Elem.REVIEW, accessManager.hasReviewPermission(context, id));
         doc.put(Edit.Info.Elem.OWNER, isOwner);
         doc.put(Edit.Info.Elem.IS_PUBLISHED_TO_ALL, hasOperation(doc, ReservedGroup.all, ReservedOperation.view));
         addReservedOperation(doc, operations, ReservedOperation.view);

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataSharingApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataSharingApi.java
@@ -266,9 +266,7 @@ public class MetadataSharingApi {
 
         //--- in case of owner, privileges for groups 0,1 and GUEST are disabled
         //--- and are not sent to the server. So we cannot remove them
-        UserSession us = ApiUtils.getUserSession(session);
-        boolean isAdmin = Profile.Administrator == us.getProfile();
-        if (!isAdmin && !accessManager.hasReviewPermission(context, Integer.toString(metadata.getId()))) {
+        if (!accessManager.hasReviewPermission(context, Integer.toString(metadata.getId()))) {
             skipAllReservedGroup = true;
         }
 
@@ -999,18 +997,11 @@ public class MetadataSharingApi {
         ApplicationContext appContext = ApplicationContextHolder.get();
         ServiceContext context = ApiUtils.createServiceContext(request);
 
-
-        //--- in case of owner, privileges for groups 0,1 and GUEST are disabled
-        //--- and are not sent to the server. So we cannot remove them
-        UserSession us = ApiUtils.getUserSession(session);
-        boolean isAdmin = Profile.Administrator == us.getProfile();
-        boolean isMdGroupReviewer = accessManager.getReviewerGroups(us).contains(metadata.getSourceInfo().getGroupOwner());
-        boolean isReviewOperationAllowedOnMdForUser = accessManager.hasReviewPermission(context, Integer.toString(metadata.getId()));
-        boolean isPublishForbiden = !isMdGroupReviewer && !isAdmin && !isReviewOperationAllowedOnMdForUser;
-        if (isPublishForbiden) {
-
-            throw new Exception(String.format("User not allowed to publish the metadata %s. You need to be administrator, or reviewer of the metadata group or reviewer with edit privilege on the metadata.",
-                    metadataUuid));
+        if (!accessManager.hasReviewPermission(context, Integer.toString(metadata.getId()))) {
+            throw new Exception(String.format(
+                 "User not allowed to publish the metadata %s. %s",
+                    metadataUuid,
+                    accessManager.getReviewerRule()));
 
         }
 
@@ -1057,9 +1048,6 @@ public class MetadataSharingApi {
             final AccessManager accessMan = appContext.getBean(AccessManager.class);
             final IMetadataUtils metadataRepository = appContext.getBean(IMetadataUtils.class);
 
-            UserSession us = ApiUtils.getUserSession(session);
-            boolean isAdmin = Profile.Administrator == us.getProfile();
-
             ServiceContext context = ApiUtils.createServiceContext(request);
 
             List<String> listOfUpdatedRecords = new ArrayList<>();
@@ -1072,7 +1060,7 @@ public class MetadataSharingApi {
                     report.addNotEditableMetadataId(metadata.getId());
                 } else {
                     boolean skipAllReservedGroup = false;
-                    if (!isAdmin && accessMan.hasReviewPermission(context, Integer.toString(metadata.getId()))) {
+                    if (!accessMan.hasReviewPermission(context, Integer.toString(metadata.getId()))) {
                         skipAllReservedGroup = true;
                     }
 

--- a/web-ui/src/main/resources/catalog/components/common/share/ShareDirective.js
+++ b/web-ui/src/main/resources/catalog/components/common/share/ShareDirective.js
@@ -70,6 +70,9 @@
 
 
           scope.onlyUserGroup = gnConfig['system.metadataprivs.usergrouponly'];
+          scope.publicationbyrevieweringroupowneronly =
+            gnConfig['system.metadataprivs.publicationbyrevieweringroupowneronly'] === false
+              ? false : true;
           scope.disableAllCol = gnShareConstants.disableAllCol;
           scope.displayProfile = gnShareConstants.displayProfile;
           scope.icons = gnShareConstants.icons;

--- a/web-ui/src/main/resources/catalog/components/common/share/ShareService.js
+++ b/web-ui/src/main/resources/catalog/components/common/share/ShareService.js
@@ -62,10 +62,15 @@
    * (eg. view, download, edit) a group of user can do.
    */
   module.factory('gnShareService', [
-    '$q', '$http', 'gnShareConstants',
-    function($q, $http, gnShareConstants) {
+    '$q', '$http', 'gnShareConstants', 'gnConfig',
+    function($q, $http, gnShareConstants, gnConfig) {
       var isAdminOrReviewer = function(userProfile, groupOwner,
                                        privileges, batchMode) {
+
+        var publicationbyrevieweringroupowneronly =
+          gnConfig['system.metadataprivs.publicationbyrevieweringroupowneronly'] === false
+            ? false : true;
+
         if ($.inArray(userProfile,
                       gnShareConstants.internalGroupsProfiles) === -1) {
           return false;
@@ -76,9 +81,13 @@
           // Check if user is member of groupOwner
           // or check if user is Reviewer and can edit record
           var ownerGroupInfo = $.grep(privileges, function(g) {
-            return g.group == groupOwner ||
-                   (g.operations.editing &&
-                    $.inArray('Reviewer', g.userProfiles) !== -1);
+            if (publicationbyrevieweringroupowneronly) {
+              return g.group == groupOwner;
+            } else {
+              return g.group == groupOwner ||
+                (g.operations.editing &&
+                  $.inArray('Reviewer', g.userProfiles) !== -1);
+            }
           });
 
           var profiles = [];

--- a/web-ui/src/main/resources/catalog/components/common/share/partials/panel.html
+++ b/web-ui/src/main/resources/catalog/components/common/share/partials/panel.html
@@ -56,7 +56,10 @@
       </thead>
       <tbody>
       <tr class="info"
-          data-ng-repeat="g in privileges | filter:{reserved: true} | orderBy:'id':true">
+          data-ng-repeat="g in privileges | filter:{reserved: true} | orderBy:'id':true"
+          title="{{!isAdminOrReviewer ?
+            (('privilegesNeededForPublicationRecordGroupOnly-' + publicationbyrevieweringroupowneronly) | translate)
+            : ''}}">
         <td><strong>{{('group-' + g.group) | translate}}</strong></td>
         <td data-ng-repeat="key in operations" class="text-center">
           <input type="checkbox"
@@ -108,7 +111,7 @@
 
 <div class="btn-toolbar pull-right">
   <div data-gn-need-help="user-guide/publishing/index.html"
-       data-icon-only="true"></div> 
+       data-icon-only="true"></div>
   <button type="button" class="btn btn-primary"
           id="gn-share-btn-replace"
           title="{{'replaceByThoseOperations-help' | translate}}"

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -876,6 +876,8 @@
     "system/metadata/allThesaurus-help": "If true then a virtual thesaurus will be created that contains all keywords in all other thesauri.  This is useful in editor when the name of the thesaurus is unimportant and only the keyword is important.  In order to ensure that the correct keyword blocks are maintained (with correct thesaurus name) enabling this will also enable a transform in update-fixed-info that will assign the keyword in the 'all' thesaurus to keyword blocks with the correct thesaurus for the keyword",
     "system/metadataprivs": "Metadata privileges",
     "system/metadataprivs/usergrouponly": "Only set privileges to user's groups",
+    "system/metadataprivs/publicationbyrevieweringroupowneronly": "Publication by users reviewer in record group only",
+    "system/metadataprivs/publicationbyrevieweringroupowneronly-help": "Allow publication by administrator and reviewer member of record group. If false, then also all users reviewer in group with editing rights can publish/unpublish a record.",
     "system/metadatacreate" : "Metadata create",
     "system/metadatacreate/generateUuid" : "Generate UUID",
     "system/metadatacreate/generateUuid-help" : "GeoNetwork assigns a random metadata UUID to the metadata created by a user (default). To assign the metadata UUID manually disable this option and fill the metadata UUID prefix.",

--- a/web-ui/src/main/resources/catalog/locales/en-v4.json
+++ b/web-ui/src/main/resources/catalog/locales/en-v4.json
@@ -190,6 +190,8 @@
   "replaceByThoseCategories-help": "Remove record categories and then add (checked with +) or remove (checkbox with -) selected categories.",
   "clearValidationStatus": "Clear validation status",
   "addThoseOperations-help": "Append (checked with +) or remove (checkbox with -) selected privileges.",
+  "privilegesNeededForPublicationRecordGroupOnly-true": "To publish a record, you need to be administrator or reviewer of record group",
+  "privilegesNeededForPublicationRecordGroupOnly-false": "To publish a record, you need to be administrator or reviewer of record group or reviewer of a group with editing rights.",
   "replaceByThoseOperations-help": "Remove record priviliges and then add (checked with +) or remove (checkbox with -) selected privileges.",
   "ui-dateFormat": "Date format",
   "ui-dateFormat-help": "Format of the dates in record default view.",

--- a/web-ui/src/main/resources/catalog/views/default/directives/partials/mdactionmenu.html
+++ b/web-ui/src/main/resources/catalog/views/default/directives/partials/mdactionmenu.html
@@ -45,7 +45,9 @@
         </a></li>
       <!-- Retired metadata can't be published -->
       <li role="menuitem"
-          data-ng-if="user.canManagePrivileges(md) && (user.isAdmin() || user.isReviewerForGroup(md.groupOwner)) && md.draft != 'y' && md.mdStatus != 3"
+          data-ng-if="md.canReview
+                      && md.draft != 'y'
+                      && md.mdStatus != 3"
           data-ng-class="
             (md.isPublished() || (allowPublishInvalidMd() === true) ||
             (!md.isPublished() && (allowPublishInvalidMd() === false) &&

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
@@ -658,6 +658,7 @@ INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/metadatacreate/preferredTemplate', '', 0, 9106, 'n');
 
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/metadataprivs/usergrouponly', 'false', 2, 9180, 'n');
+INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/metadataprivs/publicationbyrevieweringroupowneronly', 'true', 2, 9181, 'n');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/index/indexingTimeRecordLink', 'false', 2, 9209, 'n');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/threadedindexing/maxthreads', '1', 1, 9210, 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/inspire/remotevalidation/url', '', 0, 7211, 'n');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v421/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v421/migrate-default.sql
@@ -1,2 +1,5 @@
+
+INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/metadataprivs/publicationbyrevieweringroupowneronly', 'true', 2, 9181, 'n');
+
 UPDATE Settings SET value='4.2.1' WHERE name='system/platform/version';
 UPDATE Settings SET value='SNAPSHOT' WHERE name='system/platform/subVersion';


### PR DESCRIPTION
Test:
* Create Group A, Group B
* Create User 1, Editor in Group A, Reviewer in Group B
* Create new record in Group A
* Allow editing to Group B
* Connect as User 1
 * Privileges popup allows checking All/Intranet/Guest groups but API will skip them (see https://github.com/geonetwork/core-geonetwork/blob/main/services/src/main/java/org/fao/geonet/api/records/MetadataSharingApi.java#L271-L272)

Some API call returns
```
"description": "User not allowed to publish the metadata 127.
You need to be administrator, 
or reviewer of the metadata group 
or reviewer with edit privilege on the metadata."
```
See https://github.com/geonetwork/core-geonetwork/commit/36a2a588ebd236dd86eb504c5eeb78c21cdd9f96

Privileges management popup check if user is Reviewer in groupOwner or in groups with editing allowed (see
https://github.com/geonetwork/core-geonetwork/blob/main/web-ui/src/main/resources/catalog/components/common/share/ShareService.js#L67-L98)

So we are balanced between 2 mechanisms for defining who can publish to all:
* administrator, or reviewer of the metadata group
* administrator, or reviewer of the metadata group or reviewer with edit privilege on the metadata

Adding a settings for defining those 2 modes.

![image](https://user-images.githubusercontent.com/1701393/171159454-bc837ea6-b467-492c-9bcf-2b89f81df757.png)

Make client app and API more consistent. Add a `canReview` property in document in search response to apply same rules (see `hasReviewPermission`). Cleanup some duplicated methods.

Add user info

![image](https://user-images.githubusercontent.com/1701393/171159530-d03fb352-e22c-4dd1-a652-b41f5720056b.png)
or 
![image](https://user-images.githubusercontent.com/1701393/171159550-8fa5c3d3-20a0-48b5-926d-0fe51bcf5e2f.png)


