### PR TITLE
Metadata map thumbnail - don't rotate the image when using the Landscape

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -635,7 +635,7 @@
                       '/attachments/print-thumbnail', null, {
                         params: {
                           jsonConfig: angular.fromJson(jsonSpec),
-                          rotationAngle: ((jsonSpec.layout == 'landscape')? 90 : 0)
+                          rotationAngle: 0
                         }
                       }).then(function() {
                     $rootScope.$broadcast('gnFileStoreUploadDone');


### PR DESCRIPTION
This change was introduced in https://github.com/geonetwork/core-geonetwork/pull/2811

It rotates the thumbnail image for an unclear reason (maybe and older version of map fish print required that rotation to produce the correct image, but unclear).


**Without the fix:**

<img width="1566" alt="rotated-thumbnail" src="https://user-images.githubusercontent.com/1695003/171380137-d8c68baf-8aef-4dfd-90ee-38fe54f4babc.png">

**With the fix:**

<img width="1570" alt="rotated-thumbnail-2" src="https://user-images.githubusercontent.com/1695003/171380275-2f27b445-ab88-476a-a126-00c28d4b76a5.png">

