### PR TITLE
Add inline messages for the Add Feedback form

### DIFF
--- a/web-ui/src/main/resources/WEB-INF/classes/web-ui-wro-sources.xml
+++ b/web-ui/src/main/resources/WEB-INF/classes/web-ui-wro-sources.xml
@@ -43,6 +43,7 @@
     <jsSource webappPath="/catalog/lib/angular/angular-route.min.js" minimize="false"/>
     <jsSource webappPath="/catalog/lib/angular/angular-sanitize.min.js" minimize="false"/>
     <jsSource webappPath="/catalog/lib/angular/angular-cookies.min.js" minimize="false"/>
+    <jsSource webappPath="/catalog/lib/angular/angular-messages.min.js" minimize="false"/>
     <jsSource webappPath="/catalog/lib/angular-translate.min.js" minimize="false"/>
     <jsSource webappPath="/catalog/lib/angular-md5.min.js" minimize="false"/>
     <jsSource webappPath="/catalog/lib/angular.ext/hotkeys/hotkeys.min.js" minimize="false"/>
@@ -110,6 +111,7 @@
     <jsSource webappPath="/catalog/lib/angular/angular-route.min.js" minimize="false"/>
     <jsSource webappPath="/catalog/lib/angular/angular-sanitize.min.js" minimize="false"/>
     <jsSource webappPath="/catalog/lib/angular/angular-cookies.min.js" minimize="false"/>
+    <jsSource webappPath="/catalog/lib/angular-messages.min.js" minimize="false"/>
     <jsSource webappPath="/catalog/lib/angular.ext/angular-floatThead.js"/>
     <jsSource webappPath="/catalog/lib/angular.ext/date.js"/>
     <jsSource webappPath="/catalog/lib/angular-translate.min.js" minimize="false"/>

--- a/web-ui/src/main/resources/WEB-INF/classes/web-ui-wro-sources.xml
+++ b/web-ui/src/main/resources/WEB-INF/classes/web-ui-wro-sources.xml
@@ -111,7 +111,7 @@
     <jsSource webappPath="/catalog/lib/angular/angular-route.min.js" minimize="false"/>
     <jsSource webappPath="/catalog/lib/angular/angular-sanitize.min.js" minimize="false"/>
     <jsSource webappPath="/catalog/lib/angular/angular-cookies.min.js" minimize="false"/>
-    <jsSource webappPath="/catalog/lib/angular-messages.min.js" minimize="false"/>
+    <jsSource webappPath="/catalog/lib/angular/angular-messages.min.js" minimize="false"/>
     <jsSource webappPath="/catalog/lib/angular.ext/angular-floatThead.js"/>
     <jsSource webappPath="/catalog/lib/angular.ext/date.js"/>
     <jsSource webappPath="/catalog/lib/angular-translate.min.js" minimize="false"/>

--- a/web-ui/src/main/resources/catalog/components/userfeedback/GnUserfeedbackDirective.js
+++ b/web-ui/src/main/resources/catalog/components/userfeedback/GnUserfeedbackDirective.js
@@ -29,7 +29,7 @@
   goog.require('gn_catalog_service');
   goog.require('gn_search_location');
 
-  var module = angular.module('gn_userfeedback_directive', ['vcRecaptcha']);
+  var module = angular.module('gn_userfeedback_directive', ['vcRecaptcha', 'ngMessages']);
 
   module.service('gnUserfeedbackService', [
     '$http', '$q',
@@ -360,50 +360,6 @@
 
                 scope.resolveRecaptcha = false;
                 scope.uf.captcha = vcRecaptchaService.getResponse();
-              }
-
-
-              if (!scope.loggedIn) {
-
-                scope.authorNameError = false;
-                scope.authorEmailError = false;
-                scope.authorOrganizationError = false;
-
-                if (!data.authorName) {
-                  scope.authorNameError = $translate.instant('GUFrequired');
-
-                  return false;
-                }
-                if (!data.authorEmail) {
-                  scope.authorEmailError = $translate.instant('GUFrequired');
-
-                  return false;
-                }
-                if (scope.uf.authorName.length > 64) {
-                  scope.authorNameError = $translate.instant('GUFtooLong');
-
-                  return false;
-                }
-                if (scope.uf.authorEmail.length > 64) {
-                  scope.authorEmailError = $translate.instant('GUFtooLong');
-
-                  return false;
-                }
-
-                var re = /^(([^<>()\[\]\\.,;:\s@"]+(\.[^<>()\[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/;
-
-                if (!re.test(scope.uf.authorEmail)) {
-                  scope.authorEmailError =
-                    $translate.instant('GUFnotValidFormat');
-
-                  return false;
-                }
-                if (scope.uf.authorOrganization && scope.uf.authorOrganization.length > 64) {
-                  scope.authorOrganizationError =
-                    $translate.instant('GUFtooLong');
-
-                  return false;
-                }
               }
 
               scope.uf.metadataUUID = scope.metatdataUUID;

--- a/web-ui/src/main/resources/catalog/components/userfeedback/partials/userfeedbacknew.html
+++ b/web-ui/src/main/resources/catalog/components/userfeedback/partials/userfeedbacknew.html
@@ -7,6 +7,10 @@
     <i class="fa fa-plus"></i>&nbsp;
   </button>
   <!-- Add comment Modal -->
+  <form name="gnUserfeedbackAddcomment"
+        id="gn-userfeedback-addcomment-form"
+        class="form-horizontal"
+        role="form" novalidate>
   <div class="modal gn-userfeedback-modal"
        id="gn-userfeedback-addcomment"
        tabindex="-1"
@@ -65,9 +69,19 @@
                     <h2 data-translate="">GUFaddYourReview</h2>
                   </div>
                   <p class="text-muted" data-translate="">GUFaddYourReviewInfo</p>
-                  <textarea class="form-control" rows="5"
-                    data-ng-model="uf.comment" required></textarea>
-                  <!-- TODO: Add check on text length-->
+                  <textarea class="form-control"
+                            rows="5"
+                            name="comment"
+                            data-ng-model="uf.comment"
+                            data-ng-maxlength="255" required></textarea>
+                  <div class="help-block" data-ng-messages="gnUserfeedbackAddcomment.comment.$error" ng-if="gnUserfeedbackAddcomment.comment.$touched">
+                    <p data-ng-message="maxlength"
+                       data-translate=""
+                       data-translate-values="{maxChar: '255'}">
+                      fieldTooLongMax
+                    </p>
+                    <p data-ng-message="required" data-translate="">fieldRequired</p>
+                  </div>
                 </div>
                 <!-- /.panel-body -->
               </div>
@@ -101,21 +115,32 @@
                         aria-label="{{'GUFname' | translate}}"
                         data-ng-model="uf.authorName"
                         data-ng-maxlength="64" required>
-                      <p data-ng-show="authorNameError" class="help-block">{{authorNameError}}</p>
+                      <div class="help-block" data-ng-messages="gnUserfeedbackAddcomment.authorName.$error" ng-if="gnUserfeedbackAddcomment.authorName.$touched">
+                        <p data-ng-message="maxlength" data-translate="">fieldTooLong</p>
+                        <p data-ng-message="required" data-translate="">fieldRequired</p>
+                      </div>
 
                       <input type="email" name="authorEmail" class="form-control"
                         placeholder="{{'GUFemail' | translate}}"
                         aria-label="{{'GUFemail' | translate}}"
                         data-ng-model="uf.authorEmail"
-                        data-ng-maxlength="64" required>
-                      <p data-ng-show="authorEmailError" class="help-block">{{authorEmailError}}</p>
+                        data-ng-pattern="/^[a-z][a-zA-Z0-9_]*(\.[a-zA-Z][a-zA-Z0-9_]*)?@[a-z][a-zA-Z-0-9]*\.[a-z]+(\.[a-z]+)?$/"
+                        data-ng-maxlength="64" required/>
+                      <div class="help-block" data-ng-messages="gnUserfeedbackAddcomment.authorEmail.$error" ng-if="gnUserfeedbackAddcomment.authorEmail.$touched">
+                        <p data-ng-message="maxlength" data-translate="">fieldTooLong</p>
+                        <p data-ng-message="required" data-translate="">fieldRequired</p>
+                        <p data-ng-message="pattern" data-translate="">fieldEmailNotValid</p>
+                      </div>
 
                       <input type="text" name="authorOrganization"
                         class="form-control"
                         placeholder="{{'GUForganization' | translate}}"
                         aria-label="{{'GUForganization' | translate}}"
                         data-ng-model="uf.authorOrganization" data-ng-maxlength="64">
-                      <p data-ng-show="authorOrganizationError" class="help-block">{{authorOrganizationError}}</p>
+                      <div class="help-block" data-ng-messages="gnUserfeedbackAddcomment.authorOrganization.$error" ng-if="gnUserfeedbackAddcomment.authorOrganization.$touched">
+                        <p data-ng-message="maxlength" data-translate="">fieldTooLong</p>
+                        <p data-ng-message="required" data-translate="">fieldRequired</p>
+                      </div>
                     </div>
                     <p>
                       <div class="checkbox anonymous">
@@ -140,7 +165,7 @@
                  theme="'light'"
                  key="recaptchaKey"></div>
 
-            <span class="col-lg-8" style="color: red;" data-ng-show="resolveRecaptcha" data-translate="">
+            <span class="col-lg-8 help-block" data-ng-show="resolveRecaptcha" data-translate="">
               resolveCaptcha
             </span>
           </div>
@@ -149,9 +174,12 @@
           <button type="button" class="btn btn-default" data-dismiss="modal"
             data-translate="">GUFclose</button>
           <button type="button" class="btn btn-primary"
-            data-ng-click="submitForm(uf, modal)" data-translate="">GUFsave</button>
+                  data-ng-disabled="!gnUserfeedbackAddcomment.$valid && !gnUserfeedbackAddcomment.dirty"
+                  data-ng-click="submitForm(uf, modal)"
+                  data-translate="">GUFsave</button>
         </div>
       </div>
     </div>
   </div>
+  </form>
 </div>

--- a/web-ui/src/main/resources/catalog/locales/en-search.json
+++ b/web-ui/src/main/resources/catalog/locales/en-search.json
@@ -540,5 +540,10 @@
   "esriCapabilitiesNoValid": "The response is not a valid ESRI Rest capabilities document.",
   "seriesComposedOf": "Composed of",
   "seriesCoveringPeriod": "Covering period",
-  "approve": "Approve"
+  "approve": "Approve",
+  "fieldRequired": "The value is required",
+  "fieldTooLong": "The value is too long",
+  "fieldTooLongMax": "The value is too long (max {{maxChar}} characters)",
+  "fieldTooShort": "The value is too short",
+  "fieldEmailNotValid": "A valid email address is required"
 }

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_feedback_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_feedback_default.less
@@ -266,6 +266,18 @@ q, blockquote {
       }
     }
   }
+  // errors
+  input, textarea {
+    &.ng-invalid {
+      border-color: @brand-danger;
+      &:focus {
+        box-shadow: none;
+      }
+    }
+  }
+  .help-block {
+    color: @brand-danger;
+  }
   // panels
   .panel {
     border: 0;

--- a/web/src/main/webapp/xslt/base-layout-cssjs-loader.xsl
+++ b/web/src/main/webapp/xslt/base-layout-cssjs-loader.xsl
@@ -118,6 +118,7 @@
         <script src="{$uiResourcesPath}lib/angular/angular-route.js?v={$buildNumber}"></script>
         <script src="{$uiResourcesPath}lib/angular/angular-sanitize.js?v={$buildNumber}"></script>
         <script src="{$uiResourcesPath}lib/angular/angular-cookies.js?v={$buildNumber}"></script>
+        <script src="{$uiResourcesPath}lib/angular/angular-messages.js?v={$buildNumber}"></script>
         <script src="{$uiResourcesPath}lib/angular-translate.js?v={$buildNumber}"></script>
         <script src="{$uiResourcesPath}lib/angular-md5.js?v={$buildNumber}"></script>
         <script src="{$uiResourcesPath}lib/angular-filter.min.js?v={$buildNumber}"></script>


### PR DESCRIPTION
This PR improves the messages when adding new feedback by using `ngMessages`. Messages are shown inline, and the `Save` is enabled when everything is valid.

An additional check is done on the 'review' input, a check on the maximum characters.

<img width="1021" alt="gn-add-feedback" src="https://user-images.githubusercontent.com/19608667/171417376-5420a22d-ae40-4475-9b38-998573bd0e0c.png">


