### PR TITLE
Switch from itext to openpdf for PDF map rendering

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -171,8 +171,8 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>diff_match_patch</groupId>
-      <artifactId>diff_match_patch</artifactId>
+      <groupId>org.bitbucket.cowwoc</groupId>
+      <artifactId>diff-match-patch</artifactId>
     </dependency>
   </dependencies>
 

--- a/common/src/main/java/org/fao/geonet/utils/Diff.java
+++ b/common/src/main/java/org/fao/geonet/utils/Diff.java
@@ -1,6 +1,6 @@
 package org.fao.geonet.utils;
 
-import name.fraser.neil.plaintext.diff_match_patch;
+import org.bitbucket.cowwoc.diffmatchpatch.DiffMatchPatch;
 import org.jdom.Element;
 
 import java.util.LinkedList;
@@ -8,17 +8,17 @@ import java.util.LinkedList;
 public class Diff {
 
     public static String diff(String oldVersion, String newVersion, DiffType diffType) {
-        diff_match_patch dmp = new diff_match_patch();
+        DiffMatchPatch dmp = new DiffMatchPatch();
         if (DiffType.patch.equals(diffType)) {
-            LinkedList<diff_match_patch.Patch> diffs =
-                dmp.patch_make(oldVersion, newVersion);
+            LinkedList<DiffMatchPatch.Patch> diffs =
+                dmp.patchMake(oldVersion, newVersion);
             return diffs.toString();
         } else if (DiffType.diff.equals(diffType)) {
-            LinkedList<diff_match_patch.Diff> diffs = dmp.diff_main(oldVersion, newVersion);
+            LinkedList<DiffMatchPatch.Diff> diffs = dmp.diffMain(oldVersion, newVersion);
             return diffs.toString();
         } else {
-            LinkedList<diff_match_patch.Diff> diffs = dmp.diff_main(oldVersion, newVersion);
-            return dmp.diff_prettyHtml(diffs);
+            LinkedList<DiffMatchPatch.Diff> diffs = dmp.diffMain(oldVersion, newVersion);
+            return dmp.diffPrettyHtml(diffs);
         }
     }
 }

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -374,9 +374,18 @@
 
     <!-- Print service: MapFish -->
     <dependency>
+      <groupId>com.github.librepdf</groupId>
+      <artifactId>openpdf</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.mapfish.print</groupId>
       <artifactId>print-lib</artifactId>
       <exclusions>
+        <exclusion>
+          <!-- provided by openpdf -->
+          <groupId>com.itextpdf</groupId>
+          <artifactId>itextpdf</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>commons-httpclient</groupId>
           <artifactId>commons-httpclient</artifactId>

--- a/core/src/main/java/org/fao/geonet/kernel/thumbnail/ThumbnailMaker.java
+++ b/core/src/main/java/org/fao/geonet/kernel/thumbnail/ThumbnailMaker.java
@@ -149,7 +149,7 @@ public class ThumbnailMaker {
     }
 
     public Path generateThumbnail(String jsonConfig, Integer rotationAngle)
-        throws IOException, com.itextpdf.text.DocumentException {
+        throws IOException {
 
         PJsonObject specJson = MapPrinter.parseSpec(jsonConfig);
         if (Log.isDebugEnabled(LOGGER_NAME)) {

--- a/pom.xml
+++ b/pom.xml
@@ -1191,66 +1191,42 @@
 
   <!-- ================================================================== -->
   <!--     Repositories. This is where Maven looks for dependencies. The  -->
-  <!--     Maven repository is implicit and doesn't need to be specified. -->
+  <!--     Maven central repo is implicit and doesn't need to be listed.  -->
+  <!--                                                                    -->
+  <!--     Please do not add additional repositories as this increases    -->
+  <!--     build times, instead upload third-party dependencies to osgeo  -->
+  <!--     repo.osgeo.org geonetwork-cache repository, or configure osgeo -->
+  <!--     releases repository to cache additional repos of interest:     -->
+  <!--                                                                    -->
+  <!--     The following are cached for geonetwork:                       -->
+  <!--     http://maven.k-int.com/content/repositories/releases/          -->
+  <!--     repo.osgeo.org geonetwork-cache                                -->
+  <!--     https://raw.githubusercontent.com/geonetwork/core-maven-repo/  -->
+  <!--     http://maven.seasar.org/maven2                                 -->
   <!-- ================================================================== -->
   <repositories>
+
     <repository>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>
       <id>osgeo</id>
-      <name>OSGeo repository</name>
+      <name>OSGeo Release repository</name>
       <url>https://repo.osgeo.org/repository/release/</url>
     </repository>
 
-    <!-- managed by repo.osgeo.org k-int-cache -->
-    <!-- /marcxml/marcxml/*                    -->
-    <!-- /marc4j/marc4j/*                      -->
-    <!--repository>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-      <id>k-int</id>
-      <name>Developer k-int repository</name>
-      <url>http://maven.k-int.com/content/repositories/releases/</url>
-    </repository-->
-
-    <!-- managed by repo.osgeo.org geonetwork-cache     -->
-    <!-- third party jar upload                         -->
-    <!-- TODO: move this content to geonetwork-releases -->
-    <!--
     <repository>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
       <releases>
-        <enabled>true</enabled>
+        <enabled>false</enabled>
       </releases>
-      <id>core-maven-repo</id>
-      <name>GeoNetwork remote repository</name>
-      <url>https://raw.githubusercontent.com/geonetwork/core-maven-repo/master</url>
+      <snapshots>
+        <enabled>true</enabled>
+      </snapshots>
+      <id>osgeo-snapshot</id>
+      <name>OSGeo Snapshot repository</name>
+      <url>https://repo.osgeo.org/repository/snapshot/</url>
     </repository>
-    -->
-    <!-- managed by repo.osgeo.org seasar-cache       -->
-    <!-- /net.arnx.jsonic/jsonic/*                    -->
-    <!-- seasar repo, has jsonic - used by langdetect -->
-    <!--
-    <repository>
-      <id>maven.seasar.org</id>
-      <name>The Seasar Foundation Maven2 Repository</name>
-      <url>http://maven.seasar.org/maven2</url>
-    </repository>
-    -->
-    <!-- managed by repo.osgeo.org geonetwork-releases  -->
-    <!-- third party jar upload                        -->
-    <!-- org.mapfish.print:print-lib-2.1.6.jar         -->
-    <!--
-    <repository>
-      <id>georchestra-mfprint</id>
-      <name>build-releases</name>
-      <url>https://packages.georchestra.org/artifactory/mapfish-print</url>
-    </repository>
-    -->
+
   </repositories>
 
 

--- a/pom.xml
+++ b/pom.xml
@@ -428,11 +428,11 @@
       </dependency>
 
       <!-- PDF stuff: Managed by Mapfish -->
-      <!--dependency>
-        <groupId>com.lowagie</groupId>
-        <artifactId>itext</artifactId>
-        <version>2.0.6</version>
-      </dependency-->
+      <dependency>
+        <groupId>com.github.librepdf</groupId>
+        <artifactId>openpdf</artifactId>
+        <version>1.3.26</version>
+      </dependency>
       <dependency>
         <groupId>org.apache.xmlgraphics</groupId>
         <artifactId>fop</artifactId>
@@ -912,19 +912,11 @@
         <artifactId>mysql-connector-java</artifactId>
         <version>8.0.20</version>
       </dependency>
-      <!-- Not permitted under oracle licensing rules
-      <dependency>
-        <groupId>ojdbc</groupId>
-        <artifactId>ojdbc</artifactId>
-        <version>14</version>
-      </dependency>
-      -->
-      <!-- Oracle changed policy, this is from maven central -->
-      <!-- Oracle Free Use Terms and Conditions (FUTC) -->
       <dependency>
          <groupId>com.oracle.database.jdbc</groupId>
          <artifactId>ojdbc8</artifactId>
          <version>19.6.0.0</version>
+         <!-- Oracle Free Use Terms and Conditions (FUTC) -->
        </dependency>
       <dependency>
         <groupId>org.codehaus.izpack</groupId>
@@ -1108,14 +1100,8 @@
       </dependency>
       <dependency>
         <groupId>org.xhtmlrenderer</groupId>
-        <artifactId>flying-saucer-pdf-itext5</artifactId>
+        <artifactId>flying-saucer-pdf-openpdf</artifactId>
         <version>${flying-saucer}</version>
-        <exclusions>
-          <exclusion>
-            <groupId>com.itextpdf</groupId>
-            <artifactId>itextpdf</artifactId>
-          </exclusion>
-        </exclusions>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.jackson.core</groupId>
@@ -1573,7 +1559,7 @@
     <npm.version>5.8.0</npm.version>
     <xmlunit.version>2.1.1</xmlunit.version>
     <jackson.version>2.10.4</jackson.version>
-    <flying-saucer>9.0.7</flying-saucer>
+    <flying-saucer>9.1.22</flying-saucer>
     <camel.version>2.25.4</camel.version>
     <log4j.version>1.2.17</log4j.version>
     <log4j2.version>2.17.2</log4j2.version>

--- a/pom.xml
+++ b/pom.xml
@@ -813,7 +813,7 @@
       <dependency>
         <groupId>org.mapfish.print</groupId>
         <artifactId>print-lib</artifactId>
-        <version>2.1.6</version>
+        <version>2.2-SNAPSHOT</version>
       </dependency>
 
       <!-- Lib utils -->

--- a/pom.xml
+++ b/pom.xml
@@ -813,7 +813,7 @@
       <dependency>
         <groupId>org.mapfish.print</groupId>
         <artifactId>print-lib</artifactId>
-        <version>2.2-SNAPSHOT</version>
+        <version>2.2.0</version>
       </dependency>
 
       <!-- Lib utils -->

--- a/pom.xml
+++ b/pom.xml
@@ -1159,9 +1159,9 @@
         <version>${jasypt.version}</version>
       </dependency>
       <dependency>
-        <groupId>diff_match_patch</groupId>
-        <artifactId>diff_match_patch</artifactId>
-        <version>current</version>
+          <groupId>org.bitbucket.cowwoc</groupId>
+          <artifactId>diff-match-patch</artifactId>
+          <version>1.2</version>
       </dependency>
     </dependencies>
   </dependencyManagement>
@@ -1201,10 +1201,6 @@
       <id>osgeo</id>
       <name>OSGeo repository</name>
       <url>https://repo.osgeo.org/repository/release/</url>
-    </repository>
-    <repository>
-      <id>redhat</id>
-      <url>https://maven.repository.redhat.com/ga/</url>
     </repository>
 
     <!-- managed by repo.osgeo.org k-int-cache -->

--- a/schemas/dublin-core/pom.xml
+++ b/schemas/dublin-core/pom.xml
@@ -65,24 +65,6 @@
         </executions>
       </plugin>
 
-      <plugin>
-        <artifactId>maven-assembly-plugin</artifactId>
-        <executions>
-          <execution>
-            <id>plugin-assembly</id>
-            <phase>package</phase>
-            <goals><goal>single</goal></goals>
-            <inherited>false</inherited>
-            <configuration>
-             <appendAssemblyId>false</appendAssemblyId>
-             <descriptors>
-              <descriptor>src/assembly/schema-plugin.xml</descriptor>
-             </descriptors>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-
     </plugins>
   </build>
 

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -147,7 +147,7 @@
 
     <dependency>
       <groupId>org.xhtmlrenderer</groupId>
-      <artifactId>flying-saucer-pdf-itext5</artifactId>
+      <artifactId>flying-saucer-pdf-openpdf</artifactId>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterApi.java
@@ -527,7 +527,7 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
         return new String(ByteStreams.toByteArray(execute.getBody()), Constants.CHARSET);
     }
 
-    private void writerAsPDF(ServiceContext context, HttpServletResponse response, byte[] bytes, String lang) throws IOException, com.itextpdf.text.DocumentException {
+    private void writerAsPDF(ServiceContext context, HttpServletResponse response, byte[] bytes, String lang) throws IOException, com.lowagie.text.DocumentException {
         final String htmlContent = new String(bytes, Constants.CHARSET);
         try {
             XslUtil.setNoScript();

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/ImageReplacedElementFactory.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/ImageReplacedElementFactory.java
@@ -25,7 +25,7 @@ package org.fao.geonet.api.records.formatters;
 
 import com.google.common.collect.Sets;
 import com.google.common.io.Files;
-import com.itextpdf.text.Image;
+import com.lowagie.text.Image;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.api.ApiUtils;

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -282,9 +282,17 @@
 
     <!-- Print service: MapFish -->
     <dependency>
+      <groupId>com.github.librepdf</groupId>
+      <artifactId>openpdf</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.mapfish.print</groupId>
       <artifactId>print-lib</artifactId>
       <exclusions>
+        <exclusion>
+          <groupId>com.lowagie</groupId>
+          <artifactId>itext</artifactId>
+        </exclusion>
         <exclusion>
           <groupId>commons-httpclient</groupId>
           <artifactId>commons-httpclient</artifactId>


### PR DESCRIPTION
Initially focused on using dependency exclusion to swap iText to OpenPDF for map fish print.
Also found flying-saucer-pdf-itext5 was in use and changed to flying-saucer-pdf-openpdf.

The older iText library has known security vulnerabilities, OpenPDF is a drop-in replacement (forking from iText 4.2.0 to maintain an open-source license).

References:
* https://github.com/LibrePDF/OpenPDF
* https://github.com/flyingsaucerproject/flyingsaucer

Notes:
- The version dependency print-lib 2.1.6 used does not appear in maven central and may be a fork created for core-geonetwork. This version has a dependency on iText 5.5.13 and may need to be adjust to the OpenPDF (iText 4.2.0 API).
- print-lib 2.0.0 uses the iText 2.1.5 API
- Newer versions of print-lib are available that make use of jasper reports for pdf generation 

Update:

* [x] ThumbnailMaker indirectly reference com.itextpdf.text.DocumentException confirming that OpenPDF cannot be directly swapped in due to package change for iText 5.
* [x] Created mapfish-print 2.2.0 release based on Open PDF

Fixes:

* https://github.com/geonetwork/core-geonetwork/issues/6380
