### PR TITLE
User metadata feedback - fix related to #6341 to don't include  unrequired fields when the user is logged.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/userfeedback/partials/userfeedbacknew.html
+++ b/web-ui/src/main/resources/catalog/components/userfeedback/partials/userfeedbacknew.html
@@ -105,7 +105,7 @@
                     <p data-translate=""
                       data-translate-values="{authorNameValue:'{{authorNameValue}}'}">GUFyouAreLoggedInAs</p>
                   </div>
-                  <div class="gn-userfeedback-loggedout" data-ng-hide="loggedIn">
+                  <div class="gn-userfeedback-loggedout" data-ng-if="!loggedIn">
                     <div id="GUFcredentials" class="anonymous">
                       <p data-translate="">GUFyouAreNotLoggedInPleaseFillIn</p>
                       <input type="text"


### PR DESCRIPTION
 Hiding the fields trigger the validation, it is required to use `data-ng-if` directive instead of `data-ng-hide`