### PR TITLE
DOI / Configure DOI URL pattern

### DIFF
--- a/doi/src/main/java/org/fao/geonet/doi/client/DoiBuilder.java
+++ b/doi/src/main/java/org/fao/geonet/doi/client/DoiBuilder.java
@@ -22,18 +22,36 @@
 //==============================================================================
 package org.fao.geonet.doi.client;
 
+import org.fao.geonet.domain.AbstractMetadata;
+import org.fao.geonet.domain.Group;
+import org.fao.geonet.repository.GroupRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Optional;
+
 /**
  * Class to generate a DOI.
  *
  * @author Jose García
  */
 public class DoiBuilder {
+    @Autowired
+    GroupRepository groupRepository;
+
     /**
      * Creates a DOI value.
      *
      * @return
      */
-    public static String create(String prefix, String metadataUuid) {
-        return prefix + "/" + metadataUuid;
+    public String create(String doiPattern, String prefix, AbstractMetadata record) {
+        java.util.Optional<Group> groupOwner =
+            record.getSourceInfo().getGroupOwner() != null
+                ? groupRepository.findById(record.getSourceInfo().getGroupOwner())
+                : Optional.empty();
+
+        return prefix + "/" + doiPattern
+                .replace("{{groupOwner}}", groupOwner.isPresent() ? groupOwner.get().getName() : "")
+                .replace("{{id}}", record.getId() + "")
+                .replace("{{uuid}}", record.getUuid());
     }
 }

--- a/doi/src/main/java/org/fao/geonet/doi/client/DoiClient.java
+++ b/doi/src/main/java/org/fao/geonet/doi/client/DoiClient.java
@@ -283,11 +283,13 @@ public class DoiClient {
             Log.debug(LOGGER_NAME, "   -- Request status code: " + status);
 
             if (status != HttpStatus.SC_CREATED) {
+                String responseBody = httpResponse.getBody() != null
+                    ? CharStreams.toString(new InputStreamReader(httpResponse.getBody()))
+                    :  "";
                 String message = String.format(
-                    "Failed to create '%s' with '%s'. Status is %d. Error is %s.",
+                    "Failed to create '%s' with '%s'. Status is %d. Error is %s. Response body: %s",
                     url, body, status,
-                    httpResponse.getStatusText());
-
+                    httpResponse.getStatusText(), responseBody);
                 Log.info(LOGGER_NAME, message);
                 throw new DoiClientException(message);
             } else {

--- a/doi/src/main/java/org/fao/geonet/doi/client/DoiManager.java
+++ b/doi/src/main/java/org/fao/geonet/doi/client/DoiManager.java
@@ -34,7 +34,6 @@ import org.fao.geonet.kernel.AccessManager;
 import org.fao.geonet.kernel.ApplicableSchematron;
 import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.SchematronValidator;
-import org.fao.geonet.kernel.datamanager.IMetadataValidator;
 import org.fao.geonet.kernel.datamanager.base.BaseMetadataSchemaUtils;
 import org.fao.geonet.kernel.schema.MetadataSchema;
 import org.fao.geonet.kernel.setting.SettingManager;
@@ -66,11 +65,13 @@ public class DoiManager {
     private static final String DOI_ADD_XSL_PROCESS = "process/doi-add.xsl";
     private static final String DOI_REMOVE_XSL_PROCESS = "process/doi-remove.xsl";
     public static final String DATACITE_XSL_CONVERSION_FILE = "formatter/datacite/view.xsl";
-    public static final String DOI_PREFIX_PARAMETER = "doiPrefix";
+    public static final String DOI_ID_PARAMETER = "doiId";
     public static final String DOI_DEFAULT_URL = "https://doi.org/";
+    public static final String DOI_DEFAULT_PATTERN = "{{uuid}}";
 
     private DoiClient client;
     private String doiPrefix;
+    private String doiPattern;
     private String landingPageTemplate;
     private boolean initialised = false;
 
@@ -80,6 +81,9 @@ public class DoiManager {
 
     @Autowired
     SchematronValidator validator;
+
+    @Autowired
+    DoiBuilder doiBuilder;
 
     @Autowired
     SchematronRepository schematronRepository;
@@ -115,6 +119,11 @@ public class DoiManager {
             String password = sm.getValue(DoiSettings.SETTING_PUBLICATION_DOI_DOIPASSWORD);
 
             doiPrefix = sm.getValue(DoiSettings.SETTING_PUBLICATION_DOI_DOIKEY);
+            doiPattern = sm.getValue(DoiSettings.SETTING_PUBLICATION_DOI_DOIPATTERN);
+            if (StringUtils.isEmpty(doiPattern)) {
+                doiPattern = DOI_DEFAULT_PATTERN;
+            }
+
             landingPageTemplate = sm.getValue(DoiSettings.SETTING_PUBLICATION_DOI_LANDING_PAGE_TEMPLATE);
 
             final boolean emptyUrl = StringUtils.isEmpty(serverUrl);
@@ -151,13 +160,16 @@ public class DoiManager {
         }
     }
 
+    public String checkDoiUrl(AbstractMetadata metadata) {
+        return doiBuilder.create(doiPattern, doiPrefix, metadata);
+    }
 
     public Map<String, Boolean> check(ServiceContext serviceContext, AbstractMetadata metadata, Element dataciteMetadata) throws Exception {
         Map<String, Boolean> conditions = new HashMap<>();
         checkInitialised();
         conditions.put(DoiConditions.API_CONFIGURED, true);
 
-        String doi =  DoiBuilder.create(this.doiPrefix, metadata.getUuid());
+        String doi =  doiBuilder.create(doiPattern, doiPrefix, metadata);
         checkPreConditions(metadata, doi);
         conditions.put(DoiConditions.RECORD_IS_PUBLIC, true);
         conditions.put(DoiConditions.STANDARD_SUPPORT, true);
@@ -167,7 +179,7 @@ public class DoiManager {
         Element dataciteFormatMetadata =
             dataciteMetadata == null ?
             convertXmlToDataCiteFormat(metadata.getDataInfo().getSchemaId(),
-                metadata.getXmlData(false)) : dataciteMetadata;
+                metadata.getXmlData(false), doi) : dataciteMetadata;
         checkPreConditionsOnDataCite(metadata, doi, dataciteFormatMetadata, serviceContext.getLanguage());
         conditions.put(DoiConditions.DATACITE_FORMAT_IS_VALID, true);
         return conditions;
@@ -176,13 +188,13 @@ public class DoiManager {
     public Map<String, String> register(ServiceContext context, AbstractMetadata metadata) throws Exception {
         Map<String, String> doiInfo = new HashMap<>(3);
         // The new DOI for this record
-        String doi =  DoiBuilder.create(this.doiPrefix, metadata.getUuid());
+        String doi =  doiBuilder.create(doiPattern, doiPrefix, metadata);
         doiInfo.put("doi", doi);
 
         // The record in datacite format
         Element dataciteFormatMetadata =
                 convertXmlToDataCiteFormat(metadata.getDataInfo().getSchemaId(),
-                    metadata.getXmlData(false));
+                    metadata.getXmlData(false), doi);
 
         try {
             check(context, metadata, dataciteFormatMetadata);
@@ -408,7 +420,7 @@ public class DoiManager {
     public void unregisterDoi(AbstractMetadata metadata, ServiceContext context) throws DoiClientException, ResourceNotFoundException {
         checkInitialised();
 
-        final String doi = DoiBuilder.create(this.doiPrefix, metadata.getUuid());
+        final String doi = doiBuilder.create(doiPattern, doiPrefix, metadata);
         final String doiResponse = client.retrieveDoi(doi);
         if (doiResponse == null) {
             throw new ResourceNotFoundException(String.format(
@@ -479,7 +491,7 @@ public class DoiManager {
      * @return The record converted into the DataCite format.
      * @throws Exception if there is no conversion available.
      */
-    private Element convertXmlToDataCiteFormat(String schema, Element md) throws Exception {
+    private Element convertXmlToDataCiteFormat(String schema, Element md, String doi) throws Exception {
         final Path styleSheet = dm.getSchemaDir(schema).resolve(DATACITE_XSL_CONVERSION_FILE);
         final boolean exists = Files.exists(styleSheet);
         if (!exists) {
@@ -488,7 +500,7 @@ public class DoiManager {
         };
 
         Map<String,Object> params = new HashMap<String,Object>();
-        params.put(DOI_PREFIX_PARAMETER, this.doiPrefix);
+        params.put(DOI_ID_PARAMETER, doi);
         Element dataciteMetadata = Xml.transform(md, styleSheet, params);
         return dataciteMetadata;
     }

--- a/doi/src/main/java/org/fao/geonet/doi/client/DoiManager.java
+++ b/doi/src/main/java/org/fao/geonet/doi/client/DoiManager.java
@@ -111,18 +111,17 @@ public class DoiManager {
         if (sm != null) {
 
             String serverUrl = sm.getValue(DoiSettings.SETTING_PUBLICATION_DOI_DOIURL);
-            String doiPublicUrl = sm.getValue(DoiSettings.SETTING_PUBLICATION_DOI_DOIPUBLICURL);
-            if (StringUtils.isEmpty(doiPublicUrl)) {
-                doiPublicUrl = DOI_DEFAULT_URL;
-            }
+            String doiPublicUrl = StringUtils.defaultIfEmpty(
+                    sm.getValue(DoiSettings.SETTING_PUBLICATION_DOI_DOIPUBLICURL),
+                    DOI_DEFAULT_URL);
             String username = sm.getValue(DoiSettings.SETTING_PUBLICATION_DOI_DOIUSERNAME);
             String password = sm.getValue(DoiSettings.SETTING_PUBLICATION_DOI_DOIPASSWORD);
 
             doiPrefix = sm.getValue(DoiSettings.SETTING_PUBLICATION_DOI_DOIKEY);
-            doiPattern = sm.getValue(DoiSettings.SETTING_PUBLICATION_DOI_DOIPATTERN);
-            if (StringUtils.isEmpty(doiPattern)) {
-                doiPattern = DOI_DEFAULT_PATTERN;
-            }
+            doiPattern = StringUtils.defaultIfEmpty(
+                sm.getValue(DoiSettings.SETTING_PUBLICATION_DOI_DOIPATTERN),
+                DOI_DEFAULT_PATTERN
+            );
 
             landingPageTemplate = sm.getValue(DoiSettings.SETTING_PUBLICATION_DOI_LANDING_PAGE_TEMPLATE);
 

--- a/doi/src/main/java/org/fao/geonet/doi/client/DoiSettings.java
+++ b/doi/src/main/java/org/fao/geonet/doi/client/DoiSettings.java
@@ -36,6 +36,8 @@ public class DoiSettings {
         "system/publication/doi/doipassword";
     public static final String SETTING_PUBLICATION_DOI_DOIKEY =
         "system/publication/doi/doikey";
+    public static final String SETTING_PUBLICATION_DOI_DOIPATTERN =
+        "system/publication/doi/doipattern";
     public static final String SETTING_PUBLICATION_DOI_LANDING_PAGE_TEMPLATE =
         "system/publication/doi/doilandingpagetemplate";
 

--- a/doi/src/main/resources/config-spring-geonetwork.xml
+++ b/doi/src/main/resources/config-spring-geonetwork.xml
@@ -28,6 +28,9 @@
        xsi:schemaLocation="
 		http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
 	">
+  <bean id="doiBuilder"
+        class="org.fao.geonet.doi.client.DoiBuilder"
+        lazy-init="true"/>
   <bean id="doiManager"
         class="org.fao.geonet.doi.client.DoiManager"
         lazy-init="true"/>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/datacite/view.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/datacite/view.xsl
@@ -111,11 +111,10 @@
               indent="yes"/>
 
   <!-- Before attribution of a DOI the ISO19139 record does not contain yet
-  the DOI value. It is built from the DOI prefix provided as parameter
-  and the UUID of the record.
+  the DOI value. It is built from the DOI id provided as parameter.
   If the DOI already exist in the record, this parameter is not set and the DOI
   is returned as datacite:identifier -->
-  <xsl:param name="doiPrefix"
+  <xsl:param name="doiId"
              select="''"/>
   <xsl:param name="defaultDoiPrefix"
              select="'https://doi.org/'"/>
@@ -156,14 +155,14 @@
     <datacite:identifier identifierType="DOI">
       <!-- Return existing one -->
       <xsl:choose>
-        <xsl:when test="$doiPrefix = ''">
+        <xsl:when test="$doiId = ''">
           <xsl:variable name="doiFromMetadataLinkage"
                         select="normalize-space(ancestor::mdb:MD_Metadata/mdb:metadataLinkage/*/cit:linkage/gco:CharacterString[starts-with(., $defaultDoiPrefix) or ../../cit:function/*/@codeListValue = 'doi'])"/>
           <xsl:value-of select="$doiFromMetadataLinkage"/>
         </xsl:when>
         <xsl:otherwise>
           <!-- Build a new one -->
-          <xsl:value-of select="concat($doiPrefix, '/', .)"/>
+          <xsl:value-of select="$$doiId"/>
         </xsl:otherwise>
       </xsl:choose>
     </datacite:identifier>

--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/datacite/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/datacite/view.xsl
@@ -87,11 +87,10 @@
               indent="yes"/>
 
   <!-- Before attribution of a DOI the ISO19139 record does not contain yet
-  the DOI value. It is built from the DOI prefix provided as parameter
-  and the UUID of the record.
+  the DOI value. It is built from the DOI id provided as parameter.
   If the DOI already exist in the record, this parameter is not set and the DOI
   is returned as datacite:identifier -->
-  <xsl:param name="doiPrefix"
+  <xsl:param name="doiId"
              select="''"/>
   <xsl:param name="defaultDoiPrefix"
              select="'https://doi.org/'"/>
@@ -132,7 +131,7 @@
     <datacite:identifier identifierType="DOI">
       <!-- Return existing one -->
       <xsl:choose>
-        <xsl:when test="$doiPrefix = ''">
+        <xsl:when test="$doiId = ''">
           <!-- DOI can be located in different places depending on user practice.
           At least we know two:
           * citation identifier
@@ -151,8 +150,7 @@
           </xsl:if>
         </xsl:when>
         <xsl:otherwise>
-          <!-- Build a new one -->
-          <xsl:value-of select="concat($doiPrefix, '/', .)"/>
+          <xsl:value-of select="$doiId"/>
         </xsl:otherwise>
       </xsl:choose>
     </datacite:identifier>

--- a/services/src/main/java/org/fao/geonet/api/records/DoiApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/DoiApi.java
@@ -101,6 +101,37 @@ public class DoiApi {
         return new ResponseEntity<>(reportStatus, HttpStatus.OK);
     }
 
+    @io.swagger.v3.oas.annotations.Operation(
+        summary = "Check the DOI URL created based on current configuration and pattern.")
+    @RequestMapping(value = "/{metadataUuid}/doi/checkDoiUrl",
+        method = RequestMethod.GET,
+        produces = {
+            MediaType.TEXT_PLAIN_VALUE
+        }
+    )
+    @PreAuthorize("hasAuthority('Editor')")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "DOI URL created."),
+        @ApiResponse(responseCode = "404", description = "Metadata not found."),
+        @ApiResponse(responseCode = "500", description = "Service unavailable."),
+        @ApiResponse(responseCode = "403", description = ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_EDIT)
+    })
+    public
+    @ResponseBody
+    ResponseEntity<String> checkDoiUrl(
+        @Parameter(
+            description = API_PARAM_RECORD_UUID,
+            required = true)
+        @PathVariable
+            String metadataUuid,
+        @Parameter(hidden = true)
+            HttpServletRequest request
+    ) throws Exception {
+        AbstractMetadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
+
+        return new ResponseEntity<>(doiManager.checkDoiUrl(metadata), HttpStatus.OK);
+    }
+
 
     @io.swagger.v3.oas.annotations.Operation(
         summary = "Submit a record to the Datacite metadata store in order to create a DOI.")

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -765,6 +765,8 @@
     "system/clickablehyperlinks/enable-help": "If set, GeoNetwork will display clickable hyperlinks in the metadata.",
     "system/publication": "Publication",
     "system/publication/doi/doienabled": "Allow creation of Digital Object Identifier (DOI)",
+    "system/publication/doi/doipattern": "DOI pattern",
+    "system/publication/doi/doipattern-help": "Default is '\\{\\{uuid\\}\\}' but the DOI structure can be customized with database id and/or record group eg. 'example-\\{\\{groupOwner\\}\\}-\\{\\{id\\}\\}'",
     "system/publication/doi/doienabled-help": "A Digital Object Identifier (DOI) is an alphanumeric string assigned to uniquely identify an object. It is tied to a metadata description of the object as well as to a digital location, such as a URL, where all the details about the object are accessible. More information available on <a href='https://www.datacite.org/dois.html'>DataCite website</a>.",
     "system/publication/doi/doipublicurl": "The final DOI URL prefix",
     "system/publication/doi/doipublicurl-help": "Keep it empty to use the default https://doi.org prefix. Use https://mds.test.datacite.org/doi when using the test API.",

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
@@ -712,6 +712,7 @@ INSERT INTO Settings (name, value, datatype, position, internal, encrypted) VALU
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/publication/doi/doikey', '', 0, 110095, 'n');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/publication/doi/doilandingpagetemplate', 'http://localhost:8080/geonetwork/srv/resources/records/{{uuid}}', 0, 100195, 'n');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/publication/doi/doipublicurl', '', 0, 100196, 'n');
+INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/publication/doi/doipattern', '{{uuid}}', 0, 100197, 'n');
 
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/security/passwordEnforcement/minLength', '6', 1, 12000, 'n');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/security/passwordEnforcement/maxLength', '20', 1, 12001, 'n');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v421/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v421/migrate-default.sql
@@ -1,5 +1,6 @@
 
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/metadataprivs/publicationbyrevieweringroupowneronly', 'true', 2, 9181, 'n');
+INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/publication/doi/doipattern', '{{uuid}}', 0, 100197, 'n');
 
 UPDATE Settings SET value='4.2.1' WHERE name='system/platform/version';
 UPDATE Settings SET value='SNAPSHOT' WHERE name='system/platform/subVersion';


### PR DESCRIPTION
When creating a DOI, the DOI id was created using `https://doi.org/{{prefix}}/{{uuid}}`

@pvgenuchten tested to customize the DataCite prefix in https://github.com/geonetwork/core-geonetwork/pull/6148
but as discussed it can be more flexible to add a new settings to customize the DOI with a pattern.

![image](https://user-images.githubusercontent.com/1701393/172330279-7330c05f-5291-4562-af30-2c7458bf444e.png)


Default is `{{uuid}}` but the DOI structure can be customized with database id and/or record group eg. `example-{{groupOwner}}-{{id}}` or simply `{{id}}`. Some users complain about the length of current DOI - so instead of relying on https://shortdoi.org/ user could use the internal db id if it is unique in the prefix scope ...

An API operation to check the DOI created is added.

![image](https://user-images.githubusercontent.com/1701393/172330299-d9ae6da8-495a-4275-b7b0-323a2ee9e9d9.png)
