### PR TITLE
Record view / Citation / ISO19139 fix

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/citation/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/citation/view.xsl
@@ -53,7 +53,7 @@
                         select=".//gmd:individualName[1]"/>
 
           <xsl:for-each select="$name">
-            <xsl:call-template name="get-iso19115-3.2018-localised">
+            <xsl:call-template name="localised">
               <xsl:with-param name="langId" select="$langId"/>
             </xsl:call-template>
           </xsl:for-each>
@@ -114,7 +114,7 @@
                         select=".//gmd:individualName[1]"/>
 
           <xsl:for-each select="$name">
-            <xsl:call-template name="get-iso19115-3.2018-localised">
+            <xsl:call-template name="localised">
               <xsl:with-param name="langId" select="$langId"/>
             </xsl:call-template>
           </xsl:for-each>

--- a/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionsDirective.js
@@ -501,6 +501,7 @@
             })
               .then(function(r) {
                 if(format === '?') {
+                  scope.formats = [];
                   for (var i = 0; i < r.data.length; i ++) {
                     var f = r.data[i],
                       prefix = 'cite.format.',
@@ -527,7 +528,6 @@
 
           function loadCitation() {
             scope.citationAvailable = false;
-            scope.formats = [];
             scope.getCitation('?').then(function() {
               scope.getCitation(scope.format || scope.defaultFormat);
             });


### PR DESCRIPTION
Avoid error on ISO19139 records

```
Error at xsl:call-template on line 117 column 69 of view.xsl:
  XTSE0650: No template exists named get-iso19115-3.2018-localised
```
due to 19115-3 dependency.

For testing enable citation in UI config

```json
'recordview': {
          'showCitation': {
            'enabled': true,
```

Also fix formats duplicated

![image](https://user-images.githubusercontent.com/1701393/172386111-70338fb5-bf85-4762-a7ed-edcf250416d5.png)
