### PR TITLE
iso19139-to-iso19115-3-2018 xslt converter outputs the wrong metadata standard name

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ISO19139/mapping/core.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ISO19139/mapping/core.xsl
@@ -231,17 +231,16 @@
   </xsl:template>
   <xsl:template match="gmd:metadataStandardName" priority="5" mode="from19139to19115-3.2018">
     <!--
-      metadataStandardName and gmd:metadataStandardVersion are combined into a CI_Citation
+      Output the converted record's new metadata standard name
     -->
     <mdb:metadataStandard>
       <cit:CI_Citation>
         <cit:title>
           <gco:CharacterString>ISO 19115-3:2018</gco:CharacterString>
         </cit:title>
-        <xsl:call-template name="writeCharacterStringElement">
-          <xsl:with-param name="elementName" select="'cit:edition'"/>
-          <xsl:with-param name="nodeWithStringToWrite" select="../gmd:metadataStandardVersion"/>
-        </xsl:call-template>
+        <cit:edition>
+          <gco:CharacterString>1.0</gco:CharacterString>
+        </cit:edition>
       </cit:CI_Citation>
     </mdb:metadataStandard>
   </xsl:template>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ISO19139/mapping/core.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ISO19139/mapping/core.xsl
@@ -231,27 +231,23 @@
   </xsl:template>
   <xsl:template match="gmd:metadataStandardName" priority="5"
                 mode="from19139to19115-3.2018">
-    <xsl:choose>
-      <!-- Replace default standard name with fixed value ....-->
-      <xsl:when test="matches(upper-case(gcoold:CharacterString), 'ISO\s?191(15|39)((:|\.)2003/19139)?')">
-        <mdb:metadataStandard>
-          <cit:CI_Citation>
+    <mdb:metadataStandard>
+      <cit:CI_Citation>
+        <xsl:choose>
+          <!-- Replace default standard name with fixed value ....-->
+          <xsl:when test="matches(upper-case(gcoold:CharacterString), 'ISO\s?191(15|39)((:|\.)2003/19139)?')">
             <cit:title>
               <gco:CharacterString>ISO 19115-3:2018</gco:CharacterString>
             </cit:title>
             <cit:edition>
               <gco:CharacterString>1.0</gco:CharacterString>
             </cit:edition>
-          </cit:CI_Citation>
-        </mdb:metadataStandard>
-      </xsl:when>
-      <!--
-        or combined custom ones metadataStandardName and gmd:metadataStandardVersion
-        into a CI_Citation
-      -->
-      <xsl:otherwise>
-        <mdb:metadataStandard>
-          <cit:CI_Citation>
+          </xsl:when>
+          <!--
+            or combined custom ones metadataStandardName and gmd:metadataStandardVersion
+            into a CI_Citation
+          -->
+          <xsl:otherwise>
             <xsl:call-template name="writeCharacterStringElement">
               <xsl:with-param name="elementName" select="'cit:title'"/>
               <xsl:with-param name="nodeWithStringToWrite" select="."/>
@@ -260,10 +256,10 @@
               <xsl:with-param name="elementName" select="'cit:edition'"/>
               <xsl:with-param name="nodeWithStringToWrite" select="../gmd:metadataStandardVersion"/>
             </xsl:call-template>
-          </cit:CI_Citation>
-        </mdb:metadataStandard>
-      </xsl:otherwise>
-    </xsl:choose>
+          </xsl:otherwise>
+        </xsl:choose>
+      </cit:CI_Citation>
+    </mdb:metadataStandard>
   </xsl:template>
   <!-- gmd:spatialRepresentationInfo uses default templates -->
   <xsl:template match="gmi:geographicCoordinates" mode="from19139to19115-3.2018">

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ISO19139/mapping/core.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ISO19139/mapping/core.xsl
@@ -235,7 +235,7 @@
       <cit:CI_Citation>
         <xsl:choose>
           <!-- Replace default standard name with fixed value ....-->
-          <xsl:when test="matches(upper-case(gcoold:CharacterString), 'ISO\s?191(15|39)((:|\.)2003/19139)?')">
+          <xsl:when test="matches(gcoold:CharacterString, '^ISO\s?191(15|39)((:|\.)2003/19139)?$', 'i')">
             <cit:title>
               <gco:CharacterString>ISO 19115-3:2018</gco:CharacterString>
             </cit:title>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ISO19139/mapping/core.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ISO19139/mapping/core.xsl
@@ -229,20 +229,41 @@
       </xsl:otherwise>
     </xsl:choose>
   </xsl:template>
-  <xsl:template match="gmd:metadataStandardName" priority="5" mode="from19139to19115-3.2018">
-    <!--
-      Output the converted record's new metadata standard name
-    -->
-    <mdb:metadataStandard>
-      <cit:CI_Citation>
-        <cit:title>
-          <gco:CharacterString>ISO 19115-3:2018</gco:CharacterString>
-        </cit:title>
-        <cit:edition>
-          <gco:CharacterString>1.0</gco:CharacterString>
-        </cit:edition>
-      </cit:CI_Citation>
-    </mdb:metadataStandard>
+  <xsl:template match="gmd:metadataStandardName" priority="5"
+                mode="from19139to19115-3.2018">
+    <xsl:choose>
+      <!-- Replace default standard name with fixed value ....-->
+      <xsl:when test="matches(upper-case(gcoold:CharacterString), 'ISO\s?191(15|39)((:|\.)2003/19139)?')">
+        <mdb:metadataStandard>
+          <cit:CI_Citation>
+            <cit:title>
+              <gco:CharacterString>ISO 19115-3:2018</gco:CharacterString>
+            </cit:title>
+            <cit:edition>
+              <gco:CharacterString>1.0</gco:CharacterString>
+            </cit:edition>
+          </cit:CI_Citation>
+        </mdb:metadataStandard>
+      </xsl:when>
+      <!--
+        or combined custom ones metadataStandardName and gmd:metadataStandardVersion
+        into a CI_Citation
+      -->
+      <xsl:otherwise>
+        <mdb:metadataStandard>
+          <cit:CI_Citation>
+            <xsl:call-template name="writeCharacterStringElement">
+              <xsl:with-param name="elementName" select="'cit:title'"/>
+              <xsl:with-param name="nodeWithStringToWrite" select="."/>
+            </xsl:call-template>
+            <xsl:call-template name="writeCharacterStringElement">
+              <xsl:with-param name="elementName" select="'cit:edition'"/>
+              <xsl:with-param name="nodeWithStringToWrite" select="../gmd:metadataStandardVersion"/>
+            </xsl:call-template>
+          </cit:CI_Citation>
+        </mdb:metadataStandard>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
   <!-- gmd:spatialRepresentationInfo uses default templates -->
   <xsl:template match="gmi:geographicCoordinates" mode="from19139to19115-3.2018">

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ISO19139/mapping/core.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ISO19139/mapping/core.xsl
@@ -235,10 +235,9 @@
     -->
     <mdb:metadataStandard>
       <cit:CI_Citation>
-        <xsl:call-template name="writeCharacterStringElement">
-          <xsl:with-param name="elementName" select="'cit:title'"/>
-          <xsl:with-param name="nodeWithStringToWrite" select="."/>
-        </xsl:call-template>
+        <cit:title>
+          <gco:CharacterString>ISO 19115-3:2018</gco:CharacterString>
+        </cit:title>
         <xsl:call-template name="writeCharacterStringElement">
           <xsl:with-param name="elementName" select="'cit:edition'"/>
           <xsl:with-param name="nodeWithStringToWrite" select="../gmd:metadataStandardVersion"/>


### PR DESCRIPTION
The 'ISO19139-to-ISO19115-3-2018' XSLT copies the name of the old metadata standard into the converted record.

Into an 'iso19115-3' record it inserts:

```
<mdb:metadataStandard>
<cit:CI_Citation>
<cit:title>
<gco:CharacterString>ISO 19115:2003/19139</gco:CharacterString>
</cit:title>
<cit:edition>
<gco:CharacterString>1.0</gco:CharacterString>
</cit:edition>
</cit:CI_Citation>
</mdb:metadataStandard>
```


It should be inserting this:

```
<mdb:metadataStandard>
<cit:CI_Citation>
<cit:title>
<gco:CharacterString>ISO 19115-3:2018</gco:CharacterString>
</cit:title>
<cit:edition>
<gco:CharacterString>1.0</gco:CharacterString>
</cit:edition>
</cit:CI_Citation>
</mdb:metadataStandard>
```

Without this fix, when there are a lot of records to upgrade, it is very laborious. Every record has to be edited after conversion.


