### PR TITLE
Editor / Configuration / Add condition on element and session for all.

### DIFF
--- a/schemas/config-editor.xsd
+++ b/schemas/config-editor.xsd
@@ -1007,6 +1007,7 @@ the mandatory section with no name and then the inner elements.
       <xs:attribute ref="or"/>
       <xs:attribute ref="in"/>
       <xs:attribute ref="displayIfRecord"/>
+      <xs:attribute ref="displayIfServiceInfo"/>
     </xs:complexType>
     <xs:unique name="avoidDuplicateFieldWithSameXPath">
       <xs:annotation>
@@ -1043,6 +1044,7 @@ the mandatory section with no name and then the inner elements.
         <xs:element ref="field"/>
       </xs:sequence>
       <xs:attribute name="name" use="required" type="xs:string"/>
+      <xs:attribute ref="displayIfServiceInfo"/>
     </xs:complexType>
   </xs:element>
 
@@ -1118,6 +1120,7 @@ Activate the "flat" mode at the tab level to make the form display only existing
         <xs:element ref="template" minOccurs="0" maxOccurs="1"/>
         <xs:element ref="directiveAttributes" minOccurs="0" maxOccurs="1"/>
       </xs:sequence>
+      <xs:attribute ref="displayIfServiceInfo"/>
       <xs:attribute name="if">
         <xs:annotation>
           <xs:documentation><![CDATA[
@@ -1353,6 +1356,7 @@ An XPath expression to evaluate. If true, the text is displayed.
           ]]></xs:documentation>
         </xs:annotation>
       </xs:attribute>
+      <xs:attribute ref="displayIfServiceInfo"/>
     </xs:complexType>
   </xs:element>
 
@@ -1613,6 +1617,7 @@ with the metadata identifier.
           ]]></xs:documentation>
         </xs:annotation>
       </xs:attribute>
+      <xs:attribute ref="displayIfServiceInfo"/>
       <xs:attribute name="class" type="xs:string">
         <xs:annotation>
           <xs:documentation>Optional CSS class to add to the parent div element. eg. gn-required to show a *.</xs:documentation>
@@ -2195,6 +2200,8 @@ Include any custom directive with required attributes.
       ]]></xs:documentation>
     </xs:annotation>
     <xs:complexType>
+      <xs:attribute ref="displayIfServiceInfo"/>
+      <xs:attribute ref="displayIfRecord"/>
       <xs:anyAttribute/>
     </xs:complexType>
   </xs:element>

--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
@@ -4,6 +4,7 @@
                 xmlns:gn-fn-core="http://geonetwork-opensource.org/xsl/functions/core"
                 xmlns:tr="java:org.fao.geonet.api.records.formatters.SchemaLocalizations"
                 xmlns:utils="java:org.fao.geonet.util.XslUtil"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:saxon="http://saxon.sf.net/"
                 extension-element-prefixes="saxon"
                 exclude-result-prefixes="#all"
@@ -391,35 +392,48 @@
   -->
   <xsl:template mode="render-view"
                 match="section[@xpath]">
-    <div id="gn-view-{generate-id()}" class="gn-tab-content">
-      <xsl:apply-templates mode="render-view" select="@xpath"/>
-      <xsl:comment select="'icon'"/>
-    </div>
+    <xsl:variable name="isDisplayed"
+                  as="xs:boolean"
+                  select="gn-fn-metadata:check-elementandsession-visibility(
+                  $schema, $metadata, $serviceInfo, @displayIfRecord, @displayIfServiceInfo)"/>
+
+    <xsl:if test="$isDisplayed">
+      <div id="gn-view-{generate-id()}" class="gn-tab-content">
+        <xsl:apply-templates mode="render-view" select="@xpath"/>
+        <xsl:comment select="'icon'"/>
+      </div>
+    </xsl:if>
   </xsl:template>
 
 
   <xsl:template mode="render-view"
                 match="section[not(@xpath)]">
+    <xsl:variable name="isDisplayed"
+                  as="xs:boolean"
+                  select="gn-fn-metadata:check-elementandsession-visibility(
+                  $schema, $metadata, $serviceInfo, @displayIfRecord, @displayIfServiceInfo)"/>
 
-    <xsl:variable name="content">
-      <xsl:apply-templates mode="render-view"
-                           select="section|field|xsl"/>&#160;
-    </xsl:variable>
+    <xsl:if test="$isDisplayed">
+      <xsl:variable name="content">
+        <xsl:apply-templates mode="render-view"
+                             select="section|field|xsl"/>&#160;
+      </xsl:variable>
 
-    <xsl:if test="count($content/*) > 0">
-      <div id="gn-section-{generate-id()}" class="gn-tab-content">
-        <xsl:if test="@name">
-          <xsl:variable name="title"
-                        select="
-                        if (contains( @name, ':'))
-                        then gn-fn-render:get-schema-labels($schemaLabels, @name)
-                        else gn-fn-render:get-schema-strings($schemaStrings, @name) "/>
-          <xsl:element name="h{1 + count(ancestor-or-self::*[name(.) = 'section'])}">
-            <xsl:value-of select="$title"/>
-          </xsl:element>
-        </xsl:if>
-        <xsl:copy-of select="$content"/>
-      </div>
+      <xsl:if test="count($content/*) > 0">
+        <div id="gn-section-{generate-id()}" class="gn-tab-content">
+          <xsl:if test="@name">
+            <xsl:variable name="title"
+                          select="
+                          if (contains( @name, ':'))
+                          then gn-fn-render:get-schema-labels($schemaLabels, @name)
+                          else gn-fn-render:get-schema-strings($schemaStrings, @name) "/>
+            <xsl:element name="h{1 + count(ancestor-or-self::*[name(.) = 'section'])}">
+              <xsl:value-of select="$title"/>
+            </xsl:element>
+          </xsl:if>
+          <xsl:copy-of select="$content"/>
+        </div>
+      </xsl:if>
     </xsl:if>
   </xsl:template>
 

--- a/web/src/main/webapp/xslt/ui-metadata/menu-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/menu-builder.xsl
@@ -80,7 +80,7 @@
 
                 <xsl:variable name="isViewDisplayed"
                               as="xs:boolean"
-                              select="gn-fn-metadata:check-viewtab-visibility(
+                              select="gn-fn-metadata:check-elementandsession-visibility(
                                         $schema, $metadata, $serviceInfo,
                                         @displayIfRecord,
                                         @displayIfServiceInfo)"/>
@@ -168,7 +168,7 @@
   <xsl:template mode="menu-builder" match="tab">
     <xsl:variable name="isTabDisplayed"
                   as="xs:boolean"
-                  select="gn-fn-metadata:check-viewtab-visibility(
+                  select="gn-fn-metadata:check-elementandsession-visibility(
                                         $schema, $metadata, $serviceInfo,
                                         @displayIfRecord,
                                         @displayIfServiceInfo)"/>

--- a/web/src/main/webapp/xslt/ui-metadata/menu-fn.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/menu-fn.xsl
@@ -29,44 +29,44 @@
                 extension-element-prefixes="saxon"
                 exclude-result-prefixes="#all">
 
+  <xsl:function name="gn-fn-metadata:check-condition" as="xs:boolean">
+    <xsl:param name="schema" as="xs:string"/>
+    <xsl:param name="base"/>
+    <xsl:param name="condition" as="xs:string?"/>
+
+    <xsl:choose>
+      <xsl:when test="$condition">
+        <xsl:variable name="prefixPath"
+                      select="if (local-name($base) = 'gui') then '/' else '/../'"/>
+        <saxon:call-template name="{concat('evaluate-', $schema, '-boolean')}">
+          <xsl:with-param name="base" select="$base"/>
+          <xsl:with-param name="in" select="concat($prefixPath, $condition)"/>
+        </saxon:call-template>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="false()"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+
   <!-- Evaluate XPath expression to
-                    see if view should be displayed
-                    according to the metadata record or
-                    the session information. -->
-  <xsl:function name="gn-fn-metadata:check-viewtab-visibility" as="xs:boolean">
+       see if view should be displayed
+       according to the metadata record or
+       the session information. -->
+  <xsl:function name="gn-fn-metadata:check-elementandsession-visibility" as="xs:boolean">
     <xsl:param name="schema" as="xs:string"/>
     <xsl:param name="metadata"/>
     <xsl:param name="serviceInfo"/>
     <xsl:param name="displayIfRecord" as="xs:string?"/>
     <xsl:param name="displayIfServiceInfo" as="xs:string?"/>
 
-    <xsl:variable name="isInRecord" as="xs:boolean">
-      <xsl:choose>
-        <xsl:when test="$displayIfRecord">
-          <saxon:call-template name="{concat('evaluate-', $schema, '-boolean')}">
-            <xsl:with-param name="base" select="$metadata"/>
-            <xsl:with-param name="in" select="concat('/../', $displayIfRecord)"/>
-          </saxon:call-template>
-        </xsl:when>
-        <xsl:otherwise>
-          <xsl:value-of select="false()"/>
-        </xsl:otherwise>
-      </xsl:choose>
-    </xsl:variable>
+    <xsl:variable name="isInRecord"
+                  as="xs:boolean"
+                  select="gn-fn-metadata:check-condition($schema, $metadata, $displayIfRecord)"/>
 
-    <xsl:variable name="isInServiceInfo" as="xs:boolean">
-      <xsl:choose>
-        <xsl:when test="$displayIfServiceInfo">
-          <saxon:call-template name="{concat('evaluate-', $schema, '-boolean')}">
-            <xsl:with-param name="base" select="$serviceInfo"/>
-            <xsl:with-param name="in" select="concat('/', $displayIfServiceInfo)"/>
-          </saxon:call-template>
-        </xsl:when>
-        <xsl:otherwise>
-          <xsl:value-of select="false()"/>
-        </xsl:otherwise>
-      </xsl:choose>
-    </xsl:variable>
+    <xsl:variable name="isInServiceInfo"
+                  as="xs:boolean"
+                  select="gn-fn-metadata:check-condition($schema, $serviceInfo, $displayIfServiceInfo)"/>
 
     <xsl:choose>
       <xsl:when test="$displayIfServiceInfo and $displayIfRecord">


### PR DESCRIPTION
Editor configuration allows to conditionnaly display elements or not. Condition based on session info (eg. user profile) was only allowed for `view` and `tab` elements. Apply condition on the current record and on session for all elements (`field`, `section`, `text`, `directive`, `action`).

Example:
* Display a view for admin only
```xml
 <view name="custom-view"
          displayIfServiceInfo="count(session[profile = 'Administrator']) = 1"
```

* Display help text for non geographic dataset
```xml
<text if="count(gmd:MD_Metadata/gmd:hierarchyLevel[*/@codeListValue =
          'nonGeographicDataset']) = 1"
                ref="eea-conformity-help"/>
```

* Display an action if the element does not exist and user is admin
```xml
<action   type="add"
          btnLabel="eea-add-identifier"
          if="count(gmd:MD_Metadata/gmd:identificationInfo/*/gmd:citation/*/gmd:identifier/*/gmd:code) = 0"
          displayIfServiceInfo="count(session[profile = 'Administrator']) = 1"
          or="identifier"
          in="/gmd:MD_Metadata/gmd:identificationInfo/*/gmd:citation/*">
    <template>
      <snippet>
        <gmd:identifier>
          <gmd:MD_Identifier>
            <gmd:code>
              <gco:CharacterString>[Provider_DataType_EpsgCode_ScaleResolution_ScaleResUnit_DatasetShortName_PublicOrInternal_TimeCoverage_VersionNumber_RevisionNumber]</gco:CharacterString>
            </gmd:code>
          </gmd:MD_Identifier>
        </gmd:identifier>
      </snippet>
    </template>
  </action>
```

* Customize side panel based on resource type
```xml
<sidePanel>
<!-- No overview for non geographic dataset -->
<directive data-gn-overview-manager=""
           displayIfRecord="not(contains(gmd:MD_Metadata/
                            gmd:hierarchyLevel/*/@codeListValue,
                            'nonGeographicDataset'))"/>
<!-- All type of links for spatial dataset -->
<directive data-gn-onlinesrc-list=""
           data-types="onlinesrc|parent|dataset|service|source|sibling|associated|fcats"
           displayIfRecord="not(contains(gmd:MD_Metadata/
                            gmd:hierarchyLevel/*/@codeListValue,
                            'nonGeographicDataset'))"/>
<!-- only online resource, parent and source for non geographic dataset -->
<directive data-gn-onlinesrc-list=""
           data-types="onlinesrc|parent|source"
           displayIfRecord="contains(gmd:MD_Metadata/
                            gmd:hierarchyLevel/*/@codeListValue,
                            'nonGeographicDataset')"/>

```