### PR TITLE
Externalise the configuration of targetUri property

### DIFF
--- a/web/src/main/java/org/fao/geonet/proxy/URITemplateProxyServlet.java
+++ b/web/src/main/java/org/fao/geonet/proxy/URITemplateProxyServlet.java
@@ -142,7 +142,7 @@ public class URITemplateProxyServlet extends org.mitre.dsmiley.httpproxy.URITemp
         }
         super.initTarget();
 
-        // If baseUri is not set in web.xml try to resolve it from java properties or environment variables.
+        // If targetUri is not set in web.xml try to resolve it from java properties or environment variables.
         // The name is composed by the application base url,  servlet name, a point or an underscore and baseurl word.
         if (StringUtils.isBlank(targetUriTemplate)) {
             targetUriTemplate = StringUtils.defaultString(getConfigValue(TARGET_URI_NAME), "");
@@ -150,8 +150,8 @@ public class URITemplateProxyServlet extends org.mitre.dsmiley.httpproxy.URITemp
     }
 
     private String getConfigValue(String sufix) {
-        String result = null;
-        // If baseUri is not set in web.xml try to resolve it from java properties or environment variables.
+        String result;
+        // If targetUri is not set in web.xml try to resolve it from java properties or environment variables.
         // The name is composed by the servlet name, a point or an underscore and baseurl word.
 
 

--- a/web/src/main/java/org/fao/geonet/proxy/URITemplateProxyServlet.java
+++ b/web/src/main/java/org/fao/geonet/proxy/URITemplateProxyServlet.java
@@ -168,7 +168,7 @@ public class URITemplateProxyServlet extends org.mitre.dsmiley.httpproxy.URITemp
         if (StringUtils.isBlank(result)) {
             // GEONETWORK is the default prefix
 
-            LOGGER.info("Property " + TARGET_URI_NAME + " of servlet " + getServletName() + " is not set in web.xml. " +
+            LOGGER.info("Property " + sufix + " of servlet " + getServletName() + " is not set in web.xml. " +
                 "Looking for its value in Environment variables, System properties and config.properties entries");
             result = resolveConfigValue("geonetwork." + getServletName() + "." + sufix);
         }

--- a/web/src/main/java/org/fao/geonet/proxy/URITemplateProxyServlet.java
+++ b/web/src/main/java/org/fao/geonet/proxy/URITemplateProxyServlet.java
@@ -143,16 +143,17 @@ public class URITemplateProxyServlet extends org.mitre.dsmiley.httpproxy.URITemp
         super.initTarget();
 
         // If targetUri is not set in web.xml try to resolve it from java properties or environment variables.
-        // The name is composed by the application base url,  servlet name, a point or an underscore and baseurl word.
+        // The name is composed by the application base url,  servlet name, a point or an underscore and targetUri word.
         if (StringUtils.isBlank(targetUriTemplate)) {
             targetUriTemplate = StringUtils.defaultString(getConfigValue(TARGET_URI_NAME), "");
         }
     }
 
     private String getConfigValue(String sufix) {
-        String result;
         // If targetUri is not set in web.xml try to resolve it from java properties or environment variables.
-        // The name is composed by the servlet name, a point or an underscore and baseurl word.
+        // The name is composed by the servlet name, a point or an underscore and targetUri word.
+        String result;
+
 
 
         // Property defined according to webapp name


### PR DESCRIPTION
The targetUri property of proxyURITemplateProxyServlet can be now defined externally to `web.xml`. The value defined externally will override the one defined in `web.xml`.
The lookup order in that case would be:

1.  `${GEONETWORK_APP_NAME}_${SERVLET_NAME}_TARGETURI}`: look for an environment variable, for example `MYWEBAPP_MICROSERVICESPROXY_TARGETURI`
2. `${GEONETWORK_APP_NAME}.${SERVLET_NAME}.targetUri`: Look for a system property, for example `mywebapp.MicroservicesProxy.targetUri`
3. `${GEONETWORK_APP_NAME}.${SERVLET_NAME}.targetUri`: Look for a property in `config.properties`, for example `mywebapp.MicroservicesProxy.targetUri`
4. `GEONETWORK_${SERVLET_NAME}_TARGETURI`: Look for an environment variable starting by GEONETWORK, for example `GEONETWORK_MICROSERVICESPROXY_TARGETURI`
5. `geonetwork.${SERVLET_NAME}.targetUri`: Look for a property in `config.properties` starting by `geonetwork`, for example `geonetwork.MicroservicesProxy.targetUri`
6. `geonetwork.${SERVLET_NAME}.targetUri`: Look for a property in `config.properties` starting by `geonetwork`, for example `geonetwork.MicroservicesProxy.targetUri`
7.  Finally, it checks the value of `targetUri` in `web.xml` if no external config has been found.

The mechanism is similar to the one used to set the data directory, looking first for properties prefixed by the web application name and the servlet name in `web.xml` and if nothing is found using `geonetwork` as application name.