### PR TITLE
Disable the DOI publication in the metadata editor for metadata using the metadata workflow

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -353,8 +353,8 @@
    *
    */
       .directive('gnOnlinesrcList', ['gnOnlinesrc', 'gnCurrentEdit',
-        'gnConfigService', '$filter',
-        function(gnOnlinesrc, gnCurrentEdit, gnConfigService, $filter) {
+        'gnConfigService', '$filter', 'gnConfig',
+        function(gnOnlinesrc, gnCurrentEdit, gnConfigService, $filter, gnConfig) {
           return {
             restrict: 'A',
             templateUrl: '../../catalog/components/edit/onlinesrc/' +
@@ -371,6 +371,8 @@
               scope.gnCurrentEdit.associatedPanelConfigId = attrs['configId'] || 'default';
               scope.relations = {};
               scope.gnCurrentEdit.codelistFilter  = attrs['codelistFilter'];
+              scope.isMdWorkflowEnableForMetadata = gnConfig['metadata.workflow.enable'] &&
+                angular.isDefined(scope.gnCurrentEdit.metadata.mdStatus);
 
               /**
                * Calls service 'relations.get' to load

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -371,10 +371,13 @@
               scope.gnCurrentEdit.associatedPanelConfigId = attrs['configId'] || 'default';
               scope.relations = {};
               scope.gnCurrentEdit.codelistFilter  = attrs['codelistFilter'];
-              scope.isDoiEnabled = gnConfig['system.publication.doi.doienabled'];
               scope.isMdWorkflowEnableForMetadata = gnConfig['metadata.workflow.enable'] &&
                 scope.gnCurrentEdit.metadata.draft === 'y';
-              scope.isMdPublished = scope.gnCurrentEdit.metadata.isPublishedToAll === 'true';
+              scope.isDoiApplicableForMetadata = gnConfig['system.publication.doi.doienabled']
+                && scope.gnCurrentEdit.metadata.isTemplate === 'n'
+                && scope.gnCurrentEdit.metadata.isPublished()
+                && JSON.parse(scope.gnCurrentEdit.metadata.isHarvested) === false;
+
 
               /**
                * Calls service 'relations.get' to load
@@ -407,11 +410,10 @@
                *
                */
               scope.canPublishDoiForResource = function (resource){
-                return scope.isDoiEnabled
+                return scope.isDoiApplicableForMetadata
                   && resource.lUrl !== null
                   && resource.lUrl.match('doi.org') !== null
-                  && !scope.isMdWorkflowEnableForMetadata
-                  && scope.isMdPublished;
+                  && !scope.isMdWorkflowEnableForMetadata;
               }
 
               /**

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -371,8 +371,10 @@
               scope.gnCurrentEdit.associatedPanelConfigId = attrs['configId'] || 'default';
               scope.relations = {};
               scope.gnCurrentEdit.codelistFilter  = attrs['codelistFilter'];
+              scope.isDoiEnabled = gnConfig['system.publication.doi.doienabled'];
               scope.isMdWorkflowEnableForMetadata = gnConfig['metadata.workflow.enable'] &&
-                angular.isDefined(scope.gnCurrentEdit.metadata.mdStatus);
+                scope.gnCurrentEdit.metadata.draft === 'y';
+              scope.isMdPublished = scope.gnCurrentEdit.metadata.isPublishedToAll === 'true';
 
               /**
                * Calls service 'relations.get' to load
@@ -395,6 +397,22 @@
                 return angular.isUndefined(scope.types) ? true :
                         category.match(scope.types) !== null;
               };
+
+              /**
+               * Doi can be published for a resource if:
+               *   - Doi publication is enabled.
+               *   - The resource matches doi.org url
+               *   - The workflow is not enabled for the metadata and
+               *     the metadata is published.
+               *
+               */
+              scope.canPublishDoiForResource = function (resource){
+                return scope.isDoiEnabled
+                  && resource.lUrl !== null
+                  && resource.lUrl.match('doi.org') !== null
+                  && !scope.isMdWorkflowEnableForMetadata
+                  && scope.isMdPublished;
+              }
 
               /**
                * Builds metadata url checking if the resource points to internal or external url.

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/onlinesrcList.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/onlinesrcList.html
@@ -174,9 +174,7 @@
                 <strong>{{resource.title | gnLocalized: lang}}</strong><br/>
                 {{resource.description | gnLocalized: lang}}
 
-                <div data-ng-if="resource.lUrl !== null
-                                 && resource.lUrl.match('doi.org') !== null
-                                 && !isMdWorkflowEnableForMetadata"
+                <div data-ng-if="canPublishDoiForResource(resource)"
                      data-gn-doi-wizard="gnCurrentEdit.uuid"
                      data-gn-doi-url="resource.lUrl"
                      data-xs-mode="true"></div>

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/onlinesrcList.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/onlinesrcList.html
@@ -175,7 +175,8 @@
                 {{resource.description | gnLocalized: lang}}
 
                 <div data-ng-if="resource.lUrl !== null
-                                 && resource.lUrl.match('doi.org') !== null"
+                                 && resource.lUrl.match('doi.org') !== null
+                                 && !isMdWorkflowEnableForMetadata"
                      data-gn-doi-wizard="gnCurrentEdit.uuid"
                      data-gn-doi-url="resource.lUrl"
                      data-xs-mode="true"></div>


### PR DESCRIPTION
This code change, hides the DOI publication option in the metadata editor, when the metadata workflow is enabled for a metadata, as only approved / published metadata can request DOI publication. 

To publish DOI of a metadata in the workflow, first should be approved / published. This action in the metadata editor should not be available.