### PR TITLE
Standard / ISO / Collection updater / Collect temporal extent

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/process/collection-updater.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/process/collection-updater.xsl
@@ -72,11 +72,9 @@
     <tag name="mri:descriptiveKeywords" context="mri:MD_DataIdentification"
          groupBy="*/mri:thesaurusName/*/cit:title/*/text()"
          merge="mri:keyword"/>
-    <!-- TODO: temporalElement is also part of mri:extent.
-    How to group by both? -->
     <tag name="mri:extent" context="mri:MD_DataIdentification"
-         groupBy="*/gex:geographicElement"
-         merge="gex:geographicElement"/>
+         groupBy="*/(gex:geographicElement|gex:temporalElement)"
+         merge="gex:geographicElement|gex:temporalElement"/>
     <!-- TODO: mri:defaultLocale can be in various places. -->
     <tag name="mri:defaultLocale" context="mri:MD_DataIdentification"
          groupBy="mri:defaultLocaleCode/lan:PT_Locale/lan:language/lan:LanguageCode/@codeListValue"

--- a/schemas/iso19139/src/main/plugin/iso19139/process/collection-merge-utility.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/process/collection-merge-utility.xsl
@@ -77,6 +77,7 @@
                               select="saxon:evaluate(
                                 concat('$p1[', $groupBy, ' = ''',
                                  replace($groupKey, '''', '''''') ,''']'), $match)"/>
+
                 <!--
                 <xsl:message>empty: <xsl:value-of select="$emptyKey"/> </xsl:message>
                 <xsl:message> Groups: <xsl:copy-of select="$groupValues"/></xsl:message>-->
@@ -111,7 +112,7 @@
                               <xsl:choose>
                                 <!-- Merge
                                 eg. gmd:keyword -->
-                                <xsl:when test="current() = $merge">
+                                <xsl:when test="current() = tokenize($merge, '\|')">
                                   <xsl:variable name="elementsToMerge"
                                                 select="$groupValues/*/*[name() = current()]"/>
                                   <xsl:variable name="isTextElement"

--- a/schemas/iso19139/src/main/plugin/iso19139/process/collection-updater.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/process/collection-updater.xsl
@@ -68,11 +68,9 @@
     <tag name="gmd:descriptiveKeywords" context="gmd:MD_DataIdentification"
          groupBy="*/gmd:thesaurusName/*/gmd:title/*/text()"
          merge="gmd:keyword"/>
-    <!-- TODO: temporalElement is also part of gmd:extent.
-    How to group by both? -->
     <tag name="gmd:extent" context="gmd:MD_DataIdentification"
-         groupBy="*/gmd:geographicElement"
-         merge="gmd:geographicElement"/>
+         groupBy="*/(gmd:geographicElement|gmd:temporalElement)"
+         merge="gmd:geographicElement|gmd:temporalElement"/>
     <!-- TODO: gmd:language can be in various places. -->
     <tag name="gmd:language" context="gmd:MD_DataIdentification"
          groupBy="gmd:LanguageCode/@codeListValue"


### PR DESCRIPTION
Only geographic element was retrieved from members. This adds synchronization of temporal element too.

When a series is composed of one or more record the `collection-updater` suggested process can be triggered to update the series information. eg. a series composed of 2 records

![image](https://user-images.githubusercontent.com/1701393/172611263-a0e53e32-fa73-4ddc-8be1-cef51f2bbe3a.png)

Then temporal extent are now combined and added to the series:

![image](https://user-images.githubusercontent.com/1701393/172611023-1ed84fe0-e00b-4a99-80db-ae596e4ef182.png)
