### PR TITLE
Backport: iso19139-to-iso19115-3-2018 xslt converter outputs the wrong metadata standard name

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ISO19139/mapping/core.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ISO19139/mapping/core.xsl
@@ -230,19 +230,33 @@
     </xsl:choose>
   </xsl:template>
   <xsl:template match="gmd:metadataStandardName" priority="5" mode="from19139to19115-3.2018">
-    <!--
-      metadataStandardName and gmd:metadataStandardVersion are combined into a CI_Citation
-    -->
     <mdb:metadataStandard>
       <cit:CI_Citation>
-        <xsl:call-template name="writeCharacterStringElement">
-          <xsl:with-param name="elementName" select="'cit:title'"/>
-          <xsl:with-param name="nodeWithStringToWrite" select="."/>
-        </xsl:call-template>
-        <xsl:call-template name="writeCharacterStringElement">
-          <xsl:with-param name="elementName" select="'cit:edition'"/>
-          <xsl:with-param name="nodeWithStringToWrite" select="../gmd:metadataStandardVersion"/>
-        </xsl:call-template>
+        <xsl:choose>
+          <!-- Replace default standard name with fixed value ....-->
+          <xsl:when test="matches(gcoold:CharacterString, '^ISO\s?191(15|39)((:|\.)2003/19139)?$', 'i')">
+            <cit:title>
+              <gco:CharacterString>ISO 19115-3:2018</gco:CharacterString>
+            </cit:title>
+            <cit:edition>
+              <gco:CharacterString>1.0</gco:CharacterString>
+            </cit:edition>
+          </xsl:when>
+          <!--
+            or combined custom ones metadataStandardName and gmd:metadataStandardVersion
+            into a CI_Citation
+          -->
+          <xsl:otherwise>
+            <xsl:call-template name="writeCharacterStringElement">
+              <xsl:with-param name="elementName" select="'cit:title'"/>
+              <xsl:with-param name="nodeWithStringToWrite" select="."/>
+            </xsl:call-template>
+            <xsl:call-template name="writeCharacterStringElement">
+              <xsl:with-param name="elementName" select="'cit:edition'"/>
+              <xsl:with-param name="nodeWithStringToWrite" select="../gmd:metadataStandardVersion"/>
+            </xsl:call-template>
+          </xsl:otherwise>
+        </xsl:choose>
       </cit:CI_Citation>
     </mdb:metadataStandard>
   </xsl:template>


### PR DESCRIPTION
Enable fixed default metadata std name for iso19115-3 conversion
But if the source metadata name is not the standard iso19139, it will pass it through instead

This is a backport of PR#6354 for 3.12.x branch