### PR TITLE
Harvester / OGC WxS / After applying conversion, update schema

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/ogcwxs/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/ogcwxs/Harvester.java
@@ -335,7 +335,7 @@ class Harvester extends BaseAligner<OgcWxSParams> implements IHarvester<HarvestR
         }
 
 
-        final String schema = dataMan.autodetectSchema(md, null);
+        String schema = dataMan.autodetectSchema(md, null);
         if (schema == null) {
             log.warning("Skipping metadata with unknown schema.");
             result.unknownSchema++;
@@ -399,6 +399,7 @@ class Harvester extends BaseAligner<OgcWxSParams> implements IHarvester<HarvestR
             importXsl = importXsl.resolve(importXslFile);
             log.info("Applying custom import XSL " + importXsl.getFileName());
             md = Xml.transform(md, importXsl);
+            schema = dataMan.autodetectSchema(md, null);
         }
 
 
@@ -795,6 +796,19 @@ class Harvester extends BaseAligner<OgcWxSParams> implements IHarvester<HarvestR
                         resolve("OGC" + params.ogctype.substring(0, 3) + "GetCapabilitiesLayer-to-19139.xsl");
 
                     xml = Xml.transform(capa, styleSheet, param);
+
+                    // Apply custom transformation if requested
+                    Path importXsl = context.getAppPath().resolve(Geonet.Path.IMPORT_STYLESHEETS);
+                    String importXslFile = params.getImportXslt();
+                    if (importXslFile != null && !importXslFile.equals("none")) {
+                        if (!importXslFile.endsWith("xsl")) {
+                            importXslFile = importXslFile + ".xsl";
+                        }
+                        importXsl = importXsl.resolve(importXslFile);
+                        log.info("Applying custom import XSL " + importXsl.getFileName());
+                        xml = Xml.transform(xml, importXsl);
+                    }
+
                     if (log.isDebugEnabled()) {
                         log.debug("  - Layer loaded using GetCapabilities document.");
                     }

--- a/web-ui/src/main/resources/catalog/js/admin/HarvestSettingsController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/HarvestSettingsController.js
@@ -548,7 +548,7 @@
               },
               {
                 "terms": {
-                  "cl_hierarchyLevel.key": ["service"]
+                  "resourceType": ["service"]
                 }
               }]
             }
@@ -579,7 +579,7 @@
               },
                 {
                   "terms": {
-                    "cl_hierarchyLevel.key": ["dataset"]
+                    "resourceType": ["dataset"]
                   }
                 }]
             }


### PR DESCRIPTION
Eg. when running harvesting with 19139 to 115-3 conversion, the record was registered with 19139 schema (with indexing error). The conversion was also only applied to the service record and not its datasets.

Also fix the lists of template which were not listing 115-3 templates (cl_hierarchyLevel field is 19139 specific, resourceType works with all ISO schemas).

![image](https://user-images.githubusercontent.com/1701393/173533203-ddf4c28c-fe70-4e56-83a0-00fd252f91ac.png)
