### PR TITLE
[a11y] Small fix to make the copy button from the copy2clipboard option accessible

### DIFF
--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -737,6 +737,7 @@
         replace: true,
         template: '<a class="{{::btnClass || \'btn btn-default btn-xs\'}}" ' +
           '           ng-click="copy()" ' +
+          '           href=""' +
           '           title="{{::title | translate}}">' +
           '  <i class="fa fa-fw" ' +
           '   ng-class="{\'fa-copy\': !copied, \'fa-check\': copied}"/>' +


### PR DESCRIPTION
Replaces: https://github.com/geonetwork/core-geonetwork/pull/6212

Small fix to make the copy button from the copy2clipboard option accessible by adding `href`