### PR TITLE
Update datepicker widget to configure the display of the date mode selector

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/datepicker/DatePickerDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/datepicker/DatePickerDirective.js
@@ -55,7 +55,8 @@
              tagName: '@',
              indeterminatePosition: '@',
              required: '@',
-             hideTime: '@'
+             hideTime: '@',
+             hideDateMode: '@'
            },
            templateUrl: '../../catalog/components/edit/datepicker/partials/' +
            'datepicker.html',
@@ -67,6 +68,8 @@
              scope.dateTypeSupported = Modernizr.inputtypes.date;
              scope.isValidDate = true;
              scope.hideTime = scope.hideTime == 'true';
+             // Hide the date mode picker: date / datetime / month-year / year
+             scope.hideDateMode = scope.hideDateMode == 'true';
 
              var getTimeZoneOffset = function(timeZone) {
                var actualTz = timeZone;

--- a/web-ui/src/main/resources/catalog/components/edit/datepicker/partials/datepicker.html
+++ b/web-ui/src/main/resources/catalog/components/edit/datepicker/partials/datepicker.html
@@ -45,7 +45,7 @@
              data-ng-hide="mode !== '' || !hideTimezone"
              data-ng-model="timezone" />
 
-      <div class="input-group-btn">
+      <div class="input-group-btn" data-ng-show="!hideDateMode">
         <button type="button" class="btn btn-default dropdown-toggle" data-toggle="dropdown">
           <i class="fa fa-clock-o"></i>&nbsp;<span class="caret"></span>
         </button>

--- a/web-ui/src/main/resources/catalog/style/gn_editor.less
+++ b/web-ui/src/main/resources/catalog/style/gn_editor.less
@@ -330,12 +330,12 @@ form.gn-editor {
       width: 15%;
     }
     > input.gn-date.gn-notime {
-      width: 100%;
+      width: 100% !important;
     }
     > input.gn-time.hidden,
     > select.gn-timezone.hidden,
     > input.gn-timezone.hidden{
-      width: 0%;
+      width: 0% !important;
     }
     .gn-indeterminate-position {
       display: table-cell;


### PR DESCRIPTION
Add a configuration parameter to show / hide the date mode selector. To use it for example in iso19139 metadata for the data information dates, to hide the selector, update the following code:

https://github.com/geonetwork/core-geonetwork/blob/3d16732759f656ff1aa7108a6c6bbd80498b6ae8/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields-date.xsl#L135-L141

```
 <div data-gn-date-picker="{gco:Date|gco:DateTime}" 
      data-gn-field-tooltip="{$tooltip}" 
      data-label="" 
      data-element-name="{name(gco:Date|gco:DateTime)}" 
      data-element-ref="{concat('_X', gn:element/@ref)}" 
      data-hide-date-mode="true"
      data-hide-time="{if ($viewConfig/@hideTimeInCalendar = 'true') then 'true' else 'false'}"> 
 </div> 
```

This is useful to force the widget to support only date / datetime format, excluding the options for month/year and year.

![datepicker-datemode](https://user-images.githubusercontent.com/1695003/173802894-52ab7762-7571-4b27-a8f8-9accc316d9db.png)

![datepicker-nodatemode](https://user-images.githubusercontent.com/1695003/173802916-5c068fb4-bdde-4efd-b585-61bb3299e2d3.png)

