### PR TITLE
API / INSPIRE Atom / Migration to Elasticsearch

### DIFF
--- a/inspire-atom/src/main/java/org/fao/geonet/inspireatom/harvester/InspireAtomHarvester.java
+++ b/inspire-atom/src/main/java/org/fao/geonet/inspireatom/harvester/InspireAtomHarvester.java
@@ -125,7 +125,7 @@ public class InspireAtomHarvester {
                 processServiceMetadataFeeds(dataMan, serviceMetadataWithAtomFeeds, result);
 
             // Process DATASET metadata feeds related to the service metadata
-            logger.info("ATOM feed harvest : processing dataset metadata feeds (" + datasetsInformation.size() + ")");
+            logger.info("ATOM feed harvest: processing dataset metadata feeds (" + datasetsInformation.size() + ")");
             processDatasetsMetadataFeeds(dataMan, datasetsInformation, result);
 
             logger.info("ATOM feed harvest finished");
@@ -222,10 +222,9 @@ public class InspireAtomHarvester {
             String metadataUuid = dataMan.getMetadataUuid(metadataId);
 
             try {
-                logger.info("Processing feed (" + i++ + "/"+ total + ") for service metadata with uuid:" + metadataUuid);
-
                 String atomUrl = entry.getValue();
-                logger.debug("Atom feed Url for service metadata (" + metadataUuid + "): " + atomUrl);
+                logger.info("Processing feed (" + i++ + "/"+ total + ") for service metadata with uuid:" + metadataUuid);
+                logger.info("Atom feed Url for service metadata (" + metadataUuid + "): " + atomUrl);
 
                 String atomFeedDocument = InspireAtomUtil.retrieveRemoteAtomFeedDocument(gc, atomUrl);
                 logger.debug("Atom feed Document for service metadata (" + metadataUuid + "): " + atomFeedDocument);

--- a/inspire-atom/src/main/java/org/fao/geonet/inspireatom/util/InspireAtomUtil.java
+++ b/inspire-atom/src/main/java/org/fao/geonet/inspireatom/util/InspireAtomUtil.java
@@ -22,11 +22,13 @@
 //==============================================================================
 package org.fao.geonet.inspireatom.util;
 
-import jeeves.constants.Jeeves;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jeeves.server.ServiceConfig;
 import jeeves.server.context.ServiceContext;
-import org.apache.commons.lang.NotImplementedException;
 import org.apache.commons.lang.StringUtils;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.search.SearchHit;
 import org.fao.geonet.GeonetContext;
 import org.fao.geonet.api.exception.ResourceNotFoundException;
 import org.fao.geonet.constants.Geonet;
@@ -35,7 +37,8 @@ import org.fao.geonet.domain.ReservedOperation;
 import org.fao.geonet.exceptions.UnAuthorizedException;
 import org.fao.geonet.inspireatom.model.DatasetFeedInfo;
 import org.fao.geonet.kernel.DataManager;
-import org.fao.geonet.kernel.search.ISearchManager;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
+import org.fao.geonet.kernel.search.EsSearchManager;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.lib.Lib;
 import org.fao.geonet.util.XslUtil;
@@ -46,16 +49,12 @@ import org.fao.geonet.utils.XmlRequest;
 import org.jdom.Document;
 import org.jdom.Element;
 import org.jdom.Namespace;
-import org.jdom.Text;
-import org.jdom.xpath.XPath;
 
 import java.net.URL;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+
+import static org.fao.geonet.kernel.search.EsSearchManager.FIELDLIST_CORE;
 
 
 /**
@@ -224,8 +223,8 @@ public class InspireAtomUtil {
     }
 
     /**
-     * @param atomFeedDocument  Atom service feed document
-     * @param dataManager       DataManager.
+     * @param atomFeedDocument Atom service feed document
+     * @param dataManager      DataManager.
      * @return List of datasets referenced in the service feed.
      * @throws Exception Exception.
      */
@@ -331,170 +330,226 @@ public class InspireAtomUtil {
     }
 
     public static List<AbstractMetadata> searchMetadataByTypeAndProtocol(ServiceContext context,
-                                                              ISearchManager searchMan,
-                                                              String type,
-                                                              String protocol) {
-            Element request = new Element(Jeeves.Elem.REQUEST);
-            request.addContent(new Element("type").setText(type));
-            request.addContent(new Element("protocol").setText(protocol));
-            request.addContent(new Element("fast").setText("true"));
+                                                                         EsSearchManager searchMan,
+                                                                         String type,
+                                                                         String protocol) {
+        String jsonQuery = "{" +
+            "    \"bool\": {" +
+            "      \"must\": [" +
+            "        {" +
+            "          \"term\": {" +
+            "            \"resourceType\": {" +
+            "              \"value\": \"%s\"" +
+            "            }" +
+            "          }" +
+            "        }, " +
+            "        {" +
+            "          \"nested\": {" +
+            "            \"path\": \"link\"," +
+            "            \"query\": {" +
+            "              \"term\": {" +
+            "                \"link.protocol\": {" +
+            "                  \"value\": \"%s\"" +
+            "                }" +
+            "              }" +
+            "            }" +
+            "          }" +
+            "        }" +
+            "      ]" +
+            "    }" +
+            "}";
+        ObjectMapper objectMapper = new ObjectMapper();
+        List<AbstractMetadata> allMdInfo = new ArrayList<>();
 
-            // TODOES
-            throw new NotImplementedException("Not implemented in ES");
-            // perform the search and return the results read from the index
-            //        try (MetaSearcher searcher = searchMan.newSearcher(SearcherType.LUCENE, Geonet.File.SEARCH_LUCENE)) {
-            //            searcher.search(context, request, new ServiceConfig());
-            //
-            //            Map<Integer, AbstractMetadata> allMdInfo = ((LuceneSearcher) searcher).getAllMdInfo(context, searcher.getSize());
-            //            return new ArrayList<>(allMdInfo.values());
-            //        } catch (Exception ex) {
-            //            Log.error(Geonet.ATOM, ex.getMessage(), ex);
-            //            return new ArrayList<>();
+        try {
+            JsonNode esJsonQuery = objectMapper.readTree(String.format(jsonQuery, type, protocol));
+
+            final SearchResponse result = searchMan.query(
+                esJsonQuery,
+                FIELDLIST_CORE,
+                0, 10000);
+
+            IMetadataUtils dataManager = context.getBean(IMetadataUtils.class);
+            for (SearchHit hit : result.getHits()) {
+                String id = hit.getSourceAsMap().get(Geonet.IndexFieldNames.ID).toString();
+                allMdInfo.add(dataManager.findOne(id));
+            }
+        } catch (Exception ex) {
+            Log.error(Geonet.ATOM, ex.getMessage(), ex);
+            return new ArrayList<>();
         }
+        return allMdInfo;
+    }
 
 
-        public static String retrieveDatasetUuidFromIdentifier (ServiceContext context,
-            ISearchManager searchMan,
-            String datasetIdCode){
+    public static String retrieveDatasetUuidFromIdentifier(ServiceContext context,
+                                                           EsSearchManager searchMan,
+                                                           String datasetIdCode) {
+        String jsonQuery = "{" +
+            "    \"bool\": {" +
+            "      \"must\": [" +
+            "        {" +
+            "          \"term\": {" +
+            "            \"resourceIdentifier.code\": {" +
+            "              \"value\": \"%s\"" +
+            "            }" +
+            "          }" +
+            "        }" +
+            "      ]" +
+            "    }" +
+            "}";
+        ObjectMapper objectMapper = new ObjectMapper();
 
-            String uuid = "";
+        try {
+            JsonNode esJsonQuery = objectMapper.readTree(String.format(jsonQuery, datasetIdCode));
 
-            Element request = new Element(Jeeves.Elem.REQUEST);
-            request.addContent(new Element("identifier").setText(datasetIdCode));
-            request.addContent(new Element("has_atom").setText("y"));
-            request.addContent(new Element("fast").setText("true"));
+            final SearchResponse result = searchMan.query(
+                esJsonQuery,
+                FIELDLIST_CORE,
+                0, 10000);
 
-            // perform the search and return the results read from the index
-            throw new NotImplementedException("Not implemented in ES");
-//        try (MetaSearcher searcher = searchMan.newSearcher(SearcherType.LUCENE, Geonet.File.SEARCH_LUCENE)) {
-//            searcher.search(context, request, new ServiceConfig());
-//
-//            List<String> uuids = ((LuceneSearcher) searcher).getAllUuids(1, context);
-//            if (uuids.size() > 0) {
-//                uuid = uuids.get(0);
-//            }
-//        } catch (Exception ex) {
-//            ex.printStackTrace();
-//        }
-
-//        return uuid;
+            for (SearchHit hit : result.getHits()) {
+                return hit.getId();
+            }
+        } catch (Exception ex) {
+            Log.error(Geonet.ATOM, ex.getMessage(), ex);
         }
+        return "";
+    }
 
-        public static Element prepareServiceFeedEltBeforeTransform ( final String schema,
-        final Element md,
-        final DataManager dataManager)
+    public static Element prepareServiceFeedEltBeforeTransform(final String schema,
+                                                               final Element md,
+                                                               final DataManager dataManager)
         throws Exception {
 
-            List<String> datasetsUuids = extractRelatedDatasetsIdentifiers(schema, md, dataManager);
-            Element root = new Element("root");
-            Element serviceElt = new Element("service");
-            Element datasetElt = new Element("datasets");
+        List<String> datasetsUuids = extractRelatedDatasetsIdentifiers(schema, md, dataManager);
+        Element root = new Element("root");
+        Element serviceElt = new Element("service");
+        Element datasetElt = new Element("datasets");
 
-            root.addContent(serviceElt);
-            md.addContent(datasetElt);
+        root.addContent(serviceElt);
+        md.addContent(datasetElt);
 
-            for (String uuid : datasetsUuids) {
-                String id = dataManager.getMetadataId(uuid);
-                if (StringUtils.isEmpty(id))
-                    throw new ResourceNotFoundException(String.format("Dataset '%s' attached to the requested service was not found. Check the link between the 2 records (see operatesOn element).", uuid));
-                Element ds = dataManager.getMetadata(id);
-                datasetElt.addContent(ds);
-            }
-            serviceElt.addContent(md);
-
-            return root;
+        for (String uuid : datasetsUuids) {
+            String id = dataManager.getMetadataId(uuid);
+            if (StringUtils.isEmpty(id))
+                throw new ResourceNotFoundException(String.format("Dataset '%s' attached to the requested service was not found. Check the link between the 2 records (see operatesOn element).", uuid));
+            Element ds = dataManager.getMetadata(id);
+            datasetElt.addContent(ds);
         }
+        serviceElt.addContent(md);
 
-        public static Element prepareDatasetFeedEltBeforeTransform (
+        return root;
+    }
+
+    public static Element prepareDatasetFeedEltBeforeTransform(
         final Element md,
         final String serviceMdUuid)
         throws Exception {
 
-            Document doc = new Document(new Element("root"));
-            doc.getRootElement().addContent(new Element("dataset").addContent(md));
-            doc.getRootElement().addContent(new Element("serviceIdentifier").setText(serviceMdUuid));
+        Document doc = new Document(new Element("root"));
+        doc.getRootElement().addContent(new Element("dataset").addContent(md));
+        doc.getRootElement().addContent(new Element("serviceIdentifier").setText(serviceMdUuid));
 
-            return doc.getRootElement();
-        }
+        return doc.getRootElement();
+    }
 
 
-        public static String convertIso19119ToAtomFeed ( final String schema,
-        final Element md,
-        final DataManager dataManager,
-        final boolean isLocal) throws Exception {
+    public static String convertIso19119ToAtomFeed(final String schema,
+                                                   final Element md,
+                                                   final DataManager dataManager,
+                                                   final boolean isLocal) throws Exception {
 
-            java.nio.file.Path styleSheet = dataManager
-                .getSchemaDir(schema)
-                .resolve("convert/ATOM/")
-                .resolve(TRANSFORM_MD_TO_ATOM_FEED);
+        java.nio.file.Path styleSheet = dataManager
+            .getSchemaDir(schema)
+            .resolve("convert/ATOM/")
+            .resolve(TRANSFORM_MD_TO_ATOM_FEED);
 
-            Map<String, Object> params = new HashMap<>();
-            params.put("isLocal", isLocal);
+        Map<String, Object> params = new HashMap<>();
+        params.put("isLocal", isLocal);
 
-            Element atomFeed = Xml.transform(md, styleSheet, params);
-            md.detach();
-            return Xml.getString(atomFeed);
+        Element atomFeed = Xml.transform(md, styleSheet, params);
+        md.detach();
+        return Xml.getString(atomFeed);
 
-        }
+    }
 
-        /**
-         * Converts a dataset MD into an INSPIRE atom feed.
-         *
-         * @param schema      the target schema (mainly iso19139)
-         * @param md          The document on which the XSL should be applied, the following format should be followed:
-         *
-         *                    <root>
-         *                    <dataset>
-         *                    <gmd:MD_Metadata />
-         *                    </dataset>
-         *                    <serviceIdentifier>[Service Metadata UUID]</serviceIdentifier>
-         *                    ...
-         *                    </root>
-         * @param dataManager
-         * @param params      extra parameters to pass to the XSL transformation, see inspire-atom-feed.xsl for the details:
-         *                    <xsl:param name="isLocal" select="true()" />
-         *                    <xsl:param name="serviceFeedTitle" select="string('The parent service feed')" />
-         * @return the ATOM feed as a JDOM element.
-         * @throws Exception See InspireAtomUtilTest.testLocalDatasetTransform() for an example of calling this method.
-         */
-        public static Element convertDatasetMdToAtom ( final String schema, final Element md,
-        final DataManager dataManager,
-        Map<String, Object> params) throws Exception {
+    /**
+     * Converts a dataset MD into an INSPIRE atom feed.
+     *
+     * @param schema      the target schema (mainly iso19139)
+     * @param md          The document on which the XSL should be applied, the following format should be followed:
+     *
+     *                    <root>
+     *                    <dataset>
+     *                    <gmd:MD_Metadata />
+     *                    </dataset>
+     *                    <serviceIdentifier>[Service Metadata UUID]</serviceIdentifier>
+     *                    ...
+     *                    </root>
+     * @param dataManager
+     * @param params      extra parameters to pass to the XSL transformation, see inspire-atom-feed.xsl for the details:
+     *                    <xsl:param name="isLocal" select="true()" />
+     *                    <xsl:param name="serviceFeedTitle" select="string('The parent service feed')" />
+     * @return the ATOM feed as a JDOM element.
+     * @throws Exception See InspireAtomUtilTest.testLocalDatasetTransform() for an example of calling this method.
+     */
+    public static Element convertDatasetMdToAtom(final String schema, final Element md,
+                                                 final DataManager dataManager,
+                                                 Map<String, Object> params) throws Exception {
 
-            Path styleSheet = getAtomFeedXSLStylesheet(schema, dataManager);
-            return Xml.transform(md, styleSheet, params);
-        }
+        Path styleSheet = getAtomFeedXSLStylesheet(schema, dataManager);
+        return Xml.transform(md, styleSheet, params);
+    }
 
-        private static Path getAtomFeedXSLStylesheet ( final String schema, final DataManager dataManager){
-            return dataManager
-                .getSchemaDir(schema)
-                .resolve("convert/ATOM/")
-                .resolve(TRANSFORM_MD_TO_ATOM_FEED);
-        }
+    private static Path getAtomFeedXSLStylesheet(final String schema, final DataManager dataManager) {
+        return dataManager
+            .getSchemaDir(schema)
+            .resolve("convert/ATOM/")
+            .resolve(TRANSFORM_MD_TO_ATOM_FEED);
+    }
 
-        public static Element getDatasetFeed ( final ServiceContext context, final String spIdentifier,
-        final String spNamespace, final Map<String, Object> params, String requestedLanguage) throws Exception {
+    public static Element getDatasetFeed(final ServiceContext context, final String spIdentifier,
+                                         final String spNamespace, final Map<String, Object> params, String requestedLanguage) throws Exception {
 
-            ServiceConfig config = new ServiceConfig();
-            throw new NotImplementedException("Not implemented in ES");
-//
-//            SearchManager searchMan = context.getBean(SearchManager.class);
-//
-//            // Search for the dataset identified by spIdentifier
-//            AbstractMetadata datasetMd = null;
-//            Document dsLuceneSearchParams = createDefaultLuceneSearcherParams();
-//            dsLuceneSearchParams.getRootElement().addContent(new Element("identifier").setText(spIdentifier));
+        ServiceConfig config = new ServiceConfig();
+        EsSearchManager searchMan = context.getBean(EsSearchManager.class);
+
+        // Search for the dataset identified by spIdentifier
+        AbstractMetadata datasetMd = null;
+
+        String jsonQuery = "{" +
+            "    \"bool\": {" +
+            "      \"must\": [" +
+            "        {" +
+            "          \"term\": {" +
+            "            \"resourceType\": {" +
+            "              \"value\": \"%s\"" +
+            "            }" +
+            "          }" +
+            "        }, " +
+            "        {" +
+            "          \"term\": {" +
+            "            \"resourceIdentifier.code\": {" +
+            "              \"value\": \"%s\"" +
+            "            }" +
+            "          }" +
+            "        }" +
+            "      ]" +
+            "    }" +
+            "}";
+        ObjectMapper objectMapper = new ObjectMapper();
+        IMetadataUtils repo = context.getBean(IMetadataUtils.class);
+
+        try {
+//            The following was not migrated.
+//            AND query was not supported by Lucene in this case if you have more than one resource identifier
+//            With ES, we could use nested object for that or 2 distinct fields
 //            if (StringUtils.isNotBlank(spNamespace)) {
 //                dsLuceneSearchParams.getRootElement().addContent(new Element("identifierNamespace").setText(spNamespace));
 //            }
-//            dsLuceneSearchParams.getRootElement().addContent(new Element("type").setText("dataset"));
-//
-//            try (MetaSearcher searcher = searchMan.newSearcher(SearcherType.LUCENE, Geonet.File.SEARCH_LUCENE)) {
-//                searcher.search(context, dsLuceneSearchParams.getRootElement(), config);
-//                Element searchResult = searcher.present(context, dsLuceneSearchParams.getRootElement(), config);
-//
-//                XPath xp = XPath.newInstance("//response/metadata/geonet:info/uuid/text()");
-//                xp.addNamespace("geonet", "http://www.fao.org/geonetwork");
+// ...
+// search with namespace return none, then it does one without it. Only do search without namespace for now
 //                if (searchResult.getContentSize() == 0) {
 //                    if (StringUtils.isNotBlank(spNamespace)) {
 //                        dsLuceneSearchParams.getRootElement().removeChild("identifierNamespace");
@@ -502,268 +557,279 @@ public class InspireAtomUtil {
 //                        searchResult = searcher.present(context, dsLuceneSearchParams.getRootElement(), config);
 //                    }
 //                }
-//                if (searchResult.getContentSize() > 0) {
-//                    Text uuidTxt = (Text) xp.selectSingleNode(new Document(searchResult));
-//                    String datasetMdUuid = uuidTxt.getText();
-//
-//                    IMetadataUtils repo = context.getBean(IMetadataUtils.class);
-//                    datasetMd = repo.findOneByUuid(datasetMdUuid);
-//                }
-//
-//            } finally {
-//                if (datasetMd == null) {
-//                    throw new ResourceNotFoundException(String.format(
-//                        "No dataset found with resource identifier '%s'. Check that a record exist with hierarchy level is set to 'dataset' with a resource identifier set to '%s'.", spIdentifier, spIdentifier));
-//                }
-//            }
-//
-//            // check user's rights
-//            try {
-//                Lib.resource.checkPrivilege(context, String.valueOf(datasetMd.getId()), ReservedOperation.view);
-//            } catch (Exception e) {
-//                // This does not return a 403 as expected Oo
-//                throw new UnAuthorizedException("Access denied to metadata " + datasetMd.getUuid(), e);
-//            }
-//
-//            String serviceMdUuid = null;
-//            Document luceneParamSearch = createDefaultLuceneSearcherParams();
-//            luceneParamSearch.getRootElement().addContent(new Element("operatesOn").setText(datasetMd.getUuid() + " or " + spIdentifier));
-//            luceneParamSearch.getRootElement().addContent(new Element("serviceType").setText("download"));
-//
-//            try (MetaSearcher searcher = searchMan.newSearcher(SearcherType.LUCENE, Geonet.File.SEARCH_LUCENE)) {
-//                searcher.search(context, luceneParamSearch.getRootElement(), config);
-//                Element searchResult = searcher.present(context, luceneParamSearch.getRootElement(), config);
-//
-//                XPath xp = XPath.newInstance("//response/metadata/geonet:info/uuid/text()");
-//                xp.addNamespace("geonet", "http://www.fao.org/geonetwork");
-//
-//                Text uuidTxt = (Text) xp.selectSingleNode(new Document(searchResult));
-//                serviceMdUuid = uuidTxt.getText();
-//            } finally {
-//                if (serviceMdUuid == null) {
-//                    throw new ResourceNotFoundException(String.format("No service operating the dataset '%s'. Check that a service is attached to that dataset and that its service type is set to 'download'.", datasetMd.getUuid()));
-//                }
-//            }
-//
-//            DataManager dm = context.getBean(DataManager.class);
-//            Element md = datasetMd.getXmlData(false);
-//            if (StringUtils.isBlank(requestedLanguage)) {
-//                String schema = dm.getMetadataSchema(String.valueOf(datasetMd.getId()));
-//                String defaultLanguage = dm.extractDefaultLanguage(schema, md);
-//                requestedLanguage = XslUtil.twoCharLangCode(defaultLanguage);
-//            }
-//            Element inputDoc = InspireAtomUtil.prepareDatasetFeedEltBeforeTransform(md, serviceMdUuid);
-//
-//            params.put("requestedLanguage", requestedLanguage);
-//            return InspireAtomUtil.convertDatasetMdToAtom("iso19139", inputDoc, dm, params);
-        }
+            JsonNode esJsonQuery = objectMapper.readTree(String.format(jsonQuery, "dataset", spIdentifier));
 
-        private static Document createDefaultLuceneSearcherParams () {
-            Document luceneParamSearch = new Document(new Element("request").
-                addContent(new Element("from").setText("1")).
-                addContent(new Element("to").setText("1000")).
-                addContent(new Element("fast").setText("index")));
-
-            return luceneParamSearch;
-        }
-
-        public static Element prepareOpenSearchDescriptionEltBeforeTransform ( final ServiceContext context,
-        final Map<String, Object> params, final String fileIdentifier, final String schema,
-        final Element serviceAtomFeed, final String defaultLanguage,
-        final DataManager dataManager) throws Exception {
-
-            List<String> keywords = retrieveKeywordsFromFileIdentifier(context, fileIdentifier);
-            Namespace ns = serviceAtomFeed.getNamespace();
-            Document doc = new Document(new Element("root"));
-            Element response = new Element("response");
-            doc.getRootElement().addContent(response);
-            response.addContent(new Element("fileId").setText(fileIdentifier));
-            response.addContent(new Element("title").setText(serviceAtomFeed.getChildText("title", ns)));
-            response.addContent(new Element("subtitle").setText(serviceAtomFeed.getChildText("subtitle", ns)));
-            List<String> languages = new ArrayList<String>();
-            languages.add(XslUtil.twoCharLangCode(defaultLanguage));
-            Iterator<Element> linksChildren = (serviceAtomFeed.getChildren("link", ns)).iterator();
-            while (linksChildren.hasNext()) {
-                Element entry = linksChildren.next();
-                if ("application/atom+xml".equals(entry.getAttributeValue("type"))) {
-                    String language = entry.getAttributeValue("hreflang");
-                    if (language != null && !languages.contains(language)) {
-                        languages.add(language);
-                    }
-                }
+            final SearchResponse result = searchMan.query(
+                esJsonQuery,
+                FIELDLIST_CORE,
+                0, 1);
+            for (SearchHit hit : result.getHits()) {
+                datasetMd = repo.findOneByUuid(hit.getId());
             }
-            Element languagesEl = new Element("languages");
-            for (String language : languages) {
-                languagesEl.addContent(new Element("language").setText(language));
+        } catch (Exception e) {
+
+        } finally {
+            if (datasetMd == null) {
+                throw new ResourceNotFoundException(String.format(
+                    "No dataset found with resource identifier '%s'. Check that a record exist with hierarchy level is set to 'dataset'" +
+                        " with a resource identifier set to '%s'.", spIdentifier, spIdentifier));
             }
-            response.addContent(languagesEl);
-            Element serviceAuthor = serviceAtomFeed.getChild("author", ns);
-            if (serviceAuthor != null) {
-                response.addContent(new Element("authorName").setText(serviceAuthor.getChildText("name", ns)));
-                response.addContent(new Element("authorEmail").setText(serviceAuthor.getChildText("email", ns)));
+        }
+
+        try {
+            Lib.resource.checkPrivilege(context, String.valueOf(datasetMd.getId()), ReservedOperation.view);
+        } catch (Exception e) {
+            // This does not return a 403 as expected Oo
+            throw new UnAuthorizedException("Access denied to metadata " + datasetMd.getUuid(), e);
+        }
+
+        jsonQuery = "{" +
+            "    \"bool\": {" +
+            "      \"must\": [" +
+            "        {" +
+            "          \"terms\": {" +
+            "            \"recordOperateOn\": [" +
+            "              \"%s\", \"%s\"" +
+            "            ]" +
+            "          }" +
+            "        }, " +
+            "        {" +
+            "          \"term\": {" +
+            "            \"serviceType\": {" +
+            "              \"value\": \"%s\"" +
+            "            }" +
+            "          }" +
+            "        }" +
+            "      ]" +
+            "    }" +
+            "}";
+        AbstractMetadata serviceMetadata = null;
+
+        try {
+            JsonNode esJsonQuery = objectMapper.readTree(String.format(jsonQuery, datasetMd.getUuid(), spIdentifier, "download"));
+
+            final SearchResponse result = searchMan.query(
+                esJsonQuery,
+                FIELDLIST_CORE,
+                0, 1);
+            for (SearchHit hit : result.getHits()) {
+                serviceMetadata = repo.findOneByUuid(hit.getId());
             }
-            response.addContent(new Element("url").setText(serviceAtomFeed.getChildText("id", ns)));
-            Element datasetsEl = new Element("datasets");
-            response.addContent(datasetsEl);
-            Namespace inspiredlsns = serviceAtomFeed.getNamespace("inspire_dls");
-            Iterator<Element> datasets = (serviceAtomFeed.getChildren("entry", ns)).iterator();
-            List<String> fileTypes = new ArrayList<String>();
-            while (datasets.hasNext()) {
-                Element dataset = datasets.next();
-                String datasetIdCode = dataset.getChildText("spatial_dataset_identifier_code", inspiredlsns);
-                String datasetIdNs = dataset.getChildText("spatial_dataset_identifier_namespace", inspiredlsns);
+        } catch (Exception e) {
 
-                Element datasetAtomFeed = null;
-                try {
-                    datasetAtomFeed = InspireAtomUtil.getDatasetFeed(context, datasetIdCode, datasetIdNs, params, XslUtil.twoCharLangCode(defaultLanguage));
-                } catch (Exception e) {
-                    Log.error(Geonet.ATOM, "No dataset metadata found with uuid:"
-                        + fileIdentifier);
-                    continue;
-                }
-                Element datasetEl = buildDatasetInfo(datasetIdCode, datasetIdNs);
-                datasetsEl.addContent(datasetEl);
-                Element author = datasetAtomFeed.getChild("author", ns);
-                if (author != null) {
-                    String authorName = author.getChildText("name", ns);
-                    if (StringUtils.isNotBlank(authorName)) {
-                        datasetEl.addContent(new Element("authorName").setText(authorName));
-                    }
-                }
-                Map<String, Integer> downloadsCountByCrs = new HashMap<String, Integer>();
-                Iterator<Element> entries = (datasetAtomFeed.getChildren("entry", ns)).iterator();
-                while (entries.hasNext()) {
-                    Element entry = entries.next();
-                    Element category = entry.getChild("category", ns);
-                    if (category != null) {
-                        String term = category.getAttributeValue("term");
-                        Integer count = downloadsCountByCrs.get(term);
-                        if (count == null) {
-                            count = new Integer(0);
-                        }
-                        downloadsCountByCrs.put(term, count + 1);
-                    }
-                    Element link = entry.getChild("link", ns);
-                    if (link != null) {
-                        String fileType = link.getAttributeValue("type");
-                        if (!fileTypes.contains(fileType)) {
-                            fileTypes.add(fileType);
-                        }
-                    }
-                }
-                entries = (datasetAtomFeed.getChildren("entry", ns)).iterator();
-                while (entries.hasNext()) {
-                    Element entry = entries.next();
-                    Element category = entry.getChild("category", ns);
-                    if (category != null) {
-                        String term = category.getAttributeValue("term");
-                        Integer count = downloadsCountByCrs.get(term);
-                        if (count != null) {
-                            Element downloadEl = new Element("file");
-                            Element link = entry.getChild("link", ns);
-                            if (link != null) {
-                                String title = link.getAttributeValue("title");
-                                if (title != null) {
-                                    int iPos = title.indexOf(" in  -");
-                                    if (iPos > -1) {
-                                        title = title.substring(0, iPos);
-                                    }
-                                }
-                                downloadEl.addContent(new Element("title").setText(title));
-                            }
-                            Element lang = new Element("lang");
-                            if (link != null && StringUtils.isNotBlank(link.getAttributeValue("hreflang"))) {
-                                lang.setText(link.getAttributeValue("hreflang"));
-                            } else {
-                                lang.setText(XslUtil.twoCharLangCode(context.getLanguage()));
-                            }
-                            downloadEl.addContent(lang);
-                            downloadEl.addContent(new Element("url").setText(entry.getChildText("id", ns)));
-                            if (count > 1) {
-                                downloadEl.addContent(new Element("type").setText("application/atom+xml"));
-                            } else {
-                                if (link != null) {
-                                    downloadEl.addContent(new Element("type").setText(link.getAttributeValue("type")));
-                                }
-                            }
-                            downloadEl.addContent(new Element("crs").setText(term));
-                            downloadEl.addContent(new Element("crsCount").setText("" + count));
-                            datasetEl.addContent(downloadEl);
+        } finally {
+            if (serviceMetadata == null) {
+                throw new ResourceNotFoundException(String.format(
+                    "No service operating the dataset '%s'. " +
+                        "Check that a service is attached to that dataset and that its service type is set to 'download'.",
+                    datasetMd.getUuid()));
 
-                            // Remove from map to not process further downloads with same CRS,
-                            // only 1 entry with type= is added in result
-                            downloadsCountByCrs.remove(term);
-                        }
-                    }
-                }
             }
-            response.addContent(new Element("keywords").setText(StringUtils.join(keywords, ' ')));
-            Element fileTypesEl = new Element("fileTypes");
-            for (String fileType : fileTypes) {
-                fileTypesEl.addContent(new Element("fileType").setText(fileType));
-            }
-            response.addContent(fileTypesEl);
-            return doc.getRootElement();
         }
 
-        public static Element convertServiceMdToOpenSearchDescription ( final ServiceContext context, final Element md,
-        final Map<String, Object> params) throws Exception {
+        DataManager dm = context.getBean(DataManager.class);
+        Element md = datasetMd.getXmlData(false);
+        String schema = datasetMd.getDataInfo().getSchemaId();
 
-            Path styleSheet = getOpenSearchDesciptionXSLStylesheet(context);
-            return Xml.transform(md, styleSheet, params);
+        if (StringUtils.isBlank(requestedLanguage)) {
+            String defaultLanguage = dm.extractDefaultLanguage(schema, md);
+            requestedLanguage = XslUtil.twoCharLangCode(defaultLanguage);
         }
+        Element inputDoc = InspireAtomUtil.prepareDatasetFeedEltBeforeTransform(md, serviceMetadata.getUuid());
 
-        private static Path getOpenSearchDesciptionXSLStylesheet ( final ServiceContext context){
-            return context.getAppPath().resolve(Geonet.Path.XSLT_FOLDER)
-                .resolve("services/inspire-atom/")
-                .resolve(TRANSFORM_ATOM_TO_OPENSEARCHDESCRIPTION);
-        }
-
-        /**
-         * Builds JDOM element for dataset information.
-         *
-         * @param identifier Dataset identifier.
-         * @param namespace  Dataset namespace.
-         */
-        private static Element buildDatasetInfo ( final String identifier, final String namespace){
-            Element datasetEl = new Element("dataset");
-
-            Element codeEl = new Element("code");
-            codeEl.setText(identifier);
-
-            Element namespaceEl = new Element("namespace");
-            namespaceEl.setText(namespace);
-
-            datasetEl.addContent(codeEl);
-            datasetEl.addContent(namespaceEl);
-
-            return datasetEl;
-        }
-
-        public static List<String> retrieveKeywordsFromFileIdentifier (ServiceContext context, String fileIdentifier){
-//        List<String> keywordsList = new ArrayList<String>();
-//        Element request = new Element(Jeeves.Elem.REQUEST);
-//        request.addContent(new Element("fileId").setText(fileIdentifier));
-//        //request.addContent(new Element("has_atom").setText("y"));
-//        request.addContent(new Element("fast").setText("true"));
-//        SearchManager searchMan = context.getBean(SearchManager.class);
-//        // perform the search and return the results read from the index
-//
-//        try (MetaSearcher searcher = searchMan.newSearcher(SearcherType.LUCENE, Geonet.File.SEARCH_LUCENE)) {
-//            searcher.search(context, request, new ServiceConfig());
-//
-//            List<Element> keywordElems = ((LuceneSearcher) searcher).getSummary().getChild("summary").getChild("keywords").getChildren();
-//            for (Element elem : keywordElems) {
-//                String keyword = elem.getAttributeValue("name");
-//                if (!keywordsList.contains(keyword)) {
-//                    keywordsList.add(keyword);
-//                }
-//            }
-//        } catch (Exception ex) {
-//            Log.error(Geonet.ATOM, ex.getMessage(), ex);
-//        }
-
-            throw new NotImplementedException("Not implemented in ES");
-        }
+        params.put("requestedLanguage", requestedLanguage);
+        return InspireAtomUtil.convertDatasetMdToAtom(schema, inputDoc, dm, params);
     }
+
+    public static Element prepareOpenSearchDescriptionEltBeforeTransform(final ServiceContext context,
+                                                                         final Map<String, Object> params, final String fileIdentifier, final String schema,
+                                                                         final Element serviceAtomFeed, final String defaultLanguage,
+                                                                         final DataManager dataManager) throws Exception {
+
+        List<String> keywords = retrieveKeywordsFromFileIdentifier(context, fileIdentifier);
+        Namespace ns = serviceAtomFeed.getNamespace();
+        Document doc = new Document(new Element("root"));
+        Element response = new Element("response");
+        doc.getRootElement().addContent(response);
+        response.addContent(new Element("fileId").setText(fileIdentifier));
+        response.addContent(new Element("title").setText(serviceAtomFeed.getChildText("title", ns)));
+        response.addContent(new Element("subtitle").setText(serviceAtomFeed.getChildText("subtitle", ns)));
+        List<String> languages = new ArrayList<String>();
+        languages.add(XslUtil.twoCharLangCode(defaultLanguage));
+        Iterator<Element> linksChildren = (serviceAtomFeed.getChildren("link", ns)).iterator();
+        while (linksChildren.hasNext()) {
+            Element entry = linksChildren.next();
+            if ("application/atom+xml".equals(entry.getAttributeValue("type"))) {
+                String language = entry.getAttributeValue("hreflang");
+                if (language != null && !languages.contains(language)) {
+                    languages.add(language);
+                }
+            }
+        }
+        Element languagesEl = new Element("languages");
+        for (String language : languages) {
+            languagesEl.addContent(new Element("language").setText(language));
+        }
+        response.addContent(languagesEl);
+        Element serviceAuthor = serviceAtomFeed.getChild("author", ns);
+        if (serviceAuthor != null) {
+            response.addContent(new Element("authorName").setText(serviceAuthor.getChildText("name", ns)));
+            response.addContent(new Element("authorEmail").setText(serviceAuthor.getChildText("email", ns)));
+        }
+        response.addContent(new Element("url").setText(serviceAtomFeed.getChildText("id", ns)));
+        Element datasetsEl = new Element("datasets");
+        response.addContent(datasetsEl);
+        Namespace inspiredlsns = serviceAtomFeed.getNamespace("inspire_dls");
+        Iterator<Element> datasets = (serviceAtomFeed.getChildren("entry", ns)).iterator();
+        List<String> fileTypes = new ArrayList<String>();
+        while (datasets.hasNext()) {
+            Element dataset = datasets.next();
+            String datasetIdCode = dataset.getChildText("spatial_dataset_identifier_code", inspiredlsns);
+            String datasetIdNs = dataset.getChildText("spatial_dataset_identifier_namespace", inspiredlsns);
+
+            Element datasetAtomFeed = null;
+            try {
+                datasetAtomFeed = InspireAtomUtil.getDatasetFeed(context, datasetIdCode, datasetIdNs, params, XslUtil.twoCharLangCode(defaultLanguage));
+            } catch (Exception e) {
+                Log.error(Geonet.ATOM, "No dataset metadata found with uuid:"
+                    + fileIdentifier);
+                continue;
+            }
+            Element datasetEl = buildDatasetInfo(datasetIdCode, datasetIdNs);
+            datasetsEl.addContent(datasetEl);
+            Element author = datasetAtomFeed.getChild("author", ns);
+            if (author != null) {
+                String authorName = author.getChildText("name", ns);
+                if (StringUtils.isNotBlank(authorName)) {
+                    datasetEl.addContent(new Element("authorName").setText(authorName));
+                }
+            }
+            Map<String, Integer> downloadsCountByCrs = new HashMap<String, Integer>();
+            Iterator<Element> entries = (datasetAtomFeed.getChildren("entry", ns)).iterator();
+            while (entries.hasNext()) {
+                Element entry = entries.next();
+                Element category = entry.getChild("category", ns);
+                if (category != null) {
+                    String term = category.getAttributeValue("term");
+                    Integer count = downloadsCountByCrs.get(term);
+                    if (count == null) {
+                        count = new Integer(0);
+                    }
+                    downloadsCountByCrs.put(term, count + 1);
+                }
+                Element link = entry.getChild("link", ns);
+                if (link != null) {
+                    String fileType = link.getAttributeValue("type");
+                    if (!fileTypes.contains(fileType)) {
+                        fileTypes.add(fileType);
+                    }
+                }
+            }
+            entries = (datasetAtomFeed.getChildren("entry", ns)).iterator();
+            while (entries.hasNext()) {
+                Element entry = entries.next();
+                Element category = entry.getChild("category", ns);
+                if (category != null) {
+                    String term = category.getAttributeValue("term");
+                    Integer count = downloadsCountByCrs.get(term);
+                    if (count != null) {
+                        Element downloadEl = new Element("file");
+                        Element link = entry.getChild("link", ns);
+                        if (link != null) {
+                            String title = link.getAttributeValue("title");
+                            if (title != null) {
+                                int iPos = title.indexOf(" in  -");
+                                if (iPos > -1) {
+                                    title = title.substring(0, iPos);
+                                }
+                            }
+                            downloadEl.addContent(new Element("title").setText(title));
+                        }
+                        Element lang = new Element("lang");
+                        if (link != null && StringUtils.isNotBlank(link.getAttributeValue("hreflang"))) {
+                            lang.setText(link.getAttributeValue("hreflang"));
+                        } else {
+                            lang.setText(XslUtil.twoCharLangCode(context.getLanguage()));
+                        }
+                        downloadEl.addContent(lang);
+                        downloadEl.addContent(new Element("url").setText(entry.getChildText("id", ns)));
+                        if (count > 1) {
+                            downloadEl.addContent(new Element("type").setText("application/atom+xml"));
+                        } else {
+                            if (link != null) {
+                                downloadEl.addContent(new Element("type").setText(link.getAttributeValue("type")));
+                            }
+                        }
+                        downloadEl.addContent(new Element("crs").setText(term));
+                        downloadEl.addContent(new Element("crsCount").setText("" + count));
+                        datasetEl.addContent(downloadEl);
+
+                        // Remove from map to not process further downloads with same CRS,
+                        // only 1 entry with type= is added in result
+                        downloadsCountByCrs.remove(term);
+                    }
+                }
+            }
+        }
+        response.addContent(new Element("keywords").setText(StringUtils.join(keywords, ' ')));
+        Element fileTypesEl = new Element("fileTypes");
+        for (String fileType : fileTypes) {
+            fileTypesEl.addContent(new Element("fileType").setText(fileType));
+        }
+        response.addContent(fileTypesEl);
+        return doc.getRootElement();
+    }
+
+    public static Element convertServiceMdToOpenSearchDescription(final ServiceContext context, final Element md,
+                                                                  final Map<String, Object> params) throws Exception {
+
+        Path styleSheet = getOpenSearchDesciptionXSLStylesheet(context);
+        return Xml.transform(md, styleSheet, params);
+    }
+
+    private static Path getOpenSearchDesciptionXSLStylesheet(final ServiceContext context) {
+        return context.getAppPath().resolve(Geonet.Path.XSLT_FOLDER)
+            .resolve("services/inspire-atom/")
+            .resolve(TRANSFORM_ATOM_TO_OPENSEARCHDESCRIPTION);
+    }
+
+    /**
+     * Builds JDOM element for dataset information.
+     *
+     * @param identifier Dataset identifier.
+     * @param namespace  Dataset namespace.
+     */
+    private static Element buildDatasetInfo(final String identifier, final String namespace) {
+        Element datasetEl = new Element("dataset");
+
+        Element codeEl = new Element("code");
+        codeEl.setText(identifier);
+
+        Element namespaceEl = new Element("namespace");
+        namespaceEl.setText(namespace);
+
+        datasetEl.addContent(codeEl);
+        datasetEl.addContent(namespaceEl);
+
+        return datasetEl;
+    }
+
+    public static List<String> retrieveKeywordsFromFileIdentifier(ServiceContext context, String uuid) {
+        EsSearchManager searchManager = context.getBean(EsSearchManager.class);
+        List<String> keywordsList = new ArrayList<String>();
+        try {
+            Map<String, Object> document = searchManager.getDocument(uuid);
+            Object tags = document.get("tag");
+            if (tags instanceof List) {
+                ArrayList<HashMap<String, String>> list = (ArrayList) tags;
+                list.forEach(tag -> {
+                    keywordsList.add(tag.get("default"));
+                });
+            }
+        } catch (Exception ex) {
+            Log.error(Geonet.ATOM, ex.getMessage(), ex);
+        }
+        return keywordsList;
+    }
+}
 

--- a/inspire-atom/src/main/java/org/fao/geonet/services/inspireatom/AtomDescribe.java
+++ b/inspire-atom/src/main/java/org/fao/geonet/services/inspireatom/AtomDescribe.java
@@ -70,12 +70,6 @@ public class AtomDescribe implements Service {
 
     }
 
-    //--------------------------------------------------------------------------
-    //---
-    //--- Exec
-    //---
-    //--------------------------------------------------------------------------
-
     public Element exec(Element params, ServiceContext context) throws Exception {
         SettingManager sm = context.getBean(SettingManager.class);
 

--- a/inspire-atom/src/main/java/org/fao/geonet/services/inspireatom/AtomHarvester.java
+++ b/inspire-atom/src/main/java/org/fao/geonet/services/inspireatom/AtomHarvester.java
@@ -42,12 +42,6 @@ public class AtomHarvester implements Service {
     public void init(Path appPath, ServiceConfig params) throws Exception {
     }
 
-    //--------------------------------------------------------------------------
-    //---
-    //--- Exec
-    //---
-    //--------------------------------------------------------------------------
-
     public Element exec(Element params, ServiceContext context) throws Exception {
         GeonetContext gc = (GeonetContext) context.getHandlerContext(Geonet.CONTEXT_NAME);
 

--- a/inspire-atom/src/main/java/org/fao/geonet/services/inspireatom/AtomSearch.java
+++ b/inspire-atom/src/main/java/org/fao/geonet/services/inspireatom/AtomSearch.java
@@ -22,13 +22,38 @@
 //==============================================================================
 package org.fao.geonet.services.inspireatom;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.base.Joiner;
 import jeeves.interfaces.Service;
 import jeeves.server.ServiceConfig;
 import jeeves.server.context.ServiceContext;
-import org.apache.commons.lang.NotImplementedException;
+import org.apache.commons.lang3.StringUtils;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.search.SearchHit;
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.domain.InspireAtomFeed;
+import org.fao.geonet.domain.ReservedOperation;
+import org.fao.geonet.exceptions.MetadataNotFoundEx;
+import org.fao.geonet.inspireatom.InspireAtomService;
+import org.fao.geonet.inspireatom.InspireAtomType;
+import org.fao.geonet.inspireatom.util.InspireAtomUtil;
+import org.fao.geonet.kernel.DataManager;
+import org.fao.geonet.kernel.search.EsSearchManager;
+import org.fao.geonet.kernel.setting.SettingManager;
+import org.fao.geonet.kernel.setting.Settings;
+import org.fao.geonet.lib.Lib;
+import org.fao.geonet.utils.Log;
+import org.fao.geonet.utils.Xml;
+import org.jdom.Content;
 import org.jdom.Element;
 
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.fao.geonet.kernel.search.EsFilterBuilder.buildPermissionsFilter;
+import static org.fao.geonet.kernel.search.EsSearchManager.FIELDLIST_CORE;
 
 /**
  * INSPIRE atom search service.
@@ -36,84 +61,107 @@ import java.nio.file.Path;
  * @author Jose García
  */
 public class AtomSearch implements Service {
-//    private Search search = new Search();
-//    private Result result = new Result();
-
     public void init(Path appPath, ServiceConfig params) throws Exception {
-//        search.init(appPath, params);
-//        result.init(appPath, params);
     }
 
     public Element exec(Element params, ServiceContext context) throws Exception {
-        throw new NotImplementedException("Not implemented in ES");
+        SettingManager sm = context.getBean(SettingManager.class);
+        DataManager dm = context.getBean(DataManager.class);
+        InspireAtomService service = context.getBean(InspireAtomService.class);
+        EsSearchManager searchMan = context.getBean(EsSearchManager.class);
 
-//
-//        SettingManager sm = context.getBean(SettingManager.class);
-//        DataManager dm = context.getBean(DataManager.class);
-//        InspireAtomService service = context.getBean(InspireAtomService.class);
-//
-//        boolean inspireEnable = sm.getValueAsBool(Settings.SYSTEM_INSPIRE_ENABLE);
-//
-//        if (!inspireEnable) {
-//            Log.info(Geonet.ATOM, "Inspire is disabled");
-//            throw new Exception("Inspire is disabled");
-//        }
-//
-//        String fileIdentifier = params.getChildText("fileIdentifier");
-//
-//        // If fileIdentifier is provided search only in the related datasets
-//        if (StringUtils.isNotEmpty(fileIdentifier)) {
-//            String id = dm.getMetadataId(fileIdentifier);
-//            if (id == null) throw new MetadataNotFoundEx("Metadata not found.");
-//
-//            Element md = dm.getMetadata(id);
-//            String schema = dm.getMetadataSchema(id);
-//
-//            // Check if allowed to the metadata
-//            Lib.resource.checkPrivilege(context, id, ReservedOperation.view);
-//
-//            // Retrieve the datasets related to the service metadata
-//            List<String> datasetIdentifiers = InspireAtomUtil.extractRelatedDatasetsIdentifiers(schema, md, dm);
-//
-//            // Remove fileIdentifier from params
-//            params.removeChild("fileIdentifier");
-//
-//            // Add query filter
-//            String values = Joiner.on(" or ").join(datasetIdentifiers);
-//            params.addContent(new Element("identifier").setText(values));
-//        }
-//
-//        // Add query filter
-//        params.addContent(new Element("has_atom").setText("y"));
-//        params.addContent(new Element("fast").setText("true"));
-//
-//
-//        // Depending on INSPIRE atom format decide which service use.
-//        String atomFormat = sm.getValue(Settings.SYSTEM_INSPIRE_ATOM);
-//
+        boolean inspireEnable = sm.getValueAsBool(Settings.SYSTEM_INSPIRE_ENABLE);
+
+        if (!inspireEnable) {
+            Log.info(Geonet.ATOM, "Inspire is disabled");
+            throw new Exception("Inspire is disabled");
+        }
+
+        String fileIdentifier = params.getChildText("fileIdentifier");
+        List<String> datasetIdentifiers = new ArrayList<>();
+
+        // If fileIdentifier is provided search only in the related datasets
+        if (StringUtils.isNotEmpty(fileIdentifier)) {
+            String id = dm.getMetadataId(fileIdentifier);
+            if (id == null) throw new MetadataNotFoundEx("Metadata not found.");
+
+            Element md = dm.getMetadata(id);
+            String schema = dm.getMetadataSchema(id);
+
+            // Check if allowed to the metadata
+            Lib.resource.checkPrivilege(context, id, ReservedOperation.view);
+
+            // Retrieve the datasets related to the service metadata
+            datasetIdentifiers = InspireAtomUtil.extractRelatedDatasetsIdentifiers(schema, md, dm);
+
+            // Add query filter
+            String values = Joiner.on(" or ").join(datasetIdentifiers);
+            params.addContent(new Element("identifier").setText(values));
+        }
+
+        // Depending on INSPIRE atom format decide which service use.
+        String atomFormat = sm.getValue(Settings.SYSTEM_INSPIRE_ATOM);
+
 //        search.exec(params, context);
-//
-//        // Create atom feed from search results.
-//        if (atomFormat.equalsIgnoreCase(InspireAtomType.ATOM_LOCAL)) {
-//            return result.exec(params, context);
-//
-//            // Create atom feed from feeds referenced in metadata.
-//        } else {
-//            Element results = result.exec(params, context);
-//
-//            Element feeds = new Element("feeds");
-//
-//            // Loop over the results and retrieve feeds to add in results
-//            // First element in results (pos=0) is the summary, ignore it
-//            for (int i = 1; i < results.getChildren().size(); i++) {
-//                String id = ((Element) results.getChildren().get(i)).getChild("info", Edit.NAMESPACE).getChildText("id");
-//
-//                InspireAtomFeed feed = service.findByMetadataId(Integer.parseInt(id));
-//                Element feedEl = Xml.loadString(feed.getAtom(), false);
-//                feeds.addContent((Content) feedEl.clone());
-//            }
-//
-//            return feeds;
-//        }
+        String privilegesFilter = buildPermissionsFilter(context);
+        String IDENTIFIER_QUERY = "{" +
+            "          \"nested\": {" +
+            "            \"path\": \"resourceIdentifier\"," +
+            "            \"query\": {" +
+            "              \"term\": {" +
+            "                \"resourceIdentifier.code\": {" +
+            "                  \"value\": \"%s\"" +
+            "                }" +
+            "              }" +
+            "            }" +
+            "        }";
+
+        String jsonQuery = "{" +
+            "    \"bool\": {" +
+            "      \"must\": [" +
+            "        {" +
+            "          \"exists\": {" +
+            "            \"field\": \"atomfeed\"" +
+            "          }" +
+            "        }" +
+            "      ]," +
+            "      \"filter\": [{" +
+            "          \"query_string\": {" +
+            "            \"query\": \"%s\"" +
+            "        }" +
+            "      }]" +
+            "    }" +
+            "}";
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode esJsonQuery = objectMapper.readTree(String.format(jsonQuery, privilegesFilter));
+
+        final SearchResponse result = searchMan.query(
+            esJsonQuery,
+            FIELDLIST_CORE,
+            0, 1000);
+
+        // Create atom feed from search results.
+        if (atomFormat.equalsIgnoreCase(InspireAtomType.ATOM_LOCAL)) {
+            return null; // result.exec(params, context);
+
+            // Create atom feed from feeds referenced in metadata.
+        } else {
+            Element feeds = new Element("feeds");
+
+            // Loop over the results and retrieve feeds to add in results
+            // First element in results (pos=0) is the summary, ignore it
+            for (SearchHit hit : result.getHits().getHits()) {
+                String id = hit.getSourceAsMap().get(Geonet.IndexFieldNames.ID).toString();
+                InspireAtomFeed feed = service.findByMetadataId(Integer.parseInt(id));
+                if (feed != null) {
+                    Element feedEl = Xml.loadString(feed.getAtom(), false);
+                    feeds.addContent((Content) feedEl.clone());
+                } else {
+                    System.out.println(String.format("No feed available for %s", hit.getId()));
+                }
+            }
+
+            return feeds;
+        }
     }
 }

--- a/inspire-atom/src/main/java/org/fao/geonet/services/inspireatom/AtomServiceDescription.java
+++ b/inspire-atom/src/main/java/org/fao/geonet/services/inspireatom/AtomServiceDescription.java
@@ -26,6 +26,7 @@ import jeeves.interfaces.Service;
 import jeeves.server.ServiceConfig;
 import jeeves.server.context.ServiceContext;
 
+import nonapi.io.github.classgraph.utils.Join;
 import org.apache.commons.lang.NotImplementedException;
 import org.fao.geonet.Util;
 import org.fao.geonet.domain.ReservedOperation;
@@ -53,6 +54,8 @@ import java.util.List;
 import java.util.Map;
 import org.fao.geonet.exceptions.ResourceNotFoundEx;
 
+import static org.fao.geonet.inspireatom.util.InspireAtomUtil.retrieveKeywordsFromFileIdentifier;
+
 /**
  * INSPIRE OpenSearchDescription atom service.
  *
@@ -68,12 +71,6 @@ public class AtomServiceDescription implements Service {
     public void init(Path appPath, ServiceConfig params) throws Exception {
 
     }
-
-    //--------------------------------------------------------------------------
-    //---
-    //--- Exec
-    //---
-    //--------------------------------------------------------------------------
 
     public Element exec(Element params, ServiceContext context) throws Exception {
         GeonetContext gc = (GeonetContext) context.getHandlerContext(Geonet.CONTEXT_NAME);
@@ -156,25 +153,21 @@ public class AtomServiceDescription implements Service {
         String feedSubtitle = inspireAtomFeed.getSubtitle();
         String feedLang = inspireAtomFeed.getLang();
         String feedUrl = inspireAtomFeed.getAtomUrl();
+        List<String> keywords = retrieveKeywordsFromFileIdentifier(context, fileIdentifier);
 
-        throw new NotImplementedException("Not implemented in ES");
-        // TODOES
-//        String keywords = LuceneSearcher.getMetadataFromIndex(context.getLanguage(), fileIdentifier, "keyword");
-//
-//
-//        // Process datasets information
-//        Element datasetsEl = processDatasetsInfo(datasetsInformation, fileIdentifier, context);
-//
-//        // Build response.
-//        return new Element("response")
-//            .addContent(new Element("fileId").setText(fileIdentifier))
-//            .addContent(new Element("title").setText(feedTitle))
-//            .addContent(new Element("subtitle").setText(feedSubtitle))
-//            .addContent(new Element("lang").setText(feedLang))
-//            .addContent(new Element("keywords").setText(keywords))
-//            .addContent(new Element("authorName").setText(feedAuthorName))
-//            .addContent(new Element("url").setText(feedUrl))
-//            .addContent(datasetsEl);
+        // Process datasets information
+        Element datasetsEl = processDatasetsInfo(datasetsInformation, fileIdentifier, context);
+
+        // Build response.
+        return new Element("response")
+            .addContent(new Element("fileId").setText(fileIdentifier))
+            .addContent(new Element("title").setText(feedTitle))
+            .addContent(new Element("subtitle").setText(feedSubtitle))
+            .addContent(new Element("lang").setText(feedLang))
+            .addContent(new Element("keywords").setText(Join.join(", ", keywords)))
+            .addContent(new Element("authorName").setText(feedAuthorName))
+            .addContent(new Element("url").setText(feedUrl))
+            .addContent(datasetsEl);
     }
 
 

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
@@ -985,6 +985,7 @@
         </xsl:for-each>
       </xsl:for-each>
 
+      <xsl:variable name="atomProtocol" select="util:getSettingValue('system/inspire/atomProtocol')" />
 
       <xsl:for-each select="gmd:distributionInfo/*">
         <xsl:for-each
@@ -1019,6 +1020,9 @@
           <xsl:element name="linkUrlProtocol{replace($protocol[1], '[^a-zA-Z0-9]', '')}">
             <xsl:value-of select="gmd:linkage/gmd:URL"/>
           </xsl:element>
+          <xsl:if test="$protocol = $atomProtocol">
+            <atomfeed><xsl:value-of select="gmd:linkage/gmd:URL"/></atomfeed>
+          </xsl:if>
           <link type="object">{
             "protocol":"<xsl:value-of select="gn-fn-index:json-escape((gmd:protocol/*/text())[1])"/>",
             "url":"<xsl:value-of select="gn-fn-index:json-escape(gmd:linkage/gmd:URL)"/>",


### PR DESCRIPTION
The service works by enabling it in the settings with:
* Enable INSPIRE
* Configure Atom feeds: Remote
* Configure Atom protocol: INSPIRE Atom

The rule to scan for feeds made consistent in indexing and during scanning of feeds.
The `has_atom` index field is replaced by `atomfeed`. This field is populated during indexing
by the feed URL when a link use the protocol defined in the settings. Then when the harvester run,
the remote feed is added to that field (instead of any). If we want full text search on the
feed content, we can configure the search. To find records with an atom feed we can use
`_exists_:atomfeed`.

The `atom.search` provides the list of feed but don't allow search operation anymore.

For testing, load:
* https://www.nationaalgeoregister.nl/geonetwork/srv/api/records/037e55bd-a1dc-4fde-
adfe-4610d3a3d5cb/formatters/xml?approved=true
* https://www.nationaalgeoregister.nl/geonetwork/srv/api/records/76541ebb-
a554-4540-a017-399d4bb4a860/formatters/xml?approved=true

Then access:
* OpenSearchDescription
http://localhost:8080/geonetwork/opensearch/dut/037e55bd-a1dc-4fde-adfe-4610d3a3d5cb/OpenSearchDescription.xml

* Describe dataset
http://localhost:8080/geonetwork/opensearch/dut/describe?spatial_dataset_identifier_namespace=http://www.pdok.nl&spatial_dataset_identifier_code=14076c36-pdnl-2012-2020-7e65f530188b&language=nl

* Download dataset / Returns the feed as the dataset seem having several downloads.
http://localhost:8080/geonetwork/opensearch/dut/download?
spatial_dataset_identifier_namespace=http://
www.pdok.nl&spatial_dataset_identifier_code=14076c36-
pdnl-2012-2020-7e65f530188b&language=nl&crs=https://www.opengis.net/def/crs/EPSG/0/3035