### PR TITLE
Fix for the tools in the table search result opening to the right

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/recordLinksButton.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/recordLinksButton.html
@@ -44,6 +44,6 @@
         data-icon-mode="::iconMode === 'dropdownOnly' ? 'none' : iconMode"
         data-record="record"></li>
 
-    <div data-ng-transclude=""/>
+    <span data-ng-transclude=""/>
   </ul>
 </div>

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/table.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/table.html
@@ -41,7 +41,7 @@
       </div>
     </td>
     <td>
-      <div class="gn-toolbar clearfix">
+      <div class="gn-toolbar nav navbar-nav navbar-right clearfix">
         <div class="gn-md-category pull-left"
              title="{{'listOfCategories' | translate}}"
              data-ng-class="md.category.length > 0 ||
@@ -65,7 +65,7 @@
           </i>
         </div>
 
-        <gn-links-btn class="pull-left"></gn-links-btn>
+        <gn-links-btn class="pull-left navbar-right"></gn-links-btn>
       </div>
     </td>
   </tr>

--- a/web-ui/src/main/resources/catalog/style/gn_search.less
+++ b/web-ui/src/main/resources/catalog/style/gn_search.less
@@ -441,11 +441,11 @@
     .dropdown-menu {
       max-width: 500px;
       li a {
-        padding-top: 1px;
-        padding-bottom: 1px;
+        padding: 8px 20px;
         line-height: normal;
         min-width: unset;
         .text-overflow();
+        display: block;
       }
     }
 


### PR DESCRIPTION
Tools menu was opening to right which resulted in the dropdown displayed partially outside of the screen. This PR opens the submenu to the left and adds some padding to the list items

**Before**
<img width="896" alt="gn-table-before" src="https://user-images.githubusercontent.com/19608667/174103987-bfc78715-d54c-439a-844e-d44807f45595.png">

**After**
<img width="902" alt="gn-table-after" src="https://user-images.githubusercontent.com/19608667/174104059-70f9f45c-41bd-4656-b6fb-d0aa3f73808e.png">

