### PR TITLE
Enable server hostname verification on this SSL/TLS connection.

### DIFF
--- a/core/src/main/java/org/fao/geonet/util/MailUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/MailUtil.java
@@ -366,10 +366,12 @@ public class MailUtil {
         if (tls != null && tls) {
             email.setStartTLSEnabled(tls);
             email.setStartTLSRequired(tls);
+            email.setSSLCheckServerIdentity(true);
         }
 
         if (ssl != null && ssl) {
             email.setSSLOnConnect(ssl);
+            email.setSSLCheckServerIdentity(true);
             if (StringUtils.isNotBlank(smtpPort + "")) {
                 email.setSslSmtpPort(smtpPort + "");
             }
@@ -377,6 +379,8 @@ public class MailUtil {
 
         if (ignoreSslCertificateErrors != null && ignoreSslCertificateErrors) {
             try {
+                email.setSSLCheckServerIdentity(false);
+
                 Session mailSession = email.getMailSession();
                 Properties p = mailSession.getProperties();
                 p.setProperty("mail.smtp.ssl.trust", "*");


### PR DESCRIPTION
To establish a SSL/TLS connection not vulnerable to man-in-the-middle attacks,
it’s essential to make sure the server presents the right certificate.

The certificate’s hostname-specific data should match the server hostname.
