### PR TITLE
Remove unused properties from cmis call to increase performance

### DIFF
--- a/core/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
@@ -181,9 +181,14 @@ public class CMISStore extends AbstractStore {
 
         Map<String, Object> properties = new HashMap<String, Object>();
         setCmisMetadataUUIDPrimary(properties, metadataUuid);
+
+        OperationContext oc = cmisUtils.createOperationContext();
+        // Reset Filter from the default operationalContext to include all fields because we may need secondary properties.
+        oc.setRenditionFilterString("");
+
         CmisObject cmisObject;
         try {
-            cmisObject = cmisConfiguration.getClient().getObjectByPath(key);
+            cmisObject = cmisConfiguration.getClient().getObjectByPath(key, oc);
         } catch (Exception e) {
             cmisObject = null;
         }
@@ -441,6 +446,10 @@ public class CMISStore extends AbstractStore {
         final String sourceResourceTypeDir = getMetadataDir(context, sourceMetadataId) + cmisConfiguration.getFolderDelimiter() + metadataResourceVisibility.toString();
         try {
             Folder sourceParentFolder = (Folder) cmisConfiguration.getClient().getObjectByPath(sourceResourceTypeDir);
+
+            OperationContext oc = cmisUtils.createOperationContext();
+            // Reset Filter from the default operationalContext to include all fields because we may need secondary properties.
+            oc.setRenditionFilterString("");
 
             Map<String, Document> sourceDocumentMap = cmisUtils.getCmisObjectMap(sourceParentFolder, null);
 

--- a/core/src/main/java/org/fao/geonet/resources/CMISConfiguration.java
+++ b/core/src/main/java/org/fao/geonet/resources/CMISConfiguration.java
@@ -40,7 +40,10 @@ import org.fao.geonet.utils.Log;
 
 import javax.annotation.Nonnull;
 import javax.annotation.PostConstruct;
+
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.regex.Pattern;
 
@@ -575,6 +578,35 @@ public class CMISConfiguration {
                     Log.debug(Geonet.RESOURCES, "Changing default CMIS operational context to not include relationships.");
                     client.getDefaultContext().setIncludeRelationships(IncludeRelationships.NONE);
                 }
+
+                // Setup default filter. Only include properties that are used by the application.
+                // Having too many may cause performance issues on some systems.
+                // The default is generally an empty string meaning all properties are used.
+                if (StringUtils.isEmpty(client.getDefaultContext().getFilterString())) {
+                    Log.debug(Geonet.RESOURCES, "Changing default CMIS operational context filter.");
+                    // excluding "cmis:secondaryObjectTypeIds" from the list as it could decrease performance on some systems.
+                    client.getDefaultContext().setFilter(new HashSet<>(Arrays.asList(
+                        "cmis:objectTypeId",
+                        "cmis:description",
+                        "cmis:createdBy",
+                        "cmis:contentStreamFileName",
+                        "cmis:isMajorVersion",
+                        "cmis:contentStreamLength",
+                        "cmis:contentStreamMimeType",
+                        "cmis:baseTypeId",
+                        "cmis:isLatestMajorVersion",
+                        "cmis:versionLabel",
+                        "cmis:creationDate",
+                        "cmis:name",
+                        "cmis:isLatestVersion",
+                        "cmis:lastModificationDate",
+                        "cmis:objectId",
+                        "cmis:lastModifiedBy",
+                        "cmis:contentStreamId",
+                        "cmis:changeToken",
+                        "cmis:versionSeriesId")));
+                }
+
             } catch (CmisRuntimeException | CmisConnectionException e) {
                 client = null;
                 Log.error(Geonet.RESOURCES,

--- a/core/src/main/java/org/fao/geonet/resources/CMISUtils.java
+++ b/core/src/main/java/org/fao/geonet/resources/CMISUtils.java
@@ -125,7 +125,7 @@ public class CMISUtils {
                 }
             });
         } catch (ExecutionException e) {
-            throw new ResourceNotFoundException("Error getting resource from cache: " + folderKey, e);
+            throw new ResourceNotFoundException("Error getting folder resource from cache: " + folderKey, e);
         }
         if (refresh && !foundWithoutCache[0]) {
             try {
@@ -156,15 +156,23 @@ public class CMISUtils {
     }
 
     public Map<String, Document> getCmisObjectMap(Folder folder, String baseFolder) {
-        return getCmisObjectMap(folder, baseFolder, null);
+        return getCmisObjectMap(folder, baseFolder, createOperationContext(), null);
+    }
+
+    public Map<String, Document> getCmisObjectMap(Folder folder, String baseFolder, OperationContext oc) {
+        return getCmisObjectMap(folder, baseFolder,  oc, null);
     }
 
     public Map<String, Document> getCmisObjectMap(Folder folder, String baseFolder, String suffixlessKeyFilename) {
+        return getCmisObjectMap(folder, baseFolder,  createOperationContext(), null);
+    }
+
+    public Map<String, Document> getCmisObjectMap(Folder folder, String baseFolder, OperationContext oc, String suffixlessKeyFilename) {
         if (baseFolder == null) {
             baseFolder = "";
         }
         Map<String, Document> documentMap = new HashMap<>();
-        for (CmisObject cmisObject : folder.getChildren()) {
+        for (CmisObject cmisObject : folder.getChildren(oc)) {
             if (cmisObject instanceof Folder) {
                 documentMap.putAll(getCmisObjectMap((Folder) cmisObject, baseFolder + cmisConfiguration.getFolderDelimiter() + cmisObject.getName(), suffixlessKeyFilename));
                 return documentMap;


### PR DESCRIPTION
Remove cmis:secondaryObjectTypeIds as well as other properties when possible as it can causes slow performance.

Using CMIS on Open Text seems to have some performance issues when using secondary properties.  By only using the standard cmis properties, it increased some CMIS calls by 50%.

Tested on Alfresco and it still seems to perform fast as it was before this change.