### PR TITLE
Fix the `toggle all sections` button in the editor.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -853,7 +853,7 @@
             '</button>',
         link: function linkFn(scope, element, attr) {
           var selector = attr['gnSectionToggle'] ||
-              'form > fieldset > legend[data-gn-slide-toggle]',
+              'form > div > fieldset > legend[data-gn-slide-toggle]',
               event = attr['event'] || 'click';
           element.on('click', function() {
             $(selector).each(function(idx, elem) {


### PR DESCRIPTION
The toggle button stopped working due to a change in the DOM structure so no sections were selected

<img width="803" alt="gn-toggle-all" src="https://user-images.githubusercontent.com/19608667/174256817-89abde6a-8900-4258-b0da-178e3403c209.png">

