### PR TITLE
Support custom map configuration to generate map thumbnails

### DIFF
--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
@@ -715,6 +715,12 @@
                 <div ng-include="'../../catalog/components/admin/uiconfig/partials/mapconfig.html'">
                 </div>
               </div>
+              <div data-ng-switch-when="map-thumbnail">
+                <h3>{{('ui-' + key) | translate}}</h3>
+                <gn-ui-config-help/>
+                <div ng-include="'../../catalog/components/admin/uiconfig/partials/mapconfig.html'">
+                </div>
+              </div>
 
               <div data-ng-switch-when="createPageTpl">
                 <label class="control-label">{{('ui-' + key) | translate}}</label>

--- a/web-ui/src/main/resources/catalog/components/common/map/mapsManager.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapsManager.js
@@ -109,6 +109,7 @@
         VIEWER_MAP: 'viewer',
         SEARCH_MAP: 'search',
         EDITOR_MAP: 'editor',
+        GENERATE_THUMBNAIL_MAP: 'thumbnail',
 
         /**
          * @ngdoc method

--- a/web-ui/src/main/resources/catalog/components/common/map/print/PrintDirective.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/print/PrintDirective.js
@@ -73,7 +73,7 @@
           overlayCanvas.width = width;
           overlayCanvas.height = height;
           var ctx = overlayCanvas.getContext('2d');
-          
+
 
           var minx, miny, maxx, maxy;
           minx = printRectangle[0], miny = printRectangle[1],
@@ -492,14 +492,15 @@
               type: 'WMS',
               baseURL: config.wmsUrl ||
                   layer.url ||
-                  layer.getSource().getParams().URL,
+                  layer.getSource().getParams().URL ||
+                  layer.getSource().getUrls()[0],
               layers: layers,
               styles: styles,
               format: 'image/' + (config.format || 'png'),
               customParams: {
                 'EXCEPTIONS': 'XML',
                 'TRANSPARENT': 'true',
-                'CRS': proj.getCode(), 
+                'CRS': proj.getCode(),
                 'TIME': params.TIME
               },
               singleTile: config.singleTile || true

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -692,7 +692,7 @@
                 var initThumbnailMaker = function() {
 
                   if (!scope.loaded) {
-                    scope.map = gnMapsManager.createMap(gnMapsManager.VIEWER_MAP);
+                    scope.map = gnMapsManager.createMap(gnMapsManager.GENERATE_THUMBNAIL_MAP);
 
                     // scope.map = new ol.Map({
                     //   layers: [],

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -708,6 +708,11 @@ goog.require('gn_alert');
             'extent': [0, 0, 0, 0],
             'layers': [{'type': 'osm'}]
           },
+          'map-thumbnail': {
+            'context': '../../map/config-viewer.xml',
+            'extent': [0, 0, 0, 0],
+            'layers': []
+          },
           'autoFitOnLayer': false
         },
         'geocoder': {

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1309,6 +1309,8 @@
     "ui-map-search-help": "This configuration is used for the search map. Every parameter is optional. The context is applied first, then the extent and layers. Supported types are: osm, bing_aerial, stamen, wmts, wms.",
     "ui-map-editor": "Editor Maps Configuration",
     "ui-map-editor-help": "This configuration is used for the editor maps (bounding box and geometry editor). Every parameter is optional. The context is applied first, then the extent and layers. Supported types are: osm, bing_aerial, stamen, wmts, wms.",
+    "ui-map-thumbnail": "Metadata Thumbnail Map Configuration",
+    "ui-map-thumbnail-help": "This configuration is used for the metadata editor map to generate thumbnails. Every parameter is optional. The context is applied first, then the extent and layers. Supported types are: osm, bing_aerial, stamen, wmts, wms.",
     "mapConfigContext": "Path to the context file (XML)",
     "mapConfigContext-help": "URL to the map context file which can contain the variable lang, for 3 letters language code, between '{' and '}'",
     "mapConfigExtent": "Extent, expressed in current projection",


### PR DESCRIPTION
Generate map thumbnails in the metadata editor uses the same map context file used for the map viewer. When using WMTS services, the library used for printing the map images (Mapfish) seem not dealing well with the map tiles in some services, displaying an empty map.

This code change allows to configure a map configuration for the map thumbnail generation, this can be useful to configure for the map printing a WMS service that doesn't use tiles .

![map-config](https://user-images.githubusercontent.com/1695003/174325604-cb226dc1-b522-41c6-995e-c09badf5b2fa.png)
 