### PR TITLE
Exclude log4j-1.2-api dependency from MapFish

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -862,6 +862,16 @@
         <groupId>org.mapfish.print</groupId>
         <artifactId>print-lib</artifactId>
         <version>2.2.0</version>
+        <exclusions>
+          <exclusion>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-1.2-api</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j-impl</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <!-- Lib utils -->


### PR DESCRIPTION
The dependency adds some additional dependencies, causing this type of errors:
```
  java.lang.NoSuchMethodError: org.apache.logging.log4j.util.StackLocatorUtil.getCallerClassLoader(I)Ljava/lang/ClassLoader;
```
Related to https://github.com/geonetwork/core-geonetwork/pull/6392