### PR TITLE
Remote INSPIRE Atom - skip processing dataset feed entries without an identifier

### DIFF
--- a/inspire-atom/src/main/java/org/fao/geonet/inspireatom/util/InspireAtomUtil.java
+++ b/inspire-atom/src/main/java/org/fao/geonet/inspireatom/util/InspireAtomUtil.java
@@ -246,11 +246,14 @@ public class InspireAtomUtil {
         for (Object field : atomIndexFields.getChildren()) {
             Element f = (Element) field;
 
-            DatasetFeedInfo datasetFeedInfo = new DatasetFeedInfo(f.getChildText("identifier"),
-                f.getChildText("namespace"),
-                f.getChildText("feedUrl"));
+            // Some feed entries contain an empty identifier, skip them
+            if (StringUtils.isNotEmpty(f.getChildText("identifier"))) {
+                DatasetFeedInfo datasetFeedInfo = new DatasetFeedInfo(f.getChildText("identifier"),
+                    f.getChildText("namespace"),
+                    f.getChildText("feedUrl"));
 
-            datasetsInformation.add(datasetFeedInfo);
+                datasetsInformation.add(datasetFeedInfo);
+            }
         }
 
         return datasetsInformation;


### PR DESCRIPTION
For example: http://geodata.nationaalgeoregister.nl/atom/index.xml, contain some entries like the following with an empty value for `inspire_dls:spatial_dataset_identifier_code`:

```
<entry>
    <id>https://geodata.nationaalgeoregister.nl/rvo-schelpdierpercelen/atom/rvo-schelpdierpercelen.xml</id>
    <title type="text" xml:lang="nl">RVO - Schelpdierpercelen - Parent Feed (CRS)</title>
    <summary type="text" xml:lang="nl">Atom feed voor de download van dataset RVO - Schelpdierpercelen</summary>
    <category term="http://www.opengis.net/def/crs/EPSG/0/28992" label="Amersfoort / RD New"/>
    <georss:polygon>50.6 3.1 50.6 7.3 53.7 7.3 53.7 3.1 50.6 3.1</georss:polygon>
    <link href="https://www.nationaalgeoregister.nl/geonetwork/srv/dut/xml.metadata.get?uuid=" rel="describedby" type="application/xml"/>
    <link href="https://geodata.nationaalgeoregister.nl/rvo-schelpdierpercelen/atom/rvo-schelpdierpercelen.xml" rel="alternate" type="application/atom+xml" hreflang="nl" title="RVO - Schelpdierpercelen - Download Service voorgedefinieerde dataset"/>
    <inspire_dls:spatial_dataset_identifier_code/>
    <inspire_dls:spatial_dataset_identifier_namespace>http://www.pdok.nl</inspire_dls:spatial_dataset_identifier_namespace>
</entry>
```