### PR TITLE
API / Batch editing / Add support for attribute.

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/AddElemValue.java
+++ b/core/src/main/java/org/fao/geonet/kernel/AddElemValue.java
@@ -42,7 +42,8 @@ public class AddElemValue {
         String finalStringVal = stringValue;
         Element finalNodeVal = null;
 
-        if (Xml.isXMLLike(stringValue)) {
+        String valueWithoutSpecialTag = stringValue.replaceAll("</?gn_(add|replace|delete)>", "");
+        if (Xml.isXMLLike(valueWithoutSpecialTag)) {
             try {
                 finalNodeVal = Xml.loadString(stringValue, false);
                 finalStringVal = null;
@@ -55,7 +56,7 @@ public class AddElemValue {
             }
         }
         this.nodeValue = finalNodeVal;
-        this.stringValue = finalStringVal;
+        this.stringValue = valueWithoutSpecialTag;
     }
 
     public AddElemValue(Element nodeValue) {

--- a/core/src/main/java/org/fao/geonet/kernel/EditLib.java
+++ b/core/src/main/java/org/fao/geonet/kernel/EditLib.java
@@ -500,13 +500,6 @@ public class EditLib {
                 value.getNodeValue().getName()
                     .equals(SpecialUpdateTags.CREATE);
 
-            if (isValueXml &&
-                xpathProperty.matches(".*@[^/\\]]+")) {
-                throw new AssertionError(String.format(
-                    "Cannot set Xml on an attribute. Xpath:'%s' value: '%s'.",
-                    xpathProperty, Xml.getString(value.getNodeValue())
-                ));
-            }
             LOGGER_ADD_ELEMENT.debug("Inserting at location {} the snippet or value {}", xpathProperty, value);
 
             xpathProperty = cleanRootFromXPath(xpathProperty, metadataRecord);


### PR DESCRIPTION
Add support for add/update/replace attributes.

Currently
```
Cannot set Xml on an attribute. Xpath:'/mdb:MD_Metadata/mdb:metadataScope/mdb:MD_MetadataScope/mdb:resourceScope/mcc:MD_ScopeCode/@codeListValue' value: '<gn_replace>application</gn_replace>'
```


Supported update modes:
```json
[
{"insertMode":"gn_replace",
"xpath":"/mdb:MD_Metadata/mdb:metadataScope/mdb:MD_MetadataScope/mdb:resourceScope/*/@codeListValue",
"value":"application"},
{"insertMode":"gn_delete",
"xpath":"/mdb:MD_Metadata/mdb:metadataScope/mdb:MD_MetadataScope/mdb:resourceScope/*/@codeListValue",
"value":""},
{"insertMode":"gn_add",
"xpath":"/mdb:MD_Metadata/mdb:metadataScope/mdb:MD_MetadataScope/mdb:resourceScope/*/@newAttribute",
"value":"newValue"}
]
```


