### PR TITLE
Thesaurus / Regions / Turkey is now Türkiye

### DIFF
--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v421/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v421/migrate-default.sql
@@ -4,7 +4,8 @@ INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system
 
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('metadata/delete/profilePublishedMetadata', 'Editor', 0, 12011, 'n');
 
-UPDATE metadata SET data = replace(data, 'Turkey', 'Türkiye') WHERE data LIKE '%Turkey%';
+-- cf. https://www.un.org/en/about-us/member-states/turkiye (run this manually if it applies to your catalogue)
+-- UPDATE metadata SET data = replace(data, 'Turkey', 'Türkiye') WHERE data LIKE '%Turkey%';
 
 UPDATE Settings SET value='4.2.1' WHERE name='system/platform/version';
 UPDATE Settings SET value='SNAPSHOT' WHERE name='system/platform/subVersion';

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v421/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v421/migrate-default.sql
@@ -4,5 +4,7 @@ INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system
 
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('metadata/delete/profilePublishedMetadata', 'Editor', 0, 12011, 'n');
 
+UPDATE metadata SET data = replace(data, 'Turkey', 'Türkiye') WHERE data LIKE '%Turkey%';
+
 UPDATE Settings SET value='4.2.1' WHERE name='system/platform/version';
 UPDATE Settings SET value='SNAPSHOT' WHERE name='system/platform/subVersion';

--- a/web/src/main/webapp/WEB-INF/data/config/codelist/external/thesauri/place/regions.rdf
+++ b/web/src/main/webapp/WEB-INF/data/config/codelist/external/thesauri/place/regions.rdf
@@ -3764,8 +3764,8 @@
     <skos:broader rdf:resource="http://www.naturalearthdata.com/ne_admin#Continent/Africa"/>
   </skos:Concept>
   <skos:Concept rdf:about="http://www.naturalearthdata.com/ne_admin#Country/TUR">
-    <skos:prefLabel xml:lang="en">Turkey</skos:prefLabel>
-    <skos:prefLabel xml:lang="fr">Turkey</skos:prefLabel>
+    <skos:prefLabel xml:lang="en">Türkiye</skos:prefLabel>
+    <skos:prefLabel xml:lang="fr">Türkiye</skos:prefLabel>
     <skos:altLabel>TUR</skos:altLabel>
     <gml:BoundedBy>
       <gml:Envelope gml:srsName="http://www.opengis.net/gml/srs/epsg.xml#epsg:4326">


### PR DESCRIPTION
"The Republic of Türkiye changed its official name from The Republic of
Turkey on 26 May 2022 in a request submitted to the Secretary-General by
the country's Minister of Foreign Affairs."

cf. https://www.un.org/en/about-us/member-states/turkiye