### PR TITLE
Standard / ISO / Keyword configuration and labels

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/xsl-view/view.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/xsl-view/view.xsl
@@ -128,11 +128,16 @@
             </xsl:for-each>
           </xsl:variable>
           <xsl:for-each select="mri:keyword">
-            <tag thesaurus="{$thesaurusTitle}">
+            <xsl:variable name="keyword">
               <xsl:call-template name="get-iso19115-3.2018-localised">
                 <xsl:with-param name="langId" select="$langId"/>
               </xsl:call-template>
-            </tag>
+            </xsl:variable>
+            <xsl:if test="$keyword != ''">
+              <tag thesaurus="{$thesaurusTitle}">
+                <xsl:value-of select="$keyword"/>
+              </tag>
+            </xsl:if>
           </xsl:for-each>
         </xsl:for-each>
       </xsl:variable>
@@ -825,7 +830,7 @@
                 match="mri:descriptiveKeywords[
                         */mri:thesaurusName/cit:CI_Citation/cit:title]"
                 priority="100">
-    <xsl:param name="fieldName"/>
+    <xsl:param name="fieldName" select="''" as="xs:string"/>
 
     <dl class="gn-keyword">
       <dt>
@@ -861,16 +866,26 @@
   <xsl:template mode="render-field"
                 match="mri:descriptiveKeywords[not(*/mri:thesaurusName/cit:CI_Citation/cit:title)]"
                 priority="100">
+    <xsl:param name="fieldName" select="''" as="xs:string"/>
+
     <dl class="gn-keyword">
       <dt>
-        <xsl:value-of select="$schemaStrings/noThesaurusName"/>
-        <xsl:if test="*/mri:type/*[@codeListValue != '']">
-          <xsl:variable name="thesaurusType">
-            <xsl:apply-templates mode="render-value"
-                                 select="*/mri:type/*/@codeListValue"/>
-          </xsl:variable>
-          (<xsl:value-of select="normalize-space($thesaurusType)"/>)
-        </xsl:if>
+        <xsl:variable name="thesaurusType">
+          <xsl:apply-templates mode="render-value"
+                               select="*/mri:type/*/@codeListValue[. != '']"/>
+        </xsl:variable>
+
+        <xsl:choose>
+          <xsl:when test="$fieldName != ''">
+            <xsl:value-of select="$fieldName"/>
+          </xsl:when>
+          <xsl:when test="$thesaurusType != ''">
+            <xsl:copy-of select="$thesaurusType"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:value-of select="$schemaStrings/noThesaurusName"/>
+          </xsl:otherwise>
+        </xsl:choose>
       </dt>
       <dd>
         <div>

--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
@@ -847,10 +847,19 @@
                 match="gmd:descriptiveKeywords[*/gmd:thesaurusName/gmd:CI_Citation/gmd:title and
                 count(*/gmd:keyword/*[. != '']) > 0]"
                 priority="100">
+    <xsl:param name="fieldName" select="''" as="xs:string"/>
+
     <dl class="gn-keyword">
       <dt>
-          <xsl:apply-templates mode="render-value"
-                               select="*/gmd:thesaurusName/gmd:CI_Citation/gmd:title"/>
+        <xsl:choose>
+          <xsl:when test="$fieldName != ''">
+            <xsl:value-of select="$fieldName"/>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:apply-templates mode="render-value"
+                                 select="*/gmd:thesaurusName/gmd:CI_Citation/gmd:title"/>
+          </xsl:otherwise>
+        </xsl:choose>
       </dt>
       <dd>
         <div>
@@ -871,6 +880,8 @@
   <xsl:template mode="render-field"
                 match="gmd:descriptiveKeywords[not(*/gmd:thesaurusName/gmd:CI_Citation/gmd:title)]"
                 priority="100">
+    <xsl:param name="fieldName" select="''" as="xs:string"/>
+
     <dl class="gn-keyword">
       <dt>
         <xsl:variable name="thesaurusType">
@@ -879,6 +890,9 @@
         </xsl:variable>
 
         <xsl:choose>
+          <xsl:when test="$fieldName != ''">
+            <xsl:value-of select="$fieldName"/>
+          </xsl:when>
           <xsl:when test="$thesaurusType != ''">
             <xsl:copy-of select="$thesaurusType"/>
           </xsl:when>


### PR DESCRIPTION
* Avoid empty keyword in view mode
* Allow to override thesaurus title using field name

```
<field xpath=".//mri:descriptiveKeywords[*/mri:thesaurusName]" name="verticalDatum"/>
```

![image](https://user-images.githubusercontent.com/1701393/175502218-7b4c1a8c-25da-4246-9e21-467f8026fbf4.png)


* Consistent rendering in ISO19139 and 115-3