### PR TITLE
Configuration option to display the application version and links to the About, GitHub and API pages in the footer

### DIFF
--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
@@ -543,7 +543,7 @@
 
 
               <!-- boolean -->
-              <div data-ng-switch-when="is3DModeAllowed|isVegaEnabled|isSaveMapInCatalogAllowed|isExportMapAsImageEnabled|useOSM|isUserRecordsOnly|isFilterTagsDisplayed|isFilterTagsDisplayedInSearch|showMapInFacet|autoFitOnLayer|showSocialBarInFooter|isSocialbarEnabled|isLogoInHeader|isHeaderFixed|isMenubarAccessible|fluidLayout|fluidHeaderLayout|fluidEditorLayout|showGNName|humanizeDates|sortKeywordsAlphabetically|showMosaic|showMaps"
+              <div data-ng-switch-when="is3DModeAllowed|isVegaEnabled|isSaveMapInCatalogAllowed|isExportMapAsImageEnabled|useOSM|isUserRecordsOnly|isFilterTagsDisplayed|isFilterTagsDisplayedInSearch|showMapInFacet|autoFitOnLayer|showSocialBarInFooter|isSocialbarEnabled|isLogoInHeader|isHeaderFixed|isMenubarAccessible|fluidLayout|fluidHeaderLayout|fluidEditorLayout|showGNName|humanizeDates|sortKeywordsAlphabetically|showMosaic|showMaps|showApplicationInfoAndLinksInFooter"
                    data-ng-switch-when-separator="|">
                 <input type="checkbox"
                        id="{{key}}-checkbox"

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -74,7 +74,8 @@ goog.require('gn_alert');
         },
         'footer':{
           'enabled': true,
-          'showSocialBarInFooter': true
+          'showSocialBarInFooter': true,
+          'showApplicationInfoAndLinksInFooter': true
         },
         'header': {
           'enabled': true,
@@ -1272,6 +1273,10 @@ goog.require('gn_alert');
       $scope.getSocialLinksVisible = function() {
         var onMdView =  $location.absUrl().indexOf('/metadata/') > -1;
         return !onMdView && gnGlobalSettings.gnCfg.mods.footer.showSocialBarInFooter;
+      };
+
+      $scope.getApplicationInfoVisible = function() {
+        return gnGlobalSettings.gnCfg.mods.footer.showApplicationInfoAndLinksInFooter;
       };
 
       function detectNode(detector) {

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1476,6 +1476,8 @@
     "hopCountHelp": "Control the maximum number of message hops (default to 2) before the search is terminated in a distributed search.",
     "ui-showSocialBarInFooter": "Show Social bar",
     "ui-showSocialBarInFooter-help": "Show the button bar with all the social buttons (facebook, twitter, etc.) in the footer of GeoNetwork",
+    "ui-showApplicationInfoAndLinksInFooter": "Show GeoNetwork version and links",
+    "ui-showApplicationInfoAndLinksInFooter-help": "Show the application version and links in the footer of GeoNetwork",
     "ui-fluidLayout": "Fluid container for Home and Search",
     "ui-fluidLayout-help": "If enabled, the layout of the application has a full width container, when disabled the layout has a fixed width and centered container",
     "ui-fluidEditorLayout": "Fluid container for the Editor",

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1477,7 +1477,7 @@
     "ui-showSocialBarInFooter": "Show Social bar",
     "ui-showSocialBarInFooter-help": "Show the button bar with all the social buttons (facebook, twitter, etc.) in the footer of GeoNetwork",
     "ui-showApplicationInfoAndLinksInFooter": "Show GeoNetwork version and links",
-    "ui-showApplicationInfoAndLinksInFooter-help": "Show the application version and links in the footer of GeoNetwork",
+    "ui-showApplicationInfoAndLinksInFooter-help": "Show the application version and links in the catalog page footer",
     "ui-fluidLayout": "Fluid container for Home and Search",
     "ui-fluidLayout-help": "If enabled, the layout of the application has a full width container, when disabled the layout has a fixed width and centered container",
     "ui-fluidEditorLayout": "Fluid container for the Editor",

--- a/web-ui/src/main/resources/catalog/views/default/templates/footer.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/footer.html
@@ -1,4 +1,4 @@
-<ul class="nav navbar-nav">
+<ul class="nav navbar-nav" ng-show="getApplicationInfoVisible()">
   <li class="navbar-text">
     <span data-translate=""
           data-translate-values="{platform: '{{info['system/platform/name']}}', version: '{{info['system/platform/version']}}', subversion: '{{info['system/platform/subVersion']}}'}">

--- a/web-ui/src/main/resources/catalog/views/default/templates/footer.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/footer.html
@@ -1,4 +1,4 @@
-<ul class="nav navbar-nav" ng-show="getApplicationInfoVisible()">
+<ul class="nav navbar-nav" ng-show="::getApplicationInfoVisible()">
   <li class="navbar-text">
     <span data-translate=""
           data-translate-values="{platform: '{{info['system/platform/name']}}', version: '{{info['system/platform/version']}}', subversion: '{{info['system/platform/subVersion']}}'}">


### PR DESCRIPTION
This change adds a new configuration option to allow display/hide the application version and links in the footer.

![footer-1](https://user-images.githubusercontent.com/1695003/176362940-f741c040-e706-4fed-b807-f2ebd2420132.png)

**With the option disabled:**

![footer-2](https://user-images.githubusercontent.com/1695003/176362977-99a60737-cb51-4966-9525-3adb7025d7a0.png)

**With the option enabled:**

![footer-3](https://user-images.githubusercontent.com/1695003/176363060-cc1f011f-90b2-4001-a108-99815cc1e4ab.png)

