### PR TITLE
Metadata template identifier / Always generate UUID

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/MetadataInsertDeleteApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataInsertDeleteApi.java
@@ -476,7 +476,7 @@ public class MetadataInsertDeleteApi {
         String metadataUuid = null;
 
 
-        if (generateUuid && !StringUtils.isEmpty(targetUuid)) {
+        if (!generateUuid && !StringUtils.isEmpty(targetUuid)) {
             // Check if the UUID exists
             try {
                 ApiUtils.getRecord(targetUuid);


### PR DESCRIPTION
Issue introduced by https://github.com/geonetwork/core-geonetwork/commit/28b22da39ffc32824faf47b0f00dc0788df61831#diff-fd5c78f078bd1495f232ed345a67141aea9d5c2dc34075ab6ff34b772f4b7c0aR420

See the doc - settings generateUuid is disabled to use custom identifier
https://geonetwork-opensource.org/manuals/3.10.x/fr/administrator-guide/managing-metadata-standards/metadata-identifier.html