### PR TITLE
Metadata import - store the validation status when the validation option is selected

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/mef/Importer.java
+++ b/core/src/main/java/org/fao/geonet/kernel/mef/Importer.java
@@ -55,13 +55,9 @@ import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.GeonetworkDataDirectory;
 import org.fao.geonet.kernel.datamanager.IMetadataManager;
 import org.fao.geonet.kernel.datamanager.IMetadataUtils;
+import org.fao.geonet.kernel.datamanager.IMetadataValidator;
 import org.fao.geonet.kernel.setting.SettingManager;
-import org.fao.geonet.repository.GroupRepository;
-import org.fao.geonet.repository.MetadataCategoryRepository;
-import org.fao.geonet.repository.MetadataRelationRepository;
-import org.fao.geonet.repository.OperationAllowedRepository;
-import org.fao.geonet.repository.SourceRepository;
-import org.fao.geonet.repository.Updater;
+import org.fao.geonet.repository.*;
 import org.fao.geonet.utils.FilePathChecker;
 import org.fao.geonet.utils.Log;
 import org.fao.geonet.utils.Xml;
@@ -424,6 +420,7 @@ public class Importer {
 
                         addCategoriesToMetadata(metadata, finalCategs, context);
 
+
                         if (finalGroupId == null || finalGroupId.equals("")) {
                             Group ownerGroup = addPrivileges(context, dm, iMetadataId, privileges);
                             if (ownerGroup != null) {
@@ -435,9 +432,20 @@ public class Importer {
                                 Integer.valueOf(finalGroupId));
                             allowedRepository.saveAll(allowedSet);
                         }
-
                     }
                 });
+
+                if (validate) {
+                    java.util.Optional<Metadata> md = context.getBean(MetadataRepository.class).findById(iMetadataId);
+
+                    if (md.isPresent()) {
+                        // Persist the validation status
+                        IMetadataValidator metadataValidator = context.getBean(IMetadataValidator.class);
+
+                        metadataValidator.doValidate(md.get(), context.getLanguage());
+                    }
+                }
+
                 dm.indexMetadata(metadataIdMap.get(index), true);
             }
 

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataInsertDeleteApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataInsertDeleteApi.java
@@ -75,6 +75,7 @@ import org.fao.geonet.kernel.SchemaManager;
 import org.fao.geonet.kernel.datamanager.IMetadataManager;
 import org.fao.geonet.kernel.datamanager.IMetadataOperations;
 import org.fao.geonet.kernel.datamanager.IMetadataUtils;
+import org.fao.geonet.kernel.datamanager.IMetadataValidator;
 import org.fao.geonet.kernel.mef.Importer;
 import org.fao.geonet.kernel.mef.MEFLib;
 import org.fao.geonet.kernel.search.EsSearchManager;
@@ -180,6 +181,9 @@ public class MetadataInsertDeleteApi {
 
     @Autowired
     RoleHierarchy roleHierarchy;
+
+    @Autowired
+    IMetadataValidator metadataValidator;
 
     @io.swagger.v3.oas.annotations.Operation(summary = "Delete a record", description = "User MUST be able to edit the record to delete it. "
         + "By default, a backup is made in ZIP format. After that, "
@@ -974,6 +978,13 @@ public class MetadataInsertDeleteApi {
                     }
                 }
             });
+        }
+
+        if (rejectIfInvalid) {
+            // Persist the validation status
+            AbstractMetadata metadata = metadataRepository.findOneById(iId);
+
+            metadataValidator.doValidate(metadata, context.getLanguage());
         }
 
         dataManager.indexMetadata(id.get(0), true);


### PR DESCRIPTION
Test case:

1) Import a valid xml or MEF file, checking the Validate option.

![validation0](https://user-images.githubusercontent.com/1695003/177294931-565426b8-9a48-4f2c-bb6a-b8739b917750.png)


2) In the editor boards, the metadata validation icon should be green, but without this change the icon is displayed as gray (no validation tested)

![validation1](https://user-images.githubusercontent.com/1695003/177294786-db5ffb07-48ad-4688-8424-3b567f48a2dd.png)

With the change:

![validation2](https://user-images.githubusercontent.com/1695003/177295302-7d3d46ae-6b6f-4642-96e3-41ef411179fe.png)


In the original code the Validate option was used to discard the metadata if not valid, but the metadata status when the metadata is valid was not stored.