### PR TITLE
Improved calculation of the map height

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/less/gn_layout_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_layout_default.less
@@ -15,6 +15,7 @@ html, body {
 // header
 .gn-header {
   background-color: @gn-header-background;
+  height: @gn-header-height;
 }
 
 // background image and color

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_map_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_map_default.less
@@ -3,7 +3,7 @@
 @btn-link-disabled-color: #707070;
 @dropdown-link-disabled-color: #707070;
 
-.gn-map-fixed { 
+.gn-map-fixed {
   [ol-map] {
     border: 1px solid #ccc;
     border-radius: 3px;
@@ -28,7 +28,7 @@
   left: 0px;
   right: 0px;
   [ol-map] {
-    height: calc(~"100vh - @{gn-menubar-height} - @{gn-bottombar-height} - 2px");
+    height: 100%;
   }
   .ol-attribution {
     .gn-attribution();
@@ -119,17 +119,39 @@
     }
   }
 }
-
 .gn-hide-footer {
   [gn-main-viewer] {
-    [ol-map] {
-      height: calc(~"100vh - @{gn-menubar-height} - 1px");
-    }
     .control-tools {
       bottom: 1em;
     }
   }
 }
+
+// calculate map viewer height
+
+// ----- default (menubar + map + footer)
+[gn-main-viewer] {
+  height: calc(~"100vh - @{gn-menubar-height} - @{gn-bottombar-height} - 1px");
+}
+// ----- header + menubar + map + footer
+.gn-logo-in-header {
+  [gn-main-viewer] {
+    height: calc(~"100vh - @{gn-header-height} - @{gn-menubar-height} - @{gn-bottombar-height} - 1px");
+  }
+}
+// ----- menubar + map (NO footer)
+.gn-hide-footer {
+  [gn-main-viewer] {
+    height: calc(~"100vh - @{gn-menubar-height} - 1px");
+  }
+}
+// ----- header + menubar + map (NO footer)
+.gn-logo-in-header.gn-hide-footer {
+  [gn-main-viewer] {
+    height: calc(~"100vh - @{gn-header-height} - @{gn-menubar-height} - 1px");
+  }
+}
+
 // minimap on search results
 .gn-search-map {
   [ol-map] {


### PR DESCRIPTION
Improved calculation of the map height. In some cases the height wasn't correctly which resulted in a scrollbar next to the map. This PR fixes the height and scrollbar issue.

4 possible configurations:

1. default (menubar + map + footer)
2. header + menubar + map + footer
3. menubar + map (NO footer)
4. header + menubar + map (NO footer)

Extra:
- set the header height if it is set in the admin > css