### PR TITLE
fix: entries list in registry board

### DIFF
--- a/web-ui/src/main/resources/catalog/js/edit/DirectoryController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/DirectoryController.js
@@ -180,7 +180,8 @@
                 {"terms": {"isTemplate": ["t"]}}
               ]
             }
-          }}, {cache: true}).then(function(r) {
+          },
+          "size": 1000}, {cache: true}).then(function(r) {
           if (r.data.hits.total.value > 0) {
             $scope.templates = r.data.hits.hits.map(function(md) {
               return {


### PR DESCRIPTION
Fix https://github.com/geonetwork/core-geonetwork/issues/6447

Load of templates of subtemplates when trying to add a new entry from templates.