### PR TITLE
Move xsd validation to the bottom of the mandatory rules, displaying first the schematron rules

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/validationreport/ValidationReportDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/validationreport/ValidationReportDirective.js
@@ -88,14 +88,9 @@
                     });
                   });
 
-                  // Move xsd rules to the end of the mandatory rules
-                  var xsdItem = _.find(scope.ruleTypes, function(r) { return r.id == 'xsd'; });
-                  if (xsdItem !== undefined) {
-                    scope.ruleTypes = _.without(scope.ruleTypes, xsdItem);
-
-                    scope.ruleTypes.push(xsdItem);
+                  if (scope.ruleTypes[0].id === 'xsd') {
+                    scope.ruleTypes.push(scope.ruleTypes.splice(0, 1)[0]);
                   }
-
                   scope.ruleTypes = scope.ruleTypes.concat(optional);
                   scope.hasSuccess = scope.ruleTypes.length > 0;
                   scope.loading = false;

--- a/web-ui/src/main/resources/catalog/components/edit/validationreport/ValidationReportDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/validationreport/ValidationReportDirective.js
@@ -88,6 +88,14 @@
                     });
                   });
 
+                  // Move xsd rules to the end of the mandatory rules
+                  var xsdItem = _.find(scope.ruleTypes, function(r) { return r.id == 'xsd'; });
+                  if (xsdItem !== undefined) {
+                    scope.ruleTypes = _.without(scope.ruleTypes, xsdItem);
+
+                    scope.ruleTypes.push(xsdItem);
+                  }
+
                   scope.ruleTypes = scope.ruleTypes.concat(optional);
                   scope.hasSuccess = scope.ruleTypes.length > 0;
                   scope.loading = false;


### PR DESCRIPTION
XSD rules are a bit technical for most end users, and the errors reported are usually covered by the schematron rules defined in the schemas, that are more clear to review by users. 

This change moves the position of the `xsd` validation from the top to the bottom (of the mandatory rules) to faciliate the review of the validation errors.

![xsd-validation](https://user-images.githubusercontent.com/1695003/177929265-da911c98-37cd-45b7-a61f-20f3ec47d07a.png)