### PR TITLE
CSW queries should use the draft filter

### DIFF
--- a/csw-server/src/test/java/org/fao/geonet/component/csw/CswTransactionIntegrationTest.java
+++ b/csw-server/src/test/java/org/fao/geonet/component/csw/CswTransactionIntegrationTest.java
@@ -387,6 +387,7 @@ public class CswTransactionIntegrationTest extends AbstractCoreIntegrationTest {
         List<Element> extras = Lists.newArrayList(
             SearchManager.makeField("_uuid", PHOTOGRAPHIC_UUID, false, true),
             SearchManager.makeField("_isTemplate", "n", true, true),
+            SearchManager.makeField("_draft", "n", true, true),
             SearchManager.makeField("_owner", "" + ownerId, true, true)
         );
         _searchManager.index(schemaDir, metadata.getXmlData(false), "" + metadata.getId(), extras,

--- a/web/src/main/webapp/xml/csw/filter-to-lucene.xsl
+++ b/web/src/main/webapp/xml/csw/filter-to-lucene.xsl
@@ -367,6 +367,16 @@
       <BooleanClause required="true" prohibited="false">
         <TermQuery fld="_isTemplate" txt="n"/>
       </BooleanClause>
+      <BooleanClause required="true" prohibited="false">
+        <BooleanQuery>
+          <BooleanClause required="false" prohibited="false">
+            <TermQuery fld="_draft" txt="n" />
+          </BooleanClause>
+          <BooleanClause required="false" prohibited="false">
+            <TermQuery fld="_draft" txt="e" />
+          </BooleanClause>
+        </BooleanQuery>
+      </BooleanClause>
     </BooleanQuery>
   </xsl:template>
 


### PR DESCRIPTION
Otherwise the CSW query returns the approved metadata and it's working copy (for metadata that is approved and has a working copy).

Test case:

1) With the workflow disabled: create an iso19139 metadata with the default template, change the title only.

2) Query in the UI for ISO19115

http://localhost:8080/geonetwork/srv/eng/catalog.search#/search?resultType=details&sortBy=relevance&from=1&to=20&fast=index&_content_type=json&any=ISO19115

Lucene query generated:

```
+(_op0:0 _op0:-1 _op0:1 _op0:2 _owner:1 _dummy:0) +any:iso19115 +_isTemplate:n +(_draft:n _draft:e) _locale:eng
```

3) Query in CSW for ISO19115

http://localhost:8080/geonetwork/srv/eng/csw?request=GetRecords&service=CSW&version=2.0.2&resultType=results&constraintLanguage=CQL_TEXT&constraint_language_version=1.1.0&outputSchema=IsoRecord&typeNames=csw:Record&constraint=anytext%20like%20%27ISO19115%27

Lucene query generated (the filter doesn't have the _draft field):

```
+(+(+any:iso19115) +_isTemplate:n _locale:eng) +(_op0:0 _op0:-1 _op0:1 _op0:2 _owner:1)
```

**Results are the same**

4) Enable the workflow and create an iso19139 metadata with the default template, change the title only and approve it.

5) Test the queries from 2 and 3)

**Results are the same**

6) Edit the metadata from 4) to create a working copy

7) Test the queries from 2 and 3)

**CSW result returns 3 results instead of 2**

---

This change fixes the previous issue.
