### PR TITLE
INSPIRE Registry UI improvements

### DIFF
--- a/web-ui/src/main/resources/catalog/components/admin/registry/RegistryDirective.js
+++ b/web-ui/src/main/resources/catalog/components/admin/registry/RegistryDirective.js
@@ -67,6 +67,12 @@
             scope.registryUrl = url;
           }
 
+          scope.selectAllRegistryLanguages = function(selectValues) {
+            for (var i = 0; i < scope.languages.length; i ++) {
+              scope.selectedLanguages[scope.languages[i].key] = selectValues;
+            }
+          }
+
           function getMainLanguage() {
             for (var p in scope.selectedLanguages) {
               if (scope.selectedLanguages.hasOwnProperty(p) &&

--- a/web-ui/src/main/resources/catalog/components/admin/registry/partials/registrybrowser.html
+++ b/web-ui/src/main/resources/catalog/components/admin/registry/partials/registrybrowser.html
@@ -38,6 +38,8 @@
     </label>
     <div class="row">
       <div class="col-md-6 gn-nopadding-left">
+        <a href data-ng-click="selectAllRegistryLanguages(true)" data-translate="">selectAll</a> |
+        <a href data-ng-click="selectAllRegistryLanguages(false)" data-translate="">selectNone</a>
         <ul class="list-group gn-nopadding-right">
           <li data-ng-repeat="l in languages" class="list-group-item">
             <label><input type="checkbox"

--- a/web-ui/src/main/resources/catalog/js/admin/ThesaurusController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/ThesaurusController.js
@@ -295,7 +295,7 @@
         if (!creatingThesaurus) {
           return;
         }
-        
+
         $scope.thesaurusSuggestedNs = $scope.thesaurusSelected && $scope.thesaurusNamespace
           ? $scope.thesaurusNamespace
             .replace('{{type}}', $scope.thesaurusSelected.dname)
@@ -356,7 +356,14 @@
         $scope.clear($scope.queue);
         $scope.thesaurusUrl = '';
 
-        $('#thesaurusModal').modal('hide');
+        // Don't close automatically the dialog for INSPIRE Registry.
+        // Usually the user needs to import several INSPIRE thesaurus
+        // and if closing the dialog, all the configuration for the
+        // URL end-point and languages need to be done every time.
+        if ($scope.importAs !== 'registry') {
+          $('#thesaurusModal').modal('hide');
+        }
+
 
         loadThesaurus();
       };


### PR DESCRIPTION
- Add option to select / unselect all the languages.

![inspire-registry-select-languages](https://user-images.githubusercontent.com/1695003/178746660-a97cb7dc-9f71-482b-a801-60311111eedb.png)


- Don't close automatically the thesaurus dialog after importing a thesaurus. Usually several INSPIRE thesaurus require to be loaded, and the user had to configure the form for every thesaurus