### PR TITLE
Fix lookup of data directory sub-properties

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/GeonetworkDataDirectory.java
+++ b/core/src/main/java/org/fao/geonet/kernel/GeonetworkDataDirectory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2022 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -46,10 +46,6 @@ import java.util.Iterator;
  * support files used by GeoNetwork for various purposes (eg. Lucene index, spatial index, logos).
  */
 public class GeonetworkDataDirectory {
-    /**
-     * The default GeoNetwork data directory location.
-     */
-//    static final String GEONETWORK_DEFAULT_DATA_DIR = Joiner.on("/").join(GEONETWORK_DEFAULT_DATA_DIR_PARTS);
     /**
      * A suffix of the keys used to look up paths in system.properties or system.env or in Servlet
      * context.
@@ -495,6 +491,10 @@ public class GeonetworkDataDirectory {
                     + " via bean properties, not looking up");
             }
         } else {
+            dir = lookupProperty(jeevesServlet, handlerConfig, envKey);
+        }
+        if (dir == null) {
+            envKey = Geonet.GEONETWORK + key;
             dir = lookupProperty(jeevesServlet, handlerConfig, envKey);
         }
         if (dir == null) {


### PR DESCRIPTION
When using a config property for setting the directories GN must search for
`<webappName>.propert`y name and if not found it must look for `geonetwork.property`.

This commit adds this `geonetwork.property` lookup.

This PR aligns the behaviour of GN with the [documentation](https://geonetwork-opensource.org/manuals/trunk/en/install-guide/customizing-data-directory.html#advanced-data-directory-configuration):
> All sub-directories could be configured separately using Java system property. For example, to put index directory in a custom location use:
> 
> * `<webappName>.lucene.dir` and if not set using:
> * `geonetwork.lucene.dir`
