### PR TITLE
Metadata editor - WMS resources - allow to configure the WMS layer in fo to add to the resource name and resource description fields in the url mode.

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/config/associated-panel/default.json
+++ b/schemas/iso19139/src/main/plugin/iso19139/config/associated-panel/default.json
@@ -51,7 +51,9 @@
     }],
     "multilingualFields": ["name", "desc"],
     "wmsResources": {
-      "addLayerNamesMode": "resourcename"
+      "addLayerNamesMode": "resourcename",
+      "resourceName": "layerName",
+      "resourceDescription": "layerTitle"
     }
   }
 }

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -1349,8 +1349,25 @@
 
                     angular.forEach(scope.params.selectedLayers,
                       function (layer) {
-                        names.push(layer.Name || layer.name);
-                        descs.push(layer.Title || layer.title);
+                        if (scope.config.wmsResources.addLayerNamesMode == "resourcename") {
+                          names.push(layer.Name || layer.name);
+                          descs.push(layer.Title || layer.title);
+
+                        } else {
+                          // In resourceurl mode check with WMS field use for the resource name
+                          // and the resource description
+                          if (scope.config.wmsResources.resourceName === 'layerName') {
+                            names.push(layer.Name || layer.name);
+                          } else if (scope.config.wmsResources.resourceName === 'layerTitle') {
+                            names.push(layer.Title || layer.title);
+                          }
+
+                          if (scope.config.wmsResources.resourceDescription === 'layerName') {
+                            descs.push(layer.Name || layer.name);
+                          } else if (scope.config.wmsResources.resourceDescription === 'layerTitle') {
+                            descs.push(layer.Title || layer.title);
+                          }
+                        }
                       });
 
                     if (scope.config.wmsResources.addLayerNamesMode == "resourcename") {
@@ -1364,6 +1381,35 @@
                           desc: descs.join(',')
                         });
                       }
+                    } else {
+                      if (scope.isMdMultilingual) {
+                        var langCode = scope.mdLangs[scope.mdLang];
+
+                        if (names.length > 0) {
+                          angular.forEach(scope.mdLangs, function(value,key){
+                            scope.params.name[value] = names.join(',');
+                          });
+                        }
+
+                        if (descs.length > 0) {
+                          angular.forEach(scope.mdLangs, function(value,key){
+                            scope.params.desc[langCode] = descs.join(',');
+                          });
+                        }
+                      } else {
+                        if (names.length > 0) {
+                          angular.extend(scope.params, {
+                            name: names.join(',')
+                          });
+                        }
+
+                        if (descs.length > 0) {
+                          angular.extend(scope.params, {
+                            desc: descs.join(',')
+                          });
+                        }
+                      }
+
                     }
                   }
                 });


### PR DESCRIPTION
Related to #6195

This change allows to configure when using the mode `addLayerNamesMode=url` which WMS properties should be used to fill the online resource name and the online resource description.

- `resourceName`: allowed values `layerName` (WMS layer name) | `layerTitle` (WMS layer title)
- `resourceDescription `: allowed values `layerName` (WMS layer name) | `layerTitle` (WMS layer title)

If these properties are not provided, the resource name or resource description are not filled automatically with the WMS information and the user should fill them.

This change doesn't affect the default `addLayerNamesMode` mode (`resourcename`).


Attached a screencast using the following configuration:

```
 "wmsResources": {
    "addLayerNamesMode": "url",
    "resourceName": "layerTitle"
  }
```

[wmslayers-resourcename.webm](https://user-images.githubusercontent.com/1695003/179458462-c5567f97-138a-4252-891b-f8705bd786bf.webm)

