### PR TITLE
Search / Improve error panel when Elasticsearch is down

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchFormDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchFormDirective.js
@@ -199,11 +199,13 @@
         // data is not an object: this is an error
         if (typeof data !== 'object') {
           console.warn('An error occurred while searching. Response is not an object.', esParams, data.data);
-          gnAlertService.addAlert({
-            id: 'searchError',
-            msg: $translate.instant('searchInvalidResponse'),
-            type: 'danger'
-          });
+          if($scope.showHealthIndexError !== true) { // Index status already displayed
+            gnAlertService.addAlert({
+              id: 'searchError',
+              msg: $translate.instant('searchInvalidResponse'),
+              type: 'danger'
+            });
+          }
           return;
         }
 

--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -61,6 +61,19 @@
     }
   ]);
 
+  module.directive('gnIndexErrorPanel', [
+    function() {
+      return {
+        restrict: 'A',
+        replace: true,
+        templateUrl: '../../catalog/components/utility/' +
+          'partials/indexerrorpanel.html',
+        link: function(scope, element, attrs) {
+
+        }
+      };
+    }
+  ]);
 
   module.directive('gnBatchEditExamplesSelector', [
     '$http', 'gnGlobalSettings', 'gnLangs',

--- a/web-ui/src/main/resources/catalog/components/utility/partials/indexerrorpanel.html
+++ b/web-ui/src/main/resources/catalog/components/utility/partials/indexerrorpanel.html
@@ -1,0 +1,15 @@
+<div class="col-sm-4 ng-cloak"
+     data-ng-if="showHealthIndexError">
+  <div class="alert alert-warning text-center">
+    <h3 data-translate="">indexNotAvailable</h3>
+    <i class="fa fa-fw fa-cogs fa-3x"/>
+    <br/>
+    <a class="btn btn-block btn-link"
+       data-ng-if="user.isAdministrator()"
+       data-ng-href="admin.console?debug#/dashboard">
+      <i class="fa fa-fw fa-dashboard"></i>
+      <span data-translate="">status</span>
+    </a>
+    <div data-gn-need-help="install-guide/installing-index.html"/>
+  </div>
+</div>

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -1670,7 +1670,10 @@ goog.require('gn_alert');
         var statusToApply = {};
         $.extend(statusToApply, defaultStatus, status);
 
-        gnAlertService.addAlert(statusToApply, statusToApply.timeout);
+        
+        if ($scope.showHealthIndexError !== true) {
+          gnAlertService.addAlert(statusToApply, statusToApply.timeout);
+        }
       });
 
       gnSessionService.scheduleCheck($scope.user);

--- a/web-ui/src/main/resources/catalog/templates/admin/admin.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/admin.html
@@ -65,6 +65,9 @@
         </div>
       </div>
       <!-- /.gn-row-admin-buttons -->
+
+      <div data-gn-index-error-panel=""></div>
+
       <div class="row gn-row-admin-stats">
         <div class="col-lg-2 col-md-4 col-sm-4" data-ng-repeat="type in searchInfo.facet.types" data-ng-hide="searchInfo.facet.types.length === 0">
           <div class="panel panel-default panel-primary1">

--- a/web-ui/src/main/resources/catalog/templates/editor/editorboard.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/editorboard.html
@@ -2,13 +2,13 @@
      data-ng-controller="GnSearchController">
   <div class="row" data-ng-controller="GnEditorBoardSearchController">
     <div data-ng-class="fluidEditorLayout ? 'container-fluid' : 'container'">
-
       <div class="col-sm-12"
-          data-ng-search-form=""
-          data-runSearch="true"
-          data-wait-for-user="true">
+           data-ng-search-form=""
+           data-runSearch="true"
+           data-wait-for-user="true">
         <form class="form-horizontal"
-                role="form">
+              data-ng-if="!showHealthIndexError"
+              role="form">
             <input type="hidden" name="_csrf" value="{{csrf}}"/>
             <div class="row gn-top-search">
               <div class="col-md-offset-3 col-md-6">
@@ -80,6 +80,9 @@
         </div>
 
         <div class="row">
+          <div class="col-sm-3 col-md-3 col-lg-3"
+               data-gn-index-error-panel=""></div>
+
           <div class="col-sm-3 col-md-3 col-lg-3 gn-search-facet">
             <div data-search-filter-tags
                  data-dimensions="searchResults.facets"

--- a/web-ui/src/main/resources/catalog/views/default/templates/home.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/home.html
@@ -1,14 +1,8 @@
 <div class="row gn-row-main">
   <div data-ng-class="fluidLayout ? 'container-fluid' : 'container'">
-    <div class="col-sm-4 col-sm-offset-6 ng-cloak"
-          data-ng-if="showHealthIndexError">
-      <div class="alert alert-warning text-center">
-        <h3 data-translate="">indexNotAvailable</h3>
-        <i class="fa fa-fw fa-cogs fa-3x"/>
-        <br/>
-        <div data-gn-need-help="install-guide/installing-index.html"/>
-      </div>
-    </div>
+
+    <div class="col-sm-offset-6"
+         data-gn-index-error-panel=""></div>
 
     <div class="col-md-3 well well-sm"
          data-ng-if="serviceMetadataForPortal != null">
@@ -28,7 +22,7 @@
 
     <div class="col-md-6"
          data-ng-class="{'col-md-offset-3': serviceMetadataForPortal == null}"
-          data-ng-if="!showHealthIndexError">
+         data-ng-if="!showHealthIndexError">
 
       <div class="input-group gn-form-any">
         <input type="text"

--- a/web-ui/src/main/resources/catalog/views/default/templates/home.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/home.html
@@ -5,6 +5,8 @@
       <div class="alert alert-warning text-center">
         <h3 data-translate="">indexNotAvailable</h3>
         <i class="fa fa-fw fa-cogs fa-3x"/>
+        <br/>
+        <div data-gn-need-help="install-guide/installing-index.html"/>
       </div>
     </div>
 

--- a/web-ui/src/main/resources/catalog/views/default/templates/results.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/results.html
@@ -1,8 +1,13 @@
 <div data-ng-search-form=""
      data-runSearch="true">
-  <div data-ng-include="'../../catalog/views/default/templates/searchForm.html'"></div>
+
+  <div data-ng-if="!showHealthIndexError"
+       data-ng-include="'../../catalog/views/default/templates/searchForm.html'"></div>
 
   <div class="row gn-row-results">
+    <div class="col-sm-offset-6"
+         data-gn-index-error-panel=""></div>
+
     <div data-ng-class="fluidLayout ? 'container-fluid' : 'container'">
       <div class="col-md-3 gn-search-facet">
         <div ng-if="showMapInFacet">


### PR DESCRIPTION
* Add a link to documentation

![image](https://user-images.githubusercontent.com/1701393/179504616-d47a5235-aa8d-4ea4-af79-f5064850f6a3.png)

* Do not display search errors when the panel is already here

![image](https://user-images.githubusercontent.com/1701393/179520842-e1f1b125-1154-4f19-b8ff-82f5bb0736d6.png)

* For admin display a link to status page

![image](https://user-images.githubusercontent.com/1701393/179520907-1280b8ab-fb1b-4af3-ac9f-a7606be98189.png)

* Display panel in all pages

![image](https://user-images.githubusercontent.com/1701393/179520961-e7df6b4a-6c0e-4557-ae3c-a83f8a865816.png)

