### PR TITLE
Increase the number of users in dropdown in the versioning log page

### DIFF
--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -333,6 +333,7 @@
               highlight: true
             }, {
               displayKey: 'username',
+              limit: 100,
               templates: {
                 suggestion: function(datum) {
                   return '<p>' + datum.name + ' ' + datum.surname +


### PR DESCRIPTION
Increase the number of users displayed in the users dropdown in the versioning log page.

The original value was 5 and that's increased to 100. The dropdown has a max height defined, so a scrollbar will appear when the list of users is large.

**Before**:
![gn-userpicker-before](https://user-images.githubusercontent.com/19608667/179518750-770b6adc-cbae-4865-9357-bf8298679019.png)

**After**:
![gn-userpicker-after](https://user-images.githubusercontent.com/19608667/179518787-089d1891-79fb-455f-b55e-ce3e9b2c3922.png)

