### PR TITLE
Standard / ISO / Collection updater / Better grouping of various type of extent.

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/process/collection-updater.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/process/collection-updater.xsl
@@ -4,6 +4,7 @@
                   xmlns:mcc="http://standards.iso.org/iso/19115/-3/mcc/1.0"
                   xmlns:mdb="http://standards.iso.org/iso/19115/-3/mdb/2.0"
                   xmlns:gcx="http://standards.iso.org/iso/19115/-3/gcx/1.0"
+                  xmlns:gex="http://standards.iso.org/iso/19115/-3/gex/1.0"
                   xmlns:mrd="http://standards.iso.org/iso/19115/-3/mrd/1.0"
                   xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0"
                   xmlns:mri="http://standards.iso.org/iso/19115/-3/mri/1.0"
@@ -72,9 +73,15 @@
     <tag name="mri:descriptiveKeywords" context="mri:MD_DataIdentification|srv:SV_ServiceIdentification"
          groupBy="*/mri:thesaurusName/*/cit:title/*/text()"
          merge="mri:keyword"/>
-    <tag name="mri:extent" context="mri:MD_DataIdentification|srv:SV_ServiceIdentification"
+    <!--<tag name="mri:extent" context="mri:MD_DataIdentification|srv:SV_ServiceIdentification"
          groupBy="*/(gex:geographicElement|gex:temporalElement)"
-         merge="gex:geographicElement|gex:temporalElement"/>
+         merge="gex:geographicElement|gex:temporalElement"/>-->
+    <tag name="gex:geographicElement" context="gex:EX_Extent"
+         groupBy="*"
+         merge="."/>
+    <tag name="gex:temporalElement" context="gex:EX_Extent"
+         groupBy="*"
+         merge="."/>
     <!-- TODO: mri:defaultLocale can be in various places. -->
     <tag name="mri:defaultLocale" context="mri:MD_DataIdentification|srv:SV_ServiceIdentification"
          groupBy="mri:defaultLocaleCode/lan:PT_Locale/lan:language/lan:LanguageCode/@codeListValue"
@@ -173,10 +180,13 @@
         <xsl:with-param name="elements" select="mri:topicCategory"/>
         <xsl:with-param name="name" select="'mri:topicCategory'"/>
       </xsl:call-template>
-      <xsl:call-template name="copyOrAddElement">
-        <xsl:with-param name="elements" select="mri:extent"/>
-        <xsl:with-param name="name" select="'mri:extent'"/>
-      </xsl:call-template>
+
+      <mri:extent>
+        <gex:EX_Extent>
+          <gex:geographicElement/>
+          <gex:temporalElement/>
+        </gex:EX_Extent>
+      </mri:extent>
 
       <xsl:apply-templates select="mri:additionalDocumentation" mode="expand"/>
       <xsl:apply-templates select="mri:processingLevel" mode="expand"/>

--- a/schemas/iso19139/src/main/plugin/iso19139/process/collection-merge-utility.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/process/collection-merge-utility.xsl
@@ -69,6 +69,7 @@
               </xsl:message>-->
 
               <xsl:for-each select="distinct-values($groupKey)">
+                <xsl:sort select="." order="descending"/>
                 <xsl:variable name="groupKey"
                               select="current()"/>
                 <xsl:variable name="emptyKey"

--- a/schemas/iso19139/src/main/plugin/iso19139/process/collection-merge-utility.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/process/collection-merge-utility.xsl
@@ -69,7 +69,7 @@
               </xsl:message>-->
 
               <xsl:for-each select="distinct-values($groupKey)">
-                <xsl:sort select="." order="descending"/>
+                <xsl:sort select="." order="ascending"/>
                 <xsl:variable name="groupKey"
                               select="current()"/>
                 <xsl:variable name="emptyKey"

--- a/schemas/iso19139/src/main/plugin/iso19139/process/collection-updater.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/process/collection-updater.xsl
@@ -68,9 +68,12 @@
     <tag name="gmd:descriptiveKeywords" context="gmd:MD_DataIdentification|srv:SV_ServiceIdentification"
          groupBy="*/gmd:thesaurusName/*/gmd:title/*/text()"
          merge="gmd:keyword"/>
-    <tag name="gmd:extent" context="gmd:MD_DataIdentification|srv:SV_ServiceIdentification"
-         groupBy="*/(gmd:geographicElement|gmd:temporalElement)"
-         merge="gmd:geographicElement|gmd:temporalElement"/>
+    <tag name="gmd:geographicElement" context="gmd:EX_Extent"
+         groupBy="*"
+         merge="."/>
+    <tag name="gmd:temporalElement" context="gmd:EX_Extent"
+         groupBy="*"
+         merge="."/>
     <!-- TODO: gmd:language can be in various places. -->
     <tag name="gmd:language" context="gmd:MD_DataIdentification|srv:SV_ServiceIdentification"
          groupBy="gmd:LanguageCode/@codeListValue"
@@ -191,10 +194,14 @@
         <xsl:with-param name="name" select="'gmd:topicCategory'"/>
       </xsl:call-template>
       <xsl:apply-templates select="gmd:environmentDescription" mode="expand"/>
-      <xsl:call-template name="copyOrAddElement">
-        <xsl:with-param name="elements" select="gmd:extent"/>
-        <xsl:with-param name="name" select="'gmd:extent'"/>
-      </xsl:call-template>
+
+      <gmd:extent>
+        <gmd:EX_Extent>
+          <gmd:geographicElement/>
+          <gmd:temporalElement/>
+        </gmd:EX_Extent>
+      </gmd:extent>
+
       <xsl:apply-templates select="gmd:supplementalInformation" mode="expand"/>
 
       <xsl:apply-templates select="srv:*" mode="expand"/>


### PR DESCRIPTION
Extent can contains boxes, geographic desc, polygons or temporal extent. Previous mechanism was not able to properly group elements when an extent contains more than one type. Improve that by processing each types rather than trying to group the extent container element.

Follow up of https://github.com/geonetwork/core-geonetwork/pull/6368.

Series updated by this process will have one extent block with the list of unique extents - geographicElement or temporalElement.


Sort by merging key

![image](https://user-images.githubusercontent.com/1701393/179965839-576ce5f2-23a6-4851-aa3c-0053dfddd77f.png)

