### PR TITLE
Index / Schema / First field match in mapping

### DIFF
--- a/web/src/main/webResources/WEB-INF/data/config/index/records.json
+++ b/web/src/main/webResources/WEB-INF/data/config/index/records.json
@@ -1189,14 +1189,6 @@
         }
       },
       {
-        "org": {
-          "match": "*Org*",
-          "mapping": {
-            "type": "keyword"
-          }
-        }
-      },
-      {
         "tree": {
           "match": "th_*_tree",
           "mapping": {
@@ -1280,6 +1272,14 @@
                 "type": "keyword"
               }
             }
+          }
+        }
+      },
+      {
+        "org": {
+          "match": "*Org*",
+          "mapping": {
+            "type": "keyword"
           }
         }
       },


### PR DESCRIPTION
As we provide dynamic mapping on a number of fields, more than one match rule can match. 
In such case, the first one declared in schema takes priority (and could trigger Elasticsearch error eg. when object is provided and keyword is expected - if a thesaurus end up considered as an Org).

Move `*Org*` rule to the bottom. `th_*` is more specific and a thesaurus with `Org` in key should not be matched to an Org field.