### PR TITLE
Metadata workflow - Bulk metadata submit

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java
@@ -43,10 +43,7 @@ import org.fao.geonet.api.exception.NotAllowedException;
 import org.fao.geonet.api.exception.ResourceNotFoundException;
 import org.fao.geonet.api.processing.report.MetadataProcessingReport;
 import org.fao.geonet.api.processing.report.SimpleMetadataProcessingReport;
-import org.fao.geonet.api.records.model.MetadataBatchApproveParameter;
-import org.fao.geonet.api.records.model.MetadataStatusParameter;
-import org.fao.geonet.api.records.model.MetadataStatusResponse;
-import org.fao.geonet.api.records.model.MetadataWorkflowStatusResponse;
+import org.fao.geonet.api.records.model.*;
 import org.fao.geonet.api.tools.i18n.LanguageUtils;
 import org.fao.geonet.constants.Edit;
 import org.fao.geonet.constants.Geonet;
@@ -251,12 +248,7 @@ public class MetadataWorkflowApi {
         ServiceContext context = ApiUtils.createServiceContext(request,
             languageUtils.getIso3langCode(request.getLocales()));
 
-        boolean isMdWorkflowEnable = settingManager.getValueAsBool(Settings.METADATA_WORKFLOW_ENABLE);
-
-        if (!isMdWorkflowEnable) {
-            throw new FeatureNotEnabledException(
-                "Metadata workflow is disabled, can not be set the status of metadata");
-        }
+        checkWorkflowEnabled();
 
         MetadataProcessingReport report = new SimpleMetadataProcessingReport();
 
@@ -264,8 +256,6 @@ public class MetadataWorkflowApi {
             Set<String> records = ApiUtils.getUuidsParameterOrSelection(approveParameter.getUuids(),
                 approveParameter.getBucket(), ApiUtils.getUserSession(session));
             report.setTotalRecords(records.size());
-
-            final ApplicationContext appContext = ApplicationContextHolder.get();
 
             List<String> listOfUpdatedRecords = new ArrayList<>();
             for (String uuid : records) {
@@ -276,46 +266,110 @@ public class MetadataWorkflowApi {
                     ApiUtils.createServiceContext(request), String.valueOf(metadata.getId()))) {
                     report.addNotEditableMetadataId(metadata.getId());
                 } else {
-                    boolean isAllowedSubmitApproveInvalidMd = settingManager
-                        .getValueAsBool(Settings.METADATA_WORKFLOW_ALLOW_SUBMIT_APPROVE_INVALID_MD);
-                    if (!isAllowedSubmitApproveInvalidMd) {
-                        boolean isInvalid = MetadataUtils.retrieveMetadataValidationStatus(metadata, context);
-
-                        if (isInvalid) {
-                            report.addMetadataInfos(metadata.getId(), metadata.getUuid(), true, false, "Metadata is invalid: can't be approved");
-                            continue;
-                        }
+                    if (!isAllowedMetadataStatusChange(context, metadata, report)) {
+                        continue;
                     }
 
                     MetadataStatus currentStatus = metadataStatus.getStatus(metadata.getId());
-                    // Metadata not in the workflow
-                    if (!approveParameter.isDirectApproval()) {
-                        if (currentStatus == null) {
-                            report.addMetadataInfos(metadata.getId(), metadata.getUuid(),
-                                true, false, "Metadata workflow is not enabled");
-                            continue;
-                        } else if (currentStatus.getStatusValue().getId() != Integer.parseInt(StatusValue.Status.SUBMITTED)) {
-                            report.addMetadataInfos(metadata.getId(), metadata.getUuid(),
-                                this.metadataUtils.isMetadataDraft(metadata.getId()),
-                                this.metadataUtils.isMetadataApproved(metadata.getId()),
-                                "Metadata is not in submitted status.");
-                            continue;
+
+                    if (currentStatus == null) {
+                        // Metadata not in the workflow
+                        report.addMetadataInfos(metadata.getId(), metadata.getUuid(),
+                            true, false, "Metadata workflow is not enabled");
+                        continue;
+                    } else {
+                        if (!approveParameter.isDirectApproval()) {
+                            if (currentStatus.getStatusValue().getId() != Integer.parseInt(StatusValue.Status.SUBMITTED)) {
+                                report.addMetadataInfos(metadata.getId(), metadata.getUuid(),
+                                    this.metadataUtils.isMetadataDraft(metadata.getId()),
+                                    this.metadataUtils.isMetadataApproved(metadata.getId()),
+                                    "Metadata is not in submitted status.");
+                                continue;
+                            }
                         }
                     }
 
-                    // --- use StatusActionsFactory and StatusActions class to
-                    // --- change status and carry out behaviours for status changes
-                    StatusActions sa = statusActionFactory.createStatusActions(context);
+                    // Change the metadata status to approved
+                    changeMetadataStatus(context, metadata, StatusValue.Status.APPROVED, approveParameter.getMessage());
 
-                    MetadataStatusParameter status = new MetadataStatusParameter();
-                    status.setStatus(Integer.parseInt(StatusValue.Status.APPROVED));
-                    status.setChangeMessage(approveParameter.getMessage());
+                    report.incrementProcessedRecords();
+                    listOfUpdatedRecords.add(String.valueOf(metadata.getId()));
+                }
+            }
+            dataManager.flush();
+            dataManager.indexMetadata(listOfUpdatedRecords);
 
-                    int author = context.getUserSession().getUserIdAsInt();
-                    MetadataStatus metadataStatus = convertParameter(metadata.getId(), metadata.getUuid(), status, author);
-                    List<MetadataStatus> listOfStatusChange = new ArrayList<>(1);
-                    listOfStatusChange.add(metadataStatus);
-                    sa.onStatusChange(listOfStatusChange);
+        } catch (Exception exception) {
+            report.addError(exception);
+        } finally {
+            report.close();
+        }
+
+        return report;
+    }
+
+    @io.swagger.v3.oas.annotations.Operation(summary = "Set the records status to submitted", description = "")
+    @RequestMapping(value = "/submit", method = RequestMethod.PUT)
+    @PreAuthorize("hasAuthority('Editor')")
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Metadata submitted ."),
+        @ApiResponse(responseCode = "400", description = "Metadata workflow not enabled.")})
+    @ResponseBody
+    MetadataProcessingReport submit(@RequestBody MetadataBatchSubmitParameter submitParameter,
+                                     @Parameter(hidden = true) HttpSession session,
+                                     @Parameter(hidden = true) HttpServletRequest request) throws Exception {
+        ServiceContext context = ApiUtils.createServiceContext(request,
+            languageUtils.getIso3langCode(request.getLocales()));
+
+        checkWorkflowEnabled();
+
+        MetadataProcessingReport report = new SimpleMetadataProcessingReport();
+
+        try {
+            Set<String> records = ApiUtils.getUuidsParameterOrSelection(submitParameter.getUuids(),
+                submitParameter.getBucket(), ApiUtils.getUserSession(session));
+            report.setTotalRecords(records.size());
+
+            List<String> listOfUpdatedRecords = new ArrayList<>();
+            for (String uuid : records) {
+                AbstractMetadata metadata = metadataUtils.findOneByUuid(uuid);
+                if (metadata == null) {
+                    report.incrementNullRecords();
+                } else if (!accessManager.isOwner(
+                    ApiUtils.createServiceContext(request), String.valueOf(metadata.getId()))) {
+                    report.addNotEditableMetadataId(metadata.getId());
+                } else {
+                    if (!isAllowedMetadataStatusChange(context, metadata, report)) {
+                        continue;
+                    }
+
+                    MetadataStatus currentStatus = metadataStatus.getStatus(metadata.getId());
+
+                    if (currentStatus == null) {
+                        // Metadata not in the workflow
+                        report.addMetadataInfos(metadata.getId(), metadata.getUuid(),
+                            true, false, "Metadata workflow is not enabled");
+                        continue;
+                    } else if (currentStatus.getStatusValue().getId() != Integer.parseInt(StatusValue.Status.DRAFT)) {
+                        // Metadata not in draft status
+                        report.addMetadataInfos(metadata.getId(), metadata.getUuid(),
+                            this.metadataUtils.isMetadataDraft(metadata.getId()),
+                            this.metadataUtils.isMetadataApproved(metadata.getId()),
+                            "Metadata is not in draft status.");
+                        continue;
+                    }
+
+                    // Change the metadata status to submitted
+                    changeMetadataStatus(context, metadata, StatusValue.Status.SUBMITTED, submitParameter.getMessage());
+
+                    // Reindex the metadata table record to update the field _statusWorkflow that contains the composite
+                    // status of the published and draft versions
+                    if (metadata instanceof MetadataDraft) {
+                        Metadata metadataApproved = metadataRepository.findOneByUuid(metadata.getUuid());
+
+                        if (metadataApproved != null) {
+                            listOfUpdatedRecords.add(String.valueOf(metadataApproved.getId()));
+                        }
+                    }
 
                     report.incrementProcessedRecords();
                     listOfUpdatedRecords.add(String.valueOf(metadata.getId()));
@@ -388,9 +442,6 @@ public class MetadataWorkflowApi {
         List<MetadataStatus> listOfStatusChange = new ArrayList<>(1);
         listOfStatusChange.add(metadataStatus);
         sa.onStatusChange(listOfStatusChange);
-
-        //--- reindex metadata
-        metadataIndexer.indexMetadata(String.valueOf(metadata.getId()), true);
 
         //--- reindex metadata
         metadataIndexer.indexMetadata(String.valueOf(metadata.getId()), true);
@@ -1052,5 +1103,74 @@ public class MetadataWorkflowApi {
         }
 
         return StateText;
+    }
+
+    /**
+     * Checks if the metadata workflow is enabled.
+     *
+     * @throws FeatureNotEnabledException
+     */
+    private void checkWorkflowEnabled() throws FeatureNotEnabledException {
+        boolean isMdWorkflowEnable = settingManager.getValueAsBool(Settings.METADATA_WORKFLOW_ENABLE);
+
+        if (!isMdWorkflowEnable) {
+            throw new FeatureNotEnabledException(
+                "Metadata workflow is disabled, can not be set the status of metadata")
+                .withMessageKey("exception.resourceNotEnabled.workflow")
+                .withDescriptionKey("exception.resourceNotEnabled.workflow.description");
+        }
+    }
+
+    /**
+     * Checks if the metadata status can be changed.
+     *
+     * If the setting to allow only to submit / approve valid metadata only is enabled,
+     * the metadata should be valid, to allow the status change.
+     *
+     * @param context
+     * @param metadata
+     * @param report
+     * @throws Exception
+     */
+    private boolean isAllowedMetadataStatusChange(ServiceContext context, AbstractMetadata metadata,
+                                                  MetadataProcessingReport report) throws Exception {
+        boolean isAllowedSubmitApproveInvalidMd = settingManager
+            .getValueAsBool(Settings.METADATA_WORKFLOW_ALLOW_SUBMIT_APPROVE_INVALID_MD);
+        if (!isAllowedSubmitApproveInvalidMd) {
+            boolean isInvalid = MetadataUtils.retrieveMetadataValidationStatus(metadata, context);
+
+            if (isInvalid) {
+                report.addMetadataInfos(metadata.getId(), metadata.getUuid(), true, false, "Metadata is invalid: can't be approved");
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * Change the status of a metadata.
+     *
+     * @param context
+     * @param metadata
+     * @param newStatus
+     * @param changeMessage
+     * @throws Exception
+     */
+    private void changeMetadataStatus(ServiceContext context, AbstractMetadata metadata, String newStatus, String changeMessage)
+        throws Exception {
+        // --- use StatusActionsFactory and StatusActions class to
+        // --- change status and carry out behaviours for status changes
+        StatusActions sa = statusActionFactory.createStatusActions(context);
+
+        MetadataStatusParameter status = new MetadataStatusParameter();
+        status.setStatus(Integer.parseInt(newStatus));
+        status.setChangeMessage(changeMessage);
+
+        int author = context.getUserSession().getUserIdAsInt();
+        MetadataStatus metadataStatus = convertParameter(metadata.getId(), metadata.getUuid(), status, author);
+        List<MetadataStatus> listOfStatusChange = new ArrayList<>(1);
+        listOfStatusChange.add(metadataStatus);
+        sa.onStatusChange(listOfStatusChange);
     }
 }

--- a/services/src/main/java/org/fao/geonet/api/records/model/MetadataBatchSubmitParameter.java
+++ b/services/src/main/java/org/fao/geonet/api/records/model/MetadataBatchSubmitParameter.java
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2001-2022 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+package org.fao.geonet.api.records.model;
+
+public class MetadataBatchSubmitParameter {
+    public String[] getUuids() {
+        return uuids;
+    }
+
+    public void setUuids(String[] uuids) {
+        this.uuids = uuids;
+    }
+
+    public String getBucket() {
+        return bucket;
+    }
+
+    public void setBucket(String bucket) {
+        this.bucket = bucket;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    private  String[] uuids;
+    private String bucket;
+    private String message;
+}

--- a/services/src/test/java/org/fao/geonet/api/records/MetadataWorkflowApiTest.java
+++ b/services/src/test/java/org/fao/geonet/api/records/MetadataWorkflowApiTest.java
@@ -3,23 +3,32 @@ package org.fao.geonet.api.records;
 import static org.fao.geonet.schema.iso19139.ISO19139Namespaces.GCO;
 import static org.fao.geonet.schema.iso19139.ISO19139Namespaces.GMD;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.util.Arrays;
+import java.util.Optional;
 import java.util.Random;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 
+import com.google.gson.Gson;
+import jeeves.server.UserSession;
 import jeeves.server.context.ServiceContext;
 import org.fao.geonet.GeonetContext;
+import org.fao.geonet.api.ApiUtils;
+import org.fao.geonet.api.records.model.MetadataBatchSubmitParameter;
 import org.fao.geonet.domain.*;
 import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.SchemaManager;
+import org.fao.geonet.kernel.SelectionManager;
 import org.fao.geonet.kernel.UpdateDatestamp;
 import org.fao.geonet.kernel.datamanager.IMetadataManager;
 import org.fao.geonet.kernel.metadata.StatusActionsFactory;
+import org.fao.geonet.kernel.setting.SettingManager;
+import org.fao.geonet.kernel.setting.Settings;
 import org.fao.geonet.repository.MetadataStatusRepository;
 import org.fao.geonet.repository.SourceRepository;
 import org.fao.geonet.repository.StatusValueRepository;
@@ -29,6 +38,7 @@ import org.fao.geonet.utils.Xml;
 import org.jdom.Element;
 import org.junit.Before;
 import org.junit.Test;
+import org.locationtech.jts.util.Assert;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
@@ -56,7 +66,14 @@ public class MetadataWorkflowApiTest  extends AbstractServiceIntegrationTest {
     @Autowired
     private SchemaManager schemaManager;
 
+    @Autowired
+    private SettingManager settingManager;
+
+    @Autowired
+    private StatusValueRepository statusValueRepository;
+
     private String uuid;
+    private String uuid2;
     private ServiceContext context;
 
 
@@ -68,8 +85,11 @@ public class MetadataWorkflowApiTest  extends AbstractServiceIntegrationTest {
 
     private void createTestData() throws Exception {
         this.uuid = UUID.randomUUID().toString();
+        this.uuid2 = UUID.randomUUID().toString();
 
         loginAsAdmin(context);
+        settingManager.setValue(Settings.METADATA_WORKFLOW_ENABLE, true);
+        settingManager.setValue(Settings.METADATA_WORKFLOW_DRAFT_WHEN_IN_GROUP, ".*");
 
         final Element sampleMetadataXml = getSampleMetadataXml();
         this.uuid = UUID.randomUUID().toString();
@@ -102,11 +122,44 @@ public class MetadataWorkflowApiTest  extends AbstractServiceIntegrationTest {
         metadataStatus.setOwner(1);
         metadataStatus.setUuid(uuid);
 
-        Random random = new Random();
-        AtomicInteger inc = new AtomicInteger(random.nextInt(16));
-        final StatusValue statusValue = statusValueRepo.save(StatusValueRepositoryTest.newStatusValue(inc));
-        metadataStatus.setStatusValue(statusValue);
+        Optional<StatusValue> statusValue = statusValueRepository.findById(Integer.parseInt(StatusValue.Status.DRAFT));
+        metadataStatus.setStatusValue(statusValue.get());
         metadataStatusRepo.save(metadataStatus);
+
+        final Element sampleMetadataXml2 = getSampleMetadataXml();
+        this.uuid2 = UUID.randomUUID().toString();
+        Xml.selectElement(sampleMetadataXml2, "gmd:fileIdentifier/gco:CharacterString", Arrays.asList(GMD, GCO)).setText(this.uuid2);
+
+        final Metadata metadata2 = (Metadata) new Metadata()
+            .setDataAndFixCR(sampleMetadataXml2)
+            .setUuid(uuid2);
+        metadata2.getDataInfo()
+            .setRoot(sampleMetadataXml.getQualifiedName())
+            .setSchemaId(schema)
+            .setType(MetadataType.METADATA)
+            .setPopularity(1000);
+        metadata2.getSourceInfo()
+            .setOwner(1)
+            .setSourceId(source);
+        metadata2.getHarvestInfo()
+            .setHarvested(false);
+
+        id = dataManager.insertMetadata(context, metadata2, sampleMetadataXml, true, false, UpdateDatestamp.NO,
+            false, false).getId();
+
+        metadataStatus = new MetadataStatus();
+        metadataStatus.setMetadataId(id);
+        metadataStatus.setChangeDate(new ISODate());
+        metadataStatus.setUserId(1);
+        metadataStatus.setChangeMessage("change message test");
+        metadataStatus.setOwner(1);
+        metadataStatus.setUuid(uuid);
+
+
+        statusValue = statusValueRepository.findById(Integer.parseInt(StatusValue.Status.APPROVED));
+        metadataStatus.setStatusValue(statusValue.get());
+        metadataStatusRepo.save(metadataStatus);
+
     }
 
     @Test
@@ -121,6 +174,37 @@ public class MetadataWorkflowApiTest  extends AbstractServiceIntegrationTest {
             .andExpect(status().is2xxSuccessful())
             .andExpect(content().contentType(API_JSON_EXPECTED_ENCODING))
             .andExpect(jsonPath("$.[0].uuid").value(uuid));
+
+    }
+
+    @Test
+    public void testBatchSubmit() throws Exception {
+        MockMvc mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
+        MockHttpSession mockHttpSession = loginAsAdmin();
+
+        // Select the metadata
+        UserSession session = ApiUtils.getUserSession( mockHttpSession);
+        SelectionManager.getManager(session).getSelection(SelectionManager.SELECTION_METADATA).add(this.uuid);
+        SelectionManager.getManager(session).getSelection(SelectionManager.SELECTION_METADATA).add(this.uuid2);
+        int selected = SelectionManager.getManager(session).getSelection(SelectionManager.SELECTION_METADATA).size();
+        Assert.isTrue(selected == 2);
+
+        MetadataBatchSubmitParameter submitParameter = new MetadataBatchSubmitParameter();
+        submitParameter.setBucket(SelectionManager.SELECTION_METADATA);
+        submitParameter.setMessage("");
+        Gson gson = new Gson();
+        String json = gson.toJson(submitParameter);
+
+
+        mockMvc.perform(put("/srv/api/records/submit")
+                .content(json)
+                .contentType(API_JSON_EXPECTED_ENCODING)
+                .accept(MediaType.parseMediaType("application/json"))
+                .session(mockHttpSession))
+            .andDo(MockMvcResultHandlers.print())
+            .andExpect(status().is2xxSuccessful())
+            .andExpect(content().contentType(API_JSON_EXPECTED_ENCODING))
+            .andExpect(jsonPath("$.numberOfRecordsProcessed").value(1));
 
     }
 

--- a/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionService.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionService.js
@@ -368,12 +368,18 @@
         );
       };
 
-      this.openPrivilegesBatchPanel = function (scope, bucket) {
-        gnUtilityService.openModal(
-          {
-            title: "privileges",
-            content:
-              '<div gn-share="" ' +
+      this.submit = function(bucket, scope) {
+        gnUtilityService.openModal({
+          title: 'batchSubmitTitle',
+          content: '<div gn-metadata-batch-submit selection-bucket="' + bucket + '"></div>'
+        }, scope, 'StatusUpdated');
+
+      };
+
+      this.openPrivilegesBatchPanel = function(scope, bucket) {
+        gnUtilityService.openModal({
+          title: 'privileges',
+          content: '<div gn-share="" ' +
               'gn-share-batch="true" ' +
               'selection-bucket="' +
               bucket +

--- a/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionService.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionService.js
@@ -368,18 +368,24 @@
         );
       };
 
-      this.submit = function(bucket, scope) {
-        gnUtilityService.openModal({
-          title: 'batchSubmitTitle',
-          content: '<div gn-metadata-batch-submit selection-bucket="' + bucket + '"></div>'
-        }, scope, 'StatusUpdated');
-
+      this.submit = function (bucket, scope) {
+        gnUtilityService.openModal(
+          {
+            title: "batchSubmitTitle",
+            content:
+              '<div gn-metadata-batch-submit selection-bucket="' + bucket + '"></div>'
+          },
+          scope,
+          "StatusUpdated"
+        );
       };
 
-      this.openPrivilegesBatchPanel = function(scope, bucket) {
-        gnUtilityService.openModal({
-          title: 'privileges',
-          content: '<div gn-share="" ' +
+      this.openPrivilegesBatchPanel = function (scope, bucket) {
+        gnUtilityService.openModal(
+          {
+            title: "privileges",
+            content:
+              '<div gn-share="" ' +
               'gn-share-batch="true" ' +
               'selection-bucket="' +
               bucket +

--- a/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionsDirective.js
@@ -69,28 +69,83 @@
 
                   scope.$broadcast("operationOnSelectionStop");
 
-                  // A report is returned
-                  gnUtilityService.openModal(
-                    {
-                      title: translations.metadataApproved,
-                      content:
-                        '<div gn-batch-report="processReport" template-url="' +
-                        reportTemplate +
-                        '"></div>',
-                      className: "gn-status-popup",
-                      onCloseCallback: function () {
-                        scope.$emit("StatusUpdated", true);
-                        scope.$broadcast("operationOnSelectionStop");
-                        scope.processReport = null;
-                      }
-                    },
-                    scope,
-                    "StatusUpdated"
-                  );
-                },
-                function (response) {
-                  scope.$broadcast("operationOnSelectionStop");
-                  scope.$emit("metadataStatusUpdated", false);
+                // A report is returned
+                gnUtilityService.openModal({
+                  title: translations.metadataApproved,
+                  content: '<div gn-batch-report="processReport" template-url="' + reportTemplate + '"></div>',
+                  className: 'gn-status-popup',
+                  onCloseCallback: function() {
+                    scope.$emit('metadataStatusUpdated', true);
+                    scope.$emit('StatusUpdated', true);
+                    scope.$broadcast('operationOnSelectionStop');
+                    scope.processReport = null;
+                  }
+                }, scope, 'StatusUpdated');
+              }, function(response) {
+                scope.$broadcast('operationOnSelectionStop');
+                scope.$emit('metadataStatusUpdated', false);
+
+                scope.$emit('StatusUpdated', {
+                  title: $translate.instant('metadataStatusUpdatedErrors'),
+                  error: response.data,
+                  timeout: 0,
+                  type: 'danger'});
+              });
+          };
+        }
+      };
+    }]);
+
+  module.directive('gnMetadataBatchSubmit', ['$translate', '$http',
+    'gnMetadataManager', 'gnUtilityService',
+    function($translate, $http, gnMetadataManager, gnUtilityService) {
+
+      return {
+        restrict: 'A',
+        replace: true,
+        templateUrl: '../../catalog/components/metadataactions/partials/' +
+          'batchsubmit.html',
+        scope: {
+          selectionBucket: '@'
+        },
+        link: function(scope) {
+          var translations = null;
+          $translate(['metadataSubmitted']).then(function(t) {
+            translations = t;
+          });
+
+          scope.changeMessage = '';
+
+          scope.submit = function() {
+            scope.$broadcast('operationOnSelectionStart');
+
+            return $http.put('../api/records/submit',
+              {
+                bucket: scope.selectionBucket,
+                message: scope.changeMessage
+              }).then(
+              function(response) {
+                scope.processReport = response.data;
+                var reportTemplate = '../../catalog/components/utility/' +
+                  'partials/batchreport-workflow.html'
+
+                scope.$broadcast('operationOnSelectionStop');
+
+                // A report is returned
+                gnUtilityService.openModal({
+                  title: translations.metadataSubmitted,
+                  content: '<div gn-batch-report="processReport" template-url="' + reportTemplate + '"></div>',
+                  className: 'gn-status-popup',
+                  onCloseCallback: function() {
+                    scope.$emit('metadataStatusUpdated', true);
+                    scope.$emit('StatusUpdated', true);
+                    scope.$broadcast('operationOnSelectionStop');
+                    scope.processReport = null;
+                  }
+                }, scope, 'StatusUpdated');
+              }, function(response) {
+                scope.$broadcast('operationOnSelectionStop');
+                scope.$emit('metadataStatusUpdated', false);
 
                   scope.$emit("StatusUpdated", {
                     title: $translate.instant("metadataStatusUpdatedErrors"),

--- a/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionsDirective.js
@@ -69,83 +69,106 @@
 
                   scope.$broadcast("operationOnSelectionStop");
 
-                // A report is returned
-                gnUtilityService.openModal({
-                  title: translations.metadataApproved,
-                  content: '<div gn-batch-report="processReport" template-url="' + reportTemplate + '"></div>',
-                  className: 'gn-status-popup',
-                  onCloseCallback: function() {
-                    scope.$emit('metadataStatusUpdated', true);
-                    scope.$emit('StatusUpdated', true);
-                    scope.$broadcast('operationOnSelectionStop');
-                    scope.processReport = null;
-                  }
-                }, scope, 'StatusUpdated');
-              }, function(response) {
-                scope.$broadcast('operationOnSelectionStop');
-                scope.$emit('metadataStatusUpdated', false);
+                  // A report is returned
+                  gnUtilityService.openModal(
+                    {
+                      title: translations.metadataApproved,
+                      content:
+                        '<div gn-batch-report="processReport" template-url="' +
+                        reportTemplate +
+                        '"></div>',
+                      className: "gn-status-popup",
+                      onCloseCallback: function () {
+                        scope.$emit("metadataStatusUpdated", true);
+                        scope.$emit("StatusUpdated", true);
+                        scope.$broadcast("operationOnSelectionStop");
+                        scope.processReport = null;
+                      }
+                    },
+                    scope,
+                    "StatusUpdated"
+                  );
+                },
+                function (response) {
+                  scope.$broadcast("operationOnSelectionStop");
+                  scope.$emit("metadataStatusUpdated", false);
 
-                scope.$emit('StatusUpdated', {
-                  title: $translate.instant('metadataStatusUpdatedErrors'),
-                  error: response.data,
-                  timeout: 0,
-                  type: 'danger'});
-              });
+                  scope.$emit("StatusUpdated", {
+                    title: $translate.instant("metadataStatusUpdatedErrors"),
+                    error: response.data,
+                    timeout: 0,
+                    type: "danger"
+                  });
+                }
+              );
           };
         }
       };
-    }]);
+    }
+  ]);
 
-  module.directive('gnMetadataBatchSubmit', ['$translate', '$http',
-    'gnMetadataManager', 'gnUtilityService',
-    function($translate, $http, gnMetadataManager, gnUtilityService) {
-
+  module.directive("gnMetadataBatchSubmit", [
+    "$translate",
+    "$http",
+    "gnMetadataManager",
+    "gnUtilityService",
+    function ($translate, $http, gnMetadataManager, gnUtilityService) {
       return {
-        restrict: 'A',
+        restrict: "A",
         replace: true,
-        templateUrl: '../../catalog/components/metadataactions/partials/' +
-          'batchsubmit.html',
+        templateUrl:
+          "../../catalog/components/metadataactions/partials/" + "batchsubmit.html",
         scope: {
-          selectionBucket: '@'
+          selectionBucket: "@"
         },
-        link: function(scope) {
+        link: function (scope) {
           var translations = null;
-          $translate(['metadataSubmitted']).then(function(t) {
+          $translate(["metadataSubmitted"]).then(function (t) {
             translations = t;
           });
 
-          scope.changeMessage = '';
+          scope.changeMessage = "";
 
-          scope.submit = function() {
-            scope.$broadcast('operationOnSelectionStart');
+          scope.submit = function () {
+            scope.$broadcast("operationOnSelectionStart");
 
-            return $http.put('../api/records/submit',
-              {
+            return $http
+              .put("../api/records/submit", {
                 bucket: scope.selectionBucket,
                 message: scope.changeMessage
-              }).then(
-              function(response) {
-                scope.processReport = response.data;
-                var reportTemplate = '../../catalog/components/utility/' +
-                  'partials/batchreport-workflow.html'
+              })
+              .then(
+                function (response) {
+                  scope.processReport = response.data;
+                  var reportTemplate =
+                    "../../catalog/components/utility/" +
+                    "partials/batchreport-workflow.html";
 
-                scope.$broadcast('operationOnSelectionStop');
+                  scope.$broadcast("operationOnSelectionStop");
 
-                // A report is returned
-                gnUtilityService.openModal({
-                  title: translations.metadataSubmitted,
-                  content: '<div gn-batch-report="processReport" template-url="' + reportTemplate + '"></div>',
-                  className: 'gn-status-popup',
-                  onCloseCallback: function() {
-                    scope.$emit('metadataStatusUpdated', true);
-                    scope.$emit('StatusUpdated', true);
-                    scope.$broadcast('operationOnSelectionStop');
-                    scope.processReport = null;
-                  }
-                }, scope, 'StatusUpdated');
-              }, function(response) {
-                scope.$broadcast('operationOnSelectionStop');
-                scope.$emit('metadataStatusUpdated', false);
+                  // A report is returned
+                  gnUtilityService.openModal(
+                    {
+                      title: translations.metadataSubmitted,
+                      content:
+                        '<div gn-batch-report="processReport" template-url="' +
+                        reportTemplate +
+                        '"></div>',
+                      className: "gn-status-popup",
+                      onCloseCallback: function () {
+                        scope.$emit("metadataStatusUpdated", true);
+                        scope.$emit("StatusUpdated", true);
+                        scope.$broadcast("operationOnSelectionStop");
+                        scope.processReport = null;
+                      }
+                    },
+                    scope,
+                    "StatusUpdated"
+                  );
+                },
+                function (response) {
+                  scope.$broadcast("operationOnSelectionStop");
+                  scope.$emit("metadataStatusUpdated", false);
 
                   scope.$emit("StatusUpdated", {
                     title: $translate.instant("metadataStatusUpdatedErrors"),

--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/batchsubmit.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/batchsubmit.html
@@ -3,23 +3,28 @@
     <p data-translate="">batchSubmitInfo</p>
 
     <div class="form-group">
-      <label for="gn-change-message"
-             data-translate="">statusLogMessage</label>
-      <textarea class="form-control"
-                id="gn-change-message"
-                rows="4"
-                data-ng-model="changeMessage"></textarea>
+      <label for="gn-change-message" data-translate="">statusLogMessage</label>
+      <textarea
+        class="form-control"
+        id="gn-change-message"
+        rows="4"
+        data-ng-model="changeMessage"
+      ></textarea>
     </div>
 
     <div class="modal-footer-inline clearfix">
       <div class="btn-toolbar pull-right">
-        <button class="btn btn-default"
-                data-gn-click-and-spin="submit()" data-translate="">submit</button>
+        <button
+          class="btn btn-default"
+          data-gn-click-and-spin="submit()"
+          data-translate=""
+        >
+          submit
+        </button>
         <button class="btn btn-default" type="button" data-dismiss="modal">
           <span data-translate="">cancel</span>
         </button>
       </div>
     </div>
   </div>
-
 </form>

--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/batchsubmit.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/batchsubmit.html
@@ -1,0 +1,25 @@
+<form id="gn-batch-approval">
+  <div>
+    <p data-translate="">batchSubmitInfo</p>
+
+    <div class="form-group">
+      <label for="gn-change-message"
+             data-translate="">statusLogMessage</label>
+      <textarea class="form-control"
+                id="gn-change-message"
+                rows="4"
+                data-ng-model="changeMessage"></textarea>
+    </div>
+
+    <div class="modal-footer-inline clearfix">
+      <div class="btn-toolbar pull-right">
+        <button class="btn btn-default"
+                data-gn-click-and-spin="submit()" data-translate="">submit</button>
+        <button class="btn btn-default" type="button" data-dismiss="modal">
+          <span data-translate="">cancel</span>
+        </button>
+      </div>
+    </div>
+  </div>
+
+</form>

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/selection-widget.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/selection-widget.html
@@ -114,15 +114,25 @@
           <i class="fa fa-fw fa-lock"></i>&nbsp;<span translate>unpublish</span>
         </a>
       </li>
-      <li  data-ng-show="!excludePattern.test('submit')"
-           data-ng-if="user.isEditorOrMore() && isMdWorkflowEnable">
-        <a href="" data-ng-click="mdService.submit(searchResults.selectionBucket, getCatScope())">
+      <li
+        data-ng-show="!excludePattern.test('submit')"
+        data-ng-if="user.isEditorOrMore() && isMdWorkflowEnable"
+      >
+        <a
+          href=""
+          data-ng-click="mdService.submit(searchResults.selectionBucket, getCatScope())"
+        >
           <i class="fa fa-fw fa-file-o"></i>&nbsp;<span translate>submit</span>
         </a>
       </li>
-      <li  data-ng-show="!excludePattern.test('approve')"
-           data-ng-if="user.isReviewerOrMore() && isMdWorkflowEnable">
-        <a href="" data-ng-click="mdService.approve(searchResults.selectionBucket, getCatScope())">
+      <li
+        data-ng-show="!excludePattern.test('approve')"
+        data-ng-if="user.isReviewerOrMore() && isMdWorkflowEnable"
+      >
+        <a
+          href=""
+          data-ng-click="mdService.approve(searchResults.selectionBucket, getCatScope())"
+        >
           <i class="fa fa-fw fa-thumbs-o-up"></i>&nbsp;<span translate>approve</span>
         </a>
       </li>

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/selection-widget.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/selection-widget.html
@@ -114,14 +114,15 @@
           <i class="fa fa-fw fa-lock"></i>&nbsp;<span translate>unpublish</span>
         </a>
       </li>
-      <li
-        data-ng-show="!excludePattern.test('approve')"
-        data-ng-if="user.isReviewerOrMore() && isMdWorkflowEnable"
-      >
-        <a
-          href=""
-          data-ng-click="mdService.approve(searchResults.selectionBucket, getCatScope())"
-        >
+      <li  data-ng-show="!excludePattern.test('submit')"
+           data-ng-if="user.isEditorOrMore() && isMdWorkflowEnable">
+        <a href="" data-ng-click="mdService.submit(searchResults.selectionBucket, getCatScope())">
+          <i class="fa fa-fw fa-file-o"></i>&nbsp;<span translate>submit</span>
+        </a>
+      </li>
+      <li  data-ng-show="!excludePattern.test('approve')"
+           data-ng-if="user.isReviewerOrMore() && isMdWorkflowEnable">
+        <a href="" data-ng-click="mdService.approve(searchResults.selectionBucket, getCatScope())">
           <i class="fa fa-fw fa-thumbs-o-up"></i>&nbsp;<span translate>approve</span>
         </a>
       </li>

--- a/web-ui/src/main/resources/catalog/js/edit/EditorBoardController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/EditorBoardController.js
@@ -168,18 +168,21 @@
       });
 
       // Refresh list when metadata statuses are updated
-      $scope.$on('metadataStatusUpdated', function(event, data) {
-        if(data && data===true) {
-          $rootScope.$broadcast('search');
+      $scope.$on("metadataStatusUpdated", function (event, data) {
+        if (data && data === true) {
+          $rootScope.$broadcast("search");
         }
       });
 
-      gnSearchSettings.resultViewTpls = [{
-        tplUrl: '../../catalog/components/search/resultsview/' +
-            'partials/viewtemplates/editor.html',
-        tooltip: 'List',
-        icon: 'fa-list'
-      }];
+      gnSearchSettings.resultViewTpls = [
+        {
+          tplUrl:
+            "../../catalog/components/search/resultsview/" +
+            "partials/viewtemplates/editor.html",
+          tooltip: "List",
+          icon: "fa-list"
+        }
+      ];
 
       gnSearchSettings.resultTemplate = gnSearchSettings.resultViewTpls[0].tplUrl;
 

--- a/web-ui/src/main/resources/catalog/js/edit/EditorBoardController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/EditorBoardController.js
@@ -167,15 +167,19 @@
         }
       });
 
-      gnSearchSettings.resultViewTpls = [
-        {
-          tplUrl:
-            "../../catalog/components/search/resultsview/" +
-            "partials/viewtemplates/editor.html",
-          tooltip: "List",
-          icon: "fa-list"
+      // Refresh list when metadata statuses are updated
+      $scope.$on('metadataStatusUpdated', function(event, data) {
+        if(data && data===true) {
+          $rootScope.$broadcast('search');
         }
-      ];
+      });
+
+      gnSearchSettings.resultViewTpls = [{
+        tplUrl: '../../catalog/components/search/resultsview/' +
+            'partials/viewtemplates/editor.html',
+        tooltip: 'List',
+        icon: 'fa-list'
+      }];
 
       gnSearchSettings.resultTemplate = gnSearchSettings.resultViewTpls[0].tplUrl;
 

--- a/web-ui/src/main/resources/catalog/locales/en-core.json
+++ b/web-ui/src/main/resources/catalog/locales/en-core.json
@@ -574,9 +574,12 @@
     "copyToClipboard": "Copy the text to the clipboard",
     "textCopied": "Text has been copied to the clipboard.",
     "metadataApproved": "Metadata approved.",
+    "metadataSubmitted": "Metadata submitted.",
     "batchApproveTitle": "Batch metadata approval",
     "batchApproveInfo": "This option approves the selected metadata owned by the user. By default, only the metadata in submitted status is approved, select the option below to  approve directly the metadata that is not in submitted status.",
     "batchApproveDirect": "Approve the metadata without requiring to be in submitted status",
     "facet-mdStatus": "Workflow progress",
-    "skipLink": "Skip and go to the content"
+    "skipLink": "Skip and go to the content",
+    "batchSubmitTitle": "Batch metadata submission",
+    "batchSubmitInfo": "This option submits the selected metadata owned by the user."
 }

--- a/web-ui/src/main/resources/catalog/locales/en-search.json
+++ b/web-ui/src/main/resources/catalog/locales/en-search.json
@@ -547,5 +547,6 @@
   "fieldTooShort": "The value is too short",
   "fieldEmailNotValid": "A valid email address is required",
   "addLayerPrefix": "Add layer",
-  "addLayerPostfix": "to the map"
+  "addLayerPostfix": "to the map",
+  "submit": "Submit"
 }


### PR DESCRIPTION
Analogue to https://github.com/geonetwork/core-geonetwork/pull/5430.

This feature allows users with `Editor`/`Reviewer` profiles to submit for review several metadata records at once from the `Editor board`,  when the metadata workflow is enabled.

![menu-option](https://user-images.githubusercontent.com/1695003/189855855-32a681ad-2ea9-4b26-824a-c919cbe8211c.png)

![dialog](https://user-images.githubusercontent.com/1695003/189856067-f6aecfe8-bfc1-49f1-86ab-325310120a9d.png)

A report with the summary of the results is displayed when the process is finished:

![report](https://user-images.githubusercontent.com/1695003/189856173-e0656766-25c3-48e7-946a-56f161a45752.png)
