### PR TITLE
Fix the operatesOn indexing when the xlink:href it's a GetRecordById, with the identifier contanining an underscore character

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
@@ -1314,7 +1314,7 @@
         <xsl:variable name="getRecordByIdId">
           <xsl:if test="@xlink:href != ''">
             <xsl:analyze-string select="@xlink:href"
-                                regex=".*[i|I][d|D]=([\w\-\.\{{\}}]*).*">
+                                regex=".*[i|I][d|D]=([_\w\-\.\{{\}}]*).*">
               <xsl:matching-substring>
                 <xsl:value-of select="regex-group(1)"/>
               </xsl:matching-substring>

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
@@ -1204,7 +1204,7 @@
         <xsl:variable name="getRecordByIdId">
           <xsl:if test="@xlink:href != ''">
             <xsl:analyze-string select="@xlink:href"
-                                regex=".*[i|I][d|D]=([\w\-\.\{{\}}]*).*">
+                                regex=".*[i|I][d|D]=([_\w\-\.\{{\}}]*).*">
               <xsl:matching-substring>
                 <xsl:value-of select="regex-group(1)"/>
               </xsl:matching-substring>


### PR DESCRIPTION
With the original code if identifier parameter of the `xlink:href` for a GetRecordsById contains an `_` character, the identifier was not extracted properly:

```
<srv:operatesOn 
xlink:href="https://SERVER/csw?service=CSW&request=GetRecordById&version=2.0.2&
outputSchema=http://www.isotc211.org/2005/gmd&elementSetName=full&id=maaamet_geoloogiline_baaskaart"/>
```

The value extracted was `maaamet` instead of `maaamet_geoloogiline_baaskaart`