### PR TITLE
Search / Track total hits

### DIFF
--- a/index/src/main/java/org/fao/geonet/index/es/EsRestClient.java
+++ b/index/src/main/java/org/fao/geonet/index/es/EsRestClient.java
@@ -299,6 +299,7 @@ public class EsRestClient implements InitializingBean {
         searchSourceBuilder.fetchSource(includedFields.toArray(new String[includedFields.size()]), null);
         searchSourceBuilder.from(from);
         searchSourceBuilder.size(size);
+        searchSourceBuilder.trackTotalHits(true);
         if (postFilterBuilder != null) {
             searchSourceBuilder.postFilter(postFilterBuilder);
         }
@@ -307,7 +308,6 @@ public class EsRestClient implements InitializingBean {
             sort.forEach(s -> searchSourceBuilder.sort(s));
         }
 
-//        searchSourceBuilder.sort(new FieldSortBuilder("_id").order(SortOrder.ASC));
         searchRequest.source(searchSourceBuilder);
 
         try {
@@ -399,7 +399,7 @@ public class EsRestClient implements InitializingBean {
                     throw new IOException(String.format(
                         "Your query '%s' returned more than one record, %d in fact. Can't retrieve field values for more than one record.",
                         query,
-                        searchResponse.getHits().getTotalHits()
+                        searchResponse.getHits().getTotalHits().value
                     ));
                 }
             } else {

--- a/index/src/main/java/org/fao/geonet/index/es/EsRestClient.java
+++ b/index/src/main/java/org/fao/geonet/index/es/EsRestClient.java
@@ -37,6 +37,7 @@ import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
 import org.apache.http.nio.conn.SchemeIOSessionStrategy;
 import org.apache.http.nio.conn.ssl.SSLIOSessionStrategy;
 import org.apache.http.ssl.SSLContextBuilder;
+import org.apache.lucene.search.TotalHits;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
@@ -382,9 +383,11 @@ public class EsRestClient implements InitializingBean {
             // TODO: Use _doc API?
             final SearchResponse searchResponse = this.query(index, query, null, fields, 0, 1, null);
             if (searchResponse.status().getStatus() == 200) {
-                if (searchResponse.getHits().getTotalHits().value == 0) {
+                TotalHits totalHits = searchResponse.getHits().getTotalHits();
+                long matches = totalHits == null ? -1 : totalHits.value; 
+                if (matches == 0) {
                     return fieldValues;
-                } else if (searchResponse.getHits().getTotalHits().value == 1) {
+                } else if (matches == 1) {
                     final SearchHit[] hits = searchResponse.getHits().getHits();
 
                     fields.forEach(f -> {
@@ -399,7 +402,7 @@ public class EsRestClient implements InitializingBean {
                     throw new IOException(String.format(
                         "Your query '%s' returned more than one record, %d in fact. Can't retrieve field values for more than one record.",
                         query,
-                        searchResponse.getHits().getTotalHits().value
+                        matches
                     ));
                 }
             } else {


### PR DESCRIPTION
Fixes https://github.com/geonetwork/core-geonetwork/issues/6478

On client side, this is set here https://github.com/geonetwork/core-geonetwork/blob/main/web-ui/src/main/resources/catalog/components/elasticsearch/EsFacet.js#L319-L324

Probably in all places we have to track total hits for metadata record searches.