### PR TITLE
Citation / Refactor to be able to use it in other XSLT

### DIFF
--- a/schemas/dublin-core/src/main/plugin/dublin-core/formatter/citation/base.xsl
+++ b/schemas/dublin-core/src/main/plugin/dublin-core/formatter/citation/base.xsl
@@ -1,0 +1,120 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:dc="http://purl.org/dc/elements/1.1/"
+                xmlns:dct="http://purl.org/dc/terms/"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:tr="java:org.fao.geonet.api.records.formatters.SchemaLocalizations"
+                xmlns:gn-fn-render="http://geonetwork-opensource.org/xsl/functions/render"
+                xmlns:gn-fn-metadata="http://geonetwork-opensource.org/xsl/functions/metadata"
+                xmlns:xslUtils="java:org.fao.geonet.util.XslUtil"
+                xmlns:saxon="http://saxon.sf.net/"
+                version="2.0"
+                extension-element-prefixes="saxon"
+                exclude-result-prefixes="#all">
+
+  <xsl:import href="sharedFormatterDir/xslt/render-variables.xsl"/>
+  <xsl:import href="../../layout/utility-fn.xsl"/>
+  <xsl:import href="../../../iso19115-3.2018/formatter/citation/common.xsl"/>
+
+  <xsl:template name="get-dublin-core-citation">
+    <xsl:param name="metadata" as="node()"/>
+    <xsl:param name="language" as="xs:string"/>
+
+    <!-- Who is the creator of the data set?  This can be an individual, a group of individuals, or an organization. -->
+    <xsl:variable name="authors"
+                  select="$metadata/dc:creator"/>
+    <xsl:variable name="authorsNameAndOrgList">
+      <xsl:for-each select="$authors">
+        <author>
+          <xsl:variable name="name"
+                        select="normalize-space(.)"/>
+          <xsl:value-of select="$name"/>
+        </author>
+      </xsl:for-each>
+    </xsl:variable>
+
+    <!-- What name is the data set called? -->
+    <xsl:variable name="title"
+                  select="$metadata/dc:title"/>
+
+    <xsl:variable name="translatedTitle">
+      <xsl:for-each select="$title">
+        <xsl:value-of select="normalize-space(.)"/>
+      </xsl:for-each>
+    </xsl:variable>
+
+    <!-- Is there a version or edition number associated with the data set? -->
+
+
+    <!-- What year was the data set published?  When was the data set posted online? -->
+    <xsl:variable name="dates"
+                  select="$metadata/dct:modified[. != '']"/>
+
+    <xsl:variable name="publicationDates">
+      <xsl:perform-sort select="$dates">
+        <xsl:sort select="." order="descending"/>
+      </xsl:perform-sort>
+    </xsl:variable>
+
+    <xsl:variable name="lastPublicationDate"
+                  select="$publicationDates[1]"/>
+
+    <!-- What entity is responsible for producing and/or distributing the data set?  Also, is there a physical location associated with the publisher? -->
+    <xsl:variable name="publishers"
+                  select="$metadata/dc:publisher"/>
+
+    <xsl:variable name="publishersNameAndOrgList">
+      <xsl:for-each select="$publishers">
+        <author>
+          <xsl:variable name="name"
+                        select="normalize-space(.)"/>
+          <xsl:value-of select="$name"/>
+        </author>
+      </xsl:for-each>
+    </xsl:variable>
+
+
+    <!-- Electronic Retrieval Location -->
+    <xsl:variable name="doiInResourceIdentifier"
+                  select="(//dc:identifier[
+                                contains(text(), 'datacite.org/doi/')
+                                or contains(text(), 'doi.org')])[1]"/>
+
+    <xsl:variable name="doiInOnline"
+                  select="//(dc:relation|dct:references)[
+                                contains(text(), 'datacite.org/doi/')
+                                or contains(text(), 'doi.org')]"/>
+
+    <xsl:variable name="doiUrl"
+                  select="if ($doiInResourceIdentifier != '')
+                          then $doiInResourceIdentifier
+                          else if ($doiInOnline != '')
+                          then $doiInOnline
+                          else ''"/>
+
+    <xsl:variable name="landingPageUrl"
+                  select="concat($nodeUrl, 'api/records/', $metadataUuid)"/>
+
+    <xsl:variable name="keywords"
+                  select="$metadata//dc:subject"/>
+
+    <xsl:variable name="translatedKeywords">
+      <xsl:for-each select="$keywords">
+        <keyword><xsl:value-of select="."/></keyword>
+      </xsl:for-each>
+    </xsl:variable>
+
+    <citation>
+      <uuid><xsl:value-of
+        select="$metadata/dc:identifier[. != '']"/></uuid>
+      <authorsNameAndOrgList><xsl:copy-of select="$authorsNameAndOrgList"/></authorsNameAndOrgList>
+      <lastPublicationDate><xsl:value-of select="$lastPublicationDate"/></lastPublicationDate>
+      <translatedTitle><xsl:value-of select="$translatedTitle"/></translatedTitle>
+      <publishersNameAndOrgList><xsl:copy-of select="$publishersNameAndOrgList"/></publishersNameAndOrgList>
+      <landingPageUrl><xsl:value-of select="$landingPageUrl"/></landingPageUrl>
+      <doi><xsl:value-of select="replace($doiUrl, '.*doi.org/(.*)', '$1')"/></doi>
+      <doiUrl><xsl:value-of select="$doiUrl"/></doiUrl>
+      <xsl:copy-of select="$translatedKeywords"/>
+    </citation>
+  </xsl:template>
+</xsl:stylesheet>

--- a/schemas/dublin-core/src/main/plugin/dublin-core/formatter/citation/base.xsl
+++ b/schemas/dublin-core/src/main/plugin/dublin-core/formatter/citation/base.xsl
@@ -14,7 +14,6 @@
 
   <xsl:import href="sharedFormatterDir/xslt/render-variables.xsl"/>
   <xsl:import href="../../layout/utility-fn.xsl"/>
-  <xsl:import href="../../../iso19115-3.2018/formatter/citation/common.xsl"/>
 
   <xsl:template name="get-dublin-core-citation">
     <xsl:param name="metadata" as="node()"/>

--- a/schemas/dublin-core/src/main/plugin/dublin-core/formatter/citation/view.xsl
+++ b/schemas/dublin-core/src/main/plugin/dublin-core/formatter/citation/view.xsl
@@ -12,9 +12,8 @@
                 extension-element-prefixes="saxon"
                 exclude-result-prefixes="#all">
 
-  <xsl:import href="sharedFormatterDir/xslt/render-variables.xsl"/>
-  <xsl:include href="../../layout/utility-fn.xsl"/>
-  <xsl:include href="../../../iso19115-3.2018/formatter/citation/citation-common.xsl"/>
+  <xsl:import href="base.xsl"/>
+  <xsl:include href="../../../iso19115-3.2018/formatter/citation/common.xsl"/>
 
   <xsl:variable name="metadata"
                 select="/root/simpledc"/>
@@ -25,104 +24,11 @@
                 select="/empty"/>
 
   <xsl:template match="/">
-
-    <!-- Who is the creator of the data set?  This can be an individual, a group of individuals, or an organization. -->
-    <xsl:variable name="authors"
-                  select="$metadata/dc:creator"/>
-    <xsl:variable name="authorsNameAndOrgList">
-      <xsl:for-each select="$authors">
-        <author>
-          <xsl:variable name="name"
-                        select="normalize-space(.)"/>
-          <xsl:value-of select="$name"/>
-        </author>
-      </xsl:for-each>
-    </xsl:variable>
-
-    <!-- What name is the data set called? -->
-    <xsl:variable name="title"
-                  select="$metadata/dc:title"/>
-
-    <xsl:variable name="translatedTitle">
-      <xsl:for-each select="$title">
-        <xsl:value-of select="normalize-space(.)"/>
-      </xsl:for-each>
-    </xsl:variable>
-
-    <!-- Is there a version or edition number associated with the data set? -->
-
-
-    <!-- What year was the data set published?  When was the data set posted online? -->
-    <xsl:variable name="dates"
-                  select="$metadata/dct:modified[. != '']"/>
-
-    <xsl:variable name="publicationDates">
-      <xsl:perform-sort select="$dates">
-        <xsl:sort select="." order="descending"/>
-      </xsl:perform-sort>
-    </xsl:variable>
-
-    <xsl:variable name="lastPublicationDate"
-                  select="$publicationDates[1]"/>
-
-    <!-- What entity is responsible for producing and/or distributing the data set?  Also, is there a physical location associated with the publisher? -->
-    <xsl:variable name="publishers"
-                  select="$metadata/dc:publisher"/>
-
-    <xsl:variable name="publishersNameAndOrgList">
-      <xsl:for-each select="$publishers">
-        <author>
-          <xsl:variable name="name"
-                        select="normalize-space(.)"/>
-          <xsl:value-of select="$name"/>
-        </author>
-      </xsl:for-each>
-    </xsl:variable>
-
-
-    <!-- Electronic Retrieval Location -->
-    <xsl:variable name="doiInResourceIdentifier"
-                  select="(//dc:identifier[
-                                contains(text(), 'datacite.org/doi/')
-                                or contains(text(), 'doi.org')])[1]"/>
-
-    <xsl:variable name="doiInOnline"
-                  select="//(dc:relation|dct:references)[
-                                contains(text(), 'datacite.org/doi/')
-                                or contains(text(), 'doi.org')]"/>
-
-    <xsl:variable name="doiUrl"
-                  select="if ($doiInResourceIdentifier != '')
-                          then $doiInResourceIdentifier
-                          else if ($doiInOnline != '')
-                          then $doiInOnline
-                          else ''"/>
-
-    <xsl:variable name="landingPageUrl"
-                  select="concat($nodeUrl, 'api/records/', $metadataUuid)"/>
-
-    <xsl:variable name="keywords"
-                  select="$metadata//dc:subject"/>
-
-    <xsl:variable name="translatedKeywords">
-      <xsl:for-each select="$keywords">
-        <keyword><xsl:value-of select="."/></keyword>
-      </xsl:for-each>
-    </xsl:variable>
-
     <xsl:variable name="citationInfo">
-      <citation>
-        <uuid><xsl:value-of
-          select="$metadata/dc:identifier[. != '']"/></uuid>
-        <authorsNameAndOrgList><xsl:copy-of select="$authorsNameAndOrgList"/></authorsNameAndOrgList>
-        <lastPublicationDate><xsl:value-of select="$lastPublicationDate"/></lastPublicationDate>
-        <translatedTitle><xsl:value-of select="$translatedTitle"/></translatedTitle>
-        <publishersNameAndOrgList><xsl:copy-of select="$publishersNameAndOrgList"/></publishersNameAndOrgList>
-        <landingPageUrl><xsl:value-of select="$landingPageUrl"/></landingPageUrl>
-        <doi><xsl:value-of select="replace($doiUrl, '.*doi.org/(.*)', '$1')"/></doi>
-        <doiUrl><xsl:value-of select="$doiUrl"/></doiUrl>
-        <xsl:copy-of select="$translatedKeywords"/>
-      </citation>
+      <xsl:call-template name="get-dublin-core-citation">
+        <xsl:with-param name="metadata" select="$metadata"/>
+        <xsl:with-param name="language" select="$language"/>
+      </xsl:call-template>
     </xsl:variable>
 
     <xsl:apply-templates mode="citation" select="$citationInfo"/>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/citation/base.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/citation/base.xsl
@@ -1,0 +1,177 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="2.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:cit="http://standards.iso.org/iso/19115/-3/cit/2.0"
+                xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0"
+                xmlns:mcc="http://standards.iso.org/iso/19115/-3/mcc/1.0"
+                xmlns:mdb="http://standards.iso.org/iso/19115/-3/mdb/2.0"
+                xmlns:mri="http://standards.iso.org/iso/19115/-3/mri/1.0"
+                xmlns:mrd="http://standards.iso.org/iso/19115/-3/mrd/1.0"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+                xmlns:gn-fn-iso19115-3.2018="http://geonetwork-opensource.org/xsl/functions/profiles/iso19115-3.2018"
+                xmlns:saxon="http://saxon.sf.net/"
+                extension-element-prefixes="saxon"
+                exclude-result-prefixes="#all">
+
+  <xsl:import href="sharedFormatterDir/xslt/render-variables.xsl"/>
+  <xsl:import href="../../layout/utility-tpl-multilingual.xsl"/>
+  <xsl:import href="../../layout/utility-fn.xsl"/>
+
+  <xsl:template name="get-iso19115-3.2018-citation">
+    <xsl:param name="metadata" as="node()"/>
+    <xsl:param name="language" as="xs:string"/>
+
+    <xsl:variable name="langId"
+                  select="gn-fn-iso19115-3.2018:getLangId($metadata, $language)"/>
+
+    <!-- Who is the creator of the data set?  This can be an individual, a group of individuals, or an organization. -->
+    <xsl:variable name="authorRoles"
+                  select="('custodian', 'author')"/>
+    <xsl:variable name="authors"
+                  select="$metadata/mdb:identificationInfo/*/mri:pointOfContact/
+                                *[cit:role/*/@codeListValue = $authorRoles]"/>
+    <xsl:variable name="authorsNameAndOrgList">
+      <xsl:for-each select="$authors">
+        <author>
+          <xsl:variable name="name"
+                        select=".//cit:individual/*/cit:name[1]"/>
+
+          <xsl:for-each select="$name">
+            <xsl:call-template name="get-iso19115-3.2018-localised">
+              <xsl:with-param name="langId" select="$langId"/>
+            </xsl:call-template>
+          </xsl:for-each>
+          <xsl:if test="normalize-space($name) != ''">(</xsl:if>
+          <xsl:for-each select="cit:party/*/cit:name">
+            <xsl:call-template name="get-iso19115-3.2018-localised">
+              <xsl:with-param name="langId" select="$langId"/>
+            </xsl:call-template>
+          </xsl:for-each>
+          <xsl:if test="normalize-space($name) != ''">)</xsl:if>
+        </author>
+      </xsl:for-each>
+    </xsl:variable>
+
+    <!-- What name is the data set called? -->
+    <xsl:variable name="title"
+                  select="$metadata/mdb:identificationInfo/*/mri:citation/*/cit:title"/>
+
+    <xsl:variable name="translatedTitle">
+      <xsl:for-each select="$title">
+        <xsl:call-template name="get-iso19115-3.2018-localised">
+          <xsl:with-param name="langId" select="$langId"/>
+        </xsl:call-template>
+      </xsl:for-each>
+    </xsl:variable>
+
+    <!-- Is there a version or edition number associated with the data set? -->
+    <xsl:variable name="edition"
+                  select="'$metadata/mdb:identificationInfo/*/mri:citation/*/cit:title/*/text()[. != '']'"/>
+
+    <!-- What year was the data set published?  When was the data set posted online? -->
+    <xsl:variable name="dates"
+                  select="$metadata/mdb:identificationInfo/*/mri:citation/*/cit:date/*[
+                                  cit:dateType/*/@codeListValue =
+                                    ('publication', 'revision')]/
+                                    cit:date/gco:*[. != '']"/>
+
+    <xsl:variable name="publicationDates">
+      <xsl:perform-sort select="$dates">
+        <xsl:sort select="." order="descending"/>
+      </xsl:perform-sort>
+    </xsl:variable>
+
+    <xsl:variable name="lastPublicationDate"
+                  select="$publicationDates[1]"/>
+
+    <!-- What entity is responsible for producing and/or distributing the data set?  Also, is there a physical location associated with the publisher? -->
+    <xsl:variable name="publisherRoles"
+                  select="('publisher')"/>
+    <xsl:variable name="publishers"
+                  select="$metadata/mdb:identificationInfo/*/mri:pointOfContact/
+                                *[cit:role/*/@codeListValue = $publisherRoles]"/>
+
+    <xsl:variable name="publishersNameAndOrgList">
+      <xsl:for-each select="$publishers">
+        <author>
+          <xsl:variable name="name"
+                        select=".//cit:individual/*/cit:name[1]"/>
+
+          <xsl:for-each select="$name">
+            <xsl:call-template name="get-iso19115-3.2018-localised">
+              <xsl:with-param name="langId" select="$langId"/>
+            </xsl:call-template>
+          </xsl:for-each>
+          <xsl:if test="normalize-space($name) != ''">(</xsl:if>
+          <xsl:for-each select="cit:party/*/cit:name">
+            <xsl:call-template name="get-iso19115-3.2018-localised">
+              <xsl:with-param name="langId" select="$langId"/>
+            </xsl:call-template>
+          </xsl:for-each>
+          <xsl:if test="normalize-space($name) != ''">)</xsl:if>
+        </author>
+      </xsl:for-each>
+    </xsl:variable>
+
+
+    <!-- Electronic Retrieval Location -->
+    <xsl:variable name="doiInResourceIdentifier"
+                  select="(//mdb:identificationInfo/*/mri:citation/*/
+                              cit:identifier/*/mcc:code[
+                                contains(*/text(), 'datacite.org/doi/')
+                                or contains(*/text(), 'doi.org')
+                                or contains(*/@xlink:href, 'doi.org')]/*/(@xlink:href|text()))[1]"/>
+
+    <xsl:variable name="doiInOnline"
+                  select="//mdb:distributionInfo//mrd:onLine/*[
+                              matches(cit:protocol/gco:CharacterString,
+                               $doiProtocolRegex)]/cit:linkage/gco:CharacterString[. != '']"/>
+
+    <xsl:variable name="doiUrl"
+                  select="if ($doiInResourceIdentifier != '')
+                          then $doiInResourceIdentifier
+                          else if ($doiInOnline != '')
+                          then $doiInOnline
+                          else ''"/>
+
+    <xsl:variable name="landingPageUrl"
+                  select="concat($nodeUrl, 'api/records/', $metadataUuid)"/>
+
+    <xsl:variable name="keywords"
+                  select="$metadata//mri:keyword"/>
+
+    <xsl:variable name="translatedKeywords">
+      <xsl:for-each select="$keywords">
+        <keyword>
+          <xsl:call-template name="get-iso19115-3.2018-localised">
+            <xsl:with-param name="langId" select="$langId"/>
+          </xsl:call-template>
+        </keyword>
+      </xsl:for-each>
+    </xsl:variable>
+
+    <xsl:variable name="additionalCitation">
+      <xsl:for-each select=".//mrd:onLine/*[cit:protocol/* = ('WWW:LINK-1.0-http--metadata-URL', 'DOI')]/cit:description">
+        <xsl:call-template name="get-iso19115-3.2018-localised">
+          <xsl:with-param name="langId" select="$langId"/>
+        </xsl:call-template>
+      </xsl:for-each>
+    </xsl:variable>
+
+    <citation>
+      <uuid><xsl:value-of
+        select="$metadata/mdb:metadataIdentifier/*/mcc:code/gco:CharacterString[. != '']"/></uuid>
+      <authorsNameAndOrgList><xsl:copy-of select="$authorsNameAndOrgList"/></authorsNameAndOrgList>
+      <lastPublicationDate><xsl:value-of select="$lastPublicationDate"/></lastPublicationDate>
+      <translatedTitle><xsl:value-of select="$translatedTitle"/></translatedTitle>
+      <publishersNameAndOrgList><xsl:copy-of select="$publishersNameAndOrgList"/></publishersNameAndOrgList>
+      <landingPageUrl><xsl:value-of select="$landingPageUrl"/></landingPageUrl>
+      <doi><xsl:value-of select="replace($doiUrl, '.*doi.org/(.*)', '$1')"/></doi>
+      <doiUrl><xsl:value-of select="$doiUrl"/></doiUrl>
+      <xsl:copy-of select="$translatedKeywords"/>
+      <additionalCitation><xsl:value-of select="$additionalCitation"/></additionalCitation>
+    </citation>
+
+  </xsl:template>
+</xsl:stylesheet>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/citation/base.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/citation/base.xsl
@@ -152,7 +152,7 @@
     </xsl:variable>
 
     <xsl:variable name="additionalCitation">
-      <xsl:for-each select=".//mrd:onLine/*[cit:protocol/* = ('WWW:LINK-1.0-http--metadata-URL', 'DOI')]/cit:description">
+      <xsl:for-each select=".//mrd:onLine/*[cit:protocol/* = 'WWW:LINK-1.0-http--publication-URL']/cit:description">
         <xsl:call-template name="get-iso19115-3.2018-localised">
           <xsl:with-param name="langId" select="$langId"/>
         </xsl:call-template>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/citation/base.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/citation/base.xsl
@@ -164,7 +164,7 @@
         select="$metadata/mdb:metadataIdentifier/*/mcc:code/gco:CharacterString[. != '']"/></uuid>
       <authorsNameAndOrgList><xsl:copy-of select="$authorsNameAndOrgList"/></authorsNameAndOrgList>
       <lastPublicationDate><xsl:value-of select="$lastPublicationDate"/></lastPublicationDate>
-      <translatedTitle><xsl:value-of select="$translatedTitle"/></translatedTitle>
+      <translatedTitle><xsl:copy-of select="$translatedTitle"/></translatedTitle>
       <publishersNameAndOrgList><xsl:copy-of select="$publishersNameAndOrgList"/></publishersNameAndOrgList>
       <landingPageUrl><xsl:value-of select="$landingPageUrl"/></landingPageUrl>
       <doi><xsl:value-of select="replace($doiUrl, '.*doi.org/(.*)', '$1')"/></doi>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/citation/common.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/citation/common.xsl
@@ -116,7 +116,7 @@
                 </xsl:if>
               </xsl:otherwise>
             </xsl:choose>
-            <strong><xsl:value-of select="translatedTitle"/>.</strong>
+            <strong><xsl:copy-of select="translatedTitle/(text()|*)"/>.</strong>
             <xsl:value-of select="string-join(publishersNameAndOrgList/*, ', ')"/>
             <br/>
             <xsl:variable name="url"

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/citation/common.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/citation/common.xsl
@@ -105,19 +105,20 @@
         </div>
         <div class="col-md-9">
           <p>
-            <xsl:value-of select="string-join(authorsNameAndOrgList/*, ', ')"/>
-            <xsl:choose>
-              <xsl:when test="lastPublicationDate != ''">
-                (<xsl:value-of select="substring(lastPublicationDate, 1, 4)"/>).
-              </xsl:when>
-              <xsl:otherwise>
-                <xsl:if test="$hasAuthor">
-                  <xsl:text>. </xsl:text>
-                </xsl:if>
-              </xsl:otherwise>
-            </xsl:choose>
-            <strong><xsl:copy-of select="translatedTitle/(text()|*)"/>.</strong>
-            <xsl:value-of select="string-join(publishersNameAndOrgList/*, ', ')"/>
+            <xsl:call-template name="citation-contact">
+              <xsl:with-param name="contact" select="authorsNameAndOrgList"/>
+            </xsl:call-template>
+
+            <xsl:value-of select="if (lastPublicationDate != '')
+                      then concat('(', substring(lastPublicationDate, 1, 4), ').')
+                      else if ($hasAuthor) then '.'
+                      else ''"/>
+
+            <div><xsl:copy-of select="translatedTitle/(text()|*)"/>.</div>
+
+            <xsl:call-template name="citation-contact">
+              <xsl:with-param name="contact" select="publishersNameAndOrgList"/>
+            </xsl:call-template>
             <br/>
             <xsl:variable name="url"
                           select="if (doiUrl != '') then doiUrl else landingPageUrl"/>
@@ -138,4 +139,17 @@
     </blockquote>
   </xsl:template>
 
+  <xsl:template name="citation-contact">
+    <xsl:param name="contact" as="node()*"/>
+
+    <xsl:for-each select="$contact/author">
+      <xsl:for-each select="(text()|*)">
+        <span>
+          <xsl:copy-of select="@*"/>
+          <xsl:value-of select="."/>
+        </span>
+      </xsl:for-each>
+      <xsl:if test="position() != last()">, </xsl:if>
+    </xsl:for-each>
+  </xsl:template>
 </xsl:stylesheet>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/citation/common.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/citation/common.xsl
@@ -93,7 +93,7 @@
   </xsl:template>
 
 
-  <xsl:template mode="citation" match="citation[lower-case($format) = 'html']">
+  <xsl:template mode="citation" match="citation[lower-case($format) = ('html', '')]">
     <xsl:variable name="hasAuthor"
                   select="count(authorsNameAndOrgList/*) > 0"/>
     <xsl:variable name="hasPublisher"
@@ -125,6 +125,13 @@
               <xsl:value-of select="$url"/>
             </a>
             <br/>
+
+            <xsl:if test="additionalCitation != ''">
+              <br/>
+              <em><xsl:value-of select="$schemaStrings/citationAdditional"/></em>
+              <br/>
+              <xsl:value-of select="additionalCitation"/>
+            </xsl:if>
           </p>
         </div>
       </div>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/citation/view.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/citation/view.xsl
@@ -13,10 +13,8 @@
                 extension-element-prefixes="saxon"
                 exclude-result-prefixes="#all">
 
-  <xsl:import href="sharedFormatterDir/xslt/render-variables.xsl"/>
-  <xsl:include href="../../layout/utility-tpl-multilingual.xsl"/>
-  <xsl:include href="../../layout/utility-fn.xsl"/>
-  <xsl:include href="citation-common.xsl"/>
+  <xsl:import href="base.xsl"/>
+  <xsl:import href="common.xsl"/>
 
   <xsl:variable name="metadata"
                 select="/root/mdb:MD_Metadata"/>
@@ -24,154 +22,13 @@
   <xsl:variable name="configuration"
                 select="/empty"/>
 
-  <xsl:variable name="langId"
-                select="gn-fn-iso19115-3.2018:getLangId($metadata, $language)"/>
-
-  <xsl:variable name="allLanguages">
-    <xsl:call-template name="get-iso19115-3.2018-other-languages"/>
-  </xsl:variable>
 
   <xsl:template match="/">
-
-    <!-- Who is the creator of the data set?  This can be an individual, a group of individuals, or an organization. -->
-    <xsl:variable name="authorRoles"
-                  select="('custodian', 'author')"/>
-    <xsl:variable name="authors"
-                  select="$metadata/mdb:identificationInfo/*/mri:pointOfContact/
-                                *[cit:role/*/@codeListValue = $authorRoles]"/>
-    <xsl:variable name="authorsNameAndOrgList">
-      <xsl:for-each select="$authors">
-        <author>
-          <xsl:variable name="name"
-                        select=".//cit:individual/*/cit:name[1]"/>
-
-          <xsl:for-each select="$name">
-            <xsl:call-template name="get-iso19115-3.2018-localised">
-              <xsl:with-param name="langId" select="$langId"/>
-            </xsl:call-template>
-          </xsl:for-each>
-          <xsl:if test="normalize-space($name) != ''">(</xsl:if>
-          <xsl:for-each select="cit:party/*/cit:name">
-            <xsl:call-template name="get-iso19115-3.2018-localised">
-              <xsl:with-param name="langId" select="$langId"/>
-            </xsl:call-template>
-          </xsl:for-each>
-          <xsl:if test="normalize-space($name) != ''">)</xsl:if>
-        </author>
-      </xsl:for-each>
-    </xsl:variable>
-
-    <!-- What name is the data set called? -->
-    <xsl:variable name="title"
-                  select="$metadata/mdb:identificationInfo/*/mri:citation/*/cit:title"/>
-
-    <xsl:variable name="translatedTitle">
-      <xsl:for-each select="$title">
-        <xsl:call-template name="get-iso19115-3.2018-localised">
-          <xsl:with-param name="langId" select="$langId"/>
-        </xsl:call-template>
-      </xsl:for-each>
-    </xsl:variable>
-
-    <!-- Is there a version or edition number associated with the data set? -->
-    <xsl:variable name="edition"
-                  select="'$metadata/mdb:identificationInfo/*/mri:citation/*/cit:title/*/text()[. != '']'"/>
-
-    <!-- What year was the data set published?  When was the data set posted online? -->
-    <xsl:variable name="dates"
-                  select="$metadata/mdb:identificationInfo/*/mri:citation/*/cit:date/*[
-                                  cit:dateType/*/@codeListValue =
-                                    ('publication', 'revision')]/
-                                    cit:date/gco:*[. != '']"/>
-
-    <xsl:variable name="publicationDates">
-      <xsl:perform-sort select="$dates">
-        <xsl:sort select="." order="descending"/>
-      </xsl:perform-sort>
-    </xsl:variable>
-
-    <xsl:variable name="lastPublicationDate"
-                  select="$publicationDates[1]"/>
-
-    <!-- What entity is responsible for producing and/or distributing the data set?  Also, is there a physical location associated with the publisher? -->
-    <xsl:variable name="publisherRoles"
-                  select="('publisher')"/>
-    <xsl:variable name="publishers"
-                  select="$metadata/mdb:identificationInfo/*/mri:pointOfContact/
-                                *[cit:role/*/@codeListValue = $publisherRoles]"/>
-
-    <xsl:variable name="publishersNameAndOrgList">
-      <xsl:for-each select="$publishers">
-        <author>
-          <xsl:variable name="name"
-                        select=".//cit:individual/*/cit:name[1]"/>
-
-          <xsl:for-each select="$name">
-            <xsl:call-template name="get-iso19115-3.2018-localised">
-              <xsl:with-param name="langId" select="$langId"/>
-            </xsl:call-template>
-          </xsl:for-each>
-          <xsl:if test="normalize-space($name) != ''">(</xsl:if>
-          <xsl:for-each select="cit:party/*/cit:name">
-            <xsl:call-template name="get-iso19115-3.2018-localised">
-              <xsl:with-param name="langId" select="$langId"/>
-            </xsl:call-template>
-          </xsl:for-each>
-          <xsl:if test="normalize-space($name) != ''">)</xsl:if>
-        </author>
-      </xsl:for-each>
-    </xsl:variable>
-
-
-    <!-- Electronic Retrieval Location -->
-    <xsl:variable name="doiInResourceIdentifier"
-                  select="(//mdb:identificationInfo/*/mri:citation/*/
-                              cit:identifier/*/mcc:code[
-                                contains(*/text(), 'datacite.org/doi/')
-                                or contains(*/text(), 'doi.org')
-                                or contains(*/@xlink:href, 'doi.org')]/*/(@xlink:href|text()))[1]"/>
-
-    <xsl:variable name="doiInOnline"
-                  select="//mdb:distributionInfo//mrd:onLine/*[
-                              matches(cit:protocol/gco:CharacterString,
-                               $doiProtocolRegex)]/cit:linkage/gco:CharacterString[. != '']"/>
-
-    <xsl:variable name="doiUrl"
-                  select="if ($doiInResourceIdentifier != '')
-                          then $doiInResourceIdentifier
-                          else if ($doiInOnline != '')
-                          then $doiInOnline
-                          else ''"/>
-
-    <xsl:variable name="landingPageUrl"
-                  select="concat($nodeUrl, 'api/records/', $metadataUuid)"/>
-
-    <xsl:variable name="keywords"
-                  select="$metadata//mri:keyword"/>
-
-    <xsl:variable name="translatedKeywords">
-      <xsl:for-each select="$keywords">
-        <keyword>
-          <xsl:call-template name="get-iso19115-3.2018-localised">
-            <xsl:with-param name="langId" select="$langId"/>
-          </xsl:call-template>
-        </keyword>
-      </xsl:for-each>
-    </xsl:variable>
-
     <xsl:variable name="citationInfo">
-      <citation>
-        <uuid><xsl:value-of
-          select="$metadata/mdb:metadataIdentifier/*/mcc:code/gco:CharacterString[. != '']"/></uuid>
-        <authorsNameAndOrgList><xsl:copy-of select="$authorsNameAndOrgList"/></authorsNameAndOrgList>
-        <lastPublicationDate><xsl:value-of select="$lastPublicationDate"/></lastPublicationDate>
-        <translatedTitle><xsl:value-of select="$translatedTitle"/></translatedTitle>
-        <publishersNameAndOrgList><xsl:copy-of select="$publishersNameAndOrgList"/></publishersNameAndOrgList>
-        <landingPageUrl><xsl:value-of select="$landingPageUrl"/></landingPageUrl>
-        <doi><xsl:value-of select="replace($doiUrl, '.*doi.org/(.*)', '$1')"/></doi>
-        <doiUrl><xsl:value-of select="$doiUrl"/></doiUrl>
-        <xsl:copy-of select="$translatedKeywords"/>
-      </citation>
+      <xsl:call-template name="get-iso19115-3.2018-citation">
+        <xsl:with-param name="metadata" select="$metadata"/>
+        <xsl:with-param name="language" select="$language"/>
+      </xsl:call-template>
     </xsl:variable>
 
     <xsl:apply-templates mode="citation" select="$citationInfo"/>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/loc/eng/strings.xml
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/loc/eng/strings.xml
@@ -63,6 +63,7 @@
   <linkToPortal-help>Read here the full details and access to the data.</linkToPortal-help>
   <citationProposal>Citation proposal</citationProposal>
   <citationProposal-help>This proposal was automatically generated, check if the metadata authors did not specified custom citation requirements.</citationProposal-help>
+  <citationAdditional>When using this resource in a publication, also cite the related work(s) with:</citationAdditional>
   <associatedResources>Associated resources</associatedResources>
 
 

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/loc/fre/strings.xml
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/loc/fre/strings.xml
@@ -52,6 +52,7 @@
   <bboxesSection>Zone géographique</bboxesSection>
   <citationProposal>Proposition de citation</citationProposal>
   <citationProposal-help>Cette proposition de citation a été générée automatiquement selon le format suggéré par DataCite. Nous vous invitons à vérifier dans les métadonnées si les auteurs n'ont pas imposé un format de citation spécifique.</citationProposal-help>
+  <citationAdditional>Pour toute utilisation de cette ressource dans une publication, merci de citer également les travaux suivants :</citationAdditional>
   <associatedResources>Ressources associées</associatedResources>
 
 

--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/citation/base.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/citation/base.xsl
@@ -128,6 +128,9 @@
                                 or contains(*/text(), 'doi.org')
                                 or contains(*/@xlink:href, 'doi.org')]/*/(@xlink:href|text()))[1]"/>
 
+    <xsl:variable name="doiProtocolRegex"
+               select="'(DOI|WWW:LINK-1.0-http--metadata-URL)'"/>
+
     <xsl:variable name="doiInOnline"
                   select="//gmd:distributionInfo//gmd:onLine/*[
                               matches(gmd:protocol/gco:CharacterString,
@@ -171,7 +174,7 @@
         select="$metadata/gmd:fileIdentifier/gco:CharacterString[. != '']"/></uuid>
       <authorsNameAndOrgList><xsl:copy-of select="$authorsNameAndOrgList"/></authorsNameAndOrgList>
       <lastPublicationDate><xsl:value-of select="$lastPublicationDate"/></lastPublicationDate>
-      <translatedTitle><xsl:value-of select="$translatedTitle"/></translatedTitle>
+      <translatedTitle><xsl:copy-of select="$translatedTitle/(text()|*)"/></translatedTitle>
       <publishersNameAndOrgList><xsl:copy-of select="$publishersNameAndOrgList"/></publishersNameAndOrgList>
       <landingPageUrl><xsl:value-of select="$landingPageUrl"/></landingPageUrl>
       <doi><xsl:value-of select="replace($doiUrl, '.*doi.org/(.*)', '$1')"/></doi>

--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/citation/base.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/citation/base.xsl
@@ -174,7 +174,7 @@
         select="$metadata/gmd:fileIdentifier/gco:CharacterString[. != '']"/></uuid>
       <authorsNameAndOrgList><xsl:copy-of select="$authorsNameAndOrgList"/></authorsNameAndOrgList>
       <lastPublicationDate><xsl:value-of select="$lastPublicationDate"/></lastPublicationDate>
-      <translatedTitle><xsl:copy-of select="$translatedTitle/(text()|*)"/></translatedTitle>
+      <translatedTitle><xsl:copy-of select="$translatedTitle"/></translatedTitle>
       <publishersNameAndOrgList><xsl:copy-of select="$publishersNameAndOrgList"/></publishersNameAndOrgList>
       <landingPageUrl><xsl:value-of select="$landingPageUrl"/></landingPageUrl>
       <doi><xsl:value-of select="replace($doiUrl, '.*doi.org/(.*)', '$1')"/></doi>

--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/citation/base.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/citation/base.xsl
@@ -1,0 +1,183 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:gmd="http://www.isotc211.org/2005/gmd"
+                xmlns:gco="http://www.isotc211.org/2005/gco"
+                xmlns:gmx="http://www.isotc211.org/2005/gmx"
+                xmlns:gts="http://www.isotc211.org/2005/gts"
+                xmlns:gml="http://www.opengis.net/gml/3.2"
+                xmlns:gml320="http://www.opengis.net/gml"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+                xmlns:tr="java:org.fao.geonet.api.records.formatters.SchemaLocalizations"
+                xmlns:gn-fn-render="http://geonetwork-opensource.org/xsl/functions/render"
+                xmlns:gn-fn-metadata="http://geonetwork-opensource.org/xsl/functions/metadata"
+                xmlns:gn-fn-iso19139="http://geonetwork-opensource.org/xsl/functions/profiles/iso19139"
+                xmlns:xslUtils="java:org.fao.geonet.util.XslUtil"
+                xmlns:saxon="http://saxon.sf.net/"
+                version="2.0"
+                extension-element-prefixes="saxon"
+                exclude-result-prefixes="#all">
+
+  <xsl:import href="sharedFormatterDir/xslt/render-variables.xsl"/>
+  <xsl:import href="../../layout/utility-tpl-multilingual.xsl"/>
+  <xsl:import href="../../layout/utility-fn.xsl"/>
+
+  <xsl:template name="get-iso19139-citation">
+    <xsl:param name="metadata" as="node()"/>
+    <xsl:param name="language" as="xs:string"/>
+
+    <xsl:variable name="langId"
+                  select="gn-fn-iso19139:getLangId($metadata, $language)"/>
+
+
+    <!-- Who is the creator of the data set?  This can be an individual, a group of individuals, or an organization. -->
+    <xsl:variable name="authorRoles"
+                  select="('author')"/>
+    <xsl:variable name="authors"
+                  select="$metadata/gmd:identificationInfo/*/gmd:pointOfContact/
+                                *[gmd:role/*/@codeListValue = $authorRoles]"/>
+    <xsl:variable name="authorsNameAndOrgList">
+      <xsl:for-each select="$authors">
+        <author>
+          <xsl:variable name="name"
+                        select=".//gmd:individualName[1]"/>
+
+          <xsl:for-each select="$name">
+            <xsl:call-template name="localised">
+              <xsl:with-param name="langId" select="$langId"/>
+            </xsl:call-template>
+          </xsl:for-each>
+          <xsl:if test="normalize-space($name) != ''">(</xsl:if>
+          <xsl:for-each select=".//gmd:organisationName">
+            <xsl:call-template name="localised">
+              <xsl:with-param name="langId" select="$langId"/>
+            </xsl:call-template>
+          </xsl:for-each>
+          <xsl:if test="normalize-space($name) != ''">)</xsl:if>
+        </author>
+      </xsl:for-each>
+    </xsl:variable>
+
+    <!-- What name is the data set called? -->
+    <xsl:variable name="title"
+                  select="$metadata/gmd:identificationInfo/*/gmd:citation/*/gmd:title"/>
+
+    <xsl:variable name="translatedTitle">
+      <xsl:for-each select="$title">
+        <xsl:call-template name="localised">
+          <xsl:with-param name="langId" select="$langId"/>
+        </xsl:call-template>
+      </xsl:for-each>
+    </xsl:variable>
+
+    <!-- Is there a version or edition number associated with the data set? -->
+    <xsl:variable name="edition"
+                  select="'$metadata/gmd:identificationInfo/*/gmd:citation/*/gmd:title/*/text()[. != '']'"/>
+
+    <!-- What year was the data set published?  When was the data set posted online? -->
+    <xsl:variable name="dates"
+                  select="$metadata/gmd:identificationInfo/*/gmd:citation/*/gmd:date/*[
+                                  gmd:dateType/*/@codeListValue =
+                                    ('publication', 'revision')]/
+                                    gmd:date/gco:*[. != '']"/>
+
+    <xsl:variable name="publicationDates">
+      <xsl:perform-sort select="$dates">
+        <xsl:sort select="." order="descending"/>
+      </xsl:perform-sort>
+    </xsl:variable>
+
+    <xsl:variable name="lastPublicationDate"
+                  select="$publicationDates[1]"/>
+
+    <!-- What entity is responsible for producing and/or distributing the data set?  Also, is there a physical location associated with the publisher? -->
+    <xsl:variable name="publisherRoles"
+                  select="('publisher')"/>
+    <xsl:variable name="publishers"
+                  select="$metadata/gmd:identificationInfo/*/gmd:pointOfContact/
+                                *[gmd:role/*/@codeListValue = $publisherRoles]"/>
+
+    <xsl:variable name="publishersNameAndOrgList">
+      <xsl:for-each select="$publishers">
+        <author>
+          <xsl:variable name="name"
+                        select=".//gmd:individualName[1]"/>
+
+          <xsl:for-each select="$name">
+            <xsl:call-template name="localised">
+              <xsl:with-param name="langId" select="$langId"/>
+            </xsl:call-template>
+          </xsl:for-each>
+          <xsl:if test="normalize-space($name) != ''">(</xsl:if>
+          <xsl:for-each select=".//gmd:organisationName">
+            <xsl:call-template name="localised">
+              <xsl:with-param name="langId" select="$langId"/>
+            </xsl:call-template>
+          </xsl:for-each>
+          <xsl:if test="normalize-space($name) != ''">)</xsl:if>
+        </author>
+      </xsl:for-each>
+    </xsl:variable>
+
+
+    <!-- Electronic Retrieval Location -->
+    <xsl:variable name="doiInResourceIdentifier"
+                  select="(//gmd:identificationInfo/*/gmd:citation/*/
+                              gmd:identifier/*/gmd:code[
+                                contains(*/text(), 'datacite.org/doi/')
+                                or contains(*/text(), 'doi.org')
+                                or contains(*/@xlink:href, 'doi.org')]/*/(@xlink:href|text()))[1]"/>
+
+    <xsl:variable name="doiInOnline"
+                  select="//gmd:distributionInfo//gmd:onLine/*[
+                              matches(gmd:protocol/gco:CharacterString,
+                               $doiProtocolRegex)]/gmd:linkage/gmd:URL[. != '']"/>
+
+    <xsl:variable name="doiUrl"
+                  select="if ($doiInResourceIdentifier != '')
+                          then $doiInResourceIdentifier
+                          else if ($doiInOnline != '')
+                          then $doiInOnline
+                          else ''"/>
+
+    <xsl:variable name="landingPageUrl"
+                  select="concat($nodeUrl, 'api/records/', $metadataUuid)"/>
+
+
+    <xsl:variable name="keywords"
+                  select="$metadata/gmd:identificationInfo/*//gmd:keyword"/>
+
+    <xsl:variable name="translatedKeywords">
+      <xsl:for-each select="$keywords">
+        <keyword>
+          <xsl:call-template name="localised">
+            <xsl:with-param name="langId" select="$langId"/>
+          </xsl:call-template>
+        </keyword>
+      </xsl:for-each>
+    </xsl:variable>
+
+
+    <xsl:variable name="additionalCitation">
+      <xsl:for-each select=".//gmd:onLine/*[gmd:protocol/* = ('WWW:LINK-1.0-http--metadata-URL', 'DOI')]/gmd:description">
+        <xsl:call-template name="localised">
+          <xsl:with-param name="langId" select="$langId"/>
+        </xsl:call-template>
+      </xsl:for-each>
+    </xsl:variable>
+
+    <citation>
+      <uuid><xsl:value-of
+        select="$metadata/gmd:fileIdentifier/gco:CharacterString[. != '']"/></uuid>
+      <authorsNameAndOrgList><xsl:copy-of select="$authorsNameAndOrgList"/></authorsNameAndOrgList>
+      <lastPublicationDate><xsl:value-of select="$lastPublicationDate"/></lastPublicationDate>
+      <translatedTitle><xsl:value-of select="$translatedTitle"/></translatedTitle>
+      <publishersNameAndOrgList><xsl:copy-of select="$publishersNameAndOrgList"/></publishersNameAndOrgList>
+      <landingPageUrl><xsl:value-of select="$landingPageUrl"/></landingPageUrl>
+      <doi><xsl:value-of select="replace($doiUrl, '.*doi.org/(.*)', '$1')"/></doi>
+      <doiUrl><xsl:value-of select="$doiUrl"/></doiUrl>
+      <xsl:copy-of select="$translatedKeywords"/>
+      <additionalCitation><xsl:value-of select="$additionalCitation"/></additionalCitation>
+    </citation>
+  </xsl:template>
+</xsl:stylesheet>

--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/citation/base.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/citation/base.xsl
@@ -159,7 +159,7 @@
 
 
     <xsl:variable name="additionalCitation">
-      <xsl:for-each select=".//gmd:onLine/*[gmd:protocol/* = ('WWW:LINK-1.0-http--metadata-URL', 'DOI')]/gmd:description">
+      <xsl:for-each select=".//gmd:onLine/*[gmd:protocol/* = 'WWW:LINK-1.0-http--publication-URL']/gmd:description">
         <xsl:call-template name="localised">
           <xsl:with-param name="langId" select="$langId"/>
         </xsl:call-template>

--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/citation/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/citation/view.xsl
@@ -18,10 +18,8 @@
                 extension-element-prefixes="saxon"
                 exclude-result-prefixes="#all">
 
-  <xsl:import href="sharedFormatterDir/xslt/render-variables.xsl"/>
-  <xsl:include href="../../layout/utility-tpl-multilingual.xsl"/>
-  <xsl:include href="../../layout/utility-fn.xsl"/>
-  <xsl:include href="../../../iso19115-3.2018/formatter/citation/citation-common.xsl"/>
+  <xsl:include href="base.xsl"/>
+  <xsl:include href="../../../iso19115-3.2018/formatter/citation/common.xsl"/>
 
   <xsl:variable name="metadata"
                 select="/root/gmd:MD_Metadata"/>
@@ -31,158 +29,13 @@
   <xsl:variable name="editorConfig"
                 select="/empty"/>
 
-  <xsl:variable name="langId"
-                select="gn-fn-iso19139:getLangId($metadata, $language)"/>
-
-  <xsl:variable name="allLanguages">
-    <xsl:call-template name="get-iso19139-other-languages"/>
-  </xsl:variable>
-
   <xsl:template match="/">
-
-    <!-- Who is the creator of the data set?  This can be an individual, a group of individuals, or an organization. -->
-    <xsl:variable name="authorRoles"
-                  select="('custodian', 'author')"/>
-    <xsl:variable name="authors"
-                  select="$metadata/gmd:identificationInfo/*/gmd:pointOfContact/
-                                *[gmd:role/*/@codeListValue = $authorRoles]"/>
-    <xsl:variable name="authorsNameAndOrgList">
-      <xsl:for-each select="$authors">
-        <author>
-          <xsl:variable name="name"
-                        select=".//gmd:individualName[1]"/>
-
-          <xsl:for-each select="$name">
-            <xsl:call-template name="localised">
-              <xsl:with-param name="langId" select="$langId"/>
-            </xsl:call-template>
-          </xsl:for-each>
-          <xsl:if test="normalize-space($name) != ''">(</xsl:if>
-          <xsl:for-each select=".//gmd:organisationName">
-            <xsl:call-template name="localised">
-              <xsl:with-param name="langId" select="$langId"/>
-            </xsl:call-template>
-          </xsl:for-each>
-          <xsl:if test="normalize-space($name) != ''">)</xsl:if>
-        </author>
-      </xsl:for-each>
-    </xsl:variable>
-
-    <!-- What name is the data set called? -->
-    <xsl:variable name="title"
-                  select="$metadata/gmd:identificationInfo/*/gmd:citation/*/gmd:title"/>
-
-    <xsl:variable name="translatedTitle">
-      <xsl:for-each select="$title">
-        <xsl:call-template name="localised">
-          <xsl:with-param name="langId" select="$langId"/>
-        </xsl:call-template>
-      </xsl:for-each>
-    </xsl:variable>
-
-    <!-- Is there a version or edition number associated with the data set? -->
-    <xsl:variable name="edition"
-                  select="'$metadata/gmd:identificationInfo/*/gmd:citation/*/gmd:title/*/text()[. != '']'"/>
-
-    <!-- What year was the data set published?  When was the data set posted online? -->
-    <xsl:variable name="dates"
-                  select="$metadata/gmd:identificationInfo/*/gmd:citation/*/gmd:date/*[
-                                  gmd:dateType/*/@codeListValue =
-                                    ('publication', 'revision')]/
-                                    gmd:date/gco:*[. != '']"/>
-
-    <xsl:variable name="publicationDates">
-      <xsl:perform-sort select="$dates">
-        <xsl:sort select="." order="descending"/>
-      </xsl:perform-sort>
-    </xsl:variable>
-
-    <xsl:variable name="lastPublicationDate"
-                  select="$publicationDates[1]"/>
-
-    <!-- What entity is responsible for producing and/or distributing the data set?  Also, is there a physical location associated with the publisher? -->
-    <xsl:variable name="publisherRoles"
-                  select="('publisher')"/>
-    <xsl:variable name="publishers"
-                  select="$metadata/gmd:identificationInfo/*/gmd:pointOfContact/
-                                *[gmd:role/*/@codeListValue = $publisherRoles]"/>
-
-    <xsl:variable name="publishersNameAndOrgList">
-      <xsl:for-each select="$publishers">
-        <author>
-          <xsl:variable name="name"
-                        select=".//gmd:individualName[1]"/>
-
-          <xsl:for-each select="$name">
-            <xsl:call-template name="localised">
-              <xsl:with-param name="langId" select="$langId"/>
-            </xsl:call-template>
-          </xsl:for-each>
-          <xsl:if test="normalize-space($name) != ''">(</xsl:if>
-          <xsl:for-each select=".//gmd:organisationName">
-            <xsl:call-template name="localised">
-              <xsl:with-param name="langId" select="$langId"/>
-            </xsl:call-template>
-          </xsl:for-each>
-          <xsl:if test="normalize-space($name) != ''">)</xsl:if>
-        </author>
-      </xsl:for-each>
-    </xsl:variable>
-
-
-    <!-- Electronic Retrieval Location -->
-    <xsl:variable name="doiInResourceIdentifier"
-                  select="(//gmd:identificationInfo/*/gmd:citation/*/
-                              gmd:identifier/*/gmd:code[
-                                contains(*/text(), 'datacite.org/doi/')
-                                or contains(*/text(), 'doi.org')
-                                or contains(*/@xlink:href, 'doi.org')]/*/(@xlink:href|text()))[1]"/>
-
-    <xsl:variable name="doiInOnline"
-                  select="//gmd:distributionInfo//gmd:onLine/*[
-                              matches(gmd:protocol/gco:CharacterString,
-                               $doiProtocolRegex)]/gmd:linkage/gmd:URL[. != '']"/>
-
-    <xsl:variable name="doiUrl"
-                  select="if ($doiInResourceIdentifier != '')
-                          then $doiInResourceIdentifier
-                          else if ($doiInOnline != '')
-                          then $doiInOnline
-                          else ''"/>
-
-    <xsl:variable name="landingPageUrl"
-                  select="concat($nodeUrl, 'api/records/', $metadataUuid)"/>
-
-
-    <xsl:variable name="keywords"
-                  select="$metadata/gmd:identificationInfo/*//gmd:keyword"/>
-
-    <xsl:variable name="translatedKeywords">
-      <xsl:for-each select="$keywords">
-        <keyword>
-          <xsl:call-template name="localised">
-            <xsl:with-param name="langId" select="$langId"/>
-          </xsl:call-template>
-        </keyword>
-      </xsl:for-each>
-    </xsl:variable>
-
-
     <xsl:variable name="citationInfo">
-      <citation>
-        <uuid><xsl:value-of
-          select="$metadata/gmd:fileIdentifier/gco:CharacterString[. != '']"/></uuid>
-        <authorsNameAndOrgList><xsl:copy-of select="$authorsNameAndOrgList"/></authorsNameAndOrgList>
-        <lastPublicationDate><xsl:value-of select="$lastPublicationDate"/></lastPublicationDate>
-        <translatedTitle><xsl:value-of select="$translatedTitle"/></translatedTitle>
-        <publishersNameAndOrgList><xsl:copy-of select="$publishersNameAndOrgList"/></publishersNameAndOrgList>
-        <landingPageUrl><xsl:value-of select="$landingPageUrl"/></landingPageUrl>
-        <doi><xsl:value-of select="replace($doiUrl, '.*doi.org/(.*)', '$1')"/></doi>
-        <doiUrl><xsl:value-of select="$doiUrl"/></doiUrl>
-        <xsl:copy-of select="$translatedKeywords"/>
-      </citation>
+      <xsl:call-template name="get-iso19139-citation">
+        <xsl:with-param name="metadata" select="$metadata"/>
+        <xsl:with-param name="language" select="$language"/>
+      </xsl:call-template>
     </xsl:variable>
-
     <xsl:apply-templates mode="citation" select="$citationInfo"/>
   </xsl:template>
 </xsl:stylesheet>

--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
@@ -68,6 +68,8 @@
   <xsl:include href="../../layout/utility-tpl-multilingual.xsl"/>
   <xsl:include href="../../layout/utility-fn.xsl"/>
   <xsl:include href="../../formatter/jsonld/iso19139-to-jsonld.xsl"/>
+  <xsl:include href="../../formatter/citation/base.xsl"/>
+  <xsl:include href="../../../iso19115-3.2018/formatter/citation/common.xsl"/>
 
   <!-- The core formatter XSL layout based on the editor configuration -->
   <xsl:include href="sharedFormatterDir/xslt/render-layout.xsl"/>
@@ -269,89 +271,74 @@
                   select="if ($doiUrl != '') then $doiUrl else concat($nodeUrl, 'api/records/', $metadataUuid)"/>
 
     <xsl:if test="$displayCitation">
-      <blockquote>
-        <div class="row">
-          <div class="col-md-3">
-            <i class="fa fa-quote-left pull-right"><xsl:comment select="'icon'"/></i>
+      <xsl:variable name="forcedCitation"
+                    select="notexist"/>
+      <!--
+      Some catalogue want to be able to override default generated citation
+      using a metadata field.
+      select="gmd:identificationInfo/*/gmd:citation/*/gmd:otherCitationDetails"/>
+      -->
+      <xsl:choose>
+        <!-- Landing page case -->
+        <xsl:when test="$language = 'all'">
+          <xsl:variable name="citationInfo">
+            <xsl:call-template name="get-iso19139-citation">
+              <xsl:with-param name="metadata" select="$metadata"/>
+              <xsl:with-param name="language" select="$language"/>
+            </xsl:call-template>
+          </xsl:variable>
+          <blockquote>
+            <div class="row">
+              <div class="col-md-1">
+                <i class="fa fa-quote-left"><xsl:comment>Cite</xsl:comment></i>
+              </div>
+              <div class="col-md-11">
+                <h2 title="{$schemaStrings/citationProposal-help}"><xsl:comment select="name()"/>
+                  <xsl:value-of select="$schemaStrings/citationProposal"/>
+                </h2>
+
+                <xsl:choose>
+                  <xsl:when test="count($forcedCitation) > 0">
+                    <xsl:for-each select="$forcedCitation">
+                      <xsl:call-template name="localised">
+                        <xsl:with-param name="langId" select="$langId"/>
+                      </xsl:call-template>
+                    </xsl:for-each>
+                  </xsl:when>
+                  <xsl:otherwise>
+                    <xsl:apply-templates mode="citation" select="$citationInfo"/>
+                  </xsl:otherwise>
+                </xsl:choose>
+              </div>
+            </div>
+          </blockquote>
+        </xsl:when>
+        <xsl:when test="count($forcedCitation) > 0">
+          <xsl:variable name="txt">
+            <xsl:for-each select="$forcedCitation">
+              <xsl:call-template name="localised">
+                <xsl:with-param name="langId" select="$langId"/>
+              </xsl:call-template>
+            </xsl:for-each>
+          </xsl:variable>
+          <xsl:variable name="citation">
+            <xsl:call-template name="addLineBreaksAndHyperlinks">
+              <xsl:with-param name="txt" select="$txt"/>
+            </xsl:call-template>
+          </xsl:variable>
+
+          <div data-ng-if="showCitation"
+               data-gn-metadata-citation=""
+               data-text="{$citation}">
           </div>
-          <div class="col-md-9">
-            <h2 title="{$schemaStrings/citationProposal-help}"><xsl:comment select="name()"/>
-              <xsl:value-of select="$schemaStrings/citationProposal"/>
-              <i class="fa fa-info-circle"><xsl:comment select="'icon'"/></i>
-            </h2>
-            <br/>
-            <p>
-              <!-- Custodians -->
-              <xsl:for-each-group select="gmd:identificationInfo/*/gmd:pointOfContact/
-                                *[gmd:role/*/@codeListValue = ('custodian', 'author')]"
-                                  group-by="gmd:individualName/gco:CharacterString">
-                <xsl:variable name="name"
-                              select="normalize-space(current-grouping-key())"/>
-                <xsl:variable name="orgName">
-                  <xsl:for-each select="current-group()/gmd:organisationName">
-                    <xsl:call-template name="localised">
-                      <xsl:with-param name="langId" select="$langId"/>
-                    </xsl:call-template>
-                  </xsl:for-each>
-                </xsl:variable>
-
-                <xsl:value-of select="if ($name != '') then $name else $orgName"/>
-                <!--<xsl:if test="$name != ''">&#160;(</xsl:if>
-                <xsl:value-of select="gmd:organisationName/*"/>
-                <xsl:if test="$name">)</xsl:if>-->
-                <xsl:if test="position() != last()">&#160;,&#160;</xsl:if>
-              </xsl:for-each-group>
-
-              <!-- Publication year: use last publication or revision date -->
-              <xsl:variable name="publicationDate">
-                <xsl:perform-sort select="gmd:identificationInfo/*/gmd:citation/*/gmd:date/*[
-                                      gmd:dateType/*/@codeListValue  = ('publication', 'revision')]/
-                                      gmd:date/gco:*[. != '']">
-                  <xsl:sort select="." order="descending"/>
-                </xsl:perform-sort>
-              </xsl:variable>
-              <xsl:choose>
-                <xsl:when test="$publicationDate/*[1]">
-                  <xsl:for-each select="$publicationDate/*[1]">
-                    (<xsl:value-of select="substring($publicationDate, 1, 4)"/>).
-                  </xsl:for-each>
-                </xsl:when>
-                <xsl:otherwise>.&#160;</xsl:otherwise>
-              </xsl:choose>
-
-
-              <xsl:choose>
-                <xsl:when test="normalize-space($publicationDate) != ''">
-                  (<xsl:value-of select="substring(normalize-space($publicationDate), 1, 4)"/>).
-                </xsl:when>
-                <xsl:otherwise>.</xsl:otherwise>
-              </xsl:choose>
-
-              <xsl:for-each select="gmd:identificationInfo/*/gmd:citation/*/gmd:title">
-                <xsl:call-template name="localised">
-                  <xsl:with-param name="langId" select="$langId"/>
-                </xsl:call-template>
-              </xsl:for-each>
-              <xsl:text>. </xsl:text>
-
-              <!-- Publishers -->
-              <xsl:for-each select="gmd:identificationInfo/*/gmd:pointOfContact/
-                                *[gmd:role/*/@codeListValue = 'publisher']/gmd:organisationName">
-                <xsl:call-template name="localised">
-                  <xsl:with-param name="langId" select="$langId"/>
-                </xsl:call-template>
-                <xsl:if test="position() != last()">&#160;-&#160;</xsl:if>
-              </xsl:for-each>
-
-              <br/>
-              <a href="{$landingPageUrl}">
-                <xsl:value-of select="$landingPageUrl"/>
-              </a>
-              <br/>
-            </p>
+        </xsl:when>
+        <xsl:otherwise>
+          <div data-ng-if="showCitation"
+               data-gn-metadata-citation="md">
+            <xsl:comment>citation</xsl:comment>
           </div>
-        </div>
-      </blockquote>
+        </xsl:otherwise>
+      </xsl:choose>
     </xsl:if>
   </xsl:template>
 

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/eng/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/eng/strings.xml
@@ -67,6 +67,7 @@
   <linkToPortal-help>Read here the full details and access to the data.</linkToPortal-help>
   <citationProposal>Citation proposal</citationProposal>
   <citationProposal-help>This proposal was automatically generated, check if the metadata authors did not specified custom citation requirements.</citationProposal-help>
+  <citationAdditional>When using this resource in a publication, also cite the related work(s) with:</citationAdditional>
   <associatedResources>Associated resources</associatedResources>
 
   <!-- XSD error translation -->

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/fre/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/fre/strings.xml
@@ -61,6 +61,7 @@
   <bboxesSection>Zone géographique</bboxesSection>
   <citationProposal>Proposition de citation</citationProposal>
   <citationProposal-help>Cette proposition de citation a été générée automatiquement selon le format suggéré par DataCite. Nous vous invitons à vérifier dans les métadonnées si les auteurs n'ont pas imposé un format de citation spécifique.</citationProposal-help>
+  <citationAdditional>Pour toute utilisation de cette ressource dans une publication, merci de citer également les travaux suivants :</citationAdditional>
   <associatedResources>Ressources associées</associatedResources>
 
   <keywordFrom>Mots clés - </keywordFrom>


### PR DESCRIPTION
Follow up of https://github.com/titellus/core-geonetwork/pull/41

The main goal here is to be able to add citation in other pages eg.
landing page. The citation formatter is reworked so that it can be
imported and used (like JSON-LD formatter).

eg.

```xsl

  <xsl:include href="../../formatter/citation/base.xsl"/>
  <xsl:include href="../../../iso19115-3.2018/formatter/citation/common.xsl"/>

  <xsl:variable name="citationInfo">
    <xsl:call-template name="get-iso19139-citation">
      <xsl:with-param name="metadata" select="$metadata"/>
      <xsl:with-param name="language" select="$language"/>
    </xsl:call-template>
  </xsl:variable>

  <xsl:apply-templates mode="citation" select="$citationInfo"/>
```

Also add the possibility to have an additional citation in the HTML
format. The additional citation is stored in the DOI online resource
description and indicate extra related work(s) to cite.


Improve multilingual support for title and organisation name

eg. http://localhost:8080/geonetwork/srv/api/records/a46af25c-f949-48a2-9b7e-ac472230cda8/formatters/citation?language=fre&format=text

![image](https://user-images.githubusercontent.com/1701393/205600801-816c87f1-ff8e-4521-acb0-d4337cc67adc.png)


Added some doc about the citation configuration in https://github.com/geonetwork/doc/pull/216 