### PR TITLE
Fix for OCGWxS harvester resource constraint errors

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ogcwxs-info-injection.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ogcwxs-info-injection.xsl
@@ -873,19 +873,29 @@
           </xsl:otherwise>
         </xsl:choose>
       </mco:MD_LegalConstraints>
-      <!-- Copy security constraints & general constraints from the template record -->
-      <xsl:apply-templates mode="copy" select="$securityConstraints"/>
-      <xsl:apply-templates mode="copy" select="$generalConstraints"/>
+    </mri:resourceConstraints>
+    <!-- If they exist copy security constraints & general constraints from the template record -->
+    <xsl:if test="$securityConstraints">
+      <mri:resourceConstraints>
+        <xsl:apply-templates mode="copy" select="$securityConstraints"/>
+      </mri:resourceConstraints>
+    </xsl:if>
+    <xsl:if test="$generalConstraints">
+      <mri:resourceConstraints>
+        <xsl:apply-templates mode="copy" select="$generalConstraints"/>
+      </mri:resourceConstraints>
+    </xsl:if>
       <!-- If general constraints not in template record and GetCaps "<AccessConstraints>" is "NONE" output 'no conditions apply' -->
       <xsl:if test="not($generalConstraints) and lower-case(.) = 'none'">
-        <mco:MD_Constraints>
-          <xsl:attribute name="gco:nilReason" select="$nilReasonValue"/>
-          <mco:useLimitation>
-            <gco:CharacterString>no conditions apply</gco:CharacterString>
-          </mco:useLimitation>
-        </mco:MD_Constraints>
+        <mri:resourceConstraints>
+          <mco:MD_Constraints>
+            <xsl:attribute name="gco:nilReason" select="$nilReasonValue"/>
+            <mco:useLimitation>
+              <gco:CharacterString>no conditions apply</gco:CharacterString>
+            </mco:useLimitation>
+          </mco:MD_Constraints>
+        </mri:resourceConstraints>
       </xsl:if>
-    </mri:resourceConstraints>
   </xsl:template>
 
 

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ogcwxs-info-injection.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ogcwxs-info-injection.xsl
@@ -554,6 +554,12 @@
                              select="."/>
       </xsl:for-each>
 
+      <!-- If no '<AccessConstraints>' in "getCapabilities" response then 
+           copy constraints from template record -->
+      <xsl:if test="not($constraints)">
+        <xsl:apply-templates mode="copy" select="mri:resourceConstraints"/>
+      </xsl:if>
+
       <xsl:apply-templates mode="copy" select="mri:associatedResource"/>
       <xsl:apply-templates mode="copy" select="mri:defaultLocale"/>
       <xsl:apply-templates mode="copy" select="mri:otherLocale"/>
@@ -791,7 +797,8 @@
     </mri:descriptiveKeywords>
   </xsl:template>
 
-  <!-- Resource Constraints -->
+  <!-- Resource constraints -->
+  <!-- If there is 'AccessConstraints' in getCapabilities response -->
   <xsl:template mode="convert"
                 match="wms:AccessConstraints">
     <xsl:variable name="resConstraints"
@@ -834,7 +841,7 @@
                 codeListValue="{.}"/>
             </mco:accessConstraints>
           </xsl:when>
-          <!-- Second option: if there is an entry in the template record use that -->
+          <!-- Second option: if there is a legal constraints entry in the template record use that -->
           <xsl:when test="$useLimitation != ''">
             <xsl:apply-templates mode="copy" select="$legalConstraints"/>
           </xsl:when>
@@ -871,14 +878,12 @@
       <xsl:apply-templates mode="copy" select="$generalConstraints"/>
       <!-- If general constraints not in template record and GetCaps "<AccessConstraints>" is "NONE" output 'no conditions apply' -->
       <xsl:if test="not($generalConstraints) and lower-case(.) = 'none'">
-        <mri:resourceConstraints>
+        <mco:MD_Constraints>
           <xsl:attribute name="gco:nilReason" select="$nilReasonValue"/>
-          <mco:MD_Constraints>
-            <mco:useLimitation>
-              <gco:CharacterString>no conditions apply</gco:CharacterString>
-            </mco:useLimitation>
-          </mco:MD_Constraints>
-        </mri:resourceConstraints>
+          <mco:useLimitation>
+            <gco:CharacterString>no conditions apply</gco:CharacterString>
+          </mco:useLimitation>
+        </mco:MD_Constraints>
       </xsl:if>
     </mri:resourceConstraints>
   </xsl:template>


### PR DESCRIPTION
When harvesting a WMS service with the OGCWxS harvester and:

1) The "GetCapabilities" response has "&lt;AccessConstraints&gt;NONE&lt;/AccessConstraints&gt;"
2) There is an "&lt;MD_LegalConstraints&gt;" element in the record template

The harvester outputs two "&lt;MD_LegalConstraints&gt;": a "no conditions apply" from 1) and the element from 2)

This is a problem because it is outputting two legally contradictory "&lt;MD_LegalConstraints&gt;" elements.

This fix makes sure if the GetCaps "&lt;AccessConstraints&gt;" is set to "NONE" then the template can override this with a more informative value. 'NONE' is geoserver's default value for this field.

Also I have updated the old iso19139 "MD_RestrictionCode" values with iso19115 values.

