### PR TITLE
DOI / Only manage DOI from registered prefix

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -409,9 +409,10 @@
                *
                */
               scope.canPublishDoiForResource = function (resource){
+                var doiKey = gnConfig['system.publication.doi.doikey'];
                 return scope.isDoiApplicableForMetadata
                   && resource.lUrl !== null
-                  && resource.lUrl.match('doi.org') !== null
+                  && resource.lUrl.match('doi.org/' + doiKey) !== null
                   && !scope.isMdWorkflowEnableForMetadata;
               }
 


### PR DESCRIPTION
In settings > DOI, catalogue administrator can set the DOI prefix of the organisation. 
Only propose management of those DOIs as metadata records can referenced DOI from other organisations.

![image](https://user-images.githubusercontent.com/1701393/183014518-20629e75-22d5-4ff9-805b-2b89f0262eb8.png)
