### PR TITLE
Standard / Protocol extraction when using Anchor.

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/utility-tpl.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/utility-tpl.xsl
@@ -76,7 +76,7 @@
         $pattern) and
         normalize-space(cit:CI_OnlineResource/cit:linkage/gco:CharacterString) != '']">
 
-        <xsl:variable name="protocol" select="cit:CI_OnlineResource/cit:protocol/gco:CharacterString"/>
+        <xsl:variable name="protocol" select="cit:CI_OnlineResource/cit:protocol/*/text()"/>
 
         <xsl:variable name="fileName">
           <xsl:choose>
@@ -103,7 +103,7 @@
               mri:citation/cit:CI_Citation/cit:title/gco:CharacterString)"/></title>
             <abstract><xsl:value-of select="normalize-space($metadata/
               mdb:identificationInfo/*/mri:abstract)"/></abstract>
-            <protocol><xsl:value-of select="cit:CI_OnlineResource/cit:protocol/gco:CharacterString"/></protocol>
+            <protocol><xsl:value-of select="cit:CI_OnlineResource/cit:protocol/*/text()"/></protocol>
           </resource>
         </xsl:if>
       </xsl:for-each>

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/utility-tpl.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/utility-tpl.xsl
@@ -82,9 +82,10 @@
     <config>
       <xsl:for-each select="$metadata/descendant::gmd:onLine[
         matches(
-        gmd:CI_OnlineResource/gmd:protocol/gco:CharacterString,
+        gmd:CI_OnlineResource/gmd:protocol/*/text(),
         $pattern) and
         normalize-space(gmd:CI_OnlineResource/gmd:linkage/gmd:URL) != '']">
+
         <xsl:variable name="protocol"
                       select="string(gmd:CI_OnlineResource/gmd:protocol)"/>
         <xsl:variable name="fileName">
@@ -129,7 +130,7 @@
               gmd:identificationInfo/*/gmd:abstract)"/>
             </abstract>
             <protocol>
-              <xsl:value-of select="gmd:CI_OnlineResource/gmd:protocol/gco:CharacterString"/>
+              <xsl:value-of select="gmd:CI_OnlineResource/gmd:protocol/*/text()"/>
             </protocol>
           </resource>
         </xsl:if>


### PR DESCRIPTION
Support protocol encoded using Anchor. Maybe related to INSPIRE encoding rules or to format encoding (see https://github.com/geonetwork/core-geonetwork/pull/6411). This configuration is used by the geopublication process mainly.