### PR TITLE
Top toolbar / Portal switcher / Display main node when only one portal

### DIFF
--- a/web-ui/src/main/resources/catalog/components/usersearches/partials/portalswitcher.html
+++ b/web-ui/src/main/resources/catalog/components/usersearches/partials/portalswitcher.html
@@ -1,6 +1,6 @@
 <li class="dropdown gn-clear-xs"
     role="menuitem"
-    data-ng-if="showPortalSwitcher && portals.length > 0">
+    data-ng-if="showPortalSwitcher && (portals.length > 0 || nodeId != 'srv')">
   <a title="{{'portals' | translate}}"
      href
      class="dropdown-toggle gn-menuheader-xs"
@@ -21,8 +21,9 @@
       </a>
     </li>
     <li class="divider"
-        data-ng-if="nodeId != 'srv'"></li>
-    <li class="dropdown-header" translate="">switchPortals</li>
+        data-ng-if="portals.length > 0"></li>
+    <li class="dropdown-header" translate=""
+        data-ng-if="portals.length > 0">switchPortals</li>
     <li class="gn-menuitem-xs" role="menuitem"
         data-ng-repeat="p in portals | orderBy:'name'">
       <a href="../../{{p.uuid}}/{{lang}}/catalog.search">


### PR DESCRIPTION
If catalog contains only one portal, then:
* the link back to the main node is not displayed.
* portal switcher label is displayed

Before
![image](https://user-images.githubusercontent.com/1701393/184109150-590afd66-1e40-4964-8a11-2568f8848de8.png)

After link to main node is displayed
![image](https://user-images.githubusercontent.com/1701393/184109158-719de2e5-ba27-44d8-ab72-b25331f5e9cb.png)
