### PR TITLE
Record view / Files / Display full description in tooltip

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/related.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/related.html
@@ -46,7 +46,8 @@
         </h3>
         <!-- Display description if available -->
         <p data-ng-if="::r.locDescription.length > 0
-                       && r.locDescription !== r.locTitle">
+                       && r.locDescription !== r.locTitle"
+           title="{{::r.locDescription}}">
           {{::r.locDescription | striptags | characters:150}}
         </p>
         <div data-ng-switch on="mainType">


### PR DESCRIPTION
No tooltip available before so long description was not available to end user


![image](https://user-images.githubusercontent.com/1701393/185141407-791337f9-ad27-4869-814f-c7605a29288b.png)
