### PR TITLE
XSLT / HTML parser / Handle hyperlink

### DIFF
--- a/core/src/main/java/org/fao/geonet/util/XslUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/XslUtil.java
@@ -664,11 +664,15 @@ public final class XslUtil {
     /**
      * Try to preserve some HTML layout to text layout.
      *
-     * Replace br tag by new line, li by new line with leading *.
+     * Replace
+     * br tag by new line,
+     * li by new line with leading "* "
+     * a tag by "hyperlink label (href)"
      */
     public static String htmlElement2textReplacer(String html) {
         return html
             .replaceAll("<br */?>", System.getProperty("line.separator"))
+            .replaceAll("<a.*?href=\"(?<url>https?:\\/\\/(www\\.)?[-a-zA-Z0-9@:%._\\+~#=]{1,256}\\.[a-zA-Z0-9()]{1,6}\\b([-a-zA-Z0-9()@:%_\\+.~#?&\\/\\/=]*))\".*?>(?<label>.*?)<\\/a>", "${label} (${url})")
             .replaceAll("<li>(.*)</li>", System.getProperty("line.separator") + "* $1");
     }
     public static String html2text(String html) {

--- a/core/src/test/java/org/fao/geonet/util/XslUtilTest.java
+++ b/core/src/test/java/org/fao/geonet/util/XslUtilTest.java
@@ -48,6 +48,17 @@ public class XslUtilTest {
     }
 
     @Test
+    public void testHtml2textSubstituteHtmlHyperlinkToText() {
+        String text = XslUtil.html2text("<p>This data set is mainly based on data extracted from the European Union Transaction Log (EUTL) on 1st April 2022. The EUTL checks and records all transactions taking place within the trading system.</p>^M\n" +
+            "<p>It is run by the European Commission. See: <a class=\"external\" href=\"http://ec.europa.eu/environment/ets\">http://ec.europa.eu/environment/ets</a>. The data set also includes information on auctions of allowances, compiled from auctioning platforms, as well as EEA estimates of ETS emissions for the period 2005 to 2012, to reflect the current scope of the ETS for the third trading period (2013–2020). See more information in the <a title=\"\" href=\"http://www.eea.europa.eu/data-and-maps/data/european-union-emissions-trading-scheme/eu-ets-data-viewer-manual\" class=\"internal-link\" target=\"_self\">manual</a>.</p>", true);
+
+        String expectedText = "This data set is mainly based on data extracted from the European Union Transaction Log (EUTL) on 1st April 2022. The EUTL checks and records all transactions taking place within the trading system.^M\n" +
+            "It is run by the European Commission. See: http://ec.europa.eu/environment/ets (http://ec.europa.eu/environment/ets). The data set also includes information on auctions of allowances, compiled from auctioning platforms, as well as EEA estimates of ETS emissions for the period 2005 to 2012, to reflect the current scope of the ETS for the third trading period (2013–2020). See more information in the manual (http://www.eea.europa.eu/data-and-maps/data/european-union-emissions-trading-scheme/eu-ets-data-viewer-manual).";
+
+        assertEquals(expectedText, text);
+    }
+
+    @Test
     public void testHtml2textNormalized() {
         String html = "<div><span>Sample text</span><br/><span>Sample text 2</span></div>";
         String expectedText = "Sample text Sample text 2";


### PR DESCRIPTION
Follow up of https://github.com/geonetwork/core-geonetwork/pull/6227.
Preserve hyperlink during HTML to text conversion.