### PR TITLE
Index / Temporal range / Handle cases for year and year month only

### DIFF
--- a/web/src/main/webapp/xslt/common/index-utils.xsl
+++ b/web/src/main/webapp/xslt/common/index-utils.xsl
@@ -572,7 +572,10 @@
     <xsl:param name="end" as="node()?"/>
 
     <xsl:variable name="rangeStartDetails">
-      <xsl:if test="$start castable as xs:date or $start castable as xs:dateTime">
+      <xsl:if test="$start castable as xs:date
+                    or $start castable as xs:dateTime
+                    or $start castable as xs:gYearMonth
+                    or $start castable as xs:gYear">
         <value><xsl:value-of select="concat('&quot;date&quot;: &quot;', $start, '&quot;')"/></value>
       </xsl:if>
       <xsl:for-each select="$start/@*[. != '']">
@@ -580,7 +583,10 @@
       </xsl:for-each>
     </xsl:variable>
     <xsl:variable name="rangeEndDetails">
-      <xsl:if test="$end castable as xs:date or $end castable as xs:dateTime">
+      <xsl:if test="$end castable as xs:date
+                    or $end castable as xs:dateTime
+                    or $start castable as xs:gYearMonth
+                    or $start castable as xs:gYear">
         <value><xsl:value-of select="concat('&quot;date&quot;: &quot;', $end, '&quot;')"/></value>
       </xsl:if>
       <xsl:for-each select="$end/@*[. != '']">
@@ -599,6 +605,7 @@
         }</resourceTemporalExtentDetails>
     </xsl:if>
   </xsl:template>
+
 
 
   <!-- Produce a thesaurus field name valid in an XML document


### PR DESCRIPTION
`resourceTemporalExtentDetails` field used to display temporal range in record view was not populated when range is using only year or year-month notation.

```json
"resourceTemporalExtentDateRange": [
      {
        "gte": "2004-12-31T23:00:00.000Z",
        "lte": "2020-12-31T23:00:00.000Z"
      }
    ],
    "resourceTemporalExtentDetails": [
      {
        "start": {
          "date": "2005"
        },
        "end": {
          "date": "2021"
        }
      }
    ],
```


![image](https://user-images.githubusercontent.com/1701393/185182645-8088acd9-8d56-4edb-98a3-136e0d34e2ca.png)
