### PR TITLE
Fix inconsistent metadata status when requesting the DOI publication after the metadata approval and publication

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionService.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionService.js
@@ -285,7 +285,7 @@
           title: label ? 'mdStatusTitle-' + label : "status-" + t.id,
           content: '<div data-gn-metadata-status-updater="md" ' +
                         'data-status-to-select="' + statusToBe +
-                        '" data-status-type="' + statusType + '" task="t"></div>'
+                        '" data-status-type="' + statusType + '" task="task"></div>'
         }, scope, 'metadataStatusUpdated');
       };
 


### PR DESCRIPTION
The metadata status is set to the value 0 (unknown status) instead of the value 100 that corresponds to the DOI request.

Test case:

1) Login as admin user, go to the settings and enable the metadata workflow and configure the DOI publication panel.
2) Create an iso19139 valid metadata.
3) Complete the following steps in sequence without refreshing the page:

  - Chose Manage Record > Directly approve metadata (status is set to `Approved`)
  - Chose Manage Record > Publish
  - Chose Manage Record > DOI creation request

Result:

- Record status is now `Unknown`.

Expected:

- Record status is `Approved`.

Workaround:

- Refresh page between steps in 3)