### PR TITLE
API / XPath editing / Delete and replace_all fix

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/EditLib.java
+++ b/core/src/main/java/org/fao/geonet/kernel/EditLib.java
@@ -396,7 +396,7 @@ public class EditLib {
 
             if (isReplaceAllMode) {
                 // Remove all
-                AddElemValue propertyValueToProcess = new AddElemValue("<gn_delete></gn_delete>");
+                AddElemValue propertyValueToProcess = new AddElemValue(new Element("gn_delete"));
 
                 addElementOrFragmentFromXpath(metadataRecord, metadataSchema, xpathProperty, propertyValueToProcess,
                     createXpathNodeIfNotExist);

--- a/core/src/main/java/org/fao/geonet/kernel/EditLib.java
+++ b/core/src/main/java/org/fao/geonet/kernel/EditLib.java
@@ -509,7 +509,8 @@ public class EditLib {
 
             // If a property is not found in metadata,
             // or in create mode, create it...
-            if ( (nodeList.isEmpty() && createXpathNodeIfNotExist) || isCreateMode) {
+            if (((nodeList.isEmpty() && createXpathNodeIfNotExist) || isCreateMode)
+                && !isDeleteMode) {
                 int indexOfRequiredPortion = -1;
                 // Extract the XPath for the element to match. For:
                 //  * Relative XPath (*//gmd:RS_Identifier)[2]/gmd:code/gco:CharacterString

--- a/core/src/test/java/org/fao/geonet/kernel/EditLibIntegrationTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/EditLibIntegrationTest.java
@@ -416,6 +416,32 @@ public class EditLibIntegrationTest extends AbstractCoreIntegrationTest {
         assertEquals(0, Xml.selectNodes(metadataElement, "gmd:referenceSystemInfo", Arrays.asList(GMD, GCO)).size());
     }
 
+
+    @Test
+    public void testReplaceAll() throws Exception {
+        MetadataSchema schema = _schemaManager.getSchema("iso19139");
+        String code1 = "code1";
+        String code2 = "code2";
+        String code3 = "code3";
+        final Element metadataElement = new Element("MD_Metadata", GMD).addContent(Arrays.asList(
+            createReferenceSystemInfo(code1),
+            createReferenceSystemInfo(code2),
+            createReferenceSystemInfo(code3)
+        ));
+        assertEquals(3, Xml.selectNodes(metadataElement, "gmd:referenceSystemInfo", Arrays.asList(GMD, GCO)).size());
+
+        final String refSysElemName = "gmd:referenceSystemInfo";
+        String updateConfig = "<gn_replace_all><gmd:referenceSystemInfo xmlns:gmd=\"http://www.isotc211.org/2005/gmd\"><gmd:code>NEW</gmd:code></gmd:referenceSystemInfo></gn_replace_all>";
+
+        LinkedHashMap<String, AddElemValue> updates = new LinkedHashMap<String, AddElemValue>();
+        final String attXPath = "gmd:referenceSystemInfo";
+        updates.put(attXPath, new AddElemValue(updateConfig));
+        new EditLib(_schemaManager).addElementOrFragmentFromXpaths(metadataElement, updates, schema, true);
+
+        assertEquals(1, Xml.selectNodes(metadataElement, "gmd:referenceSystemInfo", Arrays.asList(GMD, GCO)).size());
+        assertEqualsText("NEW", metadataElement, refSysElemName + "[1]/gmd:code", GMD, GCO);
+    }
+
     @Test
     public void testReplaceFragmentFromXpath_SpecialDeleteAllTag() throws Exception {
 

--- a/core/src/test/java/org/fao/geonet/kernel/EditLibIntegrationTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/EditLibIntegrationTest.java
@@ -406,6 +406,14 @@ public class EditLibIntegrationTest extends AbstractCoreIntegrationTest {
             refSysElemName, new AddElemValue(newRefSystems), true);
 
         assertEquals(0, Xml.selectNodes(metadataElement, "gmd:referenceSystemInfo", Arrays.asList(GMD, GCO)).size());
+
+        Element deleteNotExistinElement = new Element(EditLib.SpecialUpdateTags.DELETE);
+        final String elementName = "gmd:referenceSystemInfo[test = false()]";
+        new EditLib(_schemaManager)
+            .addElementOrFragmentFromXpath(metadataElement, schema,
+                elementName, new AddElemValue(deleteNotExistinElement), true);
+
+        assertEquals(0, Xml.selectNodes(metadataElement, "gmd:referenceSystemInfo", Arrays.asList(GMD, GCO)).size());
     }
 
     @Test


### PR DESCRIPTION
2 issues fixed:

* API / XPath editing / Delete non existent node
Using XPath API to update a record was creating empty node when deleting non existent node (usually when xpath contains filter with no match). In deletion mode, we should never try to create elements corresponding to the requested XPath if there is no match.


* API / XPath editing / gn_replace_all mode may keep empty elements.

Issue introduced in
https://github.com/geonetwork/core-geonetwork/pull/6423.

Symptoms : edit a record with a topic category, switch to xml view
Empty `<gmd:topicCategory/>` elements are in the record.

When `gn_replace_all` is used the `gn_delete` steps was not take into
account.
