### PR TITLE
Add validation status to cmis store and configuration

### DIFF
--- a/core/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
@@ -205,6 +205,8 @@ public class CMISStore extends AbstractStore {
                 secondaryProperties.putAll(additionalProperties);
             }
             setCmisMetadataUUIDSecondary(doc, secondaryProperties, metadataUuid);
+            MetadataResourceExternalManagementProperties.ValidationStatus status = MetadataResourceExternalManagementProperties.ValidationStatus.valueOf(cmisConfiguration.getExternalResourceManagementStatusDefaultValue());
+            setCmisExternalManagementResourceStatusSecondary(properties, status);
             try {
                 doc.updateProperties(secondaryProperties);
             } catch (Exception e) {
@@ -223,6 +225,14 @@ public class CMISStore extends AbstractStore {
             properties.put(cmisConfiguration.getCmisMetadataUUIDPropertyName(), metadataUuid);
         }
     }
+
+    protected void setCmisExternalManagementResourceStatusSecondary(Map<String, Object> properties, MetadataResourceExternalManagementProperties.ValidationStatus status) {
+        if (!StringUtils.isEmpty(cmisConfiguration.getExternalResourceManagementStatusPropertyName()) && !StringUtils.isEmpty(status) ) {
+            properties.put(cmisConfiguration.getExternalResourceManagementStatusPropertyName(), status.getValue());
+        }
+    }
+
+
 
     protected void setCmisMetadataUUIDSecondary(Document doc, Map<String, Object> properties, String metadataUuid) {
         if (!StringUtils.isEmpty(cmisConfiguration.getCmisMetadataUUIDPropertyName()) &&

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
@@ -205,8 +205,11 @@ public class CMISStore extends AbstractStore {
                 secondaryProperties.putAll(additionalProperties);
             }
             setCmisMetadataUUIDSecondary(doc, secondaryProperties, metadataUuid);
-            MetadataResourceExternalManagementProperties.ValidationStatus status = MetadataResourceExternalManagementProperties.ValidationStatus.valueOf(cmisConfiguration.getExternalResourceManagementStatusDefaultValue());
-            setCmisExternalManagementResourceStatusSecondary(properties, status);
+            if (cmisObject==null) {
+                MetadataResourceExternalManagementProperties.ValidationStatus status = MetadataResourceExternalManagementProperties.ValidationStatus.valueOf(cmisConfiguration.getExternalResourceManagementStatusDefaultValue());
+                setCmisExternalManagementResourceStatusSecondary(properties, status);
+            }
+
             try {
                 doc.updateProperties(secondaryProperties);
             } catch (Exception e) {

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
@@ -128,7 +128,7 @@ public class CMISStore extends AbstractStore {
         }
 
         MetadataResourceExternalManagementProperties metadataResourceExternalManagementProperties =
-            getMetadataResourceExternalManagementProperties(context, metadataId, metadataUuid, visibility, resourceId, filename, document.getVersionLabel(), document.getVersionSeriesId(), document.getType());
+            getMetadataResourceExternalManagementProperties(context, metadataId, metadataUuid, visibility, resourceId, filename, document.getVersionLabel(), document.getVersionSeriesId(), document.getType(), null);
 
         return new FilesystemStoreResource(metadataUuid, metadataId, filename,
             settingManager.getNodeURL() + "api/records/", visibility, document.getContentStreamLength(), document.getLastModificationDate().getTime(), versionValue, metadataResourceExternalManagementProperties, approved);
@@ -430,7 +430,7 @@ public class CMISStore extends AbstractStore {
             }
             Folder parentFolder = cmisUtils.getFolderCache(key + folderRoot);
             MetadataResourceExternalManagementProperties metadataResourceExternalManagementProperties =
-                getMetadataResourceExternalManagementProperties(context, metadataId, metadataUuid, null, String.valueOf(metadataId), null, null, parentFolder.getId(), parentFolder.getType());
+                getMetadataResourceExternalManagementProperties(context, metadataId, metadataUuid, null, String.valueOf(metadataId), null, null, parentFolder.getId(), parentFolder.getType(), null);
 
             return new FilesystemStoreResourceContainer(metadataUuid, metadataId, metadataUuid,
                 settingManager.getNodeURL() + "api/records/", metadataResourceExternalManagementProperties, approved);
@@ -559,7 +559,8 @@ public class CMISStore extends AbstractStore {
                                                                                                          String filename,
                                                                                                          String version,
                                                                                                          String cmisObjectId,
-                                                                                                         ObjectType type
+                                                                                                         ObjectType type,
+                                                                                                         MetadataResourceExternalManagementProperties.ValidationStatus status
     ) {
         String metadataResourceExternalManagementPropertiesUrl = cmisConfiguration.getExternalResourceManagementUrl();
         if (!StringUtils.isEmpty(metadataResourceExternalManagementPropertiesUrl)) {
@@ -624,6 +625,10 @@ public class CMISStore extends AbstractStore {
 
         MetadataResourceExternalManagementProperties metadataResourceExternalManagementProperties
                 = new MetadataResourceExternalManagementProperties(cmisObjectId, metadataResourceExternalManagementPropertiesUrl);
+
+        if (status != null) {
+            metadataResourceExternalManagementProperties.setStatus(status);
+        }
 
         return metadataResourceExternalManagementProperties;
     }

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
@@ -128,7 +128,7 @@ public class CMISStore extends AbstractStore {
         }
 
         MetadataResourceExternalManagementProperties metadataResourceExternalManagementProperties =
-            getMetadataResourceExternalManagementProperties(context, metadataId, metadataUuid, visibility, resourceId, filename, document.getVersionLabel(), document.getVersionSeriesId(), document.getType(), null);
+            getMetadataResourceExternalManagementProperties(context, metadataId, metadataUuid, visibility, resourceId, filename, document.getVersionLabel(), document.getVersionSeriesId(), document.getType(), MetadataResourceExternalManagementProperties.ValidationStatus.UNKNOWN);
 
         return new FilesystemStoreResource(metadataUuid, metadataId, filename,
             settingManager.getNodeURL() + "api/records/", visibility, document.getContentStreamLength(), document.getLastModificationDate().getTime(), versionValue, metadataResourceExternalManagementProperties, approved);
@@ -443,7 +443,7 @@ public class CMISStore extends AbstractStore {
             }
             Folder parentFolder = cmisUtils.getFolderCache(key + folderRoot);
             MetadataResourceExternalManagementProperties metadataResourceExternalManagementProperties =
-                getMetadataResourceExternalManagementProperties(context, metadataId, metadataUuid, null, String.valueOf(metadataId), null, null, parentFolder.getId(), parentFolder.getType(), null);
+                getMetadataResourceExternalManagementProperties(context, metadataId, metadataUuid, null, String.valueOf(metadataId), null, null, parentFolder.getId(), parentFolder.getType(), MetadataResourceExternalManagementProperties.ValidationStatus.UNKNOWN);
 
             return new FilesystemStoreResourceContainer(metadataUuid, metadataId, metadataUuid,
                 settingManager.getNodeURL() + "api/records/", metadataResourceExternalManagementProperties, approved);
@@ -639,9 +639,7 @@ public class CMISStore extends AbstractStore {
         MetadataResourceExternalManagementProperties metadataResourceExternalManagementProperties
                 = new MetadataResourceExternalManagementProperties(cmisObjectId, metadataResourceExternalManagementPropertiesUrl);
 
-        if (status != null) {
-            metadataResourceExternalManagementProperties.setStatus(status);
-        }
+        metadataResourceExternalManagementProperties.setStatus(status);
 
         return metadataResourceExternalManagementProperties;
     }

--- a/core/src/main/java/org/fao/geonet/resources/CMISConfiguration.java
+++ b/core/src/main/java/org/fao/geonet/resources/CMISConfiguration.java
@@ -83,6 +83,7 @@ public class CMISConfiguration {
     private String repositoryId;
     private String repositoryName;
     private String cmisMetadataUUIDPropertyName;
+    private String cmisMetadataStatusPropertyName;
     /**
      * Url used for managing enhanced resource properties related to the metadata.
      */
@@ -451,6 +452,11 @@ public class CMISConfiguration {
         }
         this.cmisMetadataUUIDPropertyName = cmisMetadataUUIDPropertyName;
     }
+
+    public void setCmisMetadataStatusPropertyName(String cmisMetadataStatusPropertyName) {
+        this.cmisMetadataStatusPropertyName = cmisMetadataStatusPropertyName;
+    }
+
 
     @PostConstruct
     public void init() {

--- a/core/src/main/java/org/fao/geonet/resources/CMISConfiguration.java
+++ b/core/src/main/java/org/fao/geonet/resources/CMISConfiguration.java
@@ -492,7 +492,6 @@ public class CMISConfiguration {
                 this.externalResourceManagementValidationStatusSecondaryProperty = true;
             }
         }
-        this.externalResourceManagementValidationStatusPropertyName = externalResourceManagementValidationStatusPropertyName;
     }
 
 

--- a/core/src/main/java/org/fao/geonet/resources/CMISConfiguration.java
+++ b/core/src/main/java/org/fao/geonet/resources/CMISConfiguration.java
@@ -83,7 +83,7 @@ public class CMISConfiguration {
     private String repositoryId;
     private String repositoryName;
     private String cmisMetadataUUIDPropertyName;
-    private String cmisMetadataStatusPropertyName;
+
     /**
      * Url used for managing enhanced resource properties related to the metadata.
      */
@@ -92,7 +92,8 @@ public class CMISConfiguration {
     private Boolean externalResourceManagementModalEnabled;
     private Boolean externalResourceManagementFolderEnabled;
     private String externalResourceManagementFolderRoot;
-    private String externalResourceManagementStatus;
+    private String externalResourceManagementStatusPropertyName;
+    private String externalResourceManagementStatusDefaultValue;
 
     /*
      * Enable option to add versioning in the link to the resource.
@@ -253,12 +254,12 @@ public class CMISConfiguration {
         this.externalResourceManagementFolderRoot = folderRoot;
     }
 
-    public String getExternalResourceManagementStatus() {
-        return externalResourceManagementStatus;
+    public String getExternalResourceManagementStatusDefaultValue() {
+        return externalResourceManagementStatusDefaultValue;
     }
 
-    public void setExternalResourceManagementStatus(String externalResourceManagementStatus) {
-        this.externalResourceManagementStatus = externalResourceManagementStatus;
+    public void setExternalResourceManagementStatusDefaultValue(String externalResourceManagementStatusDefaultValue) {
+        this.externalResourceManagementStatusDefaultValue = externalResourceManagementStatusDefaultValue;
     }
 
     @Nonnull
@@ -453,8 +454,12 @@ public class CMISConfiguration {
         this.cmisMetadataUUIDPropertyName = cmisMetadataUUIDPropertyName;
     }
 
-    public void setCmisMetadataStatusPropertyName(String cmisMetadataStatusPropertyName) {
-        this.cmisMetadataStatusPropertyName = cmisMetadataStatusPropertyName;
+    public String getExternalResourceManagementStatusPropertyName() {
+        return externalResourceManagementStatusPropertyName;
+    }
+
+    public void setExternalResourceManagementStatusPropertyName(String externalResourceManagementStatusPropertyName) {
+        this.externalResourceManagementStatusPropertyName = externalResourceManagementStatusPropertyName;
     }
 
 

--- a/core/src/main/java/org/fao/geonet/resources/CMISConfiguration.java
+++ b/core/src/main/java/org/fao/geonet/resources/CMISConfiguration.java
@@ -91,6 +91,7 @@ public class CMISConfiguration {
     private Boolean externalResourceManagementModalEnabled;
     private Boolean externalResourceManagementFolderEnabled;
     private String externalResourceManagementFolderRoot;
+    private String externalResourceManagementStatus;
 
     /*
      * Enable option to add versioning in the link to the resource.
@@ -249,6 +250,14 @@ public class CMISConfiguration {
         }
 
         this.externalResourceManagementFolderRoot = folderRoot;
+    }
+
+    public String getExternalResourceManagementStatus() {
+        return externalResourceManagementStatus;
+    }
+
+    public void setExternalResourceManagementStatus(String externalResourceManagementStatus) {
+        this.externalResourceManagementStatus = externalResourceManagementStatus;
     }
 
     @Nonnull

--- a/core/src/main/resources/config-store/config-cmis-overrides.properties
+++ b/core/src/main/resources/config-store/config-cmis-overrides.properties
@@ -19,6 +19,7 @@ cmis.versioning.state=#{'${CMIS_VERSIONING_STATE:MAJOR}'.toUpperCase()}
 cmis.versioning.major.on.update=${CMIS_VERSIONING_MAJOR_ON_UPDATE:#{null}}
 
 cmis.metadata.uuid.property.name=${CMIS_METADATA_UUID_PROPERTY_NAME:#{null}}
+cmis.metadata.status.property.name=${CMIS_METADATA_STATUS_PROPERTY_NAME:#{null}}
 
 #  for cmis.binding.type=browser
 cmis.browser.url=${CMIS_BROWSER_URL:#{null}}

--- a/core/src/main/resources/config-store/config-cmis-overrides.properties
+++ b/core/src/main/resources/config-store/config-cmis-overrides.properties
@@ -11,6 +11,7 @@ cmis.external.resource.management.window.parameters=${CMIS_EXTERNAL_RESOURCE_MAN
 cmis.external.resource.management.modal.enabled=${CMIS_EXTERNAL_RESOURCE_MANAGEMENT_MODAL_ENABLED:#{null}}
 cmis.external.resource.management.folder.enabled=${CMIS_EXTERNAL_RESOURCE_MANAGEMENT_FOLDER_ENABLED:#{null}}
 cmis.external.resource.management.folder.root=${CMIS_EXTERNAL_RESOURCE_MANAGEMENT_FOLDER_ROOT:#{null}}
+cmis.external.resource.management.status=${CMIS_EXTERNAL_RESOURCE_MANAGEMENT_STATUS:#{null}}
 
 
 cmis.versioning.enabled=${CMIS_VERSIONING_ENABLED:#{null}}
@@ -37,5 +38,4 @@ cmis.webservices.multifiling.service=${CMIS_WEBSERVICES_MULTIFILING_SERVICE:#{nu
 cmis.webservices.policy.service=${CMIS_WEBSERVICES_POLICY_SERVICE:#{null}}
 cmis.webservices.acl.service=${CMIS_WEBSERVICES_ACL_SERVICE:#{null}}
 cmis.webservices.memory.threshold=${CMIS_WEBSERVICES_MEMORY_THRESHOLD:#{null}}
-
 

--- a/core/src/main/resources/config-store/config-cmis-overrides.properties
+++ b/core/src/main/resources/config-store/config-cmis-overrides.properties
@@ -11,15 +11,14 @@ cmis.external.resource.management.window.parameters=${CMIS_EXTERNAL_RESOURCE_MAN
 cmis.external.resource.management.modal.enabled=${CMIS_EXTERNAL_RESOURCE_MANAGEMENT_MODAL_ENABLED:#{null}}
 cmis.external.resource.management.folder.enabled=${CMIS_EXTERNAL_RESOURCE_MANAGEMENT_FOLDER_ENABLED:#{null}}
 cmis.external.resource.management.folder.root=${CMIS_EXTERNAL_RESOURCE_MANAGEMENT_FOLDER_ROOT:#{null}}
-cmis.external.resource.management.status=${CMIS_EXTERNAL_RESOURCE_MANAGEMENT_STATUS:#{null}}
-
+cmis.external.resource.status.property.name=${CMIS_EXTERNAL_RESOURCE_STATUS_PROPERTY_NAME:#{null}}
+cmis.external.resource.management.status.default.value=${CMIS_EXTERNAL_RESOURCE_MANAGEMENT_STATUS_DEFAULT_VALUE:#{null}}
 
 cmis.versioning.enabled=${CMIS_VERSIONING_ENABLED:#{null}}
 cmis.versioning.state=#{'${CMIS_VERSIONING_STATE:MAJOR}'.toUpperCase()}
 cmis.versioning.major.on.update=${CMIS_VERSIONING_MAJOR_ON_UPDATE:#{null}}
 
 cmis.metadata.uuid.property.name=${CMIS_METADATA_UUID_PROPERTY_NAME:#{null}}
-cmis.metadata.status.property.name=${CMIS_METADATA_STATUS_PROPERTY_NAME:#{null}}
 
 #  for cmis.binding.type=browser
 cmis.browser.url=${CMIS_BROWSER_URL:#{null}}

--- a/core/src/main/resources/config-store/config-cmis.xml
+++ b/core/src/main/resources/config-store/config-cmis.xml
@@ -105,6 +105,7 @@
         <property name="versioningMajorOnUpdate" value="${cmis.versioning.major.on.update}"/>
 
         <property name="cmisMetadataUUIDPropertyName" value="${cmis.metadata.uuid.property.name}"/>
+        <property name="cmisMetadataStatusPropertyName" value="${cmis.metadata.status.property.name}"/>
 
         <property name="browserUrl" value="${cmis.browser.url}"/>
 

--- a/core/src/main/resources/config-store/config-cmis.xml
+++ b/core/src/main/resources/config-store/config-cmis.xml
@@ -121,6 +121,7 @@
         <property name="webservicesPolicyService" value="${cmis.webservices.policy.service}"/>
         <property name="webservicesAclService" value="${cmis.webservices.acl.service}"/>
         <property name="webservicesMemoryThreshold" value="${cmis.webservices.memory.threshold}"/>
+        <property name="externalResourceManagementStatus" value="${cmis.external.resource.management.status}"/>
     </bean>
 
     <bean id="cmisutils" class="org.fao.geonet.resources.CMISUtils">

--- a/core/src/main/resources/config-store/config-cmis.xml
+++ b/core/src/main/resources/config-store/config-cmis.xml
@@ -99,13 +99,14 @@
         <property name="externalResourceManagementModalEnabled" value="${cmis.external.resource.management.modal.enabled}"/>
         <property name="externalResourceManagementFolderEnabled" value="${cmis.external.resource.management.folder.enabled}"/>
         <property name="externalResourceManagementFolderRoot" value="${cmis.external.resource.management.folder.root}"/>
+        <property name="externalResourceManagementStatusPropertyName" value="${cmis.external.resource.status.property.name}"/>
+        <property name="externalResourceManagementStatusDefaultValue" value="${cmis.external.resource.management.status.default.value}"/>
 
         <property name="versioningEnabled" value="${cmis.versioning.enabled}"/>
         <property name="versioningState" value="${cmis.versioning.state}"/>
         <property name="versioningMajorOnUpdate" value="${cmis.versioning.major.on.update}"/>
 
         <property name="cmisMetadataUUIDPropertyName" value="${cmis.metadata.uuid.property.name}"/>
-        <property name="cmisMetadataStatusPropertyName" value="${cmis.metadata.status.property.name}"/>
 
         <property name="browserUrl" value="${cmis.browser.url}"/>
 
@@ -122,7 +123,6 @@
         <property name="webservicesPolicyService" value="${cmis.webservices.policy.service}"/>
         <property name="webservicesAclService" value="${cmis.webservices.acl.service}"/>
         <property name="webservicesMemoryThreshold" value="${cmis.webservices.memory.threshold}"/>
-        <property name="externalResourceManagementStatus" value="${cmis.external.resource.management.status}"/>
     </bean>
 
     <bean id="cmisutils" class="org.fao.geonet.resources.CMISUtils">

--- a/domain/src/main/java/org/fao/geonet/domain/MetadataResourceExternalManagementProperties.java
+++ b/domain/src/main/java/org/fao/geonet/domain/MetadataResourceExternalManagementProperties.java
@@ -72,7 +72,7 @@ public class MetadataResourceExternalManagementProperties {
 
         public static ValidationStatus fromValue(int value) {
             for (ValidationStatus status : values()) {
-                if (status.statusValue ==value) {
+                if (status.statusValue == value) {
                     return status;
                 }
             }

--- a/domain/src/main/java/org/fao/geonet/domain/MetadataResourceExternalManagementProperties.java
+++ b/domain/src/main/java/org/fao/geonet/domain/MetadataResourceExternalManagementProperties.java
@@ -32,21 +32,48 @@ import javax.xml.bind.annotation.XmlRootElement;
 @XmlRootElement(name = "metadataResourceExternalManagementProperties")
 @XmlAccessorType(XmlAccessType.FIELD)
 public class MetadataResourceExternalManagementProperties {
-        private final String id;
-        private final String url;
+    private final String id;
+    private final String url;
+    private ValidationStatus status=ValidationStatus.UNKNOWN;
 
-        public MetadataResourceExternalManagementProperties(String id, String url) {
-            this.id = id;
-            this.url = url;
-        }
+    public MetadataResourceExternalManagementProperties(String id, String url) {
+        this.id = id;
+        this.url = url;
+    }
 
-        public String getUrl() {
+    public String getUrl() {
             return url;
         }
 
-        public String getId() {
+    public String getId() {
             return id;
         }
+
+    public ValidationStatus getStatus() {
+        return status;
     }
+
+    public void setStatus(ValidationStatus status) {
+        this.status = status;
+    }
+
+    public static enum ValidationStatus {
+        UNKNOWN(0),VALID(1), INCOMPLETE(2), WARNING(3);
+        private int statusValue;
+
+        private ValidationStatus (int statusValue) {
+            this.statusValue = statusValue;
+        }
+
+        public static ValidationStatus fromValue(int value) {
+            for (ValidationStatus status : values()) {
+                if (status.statusValue ==value) {
+                    return status;
+                }
+            }
+            return null;
+        }
+    }
+}
 
 

--- a/domain/src/main/java/org/fao/geonet/domain/MetadataResourceExternalManagementProperties.java
+++ b/domain/src/main/java/org/fao/geonet/domain/MetadataResourceExternalManagementProperties.java
@@ -73,6 +73,10 @@ public class MetadataResourceExternalManagementProperties {
             }
             return null;
         }
+
+        public int getValue () {
+            return statusValue;
+        }
     }
 }
 

--- a/web-ui/src/main/resources/catalog/components/filestore/partials/filestore.html
+++ b/web-ui/src/main/resources/catalog/components/filestore/partials/filestore.html
@@ -29,7 +29,7 @@
       <a class="btn btn-link"
            title="{{'externalResourceManagement' | translate}}"
            data-ng-click="onlinesrcService.openExternalResourceManagement(r)">
-          <i class="fa fa-file-text"></i>
+        <span class="fa" data-ng-class="{'resource-status-unknown': r.metadataResourceExternalManagementProperties.status=='UNKNOWN', 'resource-status-valid': r.metadataResourceExternalManagementProperties.status=='VALID', 'resource-status-incomplete': r.metadataResourceExternalManagementProperties.status=='INCOMPLETE'}"></span>
         </a>
       </td>
       <td>

--- a/web-ui/src/main/resources/catalog/components/filestore/partials/filestore.html
+++ b/web-ui/src/main/resources/catalog/components/filestore/partials/filestore.html
@@ -29,7 +29,7 @@
       <a class="btn btn-link"
            title="{{'externalResourceManagement' | translate}}"
            data-ng-click="onlinesrcService.openExternalResourceManagement(r)">
-        <span class="fa" data-ng-class="{'resource-status-unknown': r.metadataResourceExternalManagementProperties.status=='UNKNOWN', 'resource-status-valid': r.metadataResourceExternalManagementProperties.status=='VALID', 'resource-status-incomplete': r.metadataResourceExternalManagementProperties.status=='INCOMPLETE'}"></span>
+        <span class="fa" data-ng-class="{'external-resource-status-unknown': r.metadataResourceExternalManagementProperties.status=='UNKNOWN', 'external-resource-status-valid': r.metadataResourceExternalManagementProperties.status=='VALID', 'external-resource-status-incomplete': r.metadataResourceExternalManagementProperties.status=='INCOMPLETE'}"></span>
         </a>
       </td>
       <td>

--- a/web-ui/src/main/resources/catalog/components/usersearches/partials/portalswitcher.html
+++ b/web-ui/src/main/resources/catalog/components/usersearches/partials/portalswitcher.html
@@ -1,6 +1,6 @@
 <li class="dropdown gn-clear-xs"
     role="menuitem"
-    data-ng-if="showPortalSwitcher && portals.length > 0">
+    data-ng-if="showPortalSwitcher && (portals.length > 0 || nodeId != 'srv')">
   <a title="{{'portals' | translate}}"
      href
      class="dropdown-toggle gn-menuheader-xs"
@@ -21,8 +21,9 @@
       </a>
     </li>
     <li class="divider"
-        data-ng-if="nodeId != 'srv'"></li>
-    <li class="dropdown-header" translate="">switchPortals</li>
+        data-ng-if="portals.length > 0"></li>
+    <li class="dropdown-header" translate=""
+        data-ng-if="portals.length > 0">switchPortals</li>
     <li class="gn-menuitem-xs" role="menuitem"
         data-ng-repeat="p in portals | orderBy:'name'">
       <a href="../../{{p.uuid}}/{{lang}}/catalog.search">

--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -1486,3 +1486,41 @@ html {
   max-height: 300px;
   overflow: scroll;
 }
+
+.resource-status-unknown,
+.resource-status-incomplete,
+.resource-status-valid {
+  position: relative;
+
+}
+
+/* CSS hex codes  https://www.fontawesomecheatsheet.com/font-awesome-cheatsheet-4x/ */
+
+.resource-status-unknown::before,
+.resource-status-incomplete::before,
+.resource-status-valid::before{
+  content: "\f15c";  /* fa-file-text */
+  position: relative;
+  font-size: 1.1em;
+  color: #3277B3;
+  left: 0;
+  vertical-align: text-top;
+}
+
+.resource-status-incomplete::after {
+  content: "\f071"; /* fa-exclamation-triangle */
+  position: absolute;
+  font-size: 0.5em;
+  left: 1.75em;
+  top: 1.9em;
+  color: darkorange;
+}
+
+.resource-status-valid::after {
+  content: "\f14a";  /* fa-check-square */
+  position: absolute;
+  font-size: 0.5em;
+  left: 1.75em;
+  top: 1.9em;
+  color: green;
+}

--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -1487,18 +1487,18 @@ html {
   overflow: scroll;
 }
 
-.resource-status-unknown,
-.resource-status-incomplete,
-.resource-status-valid {
+.external-resource-status-unknown,
+.external-resource-status-incomplete,
+.external-resource-status-valid {
   position: relative;
 
 }
 
 /* CSS hex codes  https://www.fontawesomecheatsheet.com/font-awesome-cheatsheet-4x/ */
 
-.resource-status-unknown::before,
-.resource-status-incomplete::before,
-.resource-status-valid::before{
+.external-resource-status-unknown::before,
+.external-resource-status-incomplete::before,
+.external-resource-status-valid::before{
   content: "\f15c";  /* fa-file-text */
   position: relative;
   font-size: 1.1em;
@@ -1507,7 +1507,7 @@ html {
   vertical-align: text-top;
 }
 
-.resource-status-incomplete::after {
+.external-resource-status-incomplete::after {
   content: "\f071"; /* fa-exclamation-triangle */
   position: absolute;
   font-size: 0.5em;
@@ -1516,7 +1516,7 @@ html {
   color: darkorange;
 }
 
-.resource-status-valid::after {
+.external-resource-status-valid::after {
   content: "\f14a";  /* fa-check-square */
   position: absolute;
   font-size: 0.5em;


### PR DESCRIPTION
This feature is to support variety of status which is retrievable from the backend thru cmis and have the front end icon display accordingly.

![image](https://user-images.githubusercontent.com/74916635/186302909-c1bbd137-0802-4a2b-aa09-2563352f2897.png)

I added the the property in the configuration and front end logic to parse the related icons. The implementation is just rough in for all other developers to detailed in their own system.
