### PR TITLE
Set title / url for associated resources to empty string if not defined

### DIFF
--- a/schemas/iso19115-3.2018/src/main/java/org/fao/geonet/schema/iso19115_3_2018/ISO19115_3_2018SchemaPlugin.java
+++ b/schemas/iso19115-3.2018/src/main/java/org/fao/geonet/schema/iso19115_3_2018/ISO19115_3_2018SchemaPlugin.java
@@ -195,8 +195,8 @@ public class ISO19115_3_2018SchemaPlugin
         if (StringUtils.isEmpty(sibUuid)) {
             sibUuid = ref.getTextNormalize();
         }
-        String title = ref.getAttributeValue("title", XLINK);
-        String url = ref.getAttributeValue("href", XLINK);
+        String title = ref.getAttributeValue("title", XLINK, "");
+        String url = ref.getAttributeValue("href", XLINK, "");
         return new AssociatedResource(sibUuid, "", "", url, title);
     }
 

--- a/schemas/iso19139/src/main/java/org/fao/geonet/schema/iso19139/ISO19139SchemaPlugin.java
+++ b/schemas/iso19139/src/main/java/org/fao/geonet/schema/iso19139/ISO19139SchemaPlugin.java
@@ -256,8 +256,8 @@ public class ISO19139SchemaPlugin
         if (StringUtils.isEmpty(sibUuid)) {
             sibUuid = ref.getTextNormalize();
         }
-        String title = ref.getAttributeValue("title", XLINK);
-        String url = ref.getAttributeValue("href", XLINK);
+        String title = ref.getAttributeValue("title", XLINK, "");
+        String url = ref.getAttributeValue("href", XLINK, "");
         return new AssociatedResource(sibUuid, "", "", url, title);
     }
 


### PR DESCRIPTION
Previously these values were set as `null`, displaying that text in the user interface.

For example, for a service referencing a remote dataset using `srv:operatesOn`, the dataset info was displayed like:

![dataset-info](https://user-images.githubusercontent.com/1695003/186423420-3299b9e3-4a5c-4547-adcb-f1486cd07dbb.png)

With the change, the following code works fine, displaying the url value:

https://github.com/geonetwork/core-geonetwork/blob/6e2f05ecc93f6c82a6f3ebb095ba33f45a304ef0/web-ui/src/main/resources/catalog/components/metadataactions/partials/metadataCard.html#L24

![dataset-info-2](https://user-images.githubusercontent.com/1695003/186424154-74901251-6058-4ae8-a604-622ee016d52b.png)

