### PR TITLE
CSW - Fix typo (variable endPointValue)

### DIFF
--- a/web/src/main/webapp/xml/csw/record-to-csw-capabilities.xsl
+++ b/web/src/main/webapp/xml/csw/record-to-csw-capabilities.xsl
@@ -288,7 +288,7 @@
         <ows:Operation name="GetRecordById">
           <ows:DCP>
             <ows:HTTP>
-              <ows:Get xlink:href="${$endPointValue}"/>
+              <ows:Get xlink:href="{$endPointValue}"/>
               <ows:Post xlink:href="{$endPointValue}"/>
             </ows:HTTP>
           </ows:DCP>
@@ -347,7 +347,7 @@
 
           <inspire_ds:ExtendedCapabilities>
             <inspire_com:ResourceLocator>
-              <inspire_com:URL>{$endPointValue}?SERVICE=CSW&amp;VERSION=2.0.2&amp;REQUEST=GetCapabilities</inspire_com:URL>
+              <inspire_com:URL><xsl:value-of select="$endPointValue"/>?SERVICE=CSW&amp;VERSION=2.0.2&amp;REQUEST=GetCapabilities</inspire_com:URL>
               <inspire_com:MediaType>application/xml</inspire_com:MediaType>
             </inspire_com:ResourceLocator>
 


### PR DESCRIPTION
Fix
```
<ows:Operation name="GetRecordById">
<ows:DCP>
<ows:HTTP>
<ows:Get xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="$https://metawal.wallonie.be/geonetwork/inspire/fre/csw"/>

....

<inspire_com:ResourceLocator>
<inspire_com:URL>{$endPointValue}?SERVICE=CSW&VERSION=2.0.2&REQUEST=GetCapabilities</inspire_com:URL>
<inspire_com:MediaType>application/xml</inspire_com:MediaType>
</inspire_com:ResourceLocator>
```

https://github.com/SPW-DIG/metawal-core-geonetwork/issues/762