### PR TITLE
Remove unused izpack-standalone-compiler dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -919,11 +919,6 @@
          <!-- Oracle Free Use Terms and Conditions (FUTC) -->
        </dependency>
       <dependency>
-        <groupId>org.codehaus.izpack</groupId>
-        <artifactId>izpack-standalone-compiler</artifactId>
-        <version>4.3.1</version>
-      </dependency>
-      <dependency>
         <groupId>org.springframework</groupId>
         <artifactId>spring-context</artifactId>
         <version>${spring.version}</version>


### PR DESCRIPTION
izpack installer was removed in https://github.com/geonetwork/core-geonetwork/pull/4961

When merged, should be closed also https://github.com/geonetwork/core-geonetwork/pull/6388