### PR TITLE
Add print styles and stylesheet to GeoNetwork

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/metadataCard.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/metadataCard.html
@@ -37,7 +37,7 @@
            gn-metadata-open="md"
            gn-formatter="formatter.defaultUrl">
           <div class="gn-img-thumbnail"
-               style="background-image: url('{{md.overview[0].url | thumbnailUrlSize:320}}')">
+               style="background-image: url('{{md.overview[0].url | thumbnailUrlSize:320}}') !important">
           </div>
         </a>
         <a data-ng-show="md.remoteUrl"
@@ -45,7 +45,7 @@
            rel="noopener noreferrer"
            target="_blank">
           <div class="gn-img-thumbnail"
-               style="background-image: url('{{md.overview[0].url | thumbnailUrlSize:320}}')">
+               style="background-image: url('{{md.overview[0].url | thumbnailUrlSize:320}}') !important">
           </div>
         </a>
       </div>

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid4maps.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid4maps.html
@@ -17,7 +17,7 @@
         <div class="gn-md-thumbnail"
              data-ng-class="{'gn-md-no-thumbnail': !md.overview[0]}">
           <div class="gn-img-thumbnail"
-               style="background-image: url('{{md.overview[0].data || (md.overview[0].url | thumbnailUrlSize)}}')">
+               style="background-image: url('{{md.overview[0].data || (md.overview[0].url | thumbnailUrlSize)}}') !important">
           </div>
         </div>
       </div>

--- a/web-ui/src/main/resources/catalog/components/usersearches/partials/featuredusersearchescards.html
+++ b/web-ui/src/main/resources/catalog/components/usersearches/partials/featuredusersearchescards.html
@@ -16,7 +16,7 @@
         <div class="gn-md-thumbnail"
              data-ng-class="{'gn-md-no-thumbnail': !row.logo}">
           <div class="gn-img-thumbnail"
-               style="background-image: url({{::row.logo}})">
+               style="background-image: url({{::row.logo}}) !important">
           </div>
         </div>
       </div>

--- a/web-ui/src/main/resources/catalog/style/gn_icons.less
+++ b/web-ui/src/main/resources/catalog/style/gn_icons.less
@@ -130,15 +130,18 @@
 .gn-icontype-esri-rest,
 .gn-icontype-wfs {
   background-color: @btn-success-bg !important;
+  color: @btn-success-color !important;
 }
 
 .gn-icontype-linkdownload {
   background-color: @btn-primary-bg !important;
+  color: @btn-primary-color !important;
 }
 
 .gn-icontype-legend,
 .gn-icontype-map {
   background-color: @btn-warning-bg !important;
+  color: @btn-warning-color !important;
 }
 
 

--- a/web-ui/src/main/resources/catalog/views/default/directives/partials/infolist.html
+++ b/web-ui/src/main/resources/catalog/views/default/directives/partials/infolist.html
@@ -31,7 +31,7 @@
              gn-records="searchResults.records"
              gn-formatter="formatter.defaultUrl">
             <div class="gn-img-thumbnail"
-                 style="background-image: url('{{md.overview[0].url | thumbnailUrlSize:320}}')">
+                 style="background-image: url('{{md.overview[0].url | thumbnailUrlSize:320}}') !important">
             </div>
           </a>
         </div>

--- a/web-ui/src/main/resources/catalog/views/default/templates/home.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/home.html
@@ -1,4 +1,4 @@
-<div class="row gn-row-main">
+<div class="row gn-row-main hidden-print">
   <div data-ng-class="fluidLayout ? 'container-fluid' : 'container'">
 
     <div class="col-sm-offset-6"
@@ -151,7 +151,7 @@
     <div class="col-sm-12">
 
     <!-- toggle buttons -->
-    <div id="info-toggle-buttons" class="btn-group pull-right" data-toggle="buttons">
+    <div id="info-toggle-buttons" class="btn-group pull-right hidden-print" data-toggle="buttons">
       <button id="btn-toggle-blocks" type="button" class="btn btn-default"
               data-ng-click="toggleListType('blocks')"
               data-ng-model="type"
@@ -175,7 +175,7 @@
       </button>
     </div>
 
-    <tabset id="info-tabset pull-left" type="pills" justified="false" role="tablist">
+    <tabset id="info-tabset" type="pills" justified="false" role="tablist">
       <tab heading="{{'lastRecords' | translate}}"
            active="infoTabs.lastRecords.active">
         <form class="form-horizontal"

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/metadata.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/metadata.html
@@ -1,4 +1,4 @@
-<div class="gn-margin-bottom">
+<div class="gn-margin-bottom hidden-print">
   <span class="badge badge-rounded" title="{{'updatedOn' | translate}}">
     <i class="fa fa-fw fa-file-code-o"></i>
   </span>
@@ -42,7 +42,7 @@
 </div>
 
 <div data-ng-if="mdView.current.record.uuid"
-     class="gn-margin-bottom flex-row">
+     class="gn-margin-bottom gn-md-side-uuid flex-row">
   <span class="badge badge-rounded" title="{{'uuid' | translate}}">
     <i class="fa fa-fw fa-info"></i>
   </span>

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/recordView.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/recordView.html
@@ -60,7 +60,7 @@
     <div class="row gn-md-view"
         data-ng-show="mdView.current.record">
 
-      <div class="btn-toolbar" role="toolbar">
+      <div class="btn-toolbar hidden-print" role="toolbar">
 
         <!-- back -->
         <div class="btn-group" role="group">

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/spatial.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/spatial.html
@@ -42,7 +42,7 @@
 </div>
 
 <div data-ng-if="mdView.current.record.crsDetails"
-     class="gn-margin-bottom flex-row">
+     class="gn-margin-bottom gn-md-side-crs flex-row">
       <span class="badge badge-rounded">
         <i class="fa fa-fw fa-compass"></i>
       </span>

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/type-dataset.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/type-dataset.html
@@ -35,7 +35,7 @@
 <div class="row gn-section">
   <div class="col-md-8 gn-record">
     <div ng-include="'../../catalog/views/default/templates/recordView/downloads.html'"/>
-    <div ng-include="'../../catalog/views/default/templates/recordView/constraints.html'"/>
+    <div class="gn-page-break-avoid" ng-include="'../../catalog/views/default/templates/recordView/constraints.html'"/>
   </div>
   <!-- /.col-md-8 gn-record -->
   <div class="gn-md-side"
@@ -101,11 +101,11 @@
      data-ng-if="mdView.current.record.lineage
                  || mdView.current.record.sourceDescription
                  || mdView.current.record.supplementalInformation">
-  <div class="col-md-8 gn-record">
+  <div class="col-md-8 gn-record gn-page-break-avoid">
     <div ng-include="'../../catalog/views/default/templates/recordView/lineage.html'"/>
   </div>
   <!-- /.col-md-8 gn-record -->
-  <div class="gn-md-side">
+  <div class="gn-md-side gn-page-break-avoid">
     <div ng-include="'../../catalog/views/default/templates/recordView/sources.html'"/>
   </div>
 </div>
@@ -141,17 +141,17 @@
 <div class="gn-section row">
   <h2 class="col-md-12" data-translate="">metadataInformation</h2>
   <div class="col-md-8">
-    <div ng-include="'../../catalog/views/default/templates/recordView/metadatacontact.html'"/>
+    <div class="gn-page-break-avoid" ng-include="'../../catalog/views/default/templates/recordView/metadatacontact.html'"/>
   </div>
   <div class="col-md-4 gn-md-side">
-    <div ng-include="'../../catalog/views/default/templates/recordView/metadata.html'"/>
+    <div class="gn-page-break-avoid" ng-include="'../../catalog/views/default/templates/recordView/metadata.html'"/>
   </div>
 </div>
 
-<div class="row">
+<div class="row hidden-print">
   <div class="col-md-8">
     <div ng-include="'../../catalog/views/default/templates/recordView/share.html'"/>
   </div>
 </div>
 
-<div ng-include="'../../catalog/views/default/templates/recordView/footer.html'"/>
+<div class="hidden-print" ng-include="'../../catalog/views/default/templates/recordView/footer.html'"/>

--- a/web-ui/src/main/resources/catalog/views/default/templates/results.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/results.html
@@ -2,6 +2,7 @@
      data-runSearch="true">
 
   <div data-ng-if="!showHealthIndexError"
+       class="hidden-print"
        data-ng-include="'../../catalog/views/default/templates/searchForm.html'"></div>
 
   <div class="row gn-row-results">
@@ -43,7 +44,7 @@
       <!-- /.gn-search-facet -->
 
     <div class="col-md-9 container-fluid">
-      <div class="row gn-row-tools"
+      <div class="row gn-row-tools hidden-print"
            data-ng-show="searchResults.records.length > 0">
         <div class="col-xs-12 col-sm-6 col-sm-push-3 text-center">
           <div class=""
@@ -93,7 +94,7 @@
                data-map="searchObj.searchMap"></div>
 
           <button data-ng-show="searchResults.records.length > 9"
-                  class="btn btn-link"
+                  class="btn btn-link hidden-print"
                   onClick="window.scrollTo(0,0);"
                   title="{{'scrollTop' | translate}}">
             <i class="fa fa-fw fa-chevron-up"/>
@@ -103,7 +104,7 @@
     </div>
   </div>
 
-  <div ng-if="!showMapInFacet">
+  <div ng-if="!showMapInFacet" class="hidden-print">
     <div data-gn-map-field="searchObj.searchMap"
       data-gn-map-field-geom="searchObj.params.geometry"
       data-gn-map-field-opt="searchObj.mapfieldOption"

--- a/web/src/main/webapp/xslt/base-layout-cssjs-loader.xsl
+++ b/web/src/main/webapp/xslt/base-layout-cssjs-loader.xsl
@@ -41,19 +41,22 @@
 
   <xsl:template name="css-load">
     <link href="{/root/gui/url}/static/gn_fonts.css?v={$buildNumber}&amp;{$minimizedParam}" rel="stylesheet"
-          media="screen"/>
+          media="all"/>
 
     <link href="{/root/gui/url}/static/{$customFilename}.css?v={$buildNumber}&amp;{$minimizedParam}" rel="stylesheet"
-          media="screen"/>
+          media="all"/>
+
+    <link href="{/root/gui/url}/static/gn_print_default.css?v={$buildNumber}&amp;{$minimizedParam}" rel="stylesheet"
+          media="print"/>
 
     <link href="{/root/gui/url}/static/bootstrap-table.min.css?v={$buildNumber}" rel="stylesheet"
-          media="screen"></link>
+          media="all"></link>
 
     <link href="{/root/gui/url}/static/gn_pickers.css?v={$buildNumber}&amp;{$minimizedParam}" rel="stylesheet"
           media="screen"/>
 
     <link href="{/root/gui/url}/static/gn_inspire.css?v={$buildNumber}&amp;{$minimizedParam}" rel="stylesheet"
-          media="screen"/>
+          media="all"/>
 
     <xsl:if test="$withD3">
       <link href="{/root/gui/url}/static/nv.d3.css?v={$buildNumber}&amp;{$minimizedParam}" rel="stylesheet"
@@ -62,7 +65,7 @@
 
     <link href="{/root/gui/url}/static/ng-skos.css?v={$buildNumber}" rel="stylesheet" media="screen"></link>
     <link href="{/root/gui/url}/static/{/root/gui/nodeId}_custom_style.css?v={$buildNumber}&amp;{$minimizedParam}"
-          rel="stylesheet" media="screen"/>
+          rel="stylesheet" media="all"/>
   </xsl:template>
 
   <xsl:template name="css-load-nojs">

--- a/web/src/main/webapp/xslt/ui-search/portal-list.xsl
+++ b/web/src/main/webapp/xslt/ui-search/portal-list.xsl
@@ -94,7 +94,7 @@
               <div class="gn-md-contents">
                 <div class="gn-md-thumbnail">
                   <div class="gn-img-thumbnail"
-                       style="background-image: url(../../images/harvesting/{if (logo != '') then logo else 'blank.png'})">
+                       style="background-image: url(../../images/harvesting/{if (logo != '') then logo else 'blank.png'}) !important">
                   </div>
                 </div>
                 <div class="gn-md-details">


### PR DESCRIPTION
This PR adds a new stylesheet for printing via the browser and adds Bootstrap classes to hide certain parts/components of the layout.

These Bootstrap classes are used to have more control via the HTML

The Bootstrap framework already has styles for printing that are automatically used when printing. Some of these styles have been overridden:
- to show the logo
- to hide some link urls