### PR TITLE
User Saved Selections / index amount of users that saved a record

### DIFF
--- a/core/src/main/java/org/fao/geonet/constants/Geonet.java
+++ b/core/src/main/java/org/fao/geonet/constants/Geonet.java
@@ -678,6 +678,7 @@ public final class Geonet {
         public static final String INSPIRE_REPORT_URL = "_inspireReportUrl";
         public static final String INSPIRE_VALIDATION_DATE = "_inspireValidationDate";
         public static final String STATUS_WORKFLOW = "statusWorkflow";
+        public static final String USER_SAVED_COUNT = "userSavedCount";
     }
 
     public static class SearchConfig {

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataIndexer.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataIndexer.java
@@ -533,7 +533,8 @@ public class BaseMetadataIndexer implements IMetadataIndexer, ApplicationEventPu
                     }
                 }
 
-                int savedCount = userSavedSelectionRepository.countTimesUserSavedMetadata(uuid);
+                // index the amount of users that have saved this record in the "Preferred Records" list (id=0)
+                int savedCount = userSavedSelectionRepository.countTimesUserSavedMetadata(uuid, 0);
                 fields.put(Geonet.IndexFieldNames.USER_SAVED_COUNT, savedCount);
 
                 fields.putAll(addExtraFields(fullMd));

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataIndexer.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataIndexer.java
@@ -118,6 +118,9 @@ public class BaseMetadataIndexer implements IMetadataIndexer, ApplicationEventPu
 
     private ApplicationEventPublisher publisher;
 
+    @Autowired
+    private UserSavedSelectionRepository userSavedSelectionRepository;
+
     public BaseMetadataIndexer() {
     }
 
@@ -529,6 +532,9 @@ public class BaseMetadataIndexer implements IMetadataIndexer, ApplicationEventPu
                         fields.put(Geonet.IndexFieldNames.VALID_INSPIRE, "-1");
                     }
                 }
+
+                int savedCount = userSavedSelectionRepository.countTimesUserSavedMetadata(uuid);
+                fields.put(Geonet.IndexFieldNames.USER_SAVED_COUNT, savedCount);
 
                 fields.putAll(addExtraFields(fullMd));
 

--- a/domain/src/main/java/org/fao/geonet/domain/UserSavedSelection.java
+++ b/domain/src/main/java/org/fao/geonet/domain/UserSavedSelection.java
@@ -34,6 +34,7 @@ import javax.persistence.EmbeddedId;
 import javax.persistence.Entity;
 import javax.persistence.EntityListeners;
 import javax.persistence.FetchType;
+import javax.persistence.Index;
 import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.MapsId;
@@ -45,7 +46,10 @@ import java.io.Serializable;
  */
 @Entity
 @Access(AccessType.PROPERTY)
-@Table(name = "UserSavedSelections")
+@Table(
+    name = "UserSavedSelections",
+    indexes = {@Index(name = "idx_usersavedselections_metadatauuid", columnList = "metadataUuid")}
+)
 @EntityListeners(UserMetadataSelectionEntityListenerManager.class)
 public class UserSavedSelection extends GeonetEntity implements Serializable {
     private UserSavedSelectionId _id = new UserSavedSelectionId();

--- a/domain/src/main/java/org/fao/geonet/repository/UserSavedSelectionRepository.java
+++ b/domain/src/main/java/org/fao/geonet/repository/UserSavedSelectionRepository.java
@@ -37,6 +37,6 @@ public interface UserSavedSelectionRepository extends
     JpaSpecificationExecutor<UserSavedSelection>,
     UserSavedSelectionRepositoryCustom {
 
-    @Query("SELECT COUNT(DISTINCT u.user.id) FROM UserSavedSelection u WHERE u.metadataUuid = (:uuid)")
-    int countTimesUserSavedMetadata(@Param("uuid") String metadataUuid);
+    @Query("SELECT COUNT(DISTINCT u.user.id) FROM UserSavedSelection u WHERE u.metadataUuid = (:uuid) and u.selection.id = (:selectionId)")
+    int countTimesUserSavedMetadata(@Param("uuid") String metadataUuid, @Param("selectionId") int selectionId);
 }

--- a/domain/src/main/java/org/fao/geonet/repository/UserSavedSelectionRepository.java
+++ b/domain/src/main/java/org/fao/geonet/repository/UserSavedSelectionRepository.java
@@ -26,6 +26,8 @@ package org.fao.geonet.repository;
 import org.fao.geonet.domain.UserSavedSelection;
 import org.fao.geonet.domain.UserSavedSelectionId;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 /**
  * Data Access object for accessing {@link UserSavedSelection} entities.
@@ -34,4 +36,7 @@ public interface UserSavedSelectionRepository extends
     GeonetRepository<UserSavedSelection, UserSavedSelectionId>,
     JpaSpecificationExecutor<UserSavedSelection>,
     UserSavedSelectionRepositoryCustom {
+
+    @Query("SELECT COUNT(DISTINCT u.user.id) FROM UserSavedSelection u WHERE u.metadataUuid = (:uuid)")
+    int countTimesUserSavedMetadata(@Param("uuid") String metadataUuid);
 }

--- a/services/src/main/java/org/fao/geonet/api/selections/UserSelectionsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/selections/UserSelectionsApi.java
@@ -32,6 +32,7 @@ import org.fao.geonet.api.ApiParams;
 import org.fao.geonet.api.ApiUtils;
 import org.fao.geonet.api.exception.ResourceNotFoundException;
 import org.fao.geonet.domain.*;
+import org.fao.geonet.kernel.datamanager.IMetadataIndexer;
 import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.repository.LanguageRepository;
 import org.fao.geonet.repository.SelectionRepository;
@@ -85,6 +86,9 @@ public class UserSelectionsApi {
 
     @Autowired
     UserGroupRepository userGroupRepository;
+
+    @Autowired
+    IMetadataIndexer metadataIndexer;
 
     @io.swagger.v3.oas.annotations.Operation(summary = "Get list of user selection sets")
     @RequestMapping(
@@ -318,6 +322,7 @@ public class UserSelectionsApi {
                 UserSavedSelection e = new UserSavedSelection(selection.get(), user.get(), u);
                 try {
                     umsRepository.save(e);
+                    metadataIndexer.indexMetadata(metadataRepository.getMetadataId(u), true);
                 } catch (Exception e1) {
                     Log.error(API.LOG_MODULE_NAME, "UserSelectionsApi - addToUserSelection: " + e1.getMessage(), e1);
                 }
@@ -382,6 +387,7 @@ public class UserSelectionsApi {
                     .setUserId(userIdentifier)
                     .setMetadataUuid(u);
                 umsRepository.deleteById(e);
+                metadataIndexer.indexMetadata(metadataRepository.getMetadataId(u), true);
             }
         }
 

--- a/services/src/test/java/org/fao/geonet/api/selections/UserSelectionsApiTest.java
+++ b/services/src/test/java/org/fao/geonet/api/selections/UserSelectionsApiTest.java
@@ -29,15 +29,18 @@ import org.fao.geonet.api.FieldNameExclusionStrategy;
 import org.fao.geonet.api.JsonFieldNamingStrategy;
 import org.fao.geonet.domain.Selection;
 import org.fao.geonet.kernel.DataManager;
+import org.fao.geonet.kernel.datamanager.base.BaseMetadataIndexer;
 import org.fao.geonet.kernel.mef.MEFLibIntegrationTest;
 import org.fao.geonet.repository.MetadataRepository;
 import org.fao.geonet.repository.SelectionRepository;
 import org.fao.geonet.services.AbstractServiceIntegrationTest;
 import org.junit.Before;
 import org.junit.Test;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpSession;
+import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.MvcResult;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
@@ -48,9 +51,20 @@ import java.util.Map;
 
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.*;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
  * Tests for UserSelectionsApi.
@@ -73,10 +87,17 @@ public class UserSelectionsApiTest extends AbstractServiceIntegrationTest {
     @Autowired
     private DataManager _dataManager;
 
+    @Autowired
+    private UserSelectionsApi userSelectionsApi;
+
+    private BaseMetadataIndexer metadataIndexerSpy;
+
     ServiceContext context;
 
     @Before
     public void setUp() throws Exception {
+        metadataIndexerSpy = Mockito.spy(new BaseMetadataIndexer());
+        ReflectionTestUtils.setField(userSelectionsApi, "metadataIndexer", metadataIndexerSpy);
         this.mockHttpSession = loginAsAdmin();
         context = createServiceContext();
     }
@@ -205,6 +226,8 @@ public class UserSelectionsApiTest extends AbstractServiceIntegrationTest {
             .accept(MediaType.parseMediaType("application/json")))
             .andExpect(status().isCreated());
 
+        verify(this.metadataIndexerSpy, times(1)).indexMetadata(eq(metadataId), any(Boolean.class));
+
         this.mockMvc.perform(get("/srv/api/userselections/" + createdSelection.getId() + "/1")
             .session(this.mockHttpSession)
             .accept(MediaType.parseMediaType("application/json")))
@@ -218,16 +241,15 @@ public class UserSelectionsApiTest extends AbstractServiceIntegrationTest {
             .accept(MediaType.parseMediaType("application/json")))
             .andExpect(status().isNoContent());
 
+        verify(this.metadataIndexerSpy, times(2)).indexMetadata(eq(metadataId), any(Boolean.class));
 
         // Delete
         this.mockMvc.perform(delete("/srv/api/userselections/" + createdSelection.getId())
             .accept(MediaType.parseMediaType("application/json")))
             .andExpect(status().is(204));
 
-
         // Check in DB
         assertFalse(selectionRepository.existsById(createdSelection.getId()));
-        ;
     }
 
     private String importMetadata(ServiceContext context) throws Exception {

--- a/web/src/main/webResources/WEB-INF/data/config/index/records.json
+++ b/web/src/main/webResources/WEB-INF/data/config/index/records.json
@@ -1833,6 +1833,9 @@
       },
       "statusWorkflow": {
         "type": "keyword"
+      },
+      "userSavedCount": {
+        "type": "long"
       }
     }
   }


### PR DESCRIPTION
A new `userSavedCount` field is added to the records in the index. It contains the amount of users that saved the record in at least one selection. This also adds indexation of records whenever they are added/removed to saved selections.

Note that records are not indexed when a whole selection is cleared or deleted.

Fixes https://github.com/geonetwork/core-geonetwork/issues/6509