### PR TITLE
Home / Map / Fix link adding the map to the map

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid4maps.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid4maps.html
@@ -2,8 +2,8 @@
   <li class="list-group-item panel panel-default gn-card"
       data-ng-repeat="md in searchResults.records"
       title="{{(md.resourceAbstract) | striptags}}"
-      ng-click="loadMap(maps[0], md)">
-
+      ng-click="loadMap(md.linksByType.maps[0], md)">
+    
     <div class="panel-heading gn-card-heading">
       <div class="gn-md-title">
         <a>


### PR DESCRIPTION
Use https://github.com/geonetwork/core-geonetwork/pull/6433 to easily get maps in home page (as in search results).

![image](https://user-images.githubusercontent.com/1701393/187494435-c5885797-3da3-47ac-a40c-b30b4f5a71f9.png)

For test:
* sign in
* map
* save map as metadata record
* move to home page
* click the map

```
lib.js?v=d814a8f1ca72b1bba0068f1e19a916d05c913a14:133 TypeError: Cannot read properties of undefined (reading 'url')
    at y (gn_search_default.js:107:124)
```