### PR TITLE
log4j2 upgrade - add dependency exclusions to avoid including log4j 1.2.17.

### DIFF
--- a/cachingxslt/pom.xml
+++ b/cachingxslt/pom.xml
@@ -56,8 +56,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
     </dependency>
     <dependency>
       <groupId>net.sf.saxon</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -548,6 +548,12 @@
       <groupId>org.owasp.esapi</groupId>
       <artifactId>esapi</artifactId>
       <version>2.4.0.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.xmlunit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -536,11 +536,6 @@
         <version>${log4j2.version}</version>
       </dependency>
       <dependency>
-        <groupId>log4j</groupId>
-        <artifactId>log4j</artifactId>
-        <version>${log4j.version}</version>
-      </dependency>
-      <dependency>
         <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-jcl</artifactId>
         <version>${log4j2.version}</version>
@@ -834,6 +829,12 @@
         <groupId>org.mapfish.print</groupId>
         <artifactId>print-lib</artifactId>
         <version>2.2.0</version>
+        <exclusions>
+          <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <!-- Lib utils -->
@@ -861,6 +862,12 @@
         <groupId>com.yammer.metrics</groupId>
         <artifactId>metrics-log4j</artifactId>
         <version>${metrics.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <!-- Tests -->
@@ -1561,7 +1568,6 @@
     <jackson.version>2.10.4</jackson.version>
     <flying-saucer>9.1.22</flying-saucer>
     <camel.version>2.25.1</camel.version>
-    <log4j.version>1.2.17</log4j.version>
     <log4j2.version>2.17.2</log4j2.version>
     <slf4j.version>1.8.0-beta2</slf4j.version>
     <xbean.version>3.18</xbean.version>

--- a/workers/pom.xml
+++ b/workers/pom.xml
@@ -89,8 +89,8 @@
     </dependency>
 
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-api</artifactId>
     </dependency>
     <!--
     <dependency>


### PR DESCRIPTION
The log from the libraries using log2j 1.2 should work fine, using the log4j 1.x bridge.

Related to #6397


Before the change:

![before](https://user-images.githubusercontent.com/1695003/187680882-7ce88cbb-d64c-4ea7-b9af-04758bf12b10.png)

After the change:

![after](https://user-images.githubusercontent.com/1695003/187680901-72002ba7-900c-4d67-852d-1d2b11021d6a.png)

