### PR TITLE
Direct use of Log4jLogger

### DIFF
--- a/common/src/main/java/org/fao/geonet/Logger.java
+++ b/common/src/main/java/org/fao/geonet/Logger.java
@@ -55,10 +55,12 @@ public interface Logger extends org.apache.logging.log4j.Logger {
      */
     public void info(String message);
 
-    /** Log warning message indicating potentially harmful situation, module
+    /**
+     * Log warning message indicating potentially harmful situation, module
      * will continue to try and complete current activity.
      *
      * @param message Warning message indicating potentially harmful situation
+     * @deprecated Use {@link #warn(String)}
      */
     public void warning(String message);
 
@@ -74,6 +76,7 @@ public interface Logger extends org.apache.logging.log4j.Logger {
      * current activity.
      *
      * @param ex Cause of error condition.
+     * @deprecated Use {@link #error(String, Throwable)}
      */
     public void error(Throwable ex);
 
@@ -85,7 +88,7 @@ public interface Logger extends org.apache.logging.log4j.Logger {
     public void fatal(String message);
 
     /**
-     * Functional module used for logging messages (for example {@code jeeves.engine}).
+     * Functional module used for logging messages (for example {@code jeeves}).
      *
      * @return functional module used for logging messages.
      */
@@ -97,6 +100,7 @@ public interface Logger extends org.apache.logging.log4j.Logger {
      * The file appender is also responsible for log file location provided by {@link #getFileAppender()}.
      *
      * @param fileAppender Log4j FileAppender
+     * @deprecated dynamic provision of file appender no longer supported
      */
     public void setAppender(FileAppender fileAppender);
 
@@ -115,7 +119,8 @@ public interface Logger extends org.apache.logging.log4j.Logger {
 
     /**
      * Access to module logging level.
-     * @return
+     * @return level
+     * @deprecated Use {@link #getLevel()}
      */
     public org.apache.logging.log4j.Level getThreshold();
 

--- a/common/src/main/java/org/fao/geonet/Logger.java
+++ b/common/src/main/java/org/fao/geonet/Logger.java
@@ -29,8 +29,10 @@ import org.apache.logging.log4j.core.appender.FileAppender;
 
 /**
  * GeoNetwork logger wrapper providing module based logging services.
+ *
+ * Use {@link org.fao.geonet.utils.Log#createLogger(String)} for instance creation.
  */
-public interface Logger {
+public interface Logger extends org.apache.logging.log4j.Logger {
     /**
      * Quick check to see if debug logging is available, used to avoid creating
      * expensive debug messages if they are not going to be used.
@@ -112,7 +114,7 @@ public interface Logger {
     public String getFileAppender();
 
     /**
-     * Access to omodule logging level, providing
+     * Access to module logging level.
      * @return
      */
     public org.apache.logging.log4j.Level getThreshold();

--- a/common/src/main/java/org/fao/geonet/api/API.java
+++ b/common/src/main/java/org/fao/geonet/api/API.java
@@ -1,6 +1,6 @@
 /*
  * =============================================================================
- * ===	Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * ===	Copyright (C) 2016-2022 Food and Agriculture Organization of the
  * ===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * ===	and United Nations Environment Programme (UNEP)
  * ===
@@ -25,10 +25,29 @@
 
 package org.fao.geonet.api;
 
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.MarkerManager;
+
 /**
+ * GeoNetwork Application Programming Interface constants.
+ *
  * Created by francois on 08/01/16.
+ * @author Francois
  */
 public class API {
+
+    /**
+     * @deprecated unused
+     */
     public static final String CONTACT_EMAIL = "geonetwork@osgeo.org";
+    /**
+     * Logging {@code api} module name.
+     *
+     * @deprecated Use {@link #LOG_MARKER}
+     */
     public static final String LOG_MODULE_NAME = "geonetwork.api" ;
+    /**
+     * Marker for {@code api} log messages.
+     */
+    public static final Marker LOG_MARKER = MarkerManager.getMarker("api").addParents(MarkerManager.getMarker("geonetwork"));
 }

--- a/common/src/main/java/org/fao/geonet/utils/BinaryFile.java
+++ b/common/src/main/java/org/fao/geonet/utils/BinaryFile.java
@@ -117,10 +117,10 @@ public final class BinaryFile {
             }
             while (c != '\n');
             if (b == 1) { // error
-                LOGGER.error("scp: Protocol error: {}",sb);
+                LOGGER.error("scp: Protocol error: {}", sb);
             }
             if (b == 2) { // fatal error
-                LOGGER.error("scp: Protocol error: {}",sb);
+                LOGGER.error("scp: Protocol error: {}", sb);
             }
         }
         return b;
@@ -167,7 +167,7 @@ public final class BinaryFile {
             }
 
             // now get file name from scp
-            LOGGER.debug(Log.RESOURCES_MARKER,"scp: file returned has filesize={}, file={}",filesize, file);
+            LOGGER.debug(Log.RESOURCES_MARKER, "scp: file returned has filesize={}, file={}", filesize, file);
 
             // send '\0'
             buf[0] = 0;
@@ -273,6 +273,7 @@ public final class BinaryFile {
         try {
             return new String(Files.readAllBytes(path), Constants.CHARSET);
         } catch (IOException e) {
+            // The "geonetwork" marker defined by GeoInt.GEONETWORK from core
             LOGGER.error(MarkerManager.getMarker("geonetwork"), "Error reading file: {}", path);
             return null;
         }
@@ -306,7 +307,7 @@ public final class BinaryFile {
                 remotePath = tokens[4].trim();
                 remoteProtocol = getRemoteProtocol(fileContents.toLowerCase());
                 remoteFile = true;
-                LOGGER.debug(Log.RESOURCES_MARKER,"REMOTE: {} :********:{}:{}:{}",remoteUser,remoteSite,remotePath,remoteProtocol);
+                LOGGER.debug(Log.RESOURCES_MARKER, "REMOTE: {} :********:{}:{}:{}", remoteUser, remoteSite, remotePath, remoteProtocol);
             } else {
                 LOGGER.debug(Log.RESOURCES_MARKER,"ERROR: remote file details were not valid");
                 remoteFile = false;
@@ -484,7 +485,7 @@ public final class BinaryFile {
                         session.disconnect();
                     }
                 } catch (Exception e) {
-                    LOGGER.error("Problem with scp from site: {}@{}:{}", remoteUser,remoteSite,remotePath, e);
+                    LOGGER.error("Problem with scp from site: {}@{}:{}", remoteUser, remoteSite, remotePath, e);
                 }
             } else if (remoteProtocol.equals("ftp")) {
                 // set up globus FTP client
@@ -495,7 +496,7 @@ public final class BinaryFile {
                     DataSinkStream outputSink = new DataSinkStream(output);
                     ftp.get(remotePath, outputSink, null);
                 } catch (Exception e) {
-                    LOGGER.error("Problem with ftp from site: {}@{}:{}",remoteUser,remoteSite,remotePath, e);
+                    LOGGER.error("Problem with ftp from site: {}@{}:{}", remoteUser, remoteSite, remotePath, e);
                 }
             } else {
                 LOGGER.error("Unknown remote protocol in config file");

--- a/common/src/main/java/org/fao/geonet/utils/Log.java
+++ b/common/src/main/java/org/fao/geonet/utils/Log.java
@@ -316,15 +316,28 @@ public final class Log {
      * @return Marker determined from module and fallback, or {@link Log#JEEVES_MARKER} by default.
      */
     static Marker toMarker(String module, String fallback){
-        if(module == null){
-            return Log.JEEVES_MARKER;
+        if(module.contains(".") && fallback == null){
+            Marker marker = null;
+            for(String name : module.split("\\.")){
+                Marker m = MarkerManager.getMarker(name);
+                if( marker != null){
+                    m.addParents(marker);
+                }
+                marker = m;
+            }
+            return marker;
         }
-        Marker marker = MarkerManager.getMarker(module);
-        Marker parent = fallback != null ? MarkerManager.getMarker(fallback) : Log.JEEVES_MARKER;
-        if(!marker.isInstanceOf(parent)){
-            marker.addParents(parent);
+        else {
+            if (module == null) {
+                return Log.JEEVES_MARKER;
+            }
+            Marker marker = MarkerManager.getMarker(module);
+            Marker parent = fallback != null ? MarkerManager.getMarker(fallback) : Log.JEEVES_MARKER;
+            if (!marker.isInstanceOf(parent)) {
+                marker.addParents(parent);
+            }
+            return marker;
         }
-        return marker;
     }
 
     /**
@@ -339,7 +352,7 @@ public final class Log {
         Throwable t = new Throwable("logging context");
         StackTraceElement[] stackTrace = t.getStackTrace();
         for( StackTraceElement element : stackTrace ){
-            if( element.getClassName().startsWith("org.fao.geonet.utils.Log")) {
+            if( element.getClassName().equals("org.fao.geonet.utils.Log")) {
                 continue;
             }
             return element.getClassName();

--- a/common/src/main/java/org/fao/geonet/utils/Log.java
+++ b/common/src/main/java/org/fao/geonet/utils/Log.java
@@ -361,7 +361,6 @@ public final class Log {
      */
     public static org.fao.geonet.Logger createLogger(final String module,
                                                      final String fallback) {
-        // Class<?> caller = StackLocator.getInstance().getCallerClass(1);
         String caller = toCaller();
         Marker marker = toMarker(module,fallback);
         return new LoggerWrapper(caller,marker);

--- a/common/src/main/java/org/fao/geonet/utils/Log.java
+++ b/common/src/main/java/org/fao/geonet/utils/Log.java
@@ -51,7 +51,7 @@ import java.util.Enumeration;
 public final class Log {
 
     /**
-     * Jeeves base logging moodule.
+     * Jeeves base logging module name.
      *
      * @deprecated Use {@link #JEEVES_MARKER}
      */
@@ -188,80 +188,159 @@ public final class Log {
     private Log() {
     }
 
+    /**
+     * Log debug message for module on behalf of calling class.
+     * @param module
+     * @param message
+     * @deprecated Please use {@link Log#createLogger(Class, Marker)} to create your own Logger directly
+     */
     public static void debug(String module, Object message) {
-        LogManager.getLogger(module).debug(message);
+        createLogger(module).debug(message);
     }
 
+
+    /**
+     * Log debug exception for module on behalf of calling class.
+     * @param module
+     * @param message
+     * @deprecated Please use {@link Log#createLogger(Class, Marker)} to create your own Logger directly
+     */
     public static void debug(String module, Object message, Exception e) {
-        LogManager.getLogger(module).debug(message, e);
+        createLogger(module).debug(message, e);
     }
 
+    /**
+     * Check if debug is enabled for module
+     * @param module
+     * @deprecated Please use {@link Log#createLogger(Class, Marker)} to create your own Logger directly
+     */
     public static boolean isDebugEnabled(String module) {
-        return LogManager.getLogger(module).isDebugEnabled();
+        return createLogger(module).isDebugEnabled();
     }
 
-    @SuppressWarnings("deprecation")
+    /**
+     * Check if label enabled for module
+     * @param module
+     * @param level
+     * @deprecated Please use {@link Log#createLogger(Class, Marker)} to create your own Logger directly
+     */
     public static boolean isEnabledFor(String module, Level level) {
-        return LogManager.getLogger(module).isEnabled(level);
+        return createLogger(module).isEnabled(level);
     }
     //---------------------------------------------------------------------------
 
+    /**
+     * Log trace message for module on behalf of calling class.
+     * @param module
+     * @param message
+     * @deprecated Please use {@link Log#createLogger(Class, Marker)} to create your own Logger directly
+     */
     public static void trace(String module, Object message) {
-        LogManager.getLogger(module).trace(message);
+        createLogger(module).trace(message);
     }
 
+    /**
+     * Log trace exception for module on behalf of calling class.
+     * @param module
+     * @param message
+     * @deprecated Please use {@link Log#createLogger(Class, Marker)} to create your own Logger directly
+     */
     public static void trace(String module, Object message, Exception e) {
-        LogManager.getLogger(module).trace(message, e);
+        createLogger(module).trace(message, e);
     }
 
+    /**
+     * Check if trace enabled for module.
+     * @param module
+     * @deprecated Please use {@link Log#createLogger(Class, Marker)} to create your own Logger directly
+     */
     public static boolean isTraceEnabled(String module) {
-        return LogManager.getLogger(module).isTraceEnabled();
+        return createLogger(module).isTraceEnabled();
     }
 
     //---------------------------------------------------------------------------
 
+    /**
+     * Log info message for module on behalf of calling class.
+     * @param module
+     * @param message
+     * @deprecated Please use {@link Log#createLogger(Class, Marker)} to create your own Logger directly
+     */
     public static void info(String module, Object message) {
-        LogManager.getLogger(module).info(message);
+        createLogger(module).info(message);
     }
 
+    /**
+     * Log info exception for module on behalf of calling class.
+     * @param module
+     * @param message
+     * @deprecated Please use {@link Log#createLogger(Class, Marker)} to create your own Logger directly
+     */
     public static void info(String module, Object message, Throwable t) {
-        LogManager.getLogger(module).info(message, t);
+        createLogger(module).info(message, t);
     }
 
     //---------------------------------------------------------------------------
 
+    /**
+     * Log warning message for module on behalf of calling class.
+     * @param module
+     * @param message
+     * @deprecated Please use {@link Log#createLogger(Class, Marker)} to create your own Logger directly
+     */
     public static void warning(String module, Object message) {
-        LogManager.getLogger(module).warn(message);
+        createLogger(module).warn(message);
     }
 
+    /**
+     * Log warning exception for module on behalf of calling class.
+     * @param module
+     * @param message
+     * @deprecated Please use {@link Log#createLogger(Class, Marker)} to create your own Logger directly
+     */
     public static void warning(String module, Object message, Throwable e) {
-        LogManager.getLogger(module).warn(message, e);
+        createLogger(module).warn(message, e);
     }
 
 
     //---------------------------------------------------------------------------
 
+    /**
+     * Log error message for module on behalf of calling class.
+     * @param module
+     * @param message
+     * @deprecated Please use {@link Log#createLogger(Class, Marker)} to create your own Logger directly
+     */
     public static void error(String module, Object message) {
-        LogManager.getLogger(module).error(message);
+        createLogger(module).error(message);
     }
 
+    /**
+     * Log error exception for module on behalf of calling class.
+     * @param module
+     * @param message
+     * @deprecated Please use {@link Log#createLogger(Class, Marker)} to create your own Logger directly
+     */
     public static void error(String module, Object message, Throwable t) {
-        LogManager.getLogger(module).error(message, t);
+        createLogger(module).error(message, t);
     }
 
     //---------------------------------------------------------------------------
 
+    /**
+     * Log fatal message for module on behalf of calling class.
+     * @param module
+     * @param message
+     * @deprecated Please use {@link Log#createLogger(Class, Marker)} to create your own Logger directly
+     */
     public static void fatal(String module, Object message) {
-        LogManager.getLogger(module).fatal(message);
+        createLogger(module).fatal(message);
     }
 
     //--------------------------------------------------------------------------
 
     /**
      * Logger wrapper providing module logging services.
-     * <p>
-     * The provided {@code fallbackModule} is used to indicate parent module to
-     * assist in determing log file location.
      *
      * @param module
      * @return logger providing module logging services.
@@ -291,8 +370,7 @@ public final class Log {
     /**
      * Logger wrapper providing module logging services.
      * <p>
-     * The provided {@code fallbackModule} is used to indicate parent module to
-     * assist in determing log file location.
+     * The provided {@code fallbackModule} is used to indicate parent module.
      *
      * @param clazz Class used for logger name
      * @param marker Marker used to indicate jeeves module
@@ -316,7 +394,10 @@ public final class Log {
      * @return Marker determined from module and fallback, or {@link Log#JEEVES_MARKER} by default.
      */
     static Marker toMarker(String module, String fallback){
-        if(module.contains(".") && fallback == null){
+        if (module == null) {
+            return Log.JEEVES_MARKER;
+        }
+        else if(module.contains(".") && fallback == null){
             Marker marker = null;
             for(String name : module.split("\\.")){
                 Marker m = MarkerManager.getMarker(name);
@@ -328,9 +409,6 @@ public final class Log {
             return marker;
         }
         else {
-            if (module == null) {
-                return Log.JEEVES_MARKER;
-            }
             Marker marker = MarkerManager.getMarker(module);
             Marker parent = fallback != null ? MarkerManager.getMarker(fallback) : Log.JEEVES_MARKER;
             if (!marker.isInstanceOf(parent)) {

--- a/common/src/main/java/org/fao/geonet/utils/LoggerWrapper.java
+++ b/common/src/main/java/org/fao/geonet/utils/LoggerWrapper.java
@@ -1,7 +1,8 @@
-package org.fao.geonet.utils;/* (c) {{YEAR}} Open Source Geospatial Foundation - all rights reserved
+/* (c) {{YEAR}} Open Source Geospatial Foundation - all rights reserved
  * This code is licensed under the GPL 2.0 license, available at the root
  * application directory.
  */
+package org.fao.geonet.utils;
 
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogBuilder;
@@ -72,31 +73,31 @@ public class LoggerWrapper implements Logger {
 
 
     public boolean isDebugEnabled() {
-        return LOGGER.isDebugEnabled();
+        return LOGGER.isDebugEnabled(MARKER);
     }
 
     public void debug(String message) {
-        LOGGER.debug(message);
+        LOGGER.debug(MARKER,message);
     }
 
     public void info(String message) {
-        LOGGER.info(message);
+        LOGGER.info(MARKER,message);
     }
 
     public void warning(String message) {
-        LOGGER.warn(message);
+        LOGGER.warn(MARKER,message);
     }
 
     public void error(String message) {
-        LOGGER.error(message);
+        LOGGER.error(MARKER,message);
     }
 
     public void fatal(String message) {
-        LOGGER.fatal(message);
+        LOGGER.fatal(MARKER,message);
     }
 
     public void error(Throwable t) {
-        LOGGER.error(t.getMessage(),t);
+        LOGGER.error(MARKER,t.getMessage(),t);
     }
 
     public void setAppender(FileAppender fa) {
@@ -1710,34 +1711,34 @@ public class LoggerWrapper implements Logger {
     }
 
     @Override public LogBuilder atTrace() {
-        return LOGGER.atTrace();
+        return LOGGER.atTrace().withMarker(MARKER);
     }
 
     @Override public LogBuilder atDebug() {
-        return LOGGER.atDebug();
+        return LOGGER.atDebug().withMarker(MARKER);
     }
 
     @Override public LogBuilder atInfo() {
-        return LOGGER.atInfo();
+        return LOGGER.atInfo().withMarker(MARKER);
     }
 
     @Override public LogBuilder atWarn() {
-        return LOGGER.atWarn();
+        return LOGGER.atWarn().withMarker(MARKER);
     }
 
     @Override public LogBuilder atError() {
-        return LOGGER.atError();
+        return LOGGER.atError().withMarker(MARKER);
     }
 
     @Override public LogBuilder atFatal() {
-        return LOGGER.atFatal();
+        return LOGGER.atFatal().withMarker(MARKER);
     }
 
     @Override public LogBuilder always() {
-        return LOGGER.always();
+        return LOGGER.always().withMarker(MARKER);
     }
 
     @Override public LogBuilder atLevel(Level level) {
-        return LOGGER.atLevel(level);
+        return LOGGER.atLevel(level).withMarker(MARKER);
     }
 }

--- a/common/src/main/java/org/fao/geonet/utils/LoggerWrapper.java
+++ b/common/src/main/java/org/fao/geonet/utils/LoggerWrapper.java
@@ -1,0 +1,1743 @@
+package org.fao.geonet.utils;/* (c) {{YEAR}} Open Source Geospatial Foundation - all rights reserved
+ * This code is licensed under the GPL 2.0 license, available at the root
+ * application directory.
+ */
+
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.LogBuilder;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.FileAppender;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.config.LoggerConfig;
+import org.apache.logging.log4j.message.EntryMessage;
+import org.apache.logging.log4j.message.Message;
+import org.apache.logging.log4j.message.MessageFactory;
+import org.apache.logging.log4j.util.MessageSupplier;
+import org.apache.logging.log4j.util.Supplier;
+import org.fao.geonet.Logger;
+
+import java.io.File;
+
+/**
+ * Logger wrapper providing module logging services.
+ * <p>
+ * Marker is used to indicate the module used, with module parent being used as a fallback.
+ * The provided {@code fallbackModule} is used to indicate parent module to
+ * assist in determing log file location.
+ */
+public class LoggerWrapper implements Logger {
+
+    /**
+     * Marker indicating module being logged.
+     */
+    private final Marker MARKER;
+
+    /**
+     * Log4J Logger used.
+     */
+    private final org.apache.logging.log4j.Logger LOGGER;
+
+    /**
+     * LoggerWrapper used to apply the module marker to generated messages.
+     * @param module Marker indicating module being logged
+     */
+    LoggerWrapper(Marker module){
+        this.MARKER = module != null ? module : Log.JEEVES_MARKER;
+        this.LOGGER = LogManager.getLogger(module.getName());
+    }
+
+    /**
+     * LoggerWrapper used to apply the module marker to generated messages.
+     * @param clazz Class whose name used as the Logger name
+     * @param module Marker indicating module being logged
+     */
+    LoggerWrapper(Class clazz, Marker module){
+        this.MARKER = module != null ? module : Log.JEEVES_MARKER;
+        this.LOGGER = LogManager.getLogger(clazz);
+    }
+
+    /**
+     * LoggerWrapper used to apply the module marker to generated messages.
+     * @param name Logger name
+     * @param module Marker indicating module being logged
+     */
+    LoggerWrapper(String name, Marker module){
+        this.MARKER = module != null ? module : Log.JEEVES_MARKER;
+        this.LOGGER = LogManager.getLogger(name);
+    }
+
+
+
+    public boolean isDebugEnabled() {
+        return LOGGER.isDebugEnabled();
+    }
+
+    public void debug(String message) {
+        LOGGER.debug(message);
+    }
+
+    public void info(String message) {
+        LOGGER.info(message);
+    }
+
+    public void warning(String message) {
+        LOGGER.warn(message);
+    }
+
+    public void error(String message) {
+        LOGGER.error(message);
+    }
+
+    public void fatal(String message) {
+        LOGGER.fatal(message);
+    }
+
+    public void error(Throwable t) {
+        LOGGER.error(t.getMessage(),t);
+    }
+
+    public void setAppender(FileAppender fa) {
+        throw new IllegalStateException("Please use custom log4j2.xml to manage log4j behavior");
+    }
+
+    /**
+     * The log file name from the file appender for this module.
+     *
+     * Note both module and fallback module are provided allowing providing a better opportunity
+     * to learn the log file location. Harvesters use the log file name parent directory as a good
+     * location to create {@code /harvester_logs/} folder.
+     *
+     * Built-in configuration uses log file location {@code logs/geonetwork.log} relative to the current directory, or relative to system property {@code log_file}.
+     *
+     * @return logfile location of {@code logs/geonetwork.log} file
+     */
+    public String getFileAppender() {
+
+        // Set effective level to be sure it writes the log
+        org.apache.logging.log4j.core.config.Configurator.setLevel(LOGGER, getThreshold());
+
+        LoggerContext loggerContext = (LoggerContext) LogManager.getContext(false);
+        Configuration configuration = loggerContext.getConfiguration();
+
+        LoggerConfig loggerConfig = configuration.getLoggers().get(LOGGER.getName());
+        if (loggerConfig != null) {
+            for (Appender appender : loggerConfig.getAppenders().values()) {
+                File file = Log.toLogFile(appender);
+                if (file != null && file.exists()) {
+                    return file.getName();
+                }
+            }
+        }
+
+        LoggerConfig moduleConfig = configuration.getLoggers().get(MARKER.getName());
+        if (moduleConfig != null) {
+            for (Appender appender : moduleConfig.getAppenders().values()) {
+                File file = Log.toLogFile(appender);
+                if (file != null && file.exists()) {
+                    return file.getName();
+                }
+            }
+        }
+
+        for(Marker parent : MARKER.getParents()) {
+            LoggerConfig fallbackConfig = configuration.getLoggers().get(parent);
+            if (fallbackConfig != null) {
+                for (Appender appender : fallbackConfig.getAppenders().values()) {
+                    File file = Log.toLogFile(appender);
+                    if (file != null && file.exists()) {
+                        return file.getName();
+                    }
+                }
+            }
+        }
+
+        if (System.getProperties().containsKey("log_dir")) {
+            File logDir = new File(System.getProperty("log_dir"));
+            if (logDir.exists() && logDir.isDirectory()) {
+                File logFile = new File(logDir, "logs/geonetwork.log");
+                if (logFile.exists()) {
+                    return logFile.getName();
+                }
+            }
+        } else {
+            File logFile = new File("logs/geonetwork.log");
+            if (logFile.exists()) {
+                return logFile.getName();
+            }
+        }
+        return "";
+    }
+
+    public Level getThreshold() {
+        return LOGGER.getLevel();
+    }
+
+    @Override
+    public String getModule() {
+        return MARKER.getName();
+    }
+
+    @Override public String toString() {
+        return "LoggerWrapper " + MARKER.getName() + ":" + LOGGER;
+    }
+
+    // Logging delegates
+
+    @Override public void catching(Level level, Throwable throwable) {
+        LOGGER.catching(level, throwable);
+    }
+
+    @Override public void catching(Throwable throwable) {
+        LOGGER.catching(throwable);
+    }
+
+    @Override public void debug(Marker marker, Message message) {
+        LOGGER.debug(marker, message);
+    }
+
+    @Override public void debug(Marker marker, Message message, Throwable throwable) {
+        LOGGER.debug(marker, message, throwable);
+    }
+
+    @Override public void debug(Marker marker, MessageSupplier messageSupplier) {
+        LOGGER.debug(marker, messageSupplier);
+    }
+
+    @Override public void debug(Marker marker, MessageSupplier messageSupplier, Throwable throwable) {
+        LOGGER.debug(marker, messageSupplier, throwable);
+    }
+
+    @Override public void debug(Marker marker, CharSequence message) {
+        LOGGER.debug(marker, message);
+    }
+
+    @Override public void debug(Marker marker, CharSequence message, Throwable throwable) {
+        LOGGER.debug(marker, message, throwable);
+    }
+
+    @Override public void debug(Marker marker, Object message) {
+        LOGGER.debug(marker, message);
+    }
+
+    @Override public void debug(Marker marker, Object message, Throwable throwable) {
+        LOGGER.debug(marker, message, throwable);
+    }
+
+    @Override public void debug(Marker marker, String message) {
+        LOGGER.debug(marker, message);
+    }
+
+    @Override public void debug(Marker marker, String message, Object... params) {
+        LOGGER.debug(marker, message, params);
+    }
+
+    @Override public void debug(Marker marker, String message, Supplier<?>... paramSuppliers) {
+        LOGGER.debug(marker, message, paramSuppliers);
+    }
+
+    @Override public void debug(Marker marker, String message, Throwable throwable) {
+        LOGGER.debug(marker, message, throwable);
+    }
+
+    @Override public void debug(Marker marker, Supplier<?> messageSupplier) {
+        LOGGER.debug(marker, messageSupplier);
+    }
+
+    @Override public void debug(Marker marker, Supplier<?> messageSupplier, Throwable throwable) {
+        LOGGER.debug(marker, messageSupplier, throwable);
+    }
+
+    @Override public void debug(Message message) {
+        LOGGER.debug(MARKER,message);
+    }
+
+    @Override public void debug(Message message, Throwable throwable) {
+        LOGGER.debug(MARKER,message, throwable);
+    }
+
+    @Override public void debug(MessageSupplier messageSupplier) {
+        LOGGER.debug(MARKER,messageSupplier);
+    }
+
+    @Override public void debug(MessageSupplier messageSupplier, Throwable throwable) {
+        LOGGER.debug(MARKER,messageSupplier, throwable);
+    }
+
+    @Override public void debug(CharSequence message) {
+        LOGGER.debug(MARKER,message);
+    }
+
+    @Override public void debug(CharSequence message, Throwable throwable) {
+        LOGGER.debug(MARKER,message, throwable);
+    }
+
+    @Override public void debug(Object message) {
+        LOGGER.debug(MARKER,message);
+    }
+
+    @Override public void debug(Object message, Throwable throwable) {
+        LOGGER.debug(MARKER,message, throwable);
+    }
+
+    @Override public void debug(String message, Object... params) {
+        LOGGER.debug(MARKER,message, params);
+    }
+
+    @Override public void debug(String message, Supplier<?>... paramSuppliers) {
+        LOGGER.debug(MARKER,message, paramSuppliers);
+    }
+
+    @Override public void debug(String message, Throwable throwable) {
+        LOGGER.debug(MARKER,message, throwable);
+    }
+
+    @Override public void debug(Supplier<?> messageSupplier) {
+        LOGGER.debug(MARKER,messageSupplier);
+    }
+
+    @Override public void debug(Supplier<?> messageSupplier, Throwable throwable) {
+        LOGGER.debug(MARKER,messageSupplier, throwable);
+    }
+
+    @Override public void debug(Marker marker, String message, Object p0) {
+        LOGGER.debug(marker, message, p0);
+    }
+
+    @Override public void debug(Marker marker, String message, Object p0, Object p1) {
+        LOGGER.debug(marker, message, p0, p1);
+    }
+
+    @Override public void debug(Marker marker, String message, Object p0, Object p1, Object p2) {
+        LOGGER.debug(marker, message, p0, p1, p2);
+    }
+
+    @Override public void debug(Marker marker, String message, Object p0, Object p1, Object p2, Object p3) {
+        LOGGER.debug(marker, message, p0, p1, p2, p3);
+    }
+
+    @Override public void debug(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
+        LOGGER.debug(marker, message, p0, p1, p2, p3, p4);
+    }
+
+    @Override public void debug(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
+        LOGGER.debug(marker, message, p0, p1, p2, p3, p4, p5);
+    }
+
+    @Override public void debug(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5,
+        Object p6) {
+        LOGGER.debug(marker, message, p0, p1, p2, p3, p4, p5, p6);
+    }
+
+    @Override public void debug(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
+        Object p7) {
+        LOGGER.debug(marker, message, p0, p1, p2, p3, p4, p5, p6, p7);
+    }
+
+    @Override public void debug(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
+        Object p7, Object p8) {
+        LOGGER.debug(marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
+    }
+
+    @Override public void debug(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
+        Object p7, Object p8, Object p9) {
+        LOGGER.debug(marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
+    }
+
+    @Override public void debug(String message, Object p0) {
+        LOGGER.debug(MARKER,message, p0);
+    }
+
+    @Override public void debug(String message, Object p0, Object p1) {
+        LOGGER.debug(MARKER,message, p0, p1);
+    }
+
+    @Override public void debug(String message, Object p0, Object p1, Object p2) {
+        LOGGER.debug(MARKER,message, p0, p1, p2);
+    }
+
+    @Override public void debug(String message, Object p0, Object p1, Object p2, Object p3) {
+        LOGGER.debug(MARKER,message, p0, p1, p2, p3);
+    }
+
+    @Override public void debug(String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
+        LOGGER.debug(MARKER,message, p0, p1, p2, p3, p4);
+    }
+
+    @Override public void debug(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
+        LOGGER.debug(MARKER,message, p0, p1, p2, p3, p4, p5);
+    }
+
+    @Override public void debug(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6) {
+        LOGGER.debug(MARKER,message, p0, p1, p2, p3, p4, p5, p6);
+    }
+
+    @Override public void debug(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7) {
+        LOGGER.debug(MARKER,message, p0, p1, p2, p3, p4, p5, p6, p7);
+    }
+
+    @Override public void debug(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7,
+        Object p8) {
+        LOGGER.debug(MARKER,message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
+    }
+
+    @Override public void debug(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7,
+        Object p8, Object p9) {
+        LOGGER.debug(MARKER,message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
+    }
+
+    @Override @Deprecated public void entry() {
+        LOGGER.entry();
+    }
+
+    @Override @Deprecated public void entry(Object... params) {
+        LOGGER.entry(params);
+    }
+
+    @Override public void error(Marker marker, Message message) {
+        LOGGER.error(marker, message);
+    }
+
+    @Override public void error(Marker marker, Message message, Throwable throwable) {
+        LOGGER.error(marker, message, throwable);
+    }
+
+    @Override public void error(Marker marker, MessageSupplier messageSupplier) {
+        LOGGER.error(marker, messageSupplier);
+    }
+
+    @Override public void error(Marker marker, MessageSupplier messageSupplier, Throwable throwable) {
+        LOGGER.error(marker, messageSupplier, throwable);
+    }
+
+    @Override public void error(Marker marker, CharSequence message) {
+        LOGGER.error(marker, message);
+    }
+
+    @Override public void error(Marker marker, CharSequence message, Throwable throwable) {
+        LOGGER.error(marker, message, throwable);
+    }
+
+    @Override public void error(Marker marker, Object message) {
+        LOGGER.error(marker, message);
+    }
+
+    @Override public void error(Marker marker, Object message, Throwable throwable) {
+        LOGGER.error(marker, message, throwable);
+    }
+
+    @Override public void error(Marker marker, String message) {
+        LOGGER.error(marker, message);
+    }
+
+    @Override public void error(Marker marker, String message, Object... params) {
+        LOGGER.error(marker, message, params);
+    }
+
+    @Override public void error(Marker marker, String message, Supplier<?>... paramSuppliers) {
+        LOGGER.error(marker, message, paramSuppliers);
+    }
+
+    @Override public void error(Marker marker, String message, Throwable throwable) {
+        LOGGER.error(marker, message, throwable);
+    }
+
+    @Override public void error(Marker marker, Supplier<?> messageSupplier) {
+        LOGGER.error(marker, messageSupplier);
+    }
+
+    @Override public void error(Marker marker, Supplier<?> messageSupplier, Throwable throwable) {
+        LOGGER.error(marker, messageSupplier, throwable);
+    }
+
+    @Override public void error(Message message) {
+        LOGGER.error(message);
+    }
+
+    @Override public void error(Message message, Throwable throwable) {
+        LOGGER.error(message, throwable);
+    }
+
+    @Override public void error(MessageSupplier messageSupplier) {
+        LOGGER.error(messageSupplier);
+    }
+
+    @Override public void error(MessageSupplier messageSupplier, Throwable throwable) {
+        LOGGER.error(messageSupplier, throwable);
+    }
+
+    @Override public void error(CharSequence message) {
+        LOGGER.error(message);
+    }
+
+    @Override public void error(CharSequence message, Throwable throwable) {
+        LOGGER.error(message, throwable);
+    }
+
+    @Override public void error(Object message) {
+        LOGGER.error(message);
+    }
+
+    @Override public void error(Object message, Throwable throwable) {
+        LOGGER.error(message, throwable);
+    }
+
+    @Override public void error(String message, Object... params) {
+        LOGGER.error(message, params);
+    }
+
+    @Override public void error(String message, Supplier<?>... paramSuppliers) {
+        LOGGER.error(message, paramSuppliers);
+    }
+
+    @Override public void error(String message, Throwable throwable) {
+        LOGGER.error(message, throwable);
+    }
+
+    @Override public void error(Supplier<?> messageSupplier) {
+        LOGGER.error(messageSupplier);
+    }
+
+    @Override public void error(Supplier<?> messageSupplier, Throwable throwable) {
+        LOGGER.error(messageSupplier, throwable);
+    }
+
+    @Override public void error(Marker marker, String message, Object p0) {
+        LOGGER.error(marker, message, p0);
+    }
+
+    @Override public void error(Marker marker, String message, Object p0, Object p1) {
+        LOGGER.error(marker, message, p0, p1);
+    }
+
+    @Override public void error(Marker marker, String message, Object p0, Object p1, Object p2) {
+        LOGGER.error(marker, message, p0, p1, p2);
+    }
+
+    @Override public void error(Marker marker, String message, Object p0, Object p1, Object p2, Object p3) {
+        LOGGER.error(marker, message, p0, p1, p2, p3);
+    }
+
+    @Override public void error(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
+        LOGGER.error(marker, message, p0, p1, p2, p3, p4);
+    }
+
+    @Override public void error(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
+        LOGGER.error(marker, message, p0, p1, p2, p3, p4, p5);
+    }
+
+    @Override public void error(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5,
+        Object p6) {
+        LOGGER.error(marker, message, p0, p1, p2, p3, p4, p5, p6);
+    }
+
+    @Override public void error(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
+        Object p7) {
+        LOGGER.error(marker, message, p0, p1, p2, p3, p4, p5, p6, p7);
+    }
+
+    @Override public void error(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
+        Object p7, Object p8) {
+        LOGGER.error(marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
+    }
+
+    @Override public void error(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
+        Object p7, Object p8, Object p9) {
+        LOGGER.error(marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
+    }
+
+    @Override public void error(String message, Object p0) {
+        LOGGER.error(message, p0);
+    }
+
+    @Override public void error(String message, Object p0, Object p1) {
+        LOGGER.error(message, p0, p1);
+    }
+
+    @Override public void error(String message, Object p0, Object p1, Object p2) {
+        LOGGER.error(message, p0, p1, p2);
+    }
+
+    @Override public void error(String message, Object p0, Object p1, Object p2, Object p3) {
+        LOGGER.error(message, p0, p1, p2, p3);
+    }
+
+    @Override public void error(String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
+        LOGGER.error(message, p0, p1, p2, p3, p4);
+    }
+
+    @Override public void error(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
+        LOGGER.error(message, p0, p1, p2, p3, p4, p5);
+    }
+
+    @Override public void error(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6) {
+        LOGGER.error(message, p0, p1, p2, p3, p4, p5, p6);
+    }
+
+    @Override public void error(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7) {
+        LOGGER.error(message, p0, p1, p2, p3, p4, p5, p6, p7);
+    }
+
+    @Override public void error(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7,
+        Object p8) {
+        LOGGER.error(message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
+    }
+
+    @Override public void error(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7,
+        Object p8, Object p9) {
+        LOGGER.error(message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
+    }
+
+    @Override @Deprecated public void exit() {
+        LOGGER.exit();
+    }
+
+    @Override @Deprecated public <R> R exit(R result) {
+        return LOGGER.exit(result);
+    }
+
+    @Override public void fatal(Marker marker, Message message) {
+        LOGGER.fatal(marker, message);
+    }
+
+    @Override public void fatal(Marker marker, Message message, Throwable throwable) {
+        LOGGER.fatal(marker, message, throwable);
+    }
+
+    @Override public void fatal(Marker marker, MessageSupplier messageSupplier) {
+        LOGGER.fatal(marker, messageSupplier);
+    }
+
+    @Override public void fatal(Marker marker, MessageSupplier messageSupplier, Throwable throwable) {
+        LOGGER.fatal(marker, messageSupplier, throwable);
+    }
+
+    @Override public void fatal(Marker marker, CharSequence message) {
+        LOGGER.fatal(marker, message);
+    }
+
+    @Override public void fatal(Marker marker, CharSequence message, Throwable throwable) {
+        LOGGER.fatal(marker, message, throwable);
+    }
+
+    @Override public void fatal(Marker marker, Object message) {
+        LOGGER.fatal(marker, message);
+    }
+
+    @Override public void fatal(Marker marker, Object message, Throwable throwable) {
+        LOGGER.fatal(marker, message, throwable);
+    }
+
+    @Override public void fatal(Marker marker, String message) {
+        LOGGER.fatal(marker, message);
+    }
+
+    @Override public void fatal(Marker marker, String message, Object... params) {
+        LOGGER.fatal(marker, message, params);
+    }
+
+    @Override public void fatal(Marker marker, String message, Supplier<?>... paramSuppliers) {
+        LOGGER.fatal(marker, message, paramSuppliers);
+    }
+
+    @Override public void fatal(Marker marker, String message, Throwable throwable) {
+        LOGGER.fatal(marker, message, throwable);
+    }
+
+    @Override public void fatal(Marker marker, Supplier<?> messageSupplier) {
+        LOGGER.fatal(marker, messageSupplier);
+    }
+
+    @Override public void fatal(Marker marker, Supplier<?> messageSupplier, Throwable throwable) {
+        LOGGER.fatal(marker, messageSupplier, throwable);
+    }
+
+    @Override public void fatal(Message message) {
+        LOGGER.fatal(message);
+    }
+
+    @Override public void fatal(Message message, Throwable throwable) {
+        LOGGER.fatal(message, throwable);
+    }
+
+    @Override public void fatal(MessageSupplier messageSupplier) {
+        LOGGER.fatal(messageSupplier);
+    }
+
+    @Override public void fatal(MessageSupplier messageSupplier, Throwable throwable) {
+        LOGGER.fatal(messageSupplier, throwable);
+    }
+
+    @Override public void fatal(CharSequence message) {
+        LOGGER.fatal(message);
+    }
+
+    @Override public void fatal(CharSequence message, Throwable throwable) {
+        LOGGER.fatal(message, throwable);
+    }
+
+    @Override public void fatal(Object message) {
+        LOGGER.fatal(message);
+    }
+
+    @Override public void fatal(Object message, Throwable throwable) {
+        LOGGER.fatal(message, throwable);
+    }
+
+    @Override public void fatal(String message, Object... params) {
+        LOGGER.fatal(message, params);
+    }
+
+    @Override public void fatal(String message, Supplier<?>... paramSuppliers) {
+        LOGGER.fatal(message, paramSuppliers);
+    }
+
+    @Override public void fatal(String message, Throwable throwable) {
+        LOGGER.fatal(message, throwable);
+    }
+
+    @Override public void fatal(Supplier<?> messageSupplier) {
+        LOGGER.fatal(messageSupplier);
+    }
+
+    @Override public void fatal(Supplier<?> messageSupplier, Throwable throwable) {
+        LOGGER.fatal(messageSupplier, throwable);
+    }
+
+    @Override public void fatal(Marker marker, String message, Object p0) {
+        LOGGER.fatal(marker, message, p0);
+    }
+
+    @Override public void fatal(Marker marker, String message, Object p0, Object p1) {
+        LOGGER.fatal(marker, message, p0, p1);
+    }
+
+    @Override public void fatal(Marker marker, String message, Object p0, Object p1, Object p2) {
+        LOGGER.fatal(marker, message, p0, p1, p2);
+    }
+
+    @Override public void fatal(Marker marker, String message, Object p0, Object p1, Object p2, Object p3) {
+        LOGGER.fatal(marker, message, p0, p1, p2, p3);
+    }
+
+    @Override public void fatal(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
+        LOGGER.fatal(marker, message, p0, p1, p2, p3, p4);
+    }
+
+    @Override public void fatal(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
+        LOGGER.fatal(marker, message, p0, p1, p2, p3, p4, p5);
+    }
+
+    @Override public void fatal(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5,
+        Object p6) {
+        LOGGER.fatal(marker, message, p0, p1, p2, p3, p4, p5, p6);
+    }
+
+    @Override public void fatal(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
+        Object p7) {
+        LOGGER.fatal(marker, message, p0, p1, p2, p3, p4, p5, p6, p7);
+    }
+
+    @Override public void fatal(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
+        Object p7, Object p8) {
+        LOGGER.fatal(marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
+    }
+
+    @Override public void fatal(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
+        Object p7, Object p8, Object p9) {
+        LOGGER.fatal(marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
+    }
+
+    @Override public void fatal(String message, Object p0) {
+        LOGGER.fatal(message, p0);
+    }
+
+    @Override public void fatal(String message, Object p0, Object p1) {
+        LOGGER.fatal(message, p0, p1);
+    }
+
+    @Override public void fatal(String message, Object p0, Object p1, Object p2) {
+        LOGGER.fatal(message, p0, p1, p2);
+    }
+
+    @Override public void fatal(String message, Object p0, Object p1, Object p2, Object p3) {
+        LOGGER.fatal(message, p0, p1, p2, p3);
+    }
+
+    @Override public void fatal(String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
+        LOGGER.fatal(message, p0, p1, p2, p3, p4);
+    }
+
+    @Override public void fatal(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
+        LOGGER.fatal(message, p0, p1, p2, p3, p4, p5);
+    }
+
+    @Override public void fatal(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6) {
+        LOGGER.fatal(message, p0, p1, p2, p3, p4, p5, p6);
+    }
+
+    @Override public void fatal(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7) {
+        LOGGER.fatal(message, p0, p1, p2, p3, p4, p5, p6, p7);
+    }
+
+    @Override public void fatal(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7,
+        Object p8) {
+        LOGGER.fatal(message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
+    }
+
+    @Override public void fatal(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7,
+        Object p8, Object p9) {
+        LOGGER.fatal(message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
+    }
+
+    @Override public Level getLevel() {
+        return LOGGER.getLevel();
+    }
+
+    @Override public <MF extends MessageFactory> MF getMessageFactory() {
+        return LOGGER.getMessageFactory();
+    }
+
+    @Override public String getName() {
+        return LOGGER.getName();
+    }
+
+    @Override public void info(Marker marker, Message message) {
+        LOGGER.info(marker, message);
+    }
+
+    @Override public void info(Marker marker, Message message, Throwable throwable) {
+        LOGGER.info(marker, message, throwable);
+    }
+
+    @Override public void info(Marker marker, MessageSupplier messageSupplier) {
+        LOGGER.info(marker, messageSupplier);
+    }
+
+    @Override public void info(Marker marker, MessageSupplier messageSupplier, Throwable throwable) {
+        LOGGER.info(marker, messageSupplier, throwable);
+    }
+
+    @Override public void info(Marker marker, CharSequence message) {
+        LOGGER.info(marker, message);
+    }
+
+    @Override public void info(Marker marker, CharSequence message, Throwable throwable) {
+        LOGGER.info(marker, message, throwable);
+    }
+
+    @Override public void info(Marker marker, Object message) {
+        LOGGER.info(marker, message);
+    }
+
+    @Override public void info(Marker marker, Object message, Throwable throwable) {
+        LOGGER.info(marker, message, throwable);
+    }
+
+    @Override public void info(Marker marker, String message) {
+        LOGGER.info(marker, message);
+    }
+
+    @Override public void info(Marker marker, String message, Object... params) {
+        LOGGER.info(marker, message, params);
+    }
+
+    @Override public void info(Marker marker, String message, Supplier<?>... paramSuppliers) {
+        LOGGER.info(marker, message, paramSuppliers);
+    }
+
+    @Override public void info(Marker marker, String message, Throwable throwable) {
+        LOGGER.info(marker, message, throwable);
+    }
+
+    @Override public void info(Marker marker, Supplier<?> messageSupplier) {
+        LOGGER.info(marker, messageSupplier);
+    }
+
+    @Override public void info(Marker marker, Supplier<?> messageSupplier, Throwable throwable) {
+        LOGGER.info(marker, messageSupplier, throwable);
+    }
+
+    @Override public void info(Message message) {
+        LOGGER.info(message);
+    }
+
+    @Override public void info(Message message, Throwable throwable) {
+        LOGGER.info(message, throwable);
+    }
+
+    @Override public void info(MessageSupplier messageSupplier) {
+        LOGGER.info(messageSupplier);
+    }
+
+    @Override public void info(MessageSupplier messageSupplier, Throwable throwable) {
+        LOGGER.info(messageSupplier, throwable);
+    }
+
+    @Override public void info(CharSequence message) {
+        LOGGER.info(message);
+    }
+
+    @Override public void info(CharSequence message, Throwable throwable) {
+        LOGGER.info(message, throwable);
+    }
+
+    @Override public void info(Object message) {
+        LOGGER.info(message);
+    }
+
+    @Override public void info(Object message, Throwable throwable) {
+        LOGGER.info(message, throwable);
+    }
+
+    @Override public void info(String message, Object... params) {
+        LOGGER.info(message, params);
+    }
+
+    @Override public void info(String message, Supplier<?>... paramSuppliers) {
+        LOGGER.info(message, paramSuppliers);
+    }
+
+    @Override public void info(String message, Throwable throwable) {
+        LOGGER.info(message, throwable);
+    }
+
+    @Override public void info(Supplier<?> messageSupplier) {
+        LOGGER.info(messageSupplier);
+    }
+
+    @Override public void info(Supplier<?> messageSupplier, Throwable throwable) {
+        LOGGER.info(messageSupplier, throwable);
+    }
+
+    @Override public void info(Marker marker, String message, Object p0) {
+        LOGGER.info(marker, message, p0);
+    }
+
+    @Override public void info(Marker marker, String message, Object p0, Object p1) {
+        LOGGER.info(marker, message, p0, p1);
+    }
+
+    @Override public void info(Marker marker, String message, Object p0, Object p1, Object p2) {
+        LOGGER.info(marker, message, p0, p1, p2);
+    }
+
+    @Override public void info(Marker marker, String message, Object p0, Object p1, Object p2, Object p3) {
+        LOGGER.info(marker, message, p0, p1, p2, p3);
+    }
+
+    @Override public void info(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
+        LOGGER.info(marker, message, p0, p1, p2, p3, p4);
+    }
+
+    @Override public void info(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
+        LOGGER.info(marker, message, p0, p1, p2, p3, p4, p5);
+    }
+
+    @Override public void info(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6) {
+        LOGGER.info(marker, message, p0, p1, p2, p3, p4, p5, p6);
+    }
+
+    @Override public void info(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
+        Object p7) {
+        LOGGER.info(marker, message, p0, p1, p2, p3, p4, p5, p6, p7);
+    }
+
+    @Override public void info(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
+        Object p7, Object p8) {
+        LOGGER.info(marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
+    }
+
+    @Override public void info(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
+        Object p7, Object p8, Object p9) {
+        LOGGER.info(marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
+    }
+
+    @Override public void info(String message, Object p0) {
+        LOGGER.info(message, p0);
+    }
+
+    @Override public void info(String message, Object p0, Object p1) {
+        LOGGER.info(message, p0, p1);
+    }
+
+    @Override public void info(String message, Object p0, Object p1, Object p2) {
+        LOGGER.info(message, p0, p1, p2);
+    }
+
+    @Override public void info(String message, Object p0, Object p1, Object p2, Object p3) {
+        LOGGER.info(message, p0, p1, p2, p3);
+    }
+
+    @Override public void info(String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
+        LOGGER.info(message, p0, p1, p2, p3, p4);
+    }
+
+    @Override public void info(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
+        LOGGER.info(message, p0, p1, p2, p3, p4, p5);
+    }
+
+    @Override public void info(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6) {
+        LOGGER.info(message, p0, p1, p2, p3, p4, p5, p6);
+    }
+
+    @Override public void info(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7) {
+        LOGGER.info(message, p0, p1, p2, p3, p4, p5, p6, p7);
+    }
+
+    @Override public void info(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7,
+        Object p8) {
+        LOGGER.info(message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
+    }
+
+    @Override public void info(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7,
+        Object p8, Object p9) {
+        LOGGER.info(message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
+    }
+
+    @Override public boolean isDebugEnabled(Marker marker) {
+        return LOGGER.isDebugEnabled(marker);
+    }
+
+    @Override public boolean isEnabled(Level level) {
+        return LOGGER.isEnabled(level);
+    }
+
+    @Override public boolean isEnabled(Level level, Marker marker) {
+        return LOGGER.isEnabled(level, marker);
+    }
+
+    @Override public boolean isErrorEnabled() {
+        return LOGGER.isErrorEnabled();
+    }
+
+    @Override public boolean isErrorEnabled(Marker marker) {
+        return LOGGER.isErrorEnabled(marker);
+    }
+
+    @Override public boolean isFatalEnabled() {
+        return LOGGER.isFatalEnabled();
+    }
+
+    @Override public boolean isFatalEnabled(Marker marker) {
+        return LOGGER.isFatalEnabled(marker);
+    }
+
+    @Override public boolean isInfoEnabled() {
+        return LOGGER.isInfoEnabled();
+    }
+
+    @Override public boolean isInfoEnabled(Marker marker) {
+        return LOGGER.isInfoEnabled(marker);
+    }
+
+    @Override public boolean isTraceEnabled() {
+        return LOGGER.isTraceEnabled();
+    }
+
+    @Override public boolean isTraceEnabled(Marker marker) {
+        return LOGGER.isTraceEnabled(marker);
+    }
+
+    @Override public boolean isWarnEnabled() {
+        return LOGGER.isWarnEnabled();
+    }
+
+    @Override public boolean isWarnEnabled(Marker marker) {
+        return LOGGER.isWarnEnabled(marker);
+    }
+
+    @Override public void log(Level level, Marker marker, Message message) {
+        LOGGER.log(level, marker, message);
+    }
+
+    @Override public void log(Level level, Marker marker, Message message, Throwable throwable) {
+        LOGGER.log(level, marker, message, throwable);
+    }
+
+    @Override public void log(Level level, Marker marker, MessageSupplier messageSupplier) {
+        LOGGER.log(level, marker, messageSupplier);
+    }
+
+    @Override public void log(Level level, Marker marker, MessageSupplier messageSupplier, Throwable throwable) {
+        LOGGER.log(level, marker, messageSupplier, throwable);
+    }
+
+    @Override public void log(Level level, Marker marker, CharSequence message) {
+        LOGGER.log(level, marker, message);
+    }
+
+    @Override public void log(Level level, Marker marker, CharSequence message, Throwable throwable) {
+        LOGGER.log(level, marker, message, throwable);
+    }
+
+    @Override public void log(Level level, Marker marker, Object message) {
+        LOGGER.log(level, marker, message);
+    }
+
+    @Override public void log(Level level, Marker marker, Object message, Throwable throwable) {
+        LOGGER.log(level, marker, message, throwable);
+    }
+
+    @Override public void log(Level level, Marker marker, String message) {
+        LOGGER.log(level, marker, message);
+    }
+
+    @Override public void log(Level level, Marker marker, String message, Object... params) {
+        LOGGER.log(level, marker, message, params);
+    }
+
+    @Override public void log(Level level, Marker marker, String message, Supplier<?>... paramSuppliers) {
+        LOGGER.log(level, marker, message, paramSuppliers);
+    }
+
+    @Override public void log(Level level, Marker marker, String message, Throwable throwable) {
+        LOGGER.log(level, marker, message, throwable);
+    }
+
+    @Override public void log(Level level, Marker marker, Supplier<?> messageSupplier) {
+        LOGGER.log(level, marker, messageSupplier);
+    }
+
+    @Override public void log(Level level, Marker marker, Supplier<?> messageSupplier, Throwable throwable) {
+        LOGGER.log(level, marker, messageSupplier, throwable);
+    }
+
+    @Override public void log(Level level, Message message) {
+        LOGGER.log(level, message);
+    }
+
+    @Override public void log(Level level, Message message, Throwable throwable) {
+        LOGGER.log(level, message, throwable);
+    }
+
+    @Override public void log(Level level, MessageSupplier messageSupplier) {
+        LOGGER.log(level, messageSupplier);
+    }
+
+    @Override public void log(Level level, MessageSupplier messageSupplier, Throwable throwable) {
+        LOGGER.log(level, messageSupplier, throwable);
+    }
+
+    @Override public void log(Level level, CharSequence message) {
+        LOGGER.log(level, message);
+    }
+
+    @Override public void log(Level level, CharSequence message, Throwable throwable) {
+        LOGGER.log(level, message, throwable);
+    }
+
+    @Override public void log(Level level, Object message) {
+        LOGGER.log(level, message);
+    }
+
+    @Override public void log(Level level, Object message, Throwable throwable) {
+        LOGGER.log(level, message, throwable);
+    }
+
+    @Override public void log(Level level, String message) {
+        LOGGER.log(level, message);
+    }
+
+    @Override public void log(Level level, String message, Object... params) {
+        LOGGER.log(level, message, params);
+    }
+
+    @Override public void log(Level level, String message, Supplier<?>... paramSuppliers) {
+        LOGGER.log(level, message, paramSuppliers);
+    }
+
+    @Override public void log(Level level, String message, Throwable throwable) {
+        LOGGER.log(level, message, throwable);
+    }
+
+    @Override public void log(Level level, Supplier<?> messageSupplier) {
+        LOGGER.log(level, messageSupplier);
+    }
+
+    @Override public void log(Level level, Supplier<?> messageSupplier, Throwable throwable) {
+        LOGGER.log(level, messageSupplier, throwable);
+    }
+
+    @Override public void log(Level level, Marker marker, String message, Object p0) {
+        LOGGER.log(level, marker, message, p0);
+    }
+
+    @Override public void log(Level level, Marker marker, String message, Object p0, Object p1) {
+        LOGGER.log(level, marker, message, p0, p1);
+    }
+
+    @Override public void log(Level level, Marker marker, String message, Object p0, Object p1, Object p2) {
+        LOGGER.log(level, marker, message, p0, p1, p2);
+    }
+
+    @Override public void log(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3) {
+        LOGGER.log(level, marker, message, p0, p1, p2, p3);
+    }
+
+    @Override public void log(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
+        LOGGER.log(level, marker, message, p0, p1, p2, p3, p4);
+    }
+
+    @Override public void log(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4,
+        Object p5) {
+        LOGGER.log(level, marker, message, p0, p1, p2, p3, p4, p5);
+    }
+
+    @Override public void log(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5,
+        Object p6) {
+        LOGGER.log(level, marker, message, p0, p1, p2, p3, p4, p5, p6);
+    }
+
+    @Override public void log(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5,
+        Object p6, Object p7) {
+        LOGGER.log(level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7);
+    }
+
+    @Override public void log(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5,
+        Object p6, Object p7, Object p8) {
+        LOGGER.log(level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
+    }
+
+    @Override public void log(Level level, Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5,
+        Object p6, Object p7, Object p8, Object p9) {
+        LOGGER.log(level, marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
+    }
+
+    @Override public void log(Level level, String message, Object p0) {
+        LOGGER.log(level, message, p0);
+    }
+
+    @Override public void log(Level level, String message, Object p0, Object p1) {
+        LOGGER.log(level, message, p0, p1);
+    }
+
+    @Override public void log(Level level, String message, Object p0, Object p1, Object p2) {
+        LOGGER.log(level, message, p0, p1, p2);
+    }
+
+    @Override public void log(Level level, String message, Object p0, Object p1, Object p2, Object p3) {
+        LOGGER.log(level, message, p0, p1, p2, p3);
+    }
+
+    @Override public void log(Level level, String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
+        LOGGER.log(level, message, p0, p1, p2, p3, p4);
+    }
+
+    @Override public void log(Level level, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
+        LOGGER.log(level, message, p0, p1, p2, p3, p4, p5);
+    }
+
+    @Override public void log(Level level, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6) {
+        LOGGER.log(level, message, p0, p1, p2, p3, p4, p5, p6);
+    }
+
+    @Override public void log(Level level, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
+        Object p7) {
+        LOGGER.log(level, message, p0, p1, p2, p3, p4, p5, p6, p7);
+    }
+
+    @Override public void log(Level level, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
+        Object p7, Object p8) {
+        LOGGER.log(level, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
+    }
+
+    @Override public void log(Level level, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
+        Object p7, Object p8, Object p9) {
+        LOGGER.log(level, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
+    }
+
+    @Override public void printf(Level level, Marker marker, String format, Object... params) {
+        LOGGER.printf(level, marker, format, params);
+    }
+
+    @Override public void printf(Level level, String format, Object... params) {
+        LOGGER.printf(level, format, params);
+    }
+
+    @Override public <T extends Throwable> T throwing(Level level, T throwable) {
+        return LOGGER.throwing(level, throwable);
+    }
+
+    @Override public <T extends Throwable> T throwing(T throwable) {
+        return LOGGER.throwing(throwable);
+    }
+
+    @Override public void trace(Marker marker, Message message) {
+        LOGGER.trace(marker, message);
+    }
+
+    @Override public void trace(Marker marker, Message message, Throwable throwable) {
+        LOGGER.trace(marker, message, throwable);
+    }
+
+    @Override public void trace(Marker marker, MessageSupplier messageSupplier) {
+        LOGGER.trace(marker, messageSupplier);
+    }
+
+    @Override public void trace(Marker marker, MessageSupplier messageSupplier, Throwable throwable) {
+        LOGGER.trace(marker, messageSupplier, throwable);
+    }
+
+    @Override public void trace(Marker marker, CharSequence message) {
+        LOGGER.trace(marker, message);
+    }
+
+    @Override public void trace(Marker marker, CharSequence message, Throwable throwable) {
+        LOGGER.trace(marker, message, throwable);
+    }
+
+    @Override public void trace(Marker marker, Object message) {
+        LOGGER.trace(marker, message);
+    }
+
+    @Override public void trace(Marker marker, Object message, Throwable throwable) {
+        LOGGER.trace(marker, message, throwable);
+    }
+
+    @Override public void trace(Marker marker, String message) {
+        LOGGER.trace(marker, message);
+    }
+
+    @Override public void trace(Marker marker, String message, Object... params) {
+        LOGGER.trace(marker, message, params);
+    }
+
+    @Override public void trace(Marker marker, String message, Supplier<?>... paramSuppliers) {
+        LOGGER.trace(marker, message, paramSuppliers);
+    }
+
+    @Override public void trace(Marker marker, String message, Throwable throwable) {
+        LOGGER.trace(marker, message, throwable);
+    }
+
+    @Override public void trace(Marker marker, Supplier<?> messageSupplier) {
+        LOGGER.trace(marker, messageSupplier);
+    }
+
+    @Override public void trace(Marker marker, Supplier<?> messageSupplier, Throwable throwable) {
+        LOGGER.trace(marker, messageSupplier, throwable);
+    }
+
+    @Override public void trace(Message message) {
+        LOGGER.trace(message);
+    }
+
+    @Override public void trace(Message message, Throwable throwable) {
+        LOGGER.trace(message, throwable);
+    }
+
+    @Override public void trace(MessageSupplier messageSupplier) {
+        LOGGER.trace(messageSupplier);
+    }
+
+    @Override public void trace(MessageSupplier messageSupplier, Throwable throwable) {
+        LOGGER.trace(messageSupplier, throwable);
+    }
+
+    @Override public void trace(CharSequence message) {
+        LOGGER.trace(message);
+    }
+
+    @Override public void trace(CharSequence message, Throwable throwable) {
+        LOGGER.trace(message, throwable);
+    }
+
+    @Override public void trace(Object message) {
+        LOGGER.trace(message);
+    }
+
+    @Override public void trace(Object message, Throwable throwable) {
+        LOGGER.trace(message, throwable);
+    }
+
+    @Override public void trace(String message) {
+        LOGGER.trace(message);
+    }
+
+    @Override public void trace(String message, Object... params) {
+        LOGGER.trace(message, params);
+    }
+
+    @Override public void trace(String message, Supplier<?>... paramSuppliers) {
+        LOGGER.trace(message, paramSuppliers);
+    }
+
+    @Override public void trace(String message, Throwable throwable) {
+        LOGGER.trace(message, throwable);
+    }
+
+    @Override public void trace(Supplier<?> messageSupplier) {
+        LOGGER.trace(messageSupplier);
+    }
+
+    @Override public void trace(Supplier<?> messageSupplier, Throwable throwable) {
+        LOGGER.trace(messageSupplier, throwable);
+    }
+
+    @Override public void trace(Marker marker, String message, Object p0) {
+        LOGGER.trace(marker, message, p0);
+    }
+
+    @Override public void trace(Marker marker, String message, Object p0, Object p1) {
+        LOGGER.trace(marker, message, p0, p1);
+    }
+
+    @Override public void trace(Marker marker, String message, Object p0, Object p1, Object p2) {
+        LOGGER.trace(marker, message, p0, p1, p2);
+    }
+
+    @Override public void trace(Marker marker, String message, Object p0, Object p1, Object p2, Object p3) {
+        LOGGER.trace(marker, message, p0, p1, p2, p3);
+    }
+
+    @Override public void trace(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
+        LOGGER.trace(marker, message, p0, p1, p2, p3, p4);
+    }
+
+    @Override public void trace(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
+        LOGGER.trace(marker, message, p0, p1, p2, p3, p4, p5);
+    }
+
+    @Override public void trace(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5,
+        Object p6) {
+        LOGGER.trace(marker, message, p0, p1, p2, p3, p4, p5, p6);
+    }
+
+    @Override public void trace(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
+        Object p7) {
+        LOGGER.trace(marker, message, p0, p1, p2, p3, p4, p5, p6, p7);
+    }
+
+    @Override public void trace(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
+        Object p7, Object p8) {
+        LOGGER.trace(marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
+    }
+
+    @Override public void trace(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
+        Object p7, Object p8, Object p9) {
+        LOGGER.trace(marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
+    }
+
+    @Override public void trace(String message, Object p0) {
+        LOGGER.trace(message, p0);
+    }
+
+    @Override public void trace(String message, Object p0, Object p1) {
+        LOGGER.trace(message, p0, p1);
+    }
+
+    @Override public void trace(String message, Object p0, Object p1, Object p2) {
+        LOGGER.trace(message, p0, p1, p2);
+    }
+
+    @Override public void trace(String message, Object p0, Object p1, Object p2, Object p3) {
+        LOGGER.trace(message, p0, p1, p2, p3);
+    }
+
+    @Override public void trace(String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
+        LOGGER.trace(message, p0, p1, p2, p3, p4);
+    }
+
+    @Override public void trace(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
+        LOGGER.trace(message, p0, p1, p2, p3, p4, p5);
+    }
+
+    @Override public void trace(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6) {
+        LOGGER.trace(message, p0, p1, p2, p3, p4, p5, p6);
+    }
+
+    @Override public void trace(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7) {
+        LOGGER.trace(message, p0, p1, p2, p3, p4, p5, p6, p7);
+    }
+
+    @Override public void trace(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7,
+        Object p8) {
+        LOGGER.trace(message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
+    }
+
+    @Override public void trace(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7,
+        Object p8, Object p9) {
+        LOGGER.trace(message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
+    }
+
+    @Override public EntryMessage traceEntry() {
+        return LOGGER.traceEntry();
+    }
+
+    @Override public EntryMessage traceEntry(String format, Object... params) {
+        return LOGGER.traceEntry(format, params);
+    }
+
+    @Override public EntryMessage traceEntry(Supplier<?>... paramSuppliers) {
+        return LOGGER.traceEntry(paramSuppliers);
+    }
+
+    @Override public EntryMessage traceEntry(String format, Supplier<?>... paramSuppliers) {
+        return LOGGER.traceEntry(format, paramSuppliers);
+    }
+
+    @Override public EntryMessage traceEntry(Message message) {
+        return LOGGER.traceEntry(message);
+    }
+
+    @Override public void traceExit() {
+        LOGGER.traceExit();
+    }
+
+    @Override public <R> R traceExit(R result) {
+        return LOGGER.traceExit(result);
+    }
+
+    @Override public <R> R traceExit(String format, R result) {
+        return LOGGER.traceExit(format, result);
+    }
+
+    @Override public void traceExit(EntryMessage message) {
+        LOGGER.traceExit(message);
+    }
+
+    @Override public <R> R traceExit(EntryMessage message, R result) {
+        return LOGGER.traceExit(message, result);
+    }
+
+    @Override public <R> R traceExit(Message message, R result) {
+        return LOGGER.traceExit(message, result);
+    }
+
+    @Override public void warn(Marker marker, Message message) {
+        LOGGER.warn(marker, message);
+    }
+
+    @Override public void warn(Marker marker, Message message, Throwable throwable) {
+        LOGGER.warn(marker, message, throwable);
+    }
+
+    @Override public void warn(Marker marker, MessageSupplier messageSupplier) {
+        LOGGER.warn(marker, messageSupplier);
+    }
+
+    @Override public void warn(Marker marker, MessageSupplier messageSupplier, Throwable throwable) {
+        LOGGER.warn(marker, messageSupplier, throwable);
+    }
+
+    @Override public void warn(Marker marker, CharSequence message) {
+        LOGGER.warn(marker, message);
+    }
+
+    @Override public void warn(Marker marker, CharSequence message, Throwable throwable) {
+        LOGGER.warn(marker, message, throwable);
+    }
+
+    @Override public void warn(Marker marker, Object message) {
+        LOGGER.warn(marker, message);
+    }
+
+    @Override public void warn(Marker marker, Object message, Throwable throwable) {
+        LOGGER.warn(marker, message, throwable);
+    }
+
+    @Override public void warn(Marker marker, String message) {
+        LOGGER.warn(marker, message);
+    }
+
+    @Override public void warn(Marker marker, String message, Object... params) {
+        LOGGER.warn(marker, message, params);
+    }
+
+    @Override public void warn(Marker marker, String message, Supplier<?>... paramSuppliers) {
+        LOGGER.warn(marker, message, paramSuppliers);
+    }
+
+    @Override public void warn(Marker marker, String message, Throwable throwable) {
+        LOGGER.warn(marker, message, throwable);
+    }
+
+    @Override public void warn(Marker marker, Supplier<?> messageSupplier) {
+        LOGGER.warn(marker, messageSupplier);
+    }
+
+    @Override public void warn(Marker marker, Supplier<?> messageSupplier, Throwable throwable) {
+        LOGGER.warn(marker, messageSupplier, throwable);
+    }
+
+    @Override public void warn(Message message) {
+        LOGGER.warn(message);
+    }
+
+    @Override public void warn(Message message, Throwable throwable) {
+        LOGGER.warn(message, throwable);
+    }
+
+    @Override public void warn(MessageSupplier messageSupplier) {
+        LOGGER.warn(messageSupplier);
+    }
+
+    @Override public void warn(MessageSupplier messageSupplier, Throwable throwable) {
+        LOGGER.warn(messageSupplier, throwable);
+    }
+
+    @Override public void warn(CharSequence message) {
+        LOGGER.warn(message);
+    }
+
+    @Override public void warn(CharSequence message, Throwable throwable) {
+        LOGGER.warn(message, throwable);
+    }
+
+    @Override public void warn(Object message) {
+        LOGGER.warn(message);
+    }
+
+    @Override public void warn(Object message, Throwable throwable) {
+        LOGGER.warn(message, throwable);
+    }
+
+    @Override public void warn(String message) {
+        LOGGER.warn(message);
+    }
+
+    @Override public void warn(String message, Object... params) {
+        LOGGER.warn(message, params);
+    }
+
+    @Override public void warn(String message, Supplier<?>... paramSuppliers) {
+        LOGGER.warn(message, paramSuppliers);
+    }
+
+    @Override public void warn(String message, Throwable throwable) {
+        LOGGER.warn(message, throwable);
+    }
+
+    @Override public void warn(Supplier<?> messageSupplier) {
+        LOGGER.warn(messageSupplier);
+    }
+
+    @Override public void warn(Supplier<?> messageSupplier, Throwable throwable) {
+        LOGGER.warn(messageSupplier, throwable);
+    }
+
+    @Override public void warn(Marker marker, String message, Object p0) {
+        LOGGER.warn(marker, message, p0);
+    }
+
+    @Override public void warn(Marker marker, String message, Object p0, Object p1) {
+        LOGGER.warn(marker, message, p0, p1);
+    }
+
+    @Override public void warn(Marker marker, String message, Object p0, Object p1, Object p2) {
+        LOGGER.warn(marker, message, p0, p1, p2);
+    }
+
+    @Override public void warn(Marker marker, String message, Object p0, Object p1, Object p2, Object p3) {
+        LOGGER.warn(marker, message, p0, p1, p2, p3);
+    }
+
+    @Override public void warn(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
+        LOGGER.warn(marker, message, p0, p1, p2, p3, p4);
+    }
+
+    @Override public void warn(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
+        LOGGER.warn(marker, message, p0, p1, p2, p3, p4, p5);
+    }
+
+    @Override public void warn(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6) {
+        LOGGER.warn(marker, message, p0, p1, p2, p3, p4, p5, p6);
+    }
+
+    @Override public void warn(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
+        Object p7) {
+        LOGGER.warn(marker, message, p0, p1, p2, p3, p4, p5, p6, p7);
+    }
+
+    @Override public void warn(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
+        Object p7, Object p8) {
+        LOGGER.warn(marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
+    }
+
+    @Override public void warn(Marker marker, String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6,
+        Object p7, Object p8, Object p9) {
+        LOGGER.warn(marker, message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
+    }
+
+    @Override public void warn(String message, Object p0) {
+        LOGGER.warn(message, p0);
+    }
+
+    @Override public void warn(String message, Object p0, Object p1) {
+        LOGGER.warn(message, p0, p1);
+    }
+
+    @Override public void warn(String message, Object p0, Object p1, Object p2) {
+        LOGGER.warn(message, p0, p1, p2);
+    }
+
+    @Override public void warn(String message, Object p0, Object p1, Object p2, Object p3) {
+        LOGGER.warn(message, p0, p1, p2, p3);
+    }
+
+    @Override public void warn(String message, Object p0, Object p1, Object p2, Object p3, Object p4) {
+        LOGGER.warn(message, p0, p1, p2, p3, p4);
+    }
+
+    @Override public void warn(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5) {
+        LOGGER.warn(message, p0, p1, p2, p3, p4, p5);
+    }
+
+    @Override public void warn(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6) {
+        LOGGER.warn(message, p0, p1, p2, p3, p4, p5, p6);
+    }
+
+    @Override public void warn(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7) {
+        LOGGER.warn(message, p0, p1, p2, p3, p4, p5, p6, p7);
+    }
+
+    @Override public void warn(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7,
+        Object p8) {
+        LOGGER.warn(message, p0, p1, p2, p3, p4, p5, p6, p7, p8);
+    }
+
+    @Override public void warn(String message, Object p0, Object p1, Object p2, Object p3, Object p4, Object p5, Object p6, Object p7,
+        Object p8, Object p9) {
+        LOGGER.warn(message, p0, p1, p2, p3, p4, p5, p6, p7, p8, p9);
+    }
+
+    @Override public void logMessage(Level level, Marker marker, String fqcn, StackTraceElement location, Message message,
+        Throwable throwable) {
+        LOGGER.logMessage(level, marker, fqcn, location, message, throwable);
+    }
+
+    @Override public LogBuilder atTrace() {
+        return LOGGER.atTrace();
+    }
+
+    @Override public LogBuilder atDebug() {
+        return LOGGER.atDebug();
+    }
+
+    @Override public LogBuilder atInfo() {
+        return LOGGER.atInfo();
+    }
+
+    @Override public LogBuilder atWarn() {
+        return LOGGER.atWarn();
+    }
+
+    @Override public LogBuilder atError() {
+        return LOGGER.atError();
+    }
+
+    @Override public LogBuilder atFatal() {
+        return LOGGER.atFatal();
+    }
+
+    @Override public LogBuilder always() {
+        return LOGGER.always();
+    }
+
+    @Override public LogBuilder atLevel(Level level) {
+        return LOGGER.atLevel(level);
+    }
+}

--- a/common/src/main/java/org/fao/geonet/utils/Resolver.java
+++ b/common/src/main/java/org/fao/geonet/utils/Resolver.java
@@ -23,6 +23,7 @@
 
 package org.fao.geonet.utils;
 
+import org.apache.logging.log4j.Logger;
 import org.apache.xml.resolver.CatalogManager;
 import org.apache.xml.resolver.tools.CatalogResolver;
 import org.fao.geonet.Constants;
@@ -39,7 +40,7 @@ import java.util.Vector;
  */
 
 public final class Resolver implements ProxyInfoObserver {
-
+    private static Logger LOGGER = Log.createLogger(Resolver.class,Log.JEEVES_MARKER);
     /**
      * Active readers count
      */
@@ -92,8 +93,7 @@ public final class Resolver implements ProxyInfoObserver {
         } else {
             catFiles = this.oasisCatalogPath.toString();
         }
-        if (Log.isDebugEnabled(Log.JEEVES))
-            Log.debug(Log.JEEVES, "Using oasis catalog files " + catFiles);
+        LOGGER.debug(Log.JEEVES_MARKER, "Using oasis catalog files {}", catFiles);
 
         setBlankXSLFile(System.getProperty(Constants.XML_CATALOG_BLANKXSLFILE));
 
@@ -108,10 +108,9 @@ public final class Resolver implements ProxyInfoObserver {
         try {
             iCatVerb = Integer.parseInt(catVerbosity);
         } catch (NumberFormatException nfe) {
-            Log.error(Log.JEEVES, "Failed to parse " + Constants.XML_CATALOG_VERBOSITY + " " + catVerbosity, nfe);
+            LOGGER.error(Log.JEEVES_MARKER, "Failed to parse {} {}", Constants.XML_CATALOG_VERBOSITY, catVerbosity, nfe);
         }
-        if (Log.isDebugEnabled(Log.JEEVES))
-            Log.debug(Log.JEEVES, "Using catalog resolver verbosity " + iCatVerb);
+        LOGGER.debug(Log.JEEVES_MARKER, "Using catalog resolver verbosity {}", iCatVerb);
         catMan.setVerbosity(iCatVerb);
 
         catResolver = new NioPathAwareCatalogResolver(catMan);

--- a/common/src/main/java/org/fao/geonet/utils/TransformerFactoryFactory.java
+++ b/common/src/main/java/org/fao/geonet/utils/TransformerFactoryFactory.java
@@ -62,7 +62,7 @@ public class TransformerFactoryFactory {
         }
         LOGGER.debug(
             Log.TRANSFORMER_FACTORY_MARKER,
-            "TransformerFactoryFactory: {} produces transformer implementation ",
+            "TransformerFactoryFactory: {} produces transformer implementation {}",
             factory.getClass().getName(),
             factory.newTransformer().getClass().getName()
         );

--- a/common/src/main/java/org/fao/geonet/utils/TransformerFactoryFactory.java
+++ b/common/src/main/java/org/fao/geonet/utils/TransformerFactoryFactory.java
@@ -23,10 +23,10 @@
 
 package org.fao.geonet.utils;
 
+import org.apache.logging.log4j.Logger;
+
 import javax.xml.transform.TransformerConfigurationException;
 import javax.xml.transform.TransformerFactory;
-
-import java.util.Properties;
 
 /**
  * This class is to prevent the situation that rogue applications running in the same JVM as does
@@ -40,13 +40,14 @@ import java.util.Properties;
  * @author heikki doeleman
  */
 public class TransformerFactoryFactory {
+    private static Logger LOGGER = Log.createLogger(TransformerFactoryFactory.class,Log.TRANSFORMER_FACTORY_MARKER);
     public final static String SYSTEM_PROPERTY_NAME = "javax.xml.transform.TransformerFactory";
     public static final String TRANSFORMER_PATH = "/WEB-INF/classes/META-INF/services/" + SYSTEM_PROPERTY_NAME;
 
     private static TransformerFactory factory;
 
     public static void init(String implementationName) {
-        debug("Implementation name: " + implementationName);
+        LOGGER.debug(Log.TRANSFORMER_FACTORY_MARKER, "Implementation name: {}", implementationName);
         if (implementationName != null && implementationName.length() > 0) {
             factory = TransformerFactory.newInstance(implementationName, null);
         } else {
@@ -56,13 +57,15 @@ public class TransformerFactoryFactory {
 
     public static TransformerFactory getTransformerFactory() throws TransformerConfigurationException {
         if (factory == null) {
-            debug("TransformerFactoryFactory is null. Initializing ...");
+            LOGGER.debug(Log.TRANSFORMER_FACTORY_MARKER, "TransformerFactoryFactory is null. Initializing ...");
             init(null);
         }
-        debug("TransformerFactoryFactory: "
-            + factory.getClass().getName()
-            + " produces transformer implementation "
-            + factory.newTransformer().getClass().getName());
+        LOGGER.debug(
+            Log.TRANSFORMER_FACTORY_MARKER,
+            "TransformerFactoryFactory: {} produces transformer implementation ",
+            factory.getClass().getName(),
+            factory.newTransformer().getClass().getName()
+        );
         return factory;
     }
 
@@ -71,7 +74,4 @@ public class TransformerFactoryFactory {
         factory = _factory;
     }
 
-    private static void debug(String message) {
-        Log.debug(Log.TRANSFORMER_FACTORY, message);
-    }
 }

--- a/common/src/main/java/org/fao/geonet/utils/Xml.java
+++ b/common/src/main/java/org/fao/geonet/utils/Xml.java
@@ -233,7 +233,7 @@ public final class Xml {
 
             result = (Element) jdoc.getRootElement().detach();
         } catch (Exception e) {
-            LOGGER.error(Log.ENGINE_MARKER, "Error loading URL {}. Threw exception {}", url.getPath(),e.getMessage(), e);
+            LOGGER.error(Log.ENGINE_MARKER, "Error loading URL {}. Threw exception {}", url.getPath(), e.getMessage(), e);
         }
         return result;
     }
@@ -1163,7 +1163,7 @@ public final class Xml {
         public Source resolve(String href, String base) throws TransformerException {
             Resolver resolver = ResolverWrapper.getInstance();
             CatalogResolver catResolver = resolver.getCatalogResolver();
-            LOGGER.debug(Log.XML_RESOLVER_MARKER, "Trying to resolve {}:{}",href,base);
+            LOGGER.debug(Log.XML_RESOLVER_MARKER, "Trying to resolve {}:{}", href, base);
             Source s = catResolver.resolve(href, base);
 
             boolean isFile;
@@ -1193,7 +1193,7 @@ public final class Xml {
                         s.setSystemId(f.toUri().toASCIIString());
                     }
                 } catch (URISyntaxException e) {
-                    LOGGER.warn(Log.XML_RESOLVER_MARKER, "URI syntax problem: {}",e.getMessage(), e);
+                    LOGGER.warn(Log.XML_RESOLVER_MARKER, "URI syntax problem: {}", e.getMessage(), e);
                 }
             }
 

--- a/common/src/main/java/org/fao/geonet/utils/XmlResolver.java
+++ b/common/src/main/java/org/fao/geonet/utils/XmlResolver.java
@@ -35,6 +35,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 
 import org.apache.jcs.access.exception.CacheException;
+import org.apache.logging.log4j.Logger;
 import org.apache.xerces.dom.DOMInputImpl;
 import org.apache.xerces.util.XMLCatalogResolver;
 import org.fao.geonet.JeevesJCS;
@@ -48,6 +49,7 @@ import org.w3c.dom.ls.LSInput;
 	 hence this extension.  */
 
 public class XmlResolver extends XMLCatalogResolver {
+    private static final Logger LOGGER = Log.createLogger(XmlResolver.class, Log.XML_RESOLVER_MARKER);
 
     public static final String XMLRESOLVER_JCS = "XmlResolver";
     private ProxyParams proxyParams;
@@ -85,9 +87,13 @@ public class XmlResolver extends XMLCatalogResolver {
      */
     public LSInput resolveResource(String type, String namespaceURI, String publicId, String systemId, String baseURI) {
 
-        if (Log.isDebugEnabled(Log.XML_RESOLVER))
-            Log.debug(Log.XML_RESOLVER, "Jeeves XmlResolver: Before resolution: Type: " + type + " NamespaceURI :" + namespaceURI + " " +
-                "PublicId :" + publicId + " SystemId :" + systemId + " BaseURI:" + baseURI);
+        LOGGER.debug(
+            Log.XML_RESOLVER_MARKER,
+            "Jeeves XmlResolver: Before resolution: Type: {} NamespaceURI: {} " +
+            "PublicId: {} SystemId: {} BaseURI: {}",
+            type,namespaceURI,publicId,systemId,baseURI
+        );
+
         LSInput result = null;
 
         try {
@@ -107,9 +113,10 @@ public class XmlResolver extends XMLCatalogResolver {
             baseURI = result.getBaseURI();
         }
 
-        if (Log.isDebugEnabled(Log.XML_RESOLVER))
-            Log.debug(Log.XML_RESOLVER, "Jeeves XmlResolver: After resolution: PublicId :" + publicId + " SystemId :" + systemId + " " +
-                "BaseURI:" + baseURI);
+        LOGGER.debug(Log.XML_RESOLVER_MARKER,
+            "Jeeves XmlResolver: After resolution: PublicId: {} SystemId: {} BaseURI:{}",
+            publicId,systemId,baseURI
+        );
 
         URL externalRef = null;
         try {
@@ -159,8 +166,8 @@ public class XmlResolver extends XMLCatalogResolver {
                 try {
                     elResult = xml.execute();
                     addXmlToCache(externalRef.toString(), elResult);
-                    if (Log.isDebugEnabled(Log.XML_RESOLVER)) {
-                        Log.debug(Log.XML_RESOLVER, "Retrieved: \n" + Xml.getString(elResult));
+                    if (LOGGER.isDebugEnabled(Log.XML_RESOLVER_MARKER)) {
+                        LOGGER.debug(Log.XML_RESOLVER_MARKER, "Retrieved: \n{}",Xml.getString(elResult));
                     }
                 } catch (Exception e) {
                     Log.error(Log.XML_RESOLVER, "Request on " + externalRef + " failed." + e.getMessage());

--- a/common/src/main/java/org/fao/geonet/utils/XmlResolver.java
+++ b/common/src/main/java/org/fao/geonet/utils/XmlResolver.java
@@ -91,7 +91,7 @@ public class XmlResolver extends XMLCatalogResolver {
             Log.XML_RESOLVER_MARKER,
             "Jeeves XmlResolver: Before resolution: Type: {} NamespaceURI: {} " +
             "PublicId: {} SystemId: {} BaseURI: {}",
-            type,namespaceURI,publicId,systemId,baseURI
+            type, namespaceURI, publicId, systemId, baseURI
         );
 
         LSInput result = null;
@@ -115,7 +115,7 @@ public class XmlResolver extends XMLCatalogResolver {
 
         LOGGER.debug(Log.XML_RESOLVER_MARKER,
             "Jeeves XmlResolver: After resolution: PublicId: {} SystemId: {} BaseURI:{}",
-            publicId,systemId,baseURI
+            publicId, systemId, baseURI
         );
 
         URL externalRef = null;
@@ -167,7 +167,7 @@ public class XmlResolver extends XMLCatalogResolver {
                     elResult = xml.execute();
                     addXmlToCache(externalRef.toString(), elResult);
                     if (LOGGER.isDebugEnabled(Log.XML_RESOLVER_MARKER)) {
-                        LOGGER.debug(Log.XML_RESOLVER_MARKER, "Retrieved: \n{}",Xml.getString(elResult));
+                        LOGGER.debug(Log.XML_RESOLVER_MARKER, "Retrieved: \n{}", Xml.getString(elResult));
                     }
                 } catch (Exception e) {
                     Log.error(Log.XML_RESOLVER, "Request on " + externalRef + " failed." + e.getMessage());

--- a/common/src/test/java/org/fao/geonet/utils/LogTest.java
+++ b/common/src/test/java/org/fao/geonet/utils/LogTest.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2022 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+package org.fao.geonet.utils;
+
+import org.apache.logging.log4j.LogManager;
+import org.fao.geonet.Logger;
+import org.junit.Test;
+
+public class LogTest {
+
+    @Test
+    public final void modules() throws Exception {
+        Logger jeevesLogger = Log.createLogger(Log.JEEVES);
+        Logger engineLogger = Log.createLogger(Log.ENGINE);
+
+        jeevesLogger.info("jeeves is ready");
+        jeevesLogger.error("jeeves is troubled");
+        engineLogger.info("engine is ready");
+        engineLogger.error("engine is troubled");
+    }
+    @Test
+    public final void inferred() throws Exception {
+        org.apache.logging.log4j.Logger logger = LogManager.getLogger(LogTest.class);
+
+        Logger geonetworkLogger = Log.createLogger("geonetwork");
+        Logger harvesterLogger = Log.createLogger("geonetwork.harvester");
+
+        logger.info("test starting");
+        geonetworkLogger.info("geonetwork is ready");
+        geonetworkLogger.error("geonetwork is troubled");
+        harvesterLogger.info("harvester is ready");
+        harvesterLogger.error("harvester is troubled");
+    }
+    @Test
+    public final void markers() throws Exception {
+        Logger jeevesLogger = Log.createLogger(LogTest.class,Log.JEEVES_MARKER);
+        Logger engineLogger = Log.createLogger(LogTest.class,Log.ENGINE_MARKER);
+
+        jeevesLogger.info("jeeves is ready");
+        jeevesLogger.error("jeeves is troubled");
+        engineLogger.info("engine is ready");
+        engineLogger.error("engine is troubled");
+    }
+}

--- a/common/src/test/resources/log4j2-test.xml
+++ b/common/src/test/resources/log4j2-test.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<Configuration status="warn" dest="out">
+
+  <Filters>
+    <NoMarkerFilter onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+    <!-- filter by geonetwork module -->
+    <Filters>
+      <ThresholdFilter level="INFO" onMatch="NEUTRAL" onMismatch="DENY"/>
+      <MarkerFilter marker="harvester" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+      <MarkerFilter marker="engine" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+    </Filters>
+    <Filters>
+      <ThresholdFilter level="ERROR" onMatch="NEUTRAL" onMismatch="DENY"/>
+      <MarkerFilter marker="geonetwork" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+      <MarkerFilter marker="jeeves" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+    </Filters>
+  </Filters>
+
+  <Appenders>
+    <Console name="Console" target="SYSTEM_OUT">
+      <PatternLayout pattern="%date{ISO8601} %-5level [%logger] %markerSimpleName: %message%n"/>
+    </Console>
+  </Appenders>
+
+  <Loggers>
+    <Logger name="org.fao.geonet" level="error" additivity="false">
+      <AppenderRef ref="Console"/>
+    </Logger>
+    <Logger name="jeeves" level="error" additivity="false">
+      <AppenderRef ref="Console"/>
+    </Logger>
+
+    <!-- Turn off logging except when explicitly declared above -->
+    <Root level="off">
+      <AppenderRef ref="Console"/>
+    </Root>
+  </Loggers>
+</Configuration>

--- a/core/src/main/java/jeeves/component/ProfileManager.java
+++ b/core/src/main/java/jeeves/component/ProfileManager.java
@@ -26,6 +26,7 @@ package jeeves.component;
 import jeeves.config.springutil.JeevesDelegatingFilterProxy;
 import jeeves.server.context.ServiceContext;
 
+import org.apache.logging.log4j.Logger;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.domain.Profile;
 import org.fao.geonet.utils.Log;
@@ -51,6 +52,7 @@ import java.util.Set;
  * This class is a container for the user-profiles.xml file
  */
 public class ProfileManager {
+    private static Logger LOGGER = Log.createLogger(ProfileManager.class,Log.REQUEST_MARKER);
     //--------------------------------------------------------------------------
     //---
     //--- API methods
@@ -150,10 +152,10 @@ public class ProfileManager {
                 // ignore
             }
         }
-        if (Log.isDebugEnabled(Log.REQUEST)) {
-            Log.debug(Log.REQUEST, fi.toString() + " denied for " + authentication.toString());
-        }
-
+        LOGGER.debug(Log.REQUEST_MARKER,
+            "{} denied for {}",
+            fi,authentication
+        );
         return false;
     }
 

--- a/core/src/main/java/jeeves/component/ProfileManager.java
+++ b/core/src/main/java/jeeves/component/ProfileManager.java
@@ -154,7 +154,7 @@ public class ProfileManager {
         }
         LOGGER.debug(Log.REQUEST_MARKER,
             "{} denied for {}",
-            fi,authentication
+            fi, authentication
         );
         return false;
     }

--- a/core/src/main/java/jeeves/server/JeevesEngine.java
+++ b/core/src/main/java/jeeves/server/JeevesEngine.java
@@ -86,7 +86,7 @@ public class JeevesEngine {
     private boolean _generalLoaded;
 
 
-    private Logger _appHandLogger = Log.createLogger(Log.APPHAND);
+    private Logger _appHandLogger = Log.createLogger(JeevesEngine.class,Log.APPHAND_MARKER);
     private List<Element> _appHandList = new ArrayList<Element>();
     private Vector<ApplicationHandler> _appHandlers = new Vector<ApplicationHandler>();
     private List<Element> _dbServices = new ArrayList<Element>();

--- a/core/src/main/java/jeeves/server/context/BasicContext.java
+++ b/core/src/main/java/jeeves/server/context/BasicContext.java
@@ -49,7 +49,7 @@ public class BasicContext {
 
     private final ConfigurableApplicationContext jeevesApplicationContext;
 
-    protected Logger logger = Log.createLogger(BasicContext.class,Log.JEEVES_MARKER);
+    protected Logger logger = Log.createLogger(BasicContext.class, Log.JEEVES_MARKER);
     protected Map<String, Object> htContexts;
     private String baseUrl;
     private EntityManager entityManager;

--- a/core/src/main/java/jeeves/server/context/BasicContext.java
+++ b/core/src/main/java/jeeves/server/context/BasicContext.java
@@ -45,11 +45,11 @@ import javax.persistence.EntityManager;
 /**
  * Contains a minimun context for a job execution (schedule, service etc...)
  */
-
-public class BasicContext implements Logger {
+public class BasicContext {
 
     private final ConfigurableApplicationContext jeevesApplicationContext;
-    protected Logger logger = Log.createLogger(Log.JEEVES);
+
+    protected Logger logger = Log.createLogger(BasicContext.class,Log.JEEVES_MARKER);
     protected Map<String, Object> htContexts;
     private String baseUrl;
     private EntityManager entityManager;
@@ -61,7 +61,6 @@ public class BasicContext implements Logger {
     //--------------------------------------------------------------------------
 
     public BasicContext(ConfigurableApplicationContext jeevesApplicationContext, Map<String, Object> contexts, EntityManager entityManager) {
-
         this.jeevesApplicationContext = jeevesApplicationContext;
         htContexts = Collections.unmodifiableMap(contexts);
         this.entityManager = entityManager;
@@ -133,59 +132,59 @@ public class BasicContext implements Logger {
 
     //--------------------------------------------------------------------------
 
-    @Override
+    @Deprecated
     public boolean isDebugEnabled() {
-        return logger.isDebugEnabled();
+        return getLogger().isDebugEnabled();
     }
 
-    @Override
+    @Deprecated
     public void debug(final String message) {
-        logger.debug(message);
+        getLogger().debug(message);
     }
 
-    @Override
+    @Deprecated
     public void info(final String message) {
         logger.info(message);
     }
 
-    @Override
+    @Deprecated
     public void warning(final String message) {
         logger.warning(message);
     }
 
-    @Override
+    @Deprecated
     public void error(final String message) {
         logger.error(message);
     }
 
-    @Override
+    @Deprecated
     public void error(Throwable ex) {
         logger.error(ex);
     }
 
-    @Override
+    @Deprecated
     public void fatal(final String message) {
         logger.fatal(message);
     }
 
-    @Override
+    @Deprecated
     public String getModule() {
-        return logger.getModule();
+        return getLogger().getModule();
     }
 
-    @Override
+    @Deprecated
     public void setAppender(FileAppender fa) {
         logger.setAppender(fa);
     }
 
-    @Override
+    @Deprecated
     public String getFileAppender() {
-        return logger.getFileAppender();
+        return getLogger().getFileAppender();
     }
 
-    @Override
+    @Deprecated
     public Level getThreshold() {
-        return logger.getThreshold();
+        return getLogger().getThreshold();
     }
 
     /**

--- a/core/src/main/java/jeeves/server/context/ScheduleContext.java
+++ b/core/src/main/java/jeeves/server/context/ScheduleContext.java
@@ -25,6 +25,7 @@ package jeeves.server.context;
 
 import jeeves.monitor.MonitorManager;
 
+import org.apache.logging.log4j.MarkerManager;
 import org.fao.geonet.utils.Log;
 import org.springframework.context.ConfigurableApplicationContext;
 
@@ -51,7 +52,7 @@ public class ScheduleContext extends BasicContext {
                            EntityManager entityManager) {
         super(appContext, contexts, entityManager);
 
-        logger = Log.createLogger(Log.SCHEDULER + "." + name);
+        logger = Log.createLogger(name, Log.SCHEDULER);
         this.scheduleName = name;
     }
 

--- a/core/src/main/java/jeeves/server/context/ServiceContext.java
+++ b/core/src/main/java/jeeves/server/context/ServiceContext.java
@@ -33,6 +33,7 @@ import jeeves.server.sources.http.JeevesServlet;
 import jeeves.transaction.TransactionManager;
 import jeeves.transaction.TransactionTask;
 
+import org.apache.logging.log4j.MarkerManager;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.Logger;
 import org.fao.geonet.kernel.GeonetworkDataDirectory;
@@ -141,7 +142,7 @@ public class ServiceContext extends BasicContext {
 
     public void setService(final String service) {
         this._service = service;
-        logger = Log.createLogger(Log.WEBAPP + "." + service);
+        logger = Log.createLogger(getClass(), MarkerManager.getMarker(service).setParents(Log.WEBAPP_MARKER));
     }
 
     public String getIpAddress() {

--- a/core/src/main/java/jeeves/server/dispatchers/AbstractPage.java
+++ b/core/src/main/java/jeeves/server/dispatchers/AbstractPage.java
@@ -27,7 +27,9 @@ import jeeves.constants.Jeeves;
 import jeeves.server.context.ServiceContext;
 import jeeves.server.dispatchers.guiservices.GuiService;
 
+import org.fao.geonet.Logger;
 import org.fao.geonet.Util;
+import org.fao.geonet.utils.Log;
 import org.jdom.Element;
 
 import java.util.List;
@@ -36,6 +38,7 @@ import java.util.Vector;
 //=============================================================================
 
 public abstract class AbstractPage {
+    private static Logger LOGGER = Log.createLogger(AbstractPage.class,Log.SERVICE_MARKER);
     private String sheet;
     private String contentType;
     private String testCondition;
@@ -124,10 +127,8 @@ public abstract class AbstractPage {
                     root.addContent(elGui);
                 }
             } catch (Exception e) {
-                ServiceManager.error("Exception executing gui service : "
-                    + e.toString());
-                ServiceManager.error(" (C) Stack trace is :\n"
-                    + Util.getStackTrace(e));
+                LOGGER.error("Exception executing gui service : {}", e.toString());
+                LOGGER.error(" (C) Stack trace is :",e);
             }
         }
     }

--- a/core/src/main/java/jeeves/server/dispatchers/AbstractPage.java
+++ b/core/src/main/java/jeeves/server/dispatchers/AbstractPage.java
@@ -128,7 +128,7 @@ public abstract class AbstractPage {
                 }
             } catch (Exception e) {
                 LOGGER.error("Exception executing gui service : {}", e.toString());
-                LOGGER.error(" (C) Stack trace is :",e);
+                LOGGER.error(" (C) Stack trace is :", e);
             }
         }
     }

--- a/core/src/main/java/jeeves/server/dispatchers/ServiceInfo.java
+++ b/core/src/main/java/jeeves/server/dispatchers/ServiceInfo.java
@@ -211,7 +211,7 @@ public class ServiceInfo {
             return result;
         } catch (Exception e) {
             LOGGER.error("Exception during transformation");
-            LOGGER.error("  (C) message is : " + e.getMessage());
+            LOGGER.error("  (C) message is : {}", e.getMessage());
 
             Throwable t = e;
 

--- a/core/src/main/java/jeeves/server/dispatchers/ServiceInfo.java
+++ b/core/src/main/java/jeeves/server/dispatchers/ServiceInfo.java
@@ -30,7 +30,9 @@ import jeeves.transaction.TransactionManager;
 import jeeves.transaction.TransactionTask;
 
 import org.fao.geonet.ApplicationContextHolder;
+import org.fao.geonet.Logger;
 import org.fao.geonet.kernel.GeonetworkDataDirectory;
+import org.fao.geonet.utils.Log;
 import org.fao.geonet.utils.Xml;
 import org.jdom.Element;
 import org.springframework.transaction.TransactionStatus;
@@ -44,6 +46,7 @@ import java.util.Vector;
  * A container class for a service. It collect the method and the filter
  */
 public class ServiceInfo {
+    private static Logger LOGGER = Log.createLogger(ServiceInfo.class,Log.SERVICE_MARKER);
 
     private String match;
     private String sheet;
@@ -199,21 +202,21 @@ public class ServiceInfo {
         GeonetworkDataDirectory geonetworkDataDirectory = ApplicationContextHolder.get().getBean(GeonetworkDataDirectory.class);
         Path styleSheet = geonetworkDataDirectory.resolveWebResource(Jeeves.Path.XSL).resolve(sheet);
 
-        ServiceManager.info("Transforming input with stylesheet : " + styleSheet);
+        LOGGER.info("Transforming input with stylesheet : {}", styleSheet);
 
         try {
             Element result = Xml.transform(request, styleSheet);
-            ServiceManager.info("End of input transformation");
+            LOGGER.info("End of input transformation");
 
             return result;
         } catch (Exception e) {
-            ServiceManager.error("Exception during transformation");
-            ServiceManager.error("  (C) message is : " + e.getMessage());
+            LOGGER.error("Exception during transformation");
+            LOGGER.error("  (C) message is : " + e.getMessage());
 
             Throwable t = e;
 
             while (t.getCause() != null) {
-                ServiceManager.error("  (C) message is : " + t.getMessage());
+                LOGGER.error("  (C) message is : {}", t.getMessage());
                 t = t.getCause();
             }
 
@@ -234,8 +237,8 @@ public class ServiceInfo {
             return response;
         } catch (Exception e) {
             //--- in case of exception we have to abort all resources
-            ServiceManager.error("Exception when executing service");
-            ServiceManager.error(" (C) Exc : " + e);
+            LOGGER.error("Exception when executing service");
+            LOGGER.error(" (C) Exc : {}", e);
 
             throw e;
         }

--- a/core/src/main/java/jeeves/server/dispatchers/ServiceManager.java
+++ b/core/src/main/java/jeeves/server/dispatchers/ServiceManager.java
@@ -44,11 +44,12 @@ import jeeves.server.sources.ServiceRequest.OutputMethod;
 import jeeves.server.sources.http.HttpServiceRequest;
 import jeeves.server.sources.http.JeevesServlet;
 import org.apache.commons.lang.StringUtils;
+import org.apache.logging.log4j.Marker;
 import org.eclipse.jetty.io.EofException;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.Constants;
+import org.fao.geonet.Logger;
 import org.fao.geonet.NodeInfo;
-import org.fao.geonet.Util;
 import org.fao.geonet.exceptions.JeevesException;
 import org.fao.geonet.exceptions.NotAllowedEx;
 import org.fao.geonet.exceptions.ServiceNotFoundEx;
@@ -92,6 +93,8 @@ public class ServiceManager {
     private boolean startupError = false;
     private Map<String, String> startupErrors;
 
+    static Logger LOGGER = Log.createLogger(ServiceManager.class,Log.SERVICE_MARKER);
+
 
     @PersistenceContext
     private EntityManager entityManager;
@@ -102,12 +105,22 @@ public class ServiceManager {
     //---
     //---------------------------------------------------------------------------
 
+    /**
+     * Log info message with {@link Log#SERVICE_MARKER} on behalf of {@link ServiceManager}.
+     * @param message
+     * @deprecated Please use {@link Log#createLogger(Class, Marker)} to create your own Logger directly
+     */
     static void info(String message) {
-        Log.info(Log.SERVICE, message);
+        LOGGER.info(Log.SERVICE_MARKER,message);
     }
 
+    /**
+     * Log error message with {@link Log#SERVICE_MARKER} on behalf of {@link ServiceManager}.
+     * @param message
+     * @deprecated Please use {@link Log#createLogger(Class, Marker)} to create your own Logger directly
+     */
     static void error(String message) {
-        Log.error(Log.SERVICE, message);
+        LOGGER.error(Log.SERVICE_MARKER,message);
     }
 
     public void setDefaultLang(String lang) {
@@ -188,7 +201,7 @@ public class ServiceManager {
             al = new ArrayList<>();
             htServices.put(name, al);
         } else {
-            info("Service " + name + " already exist, re-register it.");
+            LOGGER.info("Service {} already exist, re-register it.", name);
             htServices.remove(name);
             al = new ArrayList<>();
             htServices.put(name, al);
@@ -419,13 +432,13 @@ public class ServiceManager {
             while (true) {
                 String srvName = req.getService();
 
-                info("Dispatching : " + srvName);
+                LOGGER.info("Dispatching : {}",srvName);
                 logParameters(req.getParams());
 
                 ArrayList<ServiceInfo> al = htServices.get(srvName);
 
                 if (al == null) {
-                    error("Service not found : " + srvName);
+                    LOGGER.error("Service not found : {}", srvName);
                     throw new ServiceNotFoundEx(srvName);
                 }
 
@@ -437,7 +450,7 @@ public class ServiceManager {
                 }
 
                 if (srvInfo == null) {
-                    error("Service not matched in list : " + srvName);
+                    LOGGER.error("Service not matched in list : {}", srvName);
                     throw new ServiceNotMatchedEx(srvName);
                 }
 
@@ -468,10 +481,10 @@ public class ServiceManager {
                 String forward = dispatchOutput(req, context, response, outPage, srvInfo.isCacheSet());
 
                 if (forward == null) {
-                    info(" -> dispatch ended for : " + srvName);
+                    LOGGER.info(" -> dispatch ended for : {}", srvName);
                     return;
                 } else {
-                    info(" -> forwarding to : " + forward);
+                    LOGGER.info(" -> forwarding to : {}", forward);
 
                     // Use servlet redirect for user.login and user.logout services.
                     // TODO: Make redirect configurable for services in jeeves
@@ -526,7 +539,8 @@ public class ServiceManager {
         int code = getErrorCode(e);
         boolean cache = (srvInfo != null) && srvInfo.isCacheSet();
 
-        if (isDebug()) debug("Raised exception while executing service\n" + Xml.getString(error));
+        if (LOGGER.isDebugEnabled(Log.SERVICE_MARKER))
+            LOGGER.debug(Log.SERVICE_MARKER, "Raised exception while executing service\n" + Xml.getString(error));
 
         try {
             InputMethod input = req.getInputMethod();
@@ -569,10 +583,10 @@ public class ServiceManager {
                 }
             }
         } catch (Exception ex) {
-            error("Raised exception while writing response to exception");
-            error("  Exception : " + ex);
-            error("  Message   : " + ex.getMessage());
-            error("  Stack     : " + Util.getStackTrace(ex));
+            LOGGER.error("Raised exception while writing response to exception");
+            LOGGER.error("  Exception : {}", ex);
+            LOGGER.error("  Message   : {}", ex.getMessage());
+            LOGGER.error("  Stack     :", e);
         }
     }
 
@@ -584,7 +598,7 @@ public class ServiceManager {
 
     private String dispatchOutput(ServiceRequest req, ServiceContext context,
                                   Element response, OutputPage outPage, boolean cache) throws Exception {
-        info("   -> dispatching to output for : " + req.getService());
+        LOGGER.info("   -> dispatching to output for : {}", req.getService());
 
         //------------------------------------------------------------------------
         //--- check if the output page is a foward
@@ -604,12 +618,14 @@ public class ServiceManager {
             //--- if there is no output page we output the xml result (if any)
 
             if (response == null)
-                warning("Response is null and there is no output page for : " + req.getService());
+                LOGGER.warn("Response is null and there is no output page for : {}", req.getService());
             else {
-                info("     -> writing xml for : " + req.getService());
+                LOGGER.info("     -> writing xml for : {}", req.getService());
 
                 //--- this logging is usefull for xml services that are called by javascript code
-                if (isDebug()) debug("Service xml is :\n" + Xml.getString(response));
+                if (LOGGER.isDebugEnabled(Log.SERVICE_MARKER)) {
+                    LOGGER.debug(Log.SERVICE_MARKER, "Service xml is :\n{}", Xml.getString(response));
+                }
 
                 InputMethod in = req.getInputMethod();
                 OutputMethod out = req.getOutputMethod();
@@ -687,9 +703,9 @@ public class ServiceManager {
                     styleSheet = dataDirectory.resolveWebResource(Jeeves.Path.XSL).resolve(styleSheet);
 
                     if (!Files.exists(styleSheet))
-                        error(" -> stylesheet not found on disk, aborting : " + styleSheet);
+                        LOGGER.error(" -> stylesheet not found on disk, aborting : {}", styleSheet);
                     else {
-                        info(" -> transforming with stylesheet : " + styleSheet);
+                        LOGGER.info(" -> transforming with stylesheet : {}", styleSheet);
 
                         try {
                             TimerContext timerContext = context.getMonitorManager().getTimer(ServiceManagerXslOutputTransformTimer.class)
@@ -727,15 +743,15 @@ public class ServiceManager {
 
                             response = BinaryFile.encode(200, file, documentName, true).getElement();
                         } catch (Exception e) {
-                            error(" -> exception during XSL/FO transformation for : " + req.getService());
-                            error(" -> (C) stylesheet : " + styleSheet);
-                            error(" -> (C) message : " + e.getMessage());
-                            error(" -> (C) exception : " + e.getClass().getSimpleName());
+                            LOGGER.error(" -> exception during XSL/FO transformation for : {}", req.getService());
+                            LOGGER.error(" -> (C) stylesheet : {}", styleSheet);
+                            LOGGER.error(" -> (C) message : {}", e.getMessage());
+                            LOGGER.error(" -> (C) exception : {}", e.getClass().getSimpleName());
 
                             throw e;
                         }
 
-                        info(" -> end transformation for : " + req.getService());
+                        LOGGER.info(" -> end transformation for : {}", req.getService());
                     }
 
 
@@ -815,9 +831,9 @@ public class ServiceManager {
                     styleSheet = dataDirectory.getWebappDir().resolve(Jeeves.Path.XSL).resolve(styleSheet);
 
                     if (!Files.exists(styleSheet))
-                        error("     -> stylesheet not found on disk, aborting : " + styleSheet);
+                        LOGGER.error("     -> stylesheet not found on disk, aborting : {}", styleSheet);
                     else {
-                        info("     -> transforming with stylesheet : " + styleSheet);
+                        LOGGER.info("     -> transforming with stylesheet : {}", styleSheet);
                         try {
                             //--- then we set the content-type and output the result
                             // If JSON output requested, run the XSLT transformation and the JSON
@@ -858,15 +874,15 @@ public class ServiceManager {
                             // ignore this.
                             // it happens because the stream closes by client.
                         } catch (Exception e) {
-                            error("   -> exception during transformation for : " + req.getService());
-                            error("   ->  (C) stylesheet : " + styleSheet);
-                            error("   ->  (C) message    : " + e.getMessage());
-                            error("   ->  (C) exception  : " + e.getClass().getSimpleName());
+                            LOGGER.error("   -> exception during transformation for : {}", req.getService());
+                            LOGGER.error("   ->  (C) stylesheet : {}",  styleSheet);
+                            LOGGER.error("   ->  (C) message    : {}",  e.getMessage());
+                            LOGGER.error("   ->  (C) exception  : {}",  e.getClass().getSimpleName());
 
                             throw e;
                         }
 
-                        info("     -> end transformation for : " + req.getService());
+                        LOGGER.info("     -> end transformation for : {}", req.getService());
                     }
                 }
             }
@@ -875,7 +891,7 @@ public class ServiceManager {
         //------------------------------------------------------------------------
         //--- end data stream
 
-        info("   -> output ended for : " + req.getService());
+        LOGGER.info("   -> output ended for : {}", req.getService());
 
         return null;
     }
@@ -892,7 +908,7 @@ public class ServiceManager {
 
     private void dispatchError(ServiceRequest req, ServiceContext context,
                                Element response, ErrorPage outPage, boolean cache) throws Exception {
-        info("   -> dispatching to error for : " + req.getService());
+        LOGGER.info("   -> dispatching to error for : {}" ,req.getService());
 
         //--- build the xml data for the XSL translation
 
@@ -916,7 +932,7 @@ public class ServiceManager {
 
             styleSheet = context.getBean(GeonetworkDataDirectory.class).resolveWebResource(Jeeves.Path.XSL).resolve(styleSheet);
 
-            info("     -> transforming with stylesheet : " + styleSheet);
+            LOGGER.info("     -> transforming with stylesheet : {}", styleSheet);
 
             try {
                 req.beginStream(outPage.getContentType(), cache);
@@ -926,12 +942,12 @@ public class ServiceManager {
                 // ignore this.
                 // it happens because the stream closes by client.
             } catch (Exception e) {
-                Log.error(Log.JEEVES, e.getMessage(), e);
+                LOGGER.error(Log.SERVICE_MARKER, e.getMessage(), e);
             }
         }
 
-        info("     -> end error transformation for : " + req.getService());
-        info("   -> error ended for : " + req.getService());
+        LOGGER.info("     -> end error transformation for : {}", req.getService());
+        LOGGER.info("   -> error ended for : {}", req.getService());
     }
 
     //---------------------------------------------------------------------------
@@ -944,7 +960,7 @@ public class ServiceManager {
                 return p;
         }
 
-        error("No default error found for id : " + id);
+        LOGGER.error("No default error found for id : {}", id);
         throw new NullPointerException("No default error found for id : " + id);
     }
 
@@ -995,25 +1011,20 @@ public class ServiceManager {
         root.addContent(new Element("serverUrl").setText(settingManager.getServerURL()));
     }
 
+    /**
+     * Log xml parameters
+     * @param params
+     */
     @SuppressWarnings("unchecked")
     private void logParameters(Element params) {
         List<Element> paramsList = params.getChildren();
 
-        if (paramsList.size() == 0)
-            if (isDebug()) debug(" -> no input parameters");
-            else if (isDebug()) debug(" -> parameters are : \n" + Xml.getString(params));
-    }
-
-    private boolean isDebug() {
-        return Log.isDebugEnabled(Log.SERVICE);
-    }
-
-    private void debug(String message) {
-        Log.debug(Log.SERVICE, message);
-    }
-
-    private void warning(String message) {
-        Log.warning(Log.SERVICE, message);
+        if (paramsList.size() == 0) {
+            LOGGER.debug(Log.SERVICE_MARKER, " -> no input parameters");
+        }
+        else {
+            LOGGER.debug(Log.SERVICE_MARKER, " -> parameters are : \n{}", Xml.getString(params));
+        }
     }
 
     public ProfileManager getProfileManager() {

--- a/core/src/main/java/jeeves/server/dispatchers/ServiceManager.java
+++ b/core/src/main/java/jeeves/server/dispatchers/ServiceManager.java
@@ -432,7 +432,7 @@ public class ServiceManager {
             while (true) {
                 String srvName = req.getService();
 
-                LOGGER.info("Dispatching : {}",srvName);
+                LOGGER.info("Dispatching : {}", srvName);
                 logParameters(req.getParams());
 
                 ArrayList<ServiceInfo> al = htServices.get(srvName);
@@ -540,7 +540,7 @@ public class ServiceManager {
         boolean cache = (srvInfo != null) && srvInfo.isCacheSet();
 
         if (LOGGER.isDebugEnabled(Log.SERVICE_MARKER))
-            LOGGER.debug(Log.SERVICE_MARKER, "Raised exception while executing service\n" + Xml.getString(error));
+            LOGGER.debug(Log.SERVICE_MARKER, "Raised exception while executing service\n{}", Xml.getString(error));
 
         try {
             InputMethod input = req.getInputMethod();

--- a/core/src/main/java/jeeves/server/dispatchers/guiservices/XmlCacheManager.java
+++ b/core/src/main/java/jeeves/server/dispatchers/guiservices/XmlCacheManager.java
@@ -25,6 +25,7 @@ package jeeves.server.dispatchers.guiservices;
 
 import jeeves.XmlFileCacher;
 
+import org.apache.logging.log4j.Logger;
 import org.fao.geonet.kernel.GeonetworkDataDirectory;
 import org.fao.geonet.utils.Log;
 import org.jdom.Element;
@@ -41,6 +42,8 @@ import java.util.WeakHashMap;
 import javax.servlet.ServletContext;
 
 public class XmlCacheManager {
+    private static Logger LOGGER = Log.createLogger(XmlCacheManager.class,Log.RESOURCES_MARKER);
+
     WeakHashMap<String, Map<String, XmlFileCacher>> xmlCaches = new WeakHashMap<String, Map<String, XmlFileCacher>>();
 
     private Map<String, XmlFileCacher> getCacheMap(boolean localized, Path base, String file) {
@@ -103,7 +106,7 @@ public class XmlCacheManager {
                 return xmlCache.get();
             }
         } catch (Exception e) {
-            Log.debug(Log.RESOURCES, "Error cloning the cached data.  Attempted to get: " + xmlFilePath + " but failed so falling back to default language", e);
+            LOGGER.debug(Log.RESOURCES_MARKER, "Error cloning the cached data.  Attempted to get: {} but failed so falling back to default language", xmlFilePath,e);
             Path xmlDefaultLangFilePath = rootPath.resolve(defaultLang).resolve(file);
             xmlCache = new XmlFileCacher(xmlDefaultLangFilePath, servletContext, appPath);
             cacheMap.put(preferedLanguage, xmlCache);

--- a/core/src/main/java/jeeves/server/dispatchers/guiservices/XmlCacheManager.java
+++ b/core/src/main/java/jeeves/server/dispatchers/guiservices/XmlCacheManager.java
@@ -106,7 +106,7 @@ public class XmlCacheManager {
                 return xmlCache.get();
             }
         } catch (Exception e) {
-            LOGGER.debug(Log.RESOURCES_MARKER, "Error cloning the cached data.  Attempted to get: {} but failed so falling back to default language", xmlFilePath,e);
+            LOGGER.debug(Log.RESOURCES_MARKER, "Error cloning the cached data.  Attempted to get: {} but failed so falling back to default language", xmlFilePath, e);
             Path xmlDefaultLangFilePath = rootPath.resolve(defaultLang).resolve(file);
             xmlCache = new XmlFileCacher(xmlDefaultLangFilePath, servletContext, appPath);
             cacheMap.put(preferedLanguage, xmlCache);

--- a/core/src/main/java/jeeves/server/sources/ServiceRequestFactory.java
+++ b/core/src/main/java/jeeves/server/sources/ServiceRequestFactory.java
@@ -28,6 +28,7 @@ import jeeves.server.sources.ServiceRequest.InputMethod;
 import jeeves.server.sources.ServiceRequest.OutputMethod;
 import jeeves.server.sources.http.HttpServiceRequest;
 
+import org.apache.logging.log4j.Logger;
 import org.fao.geonet.Constants;
 import org.fao.geonet.exceptions.FileUploadTooBigEx;
 import org.fao.geonet.utils.Log;
@@ -53,6 +54,7 @@ import javax.servlet.http.HttpServletResponse;
 //=============================================================================
 
 public final class ServiceRequestFactory {
+    private static Logger LOGGER = Log.createLogger(ServiceRequestFactory.class,Log.REQUEST_MARKER);
 
     private static final String JSON_URL_FLAG = "_content_type=json";
     private static String DEBUG_URL_FLAG = "!";
@@ -284,15 +286,14 @@ public final class ServiceRequestFactory {
             }
             String file = fileEntry.getValue().getOriginalFilename();
             final String type = multipartFile.getContentType();
-            if (Log.isDebugEnabled(Log.REQUEST)) {
-                Log.debug(Log.REQUEST, "Uploading file " + file + " type: " + type + " size: " + size);
-            }
+            LOGGER.debug(Log.REQUEST_MARKER, "Uploading file {} type: {} size: {}",
+                file,type,size
+            );
+
 
             //--- remove path information from file (some browsers put it, like IE)
             file = simplifyName(file);
-            if (Log.isDebugEnabled(Log.REQUEST)) {
-                Log.debug(Log.REQUEST, "File is called " + file + " after simplification");
-            }
+            LOGGER.debug(Log.REQUEST_MARKER, "File is called {} after simplification",file);
             multipartFile.transferTo(uploadDir.resolve(file).toFile());
 
             Element elem = new Element(multipartFile.getName())
@@ -303,8 +304,9 @@ public final class ServiceRequestFactory {
             if (type != null)
                 elem.setAttribute("content-type", type);
 
-            if (Log.isDebugEnabled(Log.REQUEST))
-                Log.debug(Log.REQUEST, "Adding to parameters: " + Xml.getString(elem));
+            if (LOGGER.isDebugEnabled(Log.REQUEST_MARKER)) {
+                LOGGER.debug(Log.REQUEST_MARKER, "Adding to parameters: {}", Xml.getString(elem));
+            }
             params.addContent(elem);
         }
 
@@ -337,7 +339,7 @@ public final class ServiceRequestFactory {
             byte[] utf8Bytes = file.getBytes("UTF8");
             file = new String(utf8Bytes, "UTF8");
         } catch (UnsupportedEncodingException e) {
-            Log.error(Log.JEEVES, e.getMessage(), e);
+            LOGGER.error(Log.JEEVES_MARKER, e.getMessage(), e);
         }
 
         //--- replace whitespace with underscore

--- a/core/src/main/java/jeeves/server/sources/ServiceRequestFactory.java
+++ b/core/src/main/java/jeeves/server/sources/ServiceRequestFactory.java
@@ -287,13 +287,13 @@ public final class ServiceRequestFactory {
             String file = fileEntry.getValue().getOriginalFilename();
             final String type = multipartFile.getContentType();
             LOGGER.debug(Log.REQUEST_MARKER, "Uploading file {} type: {} size: {}",
-                file,type,size
+                file, type, size
             );
 
 
             //--- remove path information from file (some browsers put it, like IE)
             file = simplifyName(file);
-            LOGGER.debug(Log.REQUEST_MARKER, "File is called {} after simplification",file);
+            LOGGER.debug(Log.REQUEST_MARKER, "File is called {} after simplification", file);
             multipartFile.transferTo(uploadDir.resolve(file).toFile());
 
             Element elem = new Element(multipartFile.getName())

--- a/core/src/main/java/jeeves/server/sources/http/JeevesServlet.java
+++ b/core/src/main/java/jeeves/server/sources/http/JeevesServlet.java
@@ -126,15 +126,13 @@ public class JeevesServlet extends HttpServlet {
 
         LOGGER.info(Log.REQUEST_MARKER, "==========================================================");
         LOGGER.info(Log.REQUEST_MARKER, "HTML Request (from " + ip + ") : " + req.getRequestURI());
-        if (LOGGER.isDebugEnabled(Log.REQUEST_MARKER)) {
-            LOGGER.debug(Log.REQUEST_MARKER, "Method       : {}", req.getMethod());
-            LOGGER.debug(Log.REQUEST_MARKER, "Content type : {}",  req.getContentType());
-            //		LOGGER.debug(Log.REQUEST_MARKER, "Context path : {}",  req.getContextPath());
-            //		LOGGER.debug(Log.REQUEST_MARKER, "Char encoding: {}",  req.getCharacterEncoding());
-            LOGGER.debug(Log.REQUEST_MARKER, "Accept       : {}",  req.getHeader("Accept"));
-            //		LOGGER.debug(Log.REQUEST_MARKER, "Server name  : {}",  req.getServerName());
-            //		LOGGER.debug(Log.REQUEST_MARKER, "Server port  : {}",  req.getServerPort());
-        }
+        LOGGER.debug(Log.REQUEST_MARKER, "Method       : {}", req.getMethod());
+        LOGGER.debug(Log.REQUEST_MARKER, "Content type : {}",  req.getContentType());
+        //		LOGGER.debug(Log.REQUEST_MARKER, "Context path : {}",  req.getContextPath());
+        //		LOGGER.debug(Log.REQUEST_MARKER, "Char encoding: {}",  req.getCharacterEncoding());
+        LOGGER.debug(Log.REQUEST_MARKER, "Accept       : {}",  req.getHeader("Accept"));
+        //		LOGGER.debug(Log.REQUEST_MARKER, "Server name  : {}",  req.getServerName());
+        //		LOGGER.debug(Log.REQUEST_MARKER, "Server port  : {}",  req.getServerPort());
 //		for (Enumeration e = req.getHeaderNames(); e.hasMoreElements();) {
 //			String theHeader = (String)e.nextElement();
 //        if (LOGGER.isDebugEnabled(Log.REQUEST_MARKER)) {

--- a/core/src/main/java/jeeves/server/sources/http/JeevesServlet.java
+++ b/core/src/main/java/jeeves/server/sources/http/JeevesServlet.java
@@ -32,6 +32,7 @@ import jeeves.server.UserSession;
 import jeeves.server.sources.ServiceRequest;
 import jeeves.server.sources.ServiceRequestFactory;
 
+import org.apache.logging.log4j.Logger;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.Util;
 import org.fao.geonet.domain.User;
@@ -59,6 +60,8 @@ import static javax.servlet.http.HttpServletResponse.SC_BAD_REQUEST;
  */
 
 public class JeevesServlet extends HttpServlet {
+    private static Logger LOGGER = Log.createLogger(JeevesServlet.class,Log.REQUEST_MARKER);
+
     public static final String USER_SESSION_ATTRIBUTE_KEY = Jeeves.Elem.SESSION;
     private static final long serialVersionUID = 1L;
     private boolean initialized = false;
@@ -121,28 +124,26 @@ public class JeevesServlet extends HttpServlet {
             ip = forwardedFor;
         }
 
-        Log.info(Log.REQUEST, "==========================================================");
-        Log.info(Log.REQUEST, "HTML Request (from " + ip + ") : " + req.getRequestURI());
-        if (Log.isDebugEnabled(Log.REQUEST)) {
-            Log.debug(Log.REQUEST, "Method       : " + req.getMethod());
-            Log.debug(Log.REQUEST, "Content type : " + req.getContentType());
-            //		Log.debug(Log.REQUEST, "Context path : " + req.getContextPath());
-            //		Log.debug(Log.REQUEST, "Char encoding: " + req.getCharacterEncoding());
-            Log.debug(Log.REQUEST, "Accept       : " + req.getHeader("Accept"));
-            //		Log.debug(Log.REQUEST, "Server name  : " + req.getServerName());
-            //		Log.debug(Log.REQUEST, "Server port  : " + req.getServerPort());
+        LOGGER.info(Log.REQUEST_MARKER, "==========================================================");
+        LOGGER.info(Log.REQUEST_MARKER, "HTML Request (from " + ip + ") : " + req.getRequestURI());
+        if (LOGGER.isDebugEnabled(Log.REQUEST_MARKER)) {
+            LOGGER.debug(Log.REQUEST_MARKER, "Method       : {}", req.getMethod());
+            LOGGER.debug(Log.REQUEST_MARKER, "Content type : {}",  req.getContentType());
+            //		LOGGER.debug(Log.REQUEST_MARKER, "Context path : {}",  req.getContextPath());
+            //		LOGGER.debug(Log.REQUEST_MARKER, "Char encoding: {}",  req.getCharacterEncoding());
+            LOGGER.debug(Log.REQUEST_MARKER, "Accept       : {}",  req.getHeader("Accept"));
+            //		LOGGER.debug(Log.REQUEST_MARKER, "Server name  : {}",  req.getServerName());
+            //		LOGGER.debug(Log.REQUEST_MARKER, "Server port  : {}",  req.getServerPort());
         }
 //		for (Enumeration e = req.getHeaderNames(); e.hasMoreElements();) {
 //			String theHeader = (String)e.nextElement();
-//        if(Log.isDebugEnabled(Log.REQUEST)) {
-//			Log.debug(Log.REQUEST, "Got header: "+theHeader);
-//			Log.debug(Log.REQUEST, "With value: "+req.getHeader(theHeader));
+//        if (LOGGER.isDebugEnabled(Log.REQUEST_MARKER)) {
+//			LOGGER.debug(Log.REQUEST_MARKER, "Got header: "+theHeader);
+//			LOGGER.debug(Log.REQUEST_MARKER, "With value: "+req.getHeader(theHeader));
 //        }
 //		}
         HttpSession httpSession = req.getSession();
-        if (Log.isDebugEnabled(Log.REQUEST)) {
-            Log.debug(Log.REQUEST, "Session id is " + httpSession.getId());
-        }
+        LOGGER.debug(Log.REQUEST_MARKER, "Session id is {}", httpSession.getId());
         UserSession session = (UserSession) httpSession.getAttribute(USER_SESSION_ATTRIBUTE_KEY);
 
         //------------------------------------------------------------------------
@@ -156,9 +157,7 @@ public class JeevesServlet extends HttpServlet {
             httpSession.setAttribute(USER_SESSION_ATTRIBUTE_KEY, session);
             session.setsHttpSession(httpSession);
 
-            if (Log.isDebugEnabled(Log.REQUEST)) {
-                Log.debug(Log.REQUEST, "Session created for client : " + ip);
-            }
+            LOGGER.debug(Log.REQUEST_MARKER, "Session created for client : {}", ip);
         }
 
         //------------------------------------------------------------------------
@@ -185,7 +184,7 @@ public class JeevesServlet extends HttpServlet {
             // now stick the stack trace on the end and log the whole lot
             sb.append("Stack :\n").append(Util.getStackTrace(e));
 
-            Log.error(Log.REQUEST, sb.toString());
+            LOGGER.error(Log.REQUEST_MARKER, sb.toString());
             return;
         } catch (Exception e) {
             StringBuilder sb = new StringBuilder();
@@ -195,9 +194,8 @@ public class JeevesServlet extends HttpServlet {
 
             res.sendError(SC_BAD_REQUEST, sb.toString());
 
-            // now stick the stack trace on the end and log the whole lot
-            sb.append("Stack :\n").append(Util.getStackTrace(e));
-            Log.error(Log.REQUEST, sb.toString());
+            LOGGER.error(Log.REQUEST_MARKER, sb.toString(), e);
+
             return;
         }
 

--- a/core/src/main/java/jeeves/transaction/TransactionManager.java
+++ b/core/src/main/java/jeeves/transaction/TransactionManager.java
@@ -23,6 +23,7 @@
 
 package jeeves.transaction;
 
+import org.apache.logging.log4j.Logger;
 import org.fao.geonet.utils.Log;
 import org.springframework.context.ApplicationContext;
 import org.springframework.transaction.PlatformTransactionManager;
@@ -46,6 +47,8 @@ import javax.persistence.RollbackException;
  * Created by Jesse on 3/10/14.
  */
 public class TransactionManager {
+
+    private static Logger LOGGER = Log.createLogger(TransactionManager.class,Log.JEEVES_MARKER);
     public static <V> V runInTransaction(String name,
                                          ApplicationContext context,
                                          TransactionRequirement transactionRequirement,
@@ -77,7 +80,7 @@ public class TransactionManager {
 
 
         } catch (Throwable e) {
-            Log.error(Log.JEEVES, "Error occurred within a transaction", e);
+            LOGGER.error(Log.JEEVES_MARKER, "Error occurred within a transaction", e);
             if (exception[0] == null) {
                 exception[0] = e;
             }
@@ -106,13 +109,13 @@ public class TransactionManager {
                 }
             } catch (TransactionSystemException e) {
                 if (!(e.getOriginalException() instanceof RollbackException)) {
-                    Log.error(Log.JEEVES, "ERROR committing transaction, will try to rollback", e);
+                    LOGGER.error(Log.JEEVES_MARKER, "ERROR committing transaction, will try to rollback", e);
                     doRollback(context, transactionManager, transaction);
                 } else {
-                    Log.debug(Log.JEEVES, "ERROR committing transaction, will try to rollback", e);
+                    LOGGER.debug(Log.JEEVES_MARKER, "ERROR committing transaction, will try to rollback", e);
                 }
             } catch (Throwable t) {
-                Log.error(Log.JEEVES, "ERROR committing transaction, will try to rollback", t);
+                LOGGER.error(Log.JEEVES_MARKER, "ERROR committing transaction, will try to rollback", t);
                 doRollback(context, transactionManager, transaction);
             }
         }
@@ -166,7 +169,7 @@ public class TransactionManager {
             //what if the transaction is completed?
             //maybe then we shouldn't be here
         } catch (Throwable t) {
-            Log.error(Log.JEEVES, "ERROR rolling back transaction", t);
+            LOGGER.error(Log.JEEVES_MARKER, "ERROR rolling back transaction", t);
         }
     }
 

--- a/core/src/main/java/jeeves/xlink/Processor.java
+++ b/core/src/main/java/jeeves/xlink/Processor.java
@@ -220,8 +220,7 @@ public final class Processor {
 
                 if (remoteFragment != null && !remoteFragment.getName().equalsIgnoreCase("error")) {
                     xlinkCache.putInGroup(uri.toLowerCase(), mappedURI, remoteFragment);
-                    if (LOGGER.isDebugEnabled(Log.XLINK_MARKER))
-                        LOGGER.debug(Log.XLINK_MARKER, "cache miss for {}", uri);
+                    LOGGER.debug(Log.XLINK_MARKER, "cache miss for {}", uri);
                 } else {
                     return null;
                 }
@@ -385,7 +384,7 @@ public final class Processor {
                         continue;
                     }
                 } catch (Exception e) {
-                    LOGGER.error(Log.XLINK_MARKER, "Failed to look up localxlink {}:{}", idSearch,e.getMessage(), e);
+                    LOGGER.error(Log.XLINK_MARKER, "Failed to look up localxlink {}:{}", idSearch, e.getMessage(), e);
                 }
                 if (localFragment != null) {
                     localFragment = (Element) localFragment.clone();
@@ -464,7 +463,7 @@ public final class Processor {
                             element.addContent(remoteFragment);
                         }
                     } catch (Exception e) {
-                        LOGGER.error(Log.XLINK_MARKER, "doXLink {} failed: {}", action,e.getMessage(), e);
+                        LOGGER.error(Log.XLINK_MARKER, "doXLink {} failed: {}", action, e.getMessage(), e);
                     }
                 }
                 cleanXLinkAttributes(element, action);

--- a/core/src/main/java/org/fao/geonet/MergeUsersByUsernameDatabaseMigration.java
+++ b/core/src/main/java/org/fao/geonet/MergeUsersByUsernameDatabaseMigration.java
@@ -47,18 +47,20 @@ import java.util.*;
  */
 public class MergeUsersByUsernameDatabaseMigration implements ContextAwareTask {
 
+    private static Logger LOGGER = Log.createLogger(MergeUsersByUsernameDatabaseMigration.class,Log.JEEVES_MARKER);
+
     @Transactional
     @Override
     public void run(ApplicationContext applicationContext) throws TaskExecutionException {
         UserRepository userRepository = applicationContext.getBean(UserRepository.class);
         List<String> duplicatedUsernamesList = userRepository.findDuplicatedUsernamesCaseInsensitive();
-        Log.debug(Log.JEEVES, "Found these duplicated usernames: " + duplicatedUsernamesList);
+        LOGGER.debug(Log.JEEVES_MARKER, "Found these duplicated usernames: {}", duplicatedUsernamesList);
         try {
             for (String duplicatedUsername : duplicatedUsernamesList) {
                 mergeUsers(applicationContext, duplicatedUsername);
             }
         } catch (Exception e) {
-            Log.error(Log.JEEVES, "Exception merging users", e);
+            LOGGER.error(Log.JEEVES_MARKER, "Exception merging users", e);
             throw new TaskExecutionException(e);
         }
 
@@ -175,10 +177,14 @@ public class MergeUsersByUsernameDatabaseMigration implements ContextAwareTask {
 
             List<UserGroup> userGroupsToProcess = userGroupRepository.findAll(
                 UserGroupSpecs.hasUserId(userToProcess.getId()));
-            if (Log.isDebugEnabled(Log.JEEVES)) {
-                Log.debug(Log.JEEVES, "Groups of user {" + userToProcess.getId() + " - "
-                    + userToProcess.getUsername() + "}: " + userGroupsToProcess.size());
-                Log.debug(Log.JEEVES, userGroupsToProcess);
+            if (LOGGER.isDebugEnabled(Log.JEEVES_MARKER)) {
+                LOGGER.debug(Log.JEEVES_MARKER,
+                    "Groups of user {{} - {}}: {}",
+                    userToProcess.getId(),
+                    userToProcess.getUsername(),
+                    userGroupsToProcess.size()
+                );
+                LOGGER.debug(Log.JEEVES_MARKER, userGroupsToProcess);
             }
 
             for (UserGroup ug : userGroupsToProcess) {

--- a/core/src/main/java/org/fao/geonet/MetadataResourceDatabaseMigration.java
+++ b/core/src/main/java/org/fao/geonet/MetadataResourceDatabaseMigration.java
@@ -65,6 +65,8 @@ import javax.annotation.Nullable;
  */
 public class MetadataResourceDatabaseMigration extends DatabaseMigrationTask {
 
+    private static Logger LOGGER = Log.createLogger(MetadataResourceDatabaseMigration.class,Geonet.DB_MARKER);
+
     private static final ArrayList<Namespace> NAMESPACES =
         Lists.newArrayList(
             ISO19139Namespaces.GMD,
@@ -168,7 +170,7 @@ public class MetadataResourceDatabaseMigration extends DatabaseMigrationTask {
 
     @Override
     public void update(Connection connection) throws SQLException {
-        Log.debug(Geonet.DB, "MetadataResourceDatabaseMigration");
+        LOGGER.debug(Geonet.DB_MARKER, "MetadataResourceDatabaseMigration");
 
         final SettingManager settingManager = applicationContext.getBean(SettingManager.class);
 
@@ -201,10 +203,10 @@ public class MetadataResourceDatabaseMigration extends DatabaseMigrationTask {
                 }
                 update.executeBatch();
             } catch (java.sql.BatchUpdateException e) {
-                Log.error(Geonet.GEONETWORK, "Error occurred while updating resource links:" + e.getMessage(), e);
+                LOGGER.error(Geonet.GEONETWORK_MARKER, "Error occurred while updating resource links:" + e.getMessage(), e);
                 SQLException next = e.getNextException();
                 while (next != null) {
-                    Log.error(Geonet.GEONETWORK, "Next error: " + next.getMessage(), next);
+                    LOGGER.error(Geonet.GEONETWORK_MARKER, "Next error: " + next.getMessage(), next);
                     next = e.getNextException();
                 }
 

--- a/core/src/main/java/org/fao/geonet/MetadataResourceDatabaseMigration.java
+++ b/core/src/main/java/org/fao/geonet/MetadataResourceDatabaseMigration.java
@@ -203,10 +203,10 @@ public class MetadataResourceDatabaseMigration extends DatabaseMigrationTask {
                 }
                 update.executeBatch();
             } catch (java.sql.BatchUpdateException e) {
-                LOGGER.error(Geonet.GEONETWORK_MARKER, "Error occurred while updating resource links:" + e.getMessage(), e);
+                LOGGER.error(Geonet.GEONETWORK_MARKER, "Error occurred while updating resource links: {}", e.getMessage(), e);
                 SQLException next = e.getNextException();
                 while (next != null) {
-                    LOGGER.error(Geonet.GEONETWORK_MARKER, "Next error: " + next.getMessage(), next);
+                    LOGGER.error(Geonet.GEONETWORK_MARKER, "Next error: {}", next.getMessage(), next);
                     next = e.getNextException();
                 }
 

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/ResourceLoggerStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/ResourceLoggerStore.java
@@ -26,6 +26,7 @@
 package org.fao.geonet.api.records.attachments;
 
 import jeeves.server.context.ServiceContext;
+import org.apache.logging.log4j.Logger;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.ISODate;
@@ -51,6 +52,7 @@ import javax.annotation.Nullable;
  * Decorate a store and record put/get/delete operations in database for reporting statistics.
  */
 public class ResourceLoggerStore extends AbstractStore {
+    private static Logger LOGGER = Log.createLogger(ResourceLoggerStore.class,Geonet.RESOURCES_MARKER);
 
     private Store decoratedStore;
 
@@ -188,10 +190,10 @@ public class ResourceLoggerStore extends AbstractStore {
                     metadataFileUpload = uploadRepository.findByMetadataIdAndFileNameNotDeleted(metadataId, resourceId);
 
                 } catch (org.springframework.dao.EmptyResultDataAccessException ex) {
-                    Log.debug(Geonet.RESOURCES, String.format(
-                            "No references in FileNameNotDeleted repository for metadata '%s', resource id '%s'. Get request will not be "
+                    LOGGER.debug(Geonet.RESOURCES_MARKER,
+                            "No references in FileNameNotDeleted repository for metadata '{}', resource id '{}'. Get request will not be "
                                     + "saved.",
-                            metadataUuid, resourceId));
+                            metadataUuid, resourceId);
 
                     // No related upload is found
                     metadataFileUpload = null;

--- a/core/src/main/java/org/fao/geonet/arcgis/ArcSDEConnection.java
+++ b/core/src/main/java/org/fao/geonet/arcgis/ArcSDEConnection.java
@@ -22,7 +22,11 @@
  */
 package org.fao.geonet.arcgis;
 
+import org.apache.logging.log4j.Logger;
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.MarkerManager;
 import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.utils.Log;
 
 import java.util.List;
 import java.util.Map;
@@ -35,7 +39,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * non-ISO ESRI elements they may contain.
  */
 public interface ArcSDEConnection {
-    String ARCSDE_LOG_MODULE_NAME = Geonet.HARVESTER + ".arcsde";
+
+    static String ARCSDE_LOG_MODULE_NAME = Geonet.HARVESTER + ".arcsde";
+    static Marker ARCSDE_LOG_MARKER = MarkerManager.getMarker("arcsde").addParents(Geonet.HARVEST_MARKER);
+
     String ISO_METADATA_IDENTIFIER = "MD_Metadata";
 
 

--- a/core/src/main/java/org/fao/geonet/arcgis/ArcSDEJdbcConnection.java
+++ b/core/src/main/java/org/fao/geonet/arcgis/ArcSDEJdbcConnection.java
@@ -164,7 +164,7 @@ public abstract class ArcSDEJdbcConnection implements ArcSDEConnection {
             }
         });
 
-        LOGGER.info(ARCSDE_LOG_MARKER, "Finished retrieving metadata, found: #{} metadata records",results.size());
+        LOGGER.info(ARCSDE_LOG_MARKER, "Finished retrieving metadata, found: #{} metadata records", results.size());
 
         return results;
     }

--- a/core/src/main/java/org/fao/geonet/arcgis/ArcSDEJdbcConnection.java
+++ b/core/src/main/java/org/fao/geonet/arcgis/ArcSDEJdbcConnection.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 import org.apache.commons.dbcp2.BasicDataSource;
+import org.apache.logging.log4j.Logger;
 import org.fao.geonet.utils.Log;
 import org.springframework.jdbc.core.RowCallbackHandler;
 import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
@@ -40,6 +41,7 @@ import org.springframework.jdbc.core.namedparam.NamedParameterJdbcTemplate;
  * Created by juanl on 17/02/2017.
  */
 public abstract class ArcSDEJdbcConnection implements ArcSDEConnection {
+    private static Logger LOGGER = Log.createLogger(ArcSDEJdbcConnection.class,ARCSDE_LOG_MARKER);
 
     private BasicDataSource dataSource;
     protected Connection jdbcConnection;
@@ -56,7 +58,7 @@ public abstract class ArcSDEJdbcConnection implements ArcSDEConnection {
     public ArcSDEJdbcConnection(String driverName, String connectionString, String username, String password) {
 
         try {
-            Log.debug(ARCSDE_LOG_MODULE_NAME, "Getting ArcSDE connection (via JDBC)");
+            LOGGER.debug(ARCSDE_LOG_MODULE_NAME, "Getting ArcSDE connection (via JDBC)");
 
             BasicDataSource dataSource = new BasicDataSource();
             dataSource.setDriverClassName(driverName);
@@ -68,7 +70,7 @@ public abstract class ArcSDEJdbcConnection implements ArcSDEConnection {
 
             jdbcTemplate = new NamedParameterJdbcTemplate(dataSource);
         } catch (SQLException x) {
-            Log.error(ARCSDE_LOG_MODULE_NAME, "Error getting ArcSDE connection (via JDBC)", x);
+            LOGGER.error(ARCSDE_LOG_MARKER, "Error getting ArcSDE connection (via JDBC)", x);
 
             throw new ExceptionInInitializerError(new ArcSDEConnectionException("Exception in ArcSDEConnection using JDBC: can not connect to the database", x));
         }
@@ -81,7 +83,7 @@ public abstract class ArcSDEJdbcConnection implements ArcSDEConnection {
         try {
             dataSource.close();
         } catch (SQLException ex) {
-            Log.error(ARCSDE_LOG_MODULE_NAME, "Error closing the ArcSDE connection (via JDBC)", ex);
+            LOGGER.error(ARCSDE_LOG_MARKER, "Error closing the ArcSDE connection (via JDBC)", ex);
             throw new ArcSDEConnectionException("Exception closing JDBC connection", ex);
         }
     }
@@ -95,7 +97,7 @@ public abstract class ArcSDEJdbcConnection implements ArcSDEConnection {
                 dataSource.close();
             }
         } catch (SQLException ex) {
-            Log.error(ARCSDE_LOG_MODULE_NAME, "Error closing the ArcSDE connection (via JDBC) "
+            LOGGER.error(ARCSDE_LOG_MARKER, "Error closing the ArcSDE connection (via JDBC) "
                 + "in finalize method", ex);
             throw new ArcSDEConnectionException("Exception finalizing class ArcSDEConnection", ex);
         } finally {
@@ -124,7 +126,7 @@ public abstract class ArcSDEJdbcConnection implements ArcSDEConnection {
             public void processRow(ResultSet rs) throws SQLException {
                 // Cancel processing
                 if (cancelMonitor.get()) {
-                    Log.warning(ARCSDE_LOG_MODULE_NAME, "Cancelling metadata retrieve using "
+                    LOGGER.warn(ARCSDE_LOG_MARKER, "Cancelling metadata retrieve using "
                             + "ArcSDE connection (via JDBC)");
                     rs.getStatement().cancel();
                     results.clear();
@@ -162,8 +164,7 @@ public abstract class ArcSDEJdbcConnection implements ArcSDEConnection {
             }
         });
 
-        Log.info(ARCSDE_LOG_MODULE_NAME, "Finished retrieving metadata, found: #" + results.size()
-                + " metadata records");
+        LOGGER.info(ARCSDE_LOG_MARKER, "Finished retrieving metadata, found: #{} metadata records",results.size());
 
         return results;
     }

--- a/core/src/main/java/org/fao/geonet/constants/Geonet.java
+++ b/core/src/main/java/org/fao/geonet/constants/Geonet.java
@@ -29,7 +29,7 @@ import org.jdom.Namespace;
 import javax.xml.XMLConstants;
 
 /**
- * TODO javadoc.
+ * GeoNetwork configuration constants including module names and file names.
  */
 public final class Geonet {
 

--- a/core/src/main/java/org/fao/geonet/constants/Geonet.java
+++ b/core/src/main/java/org/fao/geonet/constants/Geonet.java
@@ -24,6 +24,8 @@
 package org.fao.geonet.constants;
 
 import jeeves.constants.Jeeves;
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.MarkerManager;
 import org.jdom.Namespace;
 
 import javax.xml.XMLConstants;
@@ -42,51 +44,444 @@ public final class Geonet {
 
     public static final String CC_API_REST_URL = "http://api.creativecommons.org/rest/1.5/simple/chooser";
 
+    /**
+     * GeoNetwork base logging module name.
+     *
+     * @deprecated Use {@link #GEONETWORK_MARKER}
+     */
     public static final String GEONETWORK = "geonetwork";
-    public static final String HARVEST_MAN = GEONETWORK + ".harvest-man";
-    public static final String HARVESTER = GEONETWORK + ".harvester";
-    public static final String SETTINGS = GEONETWORK + ".settings";
-    public static final String DATA_MANAGER = GEONETWORK + ".datamanager";
-    public static final String ACCESS_MANAGER = GEONETWORK + ".accessmanager";
-    public static final String SVN_MANAGER = GEONETWORK + ".svnmanager";
-    public static final String SCHEMA_MANAGER = GEONETWORK + ".schemamanager";
-    public static final String DB = GEONETWORK + ".database";
-    public static final String THESAURUS_MAN = GEONETWORK + ".thesaurus-man";
-    public static final String THESAURUS = GEONETWORK + ".thesaurus";
-    public static final String SEARCH_ENGINE = GEONETWORK + ".search";
-    public static final String CUSTOM_ELEMENTSET = GEONETWORK + ".customelementset";
-    public static final String INDEX_ENGINE = GEONETWORK + ".index";
-    public static final String MEF = GEONETWORK + ".mef";
-    public static final String CSW = GEONETWORK + ".csw";
-    public static final String LDAP = GEONETWORK + ".ldap";
-    public static final String RESOURCES = GEONETWORK + ".resources";
-    public static final String EDITOR = GEONETWORK + ".editor";
-    public static final String EDITORADDELEMENT = GEONETWORK + ".editoraddelement";
-    public static final String EDITOREXPANDELEMENT = GEONETWORK + ".editorexpandelement";
-    public static final String EDITORFILLELEMENT = GEONETWORK + ".editorfillelement";
-    public static final String SPATIAL = GEONETWORK + ".spatial";
-    public static final String REGION = GEONETWORK + ".region";
-    public static final String CSW_SEARCH = CSW + ".search";
-    public static final String CSW_HARVEST = CSW + ".harvest";
-    public static final String SRU = GEONETWORK + ".sru";
-    public static final String SRU_SEARCH = SRU + ".search";
-    public static final String USER_WATCHLIST = GEONETWORK + ".userwatchlist";
-    public static final String OAI = GEONETWORK + ".oai";
-    public static final String SECURITY = GEONETWORK + ".security";
-    public static final String OAI_HARVESTER = OAI + ".provider";
-    // keys for logging search log
-    public static final String SEARCH_LOGGER = GEONETWORK + ".search-logger";
-    public static final String THREADPOOL = GEONETWORK + ".threadpool";
-    public static final String DATA_DIRECTORY = GEONETWORK + ".data.directory";
-    public static final String FEEDBACK = GEONETWORK + ".feedback";
-    public static final String GEOPUBLISH = GEONETWORK + ".geopublisher";
-    public static final String FORMATTER = GEONETWORK + ".formatter";
-    // key for inspire atom log
-    public static final String ATOM = GEONETWORK + ".atom";
-    public static final String EDITOR_SESSION = GEONETWORK + ".editor.session";
-    public static final String CLASSIFIER = GEONETWORK + ".classifier";
-    public static final String CORS = GEONETWORK + ".cors";
+    /**
+     * GeoNetwork marker for log messages.
+     */
+    public static final Marker GEONETWORK_MARKER =  MarkerManager.getMarker("geonetwork");
 
+    /**
+     * Marker for {@code manager} log messages.
+     *
+     * Manager classes provide a facade orchestrating geonetwork module lifecycle and interaction.
+     */
+    public static final Marker MANAGER_MARKER =  MarkerManager.getMarker("manager");
+
+    /**
+     * Logging {@code accessmanager} module name.
+     *
+     * @deprecated Use {@link #ACCESS_MANAGER_MARKER}
+     */
+    public static final String ACCESS_MANAGER = GEONETWORK + ".accessmanager";
+
+    /**
+     * Marker for {@code access_manager} log messages.
+     */
+    public static final Marker ACCESS_MANAGER_MARKER =  MarkerManager.getMarker("access_manager").addParents(GEONETWORK_MARKER,MANAGER_MARKER);
+    /**
+     * Logging {@code atom} module name.
+     *
+     * @deprecated Use {@link #ATOM_MARKER}
+     */
+    public static final String ATOM = GEONETWORK + ".atom";
+    /**
+     * Marker {@code atom} for log messages.
+     */
+    public static final Marker ATOM_MARKER = MarkerManager.getMarker("atom").addParents(GEONETWORK_MARKER);
+
+    /**
+     * Logging {@code classifier} module name.
+     *
+     * @deprecated Use {@link #CLASSIFIER_MARKER}
+     */
+    public static final String CLASSIFIER = GEONETWORK + ".classifier";
+    /**
+     * Marker for {@code acceclassifierssmanager} log messages.
+     */
+    public static final Marker CLASSIFIER_MARKER =  MarkerManager.getMarker("classifier").addParents(GEONETWORK_MARKER);
+    /**
+     * Logging {@code cors} module name.
+     *
+     * @deprecated Use {@link #CORS_MARKER}
+     */
+    public static final String CORS = GEONETWORK + ".cors";
+    /**
+     * Marker for {@code cors} log messages.
+     */
+    public static final Marker CORS_MARKER =  MarkerManager.getMarker("cors").addParents(GEONETWORK_MARKER);
+    /**
+     * Logging {@code csw} module name.
+     *
+     * @deprecated Use {@link #CSW_MARKER}
+     */
+    public static final String CSW = GEONETWORK + ".csw";
+    /**
+     * Marker for {@code csw} log messages.
+     */
+    public static final Marker CSW_MARKER =  MarkerManager.getMarker("csw").addParents(GEONETWORK_MARKER);
+    /**
+     * Logging {@code csw.harvest} module name.
+     *
+     * @deprecated Use {@link #CSW_HARVEST_MARKER}
+     */
+    public static final String CSW_HARVEST = CSW + ".harvest";
+    /**
+     * Marker for {@code csw_harvest} log messages.
+     */
+    public static final Marker CSW_HARVEST_MARKER =  MarkerManager.getMarker("csw_harvest").addParents(CSW_MARKER);
+    /**
+     * Logging {@code csw.search} module name.
+     *
+     * @deprecated Use {@link #CSW_SEARCH_MARKER}
+     */
+    public static final String CSW_SEARCH = CSW + ".search";
+    /**
+     * Marker for {@code csw_search} log messages.
+     */
+    public static final Marker CSW_SEARCH_MARKER =  MarkerManager.getMarker("csw_search").addParents(CSW_MARKER);
+    /**
+     * Logging {@code customelementset}module name.
+     *
+     * @deprecated Use {@link #CUSTOM_ELEMENTSET_MARKER}
+     */
+    public static final String CUSTOM_ELEMENTSET = GEONETWORK + ".customelementset";
+    /**
+     * Marker for {@code customelementset} log messages.
+     */
+    public static final Marker CUSTOM_ELEMENTSET_MARKER =  MarkerManager.getMarker("customelementset").addParents(GEONETWORK_MARKER);
+    /**
+     * Logging {@code data.directory} module name.
+     *
+     * @deprecated Use {@link #DATA_DIRECTORY_MARKER}
+     */
+    public static final String DATA_DIRECTORY = GEONETWORK + ".data.directory";
+    /**
+     * Marker for {@code data_directory} log messages.
+     */
+    public static final Marker DATA_DIRECTORY_MARKER =  MarkerManager.getMarker("data_directory").addParents(GEONETWORK_MARKER);
+    /**
+     * Logging {@code datamanager} module name.
+     *
+     * @deprecated Use {@link #DATA_MANAGER_MARKER}
+     */
+    public static final String DATA_MANAGER = GEONETWORK + ".datamanager";
+    /**
+     * Marker for {@code data_manager} log messages.
+     */
+    public static final Marker DATA_MANAGER_MARKER =  MarkerManager.getMarker("data_manager").addParents(GEONETWORK_MARKER,MANAGER_MARKER);
+
+    /**
+     * Logging {@code database} module name.
+     *
+     * @deprecated Use {@link #DB_MARKER}
+     */
+    public static final String DB = GEONETWORK + ".database";
+    /**
+     * Marker for {@code database} log messages.
+     */
+    public static final Marker DB_MARKER =  MarkerManager.getMarker("database").addParents(GEONETWORK_MARKER);
+    /**
+     * Logging {@code editor} module name.
+     *
+     * @deprecated Use {@link #EDITOR_MARKER}
+     */
+    public static final String EDITOR = GEONETWORK + ".editor";
+    /**
+     * Marker for {@code editor} log messages.
+     */
+    public static final Marker EDITOR_MARKER =  MarkerManager.getMarker("editor").addParents(GEONETWORK_MARKER);
+    /**
+     * Logging {@code editoraddelement} module name.
+     *
+     * @deprecated Use {@link #EDITORADDELEMENT_MARKER}
+     */
+    public static final String EDITORADDELEMENT = GEONETWORK + ".editoraddelement";
+    /**
+     * Marker for {@code editor_addelement} log messages.
+     */
+    public static final Marker EDITORADDELEMENT_MARKER = MarkerManager.getMarker("editor_addelement").addParents(EDITOR_MARKER);
+
+    /**
+     * Logging {@code editorexpandelement} module name.
+     *
+     * @deprecated Use {@link #EDITOREXPANDELEMENT_MARKER}
+     */
+    public static final String EDITOREXPANDELEMENT = GEONETWORK + ".editorexpandelement";
+    /**
+     * Marker for {@code editor_expandelement} log messages.
+     */
+    public static final Marker EDITOREXPANDELEMENT_MARKER = MarkerManager.getMarker("editor_expandelement").addParents(EDITOR_MARKER);
+    /**
+     * Logging {@code editorfileelement} module name.
+     *
+     * @deprecated Use {@link #EDITORFILLELEMENT_MARKER}
+     */
+    public static final String EDITORFILLELEMENT = GEONETWORK + ".editorfillelement";
+    /**
+     * Marker for {@code editor_fillelement} log messages.
+     */
+    public static final Marker EDITORFILLELEMENT_MARKER = MarkerManager.getMarker("editor_fillelement").addParents(EDITOR_MARKER);
+    /**
+     * Logging {@code editor.session} module name.
+     *
+     * @deprecated Use {@link #EDITOR_SESSION_MARKER}
+     */
+    public static final String EDITOR_SESSION = GEONETWORK + ".editor.session";
+    /**
+     * Marker for {@code editor_session} log messages.
+     */
+    public static final Marker EDITOR_SESSION_MARKER = MarkerManager.getMarker("editor_session").addParents(EDITOR_MARKER);
+
+    /**
+     * Logging {@code feedback} module name.
+     *
+     * @deprecated Use {@link #FEEDBACK_MARKER}
+     */
+    public static final String FEEDBACK = GEONETWORK + ".feedback";
+    /**
+     * Marker for {@code feedback} log messages.
+     */
+    public static final Marker FEEDBACK_MARKER = MarkerManager.getMarker("feedback").addParents(GEONETWORK_MARKER);
+    /**
+     * Logging {@code formatter} module name.
+     *
+     * @deprecated Use {@link #FORMATTER_MARKER}
+     */
+    public static final String FORMATTER = GEONETWORK + ".formatter";
+    /**
+     * Marker for {@code formatter} log messages.
+     */
+    public static final Marker FORMATTER_MARKER = MarkerManager.getMarker("formatter").addParents(GEONETWORK_MARKER);
+    /**
+     * Logging {@code geopublisher} module name.
+     *
+     * @deprecated Use {@link #GEOPUBLISH_MARKER}
+     */
+    public static final String GEOPUBLISH = GEONETWORK + ".geopublisher";
+    /**
+     * Marker for {@code geopublisher} log messages.
+     */
+    public static final Marker GEOPUBLISH_MARKER = MarkerManager.getMarker("geopublisher").addParents(GEONETWORK_MARKER);
+    /**
+     * Logging {@code harvester} module name.
+     *
+     * @deprecated Use {@link #HARVEST_MARKER}
+     */
+    public static final String HARVESTER = GEONETWORK + ".harvester";
+    /**
+     * Marker for {@code harvester} log messages.
+     */
+    public static final Marker HARVEST_MARKER =  MarkerManager.getMarker("harvester").addParents(GEONETWORK_MARKER);
+
+    /**
+     * Logging {@code harvest-man} module name.
+     *
+     * @deprecated Use {@link #HARVEST_MAN_MARKER}
+     */
+    @Deprecated
+    public static final String HARVEST_MAN = GEONETWORK + ".harvest-man";
+    /**
+     * Marker for {@code harvest_manager} log messages.
+     */
+    public static final Marker HARVEST_MAN_MARKER =  MarkerManager.getMarker("harvest_manager").addParents(HARVEST_MARKER,MANAGER_MARKER);
+
+
+    /**
+     * Logging {@code index} module name.
+     *
+     * @deprecated Use {@link #INDEX_MARKER}
+     */
+    public static final String INDEX_ENGINE = GEONETWORK + ".index";
+    /**
+     * Marker for {@code index} log messages.
+     */
+    public static final Marker INDEX_MARKER =  MarkerManager.getMarker("index").addParents(GEONETWORK_MARKER);
+    /**
+     * Logging {@code ldap} module name.
+     *
+     * @deprecated Use {@link #LDAP_MARKER}
+     */
+    public static final String LDAP = GEONETWORK + ".ldap";
+    /**
+     * Marker for {@code ldap} log messages.
+     */
+    public static final Marker LDAP_MARKER =  MarkerManager.getMarker("ldap").addParents(GEONETWORK_MARKER);
+    /**
+     * Logging {@code mef} module name.
+     *
+     * @deprecated Use {@link #MEF_MARKER}
+     */
+    public static final String MEF = GEONETWORK + ".mef";
+    /**
+     * Marker for {@code mef} log messages.
+     */
+    public static final Marker MEF_MARKER =  MarkerManager.getMarker("mef").addParents(GEONETWORK_MARKER);
+    /**
+     * Logging {@code oai} module name.
+     *
+     * @deprecated Use {@link #OAI_MARKER}
+     */
+    public static final String OAI = GEONETWORK + ".oai";
+    /**
+     * Marker for {@code oai} log messages.
+     */
+    public static final Marker OAI_MARKER =  MarkerManager.getMarker("oai").addParents(GEONETWORK_MARKER);
+    /**
+     * Logging {@code oai.provider} module name.
+     *
+     * @deprecated Use {@link #OAI_HARVESTER_MARKER}
+     */
+    public static final String OAI_HARVESTER = OAI + ".provider";
+    /**
+     * Marker for {@code oai.provider} log messages.
+     */
+    public static final Marker OAI_HARVESTER_MARKER =  MarkerManager.getMarker("oai.provider").addParents(OAI_MARKER);
+    /**
+     * Logging {@code region} module name.
+     *
+     * @deprecated Use {@link #REGION_MARKER}
+     */
+    public static final String REGION = GEONETWORK + ".region";
+    /**
+     * Marker for {@code region} log messages.
+     */
+    public static final Marker REGION_MARKER =  MarkerManager.getMarker("region").addParents(GEONETWORK_MARKER);
+    /**
+     * Logging {@code resources} module name.
+     *
+     * @deprecated Use {@link #RESOURCES_MARKER}
+     */
+    public static final String RESOURCES = GEONETWORK + ".resources";
+    /**
+     * Marker for {@code resources} log messages.
+     */
+    public static final Marker RESOURCES_MARKER =  MarkerManager.getMarker("resources").addParents(GEONETWORK_MARKER);
+    /**
+     * Logging {@code schemamanager} module name.
+     *
+     * @deprecated Use {@link #SCHEMA_MANAGER_MARKER}
+     */
+    public static final String SCHEMA_MANAGER = GEONETWORK + ".schemamanager";
+    /**
+     * Marker for {@code schema_manager} log messages.
+     */
+    public static final Marker SCHEMA_MANAGER_MARKER =  MarkerManager.getMarker("schema_manager").addParents(GEONETWORK_MARKER,MANAGER_MARKER);
+    /**
+     * Logging {@code search} module name.
+     *
+     * @deprecated Use {@link #SEARCH_ENGINE_MARKER}
+     */
+    public static final String SEARCH_ENGINE = GEONETWORK + ".search";
+    /**
+     * Marker for {@code search} log messages.
+     */
+    public static final Marker SEARCH_ENGINE_MARKER =  MarkerManager.getMarker("search").addParents(GEONETWORK_MARKER);
+    /**
+     * Logging {@code search-logger} module name.
+     *
+     * @deprecated Use {@link #SEARCH_LOGGER_MARKER}
+     */
+    public static final String SEARCH_LOGGER = GEONETWORK + ".search-logger";
+    /**
+     * Marker for {@code search-logger} log messages.
+     */
+    public static final Marker SEARCH_LOGGER_MARKER =  MarkerManager.getMarker("search-logger").addParents(GEONETWORK_MARKER);
+    /**
+     * Logging {@code security} module name.
+     *
+     * @deprecated Use {@link #SECURITY_MARKER}
+     */
+    public static final String SECURITY = GEONETWORK + ".security";
+    /**
+     * Marker for {@code security} log messages.
+     */
+    public static final Marker SECURITY_MARKER =  MarkerManager.getMarker("security").addParents(GEONETWORK_MARKER);
+    /**
+     * Logging {@code settings} module name.
+     *
+     * @deprecated Use {@link #SETTINGS_MARKER}
+     */
+    public static final String SETTINGS = GEONETWORK + ".settings";
+    /**
+     * Marker for {@code settings} log messages.
+     */
+    public static final Marker SETTINGS_MARKER =  MarkerManager.getMarker("settings").addParents(GEONETWORK_MARKER);
+    /**
+     * Logging {@code spatial} module name.
+     *
+     * @deprecated Use {@link #SPATIAL_MARKER}
+     */
+    public static final String SPATIAL = GEONETWORK + ".spatial";
+    /**
+     * Marker for {@code spatial} log messages.
+     */
+    public static final Marker SPATIAL_MARKER =  MarkerManager.getMarker("spatial").addParents(GEONETWORK_MARKER);
+    /**
+     * Logging {@code sru} module name.
+     *
+     * @deprecated Use {@link #SRU_MARKER}
+     */
+    public static final String SRU = GEONETWORK + ".sru";
+    /**
+     * Marker for {@code sru} log messages.
+     */
+    public static final Marker SRU_MARKER =  MarkerManager.getMarker("sru").addParents(GEONETWORK_MARKER);
+    /**
+     * Logging {@code sru.search} module name.
+     *
+     * @deprecated Use {@link #SRU_SEARCH_MARKER}
+     */
+    public static final String SRU_SEARCH = SRU + ".search";
+    /**
+     * Marker for {@code sru_search} log messages.
+     */
+    public static final Marker SRU_SEARCH_MARKER =  MarkerManager.getMarker("sru_search").addParents(SRU_MARKER);
+    /**
+     * Logging {@code svnmanager} module name.
+     *
+     * @deprecated Use {@link #SVN_MANAGER_MARKER}
+     */
+    public static final String SVN_MANAGER = GEONETWORK + ".svnmanager";
+    /**
+     * Marker for {@code svn_manager} log messages.
+     */
+    public static final Marker SVN_MANAGER_MARKER =  MarkerManager.getMarker("svn_manager").addParents(GEONETWORK_MARKER,MANAGER_MARKER);
+    /**
+     * Logging {@code thesaurus} module name.
+     *
+     * @deprecated Use {@link #THESAURUS_MARKER}
+     */
+    public static final String THESAURUS = GEONETWORK + ".thesaurus";
+    /**
+     * Marker for {@code thesaurus} log messages.
+     */
+    public static final Marker THESAURUS_MARKER =  MarkerManager.getMarker("thesaurus").addParents(GEONETWORK_MARKER);
+    /**
+     * Logging {@code thesaurus-man} module name.
+     *
+     * @deprecated Use {@link #THESAURUS_MAN_MARKER}
+     */
+    public static final String THESAURUS_MAN = GEONETWORK + ".thesaurus-man";
+    /**
+     * Marker for {@code thesaurus_manager} log messages.
+     */
+    public static final Marker THESAURUS_MAN_MARKER =  MarkerManager.getMarker("thesaurus_manager").addParents(THESAURUS_MARKER,MANAGER_MARKER);
+    /**
+     * Logging {@code threadpool} module name.
+     *
+     * @deprecated Use {@link #THREADPOOL_MARKER}
+     */
+    public static final String THREADPOOL = GEONETWORK + ".threadpool";
+    /**
+     * Marker for {@code threadpool} log messages.
+     */
+    public static final Marker THREADPOOL_MARKER =  MarkerManager.getMarker("threadpool").addParents(GEONETWORK_MARKER);
+    /**
+     * Logging {@code userwatchlist} module name.
+     *
+     * @deprecated Use {@link #USER_WATCHLIST_MARKER}
+     */
+    public static final String USER_WATCHLIST = GEONETWORK + ".userwatchlist";
+
+    /**
+     * Marker for {@code userwatchlist} log messages.
+     */
+    public static final Marker USER_WATCHLIST_MARKER =  MarkerManager.getMarker("userwatchlist").addParents(GEONETWORK_MARKER);
 
     /**
      * Container for file names.
@@ -413,8 +808,8 @@ public final class Geonet {
         public static final String SIMILARITY = "similarity";
 
         /**
-         * Parameter name: {@value #OUTPUT} - Display results as text only {@value #TEXT} or with
-         * graphic overviews {@value #FULL} (default)
+         * Parameter name: {@value #OUTPUT} - Display results as text only {@value Output#TEXT} or with
+         * graphic overviews {@value Output#FULL} (default)
          */
         public static final String OUTPUT = "output";
 
@@ -521,7 +916,7 @@ public final class Geonet {
             public static final String DATE = "changeDate";
 
             /**
-             * Parameter name: {@value #_TITLE} - Title not tokenized mainly used for sorting
+             * Parameter name: {@value #TITLE} - Title not tokenized mainly used for sorting
              * purpose
              */
             public static final String TITLE = "title";
@@ -669,6 +1064,11 @@ public final class Geonet {
         public static final String FEATUREOFRECORD = "featureOfRecord";
         public static final String RECORDLINKFLAG = "record";
         public static final String RECORDLINK = "recordLink";
+        public static final String INSPIRE_REPORT_URL = "_inspireReportUrl";
+        public static final String INSPIRE_VALIDATION_DATE = "_inspireValidationDate";
+        public static final String STATUS_WORKFLOW = "statusWorkflow";
+        public static final String USER_SAVED_COUNT = "userSavedCount";
+
         public static class RecordLink {
             public static final String ORIGIN = "origin";
             public static final String TO = "to";
@@ -676,10 +1076,6 @@ public final class Geonet {
             public static final String TITLE = "title";
             public static final String URL = "url";
         }
-        public static final String INSPIRE_REPORT_URL = "_inspireReportUrl";
-        public static final String INSPIRE_VALIDATION_DATE = "_inspireValidationDate";
-        public static final String STATUS_WORKFLOW = "statusWorkflow";
-        public static final String USER_SAVED_COUNT = "userSavedCount";
     }
 
     public static class SearchConfig {

--- a/core/src/main/java/org/fao/geonet/kernel/AddElemValue.java
+++ b/core/src/main/java/org/fao/geonet/kernel/AddElemValue.java
@@ -23,6 +23,7 @@
 
 package org.fao.geonet.kernel;
 
+import org.apache.logging.log4j.Logger;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.utils.Log;
 import org.fao.geonet.utils.Xml;
@@ -35,6 +36,7 @@ import java.io.IOException;
  * A simple container class for some add methods in {@link EditLib} Created by Jesse on 12/10/13.
  */
 public class AddElemValue {
+    private static final Logger LOGGER = Log.createLogger(AddElemValue.class, Geonet.EDITORADDELEMENT_MARKER);
     private final String stringValue;
     private final Element nodeValue;
 
@@ -46,10 +48,10 @@ public class AddElemValue {
                 finalNodeVal = Xml.loadString(stringValue, false);
                 finalStringVal = null;
             } catch (JDOMException e) {
-                Log.debug(Geonet.EDITORADDELEMENT, "Invalid XML fragment to insert " + stringValue + ". Error is: " + e.getMessage(), e);
+                LOGGER.debug(Geonet.EDITORADDELEMENT_MARKER, "Invalid XML fragment to insert {}. Error is: {}", stringValue, e.getMessage(), e);
                 throw e;
             } catch (IOException e) {
-                Log.error(Geonet.EDITORADDELEMENT, "Error with XML fragment to insert " + stringValue + ". Error is: " + e.getMessage(), e);
+                LOGGER.error(Geonet.EDITORADDELEMENT_MARKER, "Error with XML fragment to insert {}. Error is: {}", stringValue, e.getMessage(), e);
                 throw e;
             }
         }

--- a/core/src/main/java/org/fao/geonet/kernel/AllThesaurus.java
+++ b/core/src/main/java/org/fao/geonet/kernel/AllThesaurus.java
@@ -406,7 +406,7 @@ public class AllThesaurus extends Thesaurus {
             }
         }
 
-        LOGGER.debug(Geonet.THESAURUS_MARKER,  "{} has lastModified of: {}",ALL_THESAURUS_KEY,lastModified);
+        LOGGER.debug(Geonet.THESAURUS_MARKER,  "{} has lastModified of: {}",ALL_THESAURUS_KEY, lastModified);
 
         return FileTime.fromMillis(lastModified);
     }

--- a/core/src/main/java/org/fao/geonet/kernel/AllThesaurus.java
+++ b/core/src/main/java/org/fao/geonet/kernel/AllThesaurus.java
@@ -28,6 +28,7 @@ import com.google.common.base.Function;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
 
+import org.apache.logging.log4j.Logger;
 import org.locationtech.jts.util.Assert;
 
 import org.fao.geonet.Constants;
@@ -66,6 +67,8 @@ import javax.annotation.Nullable;
  * @author Jesse on 2/27/2015.
  */
 public class AllThesaurus extends Thesaurus {
+    private static Logger LOGGER = Log.createLogger(AllThesaurus.class,Geonet.THESAURUS_MARKER);
+
     public static final String FNAME = "allThesaurus";
     public static final String SEPARATOR = "@@@";
     static final String TYPE = "external";
@@ -403,9 +406,7 @@ public class AllThesaurus extends Thesaurus {
             }
         }
 
-        if (Log.isDebugEnabled(Geonet.THESAURUS)) {
-            Log.debug(Geonet.THESAURUS, ALL_THESAURUS_KEY + " has lastModified of: " + lastModified);
-        }
+        LOGGER.debug(Geonet.THESAURUS_MARKER,  "{} has lastModified of: {}",ALL_THESAURUS_KEY,lastModified);
 
         return FileTime.fromMillis(lastModified);
     }

--- a/core/src/main/java/org/fao/geonet/kernel/GeonetworkDataDirectory.java
+++ b/core/src/main/java/org/fao/geonet/kernel/GeonetworkDataDirectory.java
@@ -26,8 +26,9 @@ package org.fao.geonet.kernel;
 import jeeves.server.ServiceConfig;
 import jeeves.server.sources.http.JeevesServlet;
 import org.apache.log4j.Appender;
-import org.apache.log4j.Logger;
 import org.apache.log4j.bridge.AppenderWrapper;
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.appender.FileAppender;
 import org.apache.logging.log4j.core.appender.RollingFileAppender;
 import org.fao.geonet.ApplicationContextHolder;
@@ -52,6 +53,7 @@ import java.util.Iterator;
  * support files used by GeoNetwork for various purposes (eg. Lucene index, spatial index, logos).
  */
 public class GeonetworkDataDirectory {
+    private static Logger LOGGER = Log.createLogger(GeonetworkDataDirectory.class,Geonet.DATA_DIRECTORY_MARKER);
     /**
      * A suffix of the keys used to look up paths in system.properties or system.env or in Servlet
      * context.
@@ -102,8 +104,8 @@ public class GeonetworkDataDirectory {
      */
     public void init(final String webappName, final Path webappDir,
                      final ServiceConfig handlerConfig, final JeevesServlet jeevesServlet) throws IOException {
-        if (Log.isDebugEnabled(Geonet.DATA_DIRECTORY)) {
-            Log.debug(Geonet.DATA_DIRECTORY, "Check and create if needed GeoNetwork data directory");
+        if (LOGGER.isDebugEnabled(Geonet.DATA_DIRECTORY_MARKER)) {
+            LOGGER.debug(Geonet.DATA_DIRECTORY_MARKER, "Check and create if needed GeoNetwork data directory");
         }
         this.webappDir = webappDir;
         final ConfigurableApplicationContext applicationContext = ApplicationContextHolder.get();
@@ -143,10 +145,10 @@ public class GeonetworkDataDirectory {
         // by database settings
 
         // First, try the fileappender from the logger named "geonetwork"
-        Appender appender = Logger.getLogger(Geonet.GEONETWORK).getAppender(FILE_APPENDER_NAME);
+        Appender appender = org.apache.log4j.Logger.getLogger(Geonet.GEONETWORK).getAppender(FILE_APPENDER_NAME);
         // If still not found, try the one from the logger named "jeeves"
         if (appender == null) {
-            appender = Logger.getLogger(Log.JEEVES).getAppender(FILE_APPENDER_NAME);
+            appender = org.apache.log4j.Logger.getLogger(Log.JEEVES).getAppender(FILE_APPENDER_NAME);
         }
         if (appender != null) {
             if (appender instanceof AppenderWrapper) {
@@ -175,10 +177,12 @@ public class GeonetworkDataDirectory {
                 }
             }
         }
-        Log.warning(Geonet.GEONETWORK, "Error when getting logger file for the " + "appender named '" + FILE_APPENDER_NAME + "'. "
+        LOGGER.warn(Geonet.GEONETWORK_MARKER,
+            "Error when getting logger file for the appender named '{}'. "
             + "Check your log configuration file. "
             + "A FileAppender or RollingFileAppender is required to return last activity to the user interface."
-            + "Appender file not found.");
+            + "Appender file not found.",
+            FILE_APPENDER_NAME );
 
         if (System.getProperties().containsKey("log_dir")) {
             File logDir = new File(System.getProperty("log_dir"));
@@ -220,9 +224,7 @@ public class GeonetworkDataDirectory {
 
         String dataDirStr = null;
 
-        if (Log.isDebugEnabled(Geonet.DATA_DIRECTORY)) {
-            Log.debug(Geonet.DATA_DIRECTORY, "lookupProperty " + key);
-        }
+        LOGGER.debug(Geonet.DATA_DIRECTORY_MARKER, "lookupProperty {}", key);
 
         // Loop over variable access methods
         for (int j = 0; j < typeStrs.length && dataDirStr == null; j++) {
@@ -256,10 +258,9 @@ public class GeonetworkDataDirectory {
                     throw new IllegalArgumentException("Did not expect value: " + j);
             }
 
-            if (Log.isDebugEnabled(Geonet.DATA_DIRECTORY)) {
-                Log.debug(Geonet.DATA_DIRECTORY, " Found " + typeStr + "for " + keyToUse
-                    + " with value " + value);
-            }
+            LOGGER.debug(Geonet.DATA_DIRECTORY_MARKER,
+                " Found {} for {} with value {}",
+                    typeStr,keyToUse,value);
 
             dataDirStr = value;
         }
@@ -280,24 +281,25 @@ public class GeonetworkDataDirectory {
         }
 
         boolean useDefaultDataDir = false;
-        Log.info(Geonet.DATA_DIRECTORY, "   - Data directory initialization: " + this.systemDataDir);
+        LOGGER.info(Geonet.DATA_DIRECTORY_MARKER, "   - Data directory initialization: {}", this.systemDataDir);
 
         if (this.systemDataDir == null) {
-            Log.warning(Geonet.DATA_DIRECTORY,
-                "    - Data directory properties is not set. Use "
-                    + webappName + KEY_SUFFIX + " or " + GEONETWORK_DIR_KEY
-                    + " properties.");
+            LOGGER.warn(Geonet.DATA_DIRECTORY_MARKER,
+                "    - Data directory properties is not set. Use {} or {} properties.",
+                webappName + KEY_SUFFIX,
+                GEONETWORK_DIR_KEY
+            );
             useDefaultDataDir = true;
         } else {
             try {
                 Files.createDirectories(this.systemDataDir);
             } catch (IOException e) {
-                Log.error(Geonet.DATA_DIRECTORY, "Error creating system data directory: " + this.systemDataDir);
+                LOGGER.error(Geonet.DATA_DIRECTORY_MARKER, "Error creating system data directory: {}", this.systemDataDir);
                 useDefaultDataDir = true;
             }
 
             if (!Files.exists(this.systemDataDir)) {
-                Log.warning(Geonet.DATA_DIRECTORY,
+                LOGGER.warn(Geonet.DATA_DIRECTORY_MARKER,
                     "    - Data directory does not exist. Create it first.");
                 useDefaultDataDir = true;
             }
@@ -307,40 +309,40 @@ public class GeonetworkDataDirectory {
                 IO.touch(testFile);
                 Files.delete(testFile);
             } catch (IOException e) {
-                Log.warning(
-                    Geonet.DATA_DIRECTORY,
-                    "    - Data directory is not writable. Set read/write privileges to user starting the catalogue (ie. "
-                        + System.getProperty("user.name") + ").");
+                LOGGER.warn(
+                    Geonet.DATA_DIRECTORY_MARKER,
+                    "    - Data directory is not writable. Set read/write privileges to user starting the catalogue (ie. {}).",
+                    System.getProperty("user.name")
+                );
                 useDefaultDataDir = true;
             }
 
             if (!this.systemDataDir.isAbsolute()) {
-                Log.warning(
-                    Geonet.DATA_DIRECTORY,
+                LOGGER.warn(
+                    Geonet.DATA_DIRECTORY_MARKER,
                     "    - Data directory is not an absolute path. Relative path is not recommended.\n"
-                        + "Update "
-                        + webappName
-                        + KEY_SUFFIX + " or geonetwork.dir environment variable.");
+                        + "Update {} or geonetwork.dir environment variable.",
+                    webappName+ KEY_SUFFIX);
             }
         }
 
         if (useDefaultDataDir) {
             systemDataDir = getDefaultDataDir(webappDir);
-            Log.warning(Geonet.DATA_DIRECTORY,
-                "    - Data directory provided could not be used. Using default location: "
-                    + systemDataDir);
+            LOGGER.warn(Geonet.DATA_DIRECTORY_MARKER,
+                "    - Data directory provided could not be used. Using default location: {}",
+                    systemDataDir);
         }
 
 
         try {
             this.systemDataDir = this.systemDataDir.toRealPath();
             if (!Files.exists(this.systemDataDir)) {
-                Log.error(Geonet.DATA_DIRECTORY, "System Data Directory does not exist");
+                LOGGER.error(Geonet.DATA_DIRECTORY_MARKER, "System Data Directory does not exist");
             }
         } catch (IOException e) {
-            Log.warning(Geonet.DATA_DIRECTORY, "Unable to make a canonical path from: " + systemDataDir);
+            LOGGER.warn(Geonet.DATA_DIRECTORY_MARKER, "Unable to make a canonical path from: {}", systemDataDir);
         }
-        Log.info(Geonet.DATA_DIRECTORY, "   - Data directory is: "
+        LOGGER.info(Geonet.DATA_DIRECTORY_MARKER, "   - Data directory is: "
             + systemDataDir);
 
         // Set subfolder data directory
@@ -392,22 +394,22 @@ public class GeonetworkDataDirectory {
      * elements (ie. codelist).
      */
     private void initDataDirectory() throws IOException {
-        Log.info(Geonet.DATA_DIRECTORY, "   - Data directory initialization ...");
+        LOGGER.info(Geonet.DATA_DIRECTORY_MARKER, "   - Data directory initialization ...");
 
         if (!Files.exists(this.thesauriDir) || IO.isEmptyDir(this.thesauriDir)) {
-            Log.info(Geonet.DATA_DIRECTORY, "     - Copying codelists directory ..." + thesauriDir);
+            LOGGER.info(Geonet.DATA_DIRECTORY_MARKER, "     - Copying codelists directory ..." + thesauriDir);
             try {
                 final Path srcThesauri = getDefaultDataDir(webappDir).resolve("config").resolve("codelist");
                 IO.copyDirectoryOrFile(srcThesauri, this.thesauriDir, false);
             } catch (IOException e) {
-                Log.error(Geonet.DATA_DIRECTORY, "     - Thesaurus copy failed: " + e.getMessage(), e);
+                LOGGER.error(Geonet.DATA_DIRECTORY_MARKER, "     - Thesaurus copy failed: " + e.getMessage(), e);
             }
         }
 
         // Copy config-viewer-XXX.xml files
         Path mapDir = this.resourcesDir.resolve("map");
         if (!Files.exists(mapDir) || IO.isEmptyDir(mapDir)) {
-            Log.info(Geonet.DATA_DIRECTORY, "     - Copying config-viewer-XXX.xml files ...");
+            LOGGER.info(Geonet.DATA_DIRECTORY_MARKER, "     - Copying config-viewer-XXX.xml files ...");
 
             try {
                 final Path srcMap = webappDir.resolve("WEB-INF").resolve("data").
@@ -426,7 +428,7 @@ public class GeonetworkDataDirectory {
                 }
 
             } catch (IOException e) {
-                Log.error(Geonet.DATA_DIRECTORY, "     - config-viewer-XXX.xml copy failed: " + e.getMessage(), e);
+                LOGGER.error(Geonet.DATA_DIRECTORY_MARKER, "     - config-viewer-XXX.xml copy failed: " + e.getMessage(), e);
             }
         }
 
@@ -437,8 +439,8 @@ public class GeonetworkDataDirectory {
                 final Path srcFile = getDefaultDataDir(webappDir).resolve("data").resolve("resources").resolve("images");
                 IO.copyDirectoryOrFile(srcFile, imagesDir, false);
             } catch (IOException e) {
-                Log.info(
-                    Geonet.DATA_DIRECTORY,
+                LOGGER.info(
+                    Geonet.DATA_DIRECTORY_MARKER,
                     "      - Error copying images folder: "
                         + e.getMessage());
             }
@@ -449,8 +451,8 @@ public class GeonetworkDataDirectory {
             try {
                 Files.createDirectories(logoDir);
             } catch (IOException e) {
-                Log.info(
-                    Geonet.DATA_DIRECTORY,
+                LOGGER.info(
+                    Geonet.DATA_DIRECTORY_MARKER,
                     "      - Error creating images/logos folder: "
                         + e.getMessage());
             }
@@ -458,7 +460,7 @@ public class GeonetworkDataDirectory {
 
         logoDir = this.resourcesDir.resolve("images").resolve("harvesting");
         if (!Files.exists(logoDir) || IO.isEmptyDir(logoDir)) {
-            Log.info(Geonet.DATA_DIRECTORY, "     - Copying logos ...");
+            LOGGER.info(Geonet.DATA_DIRECTORY_MARKER, "     - Copying logos ...");
             try {
                 Files.createDirectories(logoDir);
                 final Path srcLogo = getDefaultDataDir(webappDir).resolve("data").resolve("resources").resolve("images").resolve("harvesting");
@@ -475,19 +477,19 @@ public class GeonetworkDataDirectory {
                     }
                 }
             } catch (IOException e) {
-                Log.error(Geonet.DATA_DIRECTORY, "     - Logo copy failed: " + e.getMessage(), e);
+                LOGGER.error(Geonet.DATA_DIRECTORY_MARKER, "     - Logo copy failed: " + e.getMessage(), e);
             }
         }
 
 
         if (!Files.exists(this.indexConfigDir) || IO.isEmptyDir(this.indexConfigDir)) {
-            Log.info(Geonet.DATA_DIRECTORY, "     - Copying index configuration in data directory ...");
+            LOGGER.info(Geonet.DATA_DIRECTORY_MARKER, "     - Copying index configuration in data directory ...");
             try {
                 final Path srcFile = getDefaultDataDir(webappDir).resolve("config").resolve("index");
                 IO.copyDirectoryOrFile(srcFile, this.indexConfigDir, false);
             } catch (IOException e) {
-                Log.info(
-                    Geonet.DATA_DIRECTORY,
+                LOGGER.info(
+                    Geonet.DATA_DIRECTORY_MARKER,
                     "      - Error copying index configuration: "
                         + e.getMessage());
             }
@@ -495,7 +497,7 @@ public class GeonetworkDataDirectory {
 
         Path schemaCatFile = configDir.resolve(Geonet.File.SCHEMA_PLUGINS_CATALOG);
         if (!Files.exists(schemaCatFile)) {
-            Log.info(Geonet.DATA_DIRECTORY, "     - Copying schema plugin catalogue ...");
+            LOGGER.info(Geonet.DATA_DIRECTORY_MARKER, "     - Copying schema plugin catalogue ...");
             try {
                 final Path srcFile = webappDir.resolve("WEB-INF").resolve(Geonet.File.SCHEMA_PLUGINS_CATALOG);
                 IO.copyDirectoryOrFile(srcFile, schemaCatFile, false);
@@ -514,15 +516,15 @@ public class GeonetworkDataDirectory {
                 }
 
             } catch (IOException e) {
-                Log.info(
-                    Geonet.DATA_DIRECTORY,
+                LOGGER.info(
+                    Geonet.DATA_DIRECTORY_MARKER,
                     "      - Error copying schema plugin catalogue: "
                         + e.getMessage());
             }
         }
 
 
-        Log.info(Geonet.DATA_DIRECTORY, "     - Copying encryptor.properties file...");
+        LOGGER.info(Geonet.DATA_DIRECTORY_MARKER, "     - Copying encryptor.properties file...");
         try {
             final Path srcEncryptorFile = getDefaultDataDir(webappDir).resolve("config").resolve(Geonet.File.ENCRYPTOR_CONFIGURATION);
             final Path destEncryptorFile = this.configDir.resolve("encryptor.properties");
@@ -532,8 +534,8 @@ public class GeonetworkDataDirectory {
             }
 
         } catch (IOException e) {
-            Log.info(
-                Geonet.DATA_DIRECTORY,
+            LOGGER.info(
+                Geonet.DATA_DIRECTORY_MARKER,
                 "      - Error copying encryptor.propeties file: "
                     + e.getMessage());
             throw e;
@@ -567,8 +569,8 @@ public class GeonetworkDataDirectory {
                         ServiceConfig handlerConfig, Path dir, String key, String handlerKey, String firstPathSeg, String... otherSegments) {
         String envKey = webappName + key;
         if (dir != null) {
-            if (Log.isDebugEnabled(Geonet.DATA_DIRECTORY)) {
-                Log.debug(Geonet.DATA_DIRECTORY, "path for " + envKey + " set to " + dir.toString()
+            if (LOGGER.isDebugEnabled(Geonet.DATA_DIRECTORY_MARKER)) {
+                LOGGER.debug(Geonet.DATA_DIRECTORY_MARKER, "path for " + envKey + " set to " + dir.toString()
                     + " via bean properties, not looking up");
             }
         } else {
@@ -585,9 +587,10 @@ public class GeonetworkDataDirectory {
             }
         } else {
             if (!dir.isAbsolute()) {
-                Log.info(Geonet.DATA_DIRECTORY, "    - " + envKey
-                    + " for directory " + dir
-                    + " is relative path. Use absolute path instead.");
+                LOGGER.info(Geonet.DATA_DIRECTORY_MARKER,
+                    "    - {} for directory {} is relative path. Use absolute path instead.",
+                    envKey, dir
+                );
             }
         }
         if (handlerKey != null) {
@@ -600,7 +603,7 @@ public class GeonetworkDataDirectory {
             throw new RuntimeException(e);
         }
 
-        Log.info(Geonet.DATA_DIRECTORY, "    - " + envKey + " is " + dir);
+        LOGGER.info(Geonet.DATA_DIRECTORY_MARKER, "    - {} is {}",envKey,dir);
         return dir;
     }
 

--- a/core/src/main/java/org/fao/geonet/kernel/GeonetworkDataDirectory.java
+++ b/core/src/main/java/org/fao/geonet/kernel/GeonetworkDataDirectory.java
@@ -23,6 +23,7 @@
 
 package org.fao.geonet.kernel;
 
+import bsh.commands.dir;
 import jeeves.server.ServiceConfig;
 import jeeves.server.sources.http.JeevesServlet;
 import org.apache.log4j.Appender;
@@ -104,9 +105,7 @@ public class GeonetworkDataDirectory {
      */
     public void init(final String webappName, final Path webappDir,
                      final ServiceConfig handlerConfig, final JeevesServlet jeevesServlet) throws IOException {
-        if (LOGGER.isDebugEnabled(Geonet.DATA_DIRECTORY_MARKER)) {
-            LOGGER.debug(Geonet.DATA_DIRECTORY_MARKER, "Check and create if needed GeoNetwork data directory");
-        }
+        LOGGER.debug(Geonet.DATA_DIRECTORY_MARKER, "Check and create if needed GeoNetwork data directory");
         this.webappDir = webappDir;
         final ConfigurableApplicationContext applicationContext = ApplicationContextHolder.get();
 
@@ -260,7 +259,7 @@ public class GeonetworkDataDirectory {
 
             LOGGER.debug(Geonet.DATA_DIRECTORY_MARKER,
                 " Found {} for {} with value {}",
-                    typeStr,keyToUse,value);
+                    typeStr, keyToUse, value);
 
             dataDirStr = value;
         }
@@ -342,8 +341,7 @@ public class GeonetworkDataDirectory {
         } catch (IOException e) {
             LOGGER.warn(Geonet.DATA_DIRECTORY_MARKER, "Unable to make a canonical path from: {}", systemDataDir);
         }
-        LOGGER.info(Geonet.DATA_DIRECTORY_MARKER, "   - Data directory is: "
-            + systemDataDir);
+        LOGGER.info(Geonet.DATA_DIRECTORY_MARKER, "   - Data directory is: {}", systemDataDir);
 
         // Set subfolder data directory
         indexConfigDir = setDir(jeevesServlet, webappName, handlerConfig, indexConfigDir, ".indexConfig" + KEY_SUFFIX,
@@ -397,12 +395,12 @@ public class GeonetworkDataDirectory {
         LOGGER.info(Geonet.DATA_DIRECTORY_MARKER, "   - Data directory initialization ...");
 
         if (!Files.exists(this.thesauriDir) || IO.isEmptyDir(this.thesauriDir)) {
-            LOGGER.info(Geonet.DATA_DIRECTORY_MARKER, "     - Copying codelists directory ..." + thesauriDir);
+            LOGGER.info(Geonet.DATA_DIRECTORY_MARKER, "     - Copying codelists directory ... {}", thesauriDir);
             try {
                 final Path srcThesauri = getDefaultDataDir(webappDir).resolve("config").resolve("codelist");
                 IO.copyDirectoryOrFile(srcThesauri, this.thesauriDir, false);
             } catch (IOException e) {
-                LOGGER.error(Geonet.DATA_DIRECTORY_MARKER, "     - Thesaurus copy failed: " + e.getMessage(), e);
+                LOGGER.error(Geonet.DATA_DIRECTORY_MARKER, "     - Thesaurus copy failed: {}", e.getMessage(), e);
             }
         }
 
@@ -428,7 +426,7 @@ public class GeonetworkDataDirectory {
                 }
 
             } catch (IOException e) {
-                LOGGER.error(Geonet.DATA_DIRECTORY_MARKER, "     - config-viewer-XXX.xml copy failed: " + e.getMessage(), e);
+                LOGGER.error(Geonet.DATA_DIRECTORY_MARKER, "     - config-viewer-XXX.xml copy failed: {}", e.getMessage(), e);
             }
         }
 
@@ -441,8 +439,8 @@ public class GeonetworkDataDirectory {
             } catch (IOException e) {
                 LOGGER.info(
                     Geonet.DATA_DIRECTORY_MARKER,
-                    "      - Error copying images folder: "
-                        + e.getMessage());
+                    "      - Error copying images folder: {}",
+                    e.getMessage());
             }
         }
 
@@ -453,8 +451,8 @@ public class GeonetworkDataDirectory {
             } catch (IOException e) {
                 LOGGER.info(
                     Geonet.DATA_DIRECTORY_MARKER,
-                    "      - Error creating images/logos folder: "
-                        + e.getMessage());
+                    "      - Error creating images/logos folder: {}",
+                    e.getMessage());
             }
         }
 
@@ -477,7 +475,7 @@ public class GeonetworkDataDirectory {
                     }
                 }
             } catch (IOException e) {
-                LOGGER.error(Geonet.DATA_DIRECTORY_MARKER, "     - Logo copy failed: " + e.getMessage(), e);
+                LOGGER.error(Geonet.DATA_DIRECTORY_MARKER, "     - Logo copy failed: {}", e.getMessage(), e);
             }
         }
 
@@ -490,8 +488,8 @@ public class GeonetworkDataDirectory {
             } catch (IOException e) {
                 LOGGER.info(
                     Geonet.DATA_DIRECTORY_MARKER,
-                    "      - Error copying index configuration: "
-                        + e.getMessage());
+                    "      - Error copying index configuration: {}",
+                    e.getMessage());
             }
         }
 
@@ -518,8 +516,8 @@ public class GeonetworkDataDirectory {
             } catch (IOException e) {
                 LOGGER.info(
                     Geonet.DATA_DIRECTORY_MARKER,
-                    "      - Error copying schema plugin catalogue: "
-                        + e.getMessage());
+                    "      - Error copying schema plugin catalogue: {}",
+                    e.getMessage());
             }
         }
 
@@ -536,8 +534,8 @@ public class GeonetworkDataDirectory {
         } catch (IOException e) {
             LOGGER.info(
                 Geonet.DATA_DIRECTORY_MARKER,
-                "      - Error copying encryptor.propeties file: "
-                    + e.getMessage());
+                "      - Error copying encryptor.propeties file: {}",
+                e.getMessage());
             throw e;
         }
 
@@ -569,10 +567,10 @@ public class GeonetworkDataDirectory {
                         ServiceConfig handlerConfig, Path dir, String key, String handlerKey, String firstPathSeg, String... otherSegments) {
         String envKey = webappName + key;
         if (dir != null) {
-            if (LOGGER.isDebugEnabled(Geonet.DATA_DIRECTORY_MARKER)) {
-                LOGGER.debug(Geonet.DATA_DIRECTORY_MARKER, "path for " + envKey + " set to " + dir.toString()
-                    + " via bean properties, not looking up");
-            }
+            LOGGER.debug(
+                Geonet.DATA_DIRECTORY_MARKER,
+                "path for {} set to {} via bean properties, not looking up",
+                envKey, dir);
         } else {
             dir = lookupProperty(jeevesServlet, handlerConfig, envKey);
         }
@@ -589,8 +587,7 @@ public class GeonetworkDataDirectory {
             if (!dir.isAbsolute()) {
                 LOGGER.info(Geonet.DATA_DIRECTORY_MARKER,
                     "    - {} for directory {} is relative path. Use absolute path instead.",
-                    envKey, dir
-                );
+                    envKey, dir);
             }
         }
         if (handlerKey != null) {
@@ -603,7 +600,7 @@ public class GeonetworkDataDirectory {
             throw new RuntimeException(e);
         }
 
-        LOGGER.info(Geonet.DATA_DIRECTORY_MARKER, "    - {} is {}",envKey,dir);
+        LOGGER.info(Geonet.DATA_DIRECTORY_MARKER, "    - {} is {}", envKey, dir);
         return dir;
     }
 

--- a/core/src/main/java/org/fao/geonet/kernel/IndexMetadataTask.java
+++ b/core/src/main/java/org/fao/geonet/kernel/IndexMetadataTask.java
@@ -110,7 +110,7 @@ public final class IndexMetadataTask implements Runnable {
                     dataManager.indexMetadata(metadataId.toString(), false);
                 } catch (Exception e) {
                     LOGGER.error(Geonet.INDEX_MARKER, "Error indexing metadata '{}': {}",
-                        metadataId,e.getMessage(),e);
+                        metadataId, e.getMessage(), e);
                 }
             }
             if (_user != null && _context.getUserSession().getUserId() == null) {

--- a/core/src/main/java/org/fao/geonet/kernel/IndexMetadataTask.java
+++ b/core/src/main/java/org/fao/geonet/kernel/IndexMetadataTask.java
@@ -25,6 +25,7 @@ package org.fao.geonet.kernel;
 
 import jeeves.server.context.ServiceContext;
 
+import org.apache.logging.log4j.Logger;
 import org.fao.geonet.Util;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.User;
@@ -44,6 +45,7 @@ import javax.annotation.Nullable;
  * A runnable for indexing multiple metadata in a separate thread.
  */
 public final class IndexMetadataTask implements Runnable {
+    private static Logger LOGGER = Log.createLogger(IndexMetadataTask.class,Geonet.DATA_DIRECTORY_MARKER);
 
     private final ServiceContext _context;
     private final List<?> _metadataIds;
@@ -88,9 +90,7 @@ public final class IndexMetadataTask implements Runnable {
             }
             // poll context to see whether servlet is up yet
             while (!_context.isServletInitialized()) {
-                if (Log.isDebugEnabled(Geonet.DATA_MANAGER)) {
-                    Log.debug(Geonet.DATA_MANAGER, "Waiting for servlet to finish initializing..");
-                }
+                LOGGER.debug(Geonet.DATA_MANAGER_MARKER, "Waiting for servlet to finish initializing..");
                 try {
                     Thread.sleep(10000); // sleep 10 seconds
                 } catch (InterruptedException e) {
@@ -109,8 +109,8 @@ public final class IndexMetadataTask implements Runnable {
                 try {
                     dataManager.indexMetadata(metadataId.toString(), false);
                 } catch (Exception e) {
-                    Log.error(Geonet.INDEX_ENGINE, "Error indexing metadata '" + metadataId + "': " + e.getMessage()
-                        + "\n" + Util.getStackTrace(e));
+                    LOGGER.error(Geonet.INDEX_MARKER, "Error indexing metadata '{}': {}",
+                        metadataId,e.getMessage(),e);
                 }
             }
             if (_user != null && _context.getUserSession().getUserId() == null) {

--- a/core/src/main/java/org/fao/geonet/kernel/SchemaManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/SchemaManager.java
@@ -132,15 +132,15 @@ public class SchemaManager {
             catalogProp = "";
         }
         if (!catalogProp.equals("")) {
-            LOGGER.info(Geonet.SCHEMA_MANAGER_MARKER, "Overriding " + Constants.XML_CATALOG_FILES + " property (was set to " + catalogProp + ")");
+            LOGGER.info(Geonet.SCHEMA_MANAGER_MARKER, "Overriding {}  property (was set to {})", Constants.XML_CATALOG_FILES, catalogProp);
         }
         catalogProp = webInf.resolve("oasis-catalog.xml") + ";" + schemapluginUriCatalog;
         System.setProperty(Constants.XML_CATALOG_FILES, catalogProp);
-        LOGGER.info(Geonet.SCHEMA_MANAGER_MARKER, Constants.XML_CATALOG_FILES + " property set to " + catalogProp);
+        LOGGER.info(Geonet.SCHEMA_MANAGER_MARKER, "{} property set to {}", Constants.XML_CATALOG_FILES, catalogProp);
 
         Path blankXSLFile = webappDir.resolve("xsl").resolve("blanks.xsl");
         System.setProperty(Constants.XML_CATALOG_BLANKXSLFILE, blankXSLFile.toUri().toASCIIString());
-        LOGGER.info(Geonet.SCHEMA_MANAGER_MARKER, Constants.XML_CATALOG_BLANKXSLFILE + " property set to " + blankXSLFile);
+        LOGGER.info(Geonet.SCHEMA_MANAGER_MARKER,  "{} property set to {}", Constants.XML_CATALOG_BLANKXSLFILE, blankXSLFile);
 
         return webInf;
     }
@@ -167,10 +167,9 @@ public class SchemaManager {
             }
         } catch (Exception e) {
             // No bean for this schema
-            if (LOGGER.isDebugEnabled(Geonet.SCHEMA_MANAGER_MARKER)) {
-                LOGGER.debug(Geonet.SCHEMA_MANAGER_MARKER, "No bean defined for the schema plugin '{}'. {}",
-                    schemaIdentifier, e.getMessage(),e);
-            }
+            LOGGER.debug(Geonet.SCHEMA_MANAGER_MARKER,
+                    "No bean defined for the schema plugin '{}'. {}",
+                    schemaIdentifier, e.getMessage(), e);
         }
         return schemaPlugin;
     }
@@ -233,7 +232,7 @@ public class SchemaManager {
             for (Path schemaDir : saSchemas) {
                 if (!schemaDir.getFileName().toString().equals("CVS") && !schemaDir.getFileName().startsWith(".")) {
                     if (Files.isDirectory(schemaDir)) {
-                        LOGGER.info(Geonet.SCHEMA_MANAGER_MARKER, "Loading schema {} ...",schemaDir.getFileName());
+                        LOGGER.info(Geonet.SCHEMA_MANAGER_MARKER, "Loading schema {} ...", schemaDir.getFileName());
                         processSchema(applicationContext, schemaDir, schemaPluginCatRoot);
                     }
                 }
@@ -818,13 +817,13 @@ public class SchemaManager {
                     for (Element depends : dependsList) {
                         LOGGER.debug(
                             Geonet.SCHEMA_MANAGER_MARKER,
-                            "  checkNamespace for dependency: {}",depends.getText());
+                            "  checkNamespace for dependency: {}", depends.getText());
                         return checkNamespace(md, depends.getText());
                     }
                 }
             }
         } catch (Exception e) {
-            LOGGER.warn(Geonet.SCHEMA_MANAGER_MARKER, "Schema {} not registered?",schema);
+            LOGGER.warn(Geonet.SCHEMA_MANAGER_MARKER, "Schema {} not registered?", schema);
         }
 
         return result;
@@ -987,7 +986,7 @@ public class SchemaManager {
                 config.setAttribute("base", locBase.toUri().toString());
                 config.setAttribute("file", fname);
                 if (LOGGER.isDebugEnabled(Geonet.SCHEMA_MANAGER_MARKER))
-                    LOGGER.debug(Geonet.SCHEMA_MANAGER_MARKER, "Adding XmlFile " + Xml.getString(config));
+                    LOGGER.debug(Geonet.SCHEMA_MANAGER_MARKER, "Adding XmlFile {}", Xml.getString(config));
                 XmlFile xf = new XmlFile(config, defaultLang, true);
                 xfMap.put(fname, xf);
             } else {
@@ -1002,7 +1001,7 @@ public class SchemaManager {
         mds.setReadwriteUUID(extractReadWriteUuid(xmlIdFile));
         mds.setOperationFilters(extractOperationFilters(xmlIdFile));
 
-        LOGGER.debug(Geonet.SCHEMA_MANAGER_MARKER, "  UUID is read/write mode: " + mds.isReadwriteUUID());
+        LOGGER.debug(Geonet.SCHEMA_MANAGER_MARKER, "  UUID is read/write mode: {}", mds.isReadwriteUUID());
 
         putSchemaInfo(
             schemaName,
@@ -1021,7 +1020,7 @@ public class SchemaManager {
         LOGGER.debug(
                 Geonet.SCHEMA_MANAGER_MARKER,
                 "Property {} is {}",
-                Constants.XML_CATALOG_FILES,System.getProperty(Constants.XML_CATALOG_FILES));
+                Constants.XML_CATALOG_FILES, System.getProperty(Constants.XML_CATALOG_FILES));
 
         // -- Add entry for presentation xslt to schemaPlugins catalog
         // -- if this schema is a plugin schema
@@ -1095,7 +1094,7 @@ public class SchemaManager {
             else continue; // skip this
 
             if (!uri.getName().equals("uri") || !uri.getNamespace().equals(Namespaces.OASIS_CATALOG)) {
-                LOGGER.debug(Geonet.SCHEMA_MANAGER_MARKER, "Skipping element {}:{}",uri.getQualifiedName(), uri.getNamespace());
+                LOGGER.debug(Geonet.SCHEMA_MANAGER_MARKER, "Skipping element {}:{}", uri.getQualifiedName(), uri.getNamespace());
                 continue;
             }
 
@@ -1129,7 +1128,7 @@ public class SchemaManager {
             else continue; // skip this
 
             if (!uri.getName().equals("rewriteURI") || !uri.getNamespace().equals(Namespaces.OASIS_CATALOG)) {
-                LOGGER.debug(Geonet.SCHEMA_MANAGER_MARKER, "Skipping element {}:{}", uri.getQualifiedName(),uri.getNamespace());
+                LOGGER.debug(Geonet.SCHEMA_MANAGER_MARKER, "Skipping element {}:{}", uri.getQualifiedName(), uri.getNamespace());
                 continue;
             }
 
@@ -1293,12 +1292,12 @@ public class SchemaManager {
         Path conversionsFile = schemasDir.resolve(Geonet.File.SCHEMA_CONVERSIONS);
 
         if (!Files.exists(idFile)) {
-            LOGGER.error(Geonet.SCHEMA_MANAGER_MARKER, "    Skipping : " + schemasDir.getFileName() + " as it doesn't have " +
+            LOGGER.error(Geonet.SCHEMA_MANAGER_MARKER, "    Skipping : {}  as it doesn't have [] ", schemasDir.getFileName(), 
                 Geonet.File.SCHEMA_ID);
             return;
         }
 
-        LOGGER.info(Geonet.SCHEMA_MANAGER_MARKER, "    Adding xml schema : {}",schemasDir.getFileName());
+        LOGGER.info(Geonet.SCHEMA_MANAGER_MARKER, "    Adding xml schema : {}", schemasDir.getFileName());
 
         String stage = "";
         try {
@@ -1367,9 +1366,8 @@ public class SchemaManager {
             Version schemaMinorAppVersion = Version.parseVersionNumber(minorAppVersionSupported);
 
             if (appVersion.compareTo(schemaMinorAppVersion) < 0) {
-                LOGGER.error(Geonet.SCHEMA_MANAGER_MARKER, "Schema " + schemaName +
-                    " requires min Geonetwork version: " + minorAppVersionSupported + ", current is: " +
-                    version + ". Skip load schema.");
+                LOGGER.error(Geonet.SCHEMA_MANAGER_MARKER,
+                    "Schema {} requires min Geonetwork version: {}, current is: {}. Skip load schema.", schemaName, minorAppVersionSupported, version);
                 removes.add(schemaName);
                 continue;
             }
@@ -1379,9 +1377,9 @@ public class SchemaManager {
                 Version schemaMajorAppVersion = Version.parseVersionNumber(majorAppVersionSupported);
 
                 if (appVersion.compareTo(schemaMajorAppVersion) > 0) {
-                    LOGGER.error(Geonet.SCHEMA_MANAGER_MARKER, "Schema " + schemaName +
-                        " requires max Geonetwork version: " + majorAppVersionSupported + ", current is: " +
-                        version + ". Skip load schema.");
+                    LOGGER.error(Geonet.SCHEMA_MANAGER_MARKER,
+                        "Schema {} requires max Geonetwork version: {}, current is: {}. Skip load schema.",
+                        schemaName, majorAppVersionSupported, version);
                     removes.add(schemaName);
                     continue;
                 }
@@ -1631,7 +1629,9 @@ public class SchemaManager {
 
             for (Element elem : adElems) {
                 if (LOGGER.isDebugEnabled(Geonet.SCHEMA_MANAGER_MARKER))
-                    LOGGER.debug(Geonet.SCHEMA_MANAGER_MARKER, "		Checking autodetect element " + Xml.getString(elem) + " with name " + elem.getName());
+                    LOGGER.debug(Geonet.SCHEMA_MANAGER_MARKER,
+                        "		Checking autodetect element {} with name {}",
+                        Xml.getString(elem), elem.getName());
 
                 @SuppressWarnings("unchecked")
                 List<Element> elemKids = elem.getChildren();
@@ -1675,7 +1675,10 @@ public class SchemaManager {
                             if (LOGGER.isDebugEnabled(Geonet.SCHEMA_MANAGER_MARKER))
                                 LOGGER.debug(
                                     Geonet.SCHEMA_MANAGER_MARKER,
-                                    "				Comparing " + Xml.getString(kid) + " with " + md.getName() + " with namespace " + md.getNamespace() + " : " + (kid.getName().equals(md.getName()) && kid.getNamespace().equals(md.getNamespace())));
+                                    "				Comparing {} with {}  with namespace {}: {}",
+                                    Xml.getString(kid), md.getName(), md.getNamespace(),
+                                    (kid.getName().equals(md.getName()) && kid.getNamespace().equals(md.getNamespace()))
+                                );
                             if (kid.getName().equals(md.getName()) &&
                                 kid.getNamespace().equals(md.getNamespace())) {
                                 match = true;
@@ -1819,7 +1822,7 @@ public class SchemaManager {
                     returnVal = Pattern.matches(needleVal, tempVal);
                     LOGGER.debug(
                         Geonet.SCHEMA_MANAGER_MARKER,
-                        "    Pattern {} applied to value{} match: {}",
+                        "    Pattern {} applied to value {} match: {}",
                         needleVal, tempVal, returnVal);
 
                     if (returnVal) {
@@ -1898,7 +1901,7 @@ public class SchemaManager {
             }
 
             if (missingXsdFiles) {
-                LOGGER.error(Geonet.SCHEMA_MANAGER_MARKER, "Schema " + name + " does not have any XSD files!");
+                LOGGER.error(Geonet.SCHEMA_MANAGER_MARKER, "Schema {} does not have any XSD files!", name);
             }
         }
 

--- a/core/src/main/java/org/fao/geonet/kernel/SchemaManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/SchemaManager.java
@@ -31,6 +31,7 @@ import com.google.common.annotations.VisibleForTesting;
 import jeeves.server.context.ServiceContext;
 import jeeves.server.dispatchers.guiservices.XmlFile;
 import org.apache.commons.lang.StringUtils;
+import org.apache.logging.log4j.Logger;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.Constants;
 import org.fao.geonet.SystemInfo;
@@ -90,6 +91,8 @@ import java.util.regex.Pattern;
  */
 public class SchemaManager {
 
+    private static Logger LOGGER = Log.createLogger(SchemaManager.class,Geonet.SCHEMA_MANAGER_MARKER);
+
     private static final int MODE_NEEDLE = 0;
     private static final int MODE_ROOT = 1;
     private static final int MODE_NEEDLEWITHVALUE = 2;
@@ -129,15 +132,15 @@ public class SchemaManager {
             catalogProp = "";
         }
         if (!catalogProp.equals("")) {
-            Log.info(Geonet.SCHEMA_MANAGER, "Overriding " + Constants.XML_CATALOG_FILES + " property (was set to " + catalogProp + ")");
+            LOGGER.info(Geonet.SCHEMA_MANAGER_MARKER, "Overriding " + Constants.XML_CATALOG_FILES + " property (was set to " + catalogProp + ")");
         }
         catalogProp = webInf.resolve("oasis-catalog.xml") + ";" + schemapluginUriCatalog;
         System.setProperty(Constants.XML_CATALOG_FILES, catalogProp);
-        Log.info(Geonet.SCHEMA_MANAGER, Constants.XML_CATALOG_FILES + " property set to " + catalogProp);
+        LOGGER.info(Geonet.SCHEMA_MANAGER_MARKER, Constants.XML_CATALOG_FILES + " property set to " + catalogProp);
 
         Path blankXSLFile = webappDir.resolve("xsl").resolve("blanks.xsl");
         System.setProperty(Constants.XML_CATALOG_BLANKXSLFILE, blankXSLFile.toUri().toASCIIString());
-        Log.info(Geonet.SCHEMA_MANAGER, Constants.XML_CATALOG_BLANKXSLFILE + " property set to " + blankXSLFile);
+        LOGGER.info(Geonet.SCHEMA_MANAGER_MARKER, Constants.XML_CATALOG_BLANKXSLFILE + " property set to " + blankXSLFile);
 
         return webInf;
     }
@@ -164,10 +167,9 @@ public class SchemaManager {
             }
         } catch (Exception e) {
             // No bean for this schema
-            if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER)) {
-                Log.debug(Geonet.SCHEMA_MANAGER, "No bean defined for the schema plugin '" +
-                    schemaIdentifier + "'. " +
-                    e.getMessage());
+            if (LOGGER.isDebugEnabled(Geonet.SCHEMA_MANAGER_MARKER)) {
+                LOGGER.debug(Geonet.SCHEMA_MANAGER_MARKER, "No bean defined for the schema plugin '{}'. {}",
+                    schemaIdentifier, e.getMessage(),e);
             }
         }
         return schemaPlugin;
@@ -231,7 +233,7 @@ public class SchemaManager {
             for (Path schemaDir : saSchemas) {
                 if (!schemaDir.getFileName().toString().equals("CVS") && !schemaDir.getFileName().startsWith(".")) {
                     if (Files.isDirectory(schemaDir)) {
-                        Log.info(Geonet.SCHEMA_MANAGER, "Loading schema " + schemaDir.getFileName() + "...");
+                        LOGGER.info(Geonet.SCHEMA_MANAGER_MARKER, "Loading schema {} ...",schemaDir.getFileName());
                         processSchema(applicationContext, schemaDir, schemaPluginCatRoot);
                     }
                 }
@@ -360,7 +362,7 @@ public class SchemaManager {
                 realDeletePluginSchema(name, doDependencies);
             } catch (Exception e) {
                 String errStr = "Could not update schema " + name + ", remove of outdated schema failed. Exception message if any is " + e.getMessage();
-                Log.error(Geonet.SCHEMA_MANAGER, errStr, e);
+                LOGGER.error(Geonet.SCHEMA_MANAGER_MARKER, errStr, e);
                 throw new OperationAbortedEx(errStr, e);
             }
 
@@ -713,39 +715,49 @@ public class SchemaManager {
             // -- first match wins
             schema = compareElementsAndAttributes(md, MODE_ATTRIBUTEWITHVALUE);
             if (schema != null) {
-                if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER))
-                    Log.debug(Geonet.SCHEMA_MANAGER, "  => Found schema " + schema + " using AUTODETECT(attributes) examination");
+                LOGGER.debug(
+                    Geonet.SCHEMA_MANAGER_MARKER,
+                    "  => Found schema {} using AUTODETECT(attributes) examination",
+                    schema);
             }
 
             if (schema == null) {
                 schema = compareElementsAndAttributes(md, MODE_NEEDLEWITHVALUE);
                 if (schema != null) {
-                    if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER))
-                        Log.debug(Geonet.SCHEMA_MANAGER, "  => Found schema " + schema + " using AUTODETECT(elements with value) examination");
+                    LOGGER.debug(
+                        Geonet.SCHEMA_MANAGER_MARKER,
+                        "  => Found schema {} using AUTODETECT(elements with value) examination",
+                        schema);
                 }
             }
 
             if (schema == null) {
                 schema = compareElementsAndAttributes(md, MODE_NEEDLE);
                 if (schema != null) {
-                    if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER))
-                        Log.debug(Geonet.SCHEMA_MANAGER, "  => Found schema " + schema + " using AUTODETECT(elements) examination");
+                    LOGGER.debug(
+                        Geonet.SCHEMA_MANAGER_MARKER,
+                        "  => Found schema {} using AUTODETECT(elements) examination",
+                        schema);
                 }
             }
 
             if (schema == null) {
                 schema = compareElementsAndAttributes(md, MODE_ROOT);
                 if (schema != null) {
-                    if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER))
-                        Log.debug(Geonet.SCHEMA_MANAGER, "  => Found schema " + schema + " using AUTODETECT(elements with root) examination");
+                    LOGGER.debug(
+                        Geonet.SCHEMA_MANAGER_MARKER,
+                        "  => Found schema {} using AUTODETECT(elements with root) examination",
+                        schema);
                 }
             }
 
             if (schema == null) {
                 schema = compareElementsAndAttributes(md, MODE_NAMESPACE);
                 if (schema != null) {
-                    if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER))
-                        Log.debug(Geonet.SCHEMA_MANAGER, "  => Found schema " + schema + " using AUTODETECT(namespaces) examination");
+                    LOGGER.debug(
+                        Geonet.SCHEMA_MANAGER_MARKER,
+                        "  => Found schema {} using AUTODETECT(namespaces) examination",
+                        schema);
                 }
             }
 
@@ -754,8 +766,10 @@ public class SchemaManager {
             if (schema == null && defaultSchema != null) {
                 String defaultSchemaOrDependencySchema = checkNamespace(md, defaultSchema);
                 if (defaultSchemaOrDependencySchema != null) {
-                    Log.warning(Geonet.SCHEMA_MANAGER, "  Autodetecting schema failed for " + md.getName() + " in namespace " + md.getNamespace()
-                        + ". Using default schema or one of its dependency: " + defaultSchemaOrDependencySchema);
+                    LOGGER.warn(
+                        Geonet.SCHEMA_MANAGER_MARKER,
+                        "  Autodetecting schema failed for {} in namespace {}. Using default schema or one of its dependency: {}",
+                        md.getName(), md.getNamespace(), defaultSchemaOrDependencySchema);
                     schema = defaultSchemaOrDependencySchema;
                 }
             }
@@ -789,8 +803,10 @@ public class SchemaManager {
             MetadataSchema mds = getSchema(schema);
             if (mds != null) {
                 String primeNs = mds.getPrimeNS();
-                if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER))
-                    Log.debug(Geonet.SCHEMA_MANAGER, "  primeNs " + primeNs + " for schema " + schema);
+                LOGGER.debug(
+                    Geonet.SCHEMA_MANAGER_MARKER,
+                    "  primeNs {} for schema {}",
+                    primeNs, schema);
                 if (md.getNamespace().getURI().equals(primeNs)) {
                     result = schema;
                 } else {
@@ -800,14 +816,15 @@ public class SchemaManager {
                     Schema sch = hmSchemas.get(schema);
                     List<Element> dependsList = sch.getDependElements();
                     for (Element depends : dependsList) {
-                        if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER))
-                            Log.debug(Geonet.SCHEMA_MANAGER, "  checkNamespace for dependency: " + depends.getText());
+                        LOGGER.debug(
+                            Geonet.SCHEMA_MANAGER_MARKER,
+                            "  checkNamespace for dependency: {}",depends.getText());
                         return checkNamespace(md, depends.getText());
                     }
                 }
             }
         } catch (Exception e) {
-            Log.warning(Geonet.SCHEMA_MANAGER, "Schema " + schema + " not registered?");
+            LOGGER.warn(Geonet.SCHEMA_MANAGER_MARKER, "Schema {} not registered?",schema);
         }
 
         return result;
@@ -871,7 +888,7 @@ public class SchemaManager {
                 List<String> dependsOnMe = getSchemasThatDependOnMe(name);
                 if (dependsOnMe.size() > 0) {
                     String errStr = "Cannot remove schema " + name + " because the following schemas list it as a dependency: " + dependsOnMe;
-                    Log.error(Geonet.SCHEMA_MANAGER, errStr);
+                    LOGGER.error(Geonet.SCHEMA_MANAGER_MARKER, errStr);
                     throw new OperationAbortedEx(errStr);
                 }
             }
@@ -905,7 +922,7 @@ public class SchemaManager {
 
             writeSchemaPluginCatalog(schemaPluginCatRoot);
         } catch (Exception e) {
-            Log.error(Geonet.SCHEMA_MANAGER, e.getMessage(), e);
+            LOGGER.error(Geonet.SCHEMA_MANAGER_MARKER, e.getMessage(), e);
             hmSchemas.remove(name);
             IO.deleteFileOrDirectory(schemaDir);
             throw new OperationAbortedEx("Failed to add schema " + name + " : " + e.getMessage(), e);
@@ -963,19 +980,18 @@ public class SchemaManager {
 
         for (String fname : fnames) {
             Path filePath = path.resolve("loc").resolve(defaultLang).resolve(fname);
-            if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER))
-                Log.debug(Geonet.SCHEMA_MANAGER, "Searching for " + filePath);
+            LOGGER.debug(Geonet.SCHEMA_MANAGER_MARKER, "Searching for {}", filePath);
             if (Files.exists(filePath)) {
                 Element config = new Element("xml");
                 config.setAttribute("name", schemaName);
                 config.setAttribute("base", locBase.toUri().toString());
                 config.setAttribute("file", fname);
-                if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER))
-                    Log.debug(Geonet.SCHEMA_MANAGER, "Adding XmlFile " + Xml.getString(config));
+                if (LOGGER.isDebugEnabled(Geonet.SCHEMA_MANAGER_MARKER))
+                    LOGGER.debug(Geonet.SCHEMA_MANAGER_MARKER, "Adding XmlFile " + Xml.getString(config));
                 XmlFile xf = new XmlFile(config, defaultLang, true);
                 xfMap.put(fname, xf);
             } else {
-                Log.warning(Geonet.SCHEMA_MANAGER, "Unable to load loc file: " + filePath);
+                LOGGER.warn(Geonet.SCHEMA_MANAGER_MARKER, "Unable to load loc file: {}", filePath);
             }
         }
 
@@ -986,7 +1002,7 @@ public class SchemaManager {
         mds.setReadwriteUUID(extractReadWriteUuid(xmlIdFile));
         mds.setOperationFilters(extractOperationFilters(xmlIdFile));
 
-        Log.debug(Geonet.SCHEMA_MANAGER, "  UUID is read/write mode: " + mds.isReadwriteUUID());
+        LOGGER.debug(Geonet.SCHEMA_MANAGER_MARKER, "  UUID is read/write mode: " + mds.isReadwriteUUID());
 
         putSchemaInfo(
             schemaName,
@@ -1002,9 +1018,10 @@ public class SchemaManager {
             extractConvElements(conversionsFile),
             extractDepends(xmlIdFile));
 
-        if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER)) {
-            Log.debug(Geonet.SCHEMA_MANAGER, "Property " + Constants.XML_CATALOG_FILES + " is " + System.getProperty(Constants.XML_CATALOG_FILES));
-        }
+        LOGGER.debug(
+                Geonet.SCHEMA_MANAGER_MARKER,
+                "Property {} is {}",
+                Constants.XML_CATALOG_FILES,System.getProperty(Constants.XML_CATALOG_FILES));
 
         // -- Add entry for presentation xslt to schemaPlugins catalog
         // -- if this schema is a plugin schema
@@ -1078,8 +1095,7 @@ public class SchemaManager {
             else continue; // skip this
 
             if (!uri.getName().equals("uri") || !uri.getNamespace().equals(Namespaces.OASIS_CATALOG)) {
-                if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER))
-                    Log.debug(Geonet.SCHEMA_MANAGER, "Skipping element " + uri.getQualifiedName() + ":" + uri.getNamespace());
+                LOGGER.debug(Geonet.SCHEMA_MANAGER_MARKER, "Skipping element {}:{}",uri.getQualifiedName(), uri.getNamespace());
                 continue;
             }
 
@@ -1113,8 +1129,7 @@ public class SchemaManager {
             else continue; // skip this
 
             if (!uri.getName().equals("rewriteURI") || !uri.getNamespace().equals(Namespaces.OASIS_CATALOG)) {
-                if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER))
-                    Log.debug(Geonet.SCHEMA_MANAGER, "Skipping element " + uri.getQualifiedName() + ":" + uri.getNamespace());
+                LOGGER.debug(Geonet.SCHEMA_MANAGER_MARKER, "Skipping element {}:{}", uri.getQualifiedName(),uri.getNamespace());
                 continue;
             }
 
@@ -1133,7 +1148,7 @@ public class SchemaManager {
         try {
             baseNrInt = Integer.parseInt(baseNr);
         } catch (NumberFormatException nfe) {
-            Log.error(Geonet.SCHEMA_MANAGER, "Cannot decode blank number from " + baseBlank, nfe);
+            LOGGER.error(Geonet.SCHEMA_MANAGER_MARKER, "Cannot decode blank number from {}", baseBlank, nfe);
             throw new IllegalArgumentException("Cannot decode blank number from " + baseBlank);
         }
         return baseNrInt;
@@ -1255,15 +1270,11 @@ public class SchemaManager {
         // -- FIXME: get schema directory and zip it up into the deleted metadata
         // -- directory?
 
-        if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER)) {
-            Log.debug(Geonet.SCHEMA_MANAGER, "Removing schema directory " + schemaDir);
-        }
+        LOGGER.debug(Geonet.SCHEMA_MANAGER_MARKER, "Removing schema directory {}", schemaDir);
         deleteDir(schemaDir);
 
         Path pubSchemaDir = resourcePath.resolve(Geonet.Path.SCHEMAS).resolve(name);
-        if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER)) {
-            Log.debug(Geonet.SCHEMA_MANAGER, "Removing published schemas directory " + pubSchemaDir);
-        }
+        LOGGER.debug(Geonet.SCHEMA_MANAGER_MARKER, "Removing published schemas directory {}", pubSchemaDir);
         deleteDir(pubSchemaDir);
     }
 
@@ -1282,12 +1293,12 @@ public class SchemaManager {
         Path conversionsFile = schemasDir.resolve(Geonet.File.SCHEMA_CONVERSIONS);
 
         if (!Files.exists(idFile)) {
-            Log.error(Geonet.SCHEMA_MANAGER, "    Skipping : " + schemasDir.getFileName() + " as it doesn't have " +
+            LOGGER.error(Geonet.SCHEMA_MANAGER_MARKER, "    Skipping : " + schemasDir.getFileName() + " as it doesn't have " +
                 Geonet.File.SCHEMA_ID);
             return;
         }
 
-        Log.info(Geonet.SCHEMA_MANAGER, "    Adding xml schema : " + schemasDir.getFileName());
+        LOGGER.info(Geonet.SCHEMA_MANAGER_MARKER, "    Adding xml schema : {}",schemasDir.getFileName());
 
         String stage = "";
         try {
@@ -1299,7 +1310,7 @@ public class SchemaManager {
 
             final String schemaName = schemasDir.getFileName().toString();
             if (hmSchemas.containsKey(schemaName)) { // exists so ignore it
-                Log.error(Geonet.SCHEMA_MANAGER, "Schema " + schemaName + " already exists - cannot add!");
+                LOGGER.error(Geonet.SCHEMA_MANAGER_MARKER, "Schema " + schemaName + " already exists - cannot add!");
             } else {
                 stage = "adding the schema information";
                 addSchema(applicationContext, schemasDir, schemaPluginCatRoot, schemaFile, suggestFile, substitutesFile,
@@ -1308,7 +1319,7 @@ public class SchemaManager {
             }
         } catch (Exception e) {
             String errStr = "Failed whilst " + stage + ". Exception message if any is " + e.getMessage();
-            Log.error(Geonet.SCHEMA_MANAGER, errStr, e);
+            LOGGER.error(Geonet.SCHEMA_MANAGER_MARKER, errStr, e);
             throw new OperationAbortedEx(errStr, e);
         }
 
@@ -1326,7 +1337,7 @@ public class SchemaManager {
             try {
                 checkDepends(schemaName, schema.getDependElements());
             } catch (Exception e) {
-                Log.error(Geonet.SCHEMA_MANAGER, "check dependencies failed: " + e.getMessage());
+                LOGGER.error(Geonet.SCHEMA_MANAGER_MARKER, "check dependencies failed: " + e.getMessage());
                 // add the schema to list for removal
                 removes.add(schemaName);
             }
@@ -1356,7 +1367,7 @@ public class SchemaManager {
             Version schemaMinorAppVersion = Version.parseVersionNumber(minorAppVersionSupported);
 
             if (appVersion.compareTo(schemaMinorAppVersion) < 0) {
-                Log.error(Geonet.SCHEMA_MANAGER, "Schema " + schemaName +
+                LOGGER.error(Geonet.SCHEMA_MANAGER_MARKER, "Schema " + schemaName +
                     " requires min Geonetwork version: " + minorAppVersionSupported + ", current is: " +
                     version + ". Skip load schema.");
                 removes.add(schemaName);
@@ -1368,7 +1379,7 @@ public class SchemaManager {
                 Version schemaMajorAppVersion = Version.parseVersionNumber(majorAppVersionSupported);
 
                 if (appVersion.compareTo(schemaMajorAppVersion) > 0) {
-                    Log.error(Geonet.SCHEMA_MANAGER, "Schema " + schemaName +
+                    LOGGER.error(Geonet.SCHEMA_MANAGER_MARKER, "Schema " + schemaName +
                         " requires max Geonetwork version: " + majorAppVersionSupported + ", current is: " +
                         version + ". Skip load schema.");
                     removes.add(schemaName);
@@ -1572,8 +1583,7 @@ public class SchemaManager {
      */
     private List<Element> extractConvElements(Path xmlConvFile) throws Exception {
         if (!Files.exists(xmlConvFile)) {
-            if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER))
-                Log.debug(Geonet.SCHEMA_MANAGER, "Schema conversions file not present");
+            LOGGER.debug(Geonet.SCHEMA_MANAGER_MARKER, "Schema conversions file not present");
             return new ArrayList<Element>();
         } else {
             Element root = Xml.loadFile(xmlConvFile);
@@ -1609,18 +1619,19 @@ public class SchemaManager {
         Set<String> allSchemas = getSchemas();
         List<String> matches = new ArrayList<>();
 
-        if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER))
-            Log.debug(Geonet.SCHEMA_MANAGER, "Schema autodetection starting on " + md.getName() + " (Namespace: " + md.getNamespace() + ") using mode: " + mode + "...");
+        LOGGER.debug(
+            Geonet.SCHEMA_MANAGER_MARKER,
+            "Schema autodetection starting on {}  (Namespace: {}) using mode: {}...",
+            md.getName(), md.getNamespace(),mode);
 
         for (String schemaName : allSchemas) {
-            if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER))
-                Log.debug(Geonet.SCHEMA_MANAGER, "	Doing schema " + schemaName);
+            LOGGER.debug(Geonet.SCHEMA_MANAGER_MARKER, "	Doing schema {}", schemaName);
             Schema schema = hmSchemas.get(schemaName);
             List<Element> adElems = schema.getAutodetectElements();
 
             for (Element elem : adElems) {
-                if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER))
-                    Log.debug(Geonet.SCHEMA_MANAGER, "		Checking autodetect element " + Xml.getString(elem) + " with name " + elem.getName());
+                if (LOGGER.isDebugEnabled(Geonet.SCHEMA_MANAGER_MARKER))
+                    LOGGER.debug(Geonet.SCHEMA_MANAGER_MARKER, "		Checking autodetect element " + Xml.getString(elem) + " with name " + elem.getName());
 
                 @SuppressWarnings("unchecked")
                 List<Element> elemKids = elem.getChildren();
@@ -1633,9 +1644,7 @@ public class SchemaManager {
                     @SuppressWarnings("unchecked")
                     List<Attribute> atts = elem.getAttributes();
                     for (Attribute searchAtt : atts) {
-                        if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER))
-                            Log.debug(Geonet.SCHEMA_MANAGER, "				Finding attribute " + searchAtt.toString());
-
+                        LOGGER.debug(Geonet.SCHEMA_MANAGER_MARKER, "				Finding attribute {}", searchAtt);
                         if (isMatchingAttributeInMetadata(searchAtt, md)) {
                             match = true;
                         } else {
@@ -1649,8 +1658,7 @@ public class SchemaManager {
                     @SuppressWarnings("unchecked")
                     List<Namespace> nss = elem.getAdditionalNamespaces();
                     for (Namespace ns : nss) {
-                        if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER))
-                            Log.debug(Geonet.SCHEMA_MANAGER, "				Finding namespace " + ns.toString());
+                        LOGGER.debug(Geonet.SCHEMA_MANAGER_MARKER, "				Finding namespace {}", ns);
 
                         if (isMatchingNamespaceInMetadata(ns, md)) {
                             match = true;
@@ -1664,8 +1672,10 @@ public class SchemaManager {
 
                         // --- is the kid the same as the root of the md
                         if (mode == MODE_ROOT && type != null && "root".equals(type.getValue())) {
-                            if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER))
-                                Log.debug(Geonet.SCHEMA_MANAGER, "				Comparing " + Xml.getString(kid) + " with " + md.getName() + " with namespace " + md.getNamespace() + " : " + (kid.getName().equals(md.getName()) && kid.getNamespace().equals(md.getNamespace())));
+                            if (LOGGER.isDebugEnabled(Geonet.SCHEMA_MANAGER_MARKER))
+                                LOGGER.debug(
+                                    Geonet.SCHEMA_MANAGER_MARKER,
+                                    "				Comparing " + Xml.getString(kid) + " with " + md.getName() + " with namespace " + md.getNamespace() + " : " + (kid.getName().equals(md.getName()) && kid.getNamespace().equals(md.getNamespace())));
                             if (kid.getName().equals(md.getName()) &&
                                 kid.getNamespace().equals(md.getNamespace())) {
                                 match = true;
@@ -1675,9 +1685,15 @@ public class SchemaManager {
                             }
                             // --- try and find the kid in the md (kid only, not value)
                         } else if (mode == MODE_NEEDLE && type != null && "search".equals(type.getValue())) {
-                            if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER))
-                                Log.debug(Geonet.SCHEMA_MANAGER, "				Comparing " + Xml.getString(kid) + " with " + md.getName() + " with namespace " + md.getNamespace() + " : " + (kid.getName().equals(md.getName()) && kid.getNamespace().equals(md.getNamespace())));
-
+                            if (LOGGER.isDebugEnabled(Geonet.SCHEMA_MANAGER_MARKER )) {
+                                LOGGER.debug(Geonet.SCHEMA_MANAGER_MARKER,
+                                    "				Comparing {} with {} with namespace {} : ",
+                                    Xml.getString(kid),
+                                    md.getNamespace(),
+                                    md.getName(),
+                                    (kid.getName().equals(md.getName()) && kid.getNamespace().equals(md.getNamespace()))
+                                );
+                            }
                             if (isMatchingElementInMetadata(kid, md, false)) {
                                 match = true;
                             } else {
@@ -1720,8 +1736,7 @@ public class SchemaManager {
         @SuppressWarnings("unchecked")
         Iterator<Element> haystackIterator = haystack.getDescendants(new ElementFilter());
 
-        if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER))
-            Log.debug(Geonet.SCHEMA_MANAGER, "Matching " + needle.toString());
+        LOGGER.debug(Geonet.SCHEMA_MANAGER_MARKER, "Matching {}", needle.toString());
 
         while (haystackIterator.hasNext()) {
             Element tempElement = haystackIterator.next();
@@ -1742,8 +1757,7 @@ public class SchemaManager {
      * @param haystack the XML metadata record we are searching
      */
     private boolean isMatchingNamespaceInMetadata(Namespace needle, Element haystack) {
-        if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER))
-            Log.debug(Geonet.SCHEMA_MANAGER, "Matching " + needle.toString());
+        LOGGER.debug(Geonet.SCHEMA_MANAGER_MARKER, "Matching {}", needle);
 
         if (checkNamespacesOnElement(needle, haystack)) return true;
 
@@ -1789,23 +1803,25 @@ public class SchemaManager {
 
         String needleName = needle.getName();
         Namespace needleNS = needle.getNamespace();
-        if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER))
-            Log.debug(Geonet.SCHEMA_MANAGER, "Matching " + Xml.getString(needle));
+        if (LOGGER.isDebugEnabled(Geonet.SCHEMA_MANAGER_MARKER)) {
+            LOGGER.debug(Geonet.SCHEMA_MANAGER_MARKER, "Matching {}", Xml.getString(needle));
+        }
 
         while (haystackIterator.hasNext()) {
             Element tempElement = haystackIterator.next();
 
             if (tempElement.getName().equals(needleName) && tempElement.getNamespace().equals(needleNS)) {
                 if (checkValue) {
-                    if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER))
-                        Log.debug(Geonet.SCHEMA_MANAGER, "  Searching value for element: " + tempElement.getName());
+                    LOGGER.debug(Geonet.SCHEMA_MANAGER_MARKER, "  Searching value for element: {}", tempElement.getName());
 
                     String needleVal = StringUtils.deleteWhitespace(needle.getValue());
                     String tempVal = StringUtils.deleteWhitespace(tempElement.getValue());
                     returnVal = Pattern.matches(needleVal, tempVal);
-                    if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER)) {
-                        Log.debug(Geonet.SCHEMA_MANAGER, "    Pattern " + needleVal + " applied to value " + tempVal + " match: " + returnVal);
-                    }
+                    LOGGER.debug(
+                        Geonet.SCHEMA_MANAGER_MARKER,
+                        "    Pattern {} applied to value{} match: {}",
+                        needleVal, tempVal, returnVal);
+
                     if (returnVal) {
                         break;
                     }
@@ -1828,7 +1844,7 @@ public class SchemaManager {
         try {
             IO.deleteFileOrDirectory(dir);
         } catch (IOException e) {
-            Log.warning(Geonet.SCHEMA_MANAGER, "Unable to delete directory: " + dir);
+            LOGGER.warn(Geonet.SCHEMA_MANAGER_MARKER, "Unable to delete directory: {}", dir);
         }
     }
 
@@ -1882,7 +1898,7 @@ public class SchemaManager {
             }
 
             if (missingXsdFiles) {
-                Log.error(Geonet.SCHEMA_MANAGER, "Schema " + name + " does not have any XSD files!");
+                LOGGER.error(Geonet.SCHEMA_MANAGER_MARKER, "Schema " + name + " does not have any XSD files!");
             }
         }
 

--- a/core/src/main/java/org/fao/geonet/kernel/SchematronValidator.java
+++ b/core/src/main/java/org/fao/geonet/kernel/SchematronValidator.java
@@ -24,6 +24,7 @@
 package org.fao.geonet.kernel;
 
 import com.google.common.collect.Lists;
+import org.apache.logging.log4j.Logger;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.constants.Edit;
 import org.fao.geonet.constants.Geonet;
@@ -49,6 +50,8 @@ import java.util.List;
  * @author Jesse on 4/1/2015.
  */
 public class SchematronValidator extends AbstractSchematronValidator {
+
+    private static Logger LOGGER = Log.createLogger(SchematronValidator.class,Geonet.DATA_MANAGER_MARKER);
 
     public Element applyCustomSchematronRules(String schema, int metadataId, Element md,
                                               String lang,
@@ -106,9 +109,7 @@ public class SchematronValidator extends AbstractSchematronValidator {
 
 
             if (applicable.requirement != SchematronRequirement.DISABLED) {
-                if (Log.isDebugEnabled(Geonet.DATA_MANAGER)) {
-                    Log.debug(Geonet.DATA_MANAGER, " - rule:" + schematron.getRuleName());
-                }
+                LOGGER.debug(Geonet.DATA_MANAGER_MARKER, " - rule:{}", schematron.getRuleName());
 
                 applicableSchematron.add(applicable);
             }
@@ -141,10 +142,12 @@ public class SchematronValidator extends AbstractSchematronValidator {
             }
 
             if (apply) {
-                if (Log.isDebugEnabled(Geonet.DATA_MANAGER)) {
-                    Log.debug(Geonet.DATA_MANAGER, " - Schematron group is accepted:" + criteriaGroup.getId().getName() +
-                        " for schematron: " + schematron.getRuleName());
-                }
+                LOGGER.debug(
+                    Geonet.DATA_MANAGER_MARKER,
+                    " - Schematron group is accepted: {} for schematron: {}",
+                    criteriaGroup.getId().getName(),
+                    schematron.getRuleName());
+
                 requirement = requirement.highestRequirement(criteriaGroup.getRequirement());
             } else {
                 requirement = requirement.highestRequirement(SchematronRequirement.DISABLED);

--- a/core/src/main/java/org/fao/geonet/kernel/SchematronValidatorExternalMd.java
+++ b/core/src/main/java/org/fao/geonet/kernel/SchematronValidatorExternalMd.java
@@ -24,6 +24,7 @@
 package org.fao.geonet.kernel;
 
 import com.google.common.collect.Lists;
+import org.apache.logging.log4j.Logger;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.constants.Edit;
 import org.fao.geonet.constants.Geonet;
@@ -43,6 +44,8 @@ import java.util.*;
  *
  */
 public class SchematronValidatorExternalMd extends AbstractSchematronValidator {
+
+    private static final Logger LOGGER = Log.createLogger(SchematronValidatorExternalMd.class,Geonet.DATA_MANAGER_MARKER);
 
     public Element applyCustomSchematronRules(String schema, Element md,
                                               String lang, List<MetadataValidation> validations, Integer groupOwnerId) {
@@ -85,9 +88,7 @@ public class SchematronValidatorExternalMd extends AbstractSchematronValidator {
             final ApplicableSchematron applicable = getApplicableSchematron(md, metadataSchema, schematron, groupOwnerId);
 
             if (applicable.requirement != SchematronRequirement.DISABLED) {
-                if (Log.isDebugEnabled(Geonet.DATA_MANAGER)) {
-                    Log.debug(Geonet.DATA_MANAGER, " - rule:" + schematron.getRuleName());
-                }
+                LOGGER.debug(Geonet.DATA_MANAGER_MARKER, " - rule:{}", schematron.getRuleName());
 
                 applicableSchematron.add(applicable);
             }
@@ -125,10 +126,12 @@ public class SchematronValidatorExternalMd extends AbstractSchematronValidator {
             }
 
             if (apply) {
-                if (Log.isDebugEnabled(Geonet.DATA_MANAGER)) {
-                    Log.debug(Geonet.DATA_MANAGER, " - Schematron group is accepted:" + criteriaGroup.getId().getName() +
-                        " for schematron: " + schematron.getRuleName());
-                }
+                LOGGER.debug(
+                    Geonet.DATA_MANAGER_MARKER,
+                    " - Schematron group is accepted:{} for schematron: {}",
+                    criteriaGroup.getId().getName(),
+                    schematron.getRuleName());
+
                 requirement = requirement.highestRequirement(criteriaGroup.getRequirement());
             } else {
                 requirement = requirement.highestRequirement(SchematronRequirement.DISABLED);

--- a/core/src/main/java/org/fao/geonet/kernel/SvnManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/SvnManager.java
@@ -40,6 +40,7 @@ import javax.annotation.Nonnull;
 import javax.sql.DataSource;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.logging.log4j.Logger;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.Constants;
 import org.fao.geonet.constants.Geonet;
@@ -91,6 +92,8 @@ import jeeves.transaction.BeforeRollbackTransactionListener;
 import static org.fao.geonet.kernel.setting.Settings.METADATA_VCS;
 
 public class SvnManager implements AfterCommitTransactionListener, BeforeRollbackTransactionListener {
+
+    private static final Logger LOGGER = Log.createLogger(SvnManager.class,Geonet.SVN_MANAGER_MARKER);
     private static String username = "geonetwork";
     private static String password = "geonetwork";
     // configure via setter in Geonetwork app
@@ -111,7 +114,7 @@ public class SvnManager implements AfterCommitTransactionListener, BeforeRollbac
 
         SettingManager _settingManager = ApplicationContextHolder.get().getBean(SettingManager.class);
         if (!_settingManager.getValueAsBool(METADATA_VCS)) {
-            Log.debug(Geonet.SVN_MANAGER, String.format(
+            LOGGER.debug(Geonet.SVN_MANAGER_MARKER, String.format(
                 "VCS is disabled. Change the %s setting and restart the application", METADATA_VCS
             ));
             return;
@@ -144,7 +147,7 @@ public class SvnManager implements AfterCommitTransactionListener, BeforeRollbac
                 repoUrl = SVNURL.fromFile(subFile);
 
             } else {
-                Log.error(Geonet.SVN_MANAGER, "Problem creating or using repository at path " + subversionPath + ", " + e.getMessage(),  e);
+                LOGGER.error(Geonet.SVN_MANAGER_MARKER, "Problem creating or using repository at path " + subversionPath + ", " + e.getMessage(),  e);
                 throw new IllegalArgumentException("Problem creating or using repository at path " + subversionPath);
             }
         }
@@ -154,7 +157,7 @@ public class SvnManager implements AfterCommitTransactionListener, BeforeRollbac
         try {
             repo = getRepository();
         } catch (SVNException se) {
-            Log.error(Geonet.SVN_MANAGER, "Failed to open subversion repo at path " + subversionPath, se);
+            LOGGER.error(Geonet.SVN_MANAGER_MARKER, "Failed to open subversion repo at path " + subversionPath, se);
             throw se;
         }
 
@@ -173,8 +176,7 @@ public class SvnManager implements AfterCommitTransactionListener, BeforeRollbac
                 // if nothing in repo and it doesn't have the uuid we expect then
                 // recreate it and reopen it
                 if (!uuid.equals(repoUuid)) {
-                    Log.warning(Geonet.SVN_MANAGER, "Recreating subversion repository at " + subversionPath
-                        + " as previous repository was empty");
+                    LOGGER.warn(Geonet.SVN_MANAGER_MARKER, "Recreating subversion repository at {} as previous repository was empty",subversionPath);
                     boolean enableRevisionProperties = true;
                     boolean force = true;
                     repoUrl = SVNRepositoryFactory.createLocalRepository(subFile, uuid, enableRevisionProperties, force);
@@ -205,8 +207,8 @@ public class SvnManager implements AfterCommitTransactionListener, BeforeRollbac
             SvnUtils.modifyFileProps(editor, "/", props);
             editor.closeDir();
             SVNCommitInfo info = editor.closeEdit();
-            if (Log.isDebugEnabled(Geonet.SVN_MANAGER))
-                Log.debug(Geonet.SVN_MANAGER, "Committed " + dbUrl + " as property " + Params.Svn.DBURLPROP + ":" + info);
+            LOGGER.debug(Geonet.SVN_MANAGER_MARKER,
+                "Committed {} as property {}:{}", dbUrl, Params.Svn.DBURLPROP, info);
         } else {
             // get database URL from root of repository and check against dbUrl
             // if it doesn't match then stop
@@ -246,15 +248,14 @@ public class SvnManager implements AfterCommitTransactionListener, BeforeRollbac
                     it.remove();
                 }
                 editor.closeDir(); // close the root directory.
-                if (Log.isDebugEnabled(Geonet.SVN_MANAGER))
-                    Log.debug(Geonet.SVN_MANAGER, "Committed changes to subversion repository for metadata ids " + task.ids);
+                LOGGER.debug(Geonet.SVN_MANAGER_MARKER, "Committed changes to subversion repository for metadata ids {}", task.ids);
             } catch (Exception e) {
-                Log.error(Geonet.SVN_MANAGER, "Failed to commit changes to subversion repository for metadata ids " + task.ids, e);
+                LOGGER.error(Geonet.SVN_MANAGER_MARKER, "Failed to commit changes to subversion repository for metadata ids {}", task.ids, e);
                 if (editor != null) {
                     try {
                         editor.abortEdit();
                     } catch (Exception ex) {
-                        Log.error(Geonet.SVN_MANAGER, "Failed to abort subversion editor", ex);
+                        LOGGER.error(Geonet.SVN_MANAGER_MARKER, "Failed to abort subversion editor", ex);
                     }
                 }
             } finally {
@@ -345,20 +346,19 @@ public class SvnManager implements AfterCommitTransactionListener, BeforeRollbac
         if (!exists(id))
             return; // not in repo so exit
 
-        if (Log.isDebugEnabled(Geonet.SVN_MANAGER))
-            Log.debug(Geonet.SVN_MANAGER, "History will be recorded on metadata " + id);
+        LOGGER.debug(Geonet.SVN_MANAGER_MARKER, "History will be recorded on metadata {}", id);
 
         final Map<String, String> props = sessionToProps(context, new HashMap<String, String>());
 
         try {
             final TransactionStatus status = TransactionAspectSupport.currentTransactionStatus();
             checkSvnTask(status, id, sessionToLogMessage(context), props);
-            if (Log.isDebugEnabled(Geonet.SVN_MANAGER)) {
-                Log.debug(Geonet.SVN_MANAGER, "Changes to metadata " + id + " will be committed/aborted with the database "
-                    + "channel " + status);
-            }
+            LOGGER.debug(
+                Geonet.SVN_MANAGER_MARKER,
+                "Changes to metadata {} will be committed/aborted with the database channel {}",
+                id,status);
         } catch (Exception e) {
-            Log.error(Geonet.SVN_MANAGER, "Failed to set history for metadata to subversion repo at path " + subversionPath, e);
+            LOGGER.error(Geonet.SVN_MANAGER_MARKER, "Failed to set history for metadata to subversion repo at path " + subversionPath, e);
         }
     }
 
@@ -402,8 +402,7 @@ public class SvnManager implements AfterCommitTransactionListener, BeforeRollbac
             return; // already in repo so exit
 
         String logMessage = sessionToLogMessage(context) + " adding directory for metadata " + id;
-        if (Log.isDebugEnabled(Geonet.SVN_MANAGER))
-            Log.debug(Geonet.SVN_MANAGER, logMessage);
+        LOGGER.debug(Geonet.SVN_MANAGER_MARKER, logMessage);
 
         ISVNEditor editor = getEditor(logMessage);
 
@@ -411,12 +410,11 @@ public class SvnManager implements AfterCommitTransactionListener, BeforeRollbac
             // Create an id/ directory item in the repository
             editor.openRoot(-1);
             SvnUtils.addDir(editor, id);
-            if (Log.isDebugEnabled(Geonet.SVN_MANAGER))
-                Log.debug(Geonet.SVN_MANAGER, "Directory for metadata " + id + " was added");
+            LOGGER.debug(Geonet.SVN_MANAGER_MARKER, "Directory for metadata {} was added", id);
             editor.closeDir();
             editor.closeEdit();
         } catch (SVNException svne) {
-            Log.error(Geonet.SVN_MANAGER, "Create metadata dir. error: " + svne.getMessage(), svne);
+            LOGGER.error(Geonet.SVN_MANAGER_MARKER, "Create metadata dir. error: " + svne.getMessage(), svne);
             editor.abortEdit();
             throw svne;
         }
@@ -430,14 +428,12 @@ public class SvnManager implements AfterCommitTransactionListener, BeforeRollbac
 
             commitMetadata(id, finalEditor);
 
-            if (Log.isDebugEnabled(Geonet.SVN_MANAGER))
-                Log.debug(Geonet.SVN_MANAGER, "Metadata " + id + " was added");
+            LOGGER.debug(Geonet.SVN_MANAGER_MARKER, "Metadata {} was added",id);
             editor.closeDir();
             SVNCommitInfo commitInfo = editor.closeEdit();
-            if (Log.isDebugEnabled(Geonet.SVN_MANAGER))
-                Log.debug(Geonet.SVN_MANAGER, "Commit returned " + commitInfo);
+            LOGGER.debug(Geonet.SVN_MANAGER_MARKER, "Commit returned {}", commitInfo);
         } catch (SVNException svne) {
-            Log.error(Geonet.SVN_MANAGER, "Create metadata dir. error: " + svne.getMessage(), svne);
+            LOGGER.error(Geonet.SVN_MANAGER_MARKER, "Create metadata dir. error: " + svne.getMessage(), svne);
             editor.abortEdit();
             throw svne;
         }
@@ -459,18 +455,16 @@ public class SvnManager implements AfterCommitTransactionListener, BeforeRollbac
             return; // not in repo so exit
 
         String logMessage = sessionToLogMessage(context) + " deleting directory for metadata " + id;
-        if (Log.isDebugEnabled(Geonet.SVN_MANAGER))
-            Log.debug(Geonet.SVN_MANAGER, logMessage);
+        LOGGER.debug(Geonet.SVN_MANAGER_MARKER, logMessage);
 
         ISVNEditor editor = getEditor(logMessage);
 
         try {
             SvnUtils.deleteDir(editor, id);
             SVNCommitInfo commitInfo = editor.closeEdit();
-            if (Log.isDebugEnabled(Geonet.SVN_MANAGER))
-                Log.debug(Geonet.SVN_MANAGER, "Directory for metadata " + id + " deleted: " + commitInfo);
+            LOGGER.debug(Geonet.SVN_MANAGER_MARKER, "Directory for metadata {} deleted: {}", id, commitInfo);
         } catch (SVNException svne) {
-            Log.error(Geonet.SVN_MANAGER, "Delete metadata dir. error: " +  svne.getMessage(),  svne);
+            LOGGER.error(Geonet.SVN_MANAGER_MARKER, "Delete metadata dir. error: " +  svne.getMessage(),  svne);
             editor.abortEdit(); // abort the update on the XML in the repository
             throw svne;
         }
@@ -571,7 +565,7 @@ public class SvnManager implements AfterCommitTransactionListener, BeforeRollbac
             // get the metadata status and if different commit changes
             commitMetadataStatus(editor, id, dataMan);
         } catch (Exception e) {
-            Log.error(Geonet.SVN_MANAGER, "Failed to commit metadata to  subversion repo at path " + subversionPath, e);
+            LOGGER.error(Geonet.SVN_MANAGER_MARKER, "Failed to commit metadata to  subversion repo at path " + subversionPath, e);
             editor.abortEdit();
             throw e;
         }
@@ -605,14 +599,12 @@ public class SvnManager implements AfterCommitTransactionListener, BeforeRollbac
             String old = Xml.getString(categsPrevVersion);
             if (!old.equals(now)) {
                 SvnUtils.modifyFile(editor, id + "/categories.xml", old.getBytes(Constants.ENCODING), now.getBytes(Constants.ENCODING));
-                if (Log.isDebugEnabled(Geonet.SVN_MANAGER))
-                    Log.debug(Geonet.SVN_MANAGER, "Categories of metadata " + id + " updated");
+                LOGGER.debug(Geonet.SVN_MANAGER_MARKER, "Categories of metadata {} updated", id);
             }
         } else {
             // Add the id/owner.xml item to the repository
             SvnUtils.addFile(editor, id + "/categories.xml", now.getBytes(Constants.ENCODING));
-            if (Log.isDebugEnabled(Geonet.SVN_MANAGER))
-                Log.debug(Geonet.SVN_MANAGER, "Categories of metadata " + id + " added");
+            LOGGER.debug(Geonet.SVN_MANAGER_MARKER, "Categories of metadata {} added", id);
 
         }
     }
@@ -641,15 +633,12 @@ public class SvnManager implements AfterCommitTransactionListener, BeforeRollbac
             if (!old.equals(now)) {
 
                 SvnUtils.modifyFile(editor, id + "/status.xml", old.getBytes(Constants.ENCODING), now.getBytes(Constants.ENCODING));
-                if (Log.isDebugEnabled(Geonet.SVN_MANAGER))
-                    Log.debug(Geonet.SVN_MANAGER, "Status of metadata " + id + " was updated");
+                LOGGER.debug(Geonet.SVN_MANAGER_MARKER, "Status of metadata {} was updated", id);
             }
         } else {
             // Add the id/owner.xml item to the repository
             SvnUtils.addFile(editor, id + "/status.xml", now.getBytes(Constants.ENCODING));
-            if (Log.isDebugEnabled(Geonet.SVN_MANAGER))
-                Log.debug(Geonet.SVN_MANAGER, "Status of metadata " + id + " was added");
-
+            LOGGER.debug(Geonet.SVN_MANAGER_MARKER, "Status of metadata {} was added",id);
         }
     }
 
@@ -674,8 +663,7 @@ public class SvnManager implements AfterCommitTransactionListener, BeforeRollbac
                 // Update the id/metadata.xml item in the repository
                 SvnUtils.modifyFile(editor, id + "/metadata.xml", old.getBytes(Constants.ENCODING), now.getBytes(Constants.ENCODING));
 
-                if (Log.isDebugEnabled(Geonet.SVN_MANAGER))
-                    Log.debug(Geonet.SVN_MANAGER, "Metadata " + id + " was updated");
+                LOGGER.debug(Geonet.SVN_MANAGER_MARKER, "Metadata {} was updated", id);
             }
         } else {
             SvnUtils.addFile(editor, id + "/metadata.xml", now.getBytes(Constants.ENCODING));
@@ -716,15 +704,12 @@ public class SvnManager implements AfterCommitTransactionListener, BeforeRollbac
             if (!old.equals(now)) {
 
                 SvnUtils.modifyFile(editor, id + "/owner.xml", old.getBytes(Constants.ENCODING), now.getBytes(Constants.ENCODING));
-                if (Log.isDebugEnabled(Geonet.SVN_MANAGER))
-                    Log.debug(Geonet.SVN_MANAGER, "Ownership of metadata " + id + " was updated");
+                LOGGER.debug(Geonet.SVN_MANAGER_MARKER, "Ownership of metadata {} was updated",id);
             }
         } else {
             // Add the id/owner.xml item to the repository
             SvnUtils.addFile(editor, id + "/owner.xml", now.getBytes(Constants.ENCODING));
-            if (Log.isDebugEnabled(Geonet.SVN_MANAGER))
-                Log.debug(Geonet.SVN_MANAGER, "Ownership of metadata " + id + " was added");
-
+            LOGGER.debug(Geonet.SVN_MANAGER_MARKER, "Ownership of metadata {} was added", id);
         }
     }
 
@@ -768,14 +753,12 @@ public class SvnManager implements AfterCommitTransactionListener, BeforeRollbac
 
                 SvnUtils.modifyFile(editor, id + "/privileges.xml", old.getBytes(Constants.ENCODING), now.getBytes(Constants.ENCODING));
 
-                if (Log.isDebugEnabled(Geonet.SVN_MANAGER))
-                    Log.debug(Geonet.SVN_MANAGER, "Privileges of metadata " + id + " were updated");
+                LOGGER.debug(Geonet.SVN_MANAGER_MARKER, "Privileges of metadata {} were updated", id);
             }
         } else {
             // Add the id/owner.xml item to the repository
             SvnUtils.addFile(editor, id + "/privileges.xml", now.getBytes(Constants.ENCODING));
-            if (Log.isDebugEnabled(Geonet.SVN_MANAGER))
-                Log.debug(Geonet.SVN_MANAGER, "Privileges of metadata " + id + " were added");
+            LOGGER.debug(Geonet.SVN_MANAGER_MARKER, "Privileges of metadata {} were added", id);
         }
     }
 

--- a/core/src/main/java/org/fao/geonet/kernel/SvnManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/SvnManager.java
@@ -147,7 +147,9 @@ public class SvnManager implements AfterCommitTransactionListener, BeforeRollbac
                 repoUrl = SVNURL.fromFile(subFile);
 
             } else {
-                LOGGER.error(Geonet.SVN_MANAGER_MARKER, "Problem creating or using repository at path " + subversionPath + ", " + e.getMessage(),  e);
+                LOGGER.error(Geonet.SVN_MANAGER_MARKER,
+                    "Problem creating or using repository at path {}, {} ",
+                    subversionPath, e.getMessage(),  e);
                 throw new IllegalArgumentException("Problem creating or using repository at path " + subversionPath);
             }
         }
@@ -157,7 +159,7 @@ public class SvnManager implements AfterCommitTransactionListener, BeforeRollbac
         try {
             repo = getRepository();
         } catch (SVNException se) {
-            LOGGER.error(Geonet.SVN_MANAGER_MARKER, "Failed to open subversion repo at path " + subversionPath, se);
+            LOGGER.error(Geonet.SVN_MANAGER_MARKER, "Failed to open subversion repo at path {}", subversionPath, se);
             throw se;
         }
 
@@ -176,7 +178,7 @@ public class SvnManager implements AfterCommitTransactionListener, BeforeRollbac
                 // if nothing in repo and it doesn't have the uuid we expect then
                 // recreate it and reopen it
                 if (!uuid.equals(repoUuid)) {
-                    LOGGER.warn(Geonet.SVN_MANAGER_MARKER, "Recreating subversion repository at {} as previous repository was empty",subversionPath);
+                    LOGGER.warn(Geonet.SVN_MANAGER_MARKER, "Recreating subversion repository at {} as previous repository was empty", subversionPath);
                     boolean enableRevisionProperties = true;
                     boolean force = true;
                     repoUrl = SVNRepositoryFactory.createLocalRepository(subFile, uuid, enableRevisionProperties, force);
@@ -356,9 +358,9 @@ public class SvnManager implements AfterCommitTransactionListener, BeforeRollbac
             LOGGER.debug(
                 Geonet.SVN_MANAGER_MARKER,
                 "Changes to metadata {} will be committed/aborted with the database channel {}",
-                id,status);
+                id, status);
         } catch (Exception e) {
-            LOGGER.error(Geonet.SVN_MANAGER_MARKER, "Failed to set history for metadata to subversion repo at path " + subversionPath, e);
+            LOGGER.error(Geonet.SVN_MANAGER_MARKER, "Failed to set history for metadata to subversion repo at path {}", subversionPath, e);
         }
     }
 
@@ -414,7 +416,7 @@ public class SvnManager implements AfterCommitTransactionListener, BeforeRollbac
             editor.closeDir();
             editor.closeEdit();
         } catch (SVNException svne) {
-            LOGGER.error(Geonet.SVN_MANAGER_MARKER, "Create metadata dir. error: " + svne.getMessage(), svne);
+            LOGGER.error(Geonet.SVN_MANAGER_MARKER, "Create metadata dir. error: {}", svne.getMessage(), svne);
             editor.abortEdit();
             throw svne;
         }
@@ -428,12 +430,12 @@ public class SvnManager implements AfterCommitTransactionListener, BeforeRollbac
 
             commitMetadata(id, finalEditor);
 
-            LOGGER.debug(Geonet.SVN_MANAGER_MARKER, "Metadata {} was added",id);
+            LOGGER.debug(Geonet.SVN_MANAGER_MARKER, "Metadata {} was added", id);
             editor.closeDir();
             SVNCommitInfo commitInfo = editor.closeEdit();
             LOGGER.debug(Geonet.SVN_MANAGER_MARKER, "Commit returned {}", commitInfo);
         } catch (SVNException svne) {
-            LOGGER.error(Geonet.SVN_MANAGER_MARKER, "Create metadata dir. error: " + svne.getMessage(), svne);
+            LOGGER.error(Geonet.SVN_MANAGER_MARKER, "Create metadata dir. error: {}", svne.getMessage(), svne);
             editor.abortEdit();
             throw svne;
         }
@@ -464,7 +466,7 @@ public class SvnManager implements AfterCommitTransactionListener, BeforeRollbac
             SVNCommitInfo commitInfo = editor.closeEdit();
             LOGGER.debug(Geonet.SVN_MANAGER_MARKER, "Directory for metadata {} deleted: {}", id, commitInfo);
         } catch (SVNException svne) {
-            LOGGER.error(Geonet.SVN_MANAGER_MARKER, "Delete metadata dir. error: " +  svne.getMessage(),  svne);
+            LOGGER.error(Geonet.SVN_MANAGER_MARKER, "Delete metadata dir. error: {}", svne.getMessage(),  svne);
             editor.abortEdit(); // abort the update on the XML in the repository
             throw svne;
         }
@@ -565,7 +567,7 @@ public class SvnManager implements AfterCommitTransactionListener, BeforeRollbac
             // get the metadata status and if different commit changes
             commitMetadataStatus(editor, id, dataMan);
         } catch (Exception e) {
-            LOGGER.error(Geonet.SVN_MANAGER_MARKER, "Failed to commit metadata to  subversion repo at path " + subversionPath, e);
+            LOGGER.error(Geonet.SVN_MANAGER_MARKER, "Failed to commit metadata to  subversion repo at path {}", subversionPath, e);
             editor.abortEdit();
             throw e;
         }
@@ -704,7 +706,7 @@ public class SvnManager implements AfterCommitTransactionListener, BeforeRollbac
             if (!old.equals(now)) {
 
                 SvnUtils.modifyFile(editor, id + "/owner.xml", old.getBytes(Constants.ENCODING), now.getBytes(Constants.ENCODING));
-                LOGGER.debug(Geonet.SVN_MANAGER_MARKER, "Ownership of metadata {} was updated",id);
+                LOGGER.debug(Geonet.SVN_MANAGER_MARKER, "Ownership of metadata {} was updated", id);
             }
         } else {
             // Add the id/owner.xml item to the repository

--- a/core/src/main/java/org/fao/geonet/kernel/Thesaurus.java
+++ b/core/src/main/java/org/fao/geonet/kernel/Thesaurus.java
@@ -23,6 +23,7 @@
 package org.fao.geonet.kernel;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.logging.log4j.Logger;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.ISODate;
 import org.fao.geonet.exceptions.TermNotFoundException;
@@ -77,6 +78,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 
 public class Thesaurus {
+    private static final Logger LOGGER = Log.createLogger(Thesaurus.class,Geonet.THESAURUS_MARKER);
     private static final String DEFAULT_THESAURUS_NAMESPACE = "http://custom.shared.obj.ch/concept#";
 
     private String fname;
@@ -224,10 +226,7 @@ public class Thesaurus {
         } catch (IOException e) {
             lastModified = FileTime.fromMillis(System.currentTimeMillis());
         }
-
-        if (Log.isDebugEnabled(Geonet.THESAURUS)) {
-            Log.debug(Geonet.THESAURUS, title + " has lastModified of: " + lastModified.toMillis());
-        }
+        LOGGER.debug(Geonet.THESAURUS_MARKER, "{} has lastModified of: {}",title, lastModified.toMillis());
 
         return lastModified;
     }
@@ -288,7 +287,7 @@ public class Thesaurus {
     public synchronized QueryResultsTable performRequest(String query) throws IOException, MalformedQueryException,
         QueryEvaluationException, AccessDeniedException {
         if (Log.isDebugEnabled(Geonet.THESAURUS))
-            Log.debug(Geonet.THESAURUS, "Query : " + query);
+            LOGGER.debug(Geonet.THESAURUS_MARKER, "Query : " + query);
 
         //printResultsTable(resultsTable);
         return repository.performTableQuery(QueryLanguage.SERQL, query);
@@ -462,7 +461,7 @@ public class Thesaurus {
         int removedItems = myGraph.remove(subject, null, null);
         if (Log.isDebugEnabled(Geonet.THESAURUS)) {
             String msg = "Removed " + removedItems + " elements from thesaurus " + this.title + " with uri: " + subject;
-            Log.debug(Geonet.THESAURUS, msg);
+            LOGGER.debug(Geonet.THESAURUS_MARKER, msg);
         }
         return this;
     }

--- a/core/src/main/java/org/fao/geonet/kernel/Thesaurus.java
+++ b/core/src/main/java/org/fao/geonet/kernel/Thesaurus.java
@@ -226,7 +226,7 @@ public class Thesaurus {
         } catch (IOException e) {
             lastModified = FileTime.fromMillis(System.currentTimeMillis());
         }
-        LOGGER.debug(Geonet.THESAURUS_MARKER, "{} has lastModified of: {}",title, lastModified.toMillis());
+        LOGGER.debug(Geonet.THESAURUS_MARKER, "{} has lastModified of: {}", title, lastModified.toMillis());
 
         return lastModified;
     }
@@ -287,7 +287,7 @@ public class Thesaurus {
     public synchronized QueryResultsTable performRequest(String query) throws IOException, MalformedQueryException,
         QueryEvaluationException, AccessDeniedException {
         if (Log.isDebugEnabled(Geonet.THESAURUS))
-            LOGGER.debug(Geonet.THESAURUS_MARKER, "Query : " + query);
+            LOGGER.debug(Geonet.THESAURUS_MARKER, "Query : {}", query);
 
         //printResultsTable(resultsTable);
         return repository.performTableQuery(QueryLanguage.SERQL, query);

--- a/core/src/main/java/org/fao/geonet/kernel/ThesaurusManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/ThesaurusManager.java
@@ -41,6 +41,7 @@ import java.util.concurrent.Executors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import org.apache.logging.log4j.Logger;
 import org.fao.geonet.Util;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.AbstractMetadata;
@@ -556,6 +557,7 @@ public class ThesaurusManager implements ThesaurusFinder {
      * servlet is up before reading the thesauri and creating the thesaurus table.
      */
     final class InitThesauriTableTask implements Runnable {
+        private Logger LOGGER = Log.createLogger(InitThesauriTableTask.class,Geonet.THESAURUS_MAN_MARKER);
 
         private final ServiceContext context;
         private final Path thesauriDir;
@@ -570,18 +572,16 @@ public class ThesaurusManager implements ThesaurusFinder {
             try {
                 // poll context to see whether servlet is up yet
                 while (!context.isServletInitialized()) {
-                    if (Log.isDebugEnabled(Geonet.THESAURUS_MAN)) {
-                        Log.debug(Geonet.THESAURUS_MAN, "Waiting for servlet to finish initializing..");
-                    }
+                    LOGGER.debug(Geonet.THESAURUS_MAN_MARKER, "Waiting for servlet to finish initializing..");
                     Thread.sleep(10000); // sleep 10 seconds
                 }
                 try {
                     initThesauriTable(thesauriDir, context);
                 } catch (Exception e) {
-                    Log.error(Geonet.THESAURUS_MAN, "Error rebuilding thesaurus table : " + e.getMessage() + "\n" + Util.getStackTrace(e));
+                    LOGGER.error(Geonet.THESAURUS_MAN_MARKER, "Error rebuilding thesaurus table : {}", e.getMessage(),e);
                 }
             } catch (Exception e) {
-                Log.debug(Geonet.THESAURUS_MAN, "Thesaurus table rebuilding thread threw exception", e);
+                LOGGER.debug(Geonet.THESAURUS_MAN_MARKER, "Thesaurus table rebuilding thread threw exception", e);
             }
         }
     }

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataSchemaUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataSchemaUtils.java
@@ -42,7 +42,11 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import jeeves.server.context.ServiceContext;
 
+import static org.fao.geonet.constants.Geonet.DATA_MANAGER_MARKER;
+
 public class BaseMetadataSchemaUtils implements IMetadataSchemaUtils {
+
+    final private static org.apache.logging.log4j.Logger LOGGER = Log.createLogger(BaseMetadataSchemaUtils.class, DATA_MANAGER_MARKER);
 
     @Autowired
     private SchemaManager schemaManager;
@@ -124,13 +128,15 @@ public class BaseMetadataSchemaUtils implements IMetadataSchemaUtils {
     String autodetectSchema(Element md, String defaultSchema)
         throws SchemaMatchConflictException, NoSchemaMatchesException {
 
-        if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
-            Log.debug(Geonet.DATA_MANAGER,
-                "Autodetect schema for metadata with :\n * root element:'" + md.getQualifiedName() + "'\n * with namespace:'"
-                    + md.getNamespace() + "\n * with additional namespaces:" + md.getAdditionalNamespaces().toString());
+        LOGGER.debug(DATA_MANAGER_MARKER,
+                "Autodetect schema for metadata with :\n" +
+                " * root element:'{}'\n" +
+                " * with namespace:'{}\n" +
+                " * with additional namespaces: {}",
+                    md.getQualifiedName(), md.getNamespace(), md.getAdditionalNamespaces());
+
         String schema = schemaManager.autodetectSchema(md, defaultSchema);
-        if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
-            Log.debug(Geonet.DATA_MANAGER, "Schema detected was " + schema);
+        LOGGER.debug(DATA_MANAGER_MARKER, "Schema detected was {}", schema);
         return schema;
     }
 }

--- a/core/src/main/java/org/fao/geonet/kernel/mef/ExportFormat.java
+++ b/core/src/main/java/org/fao/geonet/kernel/mef/ExportFormat.java
@@ -30,7 +30,9 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.apache.logging.log4j.Logger;
 import org.fao.geonet.GeonetContext;
+import org.fao.geonet.api.API;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.AbstractMetadata;
 import org.fao.geonet.domain.Metadata;
@@ -46,12 +48,16 @@ import org.jdom.Element;
 
 import jeeves.server.context.ServiceContext;
 
+import static org.fao.geonet.constants.Geonet.MEF_MARKER;
+
 /**
  * An extension point called to create files to export as part of the MEF export.
  *
  * User: Jesse Date: 11/8/13 Time: 3:21 PM
  */
 public class ExportFormat implements GeonetworkExtension {
+
+    private static Logger LOGGER = Log.createLogger(ExportFormat.class, MEF_MARKER);
     /**
      * Return a list of &lt;filename, fileContents>.
      *
@@ -76,11 +82,9 @@ public class ExportFormat implements GeonetworkExtension {
                     allExports.add(Pair.read(outputFileName, outputData));
                 } else {
                     // A conversion that does not exist
-                    if (Log.isDebugEnabled(Geonet.MEF)) {
-                        Log.debug(Geonet.MEF, String.format("Exporting MEF file for '%s' schema plugin formats. File '%s' not found",
-                            metadataSchema.getName(),
-                            path.getFileName()));
-                    }
+                    LOGGER.debug(MEF_MARKER, String.format("Exporting MEF file for '%s' schema plugin formats. File '%s' not found",
+                        metadataSchema.getName(),
+                        path.getFileName()));
                 }
             }
             return allExports;

--- a/core/src/main/java/org/fao/geonet/kernel/metadata/DefaultStatusActions.java
+++ b/core/src/main/java/org/fao/geonet/kernel/metadata/DefaultStatusActions.java
@@ -160,8 +160,8 @@ public class DefaultStatusActions implements StatusActions {
             // of status then do nothing. This does not apply to task and event.
             if (status.getStatusValue().getType().equals(StatusValueType.workflow) &&
                (statusId).equals(currentStatusId)) {
-                if (context.isDebugEnabled())
-                    context.debug(String.format("Metadata %s already has status %s ",
+                if (context.getLogger().isDebugEnabled())
+                    context.getLogger().debug(String.format("Metadata %s already has status %s ",
                         status.getMetadataId(), status.getStatusValue().getId()));
                 unchanged.add(status.getMetadataId());
                 continue;
@@ -174,7 +174,7 @@ public class DefaultStatusActions implements StatusActions {
             try {
                 notify(getUserToNotify(status), status);
             } catch (Exception e) {
-                context.warning(String.format(
+                context.getLogger().warning(String.format(
                     "Failed to send notification on status change for metadata %s with status %s. Error is: %s",
                     status.getMetadataId(), status.getStatusValue().getId(), e.getMessage()));
             }
@@ -380,7 +380,7 @@ public class DefaultStatusActions implements StatusActions {
     protected void sendEmail(String sendTo, String subject, String message) throws Exception {
 
         if (!emailNotes) {
-            context.info("Would send email \nTo: " + sendTo + "\nSubject: " + subject + "\n Message:\n" + message);
+            context.getLogger().info("Would send email \nTo: " + sendTo + "\nSubject: " + subject + "\n Message:\n" + message);
         } else {
             ApplicationContext applicationContext = ApplicationContextHolder.get();
             SettingManager sm = applicationContext.getBean(SettingManager.class);

--- a/core/src/main/java/org/fao/geonet/kernel/oaipmh/OaiPmhDispatcher.java
+++ b/core/src/main/java/org/fao/geonet/kernel/oaipmh/OaiPmhDispatcher.java
@@ -126,7 +126,7 @@ public class OaiPmhDispatcher {
         } catch (OaiPmhException e) {
             return OaiPmhException.marshal(e, url, params);
         } catch (Exception e) {
-            context.info("Exception stack trace : \n" + Util.getStackTrace(e));
+            context.getLogger().info("Exception stack trace : \n" + Util.getStackTrace(e));
 
             //--- we should use another exception type but we don't have a specific
             //--- type to handle internal errors
@@ -146,13 +146,13 @@ public class OaiPmhDispatcher {
     private void validateResponse(ServiceContext context, Element response) {
         Path schema = context.getAppPath().resolve(Geonet.SchemaPath.OAI_PMH);
 
-        if (context.isDebugEnabled())
-            context.debug("Validating against : " + schema);
+        if (context.getLogger().isDebugEnabled())
+            context.getLogger().debug("Validating against : " + schema);
 
         try {
             Xml.validate(schema, response);
         } catch (Exception e) {
-            context.warning("OAI-PMH response does not validate : " + e.getMessage());
+            context.getLogger().warning("OAI-PMH response does not validate : " + e.getMessage());
         }
     }
 

--- a/core/src/main/java/org/fao/geonet/kernel/oaipmh/ResumptionTokenCache.java
+++ b/core/src/main/java/org/fao/geonet/kernel/oaipmh/ResumptionTokenCache.java
@@ -23,6 +23,7 @@
 
 package org.fao.geonet.kernel.oaipmh;
 
+import org.apache.logging.log4j.Logger;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.ISODate;
 import org.fao.geonet.kernel.setting.SettingManager;
@@ -36,6 +37,7 @@ import java.util.Map;
 import java.util.TimeZone;
 
 public class ResumptionTokenCache extends Thread {
+    private static Logger LOGGER = Log.createLogger(ResumptionTokenCache.class, Geonet.OAI_MARKER);
 
 
     public final static int CACHE_EXPUNGE_DELAY = 10 * 1000; // 10 seconds
@@ -51,8 +53,9 @@ public class ResumptionTokenCache extends Thread {
     public ResumptionTokenCache(SettingManager sm) {
 
         this.settingMan = sm;
-        if (Log.isDebugEnabled(Geonet.OAI_HARVESTER))
-            Log.debug(Geonet.OAI_HARVESTER, "OAI cache ::init timout:" + getTimeout());
+        if (LOGGER.isDebugEnabled(Geonet.OAI_HARVESTER_MARKER)) {
+            LOGGER.debug(Geonet.OAI_HARVESTER_MARKER, "OAI cache ::init timout:{}", getTimeout());
+        }
 
         map = Collections.synchronizedMap(new HashMap<String, GeonetworkResumptionToken>());
 
@@ -102,11 +105,11 @@ public class ResumptionTokenCache extends Thread {
                         expunge();
                     }
                 } catch (java.lang.InterruptedException ie) {
-                    Log.debug(Geonet.OAI_HARVESTER,"OAI execution error: " + ie.getMessage(), ie);
+                    LOGGER.debug(Geonet.OAI_HARVESTER_MARKER,"OAI execution error: {}",ie.getMessage(), ie);
                 }
             }
         }
-        Log.info(Geonet.OAI_HARVESTER, "ResumptionTokenCache thread end");
+        LOGGER.info(Geonet.OAI_HARVESTER_MARKER, "ResumptionTokenCache thread end");
     }
 
     private synchronized void expunge() {
@@ -116,17 +119,16 @@ public class ResumptionTokenCache extends Thread {
         for (Map.Entry entry : map.entrySet()) {
             if (((GeonetworkResumptionToken) entry.getValue()).getExpirDate().toDate().getTime() / 1000 < (now.getTime() / 1000)) {
                 map.remove(entry.getKey());
-                if (Log.isDebugEnabled(Geonet.OAI_HARVESTER))
-                    Log.debug(Geonet.OAI_HARVESTER, "OAI cache ::expunge removing:" + entry.getKey());
+                if (LOGGER.isDebugEnabled(Geonet.OAI_HARVESTER_MARKER)) {
+                    LOGGER.debug(Geonet.OAI_HARVESTER_MARKER, "OAI cache ::expunge removing:{}", entry.getKey());
+                }
             }
         }
     }
 
     // remove oldest token from cache
     private void removeLast() {
-        if (Log.isDebugEnabled(Geonet.OAI_HARVESTER))
-            Log.debug(Geonet.OAI_HARVESTER, "OAI cache ::removeLast");
-
+        LOGGER.debug(Geonet.OAI_HARVESTER_MARKER, "OAI cache ::removeLast");
 
         long oldest = Long.MAX_VALUE;
         Object oldkey = "";
@@ -140,10 +142,7 @@ public class ResumptionTokenCache extends Thread {
         }
 
         map.remove(oldkey);
-        if (Log.isDebugEnabled(Geonet.OAI_HARVESTER))
-            Log.debug(Geonet.OAI_HARVESTER, "OAI cache ::removeLast removing:" + oldkey);
-
-
+        LOGGER.debug(Geonet.OAI_HARVESTER_MARKER, "OAI cache ::removeLast removing:{}", oldkey);
     }
 
     public synchronized GeonetworkResumptionToken getResumptionToken(String str) {
@@ -151,8 +150,9 @@ public class ResumptionTokenCache extends Thread {
     }
 
     public synchronized void storeResumptionToken(GeonetworkResumptionToken resumptionToken) {
-        if (Log.isDebugEnabled(Geonet.OAI_HARVESTER))
-            Log.debug(Geonet.OAI_HARVESTER, "OAI cache ::store " + resumptionToken.getKey() + " size: " + map.size());
+        if (LOGGER.isDebugEnabled(Geonet.OAI_HARVESTER_MARKER)) {
+            LOGGER.debug(Geonet.OAI_HARVESTER_MARKER, "OAI cache ::store {} size: {}", resumptionToken.getKey(), map.size());
+        }
 
         if (map.size() == getCachemaxsize()) {
             removeLast();
@@ -169,7 +169,7 @@ public class ResumptionTokenCache extends Thread {
         }
         try {
             this.join();
-            Log.info(Geonet.OAI_HARVESTER, "ResumptionTokenCache thread stopped");
+            LOGGER.info(Geonet.OAI_HARVESTER_MARKER, "ResumptionTokenCache thread stopped");
         } catch (InterruptedException ignored) {
         }
     }

--- a/core/src/main/java/org/fao/geonet/kernel/oaipmh/ResumptionTokenCache.java
+++ b/core/src/main/java/org/fao/geonet/kernel/oaipmh/ResumptionTokenCache.java
@@ -105,7 +105,7 @@ public class ResumptionTokenCache extends Thread {
                         expunge();
                     }
                 } catch (java.lang.InterruptedException ie) {
-                    LOGGER.debug(Geonet.OAI_HARVESTER_MARKER,"OAI execution error: {}",ie.getMessage(), ie);
+                    LOGGER.debug(Geonet.OAI_HARVESTER_MARKER,"OAI execution error: {}", ie.getMessage(), ie);
                 }
             }
         }
@@ -119,9 +119,7 @@ public class ResumptionTokenCache extends Thread {
         for (Map.Entry entry : map.entrySet()) {
             if (((GeonetworkResumptionToken) entry.getValue()).getExpirDate().toDate().getTime() / 1000 < (now.getTime() / 1000)) {
                 map.remove(entry.getKey());
-                if (LOGGER.isDebugEnabled(Geonet.OAI_HARVESTER_MARKER)) {
-                    LOGGER.debug(Geonet.OAI_HARVESTER_MARKER, "OAI cache ::expunge removing:{}", entry.getKey());
-                }
+                LOGGER.debug(Geonet.OAI_HARVESTER_MARKER, "OAI cache ::expunge removing:{}", entry.getKey());
             }
         }
     }
@@ -150,9 +148,7 @@ public class ResumptionTokenCache extends Thread {
     }
 
     public synchronized void storeResumptionToken(GeonetworkResumptionToken resumptionToken) {
-        if (LOGGER.isDebugEnabled(Geonet.OAI_HARVESTER_MARKER)) {
-            LOGGER.debug(Geonet.OAI_HARVESTER_MARKER, "OAI cache ::store {} size: {}", resumptionToken.getKey(), map.size());
-        }
+        LOGGER.debug(Geonet.OAI_HARVESTER_MARKER, "OAI cache ::store {} size: {}", resumptionToken.getKey(), map.size());
 
         if (map.size() == getCachemaxsize()) {
             removeLast();

--- a/core/src/main/java/org/fao/geonet/kernel/oaipmh/services/AbstractTokenLister.java
+++ b/core/src/main/java/org/fao/geonet/kernel/oaipmh/services/AbstractTokenLister.java
@@ -23,6 +23,7 @@
 
 package org.fao.geonet.kernel.oaipmh.services;
 
+import org.apache.logging.log4j.Logger;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.ISODate;
 import org.fao.geonet.kernel.SchemaManager;
@@ -49,8 +50,12 @@ import java.util.List;
 
 import jeeves.server.context.ServiceContext;
 
+import static org.fao.geonet.constants.Geonet.OAI_HARVESTER_MARKER;
+
 
 public abstract class AbstractTokenLister implements OaiPmhService {
+
+    final private static Logger LOGGER = Log.createLogger(AbstractTokenLister.class, OAI_HARVESTER_MARKER);
 
     protected ResumptionTokenCache cache;
 
@@ -109,8 +114,7 @@ public abstract class AbstractTokenLister implements OaiPmhService {
     public AbstractResponse execute(AbstractRequest request,
                                     ServiceContext context) throws Exception {
 
-        if (Log.isDebugEnabled(Geonet.OAI_HARVESTER))
-            Log.debug(Geonet.OAI_HARVESTER, "OAI " + this.getClass().getSimpleName() + " execute: ");
+        LOGGER.debug(OAI_HARVESTER_MARKER, "OAI {} execute: ", this.getClass().getSimpleName());
 
         TokenListRequest req = (TokenListRequest) request;
 
@@ -125,8 +129,8 @@ public abstract class AbstractTokenLister implements OaiPmhService {
         int pos = 0;
 
         if (strToken == null) {
-            if (Log.isDebugEnabled(Geonet.OAI_HARVESTER))
-                Log.debug(Geonet.OAI_HARVESTER, "OAI " + this.getClass().getSimpleName() + " : new request (no resumptionToken)");
+            LOGGER.debug(OAI_HARVESTER_MARKER,
+                "OAI {} : new request (no resumptionToken)", this.getClass().getSimpleName());
             Element params = new Element("request");
 
             ISODate from = req.getFrom();
@@ -180,8 +184,8 @@ public abstract class AbstractTokenLister implements OaiPmhService {
         } else {
             //result = (SearchResult) session.getProperty(Lib.SESSION_OBJECT);
             token = cache.getResumptionToken(GeonetworkResumptionToken.buildKey(req));
-            if (Log.isDebugEnabled(Geonet.OAI_HARVESTER))
-                Log.debug(Geonet.OAI_HARVESTER, "OAI ListRecords : using ResumptionToken :" + GeonetworkResumptionToken.buildKey(req));
+            LOGGER.debug(OAI_HARVESTER_MARKER,
+            "OAI ListRecords : using ResumptionToken :{}",GeonetworkResumptionToken.buildKey(req));
 
             if (token == null)
                 throw new BadResumptionTokenException("No session for token : " + GeonetworkResumptionToken.buildKey(req));

--- a/core/src/main/java/org/fao/geonet/kernel/schema/MetadataSchema.java
+++ b/core/src/main/java/org/fao/geonet/kernel/schema/MetadataSchema.java
@@ -70,6 +70,8 @@ import javax.xml.bind.JAXBContext;
 import javax.xml.bind.JAXBException;
 import javax.xml.bind.Unmarshaller;
 
+import static org.fao.geonet.constants.Geonet.SCHEMA_MANAGER_MARKER;
+
 
 //==============================================================================
 
@@ -78,6 +80,9 @@ import javax.xml.bind.Unmarshaller;
     "readwriteUUID", "schematronRules"
 })
 public class MetadataSchema {
+
+    final private static org.apache.logging.log4j.Logger LOGGER = Log.createLogger(MetadataSchema.class, SCHEMA_MANAGER_MARKER);
+
     public static final String SCHEMATRON_DIR = "schematron";
     private static final String XSL_FILE_EXTENSION = ".xsl";
     private static final String SCH_FILE_EXTENSION = ".sch";
@@ -163,7 +168,7 @@ public class MetadataSchema {
                 Unmarshaller unmarshaller = jaxbContext.createUnmarshaller();
                 return (Editor) unmarshaller.unmarshal(metadataSchemaConfig.toFile());
             } catch (JAXBException e) {
-                Log.error(Geonet.SCHEMA_MANAGER, " Get config editor. Error is " + e.getMessage(), e);
+                LOGGER.error(SCHEMA_MANAGER_MARKER, " Get config editor. Error is " + e.getMessage(), e);
                 throw new RuntimeException(e);
             }
         }
@@ -221,7 +226,7 @@ public class MetadataSchema {
             Logger.log();
             childType = hmElements.get(elem);
             if (childType == null) {
-                Log.warning(Geonet.SCHEMA_MANAGER, "ERROR: Mismatch between schema and xml: No type for 'element' : "
+                LOGGER.warn(SCHEMA_MANAGER_MARKER, "ERROR: Mismatch between schema and xml: No type for 'element' : "
                     + oldelem + " with parent " + parent + ". Returning xs:string");
                 return "xs:string";
             }
@@ -402,18 +407,14 @@ public class MetadataSchema {
         Path schematronCompilationFile = schematronResourceDir.resolve("iso_svrl_for_xslt2.xsl");
         Path schematronExpandFile = schematronResourceDir.resolve("iso_abstract_expand.xsl");
 
-        if(Log.isDebugEnabled(Geonet.SCHEMA_MANAGER)) {
-            Log.debug(Geonet.SCHEMA_MANAGER, "     Schematron compilation for schema " + schemaName);
-            Log.debug(Geonet.SCHEMA_MANAGER, "          - compiling with " + schematronCompilationFile);
-            Log.debug(Geonet.SCHEMA_MANAGER, "          - rules location is " + schemaSchematronDir);
-        }
+        LOGGER.debug(SCHEMA_MANAGER_MARKER, "     Schematron compilation for schema {}", schemaName);
+        LOGGER.debug(SCHEMA_MANAGER_MARKER, "          - compiling with {}", schematronCompilationFile);
+        LOGGER.debug(SCHEMA_MANAGER_MARKER, "          - rules location is {}", schemaSchematronDir);
 
         if (Files.exists(schemaSchematronDir)) {
             try (DirectoryStream<Path> paths = Files.newDirectoryStream(schemaSchematronDir, "*.sch")) {
                 for (Path rule : paths) {
-                    if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER)) {
-                        Log.debug(Geonet.SCHEMA_MANAGER, "                - rule " + rule);
-                    }
+                    LOGGER.debug(SCHEMA_MANAGER_MARKER, "                - rule {}", rule);
 
                     // Compile all schematron rules
                     final String xslPath = rule.toAbsolutePath().toString().replace(SCH_FILE_EXTENSION, XSL_FILE_EXTENSION);
@@ -425,17 +426,21 @@ public class MetadataSchema {
                         Element schematronExpandXml = Xml.transform(schematronRule, schematronExpandFile);
                         Xml.transform(schematronExpandXml, schematronCompilationFile, schematronXsl);
                     } catch (FileNotFoundException e) {
-                        Log.error(Geonet.SCHEMA_MANAGER, "     Schematron rule file not found " + schematronXslFilePath
-                            + ". Error is " + e.getMessage());
+                        LOGGER.error(SCHEMA_MANAGER_MARKER,
+                            "     Schematron rule file not found {}. Error is {}",
+                            schematronXslFilePath, e.getMessage());
+
                     } catch (Exception e) {
-                        Log.error(Geonet.SCHEMA_MANAGER, "     Schematron rule compilation failed for " + schematronXslFilePath
-                            + ". Error is " + e.getMessage());
+                        LOGGER.error(SCHEMA_MANAGER_MARKER,
+                            "     Schematron rule compilation failed for {}. Error is {}",
+                            schematronXslFilePath, e.getMessage());
                     }
 
                 }
             } catch (IOException e) {
-                Log.error(Geonet.SCHEMA_MANAGER, "     Schematron rule file not found " + schemaSchematronDir
-                    + ". Error is " + e.getMessage());
+                LOGGER.error(SCHEMA_MANAGER_MARKER,
+                    "     Schematron rule file not found {}. Error is {}",
+                    schemaSchematronDir, e.getMessage());
             }
         }
     }
@@ -658,10 +663,7 @@ public class MetadataSchema {
         }
 
         String xpath = query.getXpath();
-        if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER)) {
-            Log.error(Geonet.SCHEMA_MANAGER, String.format(
-                "Saved query XPath: %s", xpath));
-        }
+        LOGGER.error(SCHEMA_MANAGER_MARKER, "Saved query XPath: {}", xpath);
 
         return Xml.selectString(xml,
             xpath,

--- a/core/src/main/java/org/fao/geonet/kernel/schema/SchemaLoader.java
+++ b/core/src/main/java/org/fao/geonet/kernel/schema/SchemaLoader.java
@@ -51,9 +51,14 @@ import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
 
+import static org.fao.geonet.constants.Geonet.SCHEMA_MANAGER_MARKER;
+
 //==============================================================================
 
 public class SchemaLoader {
+
+    final private static org.apache.logging.log4j.Logger LOGGER = Log.createLogger(SchemaLoader.class, SCHEMA_MANAGER_MARKER);
+
     private Element elFirst = null;
     private Map<String, String> hmElements = new HashMap<String, String>();
     private Map<String, ComplexTypeEntry> hmTypes = new HashMap<String, ComplexTypeEntry>();
@@ -174,7 +179,7 @@ public class SchemaLoader {
                 Logger.log();
                 type = recurseOnSubstitutionLinks(elem);
                 if (type == null) {
-                    Log.warning(Geonet.SCHEMA_MANAGER, "WARNING: Cannot find type for " + elem + ": assuming string");
+                    LOGGER.warn(SCHEMA_MANAGER_MARKER, "WARNING: Cannot find type for {}: assuming string", elem);
                     type = "string";
                 } else {
                     Logger.log();
@@ -400,7 +405,7 @@ public class SchemaLoader {
                 if (ee.simpleType.alEnum != null) // add enumerations if any
                     elemRestr.addAll(ee.simpleType.alEnum);
             } else {
-                Log.warning(Geonet.SCHEMA_MANAGER, "WARNING: Could not find type for " + ee.name + " - assuming string");
+                LOGGER.warn(SCHEMA_MANAGER_MARKER, "WARNING: Could not find type for {} - assuming string", ee.name);
                 ee.type = "string";
             }
         }
@@ -433,7 +438,9 @@ public class SchemaLoader {
             List<String> validSubs = hmSubsNames.get(elementName);
             for (String altSub : ssOs) {
                 if (validSubs != null && !validSubs.contains(altSub)) {
-                    Log.warning(Geonet.SCHEMA_MANAGER, "WARNING: schema-substitutions.xml specified " + altSub + " for element " + elementName + " but the schema does not define this as a valid substitute");
+                    LOGGER.warn(SCHEMA_MANAGER_MARKER,
+                        "WARNING: schema-substitutions.xml specified {} for element {} but the schema does not define this as a valid substitute",
+                        altSub, elementName);
                 }
                 for (ElementEntry ee : subs) {
                     if (ee.name.equals(altSub)) {
@@ -442,7 +449,7 @@ public class SchemaLoader {
                 }
             }
             if (results.size() == 0 && validSubs != null) {
-                Log.warning(Geonet.SCHEMA_MANAGER, "WARNING: schema-substitutions.xml has wiped out XSD substitution list for " + elementName);
+                LOGGER.warn(SCHEMA_MANAGER_MARKER, "WARNING: schema-substitutions.xml has wiped out XSD substitution list for {}", elementName);
             }
             return results;
         }
@@ -508,7 +515,8 @@ public class SchemaLoader {
         } else if (!isAbstract) {
             mdt.addRefElementWithType(ee.ref, type, ee.min, ee.max);
         } else {
-            Log.warning(Geonet.SCHEMA_MANAGER, "WARNING: element " + ee.ref + " from " + baseName + " has fallen through the logic (abstract: " + isAbstract + ") - ignoring");
+            LOGGER.warn(SCHEMA_MANAGER_MARKER, "WARNING: element {} from {} has fallen through the logic (abstract: {}) - ignoring",
+                ee.ref, baseName, isAbstract);
         }
     }
 
@@ -576,7 +584,7 @@ public class SchemaLoader {
                     mds.addElement(ee.name, ee.type, new ArrayList<String>(), new ArrayList<String>(), "");
                     mdt.addElementWithType(ee.name, ee.type, ee.min, ee.max);
                 } else {
-                    Log.warning(Geonet.SCHEMA_MANAGER, "WARNING: group element ref is NULL in " + baseName + extension + baseNr);
+                    LOGGER.warn(SCHEMA_MANAGER_MARKER, "WARNING: group element ref is NULL in {}{}{}",baseName, extension, baseNr);
                 }
 
                 // SEQUENCE
@@ -650,7 +658,7 @@ public class SchemaLoader {
         Path path = xmlSchemaFile.getParent();
 
         //--- load xml-schema
-        Log.debug(Geonet.SCHEMA_MANAGER, "Loading schema " + xmlSchemaFile);
+        LOGGER.debug(SCHEMA_MANAGER_MARKER, "Loading schema {}", xmlSchemaFile);
 
         Element elRoot = Xml.loadFile(xmlSchemaFile);
         if (elFirst == null) elFirst = elRoot;
@@ -705,14 +713,14 @@ public class SchemaLoader {
                     Resolver resolver = ResolverWrapper.getInstance();
                     final String scPath = resolver.getXmlResolver().resolveURI(schemaLoc);
 
-                    if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER)) {
-                        Log.debug(Geonet.SCHEMA_MANAGER,
-                            "Cats: " + Arrays.toString(resolver.getXmlResolver().getCatalogList()) +
-                                " Resolved " + schemaLoc + " " + scPath);
+                    if (LOGGER.isDebugEnabled(Geonet.SCHEMA_MANAGER_MARKER)) {
+                        LOGGER.debug(SCHEMA_MANAGER_MARKER,
+                            "Cats: {} Resolved {} {}",
+                            Arrays.toString(resolver.getXmlResolver().getCatalogList()), schemaLoc,  scPath);
                     }
 
                     if (scPath == null) {
-                        Log.warning(Geonet.SCHEMA_MANAGER,
+                        LOGGER.warn(SCHEMA_MANAGER_MARKER,
                             "Cannot resolve " + schemaLoc + ": will append last component to current path " +
                                 "(not sure it will help though!)");
                         int lastSlash = schemaLoc.lastIndexOf('/');
@@ -841,7 +849,7 @@ public class SchemaLoader {
 
         } else {
             if (ee.type == null && ee.substGroup == null) {
-                Log.warning(Geonet.SCHEMA_MANAGER, "WARNING: " + ee.name + " is a global element without a type - assuming a string");
+                LOGGER.warn(SCHEMA_MANAGER_MARKER, "WARNING: " + ee.name + " is a global element without a type - assuming a string");
                 ee.type = "string";
             }
             hmElements.put(ee.name, ee.type);

--- a/core/src/main/java/org/fao/geonet/kernel/security/keycloak/KeycloakUserUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/keycloak/KeycloakUserUtils.java
@@ -26,6 +26,7 @@ package org.fao.geonet.kernel.security.keycloak;
 import javax.transaction.Transactional;
 import javax.transaction.Transactional.TxType;
 
+import org.apache.logging.log4j.Logger;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.*;
 import org.fao.geonet.kernel.security.GeonetworkAuthenticationProvider;
@@ -51,6 +52,7 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 
 public class KeycloakUserUtils {
+    private static final Logger LOGGER = Log.createLogger(KeycloakUserUtils.class,Geonet.SECURITY_MARKER);
 
     @Autowired
     private UserRepository userRepository;
@@ -98,7 +100,7 @@ public class KeycloakUserUtils {
                 }
             });
         } catch (ExecutionException e) {
-            Log.debug(Geonet.SECURITY, "Error getting user details from token.", e);
+            LOGGER.debug(Geonet.SECURITY_MARKER, "Error getting user details from token.", e);
             return null;
         }
     }
@@ -125,7 +127,7 @@ public class KeycloakUserUtils {
                 user = new User();
                 user.setUsername(baselUser.getUsername());
                 newUserFlag = true;
-                Log.debug(Geonet.SECURITY, "Adding a new user: " + user);
+                LOGGER.debug(Geonet.SECURITY_MARKER, "Adding a new user: {}" ,user);
             }
 
             if (!StringUtils.isEmpty(baselUser.getSurname())) {
@@ -200,7 +202,7 @@ public class KeycloakUserUtils {
         if (accessToken.getResourceAccess(adapterDeploymentContext.resolveDeployment(null).getResourceName()) != null) {
             for (String role : accessToken.getResourceAccess(adapterDeploymentContext.resolveDeployment(null).getResourceName()).getRoles()) {
                 if (role.contains(roleGroupSeparator)) {
-                    Log.debug(Geonet.SECURITY, "Identified group:profile (" + role + ") from user token.");
+                    LOGGER.debug(Geonet.SECURITY_MARKER, "Identified group:profile ({}) from user token.",role);
                     roleGroupList.add(role);
                 } else {
                     // Only use the profiles we know of and don't add duplicates.

--- a/core/src/main/java/org/fao/geonet/kernel/security/keycloak/KeycloakUserUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/keycloak/KeycloakUserUtils.java
@@ -202,7 +202,7 @@ public class KeycloakUserUtils {
         if (accessToken.getResourceAccess(adapterDeploymentContext.resolveDeployment(null).getResourceName()) != null) {
             for (String role : accessToken.getResourceAccess(adapterDeploymentContext.resolveDeployment(null).getResourceName()).getRoles()) {
                 if (role.contains(roleGroupSeparator)) {
-                    LOGGER.debug(Geonet.SECURITY_MARKER, "Identified group:profile ({}) from user token.",role);
+                    LOGGER.debug(Geonet.SECURITY_MARKER, "Identified group:profile ({}) from user token.", role);
                     roleGroupList.add(role);
                 } else {
                     // Only use the profiles we know of and don't add duplicates.

--- a/core/src/main/java/org/fao/geonet/lib/DbLib.java
+++ b/core/src/main/java/org/fao/geonet/lib/DbLib.java
@@ -23,8 +23,10 @@
 
 package org.fao.geonet.lib;
 
+import org.apache.logging.log4j.Logger;
 import org.fao.geonet.Constants;
 import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.kernel.mef.ExportFormat;
 import org.fao.geonet.utils.IO;
 import org.fao.geonet.utils.Log;
 import org.springframework.context.ApplicationContext;
@@ -47,9 +49,14 @@ import jeeves.server.context.ServiceContext;
 import jeeves.transaction.TransactionManager;
 import jeeves.transaction.TransactionTask;
 
+import static org.fao.geonet.constants.Geonet.DB_MARKER;
+
 //=============================================================================
 
 public class DbLib {
+
+    private static Logger LOGGER = Log.createLogger(ExportFormat.class, DB_MARKER);
+
     // -----------------------------------------------------------------------------
     // ---
     // --- API methods
@@ -60,8 +67,7 @@ public class DbLib {
 
     public void insertData(ServletContext servletContext, final ServiceContext context, Path appPath, Path filePath,
                            String filePrefix) throws Exception {
-        if (Log.isDebugEnabled(Geonet.DB))
-            Log.debug(Geonet.DB, "Filling database tables");
+        LOGGER.debug(DB_MARKER, "Filling database tables");
 
         final List<String> data = loadSqlDataFile(servletContext, context.getApplicationContext(), appPath, filePath, filePrefix);
         runSQL(context, data);
@@ -81,8 +87,7 @@ public class DbLib {
 
     public void insertData(ServletContext servletContext, Statement statement, Path appPath, Path filePath,
                            String filePrefix) throws Exception {
-        if (Log.isDebugEnabled(Geonet.DB))
-            Log.debug(Geonet.DB, "Filling database tables");
+        LOGGER.debug(DB_MARKER, "Filling database tables");
 
         List<String> data = loadSqlDataFile(servletContext, statement, appPath, filePath, filePrefix);
         runSQL(statement, data, true);
@@ -109,8 +114,7 @@ public class DbLib {
 
                     sql = sql.substring(0, sql.length() - 1);
 
-                    if (Log.isDebugEnabled(Geonet.DB))
-                        Log.debug(Geonet.DB, "Executing " + sql);
+                    LOGGER.debug(DB_MARKER, "Executing {}", sql);
 
                     try {
                         final String trimmedSQL = sql.trim();
@@ -122,7 +126,7 @@ public class DbLib {
                             query.executeUpdate();
                         }
                     } catch (Throwable e) {
-                        Log.warning(Geonet.DB, "SQL failure for: " + sql + ", error is:" + e.getMessage(), e);
+                        LOGGER.warn(DB_MARKER, "SQL failure for: " + sql + ", error is:" + e.getMessage(), e);
 
                         if (failOnError)
                             throw new RuntimeException(e);
@@ -156,8 +160,7 @@ public class DbLib {
 
                     sql = sql.substring(0, sql.length() - 1);
 
-                    if (Log.isDebugEnabled(Geonet.DB))
-                        Log.debug(Geonet.DB, "Executing " + sql);
+                    LOGGER.debug(DB_MARKER, "Executing {}", sql);
 
                     try {
                         if (sql.trim().startsWith("SELECT")) {
@@ -166,8 +169,7 @@ public class DbLib {
                             statement.execute(sql);
                         }
                     } catch (SQLException e) {
-                        Log.warning(Geonet.DB, "SQL failure for: " + sql + ", error is:" + e.getMessage());
-
+                        LOGGER.warn(DB_MARKER, "SQL failure for: {}, error is: {}", sql, e.getMessage());
                         if (failOnError)
                             throw e;
                     }
@@ -214,7 +216,7 @@ public class DbLib {
         if (finalPath != null)
             return finalPath;
         else {
-            Log.debug(Geonet.DB, "  No default SQL script found: " + (filePath + "/" + prefix + type + SQL_EXTENSION));
+            LOGGER.debug(DB_MARKER, "  No default SQL script found: " + (filePath + "/" + prefix + type + SQL_EXTENSION));
         }
         return toPath("");
     }

--- a/core/src/main/java/org/fao/geonet/resources/Resources.java
+++ b/core/src/main/java/org/fao/geonet/resources/Resources.java
@@ -28,6 +28,7 @@ import com.google.common.collect.Sets;
 import com.google.common.io.Files;
 import jeeves.server.context.ServiceContext;
 
+import org.apache.logging.log4j.Logger;
 import org.fao.geonet.domain.Pair;
 import org.fao.geonet.kernel.GeonetworkDataDirectory;
 import org.fao.geonet.utils.IO;
@@ -298,9 +299,11 @@ public abstract class Resources {
         } catch (IOException e) {
             // --- we ignore exceptions here, just log them
 
-            context.getLogger().warning("Cannot copy icon -> " + e.getMessage());
-            context.getLogger().warning(" (C) Source : " + icon);
-            context.getLogger().warning(" (C) Destin : " + logosDir);
+            Logger LOGGER = context.getLogger();
+
+            LOGGER.warn("Cannot copy icon -> {}", e.getMessage());
+            LOGGER.warn(" (C) Source : {}", icon);
+            LOGGER.warn(" (C) Destin : {}", logosDir);
         }
         return filename;
     }

--- a/core/src/main/java/org/fao/geonet/resources/Resources.java
+++ b/core/src/main/java/org/fao/geonet/resources/Resources.java
@@ -298,9 +298,9 @@ public abstract class Resources {
         } catch (IOException e) {
             // --- we ignore exceptions here, just log them
 
-            context.warning("Cannot copy icon -> " + e.getMessage());
-            context.warning(" (C) Source : " + icon);
-            context.warning(" (C) Destin : " + logosDir);
+            context.getLogger().warning("Cannot copy icon -> " + e.getMessage());
+            context.getLogger().warning(" (C) Source : " + icon);
+            context.getLogger().warning(" (C) Destin : " + logosDir);
         }
         return filename;
     }

--- a/csw-server/src/main/java/org/fao/geonet/component/csw/CatalogDispatcher.java
+++ b/csw-server/src/main/java/org/fao/geonet/component/csw/CatalogDispatcher.java
@@ -82,7 +82,7 @@ public class CatalogDispatcher {
     //---------------------------------------------------------------------------
 
     public Element dispatch(Element request, ServiceContext context) {
-        context.info("Received:\n" + Xml.getString(request));
+        context.getLogger().info("Received:\n" + Xml.getString(request));
 
         InputMethod im = context.getInputMethod();
         OutputMethod om = context.getOutputMethod();
@@ -105,7 +105,7 @@ public class CatalogDispatcher {
         } catch (CatalogException e) {
             exc = e;
         } catch (Exception e) {
-            context.info("Exception stack trace : \n" + Util.getStackTrace(e));
+            context.getLogger().info("Exception stack trace : \n" + Util.getStackTrace(e));
             // TODO what's this ?
             exc = new NoApplicableCodeEx(e.toString());
         }
@@ -151,9 +151,9 @@ public class CatalogDispatcher {
 
             request = cs.adaptGetRequest(params);
 
-            if (context.isDebugEnabled())
-                context.debug("Adapted GET request is:\n" + Xml.getString(request));
-            context.info("Dispatching operation : " + operation);
+            if (context.getLogger().isDebugEnabled())
+                context.getLogger().debug("Adapted GET request is:\n" + Xml.getString(request));
+            context.getLogger().info("Dispatching operation : " + operation);
 
             return cs.execute(request, context);
         }

--- a/csw-server/src/main/java/org/fao/geonet/component/csw/DescribeRecord.java
+++ b/csw-server/src/main/java/org/fao/geonet/component/csw/DescribeRecord.java
@@ -224,7 +224,7 @@ public class DescribeRecord extends AbstractOperation implements CatalogService 
                     Element currentSC = loadSchemaComponent(context, tname, schema);
                     scElements.put(tname, currentSC);
                 } catch (Exception ex) {
-                    context.getLogger().warning("Error while getting schema " + tname + " (" + schema+"): " + ex.getMessage());
+                    context.getLogger().warn("Error while getting schema {} ({}): {}", tname, schema, ex.getMessage());
                 }
             }
         } else {
@@ -273,8 +273,8 @@ public class DescribeRecord extends AbstractOperation implements CatalogService 
             return sc;
 
         } catch (Throwable e) {
-            context.error("Cannot get schema file : " + dir);
-            context.error("  (C) StackTrace\n" + Util.getStackTrace(e));
+            context.getLogger().error("Cannot get schema file : " + dir);
+            context.getLogger().error("  (C) StackTrace\n" + Util.getStackTrace(e));
 
             throw new NoApplicableCodeEx("Cannot get schema file for : " + tname);
         }

--- a/csw-server/src/main/java/org/fao/geonet/component/csw/DescribeRecord.java
+++ b/csw-server/src/main/java/org/fao/geonet/component/csw/DescribeRecord.java
@@ -224,7 +224,7 @@ public class DescribeRecord extends AbstractOperation implements CatalogService 
                     Element currentSC = loadSchemaComponent(context, tname, schema);
                     scElements.put(tname, currentSC);
                 } catch (Exception ex) {
-                    context.warning("Error while getting schema " + tname + " (" + schema+"): " + ex.getMessage());
+                    context.getLogger().warning("Error while getting schema " + tname + " (" + schema+"): " + ex.getMessage());
                 }
             }
         } else {

--- a/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/SearchController.java
+++ b/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/SearchController.java
@@ -176,8 +176,8 @@ public class SearchController {
         } catch (InvalidParameterValueEx e) {
             throw e;
         } catch (Exception e) {
-            context.error("Error while getting metadata with id : " + id);
-            context.error("  (C) StackTrace:\n" + Util.getStackTrace(e));
+            context.getLogger().error("Error while getting metadata with id : {}", id);
+            context.getLogger().error("  (C) StackTrace:",e);
             throw new NoApplicableCodeEx("Raised exception while getting metadata :" + e);
         }
     }
@@ -549,8 +549,8 @@ public class SearchController {
             try {
                 result = Xml.transform(result, styleSheet, params);
             } catch (Exception e) {
-                context.error("Error while transforming metadata with id : " + id + " using " + styleSheet);
-                context.error("  (C) StackTrace:\n" + Util.getStackTrace(e));
+                context.getLogger().error("Error while transforming metadata with id : " + id + " using " + styleSheet);
+                context.getLogger().error("  (C) StackTrace:", e);
                 return null;
             }
             return result;
@@ -606,8 +606,8 @@ public class SearchController {
             try {
                 result = Xml.transform(result, styleSheet, params);
             } catch (Exception e) {
-                context.error("Error while transforming metadata with id : " + id + " using " + styleSheet);
-                context.error("  (C) StackTrace:\n" + Util.getStackTrace(e));
+                context.getLogger().error("Error while transforming metadata with id : {} using {}" , id, styleSheet);
+                context.getLogger().error("  (C) StackTrace:", e);
                 return null;
             }
         }

--- a/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/SearchController.java
+++ b/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/SearchController.java
@@ -537,7 +537,7 @@ public class SearchController {
         Path styleSheet = schemaDir.resolve(outputSchema + "-" + elementSetName + ".xsl");
 
         if (!Files.exists(styleSheet)) {
-            context.warning(
+            context.getLogger().warning(
                 String.format(
                     "OutputSchema '%s' not supported for metadata with '%s' (%s). Corresponding XSL transformation '%s' does not exist. The record will not be returned in response.",
                     outputSchema, id, schema, styleSheet.toString()));

--- a/domain/src/test/resources/log4j2.xml
+++ b/domain/src/test/resources/log4j2.xml
@@ -2,7 +2,7 @@
 <Configuration status="warn" dest="out">
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
-            <PatternLayout pattern="%date{HH:mm:ss.SSS} %-6level [%logger{2}] - %msg%n"/>
+            <PatternLayout pattern="%date{HH:mm:ss.SSS} %-6level [%logger{2}] - %message%n"/>
         </Console>
     </Appenders>
     <Loggers>
@@ -11,12 +11,10 @@
         <Logger name="org.apache.jcs.auxiliary" level="error"/>
         <Logger name="org.hibernate" level="error"/>
         <Logger name="org.hibernate.SQL" level="warn"/>
-
         <Logger name="org.fao.geonet.database" level="warn"/>
         <Logger name="org.fao.geonet.type" level="warn"/>
         <Logger name="org.fao.geonet.formatter" level="warn"/>
         <Logger name="org.xhtmlrenderer" level="off"/>
-
         <Root level="warn">
             <AppenderRef ref="Console"/>
         </Root>

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Harvester.java
@@ -419,9 +419,9 @@ class Harvester implements IHarvester<HarvestResult> {
         try {
             resources.createImageFromReq(context, logoDir, logo, req);
         } catch (IOException e) {
-            context.warning("Cannot retrieve logo file from : " + url);
-            context.warning("  (C) Logo  : " + logo);
-            context.warning("  (C) Excep : " + e.getMessage());
+            context.getLogger().warning("Cannot retrieve logo file from : " + url);
+            context.getLogger().warning("  (C) Logo  : " + logo);
+            context.getLogger().warning("  (C) Excep : " + e.getMessage());
 
             resources.copyUnknownLogo(context, uuid);
         }

--- a/inspire-atom/src/main/java/org/fao/geonet/services/inspireatom/AtomServiceDescription.java
+++ b/inspire-atom/src/main/java/org/fao/geonet/services/inspireatom/AtomServiceDescription.java
@@ -32,6 +32,7 @@ import jeeves.server.context.ServiceContext;
 
 import nonapi.io.github.classgraph.utils.Join;
 import org.apache.commons.lang.NotImplementedException;
+import org.apache.logging.log4j.Logger;
 import org.fao.geonet.Util;
 import org.fao.geonet.api.API;
 import org.fao.geonet.api.ApiParams;
@@ -83,6 +84,7 @@ import static org.springframework.http.HttpStatus.OK;
     description = "ATOM")
 @RestController
 public class AtomServiceDescription {
+    private static Logger LOGGER = Log.createLogger(AtomServiceDescription.class,API.LOG_MARKER);
 
     @Autowired
     InspireAtomService service;
@@ -131,10 +133,10 @@ public class AtomServiceDescription {
         try {
             record = ApiUtils.canViewRecord(metadataUuid, request);
         } catch (ResourceNotFoundException e) {
-            Log.debug(API.LOG_MODULE_NAME, e.getMessage(), e);
+            LOGGER.debug(API.LOG_MARKER, e.getMessage(), e);
             throw e;
         } catch (Exception e) {
-            Log.debug(API.LOG_MODULE_NAME, e.getMessage(), e);
+            LOGGER.debug(API.LOG_MARKER, e.getMessage(), e);
             throw new NotAllowedException(ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_VIEW);
         }
 

--- a/schemas/iso19139/src/main/java/org/fao/geonet/schema/iso19139/ISO19139SchemaPlugin.java
+++ b/schemas/iso19139/src/main/java/org/fao/geonet/schema/iso19139/ISO19139SchemaPlugin.java
@@ -275,7 +275,7 @@ public class ISO19139SchemaPlugin
             return matches;
         } catch (Exception e) {
             LOGGER.debug(LOGGER_NAME,
-                "{}: getTranslationForElement failed on element {} using XPath '{}' updatedLocalizedTextElement exception ",
+                "{}: getTranslationForElement failed on element {} using XPath '{}' updatedLocalizedTextElement exception {}",
                 getIdentifier(),
                 Xml.getString(element),
                 path,

--- a/schemas/iso19139/src/main/java/org/fao/geonet/schema/iso19139/ISO19139SchemaPlugin.java
+++ b/schemas/iso19139/src/main/java/org/fao/geonet/schema/iso19139/ISO19139SchemaPlugin.java
@@ -26,6 +26,7 @@ package org.fao.geonet.schema.iso19139;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import org.apache.commons.lang.StringUtils;
+import org.apache.logging.log4j.Logger;
 import org.fao.geonet.kernel.schema.AssociatedResource;
 import org.fao.geonet.kernel.schema.AssociatedResourcesSchemaPlugin;
 import org.fao.geonet.kernel.schema.ExportablePlugin;
@@ -64,6 +65,8 @@ public class ISO19139SchemaPlugin
     ExportablePlugin,
     ISOPlugin,
     LinkAwareSchemaPlugin {
+
+    private static Logger LOGGER = Log.createLogger(ISO19139SchemaPlugin.class,SchemaPlugin.LOGGER_MARKER);
     public static final String IDENTIFIER = "iso19139";
 
     public static ImmutableSet<Namespace> allNamespaces;
@@ -145,11 +148,11 @@ public class ISO19139SchemaPlugin
                         listOfResources.add(resource);
                     }
                 } catch (Exception e) {
-                    Log.error(Log.JEEVES, "Error getting resources UUIDs", e);
+                    LOGGER.error(Log.JEEVES_MARKER, "Error getting resources UUIDs", e);
                 }
             }
         } catch (Exception e) {
-            Log.error(Log.JEEVES, "Error getting resources UUIDs", e);
+            LOGGER.error(Log.JEEVES_MARKER, "Error getting resources UUIDs", e);
         }
         return listOfResources;
     }
@@ -271,10 +274,13 @@ public class ISO19139SchemaPlugin
             List<Element> matches = xpath.selectNodes(element);
             return matches;
         } catch (Exception e) {
-            Log.debug(LOGGER_NAME, getIdentifier() + ": getTranslationForElement failed " +
-                "on element " + Xml.getString(element) +
-                " using XPath '" + path +
-                "updatedLocalizedTextElement exception " + e.getMessage());
+            LOGGER.debug(LOGGER_NAME,
+                "{}: getTranslationForElement failed on element {} using XPath '{}' updatedLocalizedTextElement exception ",
+                getIdentifier(),
+                Xml.getString(element),
+                path,
+                e.getMessage()
+            );
         }
         return null;
     }
@@ -547,11 +553,10 @@ public class ISO19139SchemaPlugin
                                   String attributeRef,
                                   String parsedAttributeName,
                                   String attributeValue) {
-        if (Log.isDebugEnabled(LOGGER_NAME)) {
-            Log.debug(LOGGER_NAME, String.format(
-                "Processing element %s, attribute %s with attributeValue %s.",
-                    el, attributeRef, attributeValue));
-        }
+        LOGGER.debug(LOGGER_MARKER,
+            "Processing element {}, attribute {} with attributeValue {}.",
+                el, attributeRef, attributeValue
+        );
 
         boolean elementToProcess = isElementToProcess(el);
 

--- a/schemas/schema-core/src/main/java/org/fao/geonet/kernel/schema/SchemaPlugin.java
+++ b/schemas/schema-core/src/main/java/org/fao/geonet/kernel/schema/SchemaPlugin.java
@@ -24,6 +24,8 @@
 package org.fao.geonet.kernel.schema;
 
 import com.google.common.collect.ImmutableSet;
+import org.apache.logging.log4j.Marker;
+import org.apache.logging.log4j.MarkerManager;
 import org.jdom.Element;
 import org.jdom.Namespace;
 
@@ -39,6 +41,7 @@ import java.util.Set;
  */
 public abstract class SchemaPlugin implements CSWPlugin {
     public static final String LOGGER_NAME = "geonetwork.schema-plugin";
+    public static Marker LOGGER_MARKER = MarkerManager.getMarker("schema-plugin").addParents(MarkerManager.getMarker("geonetwork"));
 
     protected SchemaPlugin(String identifier,
                            ImmutableSet<Namespace> allNamespaces) {

--- a/services/src/main/java/org/fao/geonet/api/AllRequestsInterceptor.java
+++ b/services/src/main/java/org/fao/geonet/api/AllRequestsInterceptor.java
@@ -91,7 +91,7 @@ public class AllRequestsInterceptor extends HandlerInterceptorAdapter {
                 session.setsHttpSession(httpSession);
 
                 if (LOGGER.isDebugEnabled(Log.REQUEST_MARKER)) {
-                    LOGGER.debug(Log.REQUEST_MARKER, "Session created for client : {}",request.getRemoteAddr());
+                    LOGGER.debug(Log.REQUEST_MARKER, "Session created for client : {}", request.getRemoteAddr());
                 }
             }
         } else {

--- a/services/src/main/java/org/fao/geonet/api/AllRequestsInterceptor.java
+++ b/services/src/main/java/org/fao/geonet/api/AllRequestsInterceptor.java
@@ -26,6 +26,7 @@ package org.fao.geonet.api;
 import jeeves.constants.Jeeves;
 import jeeves.server.UserSession;
 import org.apache.commons.lang.StringUtils;
+import org.apache.logging.log4j.Logger;
 import org.fao.geonet.utils.Log;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.servlet.handler.HandlerInterceptorAdapter;
@@ -43,6 +44,7 @@ import java.util.regex.Pattern;
  * Avoid to create any sessions for crawlers.
  */
 public class AllRequestsInterceptor extends HandlerInterceptorAdapter {
+    private static Logger LOGGER = Log.createLogger(AllRequestsInterceptor.class,Log.REQUEST_MARKER);
 
     /**
      * List of bots to avoid.
@@ -88,18 +90,19 @@ public class AllRequestsInterceptor extends HandlerInterceptorAdapter {
                 httpSession.setAttribute(Jeeves.Elem.SESSION, session);
                 session.setsHttpSession(httpSession);
 
-                if (Log.isDebugEnabled(Log.REQUEST)) {
-                    Log.debug(Log.REQUEST, "Session created for client : " + request.getRemoteAddr());
+                if (LOGGER.isDebugEnabled(Log.REQUEST_MARKER)) {
+                    LOGGER.debug(Log.REQUEST_MARKER, "Session created for client : {}",request.getRemoteAddr());
                 }
             }
         } else {
             HttpSession httpSession = request.getSession(false);
-            if (Log.isDebugEnabled(Log.REQUEST)) {
-                Log.debug(Log.REQUEST, String.format(
-                    "Crawler '%s' detected. Session MUST be null: %s",
+            if (LOGGER.isDebugEnabled(Log.REQUEST_MARKER)) {
+                LOGGER.debug(
+                    Log.REQUEST_MARKER,
+                    "Crawler '{}' detected. Session MUST be null: {}",
                     userAgent,
                     request.getSession(false) == null
-                ));
+                );
             }
             if (httpSession != null) {
                 httpSession.invalidate();

--- a/services/src/main/java/org/fao/geonet/api/mapservers/GeoServerRest.java
+++ b/services/src/main/java/org/fao/geonet/api/mapservers/GeoServerRest.java
@@ -526,7 +526,7 @@ public class GeoServerRest {
         } catch (Exception e) {
             LOGGER.debug(
                 LOGGER_MARKER,
-                "Failed to create style for layer: {} in workspace {}, error is: ",
+                "Failed to create style for layer: {} in workspace {}, error is: {}",
                 layer,
                 ws,
                 e.getMessage()
@@ -587,12 +587,12 @@ public class GeoServerRest {
         LOGGER.debug(
             Geonet.GEOPUBLISH_MARKER,
             "Checking if a featuretype named {} already exists in workspace {}, datastore {}",
-            ft,ws,ds
+            ft, ws, ds
         );
         status = sendREST(GeoServerRest.METHOD_GET, url + "/" + ft, null, null, null, true);
         if (status != 200) {
             LOGGER.debug(Geonet.GEOPUBLISH_MARKER, "Creating featuretype {} in workspace {} within datastore {}",
-                ft,ws,ds);
+                ft, ws, ds);
             status = sendREST(GeoServerRest.METHOD_POST, url, xml, null, "text/xml",
                 true);
             checkResponseCode(status);
@@ -655,8 +655,8 @@ public class GeoServerRest {
         response = "";
         String url = this.restUrl + urlParams;
         if (LOGGER.isDebugEnabled(LOGGER_MARKER)) {
-            LOGGER.debug(LOGGER_MARKER, "url:{}",url);
-            LOGGER.debug(LOGGER_MARKER, "method:{}",method);
+            LOGGER.debug(LOGGER_MARKER, "url:{}", url);
+            LOGGER.debug(LOGGER_MARKER, "method:{}", method);
             if (postData != null) LOGGER.debug(LOGGER_MARKER, "postData:{}", postData);
         }
 
@@ -695,7 +695,7 @@ public class GeoServerRest {
         try {
             m.addHeader(new BasicScheme().authenticate(new UsernamePasswordCredentials(username, password), m));
         } catch (AuthenticationException a) {
-            LOGGER.warn(LOGGER_MARKER, "Failed to add the authentication Header, error is: {}",a.getMessage());
+            LOGGER.warn(LOGGER_MARKER, "Failed to add the authentication Header, error is: {}", a.getMessage());
         }
 
         final ClientHttpResponse httpResponse = factory.execute(m, new UsernamePasswordCredentials(username, password), AuthScope.ANY);

--- a/services/src/main/java/org/fao/geonet/api/processing/DatabaseProcessUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/processing/DatabaseProcessUtils.java
@@ -122,8 +122,8 @@ public class DatabaseProcessUtils {
                 // Using hash on processMd and metadata ?
             } catch (Exception e) {
                 report.addMetadataError(info, e);
-                context.error("  Processing failed with error " + e.getMessage());
-                context.error(e);
+                context.getLogger().error("  Processing failed with error " + e.getMessage());
+                context.getLogger().error(e);
             }
             return wellFormedXml;
         }

--- a/services/src/main/java/org/fao/geonet/api/processing/MetadataSearchAndReplace.java
+++ b/services/src/main/java/org/fao/geonet/api/processing/MetadataSearchAndReplace.java
@@ -116,7 +116,7 @@ public class MetadataSearchAndReplace extends MetadataIndexerProcessor {
 
         for (String uuid : this.metadata) {
             String id = dm.getMetadataId(uuid);
-            context.info("Processing metadata with id:" + id);
+            context.getLogger().info("Processing metadata with id:" + id);
             processInternal(id, process, "replacements", replacementsString, context);
         }
     }

--- a/services/src/main/java/org/fao/geonet/api/processing/XslProcessUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/processing/XslProcessUtils.java
@@ -290,8 +290,7 @@ public class XslProcessUtils {
                 // Using hash on processMd and metadata ?
             } catch (Exception e) {
                 report.addMetadataError(info, e);
-                context.error("  Processing failed with error " + e.getMessage());
-                context.error(e);
+                context.getLogger().error("  Processing failed with error {}", e.getMessage(),e);
             }
             return sw.toString();
         }

--- a/services/src/main/java/org/fao/geonet/api/processing/XslProcessUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/processing/XslProcessUtils.java
@@ -187,8 +187,8 @@ public class XslProcessUtils {
                 // Using hash on processMd and metadata ?
             } catch (Exception e) {
                 report.addMetadataError(info, e);
-                context.error("  Processing failed with error " + e.getMessage());
-                context.error(e);
+                context.getLogger().error("  Processing failed with error " + e.getMessage());
+                context.getLogger().error(e);
             }
             return processedMetadata;
         }

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataApi.java
@@ -31,6 +31,8 @@ import jeeves.server.context.ServiceContext;
 import jeeves.services.ReadWriteController;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
+import org.apache.logging.log4j.Level;
+import org.apache.logging.log4j.Logger;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.api.API;
 import org.fao.geonet.api.ApiParams;
@@ -82,7 +84,7 @@ import static org.fao.geonet.kernel.mef.MEFLib.Version.Constants.MEF_V2_ACCEPT_T
 @Controller("records")
 @ReadWriteController
 public class MetadataApi {
-
+    private static Logger LOGGER = Log.createLogger(MetadataApi.class,API.LOG_MARKER);
     @Autowired
     SchemaManager _schemaManager;
 
@@ -155,7 +157,7 @@ public class MetadataApi {
         try {
             ApiUtils.canViewRecord(metadataUuid, request);
         } catch (SecurityException e) {
-            Log.debug(API.LOG_MODULE_NAME, e.getMessage(), e);
+            LOGGER.debug(API.LOG_MARKER, e.getMessage(), e);
             throw new NotAllowedException(ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_VIEW);
         }
         List<String> accept = Arrays.asList(acceptHeader.split(","));
@@ -239,10 +241,10 @@ public class MetadataApi {
         try {
             metadata = ApiUtils.canViewRecord(metadataUuid, request);
         } catch (ResourceNotFoundException e) {
-            Log.debug(API.LOG_MODULE_NAME, e.getMessage(), e);
+            LOGGER.debug(API.LOG_MARKER, e.getMessage(), e);
             throw e;
         } catch (Exception e) {
-            Log.debug(API.LOG_MODULE_NAME, e.getMessage(), e);
+            LOGGER.debug(API.LOG_MARKER, e.getMessage(), e);
             throw new NotAllowedException(ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_VIEW);
         }
         ServiceContext context = ApiUtils.createServiceContext(request);
@@ -253,7 +255,7 @@ public class MetadataApi {
         } catch (Exception e) {
             // TODO: i18n
             // TODO: Report exception in JSON format
-            Log.debug(API.LOG_MODULE_NAME, e.getMessage(), e);
+            LOGGER.debug(API.LOG_MARKER, e.getMessage(), e);
             throw new NotAllowedException(ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_VIEW);
 
         }
@@ -382,7 +384,7 @@ public class MetadataApi {
         try {
             metadata = ApiUtils.canViewRecord(metadataUuid, request);
         } catch (SecurityException e) {
-            Log.debug(API.LOG_MODULE_NAME, e.getMessage(), e);
+            LOGGER.debug(API.LOG_MARKER, e.getMessage(), e);
             throw new NotAllowedException(ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_VIEW);
         }
         Path stylePath = dataDirectory.getWebappDir().resolve(Geonet.Path.SCHEMAS);
@@ -426,8 +428,7 @@ public class MetadataApi {
                 uuidsToExport.addAll(getUuidsOfAssociatedRecords(related.getHasfeaturecats()));
                 uuidsToExport.addAll(getUuidsOfAssociatedRecords(related.getHassources()));
             }
-            Log.info(Geonet.MEF, "Building MEF2 file with " + uuidsToExport.size()
-                + " records.");
+            LOGGER.info(Geonet.MEF_MARKER, "Building MEF2 file with {} records.", uuidsToExport.size());
 
             file = MEFLib.doMEF2Export(context, uuidsToExport, format.toString(), false, stylePath, withXLinksResolved, withXLinkAttribute, false, addSchemaLocation, approved);
 
@@ -474,10 +475,10 @@ public class MetadataApi {
         try {
             metadata = ApiUtils.canViewRecord(metadataUuid, request);
         } catch (ResourceNotFoundException e) {
-            Log.debug(API.LOG_MODULE_NAME, e.getMessage(), e);
+            LOGGER.debug(API.LOG_MARKER, e.getMessage(), e);
             throw e;
         } catch (Exception e) {
-            Log.debug(API.LOG_MODULE_NAME, e.getMessage(), e);
+            LOGGER.debug(API.LOG_MARKER, e.getMessage(), e);
             throw new NotAllowedException(ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_VIEW);
         }
         ServiceContext context = ApiUtils.createServiceContext(request);
@@ -528,7 +529,7 @@ public class MetadataApi {
         try {
             md = ApiUtils.canViewRecord(metadataUuid, request);
         } catch (SecurityException e) {
-            Log.debug(API.LOG_MODULE_NAME, e.getMessage(), e);
+            LOGGER.debug(API.LOG_MARKER, e.getMessage(), e);
             throw new NotAllowedException(ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_VIEW);
         }
 
@@ -613,7 +614,7 @@ public class MetadataApi {
 
             return response;
         } catch (Exception e) {
-            Log.error(API.LOG_MODULE_NAME, e.getMessage(), e);
+            LOGGER.error(API.LOG_MARKER, e.getMessage(), e);
             throw new ResourceNotFoundException();
         }
 

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataAssociatedApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataAssociatedApi.java
@@ -29,6 +29,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jeeves.server.context.ServiceContext;
 import jeeves.services.ReadWriteController;
+import org.apache.logging.log4j.Logger;
 import org.fao.geonet.api.API;
 import org.fao.geonet.api.ApiParams;
 import org.fao.geonet.api.ApiUtils;
@@ -64,6 +65,7 @@ import static org.fao.geonet.api.ApiParams.*;
 @Controller("associatedRecords")
 @ReadWriteController
 public class MetadataAssociatedApi {
+    private static Logger LOGGER = Log.createLogger(MetadataAssociatedApi.class,API.LOG_MARKER);
 
     @Autowired
     SchemaManager _schemaManager;
@@ -131,7 +133,7 @@ public class MetadataAssociatedApi {
         try {
             md = ApiUtils.canViewRecord(metadataUuid, request);
         } catch (SecurityException e) {
-            Log.debug(API.LOG_MODULE_NAME, e.getMessage(), e);
+            LOGGER.debug(API.LOG_MARKER, e.getMessage(), e);
             throw new NotAllowedException(ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_VIEW);
         }
 

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataSocialApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataSocialApi.java
@@ -153,7 +153,7 @@ public class MetadataSocialApi {
      * TODO GN-API: Needs update on new API
      */
     private int setRemoteRating(ServiceContext context, GeonetParams params, String uuid, int rating) throws Exception {
-        if (context.getLogger().isDebugEnabled()) context.debug("Rating remote metadata with uuid:" + uuid);
+        context.getLogger().debug("Rating remote metadata with uuid: {}", uuid);
 
         XmlRequest req = context.getBean(GeonetHttpRequestFactory.class).createXmlRequest(new URL(params.host));
 

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataSocialApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataSocialApi.java
@@ -153,7 +153,7 @@ public class MetadataSocialApi {
      * TODO GN-API: Needs update on new API
      */
     private int setRemoteRating(ServiceContext context, GeonetParams params, String uuid, int rating) throws Exception {
-        if (context.isDebugEnabled()) context.debug("Rating remote metadata with uuid:" + uuid);
+        if (context.getLogger().isDebugEnabled()) context.debug("Rating remote metadata with uuid:" + uuid);
 
         XmlRequest req = context.getBean(GeonetHttpRequestFactory.class).createXmlRequest(new URL(params.host));
 

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java
@@ -34,6 +34,7 @@ import jeeves.services.ReadWriteController;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.logging.log4j.Logger;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.api.API;
 import org.fao.geonet.api.ApiParams;
@@ -88,6 +89,8 @@ import static org.fao.geonet.api.ApiParams.*;
 @Controller("recordWorkflow")
 @ReadWriteController
 public class MetadataWorkflowApi {
+
+    private static Logger LOGGER = Log.createLogger(MetadataWorkflowApi.class,API.LOG_MARKER);
 
     @Autowired
     LanguageUtils languageUtils;
@@ -1094,7 +1097,7 @@ public class MetadataWorkflowApi {
         try {
             ApiUtils.canEditRecord(metadataStatus.getUuid(), request);
         } catch (SecurityException e) {
-            Log.debug(API.LOG_MODULE_NAME, e.getMessage(), e);
+            LOGGER.debug(API.LOG_MARKER, e.getMessage(), e);
             throw new NotAllowedException(ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_VIEW);
         } catch (ResourceNotFoundException e) {
             // If metadata record does not exists then it was deleted so

--- a/services/src/main/java/org/fao/geonet/api/records/editing/MetadataEditingApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/editing/MetadataEditingApi.java
@@ -721,8 +721,8 @@ public class MetadataEditingApi {
                         schemas.addContent(schemaElem);
                     }
                 } catch (Exception e) {
-                    context.error("Failed to load localization file for schema " + schema + ": " + e.getMessage());
-                    context.error(e);
+                    context.getLogger().error("Failed to load localization file for schema " + schema + ": " + e.getMessage());
+                    context.getLogger().error(e);
                 }
             }
         }

--- a/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
@@ -272,9 +272,8 @@ public class KeywordsApi {
 
         KeywordsSearcher searcher;
         // perform the search and save search result into session
-        if (Log.isDebugEnabled("KeywordsManager")) {
-            Log.debug("KeywordsManager", "Creating new keywords searcher");
-        }
+        Log.debug("KeywordsManager", "Creating new keywords searcher");
+
         searcher = new KeywordsSearcher(context, thesaurusMan);
 
         String thesauriDomainName = null;

--- a/services/src/main/java/org/fao/geonet/api/related/Related.java
+++ b/services/src/main/java/org/fao/geonet/api/related/Related.java
@@ -29,6 +29,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jeeves.server.context.ServiceContext;
 import jeeves.services.ReadWriteController;
+import org.apache.logging.log4j.Logger;
 import org.fao.geonet.api.API;
 import org.fao.geonet.api.ApiParams;
 import org.fao.geonet.api.ApiUtils;
@@ -65,6 +66,7 @@ import java.util.Map;
 @Controller("related")
 @ReadWriteController
 public class Related implements ApplicationContextAware {
+    private static final Logger LOGGER = Log.createLogger(Related.class,API.LOG_MARKER);
 
     @Autowired
     LanguageUtils languageUtils;
@@ -127,10 +129,10 @@ public class Related implements ApplicationContextAware {
                 RelatedResponse response = (RelatedResponse) Xml.unmarshall(transform, RelatedResponse.class);
                 res.put(uuid, response);
             } catch (SecurityException e) {
-                Log.debug(API.LOG_MODULE_NAME, e.getMessage(), e);
+                LOGGER.debug(API.LOG_MARKER, e.getMessage(), e);
                 throw new NotAllowedException(ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_VIEW);
             } catch (Exception exception) {
-                Log.debug(API.LOG_MODULE_NAME, exception.getMessage(), exception);
+                LOGGER.debug(API.LOG_MARKER, exception.getMessage(), exception);
             }
 
         }

--- a/services/src/main/java/org/fao/geonet/api/site/SiteApi.java
+++ b/services/src/main/java/org/fao/geonet/api/site/SiteApi.java
@@ -167,8 +167,8 @@ public class SiteApi {
             // Update http.proxyHost, http.proxyPort and http.nonProxyHosts
             Lib.net.setupProxy(settingMan);
         } catch (Exception e) {
-            context.error("Reload services. Error: " + e.getMessage());
-            context.error(e);
+            context.getLogger().error("Reload services. Error: " + e.getMessage());
+            context.getLogger().error(e);
             throw new OperationAbortedEx("Parameters saved but cannot set proxy information: " + e.getMessage());
         }
         DoiManager doiManager = gc.getBean(DoiManager.class);

--- a/services/src/main/java/org/fao/geonet/services/feedback/AddLimitations.java
+++ b/services/src/main/java/org/fao/geonet/services/feedback/AddLimitations.java
@@ -172,8 +172,8 @@ public class AddLimitations implements Service {
         elBrief.setAttribute("currdate", now());
         root.addContent(elBrief);
         root.addContent(downloaded);
-        if (context.isDebugEnabled())
-            context.debug("Passed to metadata-license-annex.xsl:\n " + Xml.getString(root));
+        if (context.getLogger().isDebugEnabled())
+            context.getLogger().debug("Passed to metadata-license-annex.xsl:\n " + Xml.getString(root));
 
         //--- create the license annex html using the info in root element and
         //--- add it to response under license element

--- a/services/src/main/java/org/fao/geonet/services/main/GenericController.java
+++ b/services/src/main/java/org/fao/geonet/services/main/GenericController.java
@@ -30,6 +30,7 @@ import jeeves.server.sources.ServiceRequest;
 import jeeves.server.sources.ServiceRequestFactory;
 import org.apache.commons.io.FileUtils;
 import org.fao.geonet.ApplicationContextHolder;
+import org.fao.geonet.Logger;
 import org.fao.geonet.NodeInfo;
 import org.fao.geonet.Util;
 import org.fao.geonet.exceptions.FileUploadTooBigEx;
@@ -77,25 +78,29 @@ public class GenericController {
         if (forwardedFor != null)
             ip = forwardedFor;
 
-        Log.info(Log.REQUEST, "==========================================================");
+        Logger LOGGER = Log.createLogger(GenericController.class, Log.REQUEST_MARKER);
 
-        Log.info(Log.REQUEST, "HTML Request (from " + ip + ") : " + request.getRequestURI());
-        if (Log.isDebugEnabled(Log.REQUEST)) {
-            Log.debug(Log.REQUEST, "Method       : " + request.getMethod());
-            Log.debug(Log.REQUEST, "Content type : " + request.getContentType());
+
+        LOGGER.info("==========================================================");
+
+        LOGGER.info("HTML Request (from " + ip + ") : " + request.getRequestURI());
+        if (LOGGER.isDebugEnabled()) {
+            LOGGER.debug("Method       : {}",request.getMethod());
+            LOGGER.debug("Content type : {}",request.getContentType());
             // Log.debug(Log.REQUEST, "Context path : "+ req.getContextPath());
             // Log.debug(Log.REQUEST, "Char encoding: "+
             // req.getCharacterEncoding());
-            Log.debug(Log.REQUEST, "Accept       : " + request.getHeader("Accept"));
+            LOGGER.debug( "Accept       : {}",request.getHeader("Accept"));
             // Log.debug(Log.REQUEST, "Server name  : "+ req.getServerName());
             // Log.debug(Log.REQUEST, "Server port  : "+ req.getServerPort());
         }
 
-        if (Log.isDebugEnabled(Log.REQUEST)) {
+        if (LOGGER.isDebugEnabled()) {
             if (httpSession != null) {
-                Log.debug(Log.REQUEST, "Session id is " + httpSession.getId());
+
+                LOGGER.debug( "Session id is {0}",httpSession.getId());
             } else {
-                Log.debug(Log.REQUEST, "No session created");
+                LOGGER.debug( "No session created");
             }
         }
 
@@ -112,8 +117,7 @@ public class GenericController {
                 httpSession.setAttribute(USER_SESSION_ATTRIBUTE_KEY, session);
                 session.setsHttpSession(httpSession);
 
-                if (Log.isDebugEnabled(Log.REQUEST))
-                    Log.debug(Log.REQUEST, "Session created for client : " + ip);
+                LOGGER.debug( "Session created for client : {}", ip);
             }
         }
 
@@ -134,7 +138,8 @@ public class GenericController {
             // now stick the stack trace on the end and log the whole lot
             sb.append("Stack :\n");
             sb.append(Util.getStackTrace(e));
-            Log.error(Log.REQUEST, sb.toString());
+
+            LOGGER.error(sb.toString());
 
         } catch (Exception e) {
             StringBuffer sb = new StringBuffer();
@@ -147,7 +152,8 @@ public class GenericController {
             // now stick the stack trace on the end and log the whole lot
             sb.append("Stack :\n");
             sb.append(Util.getStackTrace(e));
-            Log.error(Log.REQUEST, sb.toString());
+
+            LOGGER.error(sb.toString());
         }
 
         // --- execute request

--- a/services/src/main/java/org/fao/geonet/services/main/GenericController.java
+++ b/services/src/main/java/org/fao/geonet/services/main/GenericController.java
@@ -90,7 +90,7 @@ public class GenericController {
             // Log.debug(Log.REQUEST, "Context path : "+ req.getContextPath());
             // Log.debug(Log.REQUEST, "Char encoding: "+
             // req.getCharacterEncoding());
-            LOGGER.debug( "Accept       : {}",request.getHeader("Accept"));
+            LOGGER.debug( "Accept       : {}", request.getHeader("Accept"));
             // Log.debug(Log.REQUEST, "Server name  : "+ req.getServerName());
             // Log.debug(Log.REQUEST, "Server port  : "+ req.getServerPort());
         }

--- a/services/src/main/java/org/fao/geonet/services/metadata/PrepareFileDownload.java
+++ b/services/src/main/java/org/fao/geonet/services/metadata/PrepareFileDownload.java
@@ -182,7 +182,7 @@ public class PrepareFileDownload implements Service {
                 elem.setAttribute("download", "true");
                 response.addContent(elem);
             } else {
-                context.info("Unknown download link: " + Xml.getString(elem));
+                context.getLogger().info("Unknown download link: " + Xml.getString(elem));
             }
         }
 

--- a/services/src/main/java/org/fao/geonet/services/resources/DownloadArchive.java
+++ b/services/src/main/java/org/fao/geonet/services/resources/DownloadArchive.java
@@ -191,8 +191,8 @@ public class DownloadArchive implements Service {
                     BinaryFile details = BinaryFile.encode(200, resource.getPath(), false);
                     String remoteURL = details.getElement().getAttributeValue("remotepath");
                     if (remoteURL != null) {
-                        if (context.isDebugEnabled())
-                            context.debug("Downloading " + remoteURL + " to archive " + zFile.getFileName());
+                        if (context.getLogger().isDebugEnabled())
+                            context.getLogger().debug("Downloading " + remoteURL + " to archive " + zFile.getFileName());
                         fileInfo.setAttribute("size", "unknown");
                         fileInfo.setAttribute("datemodified", "unknown");
                         fileInfo.setAttribute("name", remoteURL);
@@ -200,8 +200,8 @@ public class DownloadArchive implements Service {
                             remoteURL + " (local config: " + resource.getPath() + ")", context);
                         fname = details.getElement().getAttributeValue("remotefile");
                     } else {
-                        if (context.isDebugEnabled())
-                            context.debug("Writing " + fname + " to archive " + zFile.getFileName());
+                        if (context.getLogger().isDebugEnabled())
+                            context.getLogger().debug("Writing " + fname + " to archive " + zFile.getFileName());
                         fileInfo.setAttribute("size", Long.toString(resource.getMetadata().getSize()));
                         fileInfo.setAttribute("name", fname);
                         fileInfo.setAttribute("datemodified", sdf.format(resource.getMetadata().getLastModification()));
@@ -246,8 +246,8 @@ public class DownloadArchive implements Service {
                 root.addContent(downloaded);
                 root.addContent(entered);
                 root.addContent(userDetails);
-                if (context.isDebugEnabled())
-                    context.debug("Passed to metadata-license-annex.xsl:\n " + Xml.getString(root));
+                if (context.getLogger().isDebugEnabled())
+                    context.getLogger().debug("Passed to metadata-license-annex.xsl:\n " + Xml.getString(root));
 
                 //--- create the license annex html file using the info in root element and
                 //--- add it to the zip stream
@@ -278,18 +278,18 @@ public class DownloadArchive implements Service {
         Element license = Xml.selectElement(root, "metadata/*/licenseLink");
         if (license != null) {
             String licenseURL = license.getText();
-            if (context.isDebugEnabled())
-                context.debug("license URL = " + licenseURL);
+            if (context.getLogger().isDebugEnabled())
+                context.getLogger().debug("license URL = " + licenseURL);
 
             Path licenseFilesDir = getLicenseFilesPath(licenseURL, context);
-            if (context.isDebugEnabled())
-                context.debug(" licenseFilesPath = " + licenseFilesDir);
+            if (context.getLogger().isDebugEnabled())
+                context.getLogger().debug(" licenseFilesPath = " + licenseFilesDir);
 
             if (licenseFilesDir != null && Files.exists(licenseFilesDir)) {
                 try (DirectoryStream<Path> paths = Files.newDirectoryStream(licenseFilesDir)) {
                     for (Path licenseFile : paths) {
-                        if (context.isDebugEnabled()) {
-                            context.debug("adding " + licenseFile + " to zip file");
+                        if (context.getLogger().isDebugEnabled()) {
+                            context.getLogger().debug("adding " + licenseFile + " to zip file");
                         }
                         Files.copy(licenseFile, zipFs.getPath(licenseFile.getFileName().toString()));
                     }
@@ -308,8 +308,8 @@ public class DownloadArchive implements Service {
         //--- Get license files subdirectory for license
         URL url = new URL(licenseURL);
         String licenseFilesPath = url.getHost() + url.getPath();
-        if (context.isDebugEnabled())
-            context.debug("licenseFilesPath= " + licenseFilesPath);
+        if (context.getLogger().isDebugEnabled())
+            context.getLogger().debug("licenseFilesPath= " + licenseFilesPath);
 
         //--- Get local mirror directory for license files
         Path path = context.getAppPath();
@@ -322,8 +322,8 @@ public class DownloadArchive implements Service {
         Path licenseDir = IO.toPath(licenseDirAsString);
         if (!licenseDir.isAbsolute()) licenseDir = path.resolve(licenseDir);
 
-        if (context.isDebugEnabled()) {
-            context.debug("licenseDir = " + licenseDir);
+        if (context.getLogger().isDebugEnabled()) {
+            context.getLogger().debug("licenseDir = " + licenseDir);
         }
 
         //--- return license files directory
@@ -354,15 +354,15 @@ public class DownloadArchive implements Service {
             String fromDescr = "GeoNetwork administrator";
 
             String dateTime = now();
-            context.info("DOWNLOADED:" + theFile + "," + id + "," + uuid + "," + context.getIpAddress() + "," + username);
+            context.getLogger().info("DOWNLOADED:" + theFile + "," + id + "," + uuid + "," + context.getIpAddress() + "," + username);
 
             if (host.trim().length() == 0 || from.trim().length() == 0) {
-                if (context.isDebugEnabled()) {
-                    context.debug("Skipping email notification");
+                if (context.getLogger().isDebugEnabled()) {
+                    context.getLogger().debug("Skipping email notification");
                 }
             } else {
-                if (context.isDebugEnabled()) {
-                    context.debug("Sending email notification for file : " + theFile);
+                if (context.getLogger().isDebugEnabled()) {
+                    context.getLogger().debug("Sending email notification for file : " + theFile);
                 }
 
                 OperationAllowedRepository opAllowedRepo = context.getBean(OperationAllowedRepository.class);

--- a/services/src/main/java/org/fao/geonet/services/thesaurus/GetKeywords.java
+++ b/services/src/main/java/org/fao/geonet/services/thesaurus/GetKeywords.java
@@ -115,9 +115,7 @@ public class GetKeywords {
             // perform the search and save search result into session
             ThesaurusManager thesaurusMan = applicationContext.getBean(ThesaurusManager.class);
 
-            if (Log.isDebugEnabled("KeywordsManager")) {
-                Log.debug("KeywordsManager", "Creating new keywords searcher");
-            }
+            Log.debug("KeywordsManager", "Creating new keywords searcher");
             searcher = new KeywordsSearcher(context, thesaurusMan);
 
             IsoLanguagesMapper languagesMapper = applicationContext.getBean(IsoLanguagesMapper.class);

--- a/services/src/main/java/org/fao/geonet/services/thesaurus/GetNarrowerBroader.java
+++ b/services/src/main/java/org/fao/geonet/services/thesaurus/GetNarrowerBroader.java
@@ -66,8 +66,7 @@ public class GetNarrowerBroader implements Service {
             .getHandlerContext(Geonet.CONTEXT_NAME);
         ThesaurusManager thesaurusMan = gc.getBean(ThesaurusManager.class);
 
-        if (Log.isDebugEnabled("KeywordsManager"))
-            Log.debug("KeywordsManager", "Creating new keywords searcher");
+        Log.debug("KeywordsManager", "Creating new keywords searcher");
         searcher = new KeywordsSearcher(context, thesaurusMan);
 
         String request = Util.getParam(params, "request");

--- a/web/src/main/webapp/WEB-INF/classes/log4j2.xml
+++ b/web/src/main/webapp/WEB-INF/classes/log4j2.xml
@@ -3,9 +3,27 @@
   <Properties>
     <Property name="log_dir">./logs</Property>
   </Properties>
+
+  <Filters>
+    <NoMarkerFilter onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+    <!-- filter by geonetwork module -->
+    <Filters>
+      <ThresholdFilter level="INFO" onMatch="NEUTRAL" onMismatch="DENY"/>
+      <MarkerFilter marker="atom" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+      <MarkerFilter marker="databasemigration" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+      <MarkerFilter marker="encryptor" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+      <MarkerFilter marker="harvester" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+    </Filters>
+    <Filters>
+      <ThresholdFilter level="ERROR" onMatch="NEUTRAL" onMismatch="DENY"/>
+      <MarkerFilter marker="geonetwork" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+      <MarkerFilter marker="jeeves" onMatch="ACCEPT" onMismatch="NEUTRAL"/>
+    </Filters>
+  </Filters>
+
   <Appenders>
     <Console name="Console" target="SYSTEM_OUT">
-      <PatternLayout pattern="%date{ISO8601} %-5level [%logger] - %message%n"/>
+      <PatternLayout pattern="%date{ISO8601} %-5level %marker [%logger] - %message%n"/>
     </Console>
     <RollingFile name="File">
       <filename>${sys:log_dir:-log_dir}/geonetwork.log</filename>
@@ -22,66 +40,25 @@
         <Route>
           <File name="harvester-${ctx:harvester}" fileName="${sys:log_dir:-log_dir}/${ctx:logfile}">
             <PatternLayout>
-              <pattern>%date{ISO8601}{${ctx:timeZone}} %-5level [%logger] - %message%n</pattern>
+              <pattern>%date{ISO8601}{${ctx:timeZone}} %-5level %marker [%logger] - %message%n</pattern>
             </PatternLayout>
           </File>
         </Route>
       </Routes>
     </Routing>
   </Appenders>
+
   <Loggers>
-    <!-- Geonetwork module (and submodule) logging -->
-    <Logger name="geonetwork" level="error" additivity="false">
+    <Logger name="org.fao.geonet" level="error" additivity="false">
       <AppenderRef ref="Console"/>
       <AppenderRef ref="File"/>
       <AppenderRef ref="Harvester"/>
     </Logger>
-    <Logger name="geonetwork.accessmanager" level="error"/>
-    <Logger name="geonetwork.atom" level="info"/>
-    <Logger name="geonetwork.backup" level="error"/>
-    <Logger name="geonetwork.camel-harvester" level="error"/>
-    <Logger name="geonetwork.cors" level="error"/>
-    <Logger name="geonetwork.csw" level="error"/>
-    <Logger name="geonetwork.csw.search" level="error"/>
-    <Logger name="geonetwork.data.directory" level="error"/>
-    <Logger name="geonetwork.database" level="error"/>
-    <Logger name="geonetwork.databasemigration" level="info"/>
-    <Logger name="geonetwork.datamanager" level="error"/>
-    <Logger name="geonetwork.domain" level="error"/>
-    <Logger name="geonetwork.editor" level="error"/>
-    <Logger name="geonetwork.editorexpandelement" level="error"/>
-    <Logger name="geonetwork.editorfillelement" level="error"/>
-    <Logger name="geonetwork.encryptor" level="info"/>
-    <Logger name="geonetwork.formatter" level="error"/>
-    <Logger name="geonetwork.geoserver.publisher" level="error"/>
-    <Logger name="geonetwork.geoserver.rest" level="error"/>
-    <Logger name="geonetwork.harvest.wfs.features"/>
-    <Logger name="geonetwork.harvester" level="info"/>
-    <Logger name="geonetwork.harvester" level="info"/>
-    <Logger name="geonetwork.index" level="error"/>
-    <Logger name="geonetwork.ldap" level="error"/>
-    <Logger name="geonetwork.lucene" level="error"/>
-    <Logger name="geonetwork.mef" level="error"/>
-    <Logger name="geonetwork.resources" level="error"/>
-    <Logger name="geonetwork.schemamanager" level="error"/>
-    <Logger name="geonetwork.search" level="error"/>
-    <Logger name="geonetwork.security" level="error"/>
-    <Logger name="geonetwork.spatineo" level="error"/>
-    <Logger name="geonetwork.sru" level="error"/>
-    <Logger name="geonetwork.sru.search" level="error"/>
-    <Logger name="geonetwork.thesaurus" level="error"/>
-    <Logger name="geonetwork.thesaurus-man" level="error"/>
-    <Logger name="geonetwork.userwatchlist" level="error"/>
-    <Logger name="geonetwork.wro4j" level="error"/>
-
-    <!--  Jeeves module and submodule logger configuration -->
-    <Logger name="geonetwork.engine" level="error"/>
-    <Logger name="geonetwork.monitor" level="error"/>
-    <Logger name="geonetwork.resources" level="error"/>
-    <Logger name="geonetwork.security" level="error"/>
-    <Logger name="geonetwork.transformerFactory" level="error"/>
-    <Logger name="geonetwork.xlinkprocessor" level="error"/>
-    <Logger name="geonetwork.xmlresolver" level="error"/>
+    <Logger name="jeeves" level="error" additivity="false">
+      <AppenderRef ref="Console"/>
+      <AppenderRef ref="File"/>
+      <AppenderRef ref="Harvester"/>
+    </Logger>
 
     <!--  Spring logging configuration -->
     <Logger name="org.springframework" level="error" additivity="false">

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v3110/UpdateMetadataStatus.java
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v3110/UpdateMetadataStatus.java
@@ -120,12 +120,12 @@ public class UpdateMetadataStatus extends DatabaseMigrationTask {
             // Most likely cause is that the column already exists which should be fine.
             LOGGER.error(
                 Geonet.DB_MARKER,
-                "  Exception while adding new {} column to {}. Error is: ",
+                "  Exception while adding new {} column to {}. Error is: {}",
                 MetadataStatus_.id.getName(),
                 MetadataStatus.TABLE_NAME,
                 e.getMessage()
             );
-            LOGGER.debug(Geonet.DB_MARKER,e,e);
+            LOGGER.debug(Geonet.DB_MARKER, e, e);
         }
         try (Statement statement = connection.createStatement()) {
             statement.execute("ALTER TABLE " + MetadataStatus.TABLE_NAME + " " + dialect.getAddColumnString() + "  " + MetadataStatus_.uuid.getName() + " VARCHAR(255) NULL");
@@ -327,7 +327,7 @@ public class UpdateMetadataStatus extends DatabaseMigrationTask {
                 "  Exception while dropping old primary key constraint on table {}. "
                     + "Restart application and check logs for database errors.  "
                     + "If errors exists then may need to manually drop the primary key for this table."
-                    + "Error is: ",
+                    + "Error is: {}",
                 MetadataStatus.TABLE_NAME,
                 e.getMessage()
             );
@@ -346,7 +346,7 @@ public class UpdateMetadataStatus extends DatabaseMigrationTask {
                 "  Exception while dropping old primary key on table {}. "
                     + "Restart application and check logs for database errors.  "
                     + "If errors exists then may need to manually drop the primary key for this table. "
-                    + "Error is: ",
+                    + "Error is: {}",
                 e.getMessage(),
                 MetadataStatus.TABLE_NAME
             );
@@ -363,7 +363,7 @@ public class UpdateMetadataStatus extends DatabaseMigrationTask {
             LOGGER.error(
                 Geonet.DB_MARKER,
                 "  Exception while adding primary key on {} column for {}. "
-                    + "Error is: ",
+                    + "Error is: {}",
                 MetadataStatus_.id.getName(),
                 MetadataStatus.TABLE_NAME,
                 e.getMessage());

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v3110/UpdateMetadataStatus.java
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v3110/UpdateMetadataStatus.java
@@ -23,7 +23,10 @@
 
 package v3110;
 
+import org.apache.logging.log4j.Logger;
 import org.fao.geonet.DatabaseMigrationTask;
+import org.fao.geonet.api.API;
+import org.fao.geonet.api.related.Related;
 import org.fao.geonet.domain.MetadataStatus;
 import org.fao.geonet.domain.MetadataStatus_;
 import org.fao.geonet.kernel.datamanager.IMetadataUtils;
@@ -56,7 +59,7 @@ import java.util.Map;
  * restarted to ensure that all JPA settings are applied correctly.
  */
 public class UpdateMetadataStatus extends DatabaseMigrationTask {
-
+    private static final Logger LOGGER = Log.createLogger(UpdateMetadataStatus.class, Geonet.DB_MARKER);
     private MetadataStatusRepository metadataStatusRepository;
     private IMetadataUtils metadataUtils;
 
@@ -84,7 +87,7 @@ public class UpdateMetadataStatus extends DatabaseMigrationTask {
             DialectResolutionInfo dialectResolutionInfo = new DatabaseMetaDataDialectResolutionInfoAdapter(connection.getMetaData());
             Dialect dialect = new StandardDialectResolver().resolveDialect(dialectResolutionInfo);
 
-            Log.debug(Geonet.DB, "UpdateMetadataStatus");
+            LOGGER.debug(Geonet.DB_MARKER, "UpdateMetadataStatus");
 
             // First add the id and uuid as nullable.
             addMissingColumn(connection, dialect);
@@ -115,9 +118,14 @@ public class UpdateMetadataStatus extends DatabaseMigrationTask {
         } catch (Exception e) {
             // If there was an error then we will log the error and continue.
             // Most likely cause is that the column already exists which should be fine.
-            Log.error(Geonet.DB, "  Exception while adding new " + MetadataStatus_.id.getName() + " column to " + MetadataStatus.TABLE_NAME + ". " +
-                    "Error is: " + e.getMessage());
-            Log.debug(Geonet.DB, e);
+            LOGGER.error(
+                Geonet.DB_MARKER,
+                "  Exception while adding new {} column to {}. Error is: ",
+                MetadataStatus_.id.getName(),
+                MetadataStatus.TABLE_NAME,
+                e.getMessage()
+            );
+            LOGGER.debug(Geonet.DB_MARKER,e,e);
         }
         try (Statement statement = connection.createStatement()) {
             statement.execute("ALTER TABLE " + MetadataStatus.TABLE_NAME + " " + dialect.getAddColumnString() + "  " + MetadataStatus_.uuid.getName() + " VARCHAR(255) NULL");
@@ -314,9 +322,16 @@ public class UpdateMetadataStatus extends DatabaseMigrationTask {
             statement.execute("ALTER TABLE " + MetadataStatus.TABLE_NAME + " drop constraint " + pkName);
         } catch (Exception e) {
             connection.rollback();
-            Log.error(Geonet.DB, "  Exception while dropping old primary key constraint on table " + MetadataStatus.TABLE_NAME + ". Restart application and check logs for database errors.  If errors exists then may need to manually drop the primary key for this table." +
-                    "Error is: " + e.getMessage());
-            Log.debug(Geonet.DB, e, e);
+            LOGGER.error(
+                Geonet.DB_MARKER,
+                "  Exception while dropping old primary key constraint on table {}. "
+                    + "Restart application and check logs for database errors.  "
+                    + "If errors exists then may need to manually drop the primary key for this table."
+                    + "Error is: ",
+                MetadataStatus.TABLE_NAME,
+                e.getMessage()
+            );
+            LOGGER.debug(Geonet.DB_MARKER, e, e);
         }
 
         connection.commit();
@@ -326,9 +341,16 @@ public class UpdateMetadataStatus extends DatabaseMigrationTask {
             statement.execute("ALTER TABLE " + MetadataStatus.TABLE_NAME + " drop primary key");
         } catch (Exception e) {
             connection.rollback();
-            Log.error(Geonet.DB, "  Exception while dropping old primary key on table " + MetadataStatus.TABLE_NAME + ". Restart application and check logs for database errors.  If errors exists then may need to manually drop the primary key for this table. " +
-                    "Error is: " + e.getMessage());
-            Log.debug(Geonet.DB, e, e);
+            LOGGER.error(
+                Geonet.DB_MARKER,
+                "  Exception while dropping old primary key on table {}. "
+                    + "Restart application and check logs for database errors.  "
+                    + "If errors exists then may need to manually drop the primary key for this table. "
+                    + "Error is: ",
+                e.getMessage(),
+                MetadataStatus.TABLE_NAME
+            );
+            LOGGER.debug(Geonet.DB_MARKER, e, e);
         }
 
         connection.commit();
@@ -338,9 +360,14 @@ public class UpdateMetadataStatus extends DatabaseMigrationTask {
             statement.execute("ALTER TABLE " + MetadataStatus.TABLE_NAME + " " + dialect.getAddPrimaryKeyConstraintString(MetadataStatus.TABLE_NAME + "Pk") + " (" + MetadataStatus_.id.getName() + ")");
         } catch (Exception e) {
             connection.rollback();
-            Log.error(Geonet.DB, "  Exception while adding primary key on " + MetadataStatus_.id.getName() + " column for " + MetadataStatus.TABLE_NAME + ". " +
-                    "Error is: " + e.getMessage());
-            Log.debug(Geonet.DB, e, e);
+            LOGGER.error(
+                Geonet.DB_MARKER,
+                "  Exception while adding primary key on {} column for {}. "
+                    + "Error is: ",
+                MetadataStatus_.id.getName(),
+                MetadataStatus.TABLE_NAME,
+                e.getMessage());
+            LOGGER.debug(Geonet.DB_MARKER, e, e);
         }
 
         connection.commit();
@@ -358,9 +385,13 @@ public class UpdateMetadataStatus extends DatabaseMigrationTask {
             connection.rollback();
             // If there was an error then we will log the error and continue.
             // Most likely cause is that the column already exists which should be fine.
-            Log.error(Geonet.DB, "  Exception while adding foreign key on relatedMetadataStatusId column of " + MetadataStatus.TABLE_NAME + ". " +
-                "Error is: " + e.getMessage());
-            Log.debug(Geonet.DB, e);
+            LOGGER.error(
+                Geonet.DB_MARKER,
+                "  Exception while adding foreign key on relatedMetadataStatusId column of {}. Error is: {}",
+                MetadataStatus.TABLE_NAME,
+                e.getMessage()
+            );
+            LOGGER.debug(Geonet.DB_MARKER, e, e);
         }
     }
 


### PR DESCRIPTION
Personal experiment follow up to https://github.com/geonetwork/core-geonetwork/pull/6397 looking at what it would take to use the Log4j Appenders API.

Core change:

* [x] Use `BasicContext.getLogger()` rather than asking `BasicContext` to implement Logger 
* [x] `LoggerWrapper` implementation (formally an anonymous class in `Log`)
* [x] Introduce [markers](https://logging.apache.org/log4j/2.x/manual/markers.html) for the modules named in `Log` (example `Log.JEEVES_MARKER`) 
* [x] Tag `AppenderWrapper` with appropriate marker for the functionality they wish to track
* [x] `Log.createLogger()` methods to support classname (or determine from stack trace)
* [x] Logger extends Log4J Logger (a lot of new efficient methods) 
* [x] review `LoggerWrapper.debug` methods to apply marker
* [x] review `LoggerWraper.info` methods to apply marker
* [x] review `LoggerWrapper.warn` methods to apply marker
* [x] review `LoggerWrapper.error` methods to apply marker 

Direct use of LOGGERS as a non critical follow up to improve over time:

* [ ] Remove references to ``Log.isDebugEnabled(module)`` (handy way to identify where loggers are needed)

The net effect should be using `Marker` to indicate geonetwork module (such as "jeeves" or "Jeeves.webapp") while having full access to the  Log4J Logger API (which is much more efficient) along with the class names which can be used in the `log4j2-dev.xml` profile.

### LOGGER Example

Although ``Log.createLogger()`` methods return ``org.fao.geonet.Logger`` it is better import ``org.apache.logging.log4j.Logger`` when possible to stick to "pure" Log4j2 API. The additional deprecated methods provided by ``org.fao.geonet.Logger`` are for things like ``warning(message)`` that can be replaced with ``warn(message)``.

```
import org.apache.logging.log4j.Logger;

...
private static Logger LOGGER = Log.createLogger(SchemaManager.class,Geonet.SCHEMA_MANAGER_MARKER);
```

### Use ParameterizedMessage format

Rather than use string concatenation or formatting using ParameterizedMessage approach:

```
LOGGER.info(Geonet.SCHEMA_MANAGER_MARKER,
  "Loading schema {} ...",
  schemaDir.getFileName() );
```

### Throwable

Pass in throwable as the last parameter and let configuration choose if a stack trace should be shown or not.
```
LOGGER.error(Geonet.SCHEMA_MANAGER_MARKER, "Cannot decode blank number from {}", baseBlank, nfe);
```

### isDebugEabled(Marker) rarely worthwhile

Because ParameratizedMethods ares so efficient:
```
LOGGER.debug(Geonet.SCHEMA_MANAGER_MARKER,
  "  => Found schema {} using AUTODETECT(attributes);examination",
  schema);
```
It replaces the need for most occupancy of ``isDebugEnabled(marker)``:
```
if (LOGGER.isDebugEnabled(Geonet.SCHEMA_MANAGER_MARKER)) {
   LOGGER.debug(Geonet.SCHEMA_MANAGER_MARKER,
     "  => Found schema " + schema + " using AUTODETECT(attributes) examination");
}
```

However if a method call is expensive you should still use isDebugEnabled(Marker):
```java
if (LOGGER.isDebugEnabled(Log.REQUEST_MARKER)) {
    LOGGER.debug(Log.REQUEST_MARKER, "Adding to parameters: {}", Xml.getString(elem));
}
```

### Use markers for readability (Optional)

Since the above ``LOGGER`` was created with ``Log.SCHEMA_MANAGER_MARKER`` the following are equivalent:

```
LOGGER.debug("No bean defined for the schema plugin '{}'.{}",
  schemaIdentifier, e.getMessage(),
  e);
```

```
LOGGER.debug(Log.SCHEMA_MANAGER_MARKER,
  "No bean defined for the schema plugin '{}'.{}", schemaIdentifier,
  e.getMessage(),
  e);
```

The second option with ``Log.SCHEMA_MANAGER_MARKER`` clearly indicates intent, and does not reply on the AppenderWrapper (allowing us opportunity to drop AppenderWrapper in the future).