### PR TITLE
Fix links not generated properly in schema docs

### DIFF
--- a/docs/schema-doc/src/main/resources/config-editor-to-rst.xsl
+++ b/docs/schema-doc/src/main/resources/config-editor-to-rst.xsl
@@ -226,7 +226,7 @@
           </xsl:for-each>
           <xsl:value-of select="gndoc:nl(2)"/>
 
-          <xsl:value-of select="$t/cf"/><xsl:value-of
+          <xsl:value-of select="concat($t/cf, ' ')"/><xsl:value-of
           select="gndoc:refTo(concat($schemaId, '-elem-', normalize-space($name)), true())"/>
         </xsl:when>
         <xsl:when test="$name != ''">
@@ -294,7 +294,7 @@
 
       <xsl:value-of select="gndoc:writelnfield($t/xpath, @xpath)"/>
       <xsl:value-of select="gndoc:nl(2)"/>
-      <xsl:value-of select="$t/cf"/><xsl:value-of
+      <xsl:value-of select="concat($t/cf, ' ')"/><xsl:value-of
       select="gndoc:refTo(concat($schemaId, '-elem-', normalize-space($nodeName)), true())"/>
     </xsl:if>
   </xsl:template>
@@ -360,7 +360,7 @@
         </xsl:for-each>
         <xsl:value-of select="gndoc:nl(2)"/>
 
-        <xsl:value-of select="$t/cf"/><xsl:value-of
+        <xsl:value-of select="concat($t/cf, ' ')"/><xsl:value-of
         select="gndoc:refTo(concat($schemaId, '-elem-', normalize-space($sectionName)), true())"/>
       </xsl:when>
       <xsl:when test="$sectionName != ''">
@@ -406,7 +406,7 @@
       </xsl:for-each>
       <xsl:value-of select="gndoc:nl(2)"/>
 
-      <xsl:value-of select="$t/cf"/><xsl:value-of
+      <xsl:value-of select="concat($t/cf, ' ')"/><xsl:value-of
       select="gndoc:refTo(concat($schemaId, '-elem-', normalize-space($nodeName)), true())"/>
       <xsl:value-of select="gndoc:nl(2)"/>
     </xsl:if>


### PR DESCRIPTION
Links to the schema docs sections were not generated properly, causing a wrong rendering as text:

![schema-doc-link](https://user-images.githubusercontent.com/1695003/187912312-95ecc26b-fd5a-4bc6-9073-c98664b0444d.png)
