### PR TITLE
[a11y] `TAB` order of the row tools on the search page

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -1483,6 +1483,8 @@ gn-indexing-task-status {
     break-inside: avoid;
   }
 }
+.d-inline { display: inline; }
+.d-inline-block { display: inline-block; }
 
 html {
   // As a side-effect of setting the @viewport in bootstrap,

--- a/web-ui/src/main/resources/catalog/views/default/templates/results.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/results.html
@@ -46,7 +46,14 @@
     <div class="col-md-9 container-fluid">
       <div class="row gn-row-tools hidden-print"
            data-ng-show="searchResults.records.length > 0">
-        <div class="col-xs-12 col-sm-6 col-sm-push-3 text-center">
+
+        <div class="col-xs-6 col-sm-3 gn-nopadding-left">
+          <div data-gn-selection-widget=""
+               data-ng-if="showBatchDropdown"
+               data-results="searchResults"></div>
+        </div>
+
+        <div class="col-xs-12 col-sm-6 text-center">
           <div class=""
                data-gn-pagination="paginationInfo"
                data-hits-values="searchObj.hitsperpageValues"
@@ -54,19 +61,15 @@
                data-enable-events=""></div>
         </div>
 
-        <div class="col-xs-6 col-sm-3 col-sm-pull-6 col-lg-pull-6 gn-nopadding-left">
-          <div data-gn-selection-widget=""
-               data-ng-if="showBatchDropdown"
-               data-results="searchResults"></div>
-        </div>
+        <div class="col-xs-6 col-sm-3 gn-nopadding-right text-right navbar-right">
 
-        <div class="col-xs-6 col-sm-3 gn-nopadding-right">
-          <div class="pull-right"
-               data-gn-results-tpl-switcher=""></div>
-          <div class="pull-right"
-               data-sortby-combo=""
+          <div data-sortby-combo=""
+               class="d-inline-block"
                data-params="searchObj.params"
                data-gn-sortby-values="searchObj.sortbyValues"></div>
+
+          <div data-gn-results-tpl-switcher=""
+               class="d-inline-block"></div>
         </div>
       </div>
       <!-- /.gn-row-tools -->


### PR DESCRIPTION
[a11y] `TAB` order of the row tools on the search page

The focus/tab order of the elements on the toolbar on the search page wasn't correct.

This PR will fix the order of elements in the DOM and therefore the order of focus (when the `TAB` key is used)

<img width="1228" alt="gn-row-tools-order" src="https://user-images.githubusercontent.com/19608667/187923197-1ac3bb8c-a1d6-437f-beb0-f0a8502b2552.png">
