### PR TITLE
Add Message.properties files to core tests to avoid the failure of test that use code retrieving messages from that files

### DIFF
--- a/core/src/test/resources/org/fao/geonet/api/Messages.properties
+++ b/core/src/test/resources/org/fao/geonet/api/Messages.properties
@@ -1,0 +1,197 @@
+#
+# Copyright (C) 2001-2016 Food and Agriculture Organization of the
+# United Nations (FAO-UN), United Nations World Food Programme (WFP)
+# and United Nations Environment Programme (UNEP)
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or (at
+# your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+#
+# Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+# Rome - Italy. email: geonetwork@osgeo.org
+#
+
+mail_error=Failed to send email.
+mail_config_test_subject=%s / Test / Mail configuration
+mail_config_test_message=<html><body>Test message from %s\n\
+      <div itemscope itemtype="http://schema.org/EmailMessage">\n\
+        <meta itemprop="description" content="Open catalog"/>\n\
+        <div itemprop="potentialAction" itemscope itemtype="http://schema.org/ViewAction">\n\
+        <link itemprop="url" content="%s"/>\n\
+        <meta itemprop="name" content="Open catalog"/>\n\
+        </div>\n\
+      </div></body></html>
+mail_config_test_success=Mail sent to %s.
+mail_config_test_only_admin=Only administrator users can test mail configuration.
+password_change_subject=%s / Password change
+password_change_message=Your %s password has been changed. \n\
+                If you did not request a password change, contact the helpdesk at %s. \n\
+                \n\
+                The %s team.
+password_forgotten_subject=%s / Reset password
+password_forgotten_message=You have requested to change your %s password. \n\
+                   You can change your password using the following link:\n\
+                   %snew.password?username=%s&changeKey=%s \n\
+                   This link is valid for today only. \n\
+                   \n\
+                   The %s team.
+user_has_no_email='%s' has no email.
+user_not_found=No user found with username '%s'.
+user_from_ldap_cant_get_password=User '%s' is authenticated using LDAP. Password can't be sent by email.
+security_provider_unsupported_functionality="Functionality not supported by the security provider"
+user_password_sent=In case the user exists you should receive an email with further instructions.
+user_password_changed='%s' password was updated.
+user_password_notchanged=A problem occurred trying to change '%s' password. Contact the helpdesk.
+user_password_invalid_changekey='%s' is an invalid change key for '%s'. Change keys are only valid for one day.
+user_registered=User '%s' registered.
+user_with_that_email_found=A user with this email '%s' already exists.
+user_with_that_username_found=A user with this username '%s' already exists.
+register_email_admin_subject=%s / New account for %s as %s
+register_email_admin_message=Dear Admin,\n\
+  Newly registered user %s has requested %s access for %s.\n\
+  Yours sincerely,\n\
+  The %s team.
+register_email_subject=%s / Your account as %s
+register_email_message=Dear User,\n\
+  Your registration at %s was successful.\n\
+  Your account is: \n\
+  * username: %s\n\
+  * password: %s\n\
+  * profile: %s\n\
+  \n\
+  You've told us that you want to be %s, you will be contacted soon.\n\
+  To log in and access your account, please click on the link below.\n\
+  %s\n\
+  \n\
+  Thanks for your registration.\n\
+  \n\
+  Yours sincerely,\n\
+  The %s team.
+new_user_rating=%s / New user rating on %s
+new_user_rating_text=See record %sapi/records/%s
+user_feedback_title=%s / User feedback on %s / %s
+user_feedback_text=User %s (%s - %s)\n\
+  - Email: %s\n\
+  - Phone: %s \n\
+  sent a feedback on %s record.\n\
+  \n\
+  Feedback type: %s \n\
+  Feedback category: %s \n\
+  \n\
+  %s \n\
+  \n\
+  See record %sapi/records/%s
+status_email_text=GeoNetwork user %s (%s) edited metadata record #%s
+# SiteName / Workflow / recordTitle statusName by userName
+status_change_default_email_subject={0} / Workflow / '{{'index:resourceTitleObject'}}' {1} by {2}
+status_change_default_email_text={0} modified the status of the record '{{'index:resourceTitleObject'}}'.\n\
+The status is now: {2}.\n\
+ \n\
+Message: \n\
+{1} \n\
+ \n\
+View record: \n\
+{7}catalog.search#/metadata/'{{'index:uuid'}}'
+
+# SiteName / Task / recordTitle statusName by userName
+status_change_doiCreationTask_email_subject={0} / Task / {1} for '{{'index:resourceTitleObject'}}'
+# author
+status_change_doiCreationTask_email_text={0} requested creation of the DOI for the record '{{'index:resourceTitleObject'}}'. Could you proceed to the DOI creation by {4}.\n\
+\n\
+Responsible of the task: \n\
+Message: \n\
+{1} \n\
+\n\
+View record: \n\
+{7}catalog.search#/metadata/'{{'index:uuid'}}'
+# TODO: Link to DOI creation panel
+
+api.groups.group_not_found=Group with ID ''{0}'' not found in this catalog.
+user_watchlist_subject=%s / %d updates in your watch list since %s
+user_watchlist_message_record=<li><a href="{{link}}">{{index:resourceTitleObject}}</a></li>
+user_watchlist_message=The following records have been updated:\n\
+      <ul>%s</ul>\n\
+      \n\
+      Last notification was: %s.\n\
+      <div itemscope itemtype="http://schema.org/EmailMessage">\n\
+        <meta itemprop="description" content="View updated records"/>\n\
+        <div itemprop="potentialAction" itemscope itemtype="http://schema.org/ViewAction">\n\
+        <link itemprop="url" content="%s"/>\n\
+        <meta itemprop="name" content="View updated records"/>\n\
+        </div>\n\
+      </div>
+self_registration_disabled=User self-registration is disabled
+recaptcha_not_valid=Recaptcha is not valid
+metadata.title.createdFromTemplate=Copy of template %s created at %s
+metadata.title.createdFromRecord=Copy of record %s created at %s
+username.field.required=Username is required
+password.field.length=Password size should be between {min} and {max} characters
+password.field.invalid=Password must contain at least 1 uppercase, 1 lowercase, 1 number and 1 symbol. Symbols include: `~!@#$%^&*()-_=+[]{}\\|;:'",.<>/?');
+api.exception.forbidden=Access denied
+api.exception.forbidden.description=Access is denied. To access, try again with a user containing more priviledges.
+api.exception.resourceNotFound=Resource not found
+api.exception.resourceNotFound.description=Resource could not be located.
+api.exception.resourceAlreadyExists=Resource already exists
+api.exception.resourceAlreadyExists.description=Resource already exists.
+api.exception.unsatisfiedRequestParameter=Unsatisfied request parameter
+api.exception.unsatisfiedRequestParameter.description=Unsatisfied request parameter.
+exception.resourceNotFound.metadata=Metadata not found
+exception.resourceNotFound.metadata.description=Metadata with UUID ''{0}'' not found.
+exception.resourceNotFound.resource=Metadata resource ''{0}'' not found
+exception.resourceNotFound.resource.description=Metadata resource ''{0}'' not found for metadata ''{1}''.
+exception.resourceInvalid.metadata=Metadata is invalid
+exception.resourceInvalid.metadata.description=The metadata can't be submitted or approved
+exception.resourceNotEnabled.workflow=Metadata workflow is disabled
+exception.resourceNotEnabled.workflow.description=Can not be set the status of metadata
+exception.doi.resourceContainsDoi=Record already contains a DOI
+exception.doi.resourceContainsDoi.description=Record ''{0}'' already contains a DOI. The DOI is <a href=''{1}''>{2}</a>. You've to update existing DOI. Remove the DOI reference if it does not apply to that record.
+exception.doi.resourceAlreadyPublished=Record looks to be already published on DataCite
+exception.doi.resourceAlreadyPublished.description=Record ''{0}'' looks to be already published on DataCite with DOI <a href=''{1}''>''{2}''</a>. DOI on Datacite point to: <a href=''{3}''>''{4}''</a>. If the DOI is not correct, remove it from the record and ask for a new one.
+exception.doi.failedVisibilityCheck=Failed to check if record is visible to all for DOI creation
+exception.doi.failedVisibilityCheck.description=Failed to check if record ''{0}'' is visible to all for DOI creation. Error is ''{1}''.
+exception.doi.recordNotPublic=Record is not public
+exception.doi.recordNotPublic.description=Record ''{0}'' is not public and we cannot request a DOI for such a record. Publish this record first.
+exception.doi.resourcesContainsDoiNotEqual=Record already contains a DOI
+exception.doi.resourcesContainsDoiNotEqual.description=Record ''{0}'' already contains a DOI <a href=''{0}''>{1}</a> which is not equal to the DOI about to be created (ie. ''{3}''). Maybe current DOI does not correspond to that record? This may happen when creating a copy of a record having an existing DOI.
+exception.doi.missingSavedquery=Record missing saved query
+exception.doi.missingSavedquery.description="Record ''{0}'' is in schema ''{1}'' and we cannot find a saved query with id ''{3}'' to retrieve the DOI. Error is {4}. Check the schema {5}SchemaPlugin and add the DOI get query."
+exception.doi.recordNotConformantMissingInfo=Record is not conform with DataCite format
+exception.doi.recordNotConformantMissingInfo.description=Record ''{0}'' is not conform with DataCite format. {1} mandatory field(s) missing. {2}
+exception.doi.recordNotConformantMissingMandatory=Record is not conform with DataCite validation rules for mandatory fields
+exception.doi.recordNotConformantMissingMandatory.description=Record ''{0}'' is not conform with DataCite validation rules for mandatory fields. Error is: {1}. Required fields in DataCite are: identifier, creators, titles, publisher, publicationYear, resourceType. <a href=''{2}api/records/%s/formatters/datacite?output=xml''>Check the DataCite format output</a> and adapt the record content to add missing information.
+exception.doi.recordInvalid=Record converted to DataCite format is invalid.
+exception.doi.recordInvalid.description=Record ''{0}'' converted to DataCite format is invalid. Error is: {1}. Required fields in DataCite are: identifier, creators, titles, publisher, publicationYear, resourceType. <a href='{2}api/records/{3}/formatters/datacite?output=xml'>Check the DataCite format output</a> and adapt the record content to add missing information.
+api.metadata.import.importedWithId=Metadata imported with ID '%s'
+api.metadata.import.importedWithUuid=Metadata imported with UUID '%s'
+api.metadata.import.importedFromXMLWithUuid=Metadata imported from XML with UUID '%s'
+api.metadata.import.importedFromUrl=Metadata imported from URL with UUID '%s'
+api.metadata.import.importedFromMEF=Metadata imported from MEF with id '%s'
+api.metadata.import.importedFromServerFolder=Metadata imported from server folder with UUID '%s'
+api.metadata.import.errorImportMEF=Failed to import MEF file '%s'. Check error for details.
+api.metadata.import.errorFromUrl=Failed to import metadata from '%s'. Verify that the URL is correct and contact your administrator if the problem persists to verify the details of the error in the log files.
+api.metadata.import.errorMissingMEF=No XML or MEF or ZIP file found in server folder '%s'.
+api.metadata.import.errorMissingXMLFragmentOrUrl=XML fragment or a URL or a server folder MUST be provided.
+api.metadata.import.errorInvalidXMLFragment=XML fragment is invalid. Error is %s
+api.metadata.import.errorDuplicatedUUID=You can't create a new record with the UUID '%s' because a record already exist with this UUID.
+api.metadata.import.errorDuplicatedUUIDDetailed=A record with UUID '%s' already exist and you choose no action on UUID processing. Choose to overwrite existing record or to generate a new UUID.
+api.metadata.import.errorNotEditorInGroup=You can't create a record in this group. User MUST be an Editor in that group
+api.metadata.import.errorFileRequired=A file MUST be provided.
+api.metadata.import.errorInvalidMEF=Import 0 record, check whether the importing file is a valid MEF archive.
+api.metadata.import.errorEventStore=Impossible to store event for '%s'. Check error for details.
+api.metadata.import.errorMissingXsl=XSL transformation '%s' not found.
+api.metadata.import.errorDetectMetadataSchema=Can't detect schema for metadata automatically. You could try to force the schema with the schema parameter.
+api.metadata.share.errorMetadataNotValid=The metadata '%s' it's not valid, can't be published.
+api.metadata.share.errorMetadataNotApproved=The metadata '%s' it's not approved, can't be published.
+api.metadata.share.ErrorUserNotAllowedToPublish=User not allowed to publish the metadata %s. %s
+api.metadata.share.strategy.groupOwnerOnly=You need to be administrator, or reviewer of the metadata group.
+api.metadata.share.strategy.reviewerInGroup=You need to be administrator, or reviewer of the metadata group or reviewer with edit privilege on the metadata.

--- a/core/src/test/resources/org/fao/geonet/api/Messages_fre.properties
+++ b/core/src/test/resources/org/fao/geonet/api/Messages_fre.properties
@@ -1,0 +1,183 @@
+#
+# Copyright (C) 2001-2016 Food and Agriculture Organization of the
+# United Nations (FAO-UN), United Nations World Food Programme (WFP)
+# and United Nations Environment Programme (UNEP)
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or (at
+# your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+#
+# Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+# Rome - Italy. email: geonetwork@osgeo.org
+#
+
+mail_error=Erreur lors de l''envoi du mail.
+mail_config_test_subject=%s / Test / Configuration serveur de mail
+mail_config_test_success=Mail envoy\u00E9 \u00E0 %s.
+mail_config_test_only_admin=Seuls les administrateurs peuvent tester la configuration du serveur de mail.
+password_change_subject=%s / Mot de passe modifi\u00E9
+password_change_message=Votre mot de passe %s a \u00E9t\u00E9 mis \u00E0 jour. \n\
+                        Si vous n''avez pas demand\u00E9 une mise \u00E0 jour de votre mot de passe, contacter l''administrateur %s. \n\
+                        \n\
+                        L''\u00E9quipe %s.
+password_forgotten_subject=%s / R\u00E9initialiser votre mot de passe
+password_forgotten_message=Vous avez demand\u00E9 une r\u00E9initialisation de votre mot de passe %s. \n\
+                           Cliquer sur le lien suivant pour le mettre \u00E0 jour :\n\
+                           %snew.password?username=%s&changeKey=%s \n\
+                           Ce lien n''est valide qu''aujourd''hui. \n\
+                           \n\
+                           L''\u00E9quipe %s.
+user_has_no_email=%s n''a pas d'adresse mail.
+user_not_found=Pas d''utilisateur trouv\u00E9 avec le nom %s.
+user_from_ldap_cant_get_password=L''utilisateur %s est authentifi\u00E9 \u00E0 partir d''un annuaire LDAP. Le mot de passe ne peut \u00EAtre r\u00E9initialiser par email.
+security_provider_unsupported_functionality="Fonctionnalit\u00E9 non support\u00E9 par le fournisseur de s\u00E9curit\u00E9"
+user_password_sent=Si l''utilisateur existe, vous recevrez un courriel contenant des instructions suppl\u00E9mentaires.
+user_password_changed=Le mot de passe de %s a \u00E9t\u00E9 mis \u00E0 jour.
+user_password_notchanged=Echec lors du changement de mot de passe de %s. Contacter le support.
+user_password_invalid_changekey=%s est une cl\u00E9 invalide pour %s. Les cl\u00E9s ne sont valides que pendant une journ\u00E9e.
+user_with_that_email_found=Un utilisateur avec cette adresse email %s existe d\u00E9j\u00E0.
+user_with_that_username_found=Un utilisateur avec cette nom d''utilisateur %s existe d\u00E9j\u00E0.
+register_email_admin_subject=%s / Cr\u00E9ation de compte pour %s en tant que %s
+register_email_admin_message=Cher administrateur,\n\
+  L''utilisateur %s vient de demander une cr\u00E9ation de compte pour %s.\n\
+  Salutation,\n\
+  L''\u00E9quipe %s.
+register_email_subject=%s / Votre compte %s
+register_email_message=Cher utilisateur,\n\
+  Votre compte a \u00E9t\u00E9 cr\u00E9\u00E9 avec succ\u00E9s pour %s.\n\
+  * Nom d''utilisateur : %s\n\
+  * Mot de passe : %s\n\
+  * Profil : %s\n\
+  \n\
+  Vous avez demand\u00E9 un profil %s, vous serez contacter par notre \u00E9quipe prochainement.\n\
+  Vous pouvez d\u00E9s \u00E0 pr\u00E9sent vous connecter.\n\
+  %s\n\
+  \n\
+  Salutations,\n\
+  L''\u00E9quipe %s.
+new_user_rating=%s / Nouvelle \u00E9valuation faite pour %s
+new_user_rating_text=Consulter la fiche %sapi/records/%s
+user_feedback_title=%s / Nouveau commentaire sur %s / %s
+user_feedback_text=Utilisateur %s (%s - %s)\n\
+  - Email: %s\n\
+  - T\u00E9l\u00E9phone: %s \n\
+  a envoy\u00E9 un commentaire sur la fiche %s.\n\
+  \n\
+  Type : %s \n\
+  Cat\u00E9gorie : %s \n\
+  \n\
+  %s \n\
+  \n\
+  Consulter la fiche %sapi/records/%s
+status_email_text=L''utilisateur %s (%s) a \u00E9dit\u00E9 une fiche #%s
+# SiteName / Workflow / recordTitle statusName by userName
+status_change_default_email_subject={0} / Cycle de vie / '{{'index:resourceTitleObject'}}' {1} par {2}
+status_change_default_email_text={0} a modifi\u00E9 l''\u00E9tat de la fiche '{{'index:resourceTitleObject'}}'.\n\
+L''\u00E9tat est maintenant : {2}.\n\
+ \n\
+Message: \n\
+{1} \n\
+ \n\
+Consulter la fiche : \n\
+{7}catalog.search#/metadata/'{{'index:uuid'}}'
+
+# SiteName / Task / recordTitle statusName by userName
+status_change_doiCreationTask_email_subject={0} / Action / {1} pour '{{'index:resourceTitleObject'}}'
+# author
+
+status_change_doiCreationTask_email_text={0} a demand\u00E9 la cr\u00E9ation d''un DOI pour la fiche '{{'index:resourceTitleObject'}}'. Pouvez-vous cr\u00E9er le DOI pour le {4}.\n\
+\n\
+Responsable de l''action : \n\
+Message: \n\
+{1} \n\
+\n\
+Consulter la fiche : \n\
+{7}catalog.search#/metadata/'{{'index:uuid'}}'
+# TODO: Link to DOI creation panel
+
+api.groups.group_not_found=Le groupe avec l''identifiant ''{0}'' n''a pas \u00E9t\u00E9 trouv\u00E9 dans le catalogue.
+user_watchlist_subject=%s / %d mises \u00e0 jour dans vos fiches surveill\u00E9es %s
+user_watchlist_message_record=<li><a href="{{link}}">{{index:resourceTitleObject}}</a></li>
+user_watchlist_message=Les fiches suivantes ont \u00E9t\u00E9 mises \u00e0 jour :\n\
+      <ul>%s</ul>\n\
+      \n\
+      Derni\u00e8re notification : %s.\n\
+      <div itemscope itemtype="http://schema.org/EmailMessage">\n\
+        <meta itemprop="description" content="Voir les mises \u00e0 jour"/>\n\
+        <div itemprop="potentialAction" itemscope itemtype="http://schema.org/ViewAction">\n\
+        <link itemprop="url" content="%s"/>\n\
+        <meta itemprop="name" content="Voir les mises \u00e0 jour"/>\n\
+        </div>\n\
+      </div>
+self_registration_disabled=La cr\u00E9ation de compte par les utilisateurs est d\u00E9sactiv\u00E9e
+recaptcha_not_valid=Recaptcha invalide
+metadata.title.createdFromTemplate=Copie du mod\u00e8le %s cr\u00E9\u00E9e le %s
+metadata.title.createdFromRecord=Copie de la fiche %s cr\u00E9\u00E9e le %s
+username.field.required=Le nom d''utilisateur est requis
+password.field.length=Le mot de passe doit contenir entre {min} et {max} caract\u00E8res
+password.field.invalid=Le mot de passe doit contenir a minima 1 lettre majuscule, 1 minuscule, 1 chiffre et 1 symbole (ie. `~!@#$%^&*()-_=+[]{}\\|;:'",.<>/?'));
+api.exception.forbidden=L''acc\u00E8s est refus\u00E9
+api.exception.forbidden.description=L''acc\u00E8s est refus\u00E9. Pour y acc\u00E9der, r\u00E9essayez avec un utilisateur contenant plus de privil\u00E8ges.
+api.exception.resourceNotFound=Ressource introuvable
+api.exception.resourceNotFound.description=Ressource n''a pas pu \u00EAtre localis\u00E9e.
+api.exception.resourceAlreadyExists=La ressource existe d\u00E9j\u00E0
+api.exception.resourceAlreadyExists.description=La ressource existe d\u00E9j\u00E0.
+api.exception.unsatisfiedRequestParameter=Param\u00E8tre de demande non satisfaite
+api.exception.unsatisfiedRequestParameter.description=Param\u00E8tre de demande non satisfaite.
+exception.resourceNotFound.metadata=Fiches introuvables
+exception.resourceNotFound.metadata.description=La fiche ''{0}'' est introuvable.
+exception.resourceNotFound.resource=Ressource ''{0}'' introuvable
+exception.resourceNotFound.resource.description=Ressource ''{0}'' n''a pas pu \u00EAtre localis\u00E9e pour la fiche ''{1}''.
+exception.resourceInvalid.metadata=Les fiches ne sont pas valides
+exception.resourceInvalid.metadata.description=Les fiches ne peuvent pas \u00EAtre soumises ou approuv\u00E9es
+exception.resourceNotEnabled.workflow=Le workflow est d\u00E9sactiv\u00E9
+exception.resourceNotEnabled.workflow.description=Impossible de d\u00E9finir l'\u00E9tat des fiches
+exception.doi.resourceContainsDoi=La fiche contient d\u00E9j\u00E0 un DOI
+exception.doi.resourceContainsDoi.description=La fiche ''{0}''  contient d\u00E9j\u00E0 un DOI. Le DOI est <a href=''{1}''>''{2}''</a>. Vous devez mettre \u00E0 jour le DOI existant. Supprimez la r\u00E9f\u00E9rence au DOI si elle ne s''applique pas \u00E0 cette fiche.
+exception.doi.resourceAlreadyPublished=La fiche semble d\u00E9j\u00E0 publi\u00E9e sur DataCite
+exception.doi.resourceAlreadyPublished.description=La fiche ''{0}'' semble d\u00E9j\u00E0 publi\u00E9e sur DataCite avec DOI <a href=''{1}''>''{2}''</a>. Le DOI sur Datacite pointe vers: <a href=''{3}''>''{4}''</a>. Si le DOI n''est pas correct, retirez-le de la fiche et demandez-en un nouveau.
+exception.doi.failedVisibilityCheck=Impossible de v\u00E9rifier si la fiche est publique pour la cr\u00E9ation du DOI
+exception.doi.failedVisibilityCheck.description=Impossible de v\u00E9rifier si la fiche ''{0}'' est publique pour la cr\u00E9ation du DOI. L''erreur est ''{1}''.
+exception.doi.recordNotPublic=La fiche n''est pas publique
+exception.doi.recordNotPublic.description=La fiche ''{0}'' n''est pas publique et il n''est pas possible de demander un DOI dans ce cas. Publiez d''abord la fiche.
+exception.doi.resourcesContainsDoiNotEqual=La fiche contient d\u00E9j\u00E0 un DOI
+exception.doi.resourcesContainsDoiNotEqual.description=La fiche ''{0}'' contient d\u00E9j\u00E0 un DOI <a href=''{0}''>{1}</a> qui n''est pas le m\u00EAme que le DOI sur le point d''\u00EAtre cr\u00E9\u00E9 (ie. ''{3}''). Peut-\u00EAtre que le DOI actuel ne correspond pas \u00E0 cette fiche ? Cela peut se produire lors de la copie d''une fiche ayant un DOI.
+exception.doi.recordNotConformantMissingInfo=La fiche n''est pas conforme au format DataCite
+exception.doi.recordNotConformantMissingInfo.description=La fiche ''{0}'' n''est pas conforme au format DataCite. {1} champ(s) obligatoire(s) manquant(s). {2}
+exception.doi.recordNotConformantMissingMandatory=La fiche n''est pas conforme aux r\u00E8gles de validation DataCite pour les champs obligatoires
+exception.doi.recordNotConformantMissingMandatory.description=La fiche ''{0}'' n''est pas conforme aux r\u00E8gles de validation DataCite pour les champs obligatoires. L''erreur est: {1}. Les champs obligatoires dans DataCite sont : identifiant, créateurs, titres, éditeur, publicationYear, resourceType. <a href=''{2}api/records/%s/formatters/datacite?output=xml''>V\u00E9rifier la sortie au format DataCite</a> et adapter le contenu de la fiche pour ajouter les informations manquantes.
+
+api.metadata.import.importedWithId=Fiche import\u00E9e avec l'ID '%s'
+api.metadata.import.importedWithUuid=Fiche import\u00E9e avec l'UUID '%s'
+api.metadata.import.importedFromXMLWithUuid=Fiche import\u00E9e depuis le fichier XML avec l'UUID '%s'
+api.metadata.import.importedFromUrl=Fiche import\u00E9e de l'URL avec UUID '%s'
+api.metadata.import.importedFromMEF=Fiche import\u00E9e depuis le fichier MEF avec l'UUID '%s'
+api.metadata.import.importedFromServerFolder=Fiche import\u00E9e du dossier du serveur avec l'UUID '%s'
+api.metadata.import.errorImportMEF=\u00C9chec de l'importation du fichier MEF '%s'. V\u00E9rifiez l'erreur pour plus de d\u00E9tails.
+api.metadata.import.errorFromUrl=Impossible d'importer les fiches pour '%s'. V\u00E9rifiez que l'URL est correcte et contactez votre administrateur si le probl\u00E8me persiste pour v\u00E9rifier les d\u00E9tails de l'erreur dans les fichiers journaux.
+api.metadata.import.errorMissingMEF=Aucun fichier XML, MEF ou ZIP n'a \u00E9t\u00E9 trouv\u00E9 dans le dossier du serveur '%s'.
+api.metadata.import.errorMissingXMLFragmentOrUrl=Un fragment XML ou une URL ou un dossier de serveur DOIT \u00CAtre fourni.
+api.metadata.import.errorInvalidXMLFragment=Le fragment XML n'est pas valide. L'erreur est %s
+api.metadata.import.errorDuplicatedUUID=Vous ne pouvez pas cr\u00E9er une nouvelle fiche avec l'UUID ''%s'' car une fiche existe d\u00E9j\u00E0 avec cet UUID.
+api.metadata.import.errorDuplicatedUUIDDetailed=Une fiche avec l'UUID '%s' existe d\u00E9j\u00E0 et vous ne choisissez aucune action sur le traitement de l'UUID. Choisissez d''\u00E9craser la fiche existante ou de g\u00E9n\u00E9rer un nouvel UUID.
+api.metadata.import.errorNotEditorInGroup=Vous ne pouvez pas cr\u00E9er de fiche dans ce groupe. L'utilisateur DOIT \u00EAtre un \u00E9diteur de ce groupe
+api.metadata.import.errorFileRequired=Un fichier DOIT \u00EAtre fourni.
+api.metadata.import.errorInvalidMEF=Aucune fiche import\u00E9e, v\u00E9rifiez si le fichier d'importation est une archive MEF valide.
+api.metadata.import.errorEventStore=Impossible de stocker l'\u00E9v\u00E9nement pour '%s'. V\u00E9rifiez l'erreur pour plus de d\u00E9tails.
+api.metadata.import.errorMissingXsl=Transformation XSL '%s' introuvable.
+api.metadata.import.errorDetectMetadataSchema=Impossible de d\u00E9tecter automatiquement le sch\u00E9ma de la fiche. Vous pouvez essayer de forcer le sch\u00E9ma avec le param\u00E8tre schema.
+api.metadata.share.errorMetadataNotValid=La fiche '%s' n'est pas valide, elle ne peut pas \u00EAtre publi\u00E9e.
+api.metadata.share.errorMetadataNotApproved=La fiche '%s' n'est pas approuv\u00E9e, elle ne peut pas \u00EAtre publi\u00E9e.
+api.metadata.share.ErrorUserNotAllowedToPublish=L'utilisateur n'est pas autoris\u00E9 \u00E0 publier la fiche %s. %s
+api.metadata.share.strategy.groupOwnerOnly=Vous devez \u00EAtre administrateur ou relecteur du groupe de la fiche.
+api.metadata.share.strategy.reviewerInGroup=Vous devez \u00EAtre administrateur ou relecteur du groupe de la fiche ou relecteur avec un privil\u00E8ge de modification sur les fiches.


### PR DESCRIPTION
Related to this change https://github.com/geonetwork/core-geonetwork/pull/6508

Causing to fail the test in https://github.com/geonetwork/core-geonetwork/pull/6507

In `main` the related it's executed as an integration test, running `mvn verify -Pit` in the `core` module.