### PR TITLE
Display successful test mail sent message

### DIFF
--- a/web-ui/src/main/resources/catalog/js/admin/SystemSettingsController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/SystemSettingsController.js
@@ -482,7 +482,8 @@
         $http.get('../api/tools/mail/test')
             .then(function(response) {
               $rootScope.$broadcast('StatusUpdated', {
-                title: response.data});
+                title: response.data,
+                timeout: 2});
             }, function(response) {
               $rootScope.$broadcast('StatusUpdated', {
                 title: response.data,


### PR DESCRIPTION
Without the change, clicking the button `Test mail configuration` in the `Settings` > `Feedback` section didn't show any feedback to the user when the mail was sent successfully.

With the change an alert info message is displayed:

![mail-message](https://user-images.githubusercontent.com/1695003/188442040-9a07bc53-2f22-46ba-b6e4-c32ca95d2f4b.png)


To test:

1) Configure a mail server configuration in the settings
2) Save the configuration
3) Click the button `Test mail configuration`. If the mail configuration is correct, an info alert with the text `Mail sent to ....` should be displayed.