### PR TITLE
Add missing French messages for DOI and remove double quotes for texts used in mails

### DIFF
--- a/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages.properties
+++ b/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages.properties
@@ -168,9 +168,9 @@ exception.doi.missingSavedquery.description="Record ''{0}'' is in schema ''{1}''
 exception.doi.recordNotConformantMissingInfo=Record is not conform with DataCite format
 exception.doi.recordNotConformantMissingInfo.description=Record ''{0}'' is not conform with DataCite format. {1} mandatory field(s) missing. {2}
 exception.doi.recordNotConformantMissingMandatory=Record is not conform with DataCite validation rules for mandatory fields
-exception.doi.recordNotConformantMissingMandatory.description=Record ''{0}'' is not conform with DataCite validation rules for mandatory fields. Error is: {1}. Required fields in DataCite are: identifier, creators, titles, publisher, publicationYear, resourceType. <a href=''{2}api/records/%s/formatters/datacite?output=xml''>Check the DataCite format output</a> and adapt the record content to add missing information.
+exception.doi.recordNotConformantMissingMandatory.description=Record ''{0}'' is not conform with DataCite validation rules for mandatory fields. Error is: {1}. Required fields in DataCite are: identifier, creators, titles, publisher, publicationYear, resourceType. <a href=''{2}api/records/{3}/formatters/datacite?output=xml''>Check the DataCite format output</a> and adapt the record content to add missing information.
 exception.doi.recordInvalid=Record converted to DataCite format is invalid.
-exception.doi.recordInvalid.description=Record ''{0}'' converted to DataCite format is invalid. Error is: {1}. Required fields in DataCite are: identifier, creators, titles, publisher, publicationYear, resourceType. <a href='{2}api/records/{3}/formatters/datacite?output=xml'>Check the DataCite format output</a> and adapt the record content to add missing information.
+exception.doi.recordInvalid.description=Record ''{0}'' converted to DataCite format is invalid. Error is: {1}. Required fields in DataCite are: identifier, creators, titles, publisher, publicationYear, resourceType. <a href=''{2}api/records/{3}/formatters/datacite?output=xml''>Check the DataCite format output</a> and adapt the record content to add missing information.
 api.metadata.import.importedWithId=Metadata imported with ID '%s'
 api.metadata.import.importedWithUuid=Metadata imported with UUID '%s'
 api.metadata.import.importedFromXMLWithUuid=Metadata imported from XML with UUID '%s'

--- a/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages_fre.properties
+++ b/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages_fre.properties
@@ -21,22 +21,22 @@
 # Rome - Italy. email: geonetwork@osgeo.org
 #
 
-mail_error=Erreur lors de l''envoi du mail.
+mail_error=Erreur lors de l'envoi du mail.
 mail_config_test_subject=%s / Test / Configuration serveur de mail
 mail_config_test_success=Mail envoy\u00E9 \u00E0 %s.
 mail_config_test_only_admin=Seuls les administrateurs peuvent tester la configuration du serveur de mail.
 password_change_subject=%s / Mot de passe modifi\u00E9
 password_change_message=Votre mot de passe %s a \u00E9t\u00E9 mis \u00E0 jour. \n\
-                        Si vous n''avez pas demand\u00E9 une mise \u00E0 jour de votre mot de passe, contacter l''administrateur %s. \n\
+                        Si vous n'avez pas demand\u00E9 une mise \u00E0 jour de votre mot de passe, contacter l'administrateur %s. \n\
                         \n\
-                        L''\u00E9quipe %s.
+                        L'\u00E9quipe %s.
 password_forgotten_subject=%s / R\u00E9initialiser votre mot de passe
 password_forgotten_message=Vous avez demand\u00E9 une r\u00E9initialisation de votre mot de passe %s. \n\
                            Cliquer sur le lien suivant pour le mettre \u00E0 jour :\n\
                            %snew.password?username=%s&changeKey=%s \n\
-                           Ce lien n''est valide qu''aujourd''hui. \n\
+                           Ce lien n'est valide qu''aujourd''hui. \n\
                            \n\
-                           L''\u00E9quipe %s.
+                           L'\u00E9quipe %s.
 user_has_no_email=%s n''a pas d'adresse mail.
 user_not_found=Pas d''utilisateur trouv\u00E9 avec le nom %s.
 user_from_ldap_cant_get_password=L''utilisateur %s est authentifi\u00E9 \u00E0 partir d''un annuaire LDAP. Le mot de passe ne peut \u00EAtre r\u00E9initialiser par email.
@@ -49,13 +49,13 @@ user_with_that_email_found=Un utilisateur avec cette adresse email %s existe d\u
 user_with_that_username_found=Un utilisateur avec cette nom d''utilisateur %s existe d\u00E9j\u00E0.
 register_email_admin_subject=%s / Cr\u00E9ation de compte pour %s en tant que %s
 register_email_admin_message=Cher administrateur,\n\
-  L''utilisateur %s vient de demander une cr\u00E9ation de compte pour %s.\n\
+  L'utilisateur %s vient de demander une cr\u00E9ation de compte pour %s.\n\
   Salutation,\n\
-  L''\u00E9quipe %s.
+  L'\u00E9quipe %s.
 register_email_subject=%s / Votre compte %s
 register_email_message=Cher utilisateur,\n\
   Votre compte a \u00E9t\u00E9 cr\u00E9\u00E9 avec succ\u00E9s pour %s.\n\
-  * Nom d''utilisateur : %s\n\
+  * Nom d'utilisateur : %s\n\
   * Mot de passe : %s\n\
   * Profil : %s\n\
   \n\
@@ -64,7 +64,7 @@ register_email_message=Cher utilisateur,\n\
   %s\n\
   \n\
   Salutations,\n\
-  L''\u00E9quipe %s.
+  L'\u00E9quipe %s.
 new_user_rating=%s / Nouvelle \u00E9valuation faite pour %s
 new_user_rating_text=Consulter la fiche %sapi/records/%s
 user_feedback_title=%s / Nouveau commentaire sur %s / %s
@@ -155,8 +155,9 @@ exception.doi.resourcesContainsDoiNotEqual.description=La fiche ''{0}'' contient
 exception.doi.recordNotConformantMissingInfo=La fiche n''est pas conforme au format DataCite
 exception.doi.recordNotConformantMissingInfo.description=La fiche ''{0}'' n''est pas conforme au format DataCite. {1} champ(s) obligatoire(s) manquant(s). {2}
 exception.doi.recordNotConformantMissingMandatory=La fiche n''est pas conforme aux r\u00E8gles de validation DataCite pour les champs obligatoires
-exception.doi.recordNotConformantMissingMandatory.description=La fiche ''{0}'' n''est pas conforme aux r\u00E8gles de validation DataCite pour les champs obligatoires. L''erreur est: {1}. Les champs obligatoires dans DataCite sont : identifiant, créateurs, titres, éditeur, publicationYear, resourceType. <a href=''{2}api/records/%s/formatters/datacite?output=xml''>V\u00E9rifier la sortie au format DataCite</a> et adapter le contenu de la fiche pour ajouter les informations manquantes.
-
+exception.doi.recordNotConformantMissingMandatory.description=La fiche ''{0}'' n''est pas conforme aux r\u00E8gles de validation DataCite pour les champs obligatoires. L''erreur est: {1}. Les champs obligatoires dans DataCite sont : identifiant, créateurs, titres, éditeur, publicationYear, resourceType. <a href=''{2}api/records/{3}/formatters/datacite?output=xml''>V\u00E9rifier la sortie au format DataCite</a> et adapter le contenu de la fiche pour ajouter les informations manquantes.
+exception.doi.recordInvalid=Le fiche converti n''est pas conforme au format DataCite
+exception.doi.recordInvalid.description=Le fiche ''{0}'' converti  n''est pas conforme au format DataCite. L''erreur est: {1}. Les champs obligatoires dans DataCite sont: identifiant, créateurs, titres, éditeur, publicationYear, resourceType. <a href=''{2}api/records/{3}/formatters/datacite?output=xml''>V\u00E9rifier la sortie au format DataCite</a> et adapter le contenu de la fiche pour ajouter les informations manquantes.
 api.metadata.import.importedWithId=Fiche import\u00E9e avec l'ID '%s'
 api.metadata.import.importedWithUuid=Fiche import\u00E9e avec l'UUID '%s'
 api.metadata.import.importedFromXMLWithUuid=Fiche import\u00E9e depuis le fichier XML avec l'UUID '%s'


### PR DESCRIPTION
@fxprunayre please check the translations for `exception.doi.recordInvalid` and `exception.doi.recordInvalid.description`.