### PR TITLE
Remove duplicated dependencies declaration

### DIFF
--- a/workers/pom.xml
+++ b/workers/pom.xml
@@ -92,31 +92,15 @@
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
     </dependency>
-    <!--
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>${slf4j.version}</version>
-    </dependency> -->
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j18-impl</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j18-impl</artifactId>
-      <version>${log4j2.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-jul</artifactId>
-      <version>${log4j2.version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j18-impl</artifactId>
-      <version>${log4j2.version}</version>
-    </dependency>
+
 
     <dependency>
       <groupId>org.apache.activemq</groupId>


### PR DESCRIPTION
`log4j-slf4j18-impl` was declared more than once in the `workers/pom.xml` file. Removed the extra declarations.
Remove the version of the dependencies that have been already declared in the `managedDependencies`of the parent pom.xml file.
