### PR TITLE
Fix for the tools in the table search result opening to the right

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn_search.less
+++ b/web-ui/src/main/resources/catalog/style/gn_search.less
@@ -226,9 +226,6 @@
   &:first-letter {
     text-transform: uppercase;
   }
-  span {
-    background-color: #fff;
-  }
 }
 
 /* TODO: Deprecate due to change in gn-pager and gn-sort-by */
@@ -441,11 +438,11 @@
     .dropdown-menu {
       max-width: 500px;
       li a {
-        padding-top: 1px;
-        padding-bottom: 1px;
+        padding: 8px 20px;
         line-height: normal;
         min-width: unset;
         .text-overflow();
+        display: block;
       }
     }
 

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_card_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_card_default.less
@@ -236,15 +236,25 @@
 }
 
 // styling for all search results
-ul.gn-resultview {
+.gn-resultview {
   margin-right: -15px;
   .metadata {
     position: absolute;
     top: 0;
     width: 100%;
-    width: 100%;
     height: 100%;
     z-index: 2050;
+  }
+  .gn-toolbar {
+    .gn-md-links {
+      display: flex;
+      gap: 3px;
+    }
+    // open sub menu to the left
+    .dropdown-menu {
+      right: 0;
+      left: auto;
+    }
   }
   // both list types
   li.gn-card {
@@ -323,17 +333,6 @@ table.gn-resultview {
     font-size: 14px;
     padding: 0;
     margin: 0;
-  }
-  .gn-toolbar {
-    .gn-md-links {
-      display: flex;
-      gap: 3px;
-    }
-    // open sub menu to the left
-    .dropdown-menu {
-      right: 0;
-      left: auto;
-    }
   }
   .gn-status {
     position: inherit;

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_card_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_card_default.less
@@ -324,9 +324,16 @@ table.gn-resultview {
     padding: 0;
     margin: 0;
   }
-  .gn-md-links {
-    display: flex;
-    gap: 3px;
+  .gn-toolbar {
+    .gn-md-links {
+      display: flex;
+      gap: 3px;
+    }
+    // open sub menu to the left
+    .dropdown-menu {
+      right: 0;
+      left: auto;
+    }
   }
   .gn-status {
     position: inherit;

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_results_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_results_default.less
@@ -66,6 +66,10 @@
       }
     }
   }
+  .dropdown-menu > li > a {
+    padding: 8px 20px;
+    display: block;
+  }
 }
 
 ul.gn-resultview, [data-gn-user-searches-list] {


### PR DESCRIPTION
Replaces PR https://github.com/geonetwork/core-geonetwork/pull/6402

Tools menu was opening to right which resulted in the dropdown displayed partially outside of the screen. This PR opens the submenu to the left and adds some padding to the list items

**Before**
<img width="896" alt="gn-table-before" src="https://user-images.githubusercontent.com/19608667/174103987-bfc78715-d54c-439a-844e-d44807f45595.png">

**After**
<img width="902" alt="gn-table-after" src="https://user-images.githubusercontent.com/19608667/174104059-70f9f45c-41bd-4656-b6fb-d0aa3f73808e.png">

