### PR TITLE
Deploy / On Jetty app fails to start due to logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1534,7 +1534,7 @@
      request the list of hosts (but JPA cache db queries). -->
     <cors.allowedHosts>*</cors.allowedHosts>
 
-    <jetty.version>9.4.46.v20220331</jetty.version>
+    <jetty.version>9.4.48.v20220622</jetty.version>
     <jetty.file>jetty-distribution-${jetty.version}</jetty.file>
     <jetty.download>https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/${jetty.version}/${jetty.file}.tar.gz</jetty.download>
 

--- a/release/build.xml
+++ b/release/build.xml
@@ -109,8 +109,13 @@
     <ant dir="." target="war"/>
   </target>
 
+  <target name="log-lib">
+    <get src="https://repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.36/slf4j-api-1.7.36.jar" dest="target/slf4j-api-1.7.36.jar" usetimestamp="true"/>
+  </target>
+
+
   <!-- Create ZIP distribution for GeoNetwork + Jetty + shell scripts -->
-  <target name="zip">
+  <target name="zip" depends="log-lib">
     <mkdir dir="target/${appName}-${version}"/>
 
     <echo message="Creating ZIP file for ${appName} ${version}..."/>
@@ -124,6 +129,8 @@
       <zipfileset src="../web/target/geonetwork.war" prefix="web/geonetwork" />
       <zipfileset dir="./data" prefix="web/geonetwork/data" />
       <zipfileset dir="./schemaPlugins" prefix="web/geonetwork/WEB-INF/data/config/schema_plugins" />
+      <zipfileset dir="./schemaPlugins" prefix="web/geonetwork/WEB-INF/data/config/schema_plugins" />
+      <zipfileset dir="./target" includes="slf4j-api-1.7.36.jar" prefix="web/geonetwork/WEB-INF/lib" />
     </zip>
 
     <checksum

--- a/release/build.xml
+++ b/release/build.xml
@@ -109,13 +109,8 @@
     <ant dir="." target="war"/>
   </target>
 
-  <target name="log-lib">
-    <get src="https://repo1.maven.org/maven2/org/slf4j/slf4j-api/1.7.36/slf4j-api-1.7.36.jar" dest="target/slf4j-api-1.7.36.jar" usetimestamp="true"/>
-  </target>
-
-
   <!-- Create ZIP distribution for GeoNetwork + Jetty + shell scripts -->
-  <target name="zip" depends="log-lib">
+  <target name="zip">
     <mkdir dir="target/${appName}-${version}"/>
 
     <echo message="Creating ZIP file for ${appName} ${version}..."/>
@@ -129,7 +124,6 @@
       <zipfileset src="../web/target/geonetwork.war" prefix="web/geonetwork" />
       <zipfileset dir="./data" prefix="web/geonetwork/data" />
       <zipfileset dir="./schemaPlugins" prefix="web/geonetwork/WEB-INF/data/config/schema_plugins" />
-      <zipfileset dir="./target" includes="slf4j-api-1.7.36.jar" prefix="web/geonetwork/WEB-INF/lib" />
     </zip>
 
     <checksum

--- a/release/build.xml
+++ b/release/build.xml
@@ -129,7 +129,6 @@
       <zipfileset src="../web/target/geonetwork.war" prefix="web/geonetwork" />
       <zipfileset dir="./data" prefix="web/geonetwork/data" />
       <zipfileset dir="./schemaPlugins" prefix="web/geonetwork/WEB-INF/data/config/schema_plugins" />
-      <zipfileset dir="./schemaPlugins" prefix="web/geonetwork/WEB-INF/data/config/schema_plugins" />
       <zipfileset dir="./target" includes="slf4j-api-1.7.36.jar" prefix="web/geonetwork/WEB-INF/lib" />
     </zip>
 

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -64,11 +64,15 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j18-impl</artifactId>
-      <version>${log4j2.version}</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-jul</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.36</version>
     </dependency>
     <dependency>
       <groupId>org.tuckey</groupId>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -70,11 +70,6 @@
       <artifactId>log4j-jul</artifactId>
     </dependency>
     <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-api</artifactId>
-      <version>1.7.36</version>
-    </dependency>
-    <dependency>
       <groupId>org.tuckey</groupId>
       <artifactId>urlrewritefilter</artifactId>
     </dependency>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -1213,6 +1213,17 @@
         </dependency>
       </dependencies>
     </profile>
+
+    <profile>
+      <id>war</id>
+      <dependencies>
+        <dependency>
+          <groupId>org.slf4j</groupId>
+          <artifactId>slf4j-api</artifactId>
+          <version>1.7.36</version>
+        </dependency>
+      </dependencies>
+    </profile>
   </profiles>
 
   <properties>

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
@@ -581,7 +581,7 @@ INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/server/host', 'localhost', 0, 210, 'n');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/server/protocol', 'http', 0, 220, 'n');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/server/port', '8080', 1, 230, 'n');
-INSERT INTO settings (name, value, datatype, position, internal) VALUES ('system/server/log','log4j.xml', 0, 250, 'y');
+INSERT INTO settings (name, value, datatype, position, internal) VALUES ('system/server/log','log4j2.xml', 0, 250, 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/server/timeZone', '', 0, 260, 'n');
 
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/intranet/network', '127.0.0.1', 0, 310, 'y');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v421/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v421/migrate-default.sql
@@ -6,6 +6,7 @@ INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('metada
 
 -- cf. https://www.un.org/en/about-us/member-states/turkiye (run this manually if it applies to your catalogue)
 -- UPDATE metadata SET data = replace(data, 'Turkey', 'Türkiye') WHERE data LIKE '%Turkey%';
+UPDATE Settings SET value='log4j2.xml' WHERE name='system/server/log';
 
 UPDATE Settings SET value='4.2.1' WHERE name='system/platform/version';
 UPDATE Settings SET value='SNAPSHOT' WHERE name='system/platform/subVersion';


### PR DESCRIPTION
`jetty:run` works fine, Deploy on Tomcat also but not deploy on Jetty which fails with:

```
java.lang.NoSuchMethodError: org.apache.logging.slf4j.Log4jLoggerFactory.<init>(Lorg/apache/logging/slf4j/Log4jMarkerFactory;)V
	at org.apache.logging.slf4j.SLF4JServiceProvider.initialize(SLF4JServiceProvider.java:54)
	at org.slf4j.LoggerFactory.bind(LoggerFactory.java:153)
	at org.slf4j.LoggerFactory.performInitialization(LoggerFactory.java:141)
	at org.slf4j.LoggerFactory.getProvider(LoggerFactory.java:419)
	at org.slf4j.LoggerFactory.getILoggerFactory(LoggerFactory.java:405)
	at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:354)
	at org.apache.commons.logging.impl.SLF4JLogFactory.getInstance(SLF4JLogFactory.java:156)
	at org.apache.commons.logging.impl.SLF4JLogFactory.getInstance(SLF4JLogFactory.java:132)
	at org.apache.commons.logging.LogFactory.getLog(LogFactory.java:685)
	at org.apache.jcs.utils.servlet.JCSServletContextListener.<clinit>(JCSServletContextListener.java:48)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at org.eclipse.jetty.server.handler.ContextHandler$StaticContext.createInstance(ContextHandler.java:2902)
	at org.eclipse.jetty.servlet.ServletContextHandler$Context.createInstance(ServletContextHandler.java:1299)
	at org.eclipse.jetty.server.handler.ContextHandler$StaticContext.createListener(ContextHandler.java:2913)
	at org.eclipse.jetty.servlet.ListenerHolder.doStart(ListenerHolder.java:94)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:73)
	at org.eclipse.jetty.servlet.ServletContextHandler.startContext(ServletContextHandler.java:369)
	at org.eclipse.jetty.webapp.WebAppContext.startWebapp(WebAppContext.java:1449)
	at org.eclipse.jetty.webapp.WebAppContext.startContext(WebAppContext.java:1414)
	at org.eclipse.jetty.server.handler.ContextHandler.doStart(ContextHandler.java:916)
	at org.eclipse.jetty.servlet.ServletContextHandler.doStart(ServletContextHandler.java:288)
	at org.eclipse.jetty.webapp.WebAppContext.doStart(WebAppContext.java:524)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:73)
	at org.eclipse.jetty.deploy.bindings.StandardStarter.processBinding(StandardStarter.java:46)
	at org.eclipse.jetty.deploy.AppLifeCycle.runBindings(AppLifeCycle.java:188)
	at org.eclipse.jetty.deploy.DeploymentManager.requestAppGoal(DeploymentManager.java:517)
	at org.eclipse.jetty.deploy.DeploymentManager.addApp(DeploymentManager.java:157)
	at org.eclipse.jetty.deploy.providers.ScanningAppProvider.fileAdded(ScanningAppProvider.java:173)
	at org.eclipse.jetty.deploy.providers.WebAppProvider.fileAdded(WebAppProvider.java:428)
	at org.eclipse.jetty.deploy.providers.ScanningAppProvider$1.fileAdded(ScanningAppProvider.java:66)
	at org.eclipse.jetty.util.Scanner.reportAddition(Scanner.java:785)
	at org.eclipse.jetty.util.Scanner.reportDifferences(Scanner.java:754)
	at org.eclipse.jetty.util.Scanner.scan(Scanner.java:641)
	at org.eclipse.jetty.util.Scanner.doStart(Scanner.java:540)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:73)
	at org.eclipse.jetty.deploy.providers.ScanningAppProvider.doStart(ScanningAppProvider.java:146)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:73)
	at org.eclipse.jetty.deploy.DeploymentManager.startAppProvider(DeploymentManager.java:605)
	at org.eclipse.jetty.deploy.DeploymentManager.doStart(DeploymentManager.java:252)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:73)
	at org.eclipse.jetty.util.component.ContainerLifeCycle.start(ContainerLifeCycle.java:169)
	at org.eclipse.jetty.server.Server.start(Server.java:423)
	at org.eclipse.jetty.util.component.ContainerLifeCycle.doStart(ContainerLifeCycle.java:117)
	at org.eclipse.jetty.server.handler.AbstractHandler.doStart(AbstractHandler.java:97)
	at org.eclipse.jetty.server.Server.doStart(Server.java:387)
	at org.eclipse.jetty.util.component.AbstractLifeCycle.start(AbstractLifeCycle.java:73)
	at org.eclipse.jetty.xml.XmlConfiguration.lambda$main$3(XmlConfiguration.java:1907)
	at java.security.AccessController.doPrivileged(Native Method)
	at org.eclipse.jetty.xml.XmlConfiguration.main(XmlConfiguration.java:1857)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.eclipse.jetty.start.Main.invokeMain(Main.java:218)
	at org.eclipse.jetty.start.Main.start(Main.java:491)
	at org.eclipse.jetty.start.Main.main(Main.java:77)
```

Adding 
```xml
    <dependency>
      <groupId>org.slf4j</groupId>
      <artifactId>slf4j-api</artifactId>
      <version>1.7.36</version>
    </dependency>
```
to `web/pom.xml` fix deploy on jetty, but the same error happens now with `jetty:run`


@jodygarnett, @josegar74 if you have suggestions ?

Related to https://github.com/geonetwork/core-geonetwork/pull/6397


Also update database setting with the new log4j2 config file. Avoid the following warning: 
```
2022-09-12 13:35:01.418:INFO::main: Logging initialized @59456ms to org.eclipse.jetty.util.log.StdErrLog
2022-09-12 13:35:59,428 main WARN Continuable parsing error  2 and column 41
2022-09-12 13:35:59,435 main WARN Document root element "Configuration", must match DOCTYPE root "null".
2022-09-12 13:35:59,435 main WARN Continuable parsing error  2 and column 41
2022-09-12 13:35:59,436 main WARN Document is invalid: no grammar found.
2022-09-12 13:35:59,442 main ERROR DOM element is - not a <log4j:configuration> element.
```
