### PR TITLE
Record view / Feature catalogue / Fix link to record

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/featurecatalogue.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/featurecatalogue.html
@@ -41,5 +41,6 @@
      data-gn-related="mdView.current.record"
      data-user="user"
      data-types="fcats|related"
+     data-layout="card"
      data-title="{{'featureCatalog' | translate}}">
 </div>


### PR DESCRIPTION
Use the same layout for related metadata for feature catalog

![image](https://user-images.githubusercontent.com/1701393/190331768-7f380844-8ab3-4727-91ce-c48163fb9c04.png)


For test, associate a feature catalogue to a record and open that record in view mode.