### PR TITLE
change li to span tag

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/onlinesrcList.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/onlinesrcList.html
@@ -28,9 +28,9 @@
               <span data-translate="">addOnlinesrcTitle</span>
             </a>
           </li>
-          <li class="dropdown-header"
+          <span class="dropdown-header"
               data-translate>linkMetadata
-          </li>
+          </span>
           <li data-ng-show="::isCategoryEnable('parent')">
             <a href=""
               data-ng-click="onlinesrcService.onOpenPopup('parent')">

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/onlinesrcList.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/onlinesrcList.html
@@ -28,9 +28,9 @@
               <span data-translate="">addOnlinesrcTitle</span>
             </a>
           </li>
-          <span class="dropdown-header"
+          <li class="dropdown-header"
               data-translate>linkMetadata
-          </span>
+          </li>
           <li data-ng-show="::isCategoryEnable('parent')">
             <a href=""
               data-ng-click="onlinesrcService.onOpenPopup('parent')">

--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -369,7 +369,7 @@ div.gn-scroll-spy {
 }
 
 .dropdown-menu {
-  li {
+  li:not(.dropdown-header) {
     cursor: pointer !important;
   }
   li.disabled {


### PR DESCRIPTION
Due to dropdown li tag. This entry will always have a clickable mouse icon when hovering on it.

![image](https://user-images.githubusercontent.com/74916635/190510261-024dacec-178c-4313-85c0-357ed018d171.png)


This change convert the tag from li to span to disable such behavior.