### PR TITLE
Editor / ISO / Empty keywords are ignored for picker config.

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/layout-custom-fields-keywords.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/layout-custom-fields-keywords.xsl
@@ -174,8 +174,8 @@
         -->
         <xsl:variable name="keywords" select="string-join(
                   if ($guiLangId and mri:keyword//*[@locale = concat('#', $guiLangId)])
-                  then mri:keyword//*[@locale = concat('#', $guiLangId)]/replace(text(), ',', ',,')
-                  else mri:keyword/*[1]/replace(text(), ',', ',,'), ',')"/>
+                  then mri:keyword//*[@locale = concat('#', $guiLangId)][. != '']/replace(text(), ',', ',,')
+                  else mri:keyword/*[1][. != '']/replace(text(), ',', ',,'), ',')"/>
 
         <!-- Define the list of transformation mode available. -->
         <xsl:variable name="transformations"

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields-keywords.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields-keywords.xsl
@@ -66,12 +66,12 @@
 
     <xsl:variable name="thesaurusTitle">
       <xsl:choose>
-        <xsl:when test="normalize-space($thesaurusTitleEl/gco:CharacterString) != ''">
+        <xsl:when test="normalize-space($thesaurusTitleEl/(gco:CharacterString|gmx:Anchor)) != ''">
           <xsl:value-of select="if ($overrideLabel != '')
               then $overrideLabel
               else concat(
                       $iso19139strings/keywordFrom,
-                      normalize-space($thesaurusTitleEl/gco:CharacterString))"/>
+                      normalize-space($thesaurusTitleEl/(gco:CharacterString|gmx:Anchor)))"/>
         </xsl:when>
         <xsl:when test="normalize-space($thesaurusTitleEl/gmd:PT_FreeText/
                           gmd:textGroup/gmd:LocalisedCharacterString[
@@ -210,8 +210,8 @@
         -->
         <xsl:variable name="keywords" select="string-join(
                   if ($guiLangId and gmd:keyword//*[@locale = concat('#', $guiLangId)]) then
-                    gmd:keyword//*[@locale = concat('#', $guiLangId)]/replace(text(), ',', ',,')
-                  else gmd:keyword/*[1]/replace(text(), ',', ',,'), ',')"/>
+                    gmd:keyword//*[@locale = concat('#', $guiLangId)][. != '']/replace(text(), ',', ',,')
+                  else gmd:keyword/*[1][. != '']/replace(text(), ',', ',,'), ',')"/>
 
         <!-- Define the list of transformation mode available. -->
         <xsl:variable name="transformations"


### PR DESCRIPTION
Currently, if a record contains an empty keyword in a thesaurus block, the picker does not initialized properly.

![image](https://user-images.githubusercontent.com/1701393/191181153-fc264dc0-894b-4ff1-8bce-235a3470806e.png)

For test, create a thesaurus block with one keyword set and an empty one
```xml
               <mri:keyword>
                  <gco:CharacterString>Energy</gco:CharacterString>
               </mri:keyword>
               <mri:keyword>
                  <gco:CharacterString></gco:CharacterString>
               </mri:keyword>
```

This should not happen when using the editor, but when importing records (or running SQL update) we could end up with this.
