### PR TITLE
Search / Aggregation / Add decorator

### DIFF
--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/FacetDirective.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/FacetDirective.js
@@ -345,6 +345,44 @@
     }
   ]);
 
+  module.directive("esFacetDecorator", [
+    function () {
+      return {
+        restrict: "A",
+        replace: false,
+        scope: {
+          decorator: "=esFacetDecorator",
+          key: "="
+        },
+        templateUrl: function (elem, attrs) {
+          return (
+            attrs.template ||
+            "../../catalog/components/elasticsearch/directives/" +
+              "partials/facetDecorator.html"
+          );
+        },
+        link: function (scope, element, attrs) {
+          if (scope.decorator) {
+            var key = scope.decorator.expression
+              ? scope.key.replace(new RegExp(scope.decorator.expression), "$1")
+              : scope.key;
+
+            if (scope.decorator.map) {
+              key = scope.decorator.map[key] || "";
+            }
+
+            if (scope.decorator.type == "img") {
+              scope.ext =
+                "image/" + (key.substr(key.lastIndexOf(".") + 1, key.length) || "png");
+            }
+
+            scope.class = scope.decorator.prefix ? scope.decorator.prefix + key : key;
+          }
+        }
+      };
+    }
+  ]);
+
   module.filter("facetCssClassCode", [
     function () {
       return function (key, isInspire) {

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facet-cards.html
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facet-cards.html
@@ -4,7 +4,10 @@
   data-ng-class="isInspire ? ('bg-iti-' + (facet.key | facetCssClassCode: isInspire)) : ''"
   class="col-xs-6 col-sm-4 col-md-3 col-lg-2 gn-topic"
 >
-  <div class="panel panel-default gn-facet-{{key}}">
+  <div
+    class="panel panel-default gn-facet-{{facet.key}} gn-facet-type-{{decorator.type}}"
+    style="background-image:url('{{decorator.map[facet.key]}}')"
+  >
     <div class="panel-body">
       <a
         class="clearfix"

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facet-cards.html
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facet-cards.html
@@ -10,24 +10,19 @@
         class="clearfix"
         title="{{facet.key}}"
         role="link"
-        data-ng-init="field = (aggResponse.meta && aggResponse.meta.field)
+        data-ng-init="aggResponse = searchInfo.aggregations[key];
+                       decorator = (aggResponse.meta && aggResponse.meta.decorator) || undefined;
+                       field = (aggResponse.meta && aggResponse.meta.field)
                               || key;
-                      value = aggResponse.meta && aggResponse.meta.wildcard
+                       value = aggResponse.meta && aggResponse.meta.wildcard
                               ? (facet.key + '*') : facet.key"
         data-ng-href='#/search?query_string={"{{field}}": {"{{value === missingValue ? "%23MISSING%23" : value}}": true} }'
       >
-        <!-- TODOES Link label to icons? -->
-        <i
-          data-ng-class="isInspire
-                        ? 'gn-icon iti-' + (facet.key | facetCssClassCode: isInspire)
-                        : 'gn-icon-' + (facet.key | facetCssClassCode: isInspire)"
-          class="fa fa-2x pull-left"
-          data-ng-show="isInspire
-                        || field === 'cl_topic.key'
-                        || field === 'resourceType'
-                        || field === 'cl_hierarchyLevel.key'"
-        >
-        </i>
+        <span
+          data-ng-if="decorator"
+          data-es-facet-decorator="decorator"
+          data-key="facet.key"
+        />
         <h2
           data-ng-show="isInspire"
           class="inspire-{{(facet.key | facetCssClassCode: isInspire)}}-{{iso2lang}}"

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facet.html
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facet.html
@@ -47,6 +47,8 @@
       ng-click="ctrl.toggleInvert()"
     >
       <span class="fa" ng-class="ctrl.item.inverted ? 'fa-check' : 'fa-minus-circle'">
+      </span>
+      <span>
         {{::(ctrl.item.inverted ? 'filterWithValue' : 'allValuesExcept') | translate}}
       </span>
     </a>

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facet.html
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facet.html
@@ -25,6 +25,11 @@
         ng-class="ctrl.isInSearch(ctrl.facet, ctrl.item) ? 'fa-check-square' : 'fa-square-o'"
       >
       </span>
+      <span
+        data-ng-if="ctrl.facet.meta && ctrl.facet.meta.decorator"
+        data-es-facet-decorator="ctrl.facet.meta.decorator"
+        data-key="ctrl.item.value"
+      />
       <span class="gn-facet-label flex-shrink text-ellipsis">
         {{::ctrl.item.value | facetTranslator: ctrl.facet.key | capitalize}}
       </span>
@@ -41,7 +46,9 @@
       title="{{::(ctrl.item.inverted ? 'filterWithValue' : 'allValuesExcept') | translate}}"
       ng-click="ctrl.toggleInvert()"
     >
-      <span class="fa" ng-class="ctrl.item.inverted ? 'fa-check' : 'fa-minus'"></span>
+      <span class="fa" ng-class="ctrl.item.inverted ? 'fa-check' : 'fa-minus-circle'">
+        {{::(ctrl.item.inverted ? 'filterWithValue' : 'allValuesExcept') | translate}}
+      </span>
     </a>
   </div>
   <div class="gn-facet-children" ng-show="!ctrl.item.collapsed">

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facetDecorator.html
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facetDecorator.html
@@ -1,0 +1,8 @@
+<span data-ng-if="decorator">
+  <i data-ng-if="decorator.type === 'icon'" data-ng-class="class" />
+  <div
+    data-ng-if="decorator.type === 'img'"
+    class="gn-facet-image"
+    style="background:url('{{class}}')"
+  />
+</span>

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -121,12 +121,25 @@
                   field: "th_httpinspireeceuropaeutheme-theme_tree.key",
                   size: 34
                   // "order" : { "_key" : "asc" }
+                },
+                meta: {
+                  decorator: {
+                    type: "icon",
+                    prefix: "fa fa-2x pull-left gn-icon iti-",
+                    expression: "http://inspire.ec.europa.eu/theme/(.*)"
+                  }
                 }
               },
               "cl_topic.key": {
                 terms: {
                   field: "cl_topic.key",
                   size: 20
+                },
+                meta: {
+                  decorator: {
+                    type: "icon",
+                    prefix: "fa fa-2x pull-left gn-icon-"
+                  }
                 }
               },
               // 'OrgForResource': {
@@ -141,6 +154,12 @@
                 terms: {
                   field: "resourceType",
                   size: 10
+                },
+                meta: {
+                  decorator: {
+                    type: "icon",
+                    prefix: "fa fa-2x pull-left gn-icon-"
+                  }
                 }
               }
             },
@@ -328,6 +347,12 @@
                       field: "format"
                     }
                   }
+                },
+                meta: {
+                  decorator: {
+                    type: "icon",
+                    prefix: "fa fa-fw gn-icon-"
+                  }
                 }
               },
               // Use .default for not multilingual catalogue with one language only UI.
@@ -359,6 +384,16 @@
                       query_string: {
                         query: "+linkProtocol:/OGC:WFS.*/"
                       }
+                    }
+                  }
+                },
+                meta: {
+                  decorator: {
+                    type: "icon",
+                    prefix: "fa fa-fw ",
+                    map: {
+                      availableInViewService: "fa-globe",
+                      availableInDownloadService: "fa-download"
                     }
                   }
                 }
@@ -415,6 +450,13 @@
                   field: "th_httpinspireeceuropaeutheme-theme_tree.key",
                   size: 34
                   // "order" : { "_key" : "asc" }
+                },
+                meta: {
+                  decorator: {
+                    type: "icon",
+                    prefix: "fa fa-fw gn-icon iti-",
+                    expression: "http://inspire.ec.europa.eu/theme/(.*)"
+                  }
                 }
               },
               "tag.default": {
@@ -501,6 +543,12 @@
                   // with a large size and you want to provide filtering.
                   // 'displayFilter': true,
                   caseInsensitiveInclude: true
+                  // decorator: {
+                  //   type: 'img',
+                  //   map: {
+                  //     'EEA': 'https://upload.wikimedia.org/wikipedia/en/thumb/7/79/EEA_agency_logo.svg/220px-EEA_agency_logo.svg.png'
+                  //   }
+                  // }
                 }
               },
               "cl_maintenanceAndUpdateFrequency.key": {

--- a/web-ui/src/main/resources/catalog/style/gn_search.less
+++ b/web-ui/src/main/resources/catalog/style/gn_search.less
@@ -44,7 +44,9 @@
   //  }
   //}
   .gn-facet-container {
-    margin-left: 15px;
+    .gn-facet-container {
+      margin-left: 20px;
+    }
     margin-top: 5px;
     margin-bottom: 5px;
     a {
@@ -52,9 +54,16 @@
       .fa {
         margin-right: 3px;
       }
+      div.gn-facet-image {
+        background-size: cover !important;
+        width: 20px;
+        height: 20px;
+      }
       * {
-        color: @gray-dark;
         transition: color 0.1s;
+      }
+      span {
+        color: @gray-dark;
       }
       &:hover * {
         color: @facet-hover;

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_topics_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_topics_default.less
@@ -74,6 +74,8 @@
           vertical-align: middle;
           font-weight: normal;
           word-break: break-all;
+          border-top-left-radius: 4px;
+          border-top-right-radius: 4px;
         }
         &:hover {
           text-decoration: none;
@@ -95,6 +97,39 @@
       color: @gn-topic-text;
       i {
         margin-right: 5px;
+      }
+    }
+    &.gn-facet-type-img {
+      height: 180px;
+      border: 0;
+      background-repeat: no-repeat;
+      background-size: cover;
+      background-position: center center;
+      .panel-body {
+        a {
+          padding: 0;
+          h2 {
+            display: block;
+            width: 100%;
+            padding: 10px;
+            background-color: rgba(0, 0, 0, 0.75);
+            span {
+              display: block !important;
+              overflow: hidden;
+              white-space: nowrap;
+              text-overflow: ellipsis;
+            }
+          }
+        }
+      }
+      .panel-footer {
+        position: absolute;
+        margin: 0 10px;
+        background-color: rgba(0, 0, 0, 0.85);
+        border: 0;
+        border-radius: 5px;
+        bottom: 30px;
+        padding: 8px 12px;
       }
     }
   }

--- a/web-ui/src/main/resources/catalog/views/default/templates/home.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/home.html
@@ -140,7 +140,6 @@
           es-facet-cards="homeFacet.key"
           data-home-facet="homeFacet"
           data-search-info="searchInfo"
-          data-agg-response="aggResponse"
           data-agg-config="aggConfig"
         />
       </div>
@@ -157,7 +156,6 @@
           es-facet-cards="homeFacet.lastKey"
           data-home-facet="homeFacet"
           data-search-info="searchInfo"
-          data-agg-response="aggResponse"
           data-agg-config="aggConfig"
         />
       </div>


### PR DESCRIPTION
Currently only home page aggregations INSPIRE themes, ISO topics and resource type are illustrated with an icon. This PR makes it more generic so that we can configure the way we want to decorate an aggregation in the home page or in other pages.

A decorator can be used to add an icon or image next to an aggregation. The decorator is configured in the `meta` properties of the facet:

```js
"resourceType": {
  "terms": {
    "field": "resourceType",
    "size": 10
  },
  "meta": {
    "decorator": {
      "type": "icon",
      "prefix": "fa fa-2x pull-left gn-icon-"
    }
}
```

![image](https://user-images.githubusercontent.com/1701393/191435833-2111cbb4-c3ae-445a-821a-e9fb04c35d35.png)



Decorator types are:

### Icons


* Fixed icon. eg. adding a tag icon to all values

```js
decorator: {
  type: 'icon',
  prefix: "fa fa-fw fa-tag "
}
```

![image](https://user-images.githubusercontent.com/1701393/191435942-86be3185-7b76-4356-9bc3-0fc4ea6aca2f.png)


* Icon defined in a CSS class name using the value. eg. used for resource types `gn-icon-dataset`

```js
"decorator": {
  "type": "icon",
  "prefix": "fa fa-fw gn-icon-"
}
```

![image](https://user-images.githubusercontent.com/1701393/191435561-ccfc697f-3d6a-4931-919c-d8cb04d32d1f.png)


* Icon defined in a css class name which is using only a portion of the value. eg. used for INSPIRE themes. The expression allows to extract the value

```js
"decorator": {
  "type": "icon",
  "prefix": "fa fa-fw gn-icon iti-",
  "expression": "http://inspire.ec.europa.eu/theme/(.*)"
}
```

![image](https://user-images.githubusercontent.com/1701393/191435711-2bca50bc-1344-42ed-a6c1-0544352483f2.png)


* Icon defined with a map of values for the class name to use.

```js
"decorator": {
  "type": "icon",
  "prefix": "fa fa-fw ",
  "map": {
    "availableInViewService": "fa-globe",
    "availableInDownloadService": 'fa-download"
  }
}
```
![image](https://user-images.githubusercontent.com/1701393/191435602-7e49631a-34e0-413a-b4b3-591b0159c042.png)

### Images

Define the image to use for each values:

```js
"decorator": {
  "type": "img",
  "map": {
    "EEA": "https://upload.wikimedia.org/wikipedia/en/thumb/7/79/EEA_agency_logo.svg/220px-EEA_agency_logo.svg.png"
  }
}
```

![image](https://user-images.githubusercontent.com/1701393/191435731-30dee45b-22b0-43d0-a167-ad1c86fc1789.png)

Image decorator in the home page are rendered as background images:

![image](https://user-images.githubusercontent.com/1701393/191678180-b26b4289-e19c-4429-a642-9608f6cb1604.png)

