### PR TITLE
Remove HttpOnly for session timeout cookies, otherwise can't be processed in the UI code

### DIFF
--- a/core/src/main/java/org/geonetwork/http/SessionTimeoutCookieFilter.java
+++ b/core/src/main/java/org/geonetwork/http/SessionTimeoutCookieFilter.java
@@ -66,7 +66,6 @@ public class SessionTimeoutCookieFilter implements javax.servlet.Filter {
 
             Cookie cookie = new Cookie("serverTime", "" + currTime);
             cookie.setPath(httpReq.getContextPath());
-            cookie.setHttpOnly(req.getServletContext().getSessionCookieConfig().isHttpOnly());
             cookie.setSecure(req.getServletContext().getSessionCookieConfig().isSecure());
             httpResp.addCookie(cookie);
 
@@ -85,7 +84,6 @@ public class SessionTimeoutCookieFilter implements javax.servlet.Filter {
                 cookie = new Cookie("sessionExpiry", "" + currTime);
             }
             cookie.setPath(httpReq.getContextPath());
-            cookie.setHttpOnly(req.getServletContext().getSessionCookieConfig().isHttpOnly());
             cookie.setSecure(req.getServletContext().getSessionCookieConfig().isSecure());
             httpResp.addCookie(cookie);
         }


### PR DESCRIPTION
This was introduced in https://github.com/geonetwork/core-geonetwork/pull/6163 and prevents the UI code to display the warning message about session expiration.