### PR TITLE
Metadata publication / unpublication - fix mail notifications in recordProfileReviewer level

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/model/MetadataPublicationNotificationInfo.java
+++ b/services/src/main/java/org/fao/geonet/api/records/model/MetadataPublicationNotificationInfo.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2001-2022 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+package org.fao.geonet.api.records.model;
+
+/**
+ * Information used for metadata publication/un-publication mail notifications.
+ */
+public class MetadataPublicationNotificationInfo {
+    public String metadataUuid;
+    public int metadataId;
+    public Integer groupId;
+    public Boolean published;
+
+    public String getMetadataUuid() {
+        return metadataUuid;
+    }
+
+    public void setMetadataUuid(String metadataUuid) {
+        this.metadataUuid = metadataUuid;
+    }
+
+    public int getMetadataId() {
+        return metadataId;
+    }
+
+    public void setMetadataId(int metadataId) {
+        this.metadataId = metadataId;
+    }
+
+    public Integer getGroupId() {
+        return groupId;
+    }
+
+    public void setGroupId(Integer groupId) {
+        this.groupId = groupId;
+    }
+
+    public Boolean getPublished() {
+        return published;
+    }
+
+    public void setPublished(Boolean published) {
+        this.published = published;
+    }
+}

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1382,7 +1382,7 @@
     "OrgForResource": "Contact organisation for the resource",
     "OrgForDistribution": "Contact organisation for distribution",
     "notificationLevel-statusUserOwner": "Notify the status owner user",
-    "notificationLevel-catalogueAdministrator": "Notify the catalogue administrators",
+    "notificationLevel-catalogueAdministrator": "Notify catalogue administrator mail address defined in the Settings > Feedback",
     "notificationLevel-catalogueProfileAdministrator": "Notify the catalogue administrators",
     "notificationLevel-catalogueProfileUserAdmin": "Notify the catalogue user administrators",
     "notificationLevel-catalogueProfileReviewer": "Notify the catalogue reviewers",


### PR DESCRIPTION
Metadata publication / unpublication, in batch publication mode send thee mail notifications in recordProfileReviewer level only to the metadata group owner reviewers instead of all reviewers

Related to #6457

Test case:

1) Login as admin user
2) In the Settings, configure the mail server
3) In the Settings, Configure the metadata privileges, configure the notification level to `Notify the reviewers part of the record group owner`
4) Create the groups: groupA / groupB
5) Create the users: reviewerA as reviewer in groupA / reviewerB as reviewer  in groupB, assigning a mail address
6) Create an iso19139 metadata in groupA
7) Create an iso19139 metadata in groupB
8) In the editor board select the 2 metadata and select `Publish`

**Expected:** a mail with the metadata in groupA publication is sent to reviewerA, another mail with the metadata in groupB publication is sent to reviewerB, another mail 

Previously both mails contained the 2 metadata records listed.