### PR TITLE
Change regular expression using lookbehind not supported in Safari browser

### DIFF
--- a/web-ui/src/main/resources/catalog/components/catalog/CatalogService.js
+++ b/web-ui/src/main/resources/catalog/components/catalog/CatalogService.js
@@ -678,7 +678,10 @@
             Object.keys(this).forEach(function (th) {
               record.translate(th, record.allKeywords[th].keywords);
             });
-          } else if (key.match(/th_.*(?<!_tree|Number)$/) != null) {
+          } else if (
+            key.match(/th_.*$/) !== null &&
+            key.match(/.*(_tree|Number)$/) === null
+          ) {
             record.translate(key, this);
           }
         });


### PR DESCRIPTION
Thanks @fxprunayre for pointing about the fix.


See https://stackoverflow.com/questions/51568821/works-in-chrome-but-breaks-in-safari-invalid-regular-expression-invalid-group