### PR TITLE
MEF Import / Add UUID reference when error happens loading file

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/mef/Importer.java
+++ b/core/src/main/java/org/fao/geonet/kernel/mef/Importer.java
@@ -143,19 +143,20 @@ public class Importer {
 
             public void handleMetadataFiles(DirectoryStream<Path> metadataXmlFiles, Element info, int index) throws Exception {
                 String infoSchema = "_none_";
+                String uuid = null;
                 if (info != null && info.getContentSize() != 0) {
                     Element general = info.getChild("general");
                     if (general != null && general.getContentSize() != 0) {
                         if (general.getChildText("schema") != null) {
                             infoSchema = general.getChildText("schema");
                         }
+                        if (general.getChildText("uuid") != null) {
+                            uuid = general.getChildText("uuid");
+                        }
                     }
                 }
 
                 Path lastUnknownMetadataFolderName = null;
-                if (Log.isDebugEnabled(Geonet.MEF))
-                    Log.debug(Geonet.MEF, "Multiple metadata files");
-
                 if (Log.isDebugEnabled(Geonet.MEF))
                     Log.debug(Geonet.MEF, "info.xml says schema should be " + infoSchema);
 
@@ -165,6 +166,10 @@ public class Importer {
                 for (Path file : metadataXmlFiles) {
                     if (file != null && java.nio.file.Files.isRegularFile(file)) {
                         Element metadata = Xml.loadFile(file);
+
+                        // Important folder name to identify metadata should be ../../
+                        lastUnknownMetadataFolderName = file.getParent().getParent().relativize(file);
+
                         try {
                             String metadataSchema = dm.autodetectSchema(metadata, null);
                             // If local node doesn't know metadata
@@ -178,15 +183,13 @@ public class Importer {
                             mdFiles.put(metadataSchema, Pair.read(currFile, metadata));
 
                         } catch (NoSchemaMatchesException e) {
-                            // Important folder name to identify metadata should be ../../
-                            lastUnknownMetadataFolderName = file.getParent().getParent().relativize(file);
                             Log.debug(Geonet.MEF, "No schema match for " + lastUnknownMetadataFolderName + ".");
                         }
                     }
                 }
 
                 if (mdFiles.size() == 0) {
-                    throw new BadFormatEx("No valid metadata file found" + ((lastUnknownMetadataFolderName == null) ?
+                    throw new BadFormatEx(uuid + " / No valid metadata file found" + ((lastUnknownMetadataFolderName == null) ?
                         "" :
                         (" in " + lastUnknownMetadataFolderName)) + ".");
                 }


### PR DESCRIPTION
Before, no information provided on which records have error in the MEF so hard to find it.

![image](https://user-images.githubusercontent.com/1701393/193016934-ec8a9ef7-98ad-4b05-9cac-b55481fb5e14.png)

After, report the UUID

![image](https://user-images.githubusercontent.com/1701393/193016716-3158f79b-1094-44b1-b3bf-e722fdc0a3a9.png)

Can happen when MEF file does not contains metadata.xml file or when the file content is not supported by current catalogue (eg. custom subtemplate)