### PR TITLE
Remove check of user profile in API requests. If not allowed will return a 403 error

### DIFF
--- a/web-ui/src/main/resources/catalog/js/admin/SystemSettingsController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/SystemSettingsController.js
@@ -217,23 +217,19 @@
        * element name in XML Jeeves request element).
        */
       function loadSettings() {
-        if ($scope.user.isAdministratorOrMore()) {
-          $http.get("../api/site/info/build").success(function (data) {
-            $scope.systemInfo = data;
-          });
-        }
+        $http.get("../api/site/info/build").success(function (data) {
+          $scope.systemInfo = data;
+        });
 
         $http.get("../api/site/info/notificationLevels").success(function (data) {
           $scope.notificationLevels = data;
           $scope.notificationLevels.unshift("");
         });
 
-        if ($scope.user.isAdministratorOrMore()) {
-          // load log files
-          $http.get("../api/site/logging").success(function (data) {
-            $scope.logfiles = data;
-          });
-        }
+        // load log files
+        $http.get("../api/site/logging").success(function (data) {
+          $scope.logfiles = data;
+        });
 
         $http
           .get("../api/site/settings/details")


### PR DESCRIPTION
`$scope.user.isAdministratorOrMore()` sometimes returns an error `is not a function` while loading the settings.

It seems the code to load the settings is executed sometimes before the `$scope.user`  it is initialised.

Removed the check, if the user is not allowed, the API returns a 403 error.

Related to https://github.com/geonetwork/core-geonetwork/pull/6569

The backport of the previous PR to `3.12.x` includes already the change.