### PR TITLE
Move translation packs configuration to the web module

### DIFF
--- a/services/src/main/resources/config-spring-geonetwork.xml
+++ b/services/src/main/resources/config-spring-geonetwork.xml
@@ -163,45 +163,4 @@
   </bean>
 
   <bean id="userFeedbackService" class="org.fao.geonet.api.userfeedback.service.UserFeedbackDatabaseService"/>
-
-  <util:map id="translationPacks">
-    <entry key="gnui">
-      <util:list>
-        <value>json/gnui</value>
-        <value>standards/iso19139/codelists/gmd:MD_TopicCategoryCode+gmd:MD_ScopeCode+gmd:MD_MaintenanceFrequencyCode+gmd:MD_ProgressCode+gmd:DS_InitiativeTypeCode+gmd:MD_SpatialRepresentationTypeCode</value>
-        <value>standards/iso19115-3.2018/codelists/cit:CI_DateTypeCode</value>
-        <value>db/MetadataCategory+Operation+Group+StatusValue+Source+Translations</value>
-      </util:list>
-    </entry>
-    <entry key="login">
-      <util:list>
-        <value>json/core</value>
-      </util:list>
-    </entry>
-    <entry key="search">
-      <util:list>
-        <value>json/core+search+v4+custom</value>
-        <value>json/schemas</value>
-        <value>standards/iso19139/codelists/gmd:MD_TopicCategoryCode+gmd:MD_ScopeCode+gmd:MD_MaintenanceFrequencyCode+gmd:MD_ProgressCode+gmd:MD_SpatialRepresentationTypeCode</value>
-        <value>standards/iso19115-3.2018/codelists/cit:CI_DateTypeCode+indeterminatePosition+mri:DS_InitiativeTypeCode+mri:DS_AssociationTypeCode</value>
-        <value>db/MetadataCategory+Operation+Group+StatusValue+Source+Translations</value>
-      </util:list>
-    </entry>
-    <entry key="admin">
-      <util:list>
-        <value>json/core+search+admin+v4+custom</value>
-        <value>json/schemas</value>
-        <value>db/MetadataCategory+Operation+Group+StatusValue+Source+Translations</value>
-      </util:list>
-    </entry>
-    <entry key="editor">
-      <util:list>
-        <value>json/core+search+editor+v4+custom</value>
-        <value>json/schemas</value>
-        <value>standards/iso19139/codelists/gmd:MD_TopicCategoryCode+gmd:MD_ScopeCode+gmd:MD_MaintenanceFrequencyCode+gmd:MD_ProgressCode+gmd:MD_SpatialRepresentationTypeCode</value>
-        <value>standards/iso19115-3.2018/codelists/cit:CI_DateTypeCode+indeterminatePosition+mri:DS_InitiativeTypeCode+mri:DS_AssociationTypeCode</value>
-        <value>db/MetadataCategory+Operation+Group+StatusValue+Source+Translations</value>
-      </util:list>
-    </entry>
-  </util:map>
 </beans>

--- a/web/src/main/webResources/WEB-INF/config-spring-geonetwork.xml
+++ b/web/src/main/webResources/WEB-INF/config-spring-geonetwork.xml
@@ -191,4 +191,44 @@
           p:url="http:\/\/map1[A-Z].com" p:useProxy="true" p:authType="BASIC" p:urlType="REGEXP" p:username="test" p:password="testpass"/-->
   </util:list>
 
+  <util:map id="translationPacks">
+    <entry key="gnui">
+      <util:list>
+        <value>json/gnui</value>
+        <value>standards/iso19139/codelists/gmd:MD_TopicCategoryCode+gmd:MD_ScopeCode+gmd:MD_MaintenanceFrequencyCode+gmd:MD_ProgressCode+gmd:DS_InitiativeTypeCode+gmd:MD_SpatialRepresentationTypeCode</value>
+        <value>standards/iso19115-3.2018/codelists/cit:CI_DateTypeCode</value>
+        <value>db/MetadataCategory+Operation+Group+StatusValue+Source+Translations</value>
+      </util:list>
+    </entry>
+    <entry key="login">
+      <util:list>
+        <value>json/core</value>
+      </util:list>
+    </entry>
+    <entry key="search">
+      <util:list>
+        <value>json/core+search+v4+custom</value>
+        <value>json/schemas</value>
+        <value>standards/iso19139/codelists/gmd:MD_TopicCategoryCode+gmd:MD_ScopeCode+gmd:MD_MaintenanceFrequencyCode+gmd:MD_ProgressCode+gmd:MD_SpatialRepresentationTypeCode</value>
+        <value>standards/iso19115-3.2018/codelists/cit:CI_DateTypeCode+indeterminatePosition+mri:DS_InitiativeTypeCode+mri:DS_AssociationTypeCode</value>
+        <value>db/MetadataCategory+Operation+Group+StatusValue+Source+Translations</value>
+      </util:list>
+    </entry>
+    <entry key="admin">
+      <util:list>
+        <value>json/core+search+admin+v4+custom</value>
+        <value>json/schemas</value>
+        <value>db/MetadataCategory+Operation+Group+StatusValue+Source+Translations</value>
+      </util:list>
+    </entry>
+    <entry key="editor">
+      <util:list>
+        <value>json/core+search+editor+v4+custom</value>
+        <value>json/schemas</value>
+        <value>standards/iso19139/codelists/gmd:MD_TopicCategoryCode+gmd:MD_ScopeCode+gmd:MD_MaintenanceFrequencyCode+gmd:MD_ProgressCode+gmd:MD_SpatialRepresentationTypeCode</value>
+        <value>standards/iso19115-3.2018/codelists/cit:CI_DateTypeCode+indeterminatePosition+mri:DS_InitiativeTypeCode+mri:DS_AssociationTypeCode</value>
+        <value>db/MetadataCategory+Operation+Group+StatusValue+Source+Translations</value>
+      </util:list>
+    </entry>
+  </util:map>
 </beans>


### PR DESCRIPTION
Currently the translations pack configuration is packaged in the `services` module jar. This makes difficult to override the configuration, for example when using custom UI views or for some schemas, like [HNAP](https://github.com/metadata101/iso19139.ca.HNAP) where the codelist keys differ from the standard iso19139 codelist keys.

In this PR, the configuration is moved to a plain text configuration file in  the `web` module.

In the `services` module there are other properties that can be suitable to change also, like:

https://github.com/geonetwork/core-geonetwork/blob/cd8b267c8f638fbfedbd3ccf8aa2f458bd59a159/services/src/main/resources/config-spring-geonetwork.xml#L54-L79

Other modules probably have similar properties.

