### PR TITLE
JSON Harvester / better detect protocol in ESRI JSON transformation

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/fromJsonLdEsri.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/fromJsonLdEsri.xsl
@@ -44,8 +44,6 @@
                 xmlns:xd="http://www.oxygenxml.com/ns/doc/xsl"
                 exclude-result-prefixes="#all">
 
-    <xsl:import href="protocol-mapping.xsl"></xsl:import>
-
     <xsl:output method="xml" indent="yes"/>
     <xsl:strip-space elements="*"/>
 
@@ -416,7 +414,16 @@
             <mrd:transferOptions>
               <mrd:MD_DigitalTransferOptions>
                 <xsl:for-each select="distribution">
-                  <xsl:variable name="format" select="format"/>
+                  <xsl:variable name="protocol">
+                    <xsl:choose>
+                      <xsl:when test="contains(accessURL, 'WFSServer')">
+                        OGC:WFS
+                      </xsl:when>
+                      <xsl:otherwise>
+                        ESRI:REST
+                      </xsl:otherwise>
+                    </xsl:choose>
+                  </xsl:variable>
                   <mrd:onLine>
                     <cit:CI_OnlineResource>
                       <cit:linkage>
@@ -426,17 +433,15 @@
                       </cit:linkage>
                       <cit:protocol>
                         <gco:CharacterString>
-                          <xsl:value-of select="$format-protocol-mapping/entry[format=lower-case($format)]/protocol"/>
+                          <xsl:value-of select="$protocol"/>
                         </gco:CharacterString>
                       </cit:protocol>
                       <cit:name>
-                        <gco:CharacterString>
-                          <xsl:value-of select="title"/>
-                        </gco:CharacterString>
+                        <gco:CharacterString/> <!-- this is empty to allow automatic detection of feature type -->
                       </cit:name>
                       <cit:description>
                         <gco:CharacterString>
-                          <xsl:value-of select="$format"/>
+                          <xsl:value-of select="title"/>
                         </gco:CharacterString>
                       </cit:description>
                     </cit:CI_OnlineResource>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/protocol-mapping.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/protocol-mapping.xsl
@@ -59,10 +59,6 @@
             <protocol>WWW:LINK-1.0-http--link</protocol>
         </entry>
         <entry>
-            <format>arcgis geoservices rest api</format>
-            <protocol>ESRI:REST</protocol>
-        </entry>
-        <entry>
             <format>wms</format>
             <protocol>OGC:WMS</protocol>
         </entry>


### PR DESCRIPTION
ESRI catalogs sometimes advertise datasets through a WFS Service, but the only indication for that is the URL. E.g.:

![image](https://user-images.githubusercontent.com/10629150/193856270-fb6976ee-6037-4d7f-91ee-86046b7309a5.png)

We now read whether the URL contains `WFSServer`,  `WMSServer`, `FeatureServer` or `MapServer`, and infer the protocol accordingly (WFS, WMS or ESRI REST). The output of the example above is:

![image](https://user-images.githubusercontent.com/10629150/193857402-a0ae1c28-1e91-4371-8e07-250960ff8055.png)

