### PR TITLE
Update DateUtil regular expressions to handle dates with day 30 or 31

### DIFF
--- a/common/src/main/java/org/fao/geonet/utils/DateUtil.java
+++ b/common/src/main/java/org/fao/geonet/utils/DateUtil.java
@@ -60,8 +60,8 @@ public class DateUtil {
     private static final Pattern gsYearMonth = Pattern.compile("([0-9]{4})-([0-1][0-9])(-([0-2][0-9]):([0-5][0-9])([A-Z]{0,1}))?");
 
     // Some catalogs are using 2012-09-12Z
-    private static final Pattern gsYearMonthDayZ = Pattern.compile("([0-9]{4})-([0-1][0-9])-([0-2][0-9])Z");
-    private static final Pattern gsDayMonthYear = Pattern.compile("([0-2][0-9])/([0-1][0-9])/([0-9]{4})");
+    private static final Pattern gsYearMonthDayZ = Pattern.compile("([0-9]{4})-([0-1][0-9])-([0-3][0-9])Z");
+    private static final Pattern gsDayMonthYear = Pattern.compile("([0-3][0-9])/([0-1][0-9])/([0-9]{4})");
 
     // Fri Jan 01 2010 00:00:00 GMT+0100 (CET)
     private static final Pattern htmlFormat = Pattern

--- a/common/src/test/java/org/fao/geonet/utils/DateUtilTest.java
+++ b/common/src/test/java/org/fao/geonet/utils/DateUtilTest.java
@@ -47,6 +47,12 @@ public class DateUtilTest {
         zdt = zdt.withZoneSameInstant(ZoneOffset.UTC);
         assertEquals(DateUtil.ISO_OFFSET_DATE_TIME_NANOSECONDS.format(zdt), datetimeInIsoFormat);
 
+        datetimeInIsoFormat = DateUtil.convertToISOZuluDateTime("2020-12-31");
+        ld = LocalDate.parse("2020-12-31");
+        zdt = ld.atStartOfDay(ZoneId.systemDefault());
+        zdt = zdt.withZoneSameInstant(ZoneOffset.UTC);
+        assertEquals(DateUtil.ISO_OFFSET_DATE_TIME_NANOSECONDS.format(zdt), datetimeInIsoFormat);
+
         datetimeInIsoFormat = DateUtil.convertToISOZuluDateTime("2020-11");
         ld = LocalDate.of(2020, 11, 1);
         zdt = ld.atStartOfDay(ZoneId.systemDefault());
@@ -55,6 +61,12 @@ public class DateUtilTest {
 
         datetimeInIsoFormat = DateUtil.convertToISOZuluDateTime("2012-09-12Z");
         ld = LocalDate.parse("2012-09-12");
+        zdt = ld.atStartOfDay(ZoneId.systemDefault());
+        zdt = zdt.withZoneSameInstant(ZoneOffset.UTC);
+        assertEquals(DateUtil.ISO_OFFSET_DATE_TIME_NANOSECONDS.format(zdt), datetimeInIsoFormat);
+
+        datetimeInIsoFormat = DateUtil.convertToISOZuluDateTime("2012-12-31Z");
+        ld = LocalDate.parse("2012-12-31");
         zdt = ld.atStartOfDay(ZoneId.systemDefault());
         zdt = zdt.withZoneSameInstant(ZoneOffset.UTC);
         assertEquals(DateUtil.ISO_OFFSET_DATE_TIME_NANOSECONDS.format(zdt), datetimeInIsoFormat);


### PR DESCRIPTION
This code is used in the metadata indexing process, causing indexing errors for dates using day 30 or 31.