### PR TITLE
Fix harvester results pagination

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchFormDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchFormDirective.js
@@ -261,6 +261,8 @@
               );
               paging.from = (paging.currentPage - 1) * paging.hitsPerPage + 1;
             }
+
+            $scope.$emit("searchFinished", { count: $scope.searchResults.count });
           },
           function (data) {
             console.warn(

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -1056,7 +1056,7 @@
               }
             ],
             sortBy: "relevance",
-            facetConfig:  {
+            facetConfig: {
               valid: {
                 terms: {
                   field: "valid",

--- a/web-ui/src/main/resources/catalog/js/admin/HarvestSettingsController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/HarvestSettingsController.js
@@ -422,6 +422,7 @@
         $scope.harvesterNew = false;
         $scope.harvesterHistory = {};
         $scope.searchResults = null;
+        $scope.searchResultsTotal = null;
 
         loadHarvester(h["@id"]).then(function (data) {
           loadHistory();
@@ -431,6 +432,17 @@
           $scope.$broadcast("resetSearch", $scope.searchObj.params);
         });
       };
+
+      /**
+       * Update the total metadata in the metadata tab, ng-search-form is in a child element.
+       * Can't be moved to a parent element as causes issues with pagination, due scope
+       * conflicts.
+       *
+       * It's used an event to update the total metadata when the harvested metadata search finishes.
+       */
+      $scope.$on("searchFinished", function (event, args) {
+        $scope.searchResultsTotal = args.count;
+      });
 
       var refreshSelectedHarvester = function () {
         if ($scope.harvesterSelected) {

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/harvest-settings.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/harvest-settings.html
@@ -457,12 +457,11 @@
         </div>
       </tab>
       <tab
-        heading="{{ searchResults.count }} {{'metadataRecords' | translate}}"
+        heading="{{ searchResultsTotal }} {{'metadataRecords' | translate}}"
         data-ng-hide="harvesterSelected['@id'] == ''
-                          || searchResults.count == '-1'
+                          || searchResultsTotal == 0
                           || isLoadingOneHarvester
                           || deleting.indexOf(harvesterSelected['@id']) > -1"
-        data-ng-show="searchResults.count > 0"
         role="tab"
       >
         <div id="gn-harvest-records-panel" data-ng-search-form="" class="gn-margin-top">
@@ -484,7 +483,7 @@
               </div>
             </div>
           </div>
-          <div class="panel panel-default" data-ng-if="searchResults.count > 0">
+          <div class="panel panel-default" data-ng-show="searchResults.count > 0">
             <div class="panel-heading">
               <span id="gn-harvest-records-title" data-translate=""
                 >harvesterRecords</span


### PR DESCRIPTION
Pagination buttons in the harvester results were not working, the `data-ng-if` caused that the pagination directive for the results was initialised after the search controller, replaced by `data-ng-show`.

