### PR TITLE
Harvesters - display the button to assign the harvested records to the local node only to 'Administrator' users

### DIFF
--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/harvest-settings.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/harvest-settings.html
@@ -499,6 +499,7 @@
                   class="btn btn-primary btn-warning"
                   data-ng-disabled="harvesterSelected.info.running === true || deleting.indexOf(harvesterSelected['@id']) > -1"
                   data-gn-click-and-spin="assignHarvestedRecordToLocalNode()"
+                  data-ng-show="user.isAdministratorOrMore()"
                 >
                   <span class="fa fa-database"></span>
                   <span


### PR DESCRIPTION
This option is relevant only for 1 time harvesting, for example to import the metadata from an older catalogue. 

This change restricts it to the `Administrator` users.