### PR TITLE
Fix retrieve related resources in metadata API request to retrieve the attributes from a linked feature catalog metadata

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/MetadataApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataApi.java
@@ -618,7 +618,7 @@ public class MetadataApi {
         Map<String, String[]> decodeMap = new HashMap<>();
 
         try {
-            RelatedResponse related = getRelated(metadataUuid, type, 0, 100, request);
+            RelatedResponse related = getRelated(metadataUuid, type, 1, 100, request);
 
             if (isIncludedAttributeTable(related.getFcats())) {
                 for (AttributeTable.Element element : related.getFcats().getItem().get(0).getFeatureType().getAttributeTable().getElement()) {


### PR DESCRIPTION
The metadata API request to retrieve the attributes from a linked feature catalog metadata returns an error due to a wrong parameter value to retrieve the related resources.

http://localhost:8080/geonetwork/srv/api/records/09d1f035-d8e0-410d-a6b6-5fdac3496021/featureCatalog?_content_type=json

```
2022-10-07 07:27:45,888 ERROR [geonetwork.api] - Failed: Not enough search results (0) available to meet request for 2.
java.lang.Exception: Failed: Not enough search results (0) available to meet request for 2.
    at org.fao.geonet.kernel.search.LuceneSearcher.present(LuceneSearcher.java:1259)
    at org.fao.geonet.api.records.MetadataUtils.search(MetadataUtils.java:423)
    at org.fao.geonet.api.records.MetadataUtils.search(MetadataUtils.java:369)
    at org.fao.geonet.api.records.MetadataUtils.getRelated(MetadataUtils.java:312)
    at org.fao.geonet.api.records.MetadataApi.getRelated(MetadataApi.java:578)
    at org.fao.geonet.api.records.MetadataApi.getFeatureCatalog(MetadataApi.java:621)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
    at java.lang.reflect.Method.invoke(Method.java:498)
```

Test case:

1) Create a feature catalog metadata (iso19110)
2) Create an iso19139 dataset metadata and associate the previous metadata
3) Do the following request, providing the UUID of the dataset metadata (2).

http://localhost:8080/geonetwork/srv/api/records/DATASETUUID/featureCatalog?_content_type=json

Without the fix, the error described previously is displayed in the log file and the request fails with an error 404. 

With the fix, a json document with the attributes defined in the feature catalog metadata  is returned.