### PR TITLE
Update schemaInfoCombo to only display the section headers if a list of extra options is provided

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/formfields/FormFieldsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/formfields/FormFieldsDirective.js
@@ -720,21 +720,29 @@
 
             var isLabelSet = false;
             function appendExtraOptions() {
-              if (baseList && angular.isArray(scope.extraOptions)) {
-                if (!isLabelSet) {
-                  scope.extraOptions.unshift({
-                    value: "",
-                    label: $translate.instant("recordFormats"),
-                    disabled: true
-                  });
-                  scope.extraOptions.push({
-                    value: "",
-                    label: $translate.instant("commonProtocols"),
-                    disabled: true
-                  });
+              if (baseList) {
+                // Only add the header options if there are extra options defined.
+                if (
+                  angular.isArray(scope.extraOptions) &&
+                  scope.extraOptions.length > 0
+                ) {
+                  if (!isLabelSet) {
+                    scope.extraOptions.unshift({
+                      value: "",
+                      label: $translate.instant("recordFormats"),
+                      disabled: true
+                    });
+                    scope.extraOptions.push({
+                      value: "",
+                      label: $translate.instant("commonProtocols"),
+                      disabled: true
+                    });
+                    isLabelSet = true;
+                  }
+                  scope.infos = scope.extraOptions.concat(baseList);
+                } else {
                   isLabelSet = true;
                 }
-                scope.infos = scope.extraOptions.concat(baseList);
               }
             }
 


### PR DESCRIPTION
The `schemaInfoCombo` directive is used in the online resources dialog to display the protocols. It displays the protocols defined in a metadata schema and if the metadata has distribution formats are listed also, adding a header to distinguish the values:

![header](https://user-images.githubusercontent.com/1695003/194585187-ea14388e-772f-4d51-861e-aa7888dc2182.png)

These header values are displayed even if the metadata has no distribution formats or a schema disables that option. With this change in this case, no header entries are displayed:

![no-header](https://user-images.githubusercontent.com/1695003/194585424-27941ba6-6eac-49e4-825a-cb16583d36e3.png)

