### PR TITLE
Record view / Associated / Support empty initiativeType

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/RelatedDirective.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/RelatedDirective.js
@@ -438,7 +438,9 @@
                   scope.relations.siblings.map &&
                   scope.groupSiblingsByType
                 ) {
-                  scope.relations.siblings
+                  var siblings = angular.copy(scope.relations.siblings);
+                  scope.relations.siblings = [];
+                  siblings
                     .map(function (r) {
                       return (r.properties && r.properties.initiativeType) || "";
                     })
@@ -447,12 +449,11 @@
                     })
                     .forEach(function (type) {
                       scope.relations["siblings" + type] =
-                        scope.relations.siblings.filter(function (r) {
+                        siblings.filter(function (r) {
                           return r.properties && r.properties.initiativeType === type;
                         });
                       siblingsCount += scope.relations["siblings" + type].length;
                     });
-                  scope.relations.siblings = [];
                 } else {
                   siblingsCount = scope.relations[idx].length;
                 }


### PR DESCRIPTION
Related to https://github.com/geonetwork/core-geonetwork/pull/6328

When no initiativeType was provided, related records were not displayed.

For testing:
* create a dataset
* associate record with no initiativeTypes
* check record view.