### PR TITLE
Record view / Invalid timezone shift for years outside moment's 10 years range

### DIFF
--- a/web-ui/src/main/resources/catalog/components/utility/UtilityService.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityService.js
@@ -562,9 +562,8 @@
         }
         if (parsedDate.isValid()) {
           if (!!timezone) {
-            parsedDate = parsedDate.tz(
-              timezone === "Browser" ? moment.tz.guess() : timezone
-            );
+            var tz = moment.tz(timezone === "Browser" ? moment.tz.guess() : timezone);
+            parsedDate = parsedDate.utcOffset(tz.utcOffset());
           }
           var fromNow = parsedDate.fromNow();
 


### PR DESCRIPTION

Moment is included for a 10 years timezone range https://momentjs.com/timezone/docs/ so dates outside this range are not correctly displayed. eg. 2014-10-05 is displayed as 2014-10-04 when timezone is CET.
![image](https://user-images.githubusercontent.com/1701393/194873190-a87e7fbe-53f7-491d-a971-dbd44153bc2c.png)


```xml
               <gmd:date>
                  <gmd:CI_Date>
                     <gmd:date>
                        <gco:Date>2005-04-08</gco:Date>
                     </gmd:date>
                     <gmd:dateType>
                        <gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode"
                                             codeListValue="creation"/>
                     </gmd:dateType>
                  </gmd:CI_Date>
               </gmd:date>
               <gmd:date>
                  <gmd:CI_Date>
                     <gmd:date>
                        <gco:Date>2022-10-05</gco:Date>
                     </gmd:date>
                     <gmd:dateType>
                        <gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode"
                                             codeListValue="publication"/>
                     </gmd:dateType>
                  </gmd:CI_Date>
               </gmd:date>
               <gmd:date>
                  <gmd:CI_Date>
                     <gmd:date>
                        <gco:Date>2015-10-05</gco:Date>
                     </gmd:date>
                     <gmd:dateType>
                        <gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode"
                                             codeListValue="revision"/>
                     </gmd:dateType>
                  </gmd:CI_Date>
               </gmd:date>
               <gmd:date>
                  <gmd:CI_Date>
                     <gmd:date>
                        <gco:Date>2014-10-05</gco:Date>
                     </gmd:date>
                     <gmd:dateType>
                        <gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode"
                                             codeListValue="revision"/>
                     </gmd:dateType>
                  </gmd:CI_Date>
               </gmd:date>
               <gmd:date>
                  <gmd:CI_Date>
                     <gmd:date>
                        <gco:Date>2014-10-05</gco:Date>
                     </gmd:date>
                     <gmd:dateType>
                        <gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode"
                                             codeListValue="revision"/>
                     </gmd:dateType>
                  </gmd:CI_Date>
               </gmd:date>
               <gmd:date>
                  <gmd:CI_Date>
                     <gmd:date>
                        <gco:DateTime>2014-10-05T12:00:00+02:00</gco:DateTime>
                     </gmd:date>
                     <gmd:dateType>
                        <gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode"
                                             codeListValue="revision"/>
                     </gmd:dateType>
                  </gmd:CI_Date>
               </gmd:date>
```

2 options to fix this
a) Load all data https://momentjs.com/timezone/ and not only 10 years range - bigger JS pack
b) As timezone rules may change over time, only offset time according to nowaday rule. 

This applies b). @juanluisrp what do you think is better ?

Related to https://github.com/geonetwork/core-geonetwork/pull/5061