### PR TITLE
Admin / Status / Fix facet config for warning

### DIFF
--- a/web-ui/src/main/resources/catalog/components/elasticsearch/EsFacet.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/EsFacet.js
@@ -222,7 +222,8 @@
                 include: "Warning.*"
               },
               meta: {
-                displayFilter: false
+                displayFilter: false,
+                field: "indexingErrorMsg"
               }
             }
           },


### PR DESCRIPTION
Clicking on a warning was not setting the filter properly.  Configure the field to use for the filter as we have here 2 facets on the same field but with 2 differents includes.

![image](https://user-images.githubusercontent.com/1701393/194906097-b51ac7b6-f78f-4b5f-881e-7cfcb49de918.png)
