### PR TITLE
UI config / Properly hide empty options

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/formfields/partials/sortByCombo.html
+++ b/web-ui/src/main/resources/catalog/components/search/formfields/partials/sortByCombo.html
@@ -1,4 +1,4 @@
-<div class="gn-sort-by">
+<div class="gn-sort-by" data-ng-if="values.length > 0">
   <div class="btn-group">
     <button
       type="button"

--- a/web-ui/src/main/resources/catalog/components/search/pagination/partials/pagination.html
+++ b/web-ui/src/main/resources/catalog/components/search/pagination/partials/pagination.html
@@ -13,7 +13,18 @@
           <span class="sr-only" data-translate="">previous</span>
         </a>
       </li>
-      <li class="btn-group">
+      <li data-ng-if="values.length === 0">
+        <span ng-show="config.pages > 1">
+          {{config.from}} - {{config.to}}
+          <span translate>resultXonY</span>
+          {{config.resultsCount}}
+        </span>
+        <span ng-show="config.pages <= 1">
+          {{config.to}}
+          <span translate>results</span>
+        </span>
+      </li>
+      <li class="btn-group" data-ng-if="values.length > 0">
         <!-- A dropdown button to select the number of page
     and indicating the current page info -->
         <a href class="dropdown-toggle" data-toggle="dropdown" aria-expanded="false">

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -193,6 +193,7 @@
             queryTitle: "resourceTitleObject.\\*:(${any})",
             queryTitleExactMatch: 'resourceTitleObject.\\*:"${any}"',
             searchOptions: {
+              fullText: true,
               titleOnly: true,
               exactMatch: true,
               language: true
@@ -294,6 +295,7 @@
                           "resourceTitleObject.${searchLang}^6",
                           "resourceAbstractObject.${searchLang}^.5",
                           "tag",
+                          "uuid",
                           "resourceIdentifier"
                           // "anytext",
                           // "anytext._2gram",

--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -19,6 +19,10 @@ div[gn-transfer-ownership] * .list-group {
 .gn-pager {
   .pagination {
     margin: 0;
+    li > span, li > span:hover {
+      border: none;
+      background: none;
+    }
   }
 }
 

--- a/web-ui/src/main/resources/catalog/views/default/templates/results.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/results.html
@@ -1,6 +1,6 @@
 <div data-ng-search-form="" data-runSearch="true">
   <div
-    data-ng-if="!showHealthIndexError"
+    data-ng-if="!showHealthIndexError && searchOptions.fullText !== false"
     class="hidden-print"
     data-ng-include="'../../catalog/views/default/templates/searchForm.html'"
   ></div>
@@ -9,7 +9,11 @@
     <div class="col-sm-offset-6" data-gn-index-error-panel=""></div>
 
     <div data-ng-class="fluidLayout ? 'container-fluid' : 'container'">
-      <div class="col-md-3 gn-search-facet">
+      <div
+        class="gn-search-facet"
+        data-ng-class="(isFilterTagsDisplayedInSearch === true
+            || searchResults.facets.length > 0) ? 'col-md-3': 'hidden'"
+      >
         <div ng-if="showMapInFacet">
           <div class="panel panel-default">
             <div class="panel-heading" data-gn-slide-toggle="">
@@ -34,9 +38,9 @@
           data-gn-user-searches-panel="user"
           data-ng-if="isUserSearchesEnabled && user.isConnected()"
         ></div>
-
         <div
-          data-ng-show="searchResults.records.length > 0"
+          data-ng-show="searchResults.records.length > 0
+            && searchResults.facets.length > 0"
           data-es-facets="searchResults.facets"
         ></div>
 
@@ -47,7 +51,11 @@
       </div>
       <!-- /.gn-search-facet -->
 
-      <div class="col-md-9 container-fluid">
+      <div
+        class="container-fluid"
+        data-ng-class="(isFilterTagsDisplayedInSearch === true
+            || searchResults.facets.length > 0) ? 'col-md-9': 'col-md-12'"
+      >
         <div
           class="row gn-row-tools hidden-print"
           data-ng-show="searchResults.records.length > 0"


### PR DESCRIPTION
* Do not display side column if no filter and no facet
* Do not display page combo, if no page options.
* Do not display full text field if not enable.

For example, creating a minimal app with the following config:

```json
{
  "mods": {
    "header": {
      "enabled": false
    },
    "footer": {
      "enabled": false
    },
    "search": {
      "searchOptions": {
        "fullText": false
      },
      "facetConfig": {},
      "sortbyValues": [],
      "resultViewTpls": [],
      "isFilterTagsDisplayedInSearch": false,
      "showBatchDropdown": false
    }
  }
}
```

to simply list results full screen:

![image](https://user-images.githubusercontent.com/1701393/194911587-bf09e22c-cfb5-46c3-891d-cb50f7b5618e.png)
