### PR TITLE
Migration - don't add settings backported to 3.12.x when migrating from a 3.12.x version

### DIFF
--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v402/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v402/migrate-default.sql
@@ -35,8 +35,9 @@ UPDATE Settings SET value = 'Etc/UTC' WHERE name = 'system/server/timeZone' AND 
 --          AT TIME ZONE (SELECT value FROM Settings WHERE name = 'system/server/timeZone')), 'YYYY-MM-DDThh24:mi:ssZ')
 --        ) WHERE length(createdate) = 19 AND length(changedate) = 19;
 
+ALTER TABLE guf_userfeedbacks_guf_rating ADD COLUMN GUF_UserFeedback_uuid varchar(255);
+UPDATE guf_userfeedbacks_guf_rating SET GUF_UserFeedback_uuid = GUF_UserFeedbacks_uuid;
 ALTER TABLE guf_userfeedbacks_guf_rating DROP COLUMN GUF_UserFeedbacks_uuid;
-
 
 UPDATE Settings SET value='4.0.2' WHERE name='system/platform/version';
 UPDATE Settings SET value='SNAPSHOT' WHERE name='system/platform/subVersion';

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v406/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v406/migrate-default.sql
@@ -1,6 +1,10 @@
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/inspire/remotevalidation/nodeid', '', 0, 7212, 'n');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/inspire/remotevalidation/apikey', '', 0, 7213, 'y');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/publication/doi/doipublicurl', '', 0, 100196, 'n');
+
+-- Changes were back ported to version 3.12.x so they are no longer required unless upgrading from previous v40x which did not have 3.12.x  migrations steps.
+-- So lets try to only add the records if they don't already exists.
+INSERT INTO Settings (name, value, datatype, position, internal) SELECT distinct 'system/inspire/remotevalidation/apikey', '', 0, 7213, 'y' from settings WHERE NOT EXISTS (SELECT name FROM Settings WHERE name = 'system/inspire/remotevalidation/apikey');
+INSERT INTO Settings (name, value, datatype, position, internal) SELECT distinct 'system/publication/doi/doipublicurl', '', 0, 100196, 'n' from settings WHERE NOT EXISTS (SELECT name FROM Settings WHERE name = 'system/publication/doi/doipublicurl');
+
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/harvester/enablePrivilegesManagement', 'false', 2, 9010, 'n');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/localrating/notificationLevel', 'catalogueAdministrator', 0, 2111, 'n');
 

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v407/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v407/migrate-default.sql
@@ -2,9 +2,11 @@ INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('metada
 
 UPDATE Settings set position = 7213 WHERE name = 'system/inspire/remotevalidation/nodeid';
 UPDATE Settings set position = 7214 WHERE name = 'system/inspire/remotevalidation/apikey';
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/inspire/remotevalidation/urlquery', '', 0, 7212, 'n');
 
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('metadata/import/userprofile', 'Editor', 0, 12001, 'n');
+-- Changes were back ported to version 3.12.x so they are no longer required unless upgrading from previous v40x which did not have 3.12.x  migrations steps.
+-- So lets try to only add the records if they don't already exists.
+INSERT INTO Settings (name, value, datatype, position, internal) SELECT distinct 'system/inspire/remotevalidation/urlquery', '', 0, 7212, 'n' from settings WHERE NOT EXISTS (SELECT name FROM Settings WHERE name = 'system/inspire/remotevalidation/urlquery');
+INSERT INTO Settings (name, value, datatype, position, internal) SELECT distinct 'metadata/import/userprofile', 'Editor', 0, 12001, 'n' from settings WHERE NOT EXISTS (SELECT name FROM Settings WHERE name = 'metadata/import/userprofile');
 
 INSERT INTO Users (id, username, password, name, surname, profile, kind, organisation, security, authtype, isenabled) VALUES  (0,'nobody','','nobody','nobody',4,'','','','', 'n');
 INSERT INTO Address (id, address, city, country, state, zip) VALUES  (0, '', '', '', '', '');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v421/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v421/migrate-default.sql
@@ -2,16 +2,17 @@
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/metadataprivs/publicationbyrevieweringroupowneronly', 'true', 2, 9181, 'n');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/publication/doi/doipattern', '{{uuid}}', 0, 100197, 'n');
 
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('metadata/delete/profilePublishedMetadata', 'Editor', 0, 12011, 'n');
+-- Changes were back ported to version 3.12.x so they are no longer required unless upgrading from previous v42x which did not have 3.12.x  migrations steps.
+-- So lets try to only add the records if they don't already exists.
+INSERT INTO Settings (name, value, datatype, position, internal) SELECT distinct 'metadata/delete/profilePublishedMetadata', 'Editor', 0, 12011, 'n' from settings WHERE NOT EXISTS (SELECT name FROM Settings WHERE name = 'metadata/delete/profilePublishedMetadata');
+INSERT INTO Settings (name, value, datatype, position, internal) SELECT distinct 'system/metadataprivs/publication/notificationLevel', '', 0, 9182, 'n' from settings WHERE NOT EXISTS (SELECT name FROM Settings WHERE name = 'system/metadataprivs/publication/notificationLevel');
+INSERT INTO Settings (name, value, datatype, position, internal) SELECT distinct 'system/metadataprivs/publication/notificationGroups', '', 0, 9183, 'n' from settings WHERE NOT EXISTS (SELECT name FROM Settings WHERE name = 'system/metadataprivs/publication/notificationGroups');
 
 -- cf. https://www.un.org/en/about-us/member-states/turkiye (run this manually if it applies to your catalogue)
 -- UPDATE metadata SET data = replace(data, 'Turkey', 'Türkiye') WHERE data LIKE '%Turkey%';
 UPDATE Settings SET value='log4j2.xml' WHERE name='system/server/log';
 
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/localrating/notificationGroups', '', 0, 2112, 'n');
-
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/metadataprivs/publication/notificationLevel', '', 0, 9182, 'n');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/metadataprivs/publication/notificationGroups', '', 0, 9183, 'n');
 
 UPDATE Settings SET value='4.2.1' WHERE name='system/platform/version';
 UPDATE Settings SET value='SNAPSHOT' WHERE name='system/platform/subVersion';


### PR DESCRIPTION
Tested this type of queries:

```
INSERT INTO Settings (name, value, datatype, position, internal) 
  SELECT distinct 'system/inspire/remotevalidation/apikey', '', 0, 7213, 'y' from Settings 
  WHERE NOT EXISTS (SELECT name FROM Settings WHERE name = 'system/inspire/remotevalidation/apikey');
```

- Postgres: Ok
- MySql: Ok (tested the `INSERT` in mysql console, as trying to startup the application I got some issues trying to override the parameter `lower-case-table-names ` in the Docker container)
- H2: Ok