### PR TITLE
Fix directory entries list

### DIFF
--- a/web-ui/src/main/resources/catalog/components/elasticsearch/EsService.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/EsService.js
@@ -142,6 +142,7 @@
 
       function addSortBy(params, sortBy, sortOrder) {
         if (sortBy) {
+          sortOrder = sortOrder || "";
           var sort = {},
             orders = sortOrder.split(",", -1);
           params.sort = [];


### PR DESCRIPTION
 Related to this change https://github.com/geonetwork/core-geonetwork/pull/6555

It seems `sortOrder` can be `undefined`, causing a Javascript error preventing to display the directory entries list.

To test:

1) Login as `Administrator` user.
2) Load the iso19139 templates
3) Go to `Contribute` > `Editor board` > `Manage directory`, select `Templates`

![directory-entries](https://user-images.githubusercontent.com/1695003/195569122-972bf17a-5f8c-4a5f-82b6-9e02777e7bfe.png)

An spinning image is displayed instead of the templates and a javascript error is shown.