### PR TITLE
Editor / Configuration / Allow to include elements from flatModeExceptions

### DIFF
--- a/schemas/config-editor.xsd
+++ b/schemas/config-editor.xsd
@@ -494,14 +494,37 @@ relevant to have parent defined to have more control over the list.
       <xs:attribute ref="use"/>
       <xs:attribute ref="addDirective"/>
       <xs:attribute name="xpath" type="xs:string" use="optional"/>
+      <xs:attribute name="includeFrom" type="xs:string" use="optional">
+        <xs:annotation>
+          <xs:documentation>
+            <![CDATA[
+Used in for elements in flatModeException to include them from this mode if the parent or xpath of the element is listed in this attribute (comma separated value).
+
+For example, apply flatModeExceptions only to all mcc:description in resource identifier.
+
+.. code-block:: xml
+
+        <for name="mcc:description"
+             includeFrom="/mdb:MD_Metadata/mdb:identificationInfo/mri:MD_DataIdentification/mri:citation/cit:CI_Citation/cit:identifier/mcc:MD_Identifier"/>
+
+          ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
       <xs:attribute name="excludeFrom" type="xs:string" use="optional">
         <xs:annotation>
           <xs:documentation>
             <![CDATA[
-        Used in for elements in flatModeException to exclude them from this mode if the parent of the element is listed in this attribute.
+Used in for elements in flatModeException to exclude them from this mode if the parent of the element is listed in this attribute (comma separated value).
 
-        For example, apply flatModeExceptions to all gmd:contact, except for the ones in gmd:MD_MaintenanceInformation.
-        ]]>
+For example, apply flatModeExceptions to all gmd:contact, except for the ones in gmd:MD_MaintenanceInformation.
+
+.. code-block:: xml
+
+        <for name="gmd:contact"
+             excludeFrom="gmd:MD_MaintenanceInformation"/>
+
+          ]]>
           </xs:documentation>
         </xs:annotation>
       </xs:attribute>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/layout.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/layout.xsl
@@ -63,8 +63,9 @@
     <xsl:param name="labels" select="$labels" required="no"/>
 
     <xsl:variable name="name" select="concat(@prefix, ':', @name)"/>
+    <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(..)"/>
     <xsl:variable name="flatModeException"
-                  select="gn-fn-metadata:isFieldFlatModeException($viewConfig, $name, name())"/>
+                  select="gn-fn-metadata:isFieldFlatModeException($viewConfig, $name, name(..), $xpath)"/>
 
     <xsl:if test="$isEditing and
                   (not($isFlatMode) or $flatModeException)">

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout.xsl
@@ -66,10 +66,10 @@
     <xsl:param name="schema" select="$schema" required="no"/>
     <xsl:param name="labels" select="$labels" required="no"/>
 
-
     <xsl:variable name="name" select="concat(@prefix, ':', @name)"/>
+    <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(..)"/>
     <xsl:variable name="flatModeException"
-                  select="gn-fn-metadata:isFieldFlatModeException($viewConfig, $name,  name(..))"/>
+                  select="gn-fn-metadata:isFieldFlatModeException($viewConfig, $name,  name(..), $xpath)"/>
 
 
     <xsl:if test="$name = 'gmd:descriptiveKeywords' and count(../gmd:descriptiveKeywords) = 0">

--- a/web/src/main/webapp/xslt/common/functions-metadata.xsl
+++ b/web/src/main/webapp/xslt/common/functions-metadata.xsl
@@ -478,6 +478,14 @@
     <xsl:param name="configuration" as="node()?"/>
     <xsl:param name="name" as="xs:string"/>
     <xsl:param name="parent" as="xs:string?" />
+    <xsl:value-of select="gn-fn-metadata:isFieldFlatModeException($configuration, $name, $parent, '')"/>
+  </xsl:function>
+
+  <xsl:function name="gn-fn-metadata:isFieldFlatModeException" as="xs:boolean">
+    <xsl:param name="configuration" as="node()?"/>
+    <xsl:param name="name" as="xs:string"/>
+    <xsl:param name="parent" as="xs:string?" />
+    <xsl:param name="xpath" as="xs:string?" />
 
     <xsl:choose>
       <xsl:when test="not($configuration)">
@@ -485,11 +493,19 @@
       </xsl:when>
       <xsl:otherwise>
         <xsl:variable name="exception"
-                      select="if (string($parent))
-                  then count($configuration/flatModeExceptions/for[@name = $name and (not(@excludeFrom) or (@excludeFrom and not(contains(@excludeFrom, $parent))))])
-                  else count($configuration/flatModeExceptions/for[@name = $name])"/>
+                      select="($configuration/flatModeExceptions/for[@name = $name
+                                      and @includeFrom
+                                      and tokenize(@includeFrom, ',')[. = ($xpath, $parent)]
+                                      ]
+                              |$configuration/flatModeExceptions/for[@name = $name
+                                       and @excludeFrom
+                                       and not(tokenize(@excludeFrom, ',')[. = ($xpath, $parent)])
+                                       ]
+                              |$configuration/flatModeExceptions/for[@name = $name
+                                        and not(@includeFrom)
+                                        and not(@excludeFrom)])[1]"/>
 
-        <xsl:value-of select="if ($exception > 0)
+        <xsl:value-of select="if (count($exception) = 1)
                       then true()
                       else false()"/>
       </xsl:otherwise>


### PR DESCRIPTION

Related to https://github.com/geonetwork/core-geonetwork/pull/4343

Flat mode exceptions are used in view guided by the XML document (not the XSD). It allows to display + action to create non mandatory elements.
If an element have the same name in various places in the model, use includeFrom and excludeFrom attribute to only enable + on those elements.

eg.
* Allow adding description in resource identifier only (not in CRS identifier)
* Allow adding contact everywhere but not in maintenance section.

```xml
        <for name="mcc:description"
             includeFrom="/mdb:MD_Metadata/mdb:identificationInfo/mri:MD_DataIdentification/mri:citation/cit:CI_Citation/cit:identifier/mcc:MD_Identifier"/>

        <for name="gmd:contact"
             excludeFrom="gmd:MD_MaintenanceInformation"/>
```

Also add support to select by XPath and not only by parent name (which may not be precise enough).

Other usage example in DCAT plugins https://github.com/GIM-be/dcat2/blob/master/src/main/plugin/dcat2/layout/config-editor.xml#L866-L870