### PR TITLE
Editor / Configuration / Hide tab if condition rule is false

### DIFF
--- a/schemas/config-editor.xsd
+++ b/schemas/config-editor.xsd
@@ -820,6 +820,13 @@ The tab key used in URL parameter to activate that tab. The key is also use for 
       <xs:attribute ref="mode"/>
       <xs:attribute ref="displayIfRecord"/>
       <xs:attribute ref="displayIfServiceInfo"/>
+      <xs:attribute name="hideIfNotDisplayed" fixed="true" type="xs:boolean">
+        <xs:annotation>
+          <xs:documentation><![CDATA[
+Define if the tab should be hidden (and not disabled only) if not displayed based on display rules.
+            ]]></xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
       <xs:attribute name="toggle" fixed="true" type="xs:boolean">
         <xs:annotation>
           <xs:documentation><![CDATA[

--- a/web/src/main/webapp/xslt/ui-metadata/menu-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/menu-builder.xsl
@@ -172,23 +172,24 @@
                                         $schema, $metadata, $serviceInfo,
                                         @displayIfRecord,
                                         @displayIfServiceInfo)"/>
-    <!-- When tab displayIf filter return false, the tab is disabled.
-     Another option would be to completely hide it:
-    <xsl:if test="$isTabDisplayed">
-    </xsl:if>
+    <!-- When tab displayIf filter return false,
+     if hideIfNotDisplayed is set to true for the tab, the tab is hidden
+     else the tab is disabled.
     -->
-    <li role="menuitem"
-      class="{if ($tab = @id) then 'active' else ''} {if ($isTabDisplayed) then '' else 'disabled'}">
-      <a href="">
-        <xsl:if test="$tab != @id and $isTabDisplayed">
-          <xsl:attribute name="data-ng-click"
-                         select="concat('switchToTab(''', @id, ''', ''', @mode, ''')')"/>
-        </xsl:if>
-        <xsl:variable name="tabId" select="@id"/>
-        <xsl:variable name="tabLabel" select="$strings/*[name() = $tabId]"/>
-        <xsl:value-of select="($tabLabel|$tabId)[1]"/>
-      </a>
-    </li>
+    <xsl:if test="$isTabDisplayed or (not(@hideIfNotDisplayed))">
+      <li role="menuitem"
+          class="{if ($tab = @id) then 'active' else ''} {if ($isTabDisplayed) then '' else 'disabled'}">
+        <a href="">
+          <xsl:if test="$tab != @id and $isTabDisplayed">
+            <xsl:attribute name="data-ng-click"
+                           select="concat('switchToTab(''', @id, ''', ''', @mode, ''')')"/>
+          </xsl:if>
+          <xsl:variable name="tabId" select="@id"/>
+          <xsl:variable name="tabLabel" select="$strings/*[name() = $tabId]"/>
+          <xsl:value-of select="($tabLabel|$tabId)[1]"/>
+        </a>
+      </li>
+    </xsl:if>
 
   </xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
Add option to hide tab if display condition does not match instead of only disabled it.

![image](https://user-images.githubusercontent.com/1701393/196344924-483bcab2-c1a1-4676-92a0-af94d9b5e8bb.png)



eg. content section hidden for service metadata record

```xml
      <tab id="contentInfo"
           displayIfRecord="not(mdb:MD_Metadata/mdb:identificationInfo/srv:SV_ServiceIdentification)"
           hideIfNotDisplayed="true">
```

Co-authored-by: CMath04 <mathieu.chaussier@gim.be>