### PR TITLE
Editor configuration improvements

### DIFF
--- a/schemas/config-editor.xsd
+++ b/schemas/config-editor.xsd
@@ -22,7 +22,8 @@
   ~ Rome - Italy. email: geonetwork@osgeo.org
   -->
 
-<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified">
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           elementFormDefault="qualified">
   <xs:element name="editor">
     <xs:annotation>
       <xs:documentation>
@@ -1361,7 +1362,27 @@ The fragment is defined in localization file strings.xml:
         ]]></xs:documentation>
     </xs:annotation>
     <xs:complexType>
-      <xs:attribute name="ref" use="required" type="xs:string">
+      <xs:sequence>
+        <xs:annotation>
+          <xs:documentation><![CDATA[
+Any HTML to directly embed in the editor (if not multilingual content is required, use @ref if not).
+
+.. code-block:: xml
+
+        <section name="metadata" collapsed="true">
+          <text>
+            <div class="row">
+              <div class="col-sm-12">
+                <div class="alert alert-info">Describe here whatever you want</div>
+              </div>
+            </div>
+          </text>
+
+          ]]></xs:documentation>
+        </xs:annotation>
+        <xs:any/>
+      </xs:sequence>
+      <xs:attribute name="ref" type="xs:string">
         <xs:annotation>
           <xs:documentation>The tag name of the element to insert in the localization file.
           </xs:documentation>

--- a/schemas/config-editor.xsd
+++ b/schemas/config-editor.xsd
@@ -1015,6 +1015,18 @@ the mandatory section with no name and then the inner elements.
       <xs:attribute ref="in"/>
       <xs:attribute ref="displayIfRecord"/>
       <xs:attribute ref="displayIfServiceInfo"/>
+      <xs:attribute name="collapsed" type="xs:boolean" fixed="true">
+        <xs:annotation>
+          <xs:documentation>An optional attribute to collapse the section. If not set the section is expanded.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="collapsible" type="xs:boolean" fixed="false">
+        <xs:annotation>
+          <xs:documentation>An optional attribute to not allow collapse for the section. If not set the section is expandable.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
     </xs:complexType>
     <xs:unique name="avoidDuplicateFieldWithSameXPath">
       <xs:annotation>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/config-editor.xml
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/config-editor.xml
@@ -414,7 +414,8 @@
 
   <!-- View configuration -->
   <views>
-    <view name="default">
+    <view name="default"
+          class="gn-label-above-input gn-indent-bluescale">
       <sidePanel>
         <directive data-gn-need-help="creating-metadata"/>
         <directive data-gn-overview-manager=""
@@ -437,8 +438,8 @@
       </sidePanel>
 
       <tab id="default" default="true" mode="flat">
-        <section xpath="/mdb:MD_Metadata/mdb:identificationInfo"/>
-        <section xpath="/mdb:MD_Metadata/mdb:contentInfo"/>
+        <section xpath="/mdb:MD_Metadata/mdb:identificationInfo" collapsible="false"/>
+        <section xpath="/mdb:MD_Metadata/mdb:contentInfo" collapsible="false"/>
         <section xpath="/mdb:MD_Metadata/mdb:distributionInfo"/>
         <section xpath="/mdb:MD_Metadata/mdb:dataQualityInfo"/>
         <section xpath="/mdb:MD_Metadata/mdb:resourceLineage"/>
@@ -449,7 +450,7 @@
         <section xpath="/mdb:MD_Metadata/mdb:metadataConstraints"/>
         <section xpath="/mdb:MD_Metadata/mdb:metadataMaintenance"/>
         <section xpath="/mdb:MD_Metadata/mdb:applicationSchemaInfo"/>
-        <section name="metadata">
+        <section name="metadata" collapsed="true">
           <field xpath="/mdb:MD_Metadata/mdb:metadataIdentifier"/>
           <field xpath="/mdb:MD_Metadata/mdb:defaultLocale" or="defaultLocale"
                  in="/mdb:MD_Metadata"/>
@@ -490,7 +491,8 @@
     </view>
 
 
-    <view name="advanced">
+    <view name="advanced"
+          class="gn-label-above-input gn-indent-bluescale">
       <sidePanel>
         <directive data-gn-need-help="creating-metadata"/>
         <directive data-gn-validation-report=""/>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/layout-custom-fields.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/layout-custom-fields.xsl
@@ -33,11 +33,33 @@
                 priority="2000">
     <xsl:param name="schema" select="$schema" required="no"/>
     <xsl:param name="labels" select="$labels" required="no"/>
+    <xsl:param name="overrideLabel" select="''" required="no"/>
 
-    <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>
+    <xsl:variable name="xpath"
+                  select="gn-fn-metadata:getXPath(.)"/>
+
+    <xsl:variable name="isoType"
+                  select="if (../@gco:isoType) then ../@gco:isoType else ''"/>
+
+    <xsl:variable name="labelConfig"
+                  select="gn-fn-metadata:getLabel($schema, name(), $labels, name(..), $isoType, $xpath)"/>
+
+    <xsl:variable name="labelCfg">
+      <xsl:choose>
+        <xsl:when test="$overrideLabel != ''">
+          <element>
+            <label><xsl:value-of select="$overrideLabel"/></label>
+          </element>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:copy-of select="$labelConfig"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:variable>
+
 
     <xsl:call-template name="render-element">
-      <xsl:with-param name="label" select="gn-fn-metadata:getLabel($schema, name(), $labels)/label"/>
+      <xsl:with-param name="label" select="$labelCfg/*"/>
       <xsl:with-param name="value" select="*"/>
       <xsl:with-param name="cls" select="local-name()"/>
       <xsl:with-param name="xpath" select="gn-fn-metadata:getXPath(.)"/>
@@ -300,7 +322,7 @@
     <xsl:apply-templates mode="mode-iso19115-3.2018" select="*"/>
   </xsl:template>
 
-  
+
   <!--
     Display contact as table when mode is flat (eg. simple view) or if using xsl mode
     Match first node (or added one)

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/layout.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/layout.xsl
@@ -22,6 +22,7 @@
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns:gml="http://www.opengis.net/gml/3.2"
   xmlns:xlink="http://www.w3.org/1999/xlink"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema"
   xmlns:gn="http://www.fao.org/geonetwork"
   xmlns:gn-fn-core="http://geonetwork-opensource.org/xsl/functions/core"
   xmlns:gn-fn-metadata="http://geonetwork-opensource.org/xsl/functions/metadata"
@@ -144,6 +145,7 @@
                         not(gco:CharacterString)]">
     <xsl:param name="schema" select="$schema" required="no"/>
     <xsl:param name="labels" select="$labels" required="no"/>
+    <xsl:param name="config" required="no"/>
 
     <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>
     <xsl:variable name="isoType" select="if (../@gco:isoType) then ../@gco:isoType else ''"/>
@@ -183,6 +185,12 @@
           <xsl:with-param name="labels" select="$labels"/>
         </xsl:apply-templates>
       </xsl:with-param>
+      <xsl:with-param name="collapsible"
+                      select="if ($config and $config/@collapsible != '')
+                              then xs:boolean($config/@collapsible) else true()"/>
+      <xsl:with-param name="collapsed"
+                      select="if ($config and $config/@collapsed != '')
+                              then xs:boolean($config/@collapsed) else false()"/>
     </xsl:call-template>
   </xsl:template>
 

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/layout.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/layout.xsl
@@ -146,6 +146,7 @@
     <xsl:param name="schema" select="$schema" required="no"/>
     <xsl:param name="labels" select="$labels" required="no"/>
     <xsl:param name="config" required="no"/>
+    <xsl:param name="overrideLabel" select="''" required="no"/>
 
     <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>
     <xsl:variable name="isoType" select="if (../@gco:isoType) then ../@gco:isoType else ''"/>
@@ -170,7 +171,9 @@
 
     <xsl:call-template name="render-boxed-element">
       <xsl:with-param name="label"
-                      select="gn-fn-metadata:getLabel($schema, name(), $labels, name(..), $isoType, $xpath)/label"/>
+                      select="if ($overrideLabel != '')
+                              then $overrideLabel
+                              else gn-fn-metadata:getLabel($schema, name(), $labels, name(..), $isoType, $xpath)/label"/>
       <xsl:with-param name="editInfo" select="gn:element"/>
       <xsl:with-param name="errors" select="$errors"/>
       <xsl:with-param name="cls" select="local-name()"/>

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
@@ -3227,7 +3227,7 @@
                      data-type="onlines"/>
         </section>-->
 
-        <section xpath="/gmd:MD_Metadata/gmd:identificationInfo"/>
+        <section xpath="/gmd:MD_Metadata/gmd:identificationInfo" collapsible="false"/>
         <section xpath="/gmd:MD_Metadata/gmd:referenceSystemInfo"/>
         <section xpath="/gmd:MD_Metadata/gmd:spatialRepresentationInfo"/>
         <section xpath="/gmd:MD_Metadata/gmd:distributionInfo"/>

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
@@ -3170,7 +3170,8 @@
     <!--
     Customize the editor layout by adding a class attribute
     <view name="default" class="gn-indent-bluescale gn-label-above-input">-->
-    <view name="default">
+    <view name="default" 
+          class="gn-label-above-input gn-indent-bluescale">
       <sidePanel>
         <!-- Simple overview manager + online source manger for other types
         Limit the max number of overviews with data-number-of-overviews="3" attribute.
@@ -3233,7 +3234,7 @@
         <section xpath="/gmd:MD_Metadata/gmd:distributionInfo"/>
         <section xpath="/gmd:MD_Metadata/gmd:dataQualityInfo"/>
         <section xpath="/gmd:MD_Metadata/gmd:contentInfo"/>
-        <section>
+        <section name="metadata" collapsed="true">
           <field xpath="/gmd:MD_Metadata/gmd:fileIdentifier"/>
           <field xpath="/gmd:MD_Metadata/gmd:language" or="language" in="/gmd:MD_Metadata"/>
           <field xpath="/gmd:MD_Metadata/gmd:characterSet"/>
@@ -3297,7 +3298,8 @@
       </thesaurusList>
 
     </view>
-    <view name="advanced">
+    <view name="advanced"
+          class="gn-label-above-input gn-indent-bluescale">
       <sidePanel>
         <directive data-gn-need-help="creating-metadata"/>
         <directive data-gn-validation-report=""/>

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout.xsl
@@ -30,6 +30,7 @@
                 xmlns:gml="http://www.opengis.net/gml/3.2"
                 xmlns:gml320="http://www.opengis.net/gml"
                 xmlns:xlink="http://www.w3.org/1999/xlink"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:gn="http://www.fao.org/geonetwork"
                 xmlns:gn-fn-metadata="http://geonetwork-opensource.org/xsl/functions/metadata"
                 xmlns:gn-fn-iso19139="http://geonetwork-opensource.org/xsl/functions/profiles/iso19139"
@@ -185,6 +186,7 @@
     <xsl:param name="schema" select="$schema" required="no"/>
     <xsl:param name="labels" select="$labels" required="no"/>
     <xsl:param name="refToDelete" required="no"/>
+    <xsl:param name="config" required="no"/>
 
 
     <xsl:variable name="xpath" select="gn-fn-metadata:getXPath(.)"/>
@@ -218,6 +220,12 @@
           <xsl:with-param name="labels" select="$labels"/>
         </xsl:apply-templates>
       </xsl:with-param>
+      <xsl:with-param name="collapsible"
+                      select="if ($config and $config/@collapsible != '')
+                              then xs:boolean($config/@collapsible) else true()"/>
+      <xsl:with-param name="collapsed"
+                      select="if ($config and $config/@collapsed != '')
+                              then xs:boolean($config/@collapsed) else false()"/>
     </xsl:call-template>
 
   </xsl:template>

--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -981,14 +981,18 @@
           '<i class="fa fa-fw fa-angle-double-up"/>&nbsp;' +
           "</button>",
         link: function linkFn(scope, element, attr) {
-          var selector =
+          var collapsing = true,
+            selector =
               attr["gnSectionToggle"] ||
-              "form > div > fieldset > legend[data-gn-slide-toggle]",
+              "form > div > fieldset legend[data-gn-slide-toggle]",
             event = attr["event"] || "click";
           element.on("click", function () {
             $(selector).each(function (idx, elem) {
-              $(elem).trigger(event);
+              if (collapsing !== $(elem).hasClass("collapsed")) {
+                $(elem).trigger(event);
+              }
             });
+            collapsing = !collapsing;
             $(this).find("i").toggleClass("fa-angle-double-up fa-angle-double-down");
           });
         }

--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
@@ -546,6 +546,8 @@
   <!-- Render metadata elements defined by XPath -->
   <xsl:template mode="render-view" match="@xpath">
     <xsl:param name="base" select="$metadata"/>
+    <xsl:param name="collapsible" as="xs:boolean" required="no"/>
+    <xsl:param name="collapsed" as="xs:boolean" required="no"/>
 
     <!-- Matching nodes -->
     <xsl:variable name="nodes">
@@ -564,6 +566,8 @@
     <xsl:for-each select="$nodes">
       <xsl:apply-templates mode="render-field">
         <xsl:with-param name="fieldName" select="$fieldName"/>
+        <xsl:with-param name="collapsible" select="$collapsible"/>
+        <xsl:with-param name="collapsed" select="$collapsed"/>
       </xsl:apply-templates>
     </xsl:for-each>
   </xsl:template>

--- a/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
@@ -376,6 +376,8 @@
       <null/>
     </xsl:param>
     <xsl:param name="isDisabled" select="ancestor::node()[@xlink:href]"/>
+    <xsl:param name="collapsible" select="true()" as="xs:boolean" required="no"/>
+    <xsl:param name="collapsed" select="false()" as="xs:boolean" required="no"/>
 
 
     <xsl:variable name="hasXlink" select="@xlink:href"/>
@@ -385,8 +387,10 @@
               class="{if ($hasXlink) then 'gn-has-xlink' else ''} gn-{substring-after(name(), ':')}">
 
       <legend class="{$cls}"
-              data-gn-slide-toggle=""
               data-gn-field-tooltip="{$schema}|{name()}|{name(..)}|">
+        <xsl:if test="$collapsible">
+          <xsl:attribute name="data-gn-slide-toggle" select="$collapsed"/>
+        </xsl:if>
         <!--
          The toggle title is in conflict with the element title
          required for the element tooltip

--- a/web/src/main/webapp/xslt/ui-metadata/form-configurator.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-configurator.xsl
@@ -67,7 +67,10 @@
           <fieldset data-gn-field-highlight="" class="gn-{@name}">
             <!-- Get translation for labels.
             If labels contains ':', search into labels.xml. -->
-            <legend data-gn-slide-toggle="">
+            <legend>
+              <xsl:if test="not(@collapsible)">
+                <xsl:attribute name="data-gn-slide-toggle" select="exists(@collapsed)"/>
+              </xsl:if>
               <xsl:value-of
                 select="if (contains($sectionName, ':'))
                   then gn-fn-metadata:getLabel($schema, $sectionName, $labels)/label
@@ -172,7 +175,7 @@
 
 
   <!-- Element to ignore in that mode -->
-  <xsl:template mode="form-builder" match="@name"/>
+  <xsl:template mode="form-builder" match="@name|@collapsed|@collapsible"/>
 
   <!-- For each field, fieldset and section, check the matching xpath
     is in the current document. In that case dispatch to the schema mode

--- a/web/src/main/webapp/xslt/ui-metadata/form-configurator.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-configurator.xsl
@@ -96,7 +96,9 @@
   localization files. -->
   <xsl:template mode="form-builder" match="text">
     <xsl:variable name="id" select="@ref"/>
-    <xsl:variable name="text" select="$strings/*[name() = $id]"/>
+    <xsl:variable name="translation" select="$strings/*[name() = $id]"/>
+    <xsl:variable name="text"
+                  select="if ($translation) then $translation else ."/>
 
     <xsl:variable name="isDisplayed"
                   as="xs:boolean"

--- a/web/src/main/webapp/xslt/ui-metadata/form-configurator.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-configurator.xsl
@@ -74,7 +74,9 @@
               <xsl:value-of
                 select="if (contains($sectionName, ':'))
                   then gn-fn-metadata:getLabel($schema, $sectionName, $labels)/label
-                  else $strings/*[name() = $sectionName]"
+                  else if ($strings/*[name() = $sectionName] != '')
+                  then $strings/*[name() = $sectionName]
+                  else $sectionName"
               />
             </legend>
             <xsl:apply-templates mode="form-builder" select="@*[name() != 'displayIfRecord']|*">
@@ -256,8 +258,13 @@
           <!-- Display the matching node using standard editor mode
           propagating to the schema mode ... -->
           <xsl:for-each select="$nodes">
+            <xsl:variable name="translation"
+                          select="$strings/*[name() = $configName]"/>
+            <xsl:variable name="overrideLabel"
+                          select="if ($translation != '')
+                                  then $translation
+                                  else $configName"/>
 
-            <xsl:variable name="overrideLabel" select="$strings/*[name() = $configName]"/>
             <xsl:if test="$configName != '' and not($overrideLabel)">
               <xsl:message>Label not defined for field name <xsl:value-of select="$configName"/> in loc/{language}/strings.xml.</xsl:message>
             </xsl:if>


### PR DESCRIPTION
## Add collapsible/collapsed section support



eg. in simple view,
* do not allow collapsing main section ie. identification and content info
* collapse the metadata section by default which contains advanced element (probably not modified compared to the template values).

```xml
<tab id="default" default="true" mode="flat">
        <section xpath="/mdb:MD_Metadata/mdb:identificationInfo" collapsible="false"/>
        <section xpath="/mdb:MD_Metadata/mdb:contentInfo" collapsible="false"/>
        <section name="metadata" collapsed="true">
```

![image](https://user-images.githubusercontent.com/1701393/196895866-03e1adbb-7995-4249-b5b1-78085016cf26.png)


Collapsing all sections, also collapse inner section and take into account collapsed states.


## Insert text as HTML directly (if no localization needed)

```xml
<section name="metadata" collapsed="true">
          <text>
            <div class="row">
              <div class="col-sm-12">
                <div class="alert alert-info">Describe here whatever you want</div>
              </div>
            </div>
          </text>
```

![image](https://user-images.githubusercontent.com/1701393/196904776-aa004440-9e97-4e87-ba43-52ded1c3ebcf.png)

## Use `@name` as label directly

To simplify editor configuration in non multilingual context:

```xml
        <section name="Les métadonnées" collapsed="true">
          <field xpath="/mdb:MD_Metadata/mdb:metadataIdentifier/*/mcc:code" name="L'UUID de la fiche"/>
          <field xpath="/mdb:MD_Metadata/mdb:defaultLocale/*/lan:language" or="defaultLocale"
                 in="/mdb:MD_Metadata" name="La langue de la fiche"/>
```

![image](https://user-images.githubusercontent.com/1701393/196912051-ad9141c6-5591-4eee-863c-8acc2b6bc3af.png)


## Default mode 


* Use the label above mode.