### PR TITLE
[BP] Update bootstrap-table to v1.21.1 (#6628)

### DIFF
--- a/web-ui/src/main/resources/WEB-INF/classes/web-ui-wro-sources.xml
+++ b/web-ui/src/main/resources/WEB-INF/classes/web-ui-wro-sources.xml
@@ -84,7 +84,7 @@
               minimize="false"/>
     <jsSource webappPath="/catalog/lib/bootstrap-table/dist/bootstrap-table-locale-all.min.js"
             minimize="false"/>
-    <jsSource webappPath="/catalog/lib/bootstrap-table/dist/extensions/angular/bootstrap-table-angular.js"
+    <jsSource webappPath="/catalog/lib/bootstrap-table-angular.js"
               minimize="false"/>
     <jsSource webappPath="/catalog/lib/bootstrap-table/dist/extensions/filter-control/bootstrap-table-filter-control.min.js" />
     <jsSource webappPath="/catalog/lib/zip/zip.js"/>
@@ -153,7 +153,7 @@
     <jsSource webappPath="/catalog/lib/bootstrap-table/dist/bootstrap-table-locale-all.min.js"
               minimize="false"/>
     <jsSource webappPath="/catalog/lib/bootstrap-table/dist/extensions/filter-control/bootstrap-table-filter-control.min.js" />
-    <jsSource webappPath="/catalog/lib/bootstrap-table/dist/extensions/angular/bootstrap-table-angular.js"
+    <jsSource webappPath="/catalog/lib/bootstrap-table-angular.js"
               minimize="false"/>
     <jsSource webappPath="/catalog/lib/FileSaver/FileSaver.min.js" minimize="false"/>
     <jsSource webappPath="/catalog/lib/tableExport/tableExport.min.js" minimize="false"/>

--- a/web-ui/src/main/resources/catalog/components/viewer/gfi/FeaturesTable.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/gfi/FeaturesTable.js
@@ -56,7 +56,7 @@
   };
 
   GnFeaturesTableController.prototype.initTable = function(element, scope, getBsTableLang) {
-    
+
     // See http://stackoverflow.com/a/13382873/29655
     function getScrollbarWidth() {
       var outer = document.createElement('div');
@@ -74,11 +74,10 @@
       return widthNoScroll - widthWithScroll;
     }
 
-    // Force the table to resetWidth on window resize
+    // Force the table to resetView on window resize
     // this enables the header and the rows to be aligned
     function resizeBsTable() {
-      element.bootstrapTable('resetWidth');
-      element.bootstrapTable('resetView');
+      element.bootstrapTable("resetView");
     }
 
     this.loader.getBsTableConfig().then(function(bstConfig) {

--- a/web-ui/src/main/resources/catalog/lib/bootstrap-table-angular.js
+++ b/web-ui/src/main/resources/catalog/lib/bootstrap-table-angular.js
@@ -1,0 +1,114 @@
+(function (global, factory) {
+  if (typeof define === "function" && define.amd) {
+    define([], factory);
+  } else if (typeof exports !== "undefined") {
+    factory();
+  } else {
+    var mod = {
+      exports: {}
+    };
+    factory();
+    global.bootstrapTableAngular = mod.exports;
+  }
+})(this, function () {
+  'use strict';
+
+  // JavaScript source code
+  (function () {
+    if (typeof angular === 'undefined') {
+      return;
+    }
+    angular.module('bsTable', []).constant('uiBsTables', { bsTables: {} }).directive('bsTableControl', ['uiBsTables', function (uiBsTables) {
+      var CONTAINER_SELECTOR = '.bootstrap-table';
+      var SCROLLABLE_SELECTOR = '.fixed-table-body';
+      var SEARCH_SELECTOR = '.search input';
+      var bsTables = uiBsTables.bsTables;
+      function getBsTable(el) {
+        var result;
+        $.each(bsTables, function (id, bsTable) {
+          if (!bsTable.$el.closest(CONTAINER_SELECTOR).has(el).length) return;
+          result = bsTable;
+          return true;
+        });
+        return result;
+      }
+
+      $(window).resize(function () {
+        $.each(bsTables, function (id, bsTable) {
+          bsTable.$el.bootstrapTable('resetView');
+        });
+      });
+      function onScroll() {
+        var bsTable = this;
+        var state = bsTable.$s.bsTableControl.state;
+        bsTable.$s.$applyAsync(function () {
+          state.scroll = bsTable.$el.bootstrapTable('getScrollPosition');
+        });
+      }
+      $(document).on('post-header.bs.table', CONTAINER_SELECTOR + ' table', function (evt) {
+        // bootstrap-table calls .off('scroll') in initHeader so reattach here
+        var bsTable = getBsTable(evt.target);
+        if (!bsTable) return;
+        bsTable.$el.closest(CONTAINER_SELECTOR).find(SCROLLABLE_SELECTOR).on('scroll', onScroll.bind(bsTable));
+      }).on('sort.bs.table', CONTAINER_SELECTOR + ' table', function (evt, sortName, sortOrder) {
+        var bsTable = getBsTable(evt.target);
+        if (!bsTable) return;
+        var state = bsTable.$s.bsTableControl.state;
+        bsTable.$s.$applyAsync(function () {
+          state.sortName = sortName;
+          state.sortOrder = sortOrder;
+        });
+      }).on('page-change.bs.table', CONTAINER_SELECTOR + ' table', function (evt, pageNumber, pageSize) {
+        var bsTable = getBsTable(evt.target);
+        if (!bsTable) return;
+        var state = bsTable.$s.bsTableControl.state;
+        bsTable.$s.$applyAsync(function () {
+          state.pageNumber = pageNumber;
+          state.pageSize = pageSize;
+        });
+      }).on('search.bs.table', CONTAINER_SELECTOR + ' table', function (evt, searchText) {
+        var bsTable = getBsTable(evt.target);
+        if (!bsTable) return;
+        var state = bsTable.$s.bsTableControl.state;
+        bsTable.$s.$applyAsync(function () {
+          state.searchText = searchText;
+        });
+      }).on('focus blur', CONTAINER_SELECTOR + ' ' + SEARCH_SELECTOR, function (evt) {
+        var bsTable = getBsTable(evt.target);
+        if (!bsTable) return;
+        var state = bsTable.$s.bsTableControl.state;
+        bsTable.$s.$applyAsync(function () {
+          state.searchHasFocus = $(evt.target).is(':focus');
+        });
+      });
+
+      return {
+        restrict: 'EA',
+        scope: { bsTableControl: '=' },
+        link: function link($s, $el) {
+          var bsTable = bsTables[$s.$id] = { $s: $s, $el: $el };
+          $s.instantiated = false;
+          $s.$watch('bsTableControl.options', function (options) {
+            if (!options) options = $s.bsTableControl.options = {};
+            var state = $s.bsTableControl.state || {};
+
+            if ($s.instantiated) $el.bootstrapTable('destroy');
+            $el.bootstrapTable(angular.extend(angular.copy(options), state));
+            $s.instantiated = true;
+
+            // Update the UI for state that isn't settable via options
+            if ('scroll' in state) $el.bootstrapTable('scrollTo', state.scroll);
+            if ('searchHasFocus' in state) $el.closest(CONTAINER_SELECTOR).find(SEARCH_SELECTOR).focus(); // $el gets detached so have to recompute whole chain
+          }, true);
+          $s.$watch('bsTableControl.state', function (state) {
+            if (!state) state = $s.bsTableControl.state = {};
+            $el.trigger('directive-updated.bs.table', [state]);
+          }, true);
+          $s.$on('$destroy', function () {
+            delete bsTables[$s.$id];
+          });
+        }
+      };
+    }]);
+  })();
+});

--- a/web/src/main/webapp/xslt/base-layout-cssjs-loader.xsl
+++ b/web/src/main/webapp/xslt/base-layout-cssjs-loader.xsl
@@ -192,7 +192,7 @@
         <script
           src="{$uiResourcesPath}lib/bootstrap.ext/datepicker/bootstrap-datepicker.fr.js?v={$buildNumber}"></script>
         <script src="{$uiResourcesPath}lib/bootstrap-table/dist/bootstrap-table.js?v={$buildNumber}"></script>
-        <script src="{$uiResourcesPath}lib/bootstrap-table/src/extensions/angular/bootstrap-table-angular.js?v={$buildNumber}"></script>
+        <script src="{$uiResourcesPath}lib/bootstrap-table-angular.js?v={$buildNumber}"></script>
         <script src="{$uiResourcesPath}lib/bootstrap-table/src/extensions/export/bootstrap-table-export.js?v={$buildNumber}"></script>
         <script src="{$uiResourcesPath}lib/bootstrap-table/dist/bootstrap-table-locale-all.min.js"></script>
         <script src="{$uiResourcesPath}lib/bootstrap-table/dist/extensions/filter-control/bootstrap-table-filter-control.min.js"></script>


### PR DESCRIPTION
* Update bootstrap-table to v1.21.1
* Since bootstrap-table-angular module has been removed in v1.13.1 add the code to GN.
* `resetWidth` method has been deleted from bootstrap-table and have been merged into `resetView` method (https://github.com/wenzhixin/bootstrap-table/pull/4687)