### PR TITLE
Update metadata relation queries with the workflow filters

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/MetadataUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataUtils.java
@@ -231,7 +231,7 @@ public class MetadataUtils {
                     };
                     queries.put(type,
                         new RelatedTypeDetails(
-                            String.format("uuid:(%s)%s",
+                            String.format("(uuid:(%s)%s) AND (draft:\"n\" OR draft:\"e\")",
                             listOfUUIDs.stream()
                                 .collect(Collectors.joining("\" OR \"", "\"", "\"")),
                                 type == RelatedItemType.parent
@@ -249,7 +249,7 @@ public class MetadataUtils {
                 // and search for records associated to them
                 queries.put(type,
                     new RelatedTypeDetails(
-                        String.format("+%s:(%s) -uuid:\"%s\"",
+                        String.format("+%s:(%s) -uuid:\"%s\" AND (draft:\"n\" OR draft:\"e\")",
                         relatedIndexFields.get(type.value()),
                         listOfUUIDs.stream()
                             .collect(Collectors.joining("\" OR \"", "\"", "\"")),
@@ -268,7 +268,7 @@ public class MetadataUtils {
                 // and search for records associated and records having parentUuid equal to current
                 queries.put(type,
                     new RelatedTypeDetails(
-                        String.format("%s:\"%s\" OR uuid:(%s)",
+                        String.format("(%s:\"%s\" OR uuid:(%s)) AND (draft:\"n\" OR draft:\"e\")",
                             relatedIndexFields.get(type.value()),
                             md.getUuid(),
                             isComposedOfList.stream()


### PR DESCRIPTION
Currently, if a metadata has a working copy, it's displayed twice in the relations panel, one for the approved copy and another for the working copy:

![Screenshot 2022-10-24 at 13 04 45](https://user-images.githubusercontent.com/1695003/197512173-3efe489d-c55f-485b-84f6-69983ae5ea85.png)


This change filters the metadata to display these records once.

