### PR TITLE
Update UI settings management for UserAdmin users 

### DIFF
--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1391,6 +1391,7 @@
     "notificationLevel-catalogueProfileGuest": "Notify the catalogue guest",
     "notificationLevel-recordProfileReviewer": "Notify the reviewers part of the record group owner",
     "notificationLevel-recordUserAuthor": "Notify the record author",
-    "notificationLevel-recordGroupEmail": "Notify the group(s) emails"
+    "notificationLevel-recordGroupEmail": "Notify the group(s) emails",
+    "uiConfigDeleteError": "Error deleting user interface configuration"
 }
 

--- a/web-ui/src/main/resources/catalog/templates/admin/settings/ui.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/settings/ui.html
@@ -114,7 +114,7 @@
                 type="submit"
                 class="btn btn-danger pull-right"
                 id="gn-btn-settings-delete"
-                data-ng-disabled="!uiConfiguration"
+                data-ng-disabled="!canDeleteUiConfig()"
                 data-ng-click="deleteUiConfig()"
               >
                 <span class="fa fa-times"></span>


### PR DESCRIPTION
This pull request updates the UI settings management for users with `UserAdmin` profile. Currently users with the profile `UserAdmin` can delete *any* UI configuration.

This change disables the delete for button in the UI for the default UI `srv`.

Also updates the backend code to delete UI, so `UserAdmin` users can only delete UI's related to portals associated to their groups.

An improvement for another pull request, would be to disable also the button in the UI settings configuration in these cases.

