### PR TITLE
Map servers / sources / metadata template identifiers - delete confirmation dialog and fixes in display delete button in sources page

### DIFF
--- a/web-ui/src/main/resources/catalog/js/admin/MapServerController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/MapServerController.js
@@ -129,7 +129,12 @@
             // TODO
           });
       };
-      $scope.deleteMapServer = function () {
+
+      $scope.deleteMapserverConfig = function () {
+        $("#gn-confirm-remove-mapserver").modal("show");
+      };
+
+      $scope.confirmDeleteMapserverConfig = function () {
         $http
           .delete("../api/mapservers/" + $scope.mapserverSelected.id)
           .success(function (data) {

--- a/web-ui/src/main/resources/catalog/js/admin/MetadataIdentifierTemplatesController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/MetadataIdentifierTemplatesController.js
@@ -46,10 +46,13 @@
           event.preventDefault();
       });
 
+      $scope.isNew = false;
       $scope.mdIdentifierTemplates = [];
       $scope.mdIdentifierTemplateSelected = {};
 
       $scope.selectTemplate = function (template) {
+        $scope.isNew = false;
+
         if ($(".ng-dirty").length > 0 && confirm($translate.instant("doSaveConfirm"))) {
           $scope.saveMetadataIdentifierTemplate(false);
         }
@@ -70,6 +73,7 @@
       }
 
       $scope.addMetadataIdentifierTemplate = function () {
+        $scope.isNew = true;
         $scope.mdIdentifierTemplateSelected = {
           id: "-99",
           name: "",
@@ -77,9 +81,14 @@
         };
       };
 
-      $scope.deleteMetadataIdentifierTemplate = function (id) {
+
+      $scope.deleteTemplateConfig = function () {
+        $("#gn-confirm-remove-metadataidentifiertpl").modal("show");
+      };
+
+      $scope.confirmDeleteTemplateConfig = function () {
         $http
-          .delete("../api/identifiers/" + id)
+          .delete("../api/identifiers/" + $scope.mdIdentifierTemplateSelected.id)
           .success(function (data) {
             $(".ng-dirty").removeClass("ng-dirty");
             loadMetadataUrnTemplates();

--- a/web-ui/src/main/resources/catalog/js/admin/MetadataIdentifierTemplatesController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/MetadataIdentifierTemplatesController.js
@@ -81,7 +81,6 @@
         };
       };
 
-
       $scope.deleteTemplateConfig = function () {
         $("#gn-confirm-remove-metadataidentifiertpl").modal("show");
       };

--- a/web-ui/src/main/resources/catalog/js/admin/MetadataIdentifierTemplatesController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/MetadataIdentifierTemplatesController.js
@@ -92,7 +92,7 @@
             $(".ng-dirty").removeClass("ng-dirty");
             loadMetadataUrnTemplates();
             $rootScope.$broadcast("StatusUpdated", {
-              msg: $translate.instant("metadataUrnTemplateDeleted"),
+              msg: $translate.instant("metadataIdentifierTemplateDeleted"),
               timeout: 2,
               type: "success"
             });
@@ -100,7 +100,7 @@
           .error(function (data) {
             $(".ng-dirty").removeClass("ng-dirty");
             $rootScope.$broadcast("StatusUpdated", {
-              title: $translate.instant("metadataUrnTemplateDeletedError"),
+              title: $translate.instant("metadataIdentifierTemplateDeletedError"),
               error: data,
               timeout: 0,
               type: "danger"

--- a/web-ui/src/main/resources/catalog/js/admin/SourcesController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/SourcesController.js
@@ -64,6 +64,7 @@
         source.uiConfig = source.uiConfig && source.uiConfig.toString();
         source.groupOwner = source.groupOwner || null;
         $scope.source = source;
+        $scope.isNew = false;
       };
 
       function filterSources() {
@@ -149,7 +150,11 @@
           });
       };
 
-      $scope.removeSource = function () {
+      $scope.deleteSourceConfig = function () {
+        $("#gn-confirm-remove-source").modal("show");
+      };
+
+      $scope.confirmDeleteSourceConfig = function () {
         $http
           .delete("../api/sources/" + $scope.source.uuid)
           .success(function (data) {

--- a/web-ui/src/main/resources/catalog/js/admin/SourcesController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/SourcesController.js
@@ -165,6 +165,7 @@
             });
 
             loadSources();
+            $scope.source = null;
           })
           .error(function (data) {
             $rootScope.$broadcast("StatusUpdated", {

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1395,6 +1395,8 @@
     "confirmMapserverDelete": "Are you sure you want to delete this Map server?",
     "confirmSourceDelete": "Are you sure you want to delete this portal?",
     "confirmMetadataIdentifierTemplateDelete": "Are you sure you want to delete this metadata identifier template?",
-    "uiConfigDeleteError": "Error deleting user interface configuration"
+    "uiConfigDeleteError": "Error deleting user interface configuration",
+    "sourceRemoved": "Source removed",
+    "sourceRemovedError": "Error while removing the source"
 }
 

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1393,6 +1393,7 @@
     "notificationLevel-recordUserAuthor": "Notify the record author",
     "notificationLevel-recordGroupEmail": "Notify the group(s) emails",
     "confirmMapserverDelete": "Are you sure you want to delete this Map server?",
-    "confirmSourceDelete": "Are you sure you want to delete this portal?"
+    "confirmSourceDelete": "Are you sure you want to delete this portal?",
+    "confirmMetadataIdentifierTemplateDelete": "Are you sure you want to delete this metadata identifier template?"
 }
 

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1391,6 +1391,8 @@
     "notificationLevel-catalogueProfileGuest": "Notify the catalogue guest",
     "notificationLevel-recordProfileReviewer": "Notify the reviewers part of the record group owner",
     "notificationLevel-recordUserAuthor": "Notify the record author",
-    "notificationLevel-recordGroupEmail": "Notify the group(s) emails"
+    "notificationLevel-recordGroupEmail": "Notify the group(s) emails",
+    "confirmMapserverDelete": "Are you sure you want to delete this Map server?",
+    "confirmSourceDelete": "Are you sure you want to delete this portal?"
 }
 

--- a/web-ui/src/main/resources/catalog/style/gn_admin.less
+++ b/web-ui/src/main/resources/catalog/style/gn_admin.less
@@ -215,7 +215,9 @@ ul.pager {
 #gn-logo-container,
 #gn-group-container,
 #gn-user-container,
-#gn-uiconfig-container {
+#gn-uiconfig-container,
+#gn-mapservers-container,
+#gn-sources-container {
   // Fixes gn-modal windows; TODO: fix this globally in gn-popup style
   [gn-modal] {
     max-width: none;

--- a/web-ui/src/main/resources/catalog/style/gn_admin.less
+++ b/web-ui/src/main/resources/catalog/style/gn_admin.less
@@ -217,7 +217,8 @@ ul.pager {
 #gn-user-container,
 #gn-uiconfig-container,
 #gn-mapservers-container,
-#gn-sources-container {
+#gn-sources-container,
+#gn-metadatatemplates-container {
   // Fixes gn-modal windows; TODO: fix this globally in gn-popup style
   [gn-modal] {
     max-width: none;

--- a/web-ui/src/main/resources/catalog/templates/admin/metadata/metadata-identifier-templates.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/metadata/metadata-identifier-templates.html
@@ -1,4 +1,4 @@
-<div class="row" data-ng-controller="GnMetadataIdentifierTemplatesController">
+<div class="row" data-ng-controller="GnMetadataIdentifierTemplatesController" id="gn-metadatatemplates-container">
   <div class="col-lg-4">
     <div class="panel panel-default">
       <div class="panel-heading" data-translate="">manageMetadataIdentifierTemplates</div>
@@ -37,13 +37,23 @@
   <div class="col-lg-8" data-ng-hide="mdIdentifierTemplateSelected.id == null">
     <div class="panel panel-default">
       <div class="panel-heading">
-        {{mdIdentifierTemplateSelected.name}}
+
+        <span
+          data-ng-show="mdIdentifierTemplateSelected.id == -99"
+          data-translate=""
+        >newMetadataIdentifierTemplate</span>
+
+        <span
+          data-ng-show="mdIdentifierTemplateSelected.id != -99"
+        >{{mdIdentifierTemplateSelected.name}}</span
+        >
+
         <div class="btn-toolbar">
           <button
             type="button"
             class="btn btn-primary btn-danger pull-right"
-            data-ng-hide="mdIdentifierTemplateSelected.id == ''"
-            data-ng-click="deleteMetadataIdentifierTemplate(mdIdentifierTemplateSelected.id)"
+            data-ng-hide="isNew"
+            data-ng-click="deleteTemplateConfig()"
           >
             <i class="fa fa-times"></i>&nbsp;
             <span data-translate="">delete</span>
@@ -115,5 +125,14 @@
         </form>
       </div>
     </div>
+  </div>
+
+  <div
+    gn-modal
+    class="gn-confirm-delete"
+    gn-popup-options="{title: 'confirmDialogTitle', confirmCallback: confirmDeleteTemplateConfig}"
+    id="gn-confirm-remove-metadataidentifiertpl"
+  >
+    <p translate>confirmMetadataIdentifierTemplateDelete</p>
   </div>
 </div>

--- a/web-ui/src/main/resources/catalog/templates/admin/metadata/metadata-identifier-templates.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/metadata/metadata-identifier-templates.html
@@ -1,4 +1,8 @@
-<div class="row" data-ng-controller="GnMetadataIdentifierTemplatesController" id="gn-metadatatemplates-container">
+<div
+  class="row"
+  data-ng-controller="GnMetadataIdentifierTemplatesController"
+  id="gn-metadatatemplates-container"
+>
   <div class="col-lg-4">
     <div class="panel panel-default">
       <div class="panel-heading" data-translate="">manageMetadataIdentifierTemplates</div>
@@ -37,15 +41,12 @@
   <div class="col-lg-8" data-ng-hide="mdIdentifierTemplateSelected.id == null">
     <div class="panel panel-default">
       <div class="panel-heading">
+        <span data-ng-show="mdIdentifierTemplateSelected.id == -99" data-translate=""
+          >newMetadataIdentifierTemplate</span
+        >
 
-        <span
-          data-ng-show="mdIdentifierTemplateSelected.id == -99"
-          data-translate=""
-        >newMetadataIdentifierTemplate</span>
-
-        <span
-          data-ng-show="mdIdentifierTemplateSelected.id != -99"
-        >{{mdIdentifierTemplateSelected.name}}</span
+        <span data-ng-show="mdIdentifierTemplateSelected.id != -99"
+          >{{mdIdentifierTemplateSelected.name}}</span
         >
 
         <div class="btn-toolbar">

--- a/web-ui/src/main/resources/catalog/templates/admin/settings/mapservers.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/settings/mapservers.html
@@ -1,4 +1,4 @@
-<div class="row" data-ng-controller="GnMapServerController">
+<div class="row" data-ng-controller="GnMapServerController" id="gn-mapservers-container">
   <div class="col-lg-4">
     <div class="panel panel-default">
       <div class="panel-heading" data-translate="">mapservers</div>
@@ -69,7 +69,7 @@
             type="button"
             class="btn btn-primary btn-danger"
             data-ng-hide="mapserverSelected.id == ''"
-            data-ng-click="deleteMapServer(mapserverSelected.id)"
+            data-ng-click="deleteMapserverConfig()"
           >
             <i class="fa fa-times"></i>&nbsp;
             <span data-translate="">delete</span>
@@ -341,5 +341,14 @@
         </div>
       </div>
     </div>
+  </div>
+
+  <div
+    gn-modal
+    class="gn-confirm-delete"
+    gn-popup-options="{title: 'confirmDialogTitle', confirmCallback: confirmDeleteMapserverConfig}"
+    id="gn-confirm-remove-mapserver"
+  >
+    <p translate>confirmMapserverDelete</p>
   </div>
 </div>

--- a/web-ui/src/main/resources/catalog/templates/admin/settings/mapservers.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/settings/mapservers.html
@@ -163,7 +163,7 @@
                     type="password"
                     class="form-control"
                     required="required"
-                    autocomplete="off"
+                    autocomplete="new-password"
                     data-ng-model="mapserverSelected.password"
                   />
                 </div>

--- a/web-ui/src/main/resources/catalog/templates/admin/settings/sources.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/settings/sources.html
@@ -1,264 +1,272 @@
-<div>
-  <div class="row" data-ng-controller="GnSourcesController">
-    <div class="col-lg-4">
-      <div class="panel panel-default">
-        <div class="panel-heading" data-translate="">manageSources</div>
-        <div class="panel-body">
-          <div class="list-group">
-            <ul class="list-group">
-              <input
-                class="form-control"
-                data-ng-show="sources.length > 1"
-                data-ng-model="sourcesSearch.$"
-                autofocus=""
-                placeholder="{{'filter' | translate}}"
-              />
+<div class="row" data-ng-controller="GnSourcesController" id="gn-sources-container">
+  <div class="col-lg-4">
+    <div class="panel panel-default">
+      <div class="panel-heading" data-translate="">manageSources</div>
+      <div class="panel-body">
+        <div class="list-group">
+          <ul class="list-group">
+            <input
+              class="form-control"
+              data-ng-show="sources.length > 1"
+              data-ng-model="sourcesSearch.$"
+              autofocus=""
+              placeholder="{{'filter' | translate}}"
+            />
 
-              <div class="row">
-                <div class="col-md-3" data-ng-repeat="(k, v) in filter.types">
-                  <label title="{{::('source-' + k) | translate}}">
-                    <input
-                      type="checkbox"
-                      autocomplete="off"
-                      data-ng-model="filter.types[k]"
-                    />
-                    <i
-                      class="fa fa-fw"
-                      title="{{::('source-' + k) | translate}}"
-                      data-ng-class="{'fa-home': k === 'portal',
-                                       'fa-folder': k === 'subportal',
-                                       'fa-cloud': k === 'externalportal',
-                                       'fa-cloud-download': k === 'harvester'}"
-                    ></i>
-                  </label>
-                </div>
+            <div class="row">
+              <div class="col-md-3" data-ng-repeat="(k, v) in filter.types">
+                <label title="{{::('source-' + k) | translate}}">
+                  <input
+                    type="checkbox"
+                    autocomplete="off"
+                    data-ng-model="filter.types[k]"
+                  />
+                  <i
+                    class="fa fa-fw"
+                    title="{{::('source-' + k) | translate}}"
+                    data-ng-class="{'fa-home': k === 'portal',
+                                     'fa-folder': k === 'subportal',
+                                     'fa-cloud': k === 'externalportal',
+                                     'fa-cloud-download': k === 'harvester'}"
+                  ></i>
+                </label>
               </div>
+            </div>
 
-              <a
-                class="list-group-item"
-                data-ng-class="s.uuid === source.uuid ? 'active' : ''"
-                title="{{::('source-' + s.type) | translate}}"
-                data-ng-click="selectSource(s)"
-                data-ng-repeat="s in filteredSources | filter:sourcesSearch | orderBy:'name'"
-              >
-                <i
-                  class="fa fa-fw"
-                  data-ng-class="{'fa-home': s.type === 'portal',
-                                   'fa-folder': s.type === 'subportal',
-                                   'fa-cloud': s.type === 'externalportal',
-                                   'fa-cloud-download': s.type === 'harvester'}"
-                ></i>
-                {{::s.name}}
-                <img
-                  class="gn-source-logo"
-                  data-ng-src="{{'../../images/' + (s.type === 'subportal' ? 'harvesting/' +  s.logo : 'logos/' +  s.uuid + '.png')}}"
-                />
-              </a>
-            </ul>
-          </div>
-          <button
-            type="button"
-            class="btn btn-primary btn-block"
-            id="gn-btn-source-add"
-            data-ng-click="addSubPortal()"
-            data-ng-show="user.isAdministrator()"
-          >
-            <i class="fa fa-plus" />
-            <span data-translate="">addSubPortal</span>
-          </button>
-
-          <br />
-          <div class="well" data-translate="">sources-help</div>
+            <a
+              class="list-group-item"
+              data-ng-class="s.uuid === source.uuid ? 'active' : ''"
+              title="{{::('source-' + s.type) | translate}}"
+              data-ng-click="selectSource(s)"
+              data-ng-repeat="s in filteredSources | filter:sourcesSearch | orderBy:'name'"
+            >
+              <i
+                class="fa fa-fw"
+                data-ng-class="{'fa-home': s.type === 'portal',
+                                 'fa-folder': s.type === 'subportal',
+                                 'fa-cloud': s.type === 'externalportal',
+                                 'fa-cloud-download': s.type === 'harvester'}"
+              ></i>
+              {{::s.name}}
+              <img
+                class="gn-source-logo"
+                data-ng-src="{{'../../images/' + (s.type === 'subportal' ? 'harvesting/' +  s.logo : 'logos/' +  s.uuid + '.png')}}"
+              />
+            </a>
+          </ul>
         </div>
-      </div>
+        <button
+          type="button"
+          class="btn btn-primary btn-block"
+          id="gn-btn-source-add"
+          data-ng-click="addSubPortal()"
+          data-ng-show="user.isAdministrator()"
+        >
+          <i class="fa fa-plus" />
+          <span data-translate="">addSubPortal</span>
+        </button>
 
-      <div data-gn-need-help="portal-configuration"></div>
+        <br />
+        <div class="well" data-translate="">sources-help</div>
+      </div>
     </div>
 
-    <div class="col-lg-8" data-ng-if="source">
-      <div class="panel panel-default">
-        <div class="panel-heading">
-          {{source.name}} ({{('source-' + source.type) | translate}})
-          <div class="btn-toolbar">
-            <button
-              type="button"
-              class="btn btn-primary pull-right"
-              data-ng-disabled="source.type === 'subportal' && !gnSourceForm.$valid"
-              data-ng-click="updateSource()"
-            >
-              <i class="fa fa-floppy-o"></i>&nbsp;
-              <span data-translate="">save</span>
-            </button>
-            <button
-              type="button"
-              class="btn btn-danger pull-right"
-              data-ng-disabled="source.type !== 'subportal' || (source.type === 'subportal' && !user.isAdministrator())"
-              data-gn-click-and-spin="removeSource()"
-            >
-              <i class="fa fa-times"></i>&nbsp;
-              <span data-translate="">removeSource</span>
-            </button>
-          </div>
+    <div data-gn-need-help="portal-configuration"></div>
+  </div>
+
+  <div class="col-lg-8" data-ng-if="source">
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        {{source.name}} ({{('source-' + source.type) | translate}})
+        <div class="btn-toolbar">
+          <button
+            type="button"
+            class="btn btn-primary pull-right"
+            data-ng-disabled="source.type === 'subportal' && !gnSourceForm.$valid"
+            data-ng-click="updateSource()"
+          >
+            <i class="fa fa-floppy-o"></i>&nbsp;
+            <span data-translate="">save</span>
+          </button>
+          <button
+            type="button"
+            class="btn btn-danger pull-right"
+            data-ng-disabled="source.type !== 'subportal' || (source.type === 'subportal' && !user.isAdministrator())"
+            data-ng-hide="isNew"
+            data-ng-click="deleteSourceConfig()"
+          >
+            <i class="fa fa-times"></i>&nbsp;
+            <span data-translate="">removeSource</span>
+          </button>
         </div>
-        <div class="panel-body">
-          <div data-ng-show="source.type === 'subportal'">
-            <form name="gnSourceForm">
-              <label data-translate="" class="gn-required">sourceUuid</label>
-              <input
-                type="text"
-                class="form-control"
-                data-ng-disabled="::!user.isAdministrator()"
-                data-ng-pattern="/^[A-Za-z0-9\-_]+$/"
-                data-ng-model="source.uuid"
-              />
-              <p class="help-block" data-translate="">sourceUuid-help</p>
+      </div>
+      <div class="panel-body">
+        <div data-ng-show="source.type === 'subportal'">
+          <form name="gnSourceForm">
+            <label data-translate="" class="gn-required">sourceUuid</label>
+            <input
+              type="text"
+              class="form-control"
+              data-ng-disabled="::!user.isAdministrator()"
+              data-ng-pattern="/^[A-Za-z0-9\-_]+$/"
+              data-ng-model="source.uuid"
+            />
+            <p class="help-block" data-translate="">sourceUuid-help</p>
 
-              <p
-                class="alert alert-info"
-                data-ng-if="source.uuid != ''"
-                data-translate=""
-                data-translate-values="{'uuid': source.uuid, 'lang': lang}"
-              >
-                sourceUrlInfo
-              </p>
-              <label data-translate="">sourceName</label>
-              <input
-                type="text"
-                class="form-control"
-                data-ng-pattern="/^[A-Za-z0-9\-_]+$/"
-                data-ng-model="source.name"
-              />
-              <p class="help-block" data-translate="">sourceName-help</p>
+            <p
+              class="alert alert-info"
+              data-ng-if="source.uuid != ''"
+              data-translate=""
+              data-translate-values="{'uuid': source.uuid, 'lang': lang}"
+            >
+              sourceUrlInfo
+            </p>
+            <label data-translate="">sourceName</label>
+            <input
+              type="text"
+              class="form-control"
+              data-ng-pattern="/^[A-Za-z0-9\-_]+$/"
+              data-ng-model="source.name"
+            />
+            <p class="help-block" data-translate="">sourceName-help</p>
 
-              <label data-translate="">sourceFilter</label>
-              <input type="text" class="form-control" data-ng-model="source.filter" />
-              <p class="help-block" data-translate="">sourceFilter-help</p>
-            </form>
+            <label data-translate="">sourceFilter</label>
+            <input type="text" class="form-control" data-ng-model="source.filter" />
+            <p class="help-block" data-translate="">sourceFilter-help</p>
+          </form>
 
-            <div>
-              <label data-translate="">sourceLogo</label>
+          <div>
+            <label data-translate="">sourceLogo</label>
 
-              <div class="row" data-ng-show="source.logo">
-                <div class="col-md-6 gn-nopadding-left">
-                  <img
-                    data-ng-show="source.logo"
-                    src="../../images/harvesting/{{ source.logo }}"
-                    class="img-thumbnail form-group"
-                    data-ng-attr-title="{{ source.logo }}"
-                  />
-                </div>
-                <div class="col-md-6 gn-nopadding-left">
-                  <a href="" data-ng-click="deleteSourceLogo()" class="text-danger">
-                    <i data-ng-show="source.logo" class="fa fa-times delete"></i>
-                  </a>
-                </div>
+            <div class="row" data-ng-show="source.logo">
+              <div class="col-md-6 gn-nopadding-left">
+                <img
+                  data-ng-show="source.logo"
+                  src="../../images/harvesting/{{ source.logo }}"
+                  class="img-thumbnail form-group"
+                  data-ng-attr-title="{{ source.logo }}"
+                />
               </div>
+              <div class="col-md-6 gn-nopadding-left">
+                <a href="" data-ng-click="deleteSourceLogo()" class="text-danger">
+                  <i data-ng-show="source.logo" class="fa fa-times delete"></i>
+                </a>
+              </div>
+            </div>
 
-              <!--Display logo picker from harvester logos-->
-              <div class="row" data-ng-show="queue.length == 0">
+            <!--Display logo picker from harvester logos-->
+            <div class="row" data-ng-show="queue.length == 0">
+              <div class="col-md-12 gn-nopadding-left gn-margin-bottom" translate>
+                selectExistingLogo
+              </div>
+              <div class="col-md-12 gn-nopadding-left gn-margin-bottom">
+                <div class="form-group" gn-logo-picker="source.logo"></div>
+              </div>
+            </div>
+
+            <!--Display logo upload input-->
+            <form
+              id="gn-group-edit"
+              name="gnGroupEdit"
+              method="POST"
+              data-file-upload="logoUploadOptions"
+              role="form"
+            >
+              <input type="hidden" name="_csrf" value="{{csrf}}" />
+              <div class="row" data-ng-show="!source.logo" id="group-logo-upload">
                 <div class="col-md-12 gn-nopadding-left gn-margin-bottom" translate>
-                  selectExistingLogo
+                  addNewLogo
                 </div>
-                <div class="col-md-12 gn-nopadding-left gn-margin-bottom">
-                  <div class="form-group" gn-logo-picker="source.logo"></div>
-                </div>
-              </div>
-
-              <!--Display logo upload input-->
-              <form
-                id="gn-group-edit"
-                name="gnGroupEdit"
-                method="POST"
-                data-file-upload="logoUploadOptions"
-                role="form"
-              >
-                <input type="hidden" name="_csrf" value="{{csrf}}" />
-                <div class="row" data-ng-show="!source.logo" id="group-logo-upload">
-                  <div class="col-md-12 gn-nopadding-left gn-margin-bottom" translate>
-                    addNewLogo
-                  </div>
-                  <div class="col-md-12 gn-nopadding-left gn-nopadding-right">
-                    <div class="panel panel-default">
-                      <div class="panel-heading" data-translate="">upload</div>
-                      <div class="panel-body">
-                        <span class="btn btn-success btn-block fileinput-button">
-                          <i class="fa fa-plus fa-white"></i>
-                          <span data-translate="">chooseLogos</span>
-                          <input type="file" id="source-logo" name="file" />
-                        </span>
-                        <ul style="list-style: none">
-                          <li data-ng-repeat="file in queue">
-                            <div class="preview" data-file-upload-preview="file"></div>
-                            {{file.name}} ({{file.type}} / {{file.size | formatFileSize}})
-                            <i class="fa fa-trash-o" data-ng-click="clear(file)"></i>
-                          </li>
-                        </ul>
-                      </div>
+                <div class="col-md-12 gn-nopadding-left gn-nopadding-right">
+                  <div class="panel panel-default">
+                    <div class="panel-heading" data-translate="">upload</div>
+                    <div class="panel-body">
+                      <span class="btn btn-success btn-block fileinput-button">
+                        <i class="fa fa-plus fa-white"></i>
+                        <span data-translate="">chooseLogos</span>
+                        <input type="file" id="source-logo" name="file" />
+                      </span>
+                      <ul style="list-style: none">
+                        <li data-ng-repeat="file in queue">
+                          <div class="preview" data-file-upload-preview="file"></div>
+                          {{file.name}} ({{file.type}} / {{file.size | formatFileSize}})
+                          <i class="fa fa-trash-o" data-ng-click="clear(file)"></i>
+                        </li>
+                      </ul>
                     </div>
                   </div>
                 </div>
-              </form>
+              </div>
+            </form>
 
-              <p class="help-block" data-translate="">sourceLogo-help</p>
-            </div>
-
-            <label data-translate="">sourceUiConfig</label>
-            <select
-              id="uiConfigurationList"
-              class="form-control"
-              data-ng-options="c.id as c.id for (key, c) in uiConfigurations | orderBy: 'id'"
-              data-ng-model="source.uiConfig"
-            ></select>
-            <p class="help-block" data-translate="">sourceUiConfig-help</p>
-
-            <div>
-              <label for="serviceList"
-                >{{'system/csw/capabilityRecordUuid' | translate}}</label
-              >
-
-              <div
-                data-gn-suggest="serviceRecordSearchObj"
-                data-gn-suggest-model="source.serviceRecord"
-                data-gn-suggest-property="_id"
-                data-gn-suggest-display-title="span"
-              />
-
-              <p class="help-block">
-                {{'system/csw/capabilityRecordUuid-help' | translate}}
-              </p>
-            </div>
-
-            <div data-ng-show="groups.length">
-              <label class="control-label" data-translate="">subPortalGroupOwner</label>
-              <div
-                data-groups-combo=""
-                data-owner-group="source.groupOwner"
-                data-set-default-value="false"
-                data-optional="{{::$parent.user.isAdministrator()}}"
-                lang="lang"
-                groups="groups"
-                data-exclude-special-groups="true"
-              />
-
-              <p class="help-block" data-translate="">subPortalGroupOwnerHelp</p>
-            </div>
+            <p class="help-block" data-translate="">sourceLogo-help</p>
           </div>
 
-          <table class="table table-striped">
-            <tr data-ng-repeat="(key, value) in source.label">
-              <td>{{key | translate}}</td>
-              <td>
-                <input
-                  type="text"
-                  class="form-control"
-                  value="{{value}}"
-                  data-ng-model="source.label[key]"
-                />
-              </td>
-            </tr>
-          </table>
+          <label data-translate="">sourceUiConfig</label>
+          <select
+            id="uiConfigurationList"
+            class="form-control"
+            data-ng-options="c.id as c.id for (key, c) in uiConfigurations | orderBy: 'id'"
+            data-ng-model="source.uiConfig"
+          ></select>
+          <p class="help-block" data-translate="">sourceUiConfig-help</p>
+
+          <div>
+            <label for="serviceList"
+              >{{'system/csw/capabilityRecordUuid' | translate}}</label
+            >
+
+            <div
+              data-gn-suggest="serviceRecordSearchObj"
+              data-gn-suggest-model="source.serviceRecord"
+              data-gn-suggest-property="_id"
+              data-gn-suggest-display-title="span"
+            />
+
+            <p class="help-block">
+              {{'system/csw/capabilityRecordUuid-help' | translate}}
+            </p>
+          </div>
+
+          <div data-ng-show="groups.length">
+            <label class="control-label" data-translate="">subPortalGroupOwner</label>
+            <div
+              data-groups-combo=""
+              data-owner-group="source.groupOwner"
+              data-set-default-value="false"
+              data-optional="{{::$parent.user.isAdministrator()}}"
+              lang="lang"
+              groups="groups"
+              data-exclude-special-groups="true"
+            />
+
+            <p class="help-block" data-translate="">subPortalGroupOwnerHelp</p>
+          </div>
         </div>
+
+        <table class="table table-striped">
+          <tr data-ng-repeat="(key, value) in source.label">
+            <td>{{key | translate}}</td>
+            <td>
+              <input
+                type="text"
+                class="form-control"
+                value="{{value}}"
+                data-ng-model="source.label[key]"
+              />
+            </td>
+          </tr>
+        </table>
       </div>
     </div>
+  </div>
+
+  <div
+    gn-modal
+    class="gn-confirm-delete"
+    gn-popup-options="{title: 'confirmDialogTitle', confirmCallback: confirmDeleteSourceConfig}"
+    id="gn-confirm-remove-source"
+  >
+    <p translate>confirmSourceDelete</p>
   </div>
 </div>

--- a/web-ui/src/main/resources/catalog/templates/admin/settings/sources.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/settings/sources.html
@@ -4,7 +4,7 @@
       <div class="panel-heading" data-translate="">manageSources</div>
       <div class="panel-body">
         <div class="list-group">
-          <ul class="list-group">
+          <ul class="list-group gn-nopadding-right">
             <input
               class="form-control"
               data-ng-show="sources.length > 1"
@@ -13,7 +13,7 @@
               placeholder="{{'filter' | translate}}"
             />
 
-            <div class="row">
+            <div class="row gn-margin-bottom gn-margin-to">
               <div class="col-md-3" data-ng-repeat="(k, v) in filter.types">
                 <label title="{{::('source-' + k) | translate}}">
                   <input

--- a/web-ui/src/main/resources/catalog/templates/admin/settings/sources.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/settings/sources.html
@@ -108,6 +108,7 @@
               type="text"
               class="form-control"
               data-ng-required="true"
+              data-ng-readonly="!isNew"
               data-ng-disabled="::!user.isAdministrator()"
               data-ng-pattern="/^[A-Za-z0-9\-_]+$/"
               data-ng-model="source.uuid"

--- a/web-ui/src/main/resources/catalog/templates/admin/settings/sources.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/settings/sources.html
@@ -82,7 +82,7 @@
           <button
             type="button"
             class="btn btn-primary pull-right"
-            data-ng-disabled="source.type === 'subportal' && !gnSourceForm.$valid"
+            data-ng-disabled="source.type === 'subportal' && !gnSourceForm.$valid && !gnSourceForm.dirty"
             data-ng-click="updateSource()"
           >
             <i class="fa fa-floppy-o"></i>&nbsp;
@@ -107,6 +107,7 @@
             <input
               type="text"
               class="form-control"
+              data-ng-required="true"
               data-ng-disabled="::!user.isAdministrator()"
               data-ng-pattern="/^[A-Za-z0-9\-_]+$/"
               data-ng-model="source.uuid"
@@ -124,6 +125,7 @@
             <label data-translate="">sourceName</label>
             <input
               type="text"
+              data-ng-required="true"
               class="form-control"
               data-ng-pattern="/^[A-Za-z0-9\-_]+$/"
               data-ng-model="source.name"


### PR DESCRIPTION
Delete map server, sources and metadata template identifiers actions were not requesting confirmation, updated to display a confirmation dialog.

![delete-mapserver](https://user-images.githubusercontent.com/1695003/198035019-23dea68e-ddc1-44c6-801a-5c3c7f581bb0.png)

Also sources and metadata template identifiers pages were displaying the `Delete` button when creating a new source.

Fixed sources page logic:

- Cleanup the form when a source is deleted.
- Make identifier and name mandatory.
- Don't allow to change the identifier when editing a source, as it's used as the internal key.