### PR TITLE
Startup / Don't fail on a wrong harvester config

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/HarvestManagerImpl.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/HarvestManagerImpl.java
@@ -135,10 +135,19 @@ public class HarvestManagerImpl implements HarvestInfoProvider, HarvestManager {
 
             if (entries != null) {
                 for (Object o : entries.getChildren()) {
-                    Element node = transform((Element) o);
+                    Element node = null;
+                    try {
+                        node = transform((Element) o);
+                    } catch (Exception oae) {
+                        Log.error(Geonet.HARVEST_MAN, "Cannot read harvester configuration.", oae);
+                    }
+
+                    if (node == null) {
+                        continue;
+                    }
+
                     String type = node.getAttributeValue("type");
                     String id = node.getAttributeValue("id");
-
                     try {
                         AbstractHarvester ah = AbstractHarvester.create(type, context);
                         ah.init(node, context);
@@ -148,7 +157,6 @@ public class HarvestManagerImpl implements HarvestInfoProvider, HarvestManager {
                         Log.error(Geonet.HARVEST_MAN, "Cannot create harvester " + id + " of type \""
                             + type + "\"", oae);
                     }
-
                 }
             }
         }


### PR DESCRIPTION
When starting the catalogue on various database, user may end up on a database with wrong harvester config or unsupported harvester (eg. below a dcatap harvester unsupported). Don't break the startup in this case. Only the harvester can not be created.


Instead of having the red startup error:
```    
java.nio.file.NoSuchFileException: /data/dev/gn/aiv/web/src/main/webapp/xsl/xml/harvesting/dcatap.xsl
	at sun.nio.fs.UnixException.translateToIOException(UnixException.java:86)
	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:102)
	at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:107)
	at sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:214)
	at java.nio.file.Files.newByteChannel(Files.java:361)
	at java.nio.file.Files.newByteChannel(Files.java:407)
	at java.nio.file.spi.FileSystemProvider.newInputStream(FileSystemProvider.java:384)
	at java.nio.file.Files.newInputStream(Files.java:152)
	at org.fao.geonet.utils.IO.newInputStream(IO.java:335)
	at org.fao.geonet.utils.Xml.transform(Xml.java:494)
	at org.fao.geonet.utils.Xml.transform(Xml.java:383)
	at org.fao.geonet.kernel.harvest.HarvestManagerImpl.transform(HarvestManagerImpl.java:182)
	at org.fao.geonet.kernel.harvest.HarvestManagerImpl.init(HarvestManagerImpl.java:138)
	at org.fao.geonet.Geonetwork.start(Geonetwork.java:279)
```
	

log the harvester creation error in the log and continue startup process
```	
2022-10-26T15:21:32,439 ERROR [geonetwork.harvest-man] - Cannot read harvester configuration.
java.nio.file.NoSuchFileException: /data/dev/gn/aiv/web/src/main/webapp/xsl/xml/harvesting/dcatap.xsl
```


