### PR TITLE
Logging / Avoid exception on windows

### DIFF
--- a/web/src/main/webapp/WEB-INF/classes/log4j2-dev.xml
+++ b/web/src/main/webapp/WEB-INF/classes/log4j2-dev.xml
@@ -20,7 +20,7 @@
       <Routes pattern="$${ctx:logfile}">
         <!-- value dynamically determines the name of the log file. -->
         <Route>
-          <File name="harvester-${ctx:harvester}" fileName="${sys:log_dir:-log_dir}/${ctx:logfile}">
+          <File name="harvester-${ctx:harvester}" fileName="${sys:log_dir:-log_dir}/${ctx:logfile:-harvester_default.log}">
             <PatternLayout>
               <pattern>%date{ISO8601}{${ctx:timeZone}} %-5level [%logger] - %message%n</pattern>
             </PatternLayout>

--- a/web/src/main/webapp/WEB-INF/classes/log4j2.xml
+++ b/web/src/main/webapp/WEB-INF/classes/log4j2.xml
@@ -20,7 +20,7 @@
       <Routes pattern="$${ctx:logfile}">
         <!-- value dynamically determines the name of the log file. -->
         <Route>
-          <File name="harvester-${ctx:harvester}" fileName="${sys:log_dir:-log_dir}/${ctx:logfile}">
+          <File name="harvester-${ctx:harvester}" fileName="${sys:log_dir:-log_dir}/${ctx:logfile:-harvester-default.log}">
             <PatternLayout>
               <pattern>%date{ISO8601}{${ctx:timeZone}} %-5level [%logger] - %message%n</pattern>
             </PatternLayout>

--- a/web/src/main/webapp/WEB-INF/classes/log4j2.xml
+++ b/web/src/main/webapp/WEB-INF/classes/log4j2.xml
@@ -20,7 +20,7 @@
       <Routes pattern="$${ctx:logfile}">
         <!-- value dynamically determines the name of the log file. -->
         <Route>
-          <File name="harvester-${ctx:harvester}" fileName="${sys:log_dir:-log_dir}/${ctx:logfile:-harvester-default.log}">
+          <File name="harvester-${ctx:harvester}" fileName="${sys:log_dir:-log_dir}/${ctx:logfile:-harvester_default.log}">
             <PatternLayout>
               <pattern>%date{ISO8601}{${ctx:timeZone}} %-5level [%logger] - %message%n</pattern>
             </PatternLayout>


### PR DESCRIPTION
```
2022-10-26 15:28:35,416 main ERROR FileManager (./logs/${ctx:logfile}) java.io.IOException: The filename, directory name, or volume label syntax is incorrect java.io.IOException: The filename, directory name, or volume label syntax is incorrect
    at java.io.WinNTFileSystem.canonicalize0(Native Method)
    at java.io.WinNTFileSystem.canonicalize(WinNTFileSystem.java:485)
    at java.io.File.getCanonicalPath(File.java:626)    
```

Add a default value when the context does not set the variable.

Before
![image](https://user-images.githubusercontent.com/1701393/198267669-44eff7a7-d8ac-4be8-a80a-e0a1c360f4b7.png)

After an harvester-default.log is created instead.
![image](https://user-images.githubusercontent.com/1701393/198267684-da5343bf-e2eb-47ec-a5b0-dfbacb1be526.png)
