### PR TITLE
Database / Group / Increase size for name

### DIFF
--- a/domain/src/main/java/org/fao/geonet/domain/Group.java
+++ b/domain/src/main/java/org/fao/geonet/domain/Group.java
@@ -121,7 +121,7 @@ public class Group extends Localized implements Serializable {
      *
      * @return group name
      */
-    @Column(nullable = false, length = 32)
+    @Column(nullable = false, length = 255)
     public String getName() {
         return _name;
     }


### PR DESCRIPTION
Some users have group name with more than 32 characters.