### PR TITLE
Formatter / Set default value for collapsed state

### DIFF
--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
@@ -546,8 +546,8 @@
   <!-- Render metadata elements defined by XPath -->
   <xsl:template mode="render-view" match="@xpath">
     <xsl:param name="base" select="$metadata"/>
-    <xsl:param name="collapsible" as="xs:boolean" required="no"/>
-    <xsl:param name="collapsed" as="xs:boolean" required="no"/>
+    <xsl:param name="collapsible" as="xs:boolean" select="true()" required="no"/>
+    <xsl:param name="collapsed" as="xs:boolean" select="false()" required="no"/>
 
     <!-- Matching nodes -->
     <xsl:variable name="nodes">


### PR DESCRIPTION
Related https://github.com/geonetwork/core-geonetwork/pull/6629

It does not apply to formatter which is not collapsible. Set default values.


Avoid error
```
Error at xsl:param on line 549 of render-layout.xsl:
  XTDE0610: A value must be supplied for the parameter because the default value is not a
  valid instance of the required type
```