### PR TITLE
Fix JS error when the relations for a metadata return null when no relations of a type exists

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -77,11 +77,15 @@
                 scope.lang,
                 gnCurrentEdit.mdLanguage
               );
-              scope.relations = scope.isOverview
-                ? res.relations[scope.type]
-                : res.relations[scope.type].filter(function (l) {
+              if (angular.isArray(res.relations[scope.type])) {
+                scope.relations = scope.isOverview
+                  ? res.relations[scope.type]
+                  : res.relations[scope.type].filter(function (l) {
                     return l.protocol === scope.protocol;
                   });
+              } else {
+                scope.relations = {};
+              }
             });
           };
 


### PR DESCRIPTION
When creating an iso19139 metadata the following error is logged. 

```
angular.js?v=8c345ce00e4a76478767ac2d698810682180b3c3:14199 TypeError: Cannot read properties of null (reading 'filter')
    at OnlineSrcDirective.js:82:47
    at processQueue (angular.js?v=8c345ce00e4a76478767ac2d698810682180b3c3:16696:28)
    at angular.js?v=8c345ce00e4a76478767ac2d698810682180b3c3:16712:27
    at Scope.$eval (angular.js?v=8c345ce00e4a76478767ac2d698810682180b3c3:17994:28)
    at Scope.$digest (angular.js?v=8c345ce00e4a76478767ac2d698810682180b3c3:17808:31)
    at Scope.$apply (angular.js?v=8c345ce00e4a76478767ac2d698810682180b3c3:18102:24)
    at done (angular.js?v=8c345ce00e4a76478767ac2d698810682180b3c3:12082:47)
    at completeRequest (angular.js?v=8c345ce00e4a76478767ac2d698810682180b3c3:12291:7)
    at XMLHttpRequest.requestLoaded (angular.js?v=8c345ce00e4a76478767ac2d698810682180b3c
```

Related to this change fa94eb6a, done to unify the related response for empty relations. The change looks ok to unify the responses, although `iso19115-3.2018` doesn't have that change.

This change checks if the relations response is an array or not to apply the correct logic.