### PR TITLE
Add bootstrap-table-export to wro lib module and fix file path in lib3d to use the file in dist folder

### DIFF
--- a/web-ui/src/main/resources/WEB-INF/classes/web-ui-wro-sources.xml
+++ b/web-ui/src/main/resources/WEB-INF/classes/web-ui-wro-sources.xml
@@ -86,7 +86,12 @@
             minimize="false"/>
     <jsSource webappPath="/catalog/lib/bootstrap-table-angular.js"
               minimize="false"/>
-    <jsSource webappPath="/catalog/lib/bootstrap-table/dist/extensions/filter-control/bootstrap-table-filter-control.min.js" />
+    <jsSource webappPath="/catalog/lib/bootstrap-table/dist/extensions/filter-control/bootstrap-table-filter-control.min.js"
+              minimize="false"/>
+    <jsSource webappPath="/catalog/lib/tableExport/tableExport.min.js"
+              minimize="false"/>
+    <jsSource webappPath="/catalog/lib/bootstrap-table/dist/extensions/export/bootstrap-table-export.min.js"
+              minimize="false"/>
     <jsSource webappPath="/catalog/lib/zip/zip.js"/>
     <jsSource webappPath="/catalog/lib/zip/include.js"/>
     <jsSource webappPath="/catalog/lib/base64.js"/>
@@ -153,13 +158,15 @@
               minimize="false"/>
     <jsSource webappPath="/catalog/lib/bootstrap-table/dist/bootstrap-table-locale-all.min.js"
               minimize="false"/>
-    <jsSource webappPath="/catalog/lib/bootstrap-table/dist/extensions/filter-control/bootstrap-table-filter-control.min.js" />
     <jsSource webappPath="/catalog/lib/bootstrap-table-angular.js"
               minimize="false"/>
     <jsSource webappPath="/catalog/lib/FileSaver/FileSaver.min.js" minimize="false"/>
-    <jsSource webappPath="/catalog/lib/tableExport/tableExport.min.js" minimize="false"/>
-    <jsSource
-      webappPath="/catalog/lib/bootstrap-table/src/extensions/export/bootstrap-table-export.js"/>
+    <jsSource webappPath="/catalog/lib/bootstrap-table/dist/extensions/filter-control/bootstrap-table-filter-control.min.js"
+              minimize="false"/>
+    <jsSource webappPath="/catalog/lib/tableExport/tableExport.min.js"
+              minimize="false"/>
+    <jsSource webappPath="/catalog/lib/bootstrap-table/dist/extensions/export/bootstrap-table-export.min.js"
+              minimize="false"/>
     <jsSource webappPath="/catalog/lib/zip/zip.js"/>
     <jsSource webappPath="/catalog/lib/zip/include.js"/>
     <jsSource webappPath="/catalog/lib/base64.js"/>


### PR DESCRIPTION
In `3.12.x`, enabling the 3d mode in the UI settings:

![allow-3d-mode](https://user-images.githubusercontent.com/1695003/199071807-c1aa2beb-1f83-478b-820c-ef01f8707c0a.png)

, the following error happens, preventing to load the application:

```
Uncaught TypeError: Class constructors cannot be invoked without 'new'
    at lib3d.js?v=ff01ad3afbd8bf0fe6cbc0f240246ff6ec82705f:7920:1
lib3d.js?v=ff01ad3afbd8bf0fe6cbc0f240246ff6ec82705f:3888 Uncaught Error: [$injector:modulerr] http://errors.angularjs.org/1.5.2/$injector/modulerr?p0=gn_search_dutch&p1=Error%3A%20%5B%24injector%3Amodulerr%5D%20http%3A%2F%2Ferrors.angularjs.org%2F1.5.2%2F%24injector%2Fmodulerr%3Fp0%3Dgn_search%26p1%3DError%253A%2520%255B%2524injector%253Amodulerr%255D%2520http%253A%252F%252Ferrors.angularjs.org%252F1.5.2%252F%2524injector%252Fmodulerr%253Fp0%253Dgn_mdview%2526p1%253DError%25253A%252520%25255B%25252
```

In the application log:

```
Oct 31, 2022 6:14:35 PM com.google.javascript.jscomp.LoggerErrorManager println
SEVERE: file:/private/tmp/geonetwork-enterprise-test/enterprise/webapp/target/resources/catalog/lib/bootstrap-table/src/extensions/export/bootstrap-table-export.js:211: ERROR - this language feature is only supported in es6 mode: short function syntax. Use --language_in=ECMASCRIPT6 or ECMASCRIPT6_STRICT to enable ES6 features.
        $.each($footerRow.children(), (index, footerCell) => {
```

Updated to use the file from the `dist` folder, also synch `lib` and `lib3d` dependencies. Checked `main` branch and the path is ok in that branch.

It seems related to the update of `bootstrap-table`, see https://github.com/geonetwork/core-geonetwork/pull/6636