### PR TITLE
changes for WMTS /extents.png and /geom.png

### DIFF
--- a/core/src/main/java/org/fao/geonet/lib/NetLib.java
+++ b/core/src/main/java/org/fao/geonet/lib/NetLib.java
@@ -1,5 +1,5 @@
 //=============================================================================
-//===	Copyright (C) 2001-2007 Food and Agriculture Organization of the
+//===	Copyright (C) 2001-2022 Food and Agriculture Organization of the
 //===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
 //===	and United Nations Environment Programme (UNEP)
 //===
@@ -164,6 +164,8 @@ public class NetLib {
             Properties props = System.getProperties();
             props.put("http.proxyHost", host);
             props.put("http.proxyPort", port);
+            props.put("https.proxyHost", host);
+            props.put("https.proxyPort", port);
             props.put("http.nonProxyHosts", ignoreHostList);
 
             if (username.trim().length() > 0) {
@@ -172,6 +174,8 @@ public class NetLib {
         } else {
             System.clearProperty("http.proxyHost");
             System.clearProperty("http.proxyHost");
+            System.clearProperty("https.proxyHost");
+            System.clearProperty("https.proxyHost");
             System.clearProperty("http.nonProxyHosts");
         }
     }

--- a/core/src/main/java/org/fao/geonet/lib/NetLib.java
+++ b/core/src/main/java/org/fao/geonet/lib/NetLib.java
@@ -173,9 +173,9 @@ public class NetLib {
             }
         } else {
             System.clearProperty("http.proxyHost");
-            System.clearProperty("http.proxyHost");
+            System.clearProperty("http.proxyPort");
             System.clearProperty("https.proxyHost");
-            System.clearProperty("https.proxyHost");
+            System.clearProperty("https.proxyPort");
             System.clearProperty("http.nonProxyHosts");
         }
     }

--- a/pom.xml
+++ b/pom.xml
@@ -1540,7 +1540,7 @@
 
     <!-- NOTE: When updating GeoTools, check which version
     of Postgres is used and update pg.version if needed. -->
-    <geotools.version>27.1</geotools.version>
+    <geotools.version>28-RC</geotools.version>
     <jts.version>1.18.2</jts.version>
     <pg.version>42.3.3</pg.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1540,7 +1540,7 @@
 
     <!-- NOTE: When updating GeoTools, check which version
     of Postgres is used and update pg.version if needed. -->
-    <geotools.version>28-RC</geotools.version>
+    <geotools.version>28.0</geotools.version>
     <jts.version>1.18.2</jts.version>
     <pg.version>42.3.3</pg.version>
 

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -178,6 +178,16 @@
       <artifactId>gt-xsd-wfs</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-wmts</artifactId>
+      <version>${geotools.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.geotools</groupId>
+      <artifactId>gt-epsg-hsql</artifactId>
+      <version>${geotools.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot</artifactId>
     </dependency>

--- a/services/src/main/java/org/fao/geonet/api/records/extent/BaseMapRenderer.java
+++ b/services/src/main/java/org/fao/geonet/api/records/extent/BaseMapRenderer.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (C) 2022 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+package org.fao.geonet.api.records.extent;
+
+import jeeves.server.context.ServiceContext;
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.utils.Log;
+import org.locationtech.jts.geom.Envelope;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+
+/**
+ * Root class that hides the difference between the various background images (i.e. WMT GetMap or WMTS GetTile).
+ */
+public class BaseMapRenderer {
+
+    //TODO: make this spring injectable, but not necessary at the moment.
+    //      either make these factories, or add complexity so they don't need state
+    BaseMapRenderingEngine[] baseMapRenderingEngines = new BaseMapRenderingEngine[]{
+        new GetMapBaseMapRenderer(),
+        new WMTSBaseMapRenderer()
+    };
+    /**
+     * either a URL for a WMS (cf GetMapBaseMapRenderer)
+     * or a JSON config for a WMTS (cf WMTSBaseMapRenderer)
+     */
+    String configuration;
+    // area of interest
+    Envelope bbox;
+    //SRS of the request (ie EPSG:3857)
+    String srs;
+    //size of the image
+    Dimension imageDimensions;
+    //context of the web app (used for http proxy)
+    ServiceContext context;
+
+
+    public BaseMapRenderer(String configuration) {
+        this.configuration = configuration;
+    }
+
+    /**
+     * fluent api for setting the bbox of the AOI
+     *
+     * @param bbox
+     * @return
+     */
+    public BaseMapRenderer bbox(Envelope bbox) {
+        this.bbox = bbox;
+        return this;
+    }
+
+    /**
+     * fluent api for setting the size of the image
+     *
+     * @param imageDimensions
+     * @return
+     */
+    public BaseMapRenderer imageDimensions(Dimension imageDimensions) {
+        this.imageDimensions = imageDimensions;
+        return this;
+    }
+
+    /**
+     * fluent api for setting the SRS to use in the requests
+     *
+     * @param srs
+     * @return
+     */
+    public BaseMapRenderer srs(String srs) {
+        this.srs = srs;
+        return this;
+    }
+
+    /**
+     * fluent api for setting the web servicecontext
+     *
+     * @param context
+     * @return
+     */
+    public BaseMapRenderer context(ServiceContext context) {
+        this.context = context;
+        return this;
+    }
+
+    /**
+     * renders the background image (will retrieve from the internet).
+     * Hands off the work to either the GetMapBaseMapRenderer or WMTSBaseMapRenderer
+     *
+     * @return
+     * @throws Exception
+     */
+    public BufferedImage render() throws Exception {
+        try {
+            for (BaseMapRenderingEngine engine : baseMapRenderingEngines) {
+                if (engine.canHandle(configuration)) {
+                    engine.configure(configuration, bbox, srs, imageDimensions, context);
+                    return engine.render();
+                }
+            }
+            throw new Exception("didn't understand configuration (BaseMapRenderer) - " + configuration);
+        } catch (Exception e) {
+            Log.debug(Geonet.SPATIAL, "error occurred during BaseMapRender - " + e + " (IGNORED)");
+            return new BufferedImage(imageDimensions.width, imageDimensions.height, BufferedImage.TYPE_INT_ARGB);
+        }
+    }
+}

--- a/services/src/main/java/org/fao/geonet/api/records/extent/BaseMapRenderingEngine.java
+++ b/services/src/main/java/org/fao/geonet/api/records/extent/BaseMapRenderingEngine.java
@@ -1,0 +1,30 @@
+package org.fao.geonet.api.records.extent;
+
+import jeeves.server.context.ServiceContext;
+import org.locationtech.jts.geom.Envelope;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+
+/**
+ * interface for rendering base maps.
+ */
+public interface BaseMapRenderingEngine {
+
+    /**
+     * return true if this renderer can handle this configuration
+     *
+     * @param configString
+     * @return
+     */
+    boolean canHandle(String configString);
+
+    void configure(String configString,
+                   Envelope bbox,
+                   String srs,
+                   Dimension imageDimensions,
+                   ServiceContext context) throws Exception;
+
+    BufferedImage render() throws Exception;
+
+}

--- a/services/src/main/java/org/fao/geonet/api/records/extent/BaseMapRenderingEngine.java
+++ b/services/src/main/java/org/fao/geonet/api/records/extent/BaseMapRenderingEngine.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (C) 2022 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
 package org.fao.geonet.api.records.extent;
 
 import jeeves.server.context.ServiceContext;

--- a/services/src/main/java/org/fao/geonet/api/records/extent/GetMapBaseMapRenderer.java
+++ b/services/src/main/java/org/fao/geonet/api/records/extent/GetMapBaseMapRenderer.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2022 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+package org.fao.geonet.api.records.extent;
+
+import jeeves.server.context.ServiceContext;
+import org.apache.commons.io.IOUtils;
+import org.fao.geonet.lib.Lib;
+import org.locationtech.jts.geom.Envelope;
+
+import javax.imageio.ImageIO;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.net.URLConnection;
+
+
+/**
+ * This handles rendering a BaseMap based on a pre-configured WMS request.
+ * The configuration URL will have the following placeholders replaced with actual values;
+ * <p>
+ * {minx} and {MINX}
+ * {miny} and {MINY}
+ * {maxx} and {MAXX}
+ * {maxy} and {MAXY}
+ * {srs}  and {SRS}
+ * {width} and {WIDTH}
+ * {height} and {HEIGHT}
+ * <p>
+ * with the necessary values.
+ * <p>
+ * For example, the URL might look like this;
+ * https://ows.terrestris.de/osm/service?SERVICE=WMS&REQUEST=GetMap&VERSION=1.1.0&LAYERS=OSM-WMS&STYLES=default&SRS={srs}&BBOX={minx},{miny},{maxx},{maxy}&WIDTH={width}&HEIGHT={height}&FORMAT=image/png
+ */
+public class GetMapBaseMapRenderer implements BaseMapRenderingEngine {
+
+    String url;
+    Envelope bbox;
+    String srs;
+    Dimension imageDimensions;
+    ServiceContext context;
+
+    public GetMapBaseMapRenderer() {
+
+    }
+
+    @Override
+    public boolean canHandle(String configString) {
+        return configString.toLowerCase().startsWith("http");
+    }
+
+    public void configure(String configuration,
+                          Envelope bbox,
+                          String srs,
+                          Dimension imageDimensions,
+                          ServiceContext context) throws Exception {
+
+        if (configuration == null)
+            throw new Exception("GetMapBaseMapRenderer: null url/configuration");
+        if (bbox == null)
+            throw new Exception("GetMapBaseMapRenderer: null ubboxrl");
+        if (srs == null)
+            throw new Exception("GetMapBaseMapRenderer: null srs");
+        if (imageDimensions == null)
+            throw new Exception("GetMapBaseMapRenderer: null imageDimensions");
+
+
+        this.url = configuration;
+        this.bbox = bbox;
+        this.srs = srs;
+        this.imageDimensions = imageDimensions;
+        this.context = context;
+    }
+
+    /**
+     * creates a BufferedImage by downloading the (modified) URL
+     *
+     * @return
+     * @throws Exception
+     */
+    public BufferedImage render() throws Exception {
+        URL url = createURL();
+        InputStream in = null;
+        BufferedImage image;
+        try {
+            // Setup the proxy for the request if required
+            URLConnection conn = Lib.net.setupProxy(context, url);
+            in = conn.getInputStream();
+            BufferedImage original = ImageIO.read(in);
+            image = new BufferedImage(original.getWidth(), original.getHeight(), BufferedImage.TYPE_INT_ARGB);
+            Graphics2D g2d = image.createGraphics();
+            g2d.drawImage(original, 0, 0, null);
+            return image;
+        } finally {
+            if (in != null) {
+                IOUtils.closeQuietly(in);
+            }
+        }
+    }
+
+    /**
+     * replaces the URL placeholders with real values
+     *
+     * @return
+     * @throws MalformedURLException
+     */
+    URL createURL() throws MalformedURLException {
+        String _url = url;
+        _url = _url.replace("{minx}", Double.toString(bbox.getMinX()))
+            .replace("{maxx}", Double.toString(bbox.getMaxX()))
+            .replace("{miny}", Double.toString(bbox.getMinY()))
+            .replace("{maxy}", Double.toString(bbox.getMaxY()))
+            .replace("{srs}", srs)
+            .replace("{width}", Integer.toString(imageDimensions.width))
+            .replace("{height}", Integer.toString(imageDimensions.height))
+            .replace("{MINX}", Double.toString(bbox.getMinX()))
+            .replace("{MAXX}", Double.toString(bbox.getMaxX()))
+            .replace("{MINY}", Double.toString(bbox.getMinY()))
+            .replace("{MAXY}", Double.toString(bbox.getMaxY()))
+            .replace("{SRS}", srs)
+            .replace("{WIDTH}", Integer.toString(imageDimensions.width))
+            .replace("{HEIGHT}", Integer.toString(imageDimensions.height));
+        return new URL(_url);
+    }
+
+
+}

--- a/services/src/main/java/org/fao/geonet/api/records/extent/MapRenderer.java
+++ b/services/src/main/java/org/fao/geonet/api/records/extent/MapRenderer.java
@@ -174,7 +174,7 @@ public class MapRenderer {
             // * request param is a full url
             if (background.equalsIgnoreCase(MetadataExtentApi.SETTING_BACKGROUND)) {
                 String bgSetting = settingManager.getValue(Settings.REGION_GETMAP_BACKGROUND);
-                if (bgSetting.startsWith("http://") || bgSetting.startsWith("https://")) {
+                if (bgSetting.startsWith("http://") || bgSetting.startsWith("https://") || bgSetting.startsWith("{")) {
                     background = settingManager.getValue(Settings.REGION_GETMAP_BACKGROUND);
                 } else if (regionGetMapBackgroundLayers.containsKey(bgSetting)) {
                     background = regionGetMapBackgroundLayers.get(bgSetting);

--- a/services/src/main/java/org/fao/geonet/api/records/extent/MapRenderer.java
+++ b/services/src/main/java/org/fao/geonet/api/records/extent/MapRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2022 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -53,6 +53,7 @@ import javax.imageio.ImageIO;
 import java.awt.*;
 import java.awt.geom.AffineTransform;
 import java.awt.image.BufferedImage;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -182,37 +183,18 @@ public class MapRenderer {
                 background = regionGetMapBackgroundLayers.get(background);
             }
 
-            String minx = Double.toString(bboxOfImage.getMinX());
-            String maxx = Double.toString(bboxOfImage.getMaxX());
-            String miny = Double.toString(bboxOfImage.getMinY());
-            String maxy = Double.toString(bboxOfImage.getMaxY());
-            background = background.replace("{minx}", minx).replace("{maxx}", maxx).replace("{miny}", miny)
-                .replace("{maxy}", maxy).replace("{srs}", srs)
-                .replace("{width}", Integer.toString(imageDimensions.width))
-                .replace("{height}", Integer.toString(imageDimensions.height)).replace("{MINX}", minx)
-                .replace("{MAXX}", maxx).replace("{MINY}", miny).replace("{MAXY}", maxy).replace("{SRS}", srs)
-                .replace("{WIDTH}", Integer.toString(imageDimensions.width))
-                .replace("{HEIGHT}", Integer.toString(imageDimensions.height));
+            BaseMapRenderer baseMapRenderer = new BaseMapRenderer(background);
+            baseMapRenderer
+                .srs(srs)
+                .bbox(bboxOfImage)
+                .imageDimensions(imageDimensions)
+                .context(context)
+                ;
 
-            InputStream in = null;
-            try {
-                URL imageUrl = new URL(background);
-                // Setup the proxy for the request if required
-                URLConnection conn = Lib.net.setupProxy(context, imageUrl);
-                in = conn.getInputStream();
-                BufferedImage original = ImageIO.read(in);
-                image = new BufferedImage(original.getWidth(), original.getHeight(), BufferedImage.TYPE_INT_ARGB);
-                Graphics2D g2d = image.createGraphics();
-                g2d.drawImage(original, 0, 0, null);
-            } catch (IOException e) {
-                image = new BufferedImage(imageDimensions.width, imageDimensions.height, BufferedImage.TYPE_INT_ARGB);
-                error = e;
-            } finally {
-                if (in != null) {
-                    IOUtils.closeQuietly(in);
-                }
+            BufferedImage baseMapImage = baseMapRenderer.render();
+           // ImageIO.write(baseMapImage, "png", new File("delme.png"));
 
-            }
+            image = baseMapImage;
         } else {
             image = new BufferedImage(imageDimensions.width, imageDimensions.height, BufferedImage.TYPE_INT_ARGB);
         }

--- a/services/src/main/java/org/fao/geonet/api/records/extent/WMTSBaseMapRenderer.java
+++ b/services/src/main/java/org/fao/geonet/api/records/extent/WMTSBaseMapRenderer.java
@@ -41,7 +41,7 @@ import java.util.Map;
  * wmtsGetCapabilitiesURL - (required) URL to the GetCapabilities for the WMTS service
  * layerName - (required)  Name of the layer to use (in the WMTS GetCapabilities)
  * <p>
- * matrixSet - (optional, default is the same as SRID) Name of the WMTS GetCapabilities matrixSet to use (hardcoded)
+ * matrixSet - (optional, default is the same as SRID) Name of the WMTS GetCapabilities matrixSet to use (hardcoded for all requests)
  * SRID2MatrixSet - (optional, default is no translation)
  * flip4326 - (optional, default is NO)
  * <p>
@@ -69,6 +69,7 @@ import java.util.Map;
  * <p>
  * A request for SRID EPSG:1234 will use the "EPSG:1234" matrixSet.
  * A request for SRID EPSG:900913 will use the "EPSG:3857" matrixSet (SRID2MatrixSet).
+ * If the request is for EPSG:4326, the request bbox (AOI) will be flipped from XY to YX.
  */
 public class WMTSBaseMapRenderer implements BaseMapRenderingEngine {
 

--- a/services/src/main/java/org/fao/geonet/api/records/extent/WMTSBaseMapRenderer.java
+++ b/services/src/main/java/org/fao/geonet/api/records/extent/WMTSBaseMapRenderer.java
@@ -1,0 +1,190 @@
+/*
+ * Copyright (C) 2022 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+package org.fao.geonet.api.records.extent;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jeeves.server.context.ServiceContext;
+import org.locationtech.jts.geom.Envelope;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
+
+
+/**
+ * This handles WMTS-configured basemaps.
+ * <p>
+ * The configuration should be a json string with the following attributes;
+ * <p>
+ * wmtsGetCapabilitiesURL - (required) URL to the GetCapabilities for the WMTS service
+ * layerName - (required)  Name of the layer to use (in the WMTS GetCapabilities)
+ * <p>
+ * matrixSet - (optional, default is the same as SRID) Name of the WMTS GetCapabilities matrixSet to use (hardcoded)
+ * SRID2MatrixSet - (optional, default is no translation)
+ * flip4326 - (optional, default is NO)
+ * <p>
+ * Typically, you should just need to set the `wmtsGetCapabilitiesURL` and `layerName`.
+ * In this case, it will use the WMTS matrixSet with the same name as the SRS.
+ * <p>
+ * If you want to ALWAYS (!!) use a specific matrixSet, you can use the `matrixSet` parameter.
+ * <p>
+ * If the WMTS doesn't use the SRS as the name of the matrixSets, you can use the SRID2MatrixSet to convert the SRID
+ * to a matrixSet.
+ * <p>
+ * Most WMTS systems will use YX ordering for EPSG:4326.  If you are supplying coordinates in XY ordering, you will
+ * likely need to set flip4326 to true.
+ * <p>
+ * EXAMPLE
+ * <p>
+ * {
+ * "wmtsGetCapabilitiesURL":"URL",
+ * "layerName":"LAYERNAME",
+ * "SRID2MatrixSet": {
+ * "EPSG:900913":"EPSG:3857"
+ * },
+ * "flip4326": true
+ * }
+ * <p>
+ * A request for SRID EPSG:1234 will use the "EPSG:1234" matrixSet.
+ * A request for SRID EPSG:900913 will use the "EPSG:3857" matrixSet (SRID2MatrixSet).
+ */
+public class WMTSBaseMapRenderer implements BaseMapRenderingEngine {
+
+
+    Envelope bbox;
+    String srs;
+    Dimension imageDimensions;
+    ServiceContext context;
+
+    URL getCapabilitiesURL;
+    String layerName;
+
+    Map<String, String> SRID2MatrixSet = new HashMap<>();
+    boolean flip4326 = false;
+
+    String urn4326 = "urn:ogc:def:crs:EPSG::4326"; // YX definition
+    /**
+     * null (not in config) -> matrix set is the same as srs
+     * otherwise, use this matrix set.
+     */
+    String matrixSet; //null -> use srs
+
+    public WMTSBaseMapRenderer() {
+
+    }
+
+    @Override
+    public boolean canHandle(String configString) {
+        return configString.startsWith("{");
+    }
+
+    public void configure(String configJsonString,
+                          Envelope bbox,
+                          String srs,
+                          Dimension imageDimensions,
+                          ServiceContext context) throws Exception {
+
+        if (configJsonString == null)
+            throw new Exception("GetMapBaseMapRenderer: null json/configuration");
+        if (bbox == null)
+            throw new Exception("GetMapBaseMapRenderer: null ubboxrl");
+        if (srs == null)
+            throw new Exception("GetMapBaseMapRenderer: null srs");
+        if (imageDimensions == null)
+            throw new Exception("GetMapBaseMapRenderer: null imageDimensions");
+
+
+        this.bbox = bbox;
+        this.srs = srs;
+        this.imageDimensions = imageDimensions;
+        this.context = context;
+
+        ObjectMapper mapper = new ObjectMapper();
+        Map<String, Object> configuration = mapper.readValue(configJsonString, Map.class);
+
+        if (!configuration.containsKey("wmtsGetCapabilitiesURL")
+            || (configuration.get("wmtsGetCapabilitiesURL") == null)
+            || (!configuration.get("wmtsGetCapabilitiesURL").toString().toLowerCase().startsWith("http"))
+        ) {
+            throw new Exception("WMTSBaseMapRenderer: json config key=wmtsGetCapabilitiesURL should be start with http or https");
+        }
+
+        getCapabilitiesURL = new URL(configuration.get("wmtsGetCapabilitiesURL").toString());
+
+        if (!configuration.containsKey("layerName")
+            || (configuration.get("layerName") == null)
+            || (configuration.get("layerName").toString().trim().isEmpty())
+        ) {
+            throw new Exception("WMTSBaseMapRenderer: json config key=layerName must be present");
+        }
+
+        layerName = configuration.get("layerName").toString().trim();
+
+        if (configuration.containsKey("matrixSet")
+            && (configuration.get("matrixSet") != null)
+            && (!configuration.get("matrixSet").toString().trim().isEmpty())
+        ) {
+            this.matrixSet = configuration.get("matrixSet").toString().trim();
+        } else {
+            this.matrixSet = srs;
+        }
+
+        if ((configuration.get("SRID2MatrixSet") != null) && (configuration.get("SRID2MatrixSet") instanceof Map)) {
+            this.SRID2MatrixSet = (Map) configuration.get("SRID2MatrixSet");
+            if (SRID2MatrixSet.containsKey(matrixSet)) {
+                matrixSet = SRID2MatrixSet.get(matrixSet);
+            }
+        }
+
+        if ((configuration.get("flip4326") != null) && (configuration.get("flip4326") instanceof Boolean)) {
+            if ((Boolean) configuration.get("flip4326") && (srs.equals("EPSG:4326"))) {
+                // if we are flipping, then we should use the YX definition
+                this.srs = urn4326;
+                flip4326 = true;
+                this.bbox = new Envelope(bbox.getMinY(), bbox.getMaxY(), bbox.getMinX(), bbox.getMaxX());
+                // might have to also flip height/width
+            }
+        }
+    }
+
+    /**
+     * uses the WMTSClient to create a background map image based on the configuration and request-specific details.
+     *
+     * @return
+     * @throws Exception
+     */
+    public BufferedImage render() throws Exception {
+        WMTSClient wmtsClient = new WMTSClient(getCapabilitiesURL, layerName, matrixSet);
+
+
+        BufferedImage image = wmtsClient.createImage(
+            bbox.getMinX(), bbox.getMinY(), bbox.getMaxX(), bbox.getMaxY(),
+            (int) imageDimensions.getWidth(), (int) imageDimensions.getHeight(),
+            matrixSet);
+
+        return image;
+    }
+
+}

--- a/services/src/main/java/org/fao/geonet/api/records/extent/WMTSBaseMapRenderer.java
+++ b/services/src/main/java/org/fao/geonet/api/records/extent/WMTSBaseMapRenderer.java
@@ -73,6 +73,12 @@ import java.util.Map;
  */
 public class WMTSBaseMapRenderer implements BaseMapRenderingEngine {
 
+    public static final String JSON_CapabilitiesURLTag= "wmtsGetCapabilitiesURL";
+    public static final String JSON_layerNameTagTag= "layerName";
+    public static final String JSON_matrixSetTag= "matrixSet";
+    public static final String JSON_SRIDConvertTag= "SRID2MatrixSet";
+    public static final String JSON_flip4326Tag= "flip4326";
+
 
     Envelope bbox;
     String srs;
@@ -107,14 +113,18 @@ public class WMTSBaseMapRenderer implements BaseMapRenderingEngine {
                           Dimension imageDimensions,
                           ServiceContext context) throws Exception {
 
-        if (configJsonString == null)
+        if (configJsonString == null) {
             throw new Exception("GetMapBaseMapRenderer: null json/configuration");
-        if (bbox == null)
+        }
+        if (bbox == null) {
             throw new Exception("GetMapBaseMapRenderer: null ubboxrl");
-        if (srs == null)
+        }
+        if (srs == null) {
             throw new Exception("GetMapBaseMapRenderer: null srs");
-        if (imageDimensions == null)
+        }
+        if (imageDimensions == null) {
             throw new Exception("GetMapBaseMapRenderer: null imageDimensions");
+        }
 
 
         this.bbox = bbox;
@@ -125,42 +135,42 @@ public class WMTSBaseMapRenderer implements BaseMapRenderingEngine {
         ObjectMapper mapper = new ObjectMapper();
         Map<String, Object> configuration = mapper.readValue(configJsonString, Map.class);
 
-        if (!configuration.containsKey("wmtsGetCapabilitiesURL")
-            || (configuration.get("wmtsGetCapabilitiesURL") == null)
-            || (!configuration.get("wmtsGetCapabilitiesURL").toString().toLowerCase().startsWith("http"))
+        if (!configuration.containsKey(JSON_CapabilitiesURLTag)
+            || (configuration.get(JSON_CapabilitiesURLTag) == null)
+            || (!configuration.get(JSON_CapabilitiesURLTag).toString().toLowerCase().startsWith("http"))
         ) {
             throw new Exception("WMTSBaseMapRenderer: json config key=wmtsGetCapabilitiesURL should be start with http or https");
         }
 
-        getCapabilitiesURL = new URL(configuration.get("wmtsGetCapabilitiesURL").toString());
+        getCapabilitiesURL = new URL(configuration.get(JSON_CapabilitiesURLTag).toString());
 
-        if (!configuration.containsKey("layerName")
-            || (configuration.get("layerName") == null)
-            || (configuration.get("layerName").toString().trim().isEmpty())
+        if (!configuration.containsKey(JSON_layerNameTagTag)
+            || (configuration.get(JSON_layerNameTagTag) == null)
+            || (configuration.get(JSON_layerNameTagTag).toString().trim().isEmpty())
         ) {
             throw new Exception("WMTSBaseMapRenderer: json config key=layerName must be present");
         }
 
-        layerName = configuration.get("layerName").toString().trim();
+        layerName = configuration.get(JSON_layerNameTagTag).toString().trim();
 
-        if (configuration.containsKey("matrixSet")
-            && (configuration.get("matrixSet") != null)
-            && (!configuration.get("matrixSet").toString().trim().isEmpty())
+        if (configuration.containsKey(JSON_matrixSetTag)
+            && (configuration.get(JSON_matrixSetTag) != null)
+            && (!configuration.get(JSON_matrixSetTag).toString().trim().isEmpty())
         ) {
-            this.matrixSet = configuration.get("matrixSet").toString().trim();
+            this.matrixSet = configuration.get(JSON_matrixSetTag).toString().trim();
         } else {
             this.matrixSet = srs;
         }
 
-        if ((configuration.get("SRID2MatrixSet") != null) && (configuration.get("SRID2MatrixSet") instanceof Map)) {
-            this.SRID2MatrixSet = (Map) configuration.get("SRID2MatrixSet");
+        if ((configuration.get(JSON_SRIDConvertTag) != null) && (configuration.get(JSON_SRIDConvertTag) instanceof Map)) {
+            this.SRID2MatrixSet = (Map) configuration.get(JSON_SRIDConvertTag);
             if (SRID2MatrixSet.containsKey(matrixSet)) {
                 matrixSet = SRID2MatrixSet.get(matrixSet);
             }
         }
 
-        if ((configuration.get("flip4326") != null) && (configuration.get("flip4326") instanceof Boolean)) {
-            if ((Boolean) configuration.get("flip4326") && (srs.equals("EPSG:4326"))) {
+        if ((configuration.get(JSON_flip4326Tag) != null) && (configuration.get(JSON_flip4326Tag) instanceof Boolean)) {
+            if ((Boolean) configuration.get(JSON_flip4326Tag) && (srs.equals("EPSG:4326"))) {
                 // if we are flipping, then we should use the YX definition
                 this.srs = urn4326;
                 flip4326 = true;

--- a/services/src/main/java/org/fao/geonet/api/records/extent/WMTSClient.java
+++ b/services/src/main/java/org/fao/geonet/api/records/extent/WMTSClient.java
@@ -1,0 +1,123 @@
+/*
+ * Copyright (C) 2022 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+package org.fao.geonet.api.records.extent;
+
+import org.geotools.geometry.jts.ReferencedEnvelope;
+import org.geotools.map.MapContent;
+import org.geotools.map.MapViewport;
+import org.geotools.ows.wmts.WebMapTileServer;
+import org.geotools.ows.wmts.map.WMTSMapLayer;
+import org.geotools.ows.wmts.model.TileMatrixSet;
+import org.geotools.ows.wmts.model.WMTSLayer;
+import org.geotools.referencing.CRS;
+import org.geotools.renderer.GTRenderer;
+import org.geotools.renderer.lite.StreamingRenderer;
+
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.IOException;
+import java.net.URL;
+
+/**
+ * Simple high-level api class for using GeoTools to do the underlying WMTS work
+ * + get the appropriate tiles
+ * + convert to appropriate scale
+ * + convert to exact bounds
+ */
+public class WMTSClient {
+
+    WMTSLayer layer;
+    TileMatrixSet tileMatrixSet;
+    WebMapTileServer wmts;
+
+
+    public WMTSClient(URL url, String layerName, String matrixSet) throws Exception {
+        wmts = new WebMapTileServer(url);
+        layer = wmts.getCapabilities().getLayer(layerName);
+        if (layer == null) {
+            throw new Exception("no such layer as:" + layerName);
+        }
+
+
+        tileMatrixSet = wmts.getCapabilities().getMatrixSet(matrixSet);
+        if (tileMatrixSet == null) {
+            throw new Exception("no such tileMatrixSet:" + matrixSet);
+        }
+    }
+
+    public BufferedImage createImage(double xmin, double ymin, double xmax, double ymax,
+                                     int imageWidth, int imageHeight) throws IOException {
+        ReferencedEnvelope envelope =
+            new ReferencedEnvelope(
+                xmin, xmax, ymin, ymax,
+                tileMatrixSet.getCoordinateReferenceSystem());
+        return createImage(envelope, imageWidth, imageHeight);
+    }
+
+    public BufferedImage createImage(double xmin, double ymin, double xmax, double ymax,
+                                     int imageWidth, int imageHeight,
+                                     String crsText) throws Exception {
+        ReferencedEnvelope envelope =
+            new ReferencedEnvelope(
+                xmin, xmax, ymin, ymax,
+                CRS.decode(crsText));
+
+        ReferencedEnvelope envelope2 = envelope.transform(tileMatrixSet.getCoordinateReferenceSystem(), false);
+
+        return createImage(envelope2, imageWidth, imageHeight);
+    }
+
+    /**
+     * We use the Geotools StreamingRenderer (backed by a WMTSMapLayer) to draw the tiles appropriately.
+     *
+     * @return
+     * @throws IOException
+     */
+    public BufferedImage createImage(ReferencedEnvelope envelope, int imageWidth, int imageHeight) throws IOException {
+        WMTSMapLayer mapLayer = new WMTSMapLayer(wmts, layer, tileMatrixSet.getCoordinateReferenceSystem());
+
+        MapContent mapContent = null;
+        try {
+            mapContent = new MapContent();
+            mapContent.addLayer(mapLayer);
+            mapContent.setViewport(new MapViewport(envelope));
+
+            BufferedImage image = new BufferedImage(imageWidth, imageHeight, BufferedImage.TYPE_INT_RGB);
+            Rectangle imageBounds = new Rectangle(0, 0, imageWidth, imageHeight);
+
+            Graphics2D gr = image.createGraphics();
+            gr.setPaint(Color.WHITE);
+            gr.fill(imageBounds);
+
+            GTRenderer renderer = new StreamingRenderer();
+            renderer.setMapContent(mapContent);
+
+
+            renderer.paint(gr, imageBounds, envelope);
+            return image;
+        } finally {
+            if (mapContent != null)
+                mapContent.dispose();
+        }
+    }
+}

--- a/services/src/test/java/org/fao/geonet/api/records/extent/GetMapBaseMapRendererTest.java
+++ b/services/src/test/java/org/fao/geonet/api/records/extent/GetMapBaseMapRendererTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2022 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+package org.fao.geonet.api.records.extent;
+
+import org.junit.Test;
+import org.locationtech.jts.geom.Envelope;
+
+import java.awt.*;
+import java.net.URL;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class GetMapBaseMapRendererTest {
+
+
+    @Test
+    public void canHandle() {
+        GetMapBaseMapRenderer mapRenderer = new GetMapBaseMapRenderer();
+
+        assertTrue(mapRenderer.canHandle("http://example.com"));
+        assertTrue(mapRenderer.canHandle("https://example.com"));
+
+        assertFalse(mapRenderer.canHandle("{}"));
+    }
+
+    @Test
+    public void modifyURL() throws Exception {
+        GetMapBaseMapRenderer mapRenderer = new GetMapBaseMapRenderer();
+        mapRenderer.configure("https://ows.terrestris.de/osm/service?SERVICE=WMS&REQUEST=GetMap&VERSION=1.1.0&LAYERS=OSM-WMS&STYLES=default&SRS={srs}&BBOX={minx},{miny},{maxx},{maxy}&WIDTH={width}&HEIGHT={height}&FORMAT=image/png",
+            new Envelope(1, 2, 3, 4),
+            "EPSG:4326",
+            new Dimension(100, 100),
+            null);
+
+        URL finalURL = mapRenderer.createURL();
+
+        assertEquals(new URL("https://ows.terrestris.de/osm/service?SERVICE=WMS&REQUEST=GetMap&VERSION=1.1.0&LAYERS=OSM-WMS&STYLES=default&SRS=EPSG:4326&BBOX=1.0,3.0,2.0,4.0&WIDTH=100&HEIGHT=100&FORMAT=image/png"),
+            finalURL);
+    }
+}

--- a/services/src/test/java/org/fao/geonet/api/records/extent/WMTSBaseMapRendererTest.java
+++ b/services/src/test/java/org/fao/geonet/api/records/extent/WMTSBaseMapRendererTest.java
@@ -1,0 +1,112 @@
+/*
+ * Copyright (C) 2022 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+package org.fao.geonet.api.records.extent;
+
+import org.junit.Test;
+import org.locationtech.jts.geom.Envelope;
+
+import java.awt.*;
+import java.net.URL;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class WMTSBaseMapRendererTest {
+
+    String json = "{\n" +
+        "                     \"wmtsGetCapabilitiesURL\":\"HTTP://example.com\",\n" +
+        "                     \"layerName\":\"standard\",\n" +
+        "                     \"SRID2MatrixSet\": {\n" +
+        "                          \"EPSG:900913\":\"EPSG:3857\"\n" +
+        "                     },\n" +
+        "                     \"flip4326\": true\n" +
+        "                   }";
+    String jsonNoFlip = "{\n" +
+        "                     \"wmtsGetCapabilitiesURL\":\"HTTPS://example.com\",\n" +
+        "                     \"layerName\":\"standard\",\n" +
+        "                     \"SRID2MatrixSet\": {\n" +
+        "                          \"EPSG:900913\":\"EPSG:3857\"\n" +
+        "                     },\n" +
+        "                     \"flip4326\": false\n" +
+        "                   }";
+
+    @Test
+    public void canHandle() {
+        WMTSBaseMapRenderer mapRenderer = new WMTSBaseMapRenderer();
+
+        assertFalse(mapRenderer.canHandle("http://example.com"));
+        assertFalse(mapRenderer.canHandle("https://example.com"));
+
+        assertTrue(mapRenderer.canHandle("{}"));
+    }
+
+    @Test
+    public void parseSimple() throws Exception {
+        WMTSBaseMapRenderer mapRenderer = new WMTSBaseMapRenderer();
+
+        mapRenderer.configure(json, new Envelope(1, 2, 3, 4), "EPSG:3857", new Dimension(100, 100), null);
+
+        assertEquals(new URL("HTTP://example.com"), mapRenderer.getCapabilitiesURL);
+        assertEquals("standard", mapRenderer.layerName);
+
+        assertEquals("EPSG:3857", mapRenderer.srs);
+        assertEquals(new Dimension(100, 100), mapRenderer.imageDimensions);
+        assertEquals(new Envelope(1, 2, 3, 4), mapRenderer.bbox);
+
+    }
+
+    @Test
+    public void parseTranslate() throws Exception {
+        WMTSBaseMapRenderer mapRenderer = new WMTSBaseMapRenderer();
+
+        mapRenderer.configure(json, new Envelope(1, 2, 3, 4), "EPSG:900913", new Dimension(100, 100), null);
+
+        // translates "EPSG:900913" to "EPSG:3857"
+        assertEquals("EPSG:3857", mapRenderer.matrixSet);
+    }
+
+
+    @Test
+    public void parseNoFlip4326() throws Exception {
+        WMTSBaseMapRenderer mapRenderer = new WMTSBaseMapRenderer();
+
+        mapRenderer.configure(jsonNoFlip, new Envelope(1, 2, 3, 4), "EPSG:4326", new Dimension(100, 100), null);
+
+        assertEquals(false, mapRenderer.flip4326);
+        assertEquals("EPSG:4326", mapRenderer.srs);
+        assertEquals(new Envelope(1, 2, 3, 4), mapRenderer.bbox);
+    }
+
+    @Test
+    public void parseFlip4326() throws Exception {
+        WMTSBaseMapRenderer mapRenderer = new WMTSBaseMapRenderer();
+
+        mapRenderer.configure(json, new Envelope(1, 2, 3, 4), "EPSG:4326", new Dimension(100, 100), null);
+
+        assertEquals(true, mapRenderer.flip4326);
+        assertEquals("urn:ogc:def:crs:EPSG::4326", mapRenderer.srs); // this will change
+        assertEquals(new Envelope(3, 4, 1, 2), mapRenderer.bbox);
+    }
+
+}

--- a/web/src/main/webResources/WEB-INF/config-spring-geonetwork.xml
+++ b/web/src/main/webResources/WEB-INF/config-spring-geonetwork.xml
@@ -157,6 +157,64 @@
           p:proportion=".015" p:factor=".2"/>
   </util:set>
 
+
+  <!--
+   WMS:
+   ====
+
+     The configuration URL will have the following placeholders replaced with actual values;
+
+        + {minx} and {MINX}
+        + {miny} and {MINY}
+        + {maxx} and {MAXX}
+        + {maxy} and {MAXY}
+        + {srs}  and {SRS}
+        + {width} and {WIDTH}
+        + {height} and {HEIGHT}
+
+     with the necessary values from the request.
+
+     For example, the URL might look like this;
+     https://ows.terrestris.de/osm/service?SERVICE=WMS&REQUEST=GetMap&VERSION=1.1.0&LAYERS=OSM-WMS&STYLES=default&SRS={srs}&BBOX={minx},{miny},{maxx},{maxy}&WIDTH={width}&HEIGHT={height}&FORMAT=image/png
+
+    WMTS:
+    =====
+
+    The configuration should be a json string with the following attributes;
+
+    wmtsGetCapabilitiesURL - (required) URL to the GetCapabilities for the WMTS service
+    layerName - (required)  Name of the layer to use (in the WMTS GetCapabilities)
+
+    matrixSet - (optional, default is the same as SRID) Name of the WMTS GetCapabilities matrixSet to use (hardcoded for all requests)
+    SRID2MatrixSet - (optional, default is no translation)
+    flip4326 - (optional, default is NO)
+
+    Typically, you should just need to set the `wmtsGetCapabilitiesURL` and `layerName`.
+    In this case, it will use the WMTS matrixSet with the same name as the SRS.
+
+    If you want to ALWAYS (!!) use a specific matrixSet, you can use the `matrixSet` parameter.
+
+    If the WMTS doesn't use the SRS as the name of the matrixSets, you can use the SRID2MatrixSet to convert the SRID
+    to a matrixSet.
+
+    Most WMTS systems will use YX ordering for EPSG:4326.  If you are supplying coordinates in XY ordering, you will
+    likely need to set flip4326 to true.
+
+    EXAMPLE
+
+    {
+        "wmtsGetCapabilitiesURL":"URL",
+        "layerName":"LAYERNAME",
+        "SRID2MatrixSet": {
+             "EPSG:900913":"EPSG:3857"
+        },
+        "flip4326": true
+    }
+
+    A request for SRID EPSG:1234 will use the "EPSG:1234" matrixSet.
+    A request for SRID EPSG:900913 will use the "EPSG:3857" matrixSet (SRID2MatrixSet).
+    If the request is for EPSG:4326, the request bbox (AOI) will be flipped from XY to YX.
+  -->
   <util:map id="regionGetMapBackgroundLayers">
     <entry key="osm"
            value="\${map.bbox.background.service}"/>


### PR DESCRIPTION
NOTE: I noticed that the https proxy settings where NOT being set anywhere - so I update them at the same time as the http settings - see NetLib.java.

NOTE: this also updates GT to a newer version (required for recent changes to the GT WMTS code).  This will need to go to 28.0 when Geotools releases it.  This is a minor upgrade.

This allows for WMTS background maps for /extents.png and /geom.png - currently only WMS GetMap is supported.

For backwards compatibility, I didn't change how to WMS GetMap is used.  

If you want to use WMTS, you need to configure with a little JSON string like this (config-spring-geonetwork.xml);

 ```
<util:map id="regionGetMapBackgroundLayers">
    <entry key="osm" value="\${map.bbox.background.service}"/>
 
    <entry key='myserver.wmts.basemap'
           value='{
                     "wmtsGetCapabilitiesURL":"http://localhost:8080/geoserver/request=GetCapabilities&amp;service=WMTS",
                     "layerName":"basemap"
                   }'
    />
 
  </util:map>
```

There are a few other configuration options (see code comments) for dealing with finicky SRID problems.
