### PR TITLE
Fix showValidOnly option in editor entry selector

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/directoryentryselector/DirectoryEntrySelector.js
+++ b/web-ui/src/main/resources/catalog/components/edit/directoryentryselector/DirectoryEntrySelector.js
@@ -147,7 +147,7 @@
               };
 
               if (scope.$eval(scope.showValidOnly)) {
-                scope.searchObj.valid = 1;
+                scope.searchObj.params.valid = "1";
               }
               scope.facetConfig = gnESFacet.configs.directoryInEditor.facets;
 

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/EsFacet.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/EsFacet.js
@@ -166,7 +166,8 @@
               "group*",
               "resource*",
               "owner*",
-              "isTemplate"
+              "isTemplate",
+              "valid"
             ]
           },
           track_total_hits: true


### PR DESCRIPTION
Fix the option to only display valid subtemplates in the editor entry selector.
- only search for valid metadata if set (`showValidOnly`)
- fix the display in the list with the correct icon and color

![Screenshot from 2022-11-02 19-34-26](https://user-images.githubusercontent.com/1491924/199573314-46d6359a-89ac-446f-b00b-c4bd0a0a43d9.png)
