### PR TITLE
Use Map interface instead of implementations

### DIFF
--- a/core/src/main/java/org/fao/geonet/api/tools/i18n/TranslationPackBuilder.java
+++ b/core/src/main/java/org/fao/geonet/api/tools/i18n/TranslationPackBuilder.java
@@ -118,7 +118,7 @@ public class TranslationPackBuilder {
     public Map<String, String> getPack(
         String language, String key,
         ServiceContext context) {
-        HashMap<String, String> translations = new HashMap<>();
+        Map<String, String> translations = new HashMap<>();
         if (packages.get(key) != null) {
             packages.get(key).forEach(resource -> {
                 String[] config = resource.split(TYPE_SEPARATOR);
@@ -173,7 +173,7 @@ public class TranslationPackBuilder {
     public Map<String, String> getStandardCodelist(
         String language, String schema, List<String> codelist,
         ServiceContext context) {
-        HashMap<String, String> translations = new HashMap<>();
+        Map<String, String> translations = new HashMap<>();
         context.setLanguage(language);
 
         for (String c : codelist) {
@@ -195,7 +195,7 @@ public class TranslationPackBuilder {
 
     @Cacheable(value = "translations", cacheManager = "cacheManager")
     public Map<String, String> getDbTranslation(String language, List<String> type) {
-        HashMap<String, String> translations = new HashMap<>();
+        Map<String, String> translations = new HashMap<>();
 
         validateDbType(type);
 
@@ -282,7 +282,7 @@ public class TranslationPackBuilder {
     public Map<String, String> getJsonTranslation(
         String language,
         List<String> fileNameKeys) {
-        HashMap<String, String> translations = new HashMap<>();
+        Map<String, String> translations = new HashMap<>();
         ObjectMapper mapper = new ObjectMapper();
         String iso2letterLangCode = XslUtil.twoCharLangCode(language, "eng");
 

--- a/core/src/main/java/org/fao/geonet/kernel/EditLib.java
+++ b/core/src/main/java/org/fao/geonet/kernel/EditLib.java
@@ -289,7 +289,7 @@ public class EditLib {
 
     public void addXMLFragments(String schema, Element md, Map<String, String> xmlInputs) throws Exception {
         // Loop over each XML fragments to insert or replace
-        HashMap<String, Element> nodeRefToElem = new HashMap<>();
+        Map<String, Element> nodeRefToElem = new HashMap<>();
         for (Map.Entry<String, String> entry : xmlInputs.entrySet()) {
             String[] nodeConfig = entry.getKey().split("_");
             String nodeRef = nodeConfig[0];

--- a/core/src/main/java/org/fao/geonet/kernel/mef/MEFLib.java
+++ b/core/src/main/java/org/fao/geonet/kernel/mef/MEFLib.java
@@ -419,7 +419,7 @@ public class MEFLib {
         Integer grpOwnerId = md.getSourceInfo().getGroupOwner();
         String grpOwnerName = "";
 
-        HashMap<String, ArrayList<String>> hmPriv = new HashMap<String, ArrayList<String>>();
+        Map<String, ArrayList<String>> hmPriv = new HashMap<String, ArrayList<String>>();
 
         // --- retrieve accessible groups
 

--- a/core/src/main/java/org/fao/geonet/kernel/search/EsSearchManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/EsSearchManager.java
@@ -417,7 +417,7 @@ public class EsSearchManager implements ISearchManager {
         String jsonDocument = mapper.writeValueAsString(doc);
 
         if (forceRefreshReaders) {
-            HashMap<String, String> document = new HashMap<>();
+            Map<String, String> document = new HashMap<>();
             document.put(id, jsonDocument);
             final BulkResponse bulkItemResponses = client.bulkRequest(defaultIndex, document);
             checkIndexResponse(bulkItemResponses, document);

--- a/core/src/main/java/org/fao/geonet/kernel/setting/HarvesterSettingsManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/setting/HarvesterSettingsManager.java
@@ -91,7 +91,7 @@ public class HarvesterSettingsManager {
         Element el = null;
         if (s != null) {
             HarvesterSetting r = null;
-            HashMap<Integer, List<HarvesterSetting>> mapSettings = new HashMap<Integer, List<HarvesterSetting>>();
+            Map<Integer, List<HarvesterSetting>> mapSettings = new HashMap<Integer, List<HarvesterSetting>>();
             List<HarvesterSetting> settings = null;
             // create Map where keys are idParent
             // this is avoid to multiple call in base
@@ -351,7 +351,7 @@ public class HarvesterSettingsManager {
     /**
      * Create recursively the tree of harvesterSettings
      */
-    private Element buildFromMap(HarvesterSetting s, HashMap<Integer, List<HarvesterSetting>> mapSettings) {
+    private Element buildFromMap(HarvesterSetting s, Map<Integer, List<HarvesterSetting>> mapSettings) {
         if (s == null) {
             return null;
         }

--- a/core/src/main/java/org/fao/geonet/util/xml/NamespaceUtils.java
+++ b/core/src/main/java/org/fao/geonet/util/xml/NamespaceUtils.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.List;
 import java.util.TreeMap;
 
@@ -135,7 +136,7 @@ public class NamespaceUtils {
         }
 
         // OK, the things we inherit are the prefixes we have in scope that are also in our parent's scope.
-        HashMap<String, Namespace> parents = new HashMap<String, Namespace>();
+        Map<String, Namespace> parents = new HashMap<String, Namespace>();
         for (Namespace ns : getNamespacesInScope(element.getParentElement())) {
             parents.put(ns.getPrefix(), ns);
         }
@@ -173,7 +174,7 @@ public class NamespaceUtils {
         }
 
         // OK, the things we introduce are the prefixes we have in scope that are *not* in our parent's scope.
-        HashMap<String, Namespace> parents = new HashMap<String, Namespace>();
+        Map<String, Namespace> parents = new HashMap<String, Namespace>();
         for (Namespace ns : getNamespacesInScope(element.getParentElement())) {
             parents.put(ns.getPrefix(), ns);
         }

--- a/core/src/main/java/org/geonetwork/map/wms/SLDUtil.java
+++ b/core/src/main/java/org/geonetwork/map/wms/SLDUtil.java
@@ -46,8 +46,8 @@ public class SLDUtil {
      * @throws ServiceException if the server responds with an error
      * @throws ParseException if unable to parse content type header from server
      */
-    public static HashMap<String, String> parseSLD(URI url, String layers) throws URISyntaxException, IOException, ParseException {
-        HashMap<String, String> hash = new HashMap<String, String>();
+    public static Map<String, String> parseSLD(URI url, String layers) throws URISyntaxException, IOException, ParseException {
+        Map<String, String> hash = new HashMap<String, String>();
 
         String requestUrl = SLDUtil.getGetStyleRequest(url, layers);
 

--- a/core/src/test/java/org/geonetwork/map/wms/SLDUtilTest.java
+++ b/core/src/test/java/org/geonetwork/map/wms/SLDUtilTest.java
@@ -57,7 +57,7 @@ public class SLDUtilTest {
 //        String url = "http://sextant-test.ifremer.fr/cgi-bin/sextant/wms/bgmb";
 //        String layers= "SISMER_prelevements";
 //
-//        HashMap<String, String> hash = SLDUtil.parseSLD(new URL(url), layers);
+//        Map<String, String> hash = SLDUtil.parseSLD(new URL(url), layers);
 //        assertNotNull(hash.get("content"));
 //        assertEquals(hash.get("charset"), "UTF-8");
 //    }

--- a/csw-server/src/main/java/org/fao/geonet/component/csw/CatalogDispatcher.java
+++ b/csw-server/src/main/java/org/fao/geonet/component/csw/CatalogDispatcher.java
@@ -60,7 +60,7 @@ public class CatalogDispatcher {
     //---------------------------------------------------------------------------
 
     public static Map<String, String> extractParams(Element request) {
-        HashMap<String, String> hm = new HashMap<String, String>();
+        Map<String, String> hm = new HashMap<String, String>();
 
         @SuppressWarnings("unchecked")
         List<Element> params = request.getChildren();

--- a/csw-server/src/main/java/org/fao/geonet/component/csw/DescribeRecord.java
+++ b/csw-server/src/main/java/org/fao/geonet/component/csw/DescribeRecord.java
@@ -212,10 +212,10 @@ public class DescribeRecord extends AbstractOperation implements CatalogService 
     //---
     //---------------------------------------------------------------------------
 
-    private HashMap<String, Element> getSchemaComponents(ServiceContext context, String typeName)
+    private Map<String, Element> getSchemaComponents(ServiceContext context, String typeName)
         throws NoApplicableCodeEx, InvalidParameterValueEx {
 
-        HashMap<String, Element> scElements = new HashMap<>();
+        Map<String, Element> scElements = new HashMap<>();
 
         if (typeName == null) {
             for (String tname : _catalogConfig.getDescribeRecordTypename().keySet()) {

--- a/csw-server/src/main/java/org/fao/geonet/component/csw/GetCapabilities.java
+++ b/csw-server/src/main/java/org/fao/geonet/component/csw/GetCapabilities.java
@@ -328,7 +328,7 @@ public class GetCapabilities extends AbstractOperation implements CatalogService
         GeonetContext gc = (GeonetContext) context.getHandlerContext(Geonet.CONTEXT_NAME);
         SettingManager sm = gc.getBean(SettingManager.class);
 
-        HashMap<String, String> vars = new HashMap<String, String>();
+        Map<String, String> vars = new HashMap<String, String>();
 
         String protocol = sm.getValue(Settings.SYSTEM_SERVER_PROTOCOL);
         vars.put("$PROTOCOL", protocol);
@@ -428,7 +428,7 @@ public class GetCapabilities extends AbstractOperation implements CatalogService
             }
 
             // Current language
-            HashMap<String, String> vars = new HashMap<String, String>();
+            Map<String, String> vars = new HashMap<String, String>();
             if (languages.contains(currLang)) {
                 vars.put("$INSPIRE_LOCALE", currLang);
 

--- a/csw-server/src/main/java/org/fao/geonet/kernel/csw/CatalogConfiguration.java
+++ b/csw-server/src/main/java/org/fao/geonet/kernel/csw/CatalogConfiguration.java
@@ -240,7 +240,7 @@ public class CatalogConfiguration {
             List<Element> xpathList = param.getChildren(Csw.ConfigFile.Parameter.Child.XPATH);
             Iterator<Element> itXPath = xpathList.iterator();
             String schema, path;
-            HashMap<String, String> xpathMap = new HashMap<String, String>();
+            Map<String, String> xpathMap = new HashMap<String, String>();
             while (itXPath.hasNext()) {
                 Element xpath = itXPath.next();
 

--- a/csw-server/src/main/java/org/fao/geonet/kernel/csw/CatalogConfigurationGetRecordsField.java
+++ b/csw-server/src/main/java/org/fao/geonet/kernel/csw/CatalogConfigurationGetRecordsField.java
@@ -1,6 +1,7 @@
 package org.fao.geonet.kernel.csw;
 
 import java.util.HashMap;
+import java.util.Map;
 
 public class CatalogConfigurationGetRecordsField {
     private String name;
@@ -8,7 +9,7 @@ public class CatalogConfigurationGetRecordsField {
     private boolean range;
     private String luceneField;
     private String luceneSortField;
-    private HashMap<String, String> xpaths = new HashMap();
+    private Map<String, String> xpaths = new HashMap();
 
     public String getName() {
         return name;
@@ -30,12 +31,12 @@ public class CatalogConfigurationGetRecordsField {
         return luceneSortField;
     }
 
-    public HashMap<String, String> getXpaths() {
+    public Map<String, String> getXpaths() {
         return xpaths;
     }
 
     public CatalogConfigurationGetRecordsField(String name, String type, boolean range, String luceneField,
-                                               String luceneSortField, HashMap<String, String> xpaths) {
+                                               String luceneSortField, Map<String, String> xpaths) {
         this.name = name;
         this.type = type;
         this.range = range;

--- a/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/AbstractOperation.java
+++ b/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/AbstractOperation.java
@@ -153,7 +153,7 @@ public abstract class AbstractOperation {
     }
 
     protected Map<String, String> retrieveNamespaces(String namespaces) {
-        HashMap<String, String> hm = new HashMap<String, String>();
+        Map<String, String> hm = new HashMap<String, String>();
 
         if (namespaces != null) {
             StringTokenizer st = new StringTokenizer(namespaces, ",");

--- a/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/FieldMapper.java
+++ b/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/FieldMapper.java
@@ -24,6 +24,7 @@
 package org.fao.geonet.kernel.csw.services.getrecords;
 
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
 import org.fao.geonet.kernel.csw.CatalogConfiguration;
 import org.fao.geonet.kernel.csw.CatalogConfigurationGetRecordsField;
@@ -49,7 +50,7 @@ public class FieldMapper implements IFieldMapper {
             .get(getAbsolute(field));
 
         if (fieldInfo != null) {
-            HashMap<String, String> xpaths = fieldInfo.getXpaths();
+            Map<String, String> xpaths = fieldInfo.getXpaths();
 
             if (xpaths != null) {
                 xpath = xpaths.get(schema);

--- a/estest/src/test/java/org/fao/geonet/index/es/IndexationTest.java
+++ b/estest/src/test/java/org/fao/geonet/index/es/IndexationTest.java
@@ -34,7 +34,7 @@ public class IndexationTest {
 //        toTest.index(schemaDir, metadata, id, moreFields, metadataType, root, forceRefreshReaders);
 //
 //        String docToBeIndexed = toTest.listOfDocumentsToIndex.get(id);
-//        HashMap<String,Object> result = new ObjectMapper().readValue(docToBeIndexed, HashMap.class);
+//        Map<String,Object> result = new ObjectMapper().readValue(docToBeIndexed, HashMap.class);
 //        Assert.assertEquals(3, result.size());
 //        Assert.assertEquals("test-id", result.get("id"));
 //        Assert.assertEquals("metadata", result.get("docType"));

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Aligner.java
@@ -104,7 +104,7 @@ public class Aligner extends BaseAligner<GeonetParams> {
     private String preferredSchema;
     private Map<String, Object> processParams = new HashMap<String, Object>();
     private MetadataRepository metadataRepository;
-    private HashMap<String, HashMap<String, String>> hmRemoteGroups = new HashMap<String, HashMap<String, String>>();
+    private Map<String, Map<String, String>> hmRemoteGroups = new HashMap<String, Map<String, String>>();
     private SettingManager settingManager;
 
     public Aligner(AtomicBoolean cancelMonitor, Logger log, ServiceContext context, XmlRequest req,
@@ -139,12 +139,12 @@ public class Aligner extends BaseAligner<GeonetParams> {
 
     //--------------------------------------------------------------------------
 
-    private void setupLocEntity(List<Element> list, HashMap<String, HashMap<String, String>> hmEntity) {
+    private void setupLocEntity(List<Element> list, Map<String, Map<String, String>> hmEntity) {
 
         for (Element entity : list) {
             String name = entity.getChildText("name");
 
-            HashMap<String, String> hm = new HashMap<String, String>();
+            Map<String, String> hm = new HashMap<String, String>();
             hmEntity.put(name, hm);
 
             @SuppressWarnings("unchecked")

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataSavedQueryApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataSavedQueryApi.java
@@ -140,7 +140,7 @@ public class MetadataSavedQueryApi {
         return query(metadata, savedQuery, parameters);
     }
 
-    public Map<String, String> query(AbstractMetadata metadata, String savedQuery, HashMap<String, String> parameters) throws ResourceNotFoundException, IOException, NoResultsFoundException {
+    public Map<String, String> query(AbstractMetadata metadata, String savedQuery, Map<String, String> parameters) throws ResourceNotFoundException, IOException, NoResultsFoundException {
         String metadataUuid = metadata.getUuid();
         String schemaIdentifier = metadata.getDataInfo().getSchemaId();
         SchemaPlugin schemaPlugin = schemaManager.getSchema(schemaIdentifier).getSchemaPlugin();

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataUtils.java
@@ -908,8 +908,8 @@ public class MetadataUtils {
 
             Element finalResponseRoot = responseRoot;
             ((ArrayList) values).forEach(recordLink -> {
-                if (recordLink instanceof HashMap) {
-                    HashMap<String, String> linkProperties = (HashMap) recordLink;
+                if (recordLink instanceof Map) {
+                    Map<String, String> linkProperties = (Map) recordLink;
                     if (type.equals(linkProperties.get(Geonet.IndexFieldNames.RecordLink.TYPE))
                         && "remote".equals(linkProperties.get("origin"))) {
                         Element record = new Element("metadata");

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/groovy/util/Summary.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/groovy/util/Summary.java
@@ -34,8 +34,8 @@ import org.fao.geonet.api.records.formatters.groovy.template.FileResult;
 import org.fao.geonet.domain.MetadataResourceVisibility;
 
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Represents the summary of a metadata element.  It is often the top section of a metadata view and
@@ -81,7 +81,7 @@ public class Summary {
     }
 
     public FileResult getResult() throws Exception {
-        HashMap<String, Object> params = Maps.newHashMap();
+        Map<String, Object> params = Maps.<String,Object>newHashMap();
 
         params.put("logo", logo);
         params.put("title", title != null ? title : "");

--- a/services/src/main/java/org/fao/geonet/api/sld/SldApi.java
+++ b/services/src/main/java/org/fao/geonet/api/sld/SldApi.java
@@ -40,7 +40,7 @@ import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.HashMap;
+import java.util.Map;
 import java.util.List;
 
 @Service
@@ -182,7 +182,7 @@ public class SldApi {
         HttpServletRequest request) throws ServiceException, TransformerException, JSONException, ParseException, IOException, JDOMException, URISyntaxException {
 
         try {
-            HashMap<String, String> hash = SLDUtil.parseSLD(new URI(serverURL), layers);
+            Map<String, String> hash = SLDUtil.parseSLD(new URI(serverURL), layers);
 
             Element root = Xml.loadString(hash.get("content"), false);
 

--- a/workers/camelPeriodicProducer/src/main/java/org/fao/geonet/camelPeriodicProducer/MessageProducerService.java
+++ b/workers/camelPeriodicProducer/src/main/java/org/fao/geonet/camelPeriodicProducer/MessageProducerService.java
@@ -120,7 +120,7 @@ public class MessageProducerService implements ApplicationListener<ServerStartup
             metadataUuid);
 
         try {
-            HashMap<String, Object> applicationProfile = getApplicationProfile(metadataUuid, typeName);
+            Map<String, Object> applicationProfile = getApplicationProfile(metadataUuid, typeName);
             if(applicationProfile != null) {
                 wfsHarvesterParam.setTreeFields(getTreeField(applicationProfile)); //optional
                 wfsHarvesterParam.setTokenizedFields(getTokenizedField(applicationProfile)); //optional
@@ -137,19 +137,19 @@ public class MessageProducerService implements ApplicationListener<ServerStartup
     }
 
 
-    public List<String> getTreeField(HashMap<String, Object> map) {
+    public List<String> getTreeField(Map<String, Object> map) {
         return (List<String>) map.get("treeFields");
     }
 
-    public Map<String, String> getTokenizedField(HashMap<String, Object> map) {
+    public Map<String, String> getTokenizedField(Map<String, Object> map) {
         return (Map<String, String>) map.get("tokenizedFields");
     }
 
-    private HashMap<String, Object> getApplicationProfile(String metadataUuid, String typeName) {
+    private Map<String, Object> getApplicationProfile(String metadataUuid, String typeName) {
         try {
             Metadata metadata = metadataRepository.findOneByUuid(metadataUuid);
             if(metadata != null) {
-                HashMap<String, String> params = new HashMap<>();
+                Map<String, String> params = new HashMap<>();
                 params.put("protocol", "WFS");
                 params.put("name", typeName);
                 Map<String, String> wfsConfig = savedQueryApi.query(metadata,


### PR DESCRIPTION
This pr replaces the Map usages by using the interface instead of concrete implementations like HashMap. This improves the flexibility and interchangeability of the code base and reduces the dependencies of implementations.