### PR TITLE
Fix boostrap-table styling

### DIFF
--- a/web-ui/src/main/resources/WEB-INF/classes/web-ui-wro-sources.xml
+++ b/web-ui/src/main/resources/WEB-INF/classes/web-ui-wro-sources.xml
@@ -30,7 +30,7 @@
     <jsSource webappPath="/catalog/templates/"/>
     <cssSource webappPath="/catalog/views/"/>
     <cssSource webappPath="/catalog/style/"/>
-    <cssSource webappPath="/catalog/lib/bootstrap-table/dist"/>
+    <cssSource webappPath="/catalog/lib/bootstrap-table/dist/bootstrap-table.min.css" />
   </require>
   <declarative name="lib" pathOnDisk="web-ui/src/main/resources">
     <jsSource webappPath="/catalog/lib/modernizr.js" minimize="false"/>

--- a/web-ui/src/main/resources/catalog/style/gn_viewer.less
+++ b/web-ui/src/main/resources/catalog/style/gn_viewer.less
@@ -854,11 +854,6 @@ gn-features-tables,
   }
 }
 
-// Fixed doubled scrollbar in bootstrap-table
-gn-features-table > div > .bootstrap-table > .fixed-table-container > .fixed-table-body {
-  overflow: unset !important;
-}
-
 .gn-md-view {
   gn-features-tables {
     position: unset;


### PR DESCRIPTION
Related to https://github.com/geonetwork/core-geonetwork/pull/6628

This pull request contains 2 changes:

1. Update the wro configuration to process only the main styling file for `bootstrap-table`, see additional information in https://github.com/geonetwork/core-geonetwork/pull/6656#issuecomment-1307149067

2. Remove a styling causing a wrong rendering of the table with the updated version.

Previously:

![previous-styling](https://user-images.githubusercontent.com/1695003/200575186-30ce243a-c2a2-40c9-b4f8-49058a363d04.png)

With the change:

![fixed-styling](https://user-images.githubusercontent.com/1695003/200575211-1b85675d-360f-40a1-a6a6-9a9c5af4fe45.png)


Test case:

1) Load the iso19139 samples
2) With the admin user in the `Hydrological Basins in Africa` select the option to index the data features 

![index-data-features](https://user-images.githubusercontent.com/1695003/200577290-fd3aa8e7-bf96-4403-986c-1052222c3c7a.png)

Check the features table layout.
