### PR TITLE
[BP] Fix boostrap-table styling

### DIFF
--- a/web-ui/src/main/resources/WEB-INF/classes/web-ui-wro-sources.xml
+++ b/web-ui/src/main/resources/WEB-INF/classes/web-ui-wro-sources.xml
@@ -30,7 +30,7 @@
     <jsSource webappPath="/catalog/templates/"/>
     <cssSource webappPath="/catalog/views/"/>
     <cssSource webappPath="/catalog/style/"/>
-    <cssSource webappPath="/catalog/lib/bootstrap-table/dist"/>
+    <cssSource webappPath="/catalog/lib/bootstrap-table/dist/bootstrap-table.min.css"/>
   </require>
   <declarative name="lib" pathOnDisk="web-ui/src/main/resources">
     <jsSource webappPath="/catalog/lib/modernizr.js" minimize="false"/>

--- a/web-ui/src/main/resources/catalog/components/viewer/gfi/FeaturesTable.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/gfi/FeaturesTable.js
@@ -87,6 +87,10 @@
           angular.extend({
             height: 250,
             sortable: true,
+            iconsPrefix: "fa",
+            icons: {
+              export: "fa-download"
+            },
             onPostBody: function() {
               var trs = element.find('tbody').children();
               for (var i = 0; i < trs.length; i++) {


### PR DESCRIPTION
Backport of https://github.com/geonetwork/core-geonetwork/pull/6657

In `3.12.x` this change is not required: https://github.com/geonetwork/core-geonetwork/pull/6657/files#diff-59b6828a9edbc4aa28dd85b9a3b4210eb04fa85f31a6572ca44cf99e5fe2b677

Fixed also the download icon (not related to the the upgrade of boostrap-table, the issue existed previously).

Previously:

![export-icon-before](https://user-images.githubusercontent.com/1695003/200588601-87765e2e-a43e-4b56-84df-b84dec62af13.png)


After:

![export-icon-after](https://user-images.githubusercontent.com/1695003/200588634-03c22538-5750-4e9d-a36d-7461c94952f8.png)
