### PR TITLE
Fix schematron unit test

### DIFF
--- a/web/src/test/resources/org/fao/geonet/kernel/schema/inspire-valid-iso19139.xml
+++ b/web/src/test/resources/org/fao/geonet/kernel/schema/inspire-valid-iso19139.xml
@@ -114,7 +114,7 @@
           <gmd:onlineResource>
             <gmd:CI_OnlineResource>
               <gmd:linkage>
-                <gmd:URL>http://www.swisstopo.admin.ch</gmd:URL>
+                <gmd:URL>https://geonetwork-opensource.org</gmd:URL>
               </gmd:linkage>
               <gmd:protocol>
                 <gco:CharacterString>text/html</gco:CharacterString>
@@ -355,7 +355,7 @@
               <gmd:onlineResource>
                 <gmd:CI_OnlineResource>
                   <gmd:linkage>
-                    <gmd:URL>http://www.swisstopo.ch</gmd:URL>
+                    <gmd:URL>https://geonetwork-opensource.org/</gmd:URL>
                   </gmd:linkage>
                   <gmd:protocol>
                     <gco:CharacterString>text/html</gco:CharacterString>


### PR DESCRIPTION
Update the URLs causing the test to fail. Using https on the original URLs didn't work, it seems some issues with the certificate.