### PR TITLE
Aggregations / INSPIRE valid / Translation

### DIFF
--- a/web-ui/src/main/resources/catalog/locales/en-v4.json
+++ b/web-ui/src/main/resources/catalog/locales/en-v4.json
@@ -129,6 +129,7 @@
   "facet-valid_inspire": "INSPIRE validation status",
   "valid_inspire-1": "Valid",
   "valid_inspire-0": "Invalid",
+  "valid_inspire-3": "No rule applies",
   "valid_inspire--1": "Unknown",
   "facet-OrgForResource": "Organizations",
   "facet-sourceCatalogue": "Catalogues",


### PR DESCRIPTION
Translate "3" for INSPIRE validation which means that no conformance class can be define based on ETF validator configuration. eg. a record with no hierarchyLevel will not be validated.

Before

![image](https://user-images.githubusercontent.com/1701393/200780961-5e54473c-faf1-4915-bbc7-eb60b9e074c7.png)

After

![image](https://user-images.githubusercontent.com/1701393/200781097-1cd41e0a-69a0-4837-a8c5-05d126dc5923.png)


See https://github.com/geonetwork/core-geonetwork/blob/main/services/src/main/java/org/fao/geonet/api/processing/MInspireEtfValidateProcess.java#L256