### PR TITLE
Vocabularies / Add XLink mode producing Anchor encoding

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/convert/thesaurus-transformation.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/convert/thesaurus-transformation.xsl
@@ -59,6 +59,15 @@
     </xsl:call-template>
   </xsl:template>
 
+  <!-- Convert a concept to an ISO19139 gmd:MD_Keywords with an XLink which
+    will be resolved by XLink resolver with Anchor encoding. -->
+  <xsl:template name="to-iso19139-keyword-as-xlink-with-anchor">
+    <xsl:call-template name="to-iso19139-keyword">
+      <xsl:with-param name="withXlink" select="true()"/>
+      <xsl:with-param name="withAnchor" select="true()"/>
+    </xsl:call-template>
+  </xsl:template>
+
 
   <!-- Convert a concept to an ISO19139 keywords.
     If no keyword is provided, only thesaurus section is adaded.
@@ -143,7 +152,8 @@
                                    if (thesaurus/key) then thesaurus/key else /root/request/thesaurus,
                                   '&amp;id=', encode-for-uri(/root/request/id),
                                   if (/root/request/lang) then concat('&amp;lang=', /root/request/lang) else '',
-                                  if ($textgroupOnly) then '&amp;textgroupOnly' else '')"/>
+                                  if ($textgroupOnly) then '&amp;textgroupOnly' else '',
+                                  if ($withAnchor) then '&amp;transformation=to-iso19139-keyword-with-anchor' else '')"/>
         </xsl:when>
         <xsl:otherwise>
           <xsl:call-template name="to-md-keywords">


### PR DESCRIPTION
This is needed for user relying on XLink for keywords. In particular for those targeting INSPIRE conformity. Indeed classification of service is expected to be encoded using an `Anchor`.

Validation error:
```
The metadata record set has 1 record(s) with errors for this assertion.
XML document 'file.xml', record 'a5135c62-aae0-49ab-92ec-b23fbff3bd96':
At least one keyword shall be given with a child Anchor including an xlink:href attribute
 or CharacterString with one of the language-natural keyword values as defined in
 "Classification of Spatial Data Services" Part D 4. Please note that the URIs of all
 code list values from the INSPIRE Registry shall be referenced using the http protocol.
```

Valid fragments:
```xml
<gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
                  <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/SpatialDataServiceCategory/infoCatalogueService">Katalogdienst</gmx:Anchor>
or               
<gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
                  <gco:CharacterString>infoCatalogueService</gco:CharacterString
```
but not
```xml
<gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
                  <gco:CharacterString>Katalogdienst</gco:CharacterString
```

Currently Xlink created always encode keywords as `CharacterString`

![image](https://user-images.githubusercontent.com/1701393/201023790-29f31931-99fd-4f67-a51b-ac3d392cd129.png)


Valid XLink producing expected encoding:
```xml
<gmd:descriptiveKeywords xlink:href="local://srv/api/registries/vocabularies/keyword?skipdescriptivekeywords=true&amp;thesaurus=external.theme.httpinspireeceuropaeumetadatacodelistSpatialDataServiceCategory-SpatialDataServiceCategory&amp;id=http%3A%2F%2Finspire.ec.europa.eu%2Fmetadata-codelist%2FSpatialDataServiceCategory%2FinfoProductAccessService&amp;lang=ger,fre,eng,ita&amp;transformation=to-iso19139-keyword-with-anchor">
``` 

To configure the editor to produce the proper link use the following configuration:
```xml

        <thesaurus key="external.theme.httpinspireeceuropaeumetadatacodelistSpatialDataServiceCategory-SpatialDataServiceCategory"
                   transformations="to-iso19139-keyword-as-xlink-with-anchor"
        />
      </thesaurusList>
    </view>
```


![image](https://user-images.githubusercontent.com/1701393/201023846-b19adad6-1a60-4adf-8240-698267dae7d4.png)
