### PR TITLE
Fix close button in the metadata editor tooltips. 

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/FieldsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/FieldsDirective.js
@@ -341,9 +341,7 @@
                       0.95;
 
                     var closeBtn =
-                      '<button onclick="$(this).' +
-                      'closest(\'div.popover\').remove();" type="button" ' +
-                      'class="fa fa-times btn btn-link pull-right"></button>';
+                      '<a class="fa fa-times btn btn-link pull-right close-popover"></a>';
 
                     tooltipTarget.popover({
                       title: info.label,
@@ -366,6 +364,10 @@
                         '<h3 class="popover-title"></h3>' +
                         '<div class="popover-content"><p></p></div></div></div>',
                       trigger: isField ? "focus" : "click"
+                    });
+
+                    $(document).on("click", ".popover .close-popover", function () {
+                      $(this).closest("div.popover").remove();
                     });
 
                     if (event === "click" && !isField) {

--- a/web-ui/src/main/resources/catalog/components/edit/FieldsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/FieldsDirective.js
@@ -366,9 +366,13 @@
                       trigger: isField ? "focus" : "click"
                     });
 
-                    $(document).on("click", ".popover .close-popover", function () {
-                      $(this).closest("div.popover").remove();
-                    });
+                    // Remove first the event, to avoid ending with multiple events
+                    // every time a new popup is displayed.
+                    $(document)
+                      .off("click", ".popover .close-popover")
+                      .on("click", ".popover .close-popover", function () {
+                        $(this).closest("div.popover").remove();
+                      });
 
                     if (event === "click" && !isField) {
                       tooltipTarget.click("show");


### PR DESCRIPTION
Related to #6627

The upgrade of boostrap, includes this change, that is causing that the close button in the popup, as it's not part of the allowed elements (https://getbootstrap.com/docs/3.4/javascript/#js-sanitizer):

* Fixed a XSS vulnerability (CVE-2019-8331) in our tooltip and popover plugins by implementing a new HTML sanitizer

Previously:

![tooltips-prev](https://user-images.githubusercontent.com/1695003/201094687-7333bd17-8199-448f-a1be-97a208fbf3b8.png)

After:

![tooltips-after](https://user-images.githubusercontent.com/1695003/201094735-a26d715a-ebe4-48c8-9a83-ae8592a3d491.png)

This pull request changes the element from a `button` to an `a` element and adds dynamically the click event to handle the closing of the tooltip, readding again the button:

![tooltips-a-element](https://user-images.githubusercontent.com/1695003/201095306-7f3ae8f7-0cce-4ca7-af33-e8a133fdbda6.png)
