### PR TITLE
OIDC: added logging and better user updating

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/GeonetworkOAuth2LoginAuthenticationFilter.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/GeonetworkOAuth2LoginAuthenticationFilter.java
@@ -99,7 +99,11 @@ public class GeonetworkOAuth2LoginAuthenticationFilter extends OAuth2LoginAuthen
         OidcUser oidcUser = (OidcUser) oAuth2AuthenticationToken.getPrincipal();
 
         //save user
-        UserDetails userDetails = oAuth2SecurityProviderUtil.getUserDetails(authResult, true);
+        try {
+            UserDetails userDetails = oAuth2SecurityProviderUtil.getUserDetails(authResult, true);
+        } catch (Exception e) {
+            throw new IOException("OIDC: couldnt save user details",e);
+        }
 
         SecurityContextHolder.getContext().setAuthentication(authResult);
 

--- a/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/LoggingOidcAuthorizationCodeAuthenticationProvider.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/LoggingOidcAuthorizationCodeAuthenticationProvider.java
@@ -95,6 +95,8 @@ public class LoggingOidcAuthorizationCodeAuthenticationProvider extends OidcAuth
         Log.debug(Geonet.SECURITY, "OIDC LOGIN");
         Log.debug(Geonet.SECURITY, "----------");
 
+        Log.debug(Geonet.SECURITY,this.oidcConfiguration);
+
         OAuth2AuthorizationResponse authorizationResponse = authentication.getAuthorizationExchange().getAuthorizationResponse();
         if (authorizationResponse != null) {
             // logging the CODE should be ok at this stage, because it should have already called the OIDC server with

--- a/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/OAuth2SecurityProviderUtil.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/OAuth2SecurityProviderUtil.java
@@ -62,7 +62,7 @@ public class OAuth2SecurityProviderUtil implements SecurityProviderUtil {
         if (auth != null && auth.getPrincipal() instanceof OidcUser) {
             OidcUser user = (OidcUser) auth.getPrincipal();
             OidcIdToken idToken = user.getIdToken();
-            return oidcUser2GeonetworkUser.getUserDetails(idToken, withDbUpdate);
+            return oidcUser2GeonetworkUser.getUserDetails(idToken,user.getAttributes(), withDbUpdate);
         } else if (auth != null && auth.getPrincipal() instanceof OAuth2User) {
             OAuth2User user = (OAuth2User) auth.getPrincipal();
             return oidcUser2GeonetworkUser.getUserDetails(user.getAttributes(), withDbUpdate);

--- a/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/OAuth2SecurityProviderUtil.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/OAuth2SecurityProviderUtil.java
@@ -62,7 +62,7 @@ public class OAuth2SecurityProviderUtil implements SecurityProviderUtil {
         if (auth != null && auth.getPrincipal() instanceof OidcUser) {
             OidcUser user = (OidcUser) auth.getPrincipal();
             OidcIdToken idToken = user.getIdToken();
-            return oidcUser2GeonetworkUser.getUserDetails(idToken,user.getAttributes(), withDbUpdate);
+            return oidcUser2GeonetworkUser.getUserDetails(idToken, user.getAttributes(), withDbUpdate);
         } else if (auth != null && auth.getPrincipal() instanceof OAuth2User) {
             OAuth2User user = (OAuth2User) auth.getPrincipal();
             return oidcUser2GeonetworkUser.getUserDetails(user.getAttributes(), withDbUpdate);

--- a/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/OAuth2SecurityProviderUtil.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/OAuth2SecurityProviderUtil.java
@@ -22,7 +22,9 @@
  */
 package org.fao.geonet.kernel.security.openidconnect;
 
+import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.kernel.security.SecurityProviderUtil;
+import org.fao.geonet.utils.Log;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -52,13 +54,18 @@ public class OAuth2SecurityProviderUtil implements SecurityProviderUtil {
         return null;
     }
 
-    public UserDetails getUserDetails(Authentication auth) {
-        return getUserDetails(auth, false);
+    public UserDetails getUserDetails(Authentication auth)  {
+        try {
+            return getUserDetails(auth, false);
+        } catch (Exception e) {
+            Log.error(Geonet.SECURITY,"OIDC: couldnt get user details from OIDC user",e);
+            return null;
+        }
     }
 
     // get the user's details (spring).  This might update the GN database with the user
     // (see underlying  oidcUser2GeonetworkUser#getUserDetail for when).
-    public UserDetails getUserDetails(Authentication auth, boolean withDbUpdate) {
+    public UserDetails getUserDetails(Authentication auth, boolean withDbUpdate) throws Exception {
         if (auth != null && auth.getPrincipal() instanceof OidcUser) {
             OidcUser user = (OidcUser) auth.getPrincipal();
             OidcIdToken idToken = user.getIdToken();

--- a/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/OIDCConfiguration.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/OIDCConfiguration.java
@@ -247,4 +247,20 @@ public class OIDCConfiguration implements SecurityProviderConfiguration {
     }
 
 
+    @Override
+    public String toString() {
+        String result = "OIDC CONFIG: \n";
+        result += "      idTokenRoleLocation" +"=" +idTokenRoleLocation+  "\n";
+        result += "      updateGroup" +"=" +updateGroup+  "\n";
+        result += "      updateProfile" +"=" +updateProfile+  "\n";
+        result += "      scopes" +"=" +scopes+  "\n";
+
+        if ( (roleConverter != null) && (!roleConverter.isEmpty()) ){
+            result += "      roleConverter: \n";
+            for (Map.Entry<String, String> role : roleConverter.entrySet()) {
+                result += "            + "+ role.getKey()+" -> "+ role.getValue();
+            }
+        }
+        return result;
+    }
 }

--- a/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/OidcUser2GeonetworkUser.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/OidcUser2GeonetworkUser.java
@@ -117,8 +117,8 @@ public class OidcUser2GeonetworkUser {
      * @param withDbUpdate
      * @return
      */
-    public UserDetails getUserDetails(OidcIdToken idToken, boolean withDbUpdate) {
-        SimpleOidcUser simpleUser = simpleOidcUserFactory.create(idToken);
+    public UserDetails getUserDetails(OidcIdToken idToken,Map attributes, boolean withDbUpdate) {
+        SimpleOidcUser simpleUser = simpleOidcUserFactory.create(idToken,  attributes);
         if (!StringUtils.hasText(simpleUser.getUsername()))
             return null;
 

--- a/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/OidcUser2GeonetworkUser.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/OidcUser2GeonetworkUser.java
@@ -69,7 +69,7 @@ public class OidcUser2GeonetworkUser {
     private GeonetworkAuthenticationProvider geonetworkAuthenticationProvider;
 
 
-    public UserDetails getUserDetails(Map attributes, boolean withDbUpdate) {
+    public UserDetails getUserDetails(Map attributes, boolean withDbUpdate) throws Exception {
         SimpleOidcUser simpleUser = simpleOidcUserFactory.create(attributes);
         if (!StringUtils.hasText(simpleUser.getUsername()))
             return null;
@@ -117,7 +117,7 @@ public class OidcUser2GeonetworkUser {
      * @param withDbUpdate
      * @return
      */
-    public UserDetails getUserDetails(OidcIdToken idToken, Map attributes, boolean withDbUpdate) {
+    public UserDetails getUserDetails(OidcIdToken idToken, Map attributes, boolean withDbUpdate) throws Exception {
         SimpleOidcUser simpleUser = simpleOidcUserFactory.create(idToken, attributes);
         if (!StringUtils.hasText(simpleUser.getUsername()))
             return null;

--- a/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/OidcUser2GeonetworkUser.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/OidcUser2GeonetworkUser.java
@@ -117,7 +117,7 @@ public class OidcUser2GeonetworkUser {
      * @param withDbUpdate
      * @return
      */
-    public UserDetails getUserDetails(OidcIdToken idToken,Map attributes, boolean withDbUpdate) {
+    public UserDetails getUserDetails(OidcIdToken idToken, Map attributes, boolean withDbUpdate) {
         SimpleOidcUser simpleUser = simpleOidcUserFactory.create(idToken,  attributes);
         if (!StringUtils.hasText(simpleUser.getUsername()))
             return null;

--- a/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/OidcUser2GeonetworkUser.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/OidcUser2GeonetworkUser.java
@@ -118,7 +118,7 @@ public class OidcUser2GeonetworkUser {
      * @return
      */
     public UserDetails getUserDetails(OidcIdToken idToken, Map attributes, boolean withDbUpdate) {
-        SimpleOidcUser simpleUser = simpleOidcUserFactory.create(idToken,  attributes);
+        SimpleOidcUser simpleUser = simpleOidcUserFactory.create(idToken, attributes);
         if (!StringUtils.hasText(simpleUser.getUsername()))
             return null;
 

--- a/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/SimpleOidcUser.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/SimpleOidcUser.java
@@ -61,10 +61,8 @@ class SimpleOidcUser {
      * @param idToken  The User's ID token
      * @param attributes All the user's claims (ID Token claims + USERINFO claims)
      */
-    SimpleOidcUser(OIDCConfiguration oidcConfiguration, OIDCRoleProcessor oidcRoleProcessor, OidcIdToken idToken, Map attributes) {
-        if (attributes == null) {
-            attributes = new HashMap(); // easier if we remove all the null checks
-        }
+    SimpleOidcUser(OIDCConfiguration oidcConfiguration, OIDCRoleProcessor oidcRoleProcessor, OidcIdToken idToken, Map userAttributes) {
+        Map attributes = (userAttributes == null) ? new HashMap() : userAttributes;
 
         // -- get user name.  Should be in ID Token, but could be in the USERINFO
         username = idToken.getPreferredUsername();

--- a/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/SimpleOidcUserFactory.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/SimpleOidcUserFactory.java
@@ -39,8 +39,8 @@ public class SimpleOidcUserFactory {
     OIDCRoleProcessor oidcRoleProcessor;
 
 
-    public SimpleOidcUser create(OidcIdToken idToken) {
-        return new SimpleOidcUser(oidcConfiguration, oidcRoleProcessor, idToken);
+    public SimpleOidcUser create(OidcIdToken idToken, Map attributes) {
+        return new SimpleOidcUser(oidcConfiguration, oidcRoleProcessor, idToken, attributes);
     }
 
     public SimpleOidcUser create(Map attributes) {

--- a/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/SimpleOidcUserFactory.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/SimpleOidcUserFactory.java
@@ -39,11 +39,11 @@ public class SimpleOidcUserFactory {
     OIDCRoleProcessor oidcRoleProcessor;
 
 
-    public SimpleOidcUser create(OidcIdToken idToken, Map attributes) {
+    public SimpleOidcUser create(OidcIdToken idToken, Map attributes) throws Exception {
         return new SimpleOidcUser(oidcConfiguration, oidcRoleProcessor, idToken, attributes);
     }
 
-    public SimpleOidcUser create(Map attributes) {
+    public SimpleOidcUser create(Map attributes) throws Exception {
         return new SimpleOidcUser(oidcConfiguration, oidcRoleProcessor, attributes);
     }
 }

--- a/core/src/test/java/org/fao/geonet/kernel/security/openidconnect/SimpleOidcUserFactoryTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/security/openidconnect/SimpleOidcUserFactoryTest.java
@@ -59,7 +59,7 @@ public class SimpleOidcUserFactoryTest {
     public void testCreation() throws Exception {
         SimpleOidcUserFactory factory = createFactory();
         OidcIdToken idToken = createToken();
-        SimpleOidcUser user = factory.create(idToken);
+        SimpleOidcUser user = factory.create(idToken, null);
 
         assertNotNull(user);
         assertEquals("user@example.com", user.getUsername());
@@ -98,7 +98,7 @@ public class SimpleOidcUserFactoryTest {
     public void testUpdateUser() throws Exception {
         SimpleOidcUserFactory factory = createFactory();
         OidcIdToken idToken = createToken();
-        SimpleOidcUser user = factory.create(idToken);
+        SimpleOidcUser user = factory.create(idToken, null);
         User userGN = new User();
         userGN.setUsername(user.getUsername());
         user.updateUser(userGN);


### PR DESCRIPTION
This PR has two minor items - both to do with the OIDC (oauth2 -  open id connect) login;

1. I added a bit more logging for the OIDC configuration (only shown when `OPENIDCONNECT_LOGSENSITIVE_INFO` is `true`). This is helpful for debugging issues and to verify the configuration when troubleshooting.

2. I added better support for updating some of the user information (most notably first and last name) based on the `USERINFO` map (and not just the ID Token). This is more robust since many systems do not put the first/last name in the ID Token (only in the `userinfo` endpoint map).


