### PR TITLE
UI Settings / Unselect added option once added to the form

### DIFF
--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/UiConfigDirective.js
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/UiConfigDirective.js
@@ -163,6 +163,7 @@
           scope.$watch("optionsToAdd", function (n, o) {
             if (n && (n.path != (o && o.path) || n.path === ".")) {
               scope.jsonConfig = addOptionToConfig(n, scope.jsonConfig);
+              scope.optionsToAdd = undefined;
             }
           });
 

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -1271,7 +1271,7 @@
               result = result.concat(
                 that.getObjectKeysPaths(obj[key], stopKeyList, allLevels, prefix + key)
               );
-            } else {
+            } else if (key !== "mods") {
               result.push(prefix + key);
             }
             return result;


### PR DESCRIPTION
When choosing an option to customize, add it to the form and unselect it from the list. 
If the user swith to the JSON form and come back, he will have the possibility to add it back (without reloading the page or selecting another one).

![image](https://user-images.githubusercontent.com/1701393/203077460-2751b3f5-fd52-4de2-9ece-419c578cbd79.png)


Also fix JS error, if user set config to 

```json
{
  "mods": {}
}
```
