### PR TITLE
Table of Contents for the Feature Catalog page

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/config-editor.xml
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/config-editor.xml
@@ -596,6 +596,19 @@
         <col del=".."/>
       </row>
     </table>
+    <table for="gfc:FC_ListedValue">
+      <header>
+        <col label="gfc:code"/>
+        <col label="gfc:label"/>
+        <col label="gfc:definition"/>
+      </header>
+      <row>
+        <col xpath="gfc:code"/>
+        <col xpath="gfc:label"/>
+        <col xpath="gfc:definition"/>
+        <col del=".."/>
+      </row>
+    </table>
   </tableFields>
 
 

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -1909,7 +1909,7 @@
                 scope.mode = iAttrs["gnLinkToMetadata"];
                 scope.popupid = "#linkto" + scope.mode + "-popup";
                 scope.btn = {};
-                
+
                 scope.updateParams = function () {
                   scope.searchObj.params.any = scope.searchObj.any;
                 };

--- a/web-ui/src/main/resources/catalog/components/search/mdview/mdviewModule.js
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/mdviewModule.js
@@ -203,6 +203,19 @@
         );
       };
 
+      /**
+       * Scroll to an element in the page using it's ID
+       *
+       * @param id  unique element identifier
+       */
+      $scope.scrollToSection = function (id) {
+        var scrollToElement = document.getElementById(id);
+
+        if (scrollToElement) {
+          scrollToElement.scrollIntoView();
+        }
+      };
+
       // activate the tabs in the full metadata view
       $scope.activateTabs = function () {
         // attach click to tab

--- a/web-ui/src/main/resources/catalog/locales/en-v4.json
+++ b/web-ui/src/main/resources/catalog/locales/en-v4.json
@@ -368,5 +368,6 @@
   "mimeType": "Format",
   "uploadedResourceAlreadyExistException": "File {{file}} already exist in this record data store. Remove it first.",
   "switchPortals": "Switch to another Portal",
-  "dataPreview":  "Discover data"
+  "dataPreview":  "Discover data",
+  "tableOfContents": "Table of Contents"
 }

--- a/web-ui/src/main/resources/catalog/style/gn_metadata.less
+++ b/web-ui/src/main/resources/catalog/style/gn_metadata.less
@@ -557,11 +557,10 @@ ul.container-list {
         padding-left: 0;
       }
       &.gn-table-attribute {
-        padding: 0;
         table {
           th {
             border-top: 0;
-            border-bottom: 2px solid @table-border-color;
+            //border-bottom: 2px solid @table-border-color;
           }
           td {
             padding-left: 8px;
@@ -572,6 +571,16 @@ ul.container-list {
             }
           }
         }
+      }
+    }
+  }
+  .gn-section-featureCatalog {
+    h3 {
+      margin-top: 30px;
+    }
+    .table-striped {
+      td {
+        padding: 10px;
       }
     }
   }

--- a/web-ui/src/main/resources/catalog/views/default/directives/partials/attributetable.html
+++ b/web-ui/src/main/resources/catalog/views/default/directives/partials/attributetable.html
@@ -1,4 +1,4 @@
-<table class="table">
+<table class="table table-bordered">
   <tr>
     <th data-translate="">attributeName</th>
     <th data-translate="" data-ng-show="showCodeColumn">attributeCode</th>

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/featurecatalogue.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/featurecatalogue.html
@@ -1,6 +1,6 @@
 <div
   class="panel panel-default gn-margin-top width-50"
-  data-ng-show="mdView.current.record.featureTypes.length > 0"
+  data-ng-show="mdView.current.record.featureTypes.length > 1"
 >
   <div class="panel-heading" data-gn-slide-toggle="true">
     <span class="text-uppercase" data-translate="">tableOfContents</span>
@@ -10,6 +10,7 @@
       <li
         class="list-group-item"
         data-ng-repeat="featureType in mdView.current.record.featureTypes"
+        data-ng-if="featureType.typeName !== ''"
       >
         <a
           href
@@ -27,8 +28,12 @@
   id="gn-featurecatalog-spy-target-{{featureType.code}}"
   class="gn-margin-bottom"
 >
-  <h3><span data-translate="">featureAttributeTable</span> - {{featureType.typeName}}</h3>
-  <table class="table table-striped table-bordered">
+  <h3>
+    <span data-translate="">featureAttributeTable</span>
+    <span data-ng-if="featureType.typeName !== ''"> - </span>
+    {{featureType.typeName}}
+  </h3>
+  <table class="table table-striped table-bordered gn-margin-left-lg gn-margin-top-lg">
     <tbody>
       <tr data-ng-if="featureType.typeName">
         <th></th>

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/featurecatalogue.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/featurecatalogue.html
@@ -1,7 +1,34 @@
-<div data-ng-repeat="featureType in mdView.current.record.featureTypes">
-  <h3 data-translate="">featureAttributeTable</h3>
+<div
+  class="panel panel-default gn-margin-top width-50"
+  data-ng-show="mdView.current.record.featureTypes.length > 0"
+>
+  <div class="panel-heading" data-gn-slide-toggle="true">
+    <span class="text-uppercase" data-translate="">tableOfContents</span>
+  </div>
+  <div class="panel-body">
+    <ul class="list-group">
+      <li
+        class="list-group-item"
+        data-ng-repeat="featureType in mdView.current.record.featureTypes"
+      >
+        <a
+          href
+          data-ng-click="scrollToSection('gn-featurecatalog-spy-target-' + featureType.code)"
+        >
+          {{featureType.typeName}}
+        </a>
+      </li>
+    </ul>
+  </div>
+</div>
 
-  <table class="table table-striped">
+<div
+  data-ng-repeat="featureType in mdView.current.record.featureTypes"
+  id="gn-featurecatalog-spy-target-{{featureType.code}}"
+  class="gn-margin-bottom"
+>
+  <h3><span data-translate="">featureAttributeTable</span> - {{featureType.typeName}}</h3>
+  <table class="table table-striped table-bordered">
     <tbody>
       <tr data-ng-if="featureType.typeName">
         <th></th>
@@ -24,7 +51,10 @@
         <td>{{featureType.aliases}}</td>
       </tr>
       <tr data-ng-if="featureType.attributeTable">
-        <td colspan="2" class="gn-noborder-top gn-nopadding-top gn-nopadding-bottom" />
+        <td
+          colspan="2"
+          class="gn-noborder-top gn-noborder-bottom gn-nopadding-top gn-nopadding-bottom"
+        />
       </tr>
       <tr data-ng-if="featureType.attributeTable">
         <td colspan="2" class="gn-noborder-top gn-table-attribute">
@@ -37,6 +67,7 @@
     </tbody>
   </table>
 </div>
+
 <div
   data-ng-if="mdView.current.record.related.uuids"
   data-gn-related="mdView.current.record"

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/featurecatalogue.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/featurecatalogue.html
@@ -14,7 +14,7 @@
       >
         <a
           href
-          data-ng-click="scrollToSection('gn-featurecatalog-spy-target-' + featureType.code)"
+          data-ng-click="scrollToSection('gn-featurecatalog-spy-target-' + ((featureType.code + '-' + featureType.typeName) | md5))"
         >
           {{featureType.typeName}}
         </a>
@@ -25,7 +25,7 @@
 
 <div
   data-ng-repeat="featureType in mdView.current.record.featureTypes"
-  id="gn-featurecatalog-spy-target-{{featureType.code}}"
+  id="gn-featurecatalog-spy-target-{{((featureType.code + '-' + featureType.typeName) | md5)}}"
   class="gn-margin-bottom"
 >
   <h3>

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/type-dataset.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/type-dataset.html
@@ -23,7 +23,9 @@
 </div>
 
 <!-- map & extent -->
-<div class="row gn-section gn-padding-top">
+<div
+  class="row gn-section gn-section-{{mdView.current.record.resourceType[0]}} gn-padding-top"
+>
   <div class="gn-record" data-ng-class="showDataBrowser ? 'col-md-12' : 'col-md-8'">
     <div data-ng-if="mdView.current.record.geom">
       <h2>{{(showDataBrowser ? 'dataPreview' : 'spatialExtent') | translate}}</h2>
@@ -41,7 +43,7 @@
 </div>
 
 <!-- links (Download, API, Others) -->
-<div class="row gn-section">
+<div class="row gn-section gn-section-{{mdView.current.record.resourceType[0]}}">
   <div class="col-md-8 gn-record">
     <div ng-include="'../../catalog/views/default/templates/recordView/downloads.html'" />
     <div
@@ -89,7 +91,7 @@
   </div>
 </div>
 
-<div class="row gn-section">
+<div class="row gn-section gn-section-{{mdView.current.record.resourceType[0]}}">
   <div class="col-md-12 gn-record">
     <h2 data-translate="">technicalInformation</h2>
   </div>
@@ -108,7 +110,7 @@
 </div>
 
 <div
-  class="row gn-section"
+  class="row gn-section gn-section-{{mdView.current.record.resourceType[0]}}"
   data-ng-if="mdView.current.record.featureTypes.length
                  || mdView.current.record.related.fcats.length > 0"
 >
@@ -135,7 +137,7 @@
 </div>
 
 <div
-  class="row gn-section gn-padding-bottom-lg"
+  class="row gn-section gn-section-{{mdView.current.record.resourceType[0]}} gn-padding-bottom-lg"
   data-ng-if="mdView.current.record.specificationConformance"
 >
   <div class="col-md-8 gn-record">
@@ -143,7 +145,7 @@
   </div>
 </div>
 
-<div class="row gn-section">
+<div class="row gn-section gn-section-{{mdView.current.record.resourceType[0]}}">
   <div class="col-md-8 gn-record gn-break">
     <div ng-include="'../../catalog/views/default/templates/recordView/contact.html'" />
   </div>
@@ -165,7 +167,7 @@
 </div>
 
 <!-- metadata -->
-<div class="gn-section row">
+<div class="gn-section gn-section-{{mdView.current.record.resourceType[0]}} row">
   <h2 class="col-md-12" data-translate="">metadataInformation</h2>
   <div class="col-md-8">
     <div

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/type-series.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/type-series.html
@@ -59,7 +59,7 @@
   />
 </div>
 
-<div class="row gn-section">
+<div class="row gn-section gn-section-{{mdView.current.record.resourceType[0]}}">
   <div class="col-md-8 gn-record">
     <div ng-include="'../../catalog/views/default/templates/recordView/downloads.html'" />
   </div>
@@ -76,7 +76,7 @@
 </div>
 
 <div
-  class="row gn-section"
+  class="row gn-section gn-section-{{mdView.current.record.resourceType[0]}}"
   data-ng-if="mdView.current.record.featureTypes.length
                  || mdView.current.record.related.fcats.length > 0"
 >
@@ -88,7 +88,7 @@
 </div>
 
 <!-- constraints -->
-<div class="row gn-section">
+<div class="row gn-section gn-section-{{mdView.current.record.resourceType[0]}}">
   <div class="col-md-8 gn-record">
     <div
       ng-include="'../../catalog/views/default/templates/recordView/constraints.html'"
@@ -98,7 +98,7 @@
 
 <!-- lineage -->
 <div
-  class="row gn-section"
+  class="row gn-section gn-section-{{mdView.current.record.resourceType[0]}}"
   data-ng-if="mdView.current.record.lineage
                  || mdView.current.record.sourceDescription
                  || mdView.current.record.supplementalInformation"
@@ -125,7 +125,7 @@
 </div>
 
 <!-- metadata -->
-<div class="gn-section row">
+<div class="gn-section gn-section-{{mdView.current.record.resourceType[0]}} row">
   <h2 class="col-md-12" data-translate="">metadataInformation</h2>
   <div class="col-md-8">
     <div


### PR DESCRIPTION
The metadata page for a feature catalog can be long and contain many tables. This PR adds a table of contents in order to jump to the table of interest.

**Table closed**
![fc-toc-closed](https://user-images.githubusercontent.com/19608667/203288903-350047a7-7447-47e5-bdc7-897846e8da6a.png)

**Table open**
![fc-toc](https://user-images.githubusercontent.com/19608667/203289047-3876f2b9-496f-4073-b5c0-456fdf288441.png)
