### PR TITLE
Indexing / Thesaurus field name if no thesaurus identifier

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/ThesaurusManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/ThesaurusManager.java
@@ -380,20 +380,31 @@ public class ThesaurusManager implements ThesaurusFinder {
 
     @Override
     public Thesaurus getThesaurusByConceptScheme(String uri) {
-
         for (Map.Entry<String, Thesaurus> entry : getThesauriMap().entrySet()) {
             try {
                 Thesaurus thesaurus = entry.getValue();
-
                 if (thesaurus.hasConceptScheme(uri)) {
                     return thesaurus;
                 }
-
             } catch (Exception e) {
                 Log.error(Geonet.THESAURUS_MAN, "Get Thesaurus By Concept Scheme error", e);
             }
         }
 
+        return null;
+    }
+
+    public Thesaurus getThesaurusByTitle(String title) {
+        for (Map.Entry<String, Thesaurus> entry : getThesauriMap().entrySet()) {
+            try {
+                Thesaurus thesaurus = entry.getValue();
+                if (thesaurus.getTitle().equals(title)) {
+                    return thesaurus;
+                }
+            } catch (Exception e) {
+                Log.error(Geonet.THESAURUS_MAN, "Get thesaurus by title error", e);
+            }
+        }
         return null;
     }
 

--- a/core/src/main/java/org/fao/geonet/util/XslUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/XslUtil.java
@@ -1346,6 +1346,14 @@ public final class XslUtil {
         return thesaurusManager.getThesauriDirectory().toString();
     }
 
+    public static String getThesaurusIdByTitle(String title) {
+        ApplicationContext applicationContext = ApplicationContextHolder.get();
+        ThesaurusManager thesaurusManager = applicationContext.getBean(ThesaurusManager.class);
+        Thesaurus thesaurus = thesaurusManager.getThesaurusByTitle(title);
+
+        return thesaurus == null ? "" : "geonetwork.thesaurus." + thesaurus.getKey();
+    }
+
 
     /**
      * Utility method to retrieve the name (label) for an iso language using it's code for a specific language.

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
@@ -541,7 +541,9 @@
                                           mcc:code/(gco:CharacterString|gcx:Anchor)"/>
 
             <xsl:variable name="thesaurusId"
-                          select="normalize-space($thesaurusRef/text())"/>
+                          select="if ($thesaurusRef != '')
+                                  then normalize-space($thesaurusRef/text())
+                                  else util:getThesaurusIdByTitle($thesaurusTitle)"/>
 
             <xsl:variable name="thesaurusUri"
                           select="$thesaurusRef/@xlink:href"/>

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
@@ -494,7 +494,9 @@
                                           gmd:code/(gco:CharacterString|gmx:Anchor)"/>
 
             <xsl:variable name="thesaurusId"
-                          select="normalize-space($thesaurusRef/text())"/>
+                          select="if ($thesaurusRef != '')
+                                  then normalize-space($thesaurusRef/text())
+                                  else util:getThesaurusIdByTitle($thesaurusTitle)"/>
 
             <xsl:variable name="thesaurusUri"
                           select="$thesaurusRef/@xlink:href"/>


### PR DESCRIPTION
Some records may not encode thesaurus identifier like in

```xml
<gmd:thesaurusName>
                  <gmd:CI_Citation>
                     <gmd:title>
                        <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/theme">GEMET - INSPIRE themes, version 1.0</gmx:Anchor>
                     </gmd:title>
                     <gmd:date>
                        <gmd:CI_Date>
                           <gmd:date>
                              <gco:Date>2008-06-01</gco:Date>
                           </gmd:date>
                           <gmd:dateType>
                              <gmd:CI_DateTypeCode codeListValue="publication"
                                                   codeList="https://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode"/>
                           </gmd:dateType>
                        </gmd:CI_Date>
                     </gmd:date>
                  </gmd:CI_Citation>
               </gmd:thesaurusName>

```

In this case, the thesaurus field name is based on the title even if the thesaurus is loaded in the catalogue. Add a check to retrieve thesaurus identifier from the thesaurus title to build consistent field name whatever the encoding is.

This is useful for aggregation config.

eg. The INSPIRE theme field name should be
`th_httpinspireeceuropaeutheme-theme`