### PR TITLE
Fix Pages API in migrated databases

### DIFF
--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v400/migrate-db-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v400/migrate-db-default.sql
@@ -1,0 +1,3 @@
+-- Column names change in GeoNetwork 4.x for spg_sections table
+ALTER TABLE spg_sections RENAME COLUMN page_language TO spg_page_language;
+ALTER TABLE spg_sections RENAME COLUMN page_linktext TO spg_page_linktext;

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v400/migrate-db-sqlserver.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v400/migrate-db-sqlserver.sql
@@ -1,0 +1,3 @@
+-- Column names change in GeoNetwork 4.x for spg_sections table
+EXEC sp_rename 'spg_sections.page_language', 'spg_sections.spg_page_language';
+EXEC sp_rename 'spg_sections.page_linktext', 'spg_sections.spg_page_linktext';


### PR DESCRIPTION
Using the Pages API with a migrated database from 3.x, returns the following error:

```
{"message":"HttpMessageNotWritableException","code":"runtime_exception","description":"Could not write JSON: could not extract ResultSet; nested exception is com.fasterxml.jackson.databind.JsonMappingException: could not extract ResultSet (through reference chain: java.util.ArrayList[0]->org.fao.geonet.api.pages.PageJSONWrapper[\"sections\"])"}% 
```

It seems due to the JPA upgrade in GeoNetwork 4, the columns of the `SPG_Sections` table have change:

Migrated database:

![table-migrated](https://user-images.githubusercontent.com/1695003/203598970-ae049f9e-9fcb-4505-ac47-385d1944810a.png)

New database:

![tabla-new](https://user-images.githubusercontent.com/1695003/203599023-b8a0446b-eff2-465e-bcad-d5db568ce49e.png)

This pull request adds the migration script to rename the columns.

Users that have already migrated to version 4.2.x, should apply the SQL manually,