### PR TITLE
ISO19139 - Fix indexing of dates when the date element contains the date type as a text value

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
@@ -278,7 +278,7 @@
                           select="string(gmd:date[1]/gco:Date|gmd:date[1]/gco:DateTime)"/>
 
             <xsl:variable name="zuluDateTime" as="xs:string?">
-              <xsl:if test="gn-fn-index:is-isoDate(.)">
+              <xsl:if test="gn-fn-index:is-isoDate($date)">
                 <xsl:value-of select="date-util:convertToISOZuluDateTime(normalize-space($date))"/>
               </xsl:if>
             </xsl:variable>


### PR DESCRIPTION
Some metadata schemas based on ISO19139 store the date type with the value in the attribute `codeListValue` and also as a text, for example, see `creatie` in the following snippet:

```
<gmd:date>
  <gmd:CI_Date>
    <gmd:date>
      <gco:Date>2022-06-15</gco:Date>
    </gmd:date>
    <gmd:dateType>
      <gmd:CI_DateTypeCode codeList="https://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode" 
                           codeListValue="creation">creatie</gmd:CI_DateTypeCode>
    </gmd:dateType>
  </gmd:CI_Date>
</gmd:date>
```

The current code was not processing properly the dates, causing in the Admin console > status panel some error entries like the following, with valid dates:

```
Warning / Date creation with value '2022-06-15' was not a valid date format.
```