### PR TITLE
Add option to parse secondary properties names from a more human readable name

### DIFF
--- a/core/src/main/java/org/fao/geonet/resources/CMISConfiguration.java
+++ b/core/src/main/java/org/fao/geonet/resources/CMISConfiguration.java
@@ -23,12 +23,15 @@
 
 package org.fao.geonet.resources;
 
+import org.apache.chemistry.opencmis.client.api.Folder;
 import org.apache.chemistry.opencmis.client.api.Repository;
+import org.apache.chemistry.opencmis.client.api.SecondaryType;
 import org.apache.chemistry.opencmis.client.api.Session;
 import org.apache.chemistry.opencmis.client.api.SessionFactory;
 import org.apache.chemistry.opencmis.client.runtime.SessionFactoryImpl;
 import org.apache.chemistry.opencmis.commons.PropertyIds;
 import org.apache.chemistry.opencmis.commons.SessionParameter;
+import org.apache.chemistry.opencmis.commons.definitions.PropertyDefinition;
 import org.apache.chemistry.opencmis.commons.enums.BindingType;
 import org.apache.chemistry.opencmis.commons.enums.IncludeRelationships;
 import org.apache.chemistry.opencmis.commons.enums.VersioningState;
@@ -90,6 +93,7 @@ public class CMISConfiguration {
      * {property_name}  - for primary properties - i.e. cmis:description
      */
     private String cmisMetadataUUIDPropertyName;
+    private String parsedCmisMetadataUUIDPropertyName =  null;
     private boolean cmisMetadataUUIDSecondaryProperty = false;
 
     /**
@@ -109,6 +113,7 @@ public class CMISConfiguration {
      * If null then validation status will default to UNKNOWN.
      */
     private String externalResourceManagementValidationStatusPropertyName;
+    private String parsedExternalResourceManagementValidationStatusPropertyName =  null;
     /**
      * Default value to be used for the validation status.
      * If null then it will use INCOMPLETE as the default.
@@ -455,7 +460,12 @@ public class CMISConfiguration {
     }
 
     public String getCmisMetadataUUIDPropertyName() {
-        return cmisMetadataUUIDPropertyName;
+        // If we were able to parse the field on startup then return the parsed version.
+        if (parsedCmisMetadataUUIDPropertyName != null) {
+            return parsedCmisMetadataUUIDPropertyName;
+        } else {
+            return cmisMetadataUUIDPropertyName;
+        }
     }
 
     public void setCmisMetadataUUIDPropertyName(String cmisMetadataUUIDPropertyName) {
@@ -475,7 +485,12 @@ public class CMISConfiguration {
     }
 
     public String getExternalResourceManagementValidationStatusPropertyName() {
-        return externalResourceManagementValidationStatusPropertyName;
+        // If we were able to parse the field on startup then return the parsed version.
+        if (parsedExternalResourceManagementValidationStatusPropertyName != null) {
+            return parsedExternalResourceManagementValidationStatusPropertyName;
+        } else {
+            return externalResourceManagementValidationStatusPropertyName;
+        }
     }
 
     public void setExternalResourceManagementValidationStatusPropertyName(String externalResourceManagementValidationStatusPropertyName) {
@@ -600,6 +615,10 @@ public class CMISConfiguration {
                     repositoryUrl + "' using product '" + client.getRepositoryInfo().getProductName() + "' version '" +
                     client.getRepositoryInfo().getProductVersion() + "'.");
 
+                // Check if we can parse the secondary parameters from human readable to secondary ids.
+                parsedCmisMetadataUUIDPropertyName = parseSecondaryProperty(client, cmisMetadataUUIDPropertyName);
+                parsedExternalResourceManagementValidationStatusPropertyName = parseSecondaryProperty(client, externalResourceManagementValidationStatusPropertyName);
+
                 // Setup default options
                 // Ensure caching is on.
                 if (!client.getDefaultContext().isCacheEnabled()) {
@@ -719,5 +738,54 @@ public class CMISConfiguration {
         } else {
             return serviceUrl;
         }
+    }
+
+    /**
+     * On certain cmis system the secondary property name/id is a bunch of codes that get changed each time the application is deployed.
+     *  Example from Open Text CMIS -   otCat:43102->otCat:43102:43102_5
+     *  This can cause issues for system that are re-deployed and the new codes need to be entered.
+     *  This function help convert a human-readable entry like
+     *     Catalogue->GeoNetwork Catalogue ID
+     *  to
+     *     otCat:43102->otCat:43102:43102_5
+     *  The parsing is done by using the property display name.
+     *
+     *  Note that using the display name means that it will stop on the next restart if the display name for the property is changed.
+     *  so care should be taken in changing the display names if using this option.
+     *
+     * @param client connection to use to access CMIS server.
+     * @param propertyName to be parsed
+     * @return null if the property name cannot be parsed otherwise it will return the parsed value.
+     */
+    private String parseSecondaryProperty(Session client, String propertyName) {
+        if (!StringUtils.isEmpty(propertyName) && propertyName.contains(CMIS_SECONDARY_PROPERTY_SEPARATOR)) {
+            String[] splitPropertyNames = propertyName.split(Pattern.quote(CMIS_SECONDARY_PROPERTY_SEPARATOR));
+            if (splitPropertyNames.length == 2) {
+                Folder baseFolder = (Folder) client.getObjectByPath(this.baseRepositoryPath);
+
+                for (SecondaryType secondaryType : baseFolder.getSecondaryTypes()) {
+                    if (secondaryType.getId().equals(splitPropertyNames[0]) || secondaryType.getDisplayName().equals(splitPropertyNames[0])) {
+                        for (Map.Entry<String, PropertyDefinition<?>> entry : secondaryType.getPropertyDefinitions().entrySet()) {
+                            if (entry.getValue().getId().equals(splitPropertyNames[1]) || entry.getValue().getDisplayName().equals(splitPropertyNames[1])) {
+                                String ParsedPropertyName=secondaryType.getId() + CMIS_SECONDARY_PROPERTY_SEPARATOR + entry.getKey();
+                                // The parsed property equals to the original property then we can simply return null as there were no changes.
+                                if (ParsedPropertyName.equals(propertyName)) {
+                                    return null;
+                                } else {
+                                    Log.info(Geonet.RESOURCES,
+                                        String.format("Parsed CMIS secondary properties from '%s' to '%s'", propertyName, ParsedPropertyName));
+                                    return ParsedPropertyName;
+                                }
+                            }
+                        }
+                    }
+                }
+
+                // If we make it here then it means that we were not able to parse the value, so it is most likely invalid.
+                Log.error(Geonet.RESOURCES,
+                    String.format("Unable to locate secondary property name '%s'", propertyName));
+            }
+        }
+        return null;
     }
 }

--- a/core/src/main/java/org/fao/geonet/resources/CMISConfiguration.java
+++ b/core/src/main/java/org/fao/geonet/resources/CMISConfiguration.java
@@ -767,14 +767,14 @@ public class CMISConfiguration {
                     if (secondaryType.getId().equals(splitPropertyNames[0]) || secondaryType.getDisplayName().equals(splitPropertyNames[0])) {
                         for (Map.Entry<String, PropertyDefinition<?>> entry : secondaryType.getPropertyDefinitions().entrySet()) {
                             if (entry.getValue().getId().equals(splitPropertyNames[1]) || entry.getValue().getDisplayName().equals(splitPropertyNames[1])) {
-                                String ParsedPropertyName=secondaryType.getId() + CMIS_SECONDARY_PROPERTY_SEPARATOR + entry.getKey();
+                                String parsedPropertyName = secondaryType.getId() + CMIS_SECONDARY_PROPERTY_SEPARATOR + entry.getKey();
                                 // The parsed property equals to the original property then we can simply return null as there were no changes.
-                                if (ParsedPropertyName.equals(propertyName)) {
+                                if (parsedPropertyName.equals(propertyName)) {
                                     return null;
                                 } else {
                                     Log.info(Geonet.RESOURCES,
-                                        String.format("Parsed CMIS secondary properties from '%s' to '%s'", propertyName, ParsedPropertyName));
-                                    return ParsedPropertyName;
+                                        String.format("Parsed CMIS secondary properties from '%s' to '%s'", propertyName, parsedPropertyName));
+                                    return parsedPropertyName;
                                 }
                             }
                         }


### PR DESCRIPTION
Add option to parse secondary properties names for (CmisMetadataUUIDPropertyName ExternalResourceManagementValidationStatusPropertyName) from a more human readable name