### PR TITLE
Datastore / Metadata files / FME API Support

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -317,6 +317,10 @@
       <artifactId>httpclient</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpmime</artifactId>
+    </dependency>
+    <dependency>
       <groupId>commons-net</groupId>
       <artifactId>commons-net</artifactId>
     </dependency>
@@ -605,6 +609,10 @@
     <dependency>
       <groupId>org.jasypt</groupId>
       <artifactId>jasypt</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.httpcomponents</groupId>
+      <artifactId>httpmime</artifactId>
     </dependency>
   </dependencies>
 

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
@@ -187,6 +187,11 @@ public class CMISStore extends AbstractStore {
     }
 
     @Override
+    public void streamResource(ServiceContext context, String metadataUuid, String resourceId, Boolean approved, OutputStream out) throws Exception {
+        throw new UnsupportedOperationException(String.format("%s does not support streamResource.", this.getClass().getSimpleName()));
+    }
+
+    @Override
     public ResourceHolder getResourceInternal(String metadataUuid, MetadataResourceVisibility visibility, String resourceId, Boolean approved) throws Exception {
         throw new UnsupportedOperationException("CMISStore does not support getResourceInternal.");
     }

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/FMEStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/FMEStore.java
@@ -1,0 +1,367 @@
+/*
+ * =============================================================================
+ * ===	Copyright (C) 2001-2022 Food and Agriculture Organization of the
+ * ===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * ===	and United Nations Environment Programme (UNEP)
+ * ===
+ * ===	This program is free software; you can redistribute it and/or modify
+ * ===	it under the terms of the GNU General Public License as published by
+ * ===	the Free Software Foundation; either version 2 of the License, or (at
+ * ===	your option) any later version.
+ * ===
+ * ===	This program is distributed in the hope that it will be useful, but
+ * ===	WITHOUT ANY WARRANTY; without even the implied warranty of
+ * ===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * ===	General Public License for more details.
+ * ===
+ * ===	You should have received a copy of the GNU General Public License
+ * ===	along with this program; if not, write to the Free Software
+ * ===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ * ===
+ * ===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * ===	Rome - Italy. email: geonetwork@osgeo.org
+ * ==============================================================================
+ */
+
+package org.fao.geonet.api.records.attachments;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.io.CharStreams;
+import jeeves.server.context.ServiceContext;
+import org.apache.commons.io.IOUtils;
+import org.apache.http.client.methods.HttpDelete;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.client.methods.HttpRequestBase;
+import org.apache.http.entity.InputStreamEntity;
+import org.fao.geonet.api.exception.ResourceNotFoundException;
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.domain.MetadataResource;
+import org.fao.geonet.domain.MetadataResourceContainer;
+import org.fao.geonet.domain.MetadataResourceVisibility;
+import org.fao.geonet.kernel.setting.SettingManager;
+import org.fao.geonet.utils.DateUtil;
+import org.fao.geonet.utils.GeonetHttpRequestFactory;
+import org.fao.geonet.utils.Log;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.client.ClientHttpResponse;
+
+import javax.annotation.Nullable;
+import java.io.*;
+import java.nio.file.FileSystems;
+import java.nio.file.Path;
+import java.nio.file.PathMatcher;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * A FME store resources files in FME.
+ * <p>
+ * See https://docs.safe.com/fme/html/FME_REST/apidoc/v3/index.html#!/resources/add_post_14
+ *
+ * <pre>
+ *     datadir
+ *      |-{{metadata_uuid}}
+ *      |    |--doc.pdf
+ * </pre>
+ */
+public class FMEStore extends AbstractStore {
+    /**
+     * No support for private visibility. Once published on FME side,
+     * documents are visible.
+     */
+    public static final MetadataResourceVisibility fmeVisibility = MetadataResourceVisibility.PUBLIC;
+    public static final String ACCEPT_CONTENTS = "?accept=contents";
+    public static final String DEPTH_1 = "?depth=1";
+    public static final String CREATE_DIRECTORIES_TRUE_OVERWRITE_TRUE = "?createDirectories=true&overwrite=true";
+
+    @Autowired
+    SettingManager settingManager;
+
+    @Autowired
+    GeonetHttpRequestFactory httpRequestFactory;
+
+    /**
+     * Something like https://docs.safe.com/fmerest/v3/resources/connections/MyTest/filesys/.
+     */
+    private String fmeApiUrl;
+
+    /**
+     * A valid API token.
+     */
+    private String fmeToken;
+
+    public FMEStore() {
+    }
+
+    @Override
+    public List<MetadataResource> getResources(ServiceContext context, String metadataUuid,
+                                               MetadataResourceVisibility visibility,
+                                               String filter, Boolean approved) throws Exception {
+        if (visibility == MetadataResourceVisibility.PRIVATE) {
+            return new ArrayList<>();
+        }
+        int metadataId = canDownload(context, metadataUuid, fmeVisibility, approved);
+
+        List<MetadataResource> resourceList = new ArrayList<>();
+
+        String url = fmeApiUrl + metadataUuid + DEPTH_1;
+        HttpGet httpGet = new HttpGet(url);
+        addFmeTokenHeader(httpGet);
+        try (ClientHttpResponse httpResponse = httpRequestFactory.execute(httpGet)) {
+            if (httpResponse.getRawStatusCode() == 200) {
+                resourceList = getResourcesFromFmeFileList(metadataUuid, filter, approved, metadataId, httpResponse);
+            }
+        } catch (Exception e) {
+            Log.error(Geonet.RESOURCES,
+                String.format("Error retrieving file lists for %s. Error is: %s",
+                    metadataUuid, e.getMessage()));
+        }
+        return resourceList;
+    }
+
+    @Override
+    public ResourceHolder getResource(ServiceContext context, String metadataUuid, MetadataResourceVisibility metadataResourceVisibility, String resourceId, Boolean approved) throws Exception {
+        return null;
+    }
+
+    private List<MetadataResource> getResourcesFromFmeFileList(String metadataUuid,
+                                                               String filter,
+                                                               Boolean approved,
+                                                               int metadataId,
+                                                               ClientHttpResponse httpResponse)
+        throws IOException {
+        List<MetadataResource> resourceList = new ArrayList<>();
+        if (filter == null) {
+            filter = FilesystemStore.DEFAULT_FILTER;
+        }
+        PathMatcher matcher =
+            FileSystems.getDefault().getPathMatcher("glob:" + filter);
+
+        ObjectMapper objectMapper = new ObjectMapper();
+        JsonNode tree = objectMapper.readTree(
+            CharStreams.toString(new InputStreamReader(httpResponse.getBody())));
+        JsonNode files = tree.get("contents");
+        if (files.isArray()) {
+            for (JsonNode file : files) {
+                JsonNode name = file.get("name");
+                if (name != null) {
+                    Path keyPath = new File(name.asText()).toPath().getFileName();
+                    if (matcher.matches(keyPath)) {
+                        MetadataResource resource = new FilesystemStoreResource(metadataUuid, metadataId,
+                            name.asText(),
+                            settingManager.getNodeURL() + "api/records/", fmeVisibility,
+                            file.get("size").asLong(),
+                            new Date(
+                                DateUtil.parseBasicOrFullDateTime(file.get("date").asText())
+                                    .toInstant().toEpochMilli()),
+                            approved);
+                        resourceList.add(resource);
+                    }
+                }
+            }
+        }
+        return resourceList;
+    }
+
+    private void addFmeTokenHeader(HttpRequestBase request) {
+        request.setHeader("Authorization",
+            String.format("fmetoken token=%s", fmeToken));
+    }
+
+    @Override
+    public void streamResource(final ServiceContext context,
+                               final String metadataUuid,
+                               final String resourceId, Boolean approved,
+                               OutputStream out) throws Exception {
+        canDownload(context, metadataUuid, fmeVisibility, approved);
+        checkResourceId(resourceId);
+
+        String url = fmeApiUrl + metadataUuid + "/" + resourceId + ACCEPT_CONTENTS;
+        HttpGet httpGet = new HttpGet(url);
+        addFmeTokenHeader(httpGet);
+        try (ClientHttpResponse httpResponse = httpRequestFactory.execute(httpGet)) {
+            if (httpResponse.getRawStatusCode() == 200) {
+                IOUtils.copy(httpResponse.getBody(), out);
+                out.flush();
+                out.close();
+            } else {
+                throw new ResourceNotFoundException(
+                    String.format("Metadata resource '%s' not found for metadata '%s'", resourceId, metadataUuid))
+                    .withMessageKey("exception.resourceNotFound.resource", new String[]{resourceId})
+                    .withDescriptionKey("exception.resourceNotFound.resource.description", new String[]{resourceId, metadataUuid});
+            }
+        }
+    }
+
+
+    @Override
+    public ResourceHolder getResourceInternal(
+        final String metadataUuid,
+        final MetadataResourceVisibility visibility,
+        final String resourceId,
+        Boolean approved) throws Exception {
+        String url = fmeApiUrl + metadataUuid + "/" + resourceId + ACCEPT_CONTENTS;
+        HttpGet httpGet = new HttpGet(url);
+        addFmeTokenHeader(httpGet);
+        try (ClientHttpResponse httpResponse = httpRequestFactory.execute(httpGet)) {
+            if (httpResponse.getRawStatusCode() == 200) {
+                return new ResourceHolderImpl(null);
+            } else {
+                throw new ResourceNotFoundException(
+                    String.format("Metadata resource '%s' not found for metadata '%s'", resourceId, metadataUuid));
+            }
+        }
+    }
+
+    /**
+     * Get the resource description or null if the file doesn't exist.
+     *
+     * @param context      the service context.
+     * @param metadataUuid the uuid of the owner metadata record.
+     * @param visibility   is the resource is public or not.
+     * @param fileName     the path to the resource.
+     * @param approved     if the metadata draft has been approved or not
+     * @return the resource description or {@code null} if there is any problem accessing the file.
+     */
+    public MetadataResource getResourceDescription(final ServiceContext context, final String metadataUuid,
+                                                   final MetadataResourceVisibility visibility, final String fileName, Boolean approved) {
+        try {
+            getAndCheckMetadataId(metadataUuid, approved);
+
+            List<MetadataResource> resources =
+                getResources(
+                    context, metadataUuid, fmeVisibility,
+                    fileName, approved);
+            if (resources.size() == 1) {
+                return resources.get(0);
+            }
+        } catch (IOException e) {
+            Log.error(Geonet.RESOURCES, "Error getting size of file " + fileName + ": "
+                + e.getMessage(), e);
+        } catch (Exception e) {
+            Log.error(Geonet.RESOURCES, "Error in getResourceDescription: "
+                + e.getMessage(), e);
+        }
+        return null;
+    }
+
+    @Override
+    public MetadataResourceContainer getResourceContainerDescription(ServiceContext context, String metadataUuid, Boolean approved) throws Exception {
+        int metadataId = getAndCheckMetadataId(metadataUuid, approved);
+        return new FilesystemStoreResourceContainer(metadataUuid, metadataId, metadataUuid, settingManager.getNodeURL() + "api/records/", approved);
+    }
+
+
+    @Override
+    public MetadataResource putResource(final ServiceContext context, final String metadataUuid, final String filename,
+                                        final InputStream is, @Nullable final Date changeDate, final MetadataResourceVisibility visibility,
+                                        Boolean approved) throws Exception {
+        canEdit(context, metadataUuid, approved);
+        checkResourceId(filename);
+
+        String url = fmeApiUrl + metadataUuid
+            + CREATE_DIRECTORIES_TRUE_OVERWRITE_TRUE;
+        HttpPost httpPost = new HttpPost(url);
+        addFmeTokenHeader(httpPost);
+        httpPost.setHeader("Content-Disposition",
+            String.format("attachment; filename=\"%s\"", filename));
+        httpPost.setEntity(new InputStreamEntity(is));
+
+        try (ClientHttpResponse httpResponse = httpRequestFactory.execute(httpPost)) {
+            if (httpResponse.getRawStatusCode() == 201) {
+                return getResourceDescription(context, metadataUuid, visibility, filename, approved);
+            } else {
+                throw new ResourceNotFoundException(
+                    String.format("Failed to add resource '%s' for metadata '%s'", filename, metadataUuid));
+            }
+        }
+    }
+
+    @Override
+    public String delResources(ServiceContext context, String metadataUuid, Boolean approved) throws Exception {
+        canEdit(context, metadataUuid, approved);
+
+        String url = fmeApiUrl + metadataUuid;
+        HttpDelete httpDelete = new HttpDelete(url);
+        addFmeTokenHeader(httpDelete);
+        try (ClientHttpResponse httpResponse = httpRequestFactory.execute(httpDelete)) {
+            if (httpResponse.getRawStatusCode() == 204) {
+                return String.format("Metadata '%s' directory removed.", metadataUuid);
+            } else {
+                return String.format("Unable to remove metadata '%s' directory.", metadataUuid);
+            }
+        }
+    }
+
+    @Override
+    public String delResource(ServiceContext context, String metadataUuid, String resourceId, Boolean approved) throws Exception {
+        canEdit(context, metadataUuid, approved);
+
+        String url = fmeApiUrl + metadataUuid + "/" + resourceId;
+        HttpDelete httpDelete = new HttpDelete(url);
+        addFmeTokenHeader(httpDelete);
+        try (ClientHttpResponse httpResponse = httpRequestFactory.execute(httpDelete)) {
+            if (httpResponse.getRawStatusCode() == 204) {
+                return String.format("MetadataResource '%s' removed.", resourceId);
+            } else {
+                return String.format("Unable to remove resource '%s'.", resourceId);
+            }
+        }
+    }
+
+    @Override
+    public String delResource(final ServiceContext context, final String metadataUuid,
+                              final MetadataResourceVisibility visibility,
+                              final String resourceId, Boolean approved) throws Exception {
+        canEdit(context, metadataUuid, approved);
+        return delResource(context, metadataUuid, resourceId, approved);
+    }
+
+    @Override
+    public MetadataResource patchResourceStatus(ServiceContext context,
+                                                String metadataUuid, String resourceId,
+                                                MetadataResourceVisibility visibility, Boolean approved) throws Exception {
+        throw new UnsupportedOperationException("FME store does not support changing status of resources.");
+    }
+
+    public String getFmeToken() {
+        return fmeToken;
+    }
+
+    public void setFmeToken(String fmeToken) {
+        this.fmeToken = fmeToken;
+    }
+
+    public String getFmeApiUrl() {
+        return fmeApiUrl;
+    }
+
+    public void setFmeApiUrl(String fmeApiUrl) {
+        this.fmeApiUrl = fmeApiUrl + (fmeApiUrl.endsWith("/") ? "" : "/");
+    }
+
+    private static class ResourceHolderImpl implements ResourceHolder {
+        private final MetadataResource metadataResource;
+
+        public ResourceHolderImpl(MetadataResource metadataResource) {
+            this.metadataResource = metadataResource;
+        }
+
+        @Override
+        public Path getPath() {
+            return null;
+        }
+
+        @Override
+        public MetadataResource getMetadata() {
+            return metadataResource;
+        }
+
+        @Override
+        public void close() throws IOException {
+        }
+    }
+}

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStore.java
@@ -42,6 +42,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -140,6 +141,11 @@ public class FilesystemStore extends AbstractStore {
             throw new ResourceNotFoundException(
                 String.format("Metadata resource '%s' not found for metadata '%s'", resourceId, metadataUuid));
         }
+    }
+
+    @Override
+    public void streamResource(ServiceContext context, String metadataUuid, String resourceId, Boolean approved, OutputStream out) throws Exception {
+        throw new UnsupportedOperationException(String.format("%s does not support streamResource.", this.getClass().getSimpleName()));
     }
 
     public MetadataResource getResourceDescription(final ServiceContext context, String metadataUuid, MetadataResourceVisibility visibility,

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/JCloudStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/JCloudStore.java
@@ -52,6 +52,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -164,6 +165,11 @@ public class JCloudStore extends AbstractStore {
     @Override
     public ResourceHolder getResourceInternal(String metadataUuid, MetadataResourceVisibility visibility, String resourceId, Boolean approved) throws Exception {
         throw new UnsupportedOperationException("JCloud does not support getResourceInternal.");
+    }
+
+    @Override
+    public void streamResource(ServiceContext context, String metadataUuid, String resourceId, Boolean approved, OutputStream out) throws Exception {
+        throw new UnsupportedOperationException(String.format("%s does not support streamResource.", this.getClass().getSimpleName()));
     }
 
     private String getKey(final ServiceContext context, String metadataUuid, int metadataId, MetadataResourceVisibility visibility, String resourceId) {

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/ResourceLoggerStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/ResourceLoggerStore.java
@@ -43,6 +43,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ConfigurableApplicationContext;
 
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.util.Date;
 import java.util.List;
 import javax.annotation.Nullable;
@@ -51,6 +52,10 @@ import javax.annotation.Nullable;
  * Decorate a store and record put/get/delete operations in database for reporting statistics.
  */
 public class ResourceLoggerStore extends AbstractStore {
+
+    public Store getDecoratedStore() {
+        return decoratedStore;
+    }
 
     private Store decoratedStore;
 
@@ -93,6 +98,14 @@ public class ResourceLoggerStore extends AbstractStore {
     public ResourceHolder getResourceInternal(String metadataUuid, MetadataResourceVisibility visibility, String resourceId, Boolean approved) throws Exception {
         throw new UnsupportedOperationException("ResourceLoggerStore does not support getResourceInternal.");
     }
+
+    @Override
+    public void streamResource(ServiceContext context, String metadataUuid, String resourceId, Boolean approved, OutputStream out) throws Exception {
+        if (decoratedStore != null) {
+            decoratedStore.streamResource(context, metadataUuid, resourceId, approved, out);
+        }
+    }
+
 
     @Override
     public MetadataResource putResource(final ServiceContext context, final String metadataUuid, final String filename,

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/S3Store.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/S3Store.java
@@ -44,6 +44,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.file.*;
 import java.util.ArrayList;
 import java.util.Date;
@@ -122,6 +123,11 @@ public class S3Store extends AbstractStore {
     @Override
     public ResourceHolder getResourceInternal(String metadataUuid, MetadataResourceVisibility visibility, String resourceId, Boolean approved) throws Exception {
         throw new UnsupportedOperationException("S3Store does not support getResourceInternal.");
+    }
+
+    @Override
+    public void streamResource(ServiceContext context, String metadataUuid, String resourceId, Boolean approved, OutputStream out) throws Exception {
+        throw new UnsupportedOperationException(String.format("%s does not support streamResource.", this.getClass().getSimpleName()));
     }
 
     private String getKey(String metadataUuid, int metadataId, MetadataResourceVisibility visibility, String resourceId) throws Exception {

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/Store.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/Store.java
@@ -33,11 +33,13 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.Closeable;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.net.URL;
 import java.nio.file.Path;
 import java.util.Date;
 import java.util.List;
 import javax.annotation.Nullable;
+import javax.servlet.ServletOutputStream;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -139,6 +141,9 @@ public interface Store {
      * @return The resource
      */
     ResourceHolder getResource(ServiceContext context, String metadataUuid, String resourceId, Boolean approved) throws Exception;
+
+    void streamResource(ServiceContext context, String metadataUuid,
+                        String resourceId, Boolean approved, OutputStream out) throws Exception;
 
     /**
      * Retrieve a metadata resource path (for internal use eg. indexing)
@@ -347,6 +352,7 @@ public interface Store {
      *
      */
     void copyResources(ServiceContext context, String sourceUuid, String targetUuid, MetadataResourceVisibility metadataResourceVisibility, boolean sourceApproved, boolean targetApproved) throws Exception;
+
 
     interface ResourceHolder extends Closeable {
         Path getPath();

--- a/core/src/main/resources/config-spring-geonetwork.xml
+++ b/core/src/main/resources/config-spring-geonetwork.xml
@@ -248,6 +248,7 @@
      default - Default file system store
      s3      - AWS S3 storage (see config-store/config-s3.xml for more details)
      cmis    - CMIS storage (see config-store/config-cmis.xml for more details)
+     fme     - FME storage (see config-store/config-fme.xml for more details)
   -->
   <import resource="config-store/config-${geonetwork.store.type:default}.xml"/>
 </beans>

--- a/core/src/main/resources/config-store/config-fme-overrides.properties
+++ b/core/src/main/resources/config-store/config-fme-overrides.properties
@@ -1,0 +1,2 @@
+fme.api.url=${FME_API_URL:#{null}}
+fme.token=${FME_TOKEN:#{null}}

--- a/core/src/main/resources/config-store/config-fme.xml
+++ b/core/src/main/resources/config-store/config-fme.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+<beans
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://www.springframework.org/schema/beans"
+  xmlns:context="http://www.springframework.org/schema/context"
+  xsi:schemaLocation="
+          http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
+          http://www.springframework.org/schema/context http://www.springframework.org/schema/context/spring-context.xsd
+    ">
+
+  <context:property-placeholder location="classpath:config-store/config-fme-overrides.properties"
+                                file-encoding="UTF-8"
+                                ignore-unresolvable="true"
+  />
+
+  <bean id="filesystemStore"
+        class="org.fao.geonet.api.records.attachments.FMEStore">
+    <property name="fmeApiUrl" value="${fme.api.url}"/>
+    <property name="fmeToken" value="${fme.token}"/>
+  </bean>
+
+  <bean id="resourceStore"
+        class="org.fao.geonet.api.records.attachments.ResourceLoggerStore">
+    <constructor-arg index="0" ref="filesystemStore"/>
+  </bean>
+
+  <bean id="resources" class="org.fao.geonet.resources.FileResources"/>
+</beans>


### PR DESCRIPTION
FME provides an API to store resources and is used by some organisations to store GIS data. See API documentation https://docs.safe.com/fme/html/FME_REST/apidoc/v3/index.html#!/resources

Adding the possibility to store metadata documents in FME with one folder per metadata.

To enable the FME store use the following env variables:

```bash
GEONETWORK_STORE_TYPE=fme;
FME_API_URL=http://sdi.organisation.org/fmerest/v3/resources/connections/RESOURCE/filesys/;
FME_TOKEN=123456789;
```

The main difference with other filestore is the fact that when retrieving a resource, the resource is streamed from FME to the client app (instead of making a temporary file which is then returned to the client for other stores).