### PR TITLE
Search map - if the metadata results extent is bigger than the map view extent, zoom to the view extent

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/resultsview/ResultsviewDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/ResultsviewDirective.js
@@ -151,8 +151,28 @@
                 }
               });
               if (!ol.extent.isEmpty(extent)) {
-                // fit extent in map
-                scope.map.getView().fit(extent, scope.map.getSize());
+                var viewExtent = ol.extent.createEmpty();
+
+                // Get the search map background layer extent
+                scope.map.getLayers().forEach(function (l) {
+                  if (l.background == true) {
+                    viewExtent = l.getExtent();
+                  }
+                });
+
+                // check if the metadata extent is contained in the view extent
+                if (viewExtent && !ol.extent.isEmpty(viewExtent)) {
+                  if (ol.extent.containsExtent(viewExtent, extent)) {
+                    // fit extent in map - zoom to the metadata extent
+                    scope.map.getView().fit(extent, scope.map.getSize());
+                  } else {
+                    // fit extent in map - zoom to the view  extent
+                    scope.map.getView().fit(viewExtent, scope.map.getSize());
+                  }
+                } else {
+                  // fit extent in map - zoom to the metadata extent
+                  scope.map.getView().fit(extent, scope.map.getSize());
+                }
               }
             }
           });


### PR DESCRIPTION
When the metadata extent has a much bigger extent than the search map extent (for example, when the map covers a country area and the metadata covers the full world), the search map is not displayed properly:

![map-1](https://user-images.githubusercontent.com/1695003/205098385-041d3864-e24c-441f-a594-363cf5736b42.png)

With this fix, in these cases, the search map zooms to the map extent:

![map-2](https://user-images.githubusercontent.com/1695003/205098484-252b0c5e-a454-42ab-a973-42f531b2c225.png)
