### PR TITLE
Updated folder cache logic to improve performance

### DIFF
--- a/core/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
@@ -275,6 +275,7 @@ public class CMISStore extends AbstractStore {
             } catch (Exception e) {
                 Log.error(Geonet.RESOURCES,
                     String.format("Unable to update CMIS secondary property on metadata resource '%s' for metadata '%s'.", key, metadataUuid), e);
+                throw e;
             }
         }
 

--- a/core/src/main/java/org/fao/geonet/resources/CMISResources.java
+++ b/core/src/main/java/org/fao/geonet/resources/CMISResources.java
@@ -29,6 +29,7 @@ import org.apache.chemistry.opencmis.client.api.*;
 import org.apache.chemistry.opencmis.client.runtime.DocumentImpl;
 import org.apache.chemistry.opencmis.commons.exceptions.CmisObjectNotFoundException;
 import org.apache.commons.io.FilenameUtils;
+import org.fao.geonet.api.exception.ResourceNotFoundException;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.Pair;
 import org.fao.geonet.kernel.GeonetworkDataDirectory;
@@ -290,7 +291,7 @@ public class CMISResources extends Resources {
                     final String suffixlessKeyFolder = getKey(Paths.get(FilenameUtils.getFullPath(suffixless)));
 
                     try {
-                        Folder resourceFolder = (Folder) cmisConfiguration.getClient().getObjectByPath(suffixlessKeyFolder);
+                        Folder resourceFolder = cmisUtils.getFolderCache(suffixlessKeyFolder);
                         Map<String, Document> documentMap = cmisUtils.getCmisObjectMap(resourceFolder, null, suffixlessKeyFilename);
 
                         for (Map.Entry<String,Document> entry : documentMap.entrySet()) {
@@ -318,7 +319,7 @@ public class CMISResources extends Resources {
                                 }
                             }
                         }
-                    } catch (CmisObjectNotFoundException e) {
+                    } catch (CmisObjectNotFoundException | ResourceNotFoundException e) {
                         Log.warning(Geonet.RESOURCES,
                                 String.format("Unable to locate resource folder '%s'.", suffixlessKeyFolder));
                         // Ignore not found error.

--- a/core/src/main/java/org/fao/geonet/resources/CMISUtils.java
+++ b/core/src/main/java/org/fao/geonet/resources/CMISUtils.java
@@ -139,7 +139,17 @@ public class CMISUtils {
                 }
             });
         } catch (ExecutionException | UncheckedExecutionException e) {
-            throw new ResourceNotFoundException("Error getting folder resource from cache: " + folderKey, e);
+            if (e.getCause() instanceof CmisObjectNotFoundException) {
+                throw new ResourceNotFoundException("Error getting folder resource from cache: " + folderKey, e);
+            } else if (e.getCause() instanceof CmisPermissionDeniedException) {
+                throw new CmisPermissionDeniedException("Error getting folder resource from cache: " + folderKey, e);
+            } else if (e.getCause() instanceof CmisConstraintException) {
+                throw new CmisConstraintException("Error getting folder resource from cache: " + folderKey, e);
+            } else {
+                Log.error(Geonet.RESOURCES, String.format(
+                    "\"Error getting resource from cache: '%s'.", folderKey), e);
+                throw new RuntimeException(e.getCause());
+            }
         }
         if (refresh && !foundWithoutCache[0]) {
             try {

--- a/core/src/main/java/org/fao/geonet/resources/CMISUtils.java
+++ b/core/src/main/java/org/fao/geonet/resources/CMISUtils.java
@@ -58,6 +58,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
+import com.google.common.util.concurrent.UncheckedExecutionException;
 
 public class CMISUtils {
     @Autowired
@@ -82,10 +83,15 @@ public class CMISUtils {
     }
 
     public Folder getFolderCache(String folderKey) throws ResourceNotFoundException, CmisPermissionDeniedException {
-        return getFolderCache(folderKey, false);
+        return getFolderCache(folderKey, false, false);
     }
 
     public Folder getFolderCache(String folderKey, boolean refresh) throws ResourceNotFoundException, CmisPermissionDeniedException {
+        return getFolderCache(folderKey, refresh, false);
+    }
+
+
+    public Folder getFolderCache(String folderKey, boolean refresh, boolean createMissing) throws ResourceNotFoundException, CmisPermissionDeniedException {
         Folder folder = null;
         // Primitive object declared as an object array so that it can be marked as final so it can be used in calling class.
         // If it is set to true then it was already fetched without using cache so there is no need to refresh()
@@ -107,26 +113,32 @@ public class CMISUtils {
                         }
                         return folder;
                     } catch (CmisObjectNotFoundException e) {
-                        String parentFolderKey = folderKey.substring(0, folderKey.lastIndexOf(cmisConfiguration.getFolderDelimiter()));
-                        Folder subFolder = getFolderCache(parentFolderKey, refresh);
+                        if (createMissing) {
+                            String parentFolderKey = folderKey.substring(0, folderKey.lastIndexOf(cmisConfiguration.getFolderDelimiter()));
+                            Folder subFolder = getFolderCache(parentFolderKey, refresh, createMissing);
 
-                        // synchronize folder creation.
-                        // This will prevent cases where multiple files are uploaded on the interface
-                        // In this case there will be a race condition to create the same folder.
-                        // And if this is not synchronized then there will be a lot or CmisContentAlreadyExistsException errors.
-                        Folder folder;
-                        synchronized (this) {
-                            ObjectId objectId = cmisConfiguration.getClient().createPath(subFolder, folderKey, BaseTypeId.CMIS_FOLDER.value());
-                            folder = (Folder) cmisConfiguration.getClient().getObject(objectId);
+                            // synchronize folder creation.
+                            // This will prevent cases where multiple files are uploaded on the interface
+                            // In this case there will be a race condition to create the same folder.
+                            // And if this is not synchronized then there will be a lot or CmisContentAlreadyExistsException errors.
+                            Folder folder;
+                            synchronized (this) {
+                                Map<String, Object> properties = new HashMap();
+                                properties.put(PropertyIds.OBJECT_TYPE_ID, "cmis:folder");
+                                properties.put(PropertyIds.NAME, folderKey.substring(folderKey.lastIndexOf(cmisConfiguration.getFolderDelimiter())+1));
+                                folder = subFolder.createFolder(properties);
+                            }
+                            if (refresh) {
+                                foundWithoutCache[0] = true;
+                            }
+                            return folder;
+                        } else {
+                            throw e;
                         }
-                        if (refresh) {
-                            foundWithoutCache[0] = true;
-                        }
-                        return folder;
                     }
                 }
             });
-        } catch (ExecutionException e) {
+        } catch (ExecutionException | UncheckedExecutionException e) {
             throw new ResourceNotFoundException("Error getting folder resource from cache: " + folderKey, e);
         }
         if (refresh && !foundWithoutCache[0]) {
@@ -241,7 +253,7 @@ public class CMISUtils {
 
                 if (cmisConfiguration.existSecondaryProperty()) {
                     //need to reload document to avoid  "Document is not the latest version" when updating secondary types.
-                    doc = (Document) cmisConfiguration.getClient().getObjectByPath(key, oc);
+                    doc.refresh();
                 }
                 // Avoid CMIS API call is info is not enabled.
                 if (LogManager.getLogger(Geonet.RESOURCES).isInfoEnabled()) {
@@ -265,7 +277,7 @@ public class CMISUtils {
             // Get parent folder.
             String parentKey = key.substring(0, lastFolderDelimiterKeyIndex);
             try {
-                Folder parentFolder = getFolderCache(parentKey, true);
+                Folder parentFolder = getFolderCache(parentKey, true, true);
 
                 doc = parentFolder.createDocument(properties, contentStream, cmisConfiguration.getVersioningState(), (List)null, (List)null, (List)null, oc);
                 // Avoid CMIS API call is info is not enabled.


### PR DESCRIPTION
Updated folder cache logic to improve performance - there were some areas that were not using the folder cache and can to make things faster.

Using subFolder.createFolder instead of createPath seems seems faster.

Don't always create missing folders when looking up the cache in some cases it is ok to generate a resource not found error.

Also fixed some unhandled errors from the cache system
