### PR TITLE
CSW / GetRecords / Add default sort configuration.

### DIFF
--- a/csw-server/src/main/java/org/fao/geonet/kernel/csw/CatalogConfiguration.java
+++ b/csw-server/src/main/java/org/fao/geonet/kernel/csw/CatalogConfiguration.java
@@ -52,6 +52,7 @@ public class CatalogConfiguration {
     private final Set<String> _isoQueryables = new HashSet<String>();
     private final Set<String> _additionalQueryables = new HashSet<String>();
     private final Set<String> _getRecordsConstraintLanguage = new HashSet<String>();
+
     private String defaultSortField = "_score";
     private String defaultSortOrder = "DESC";
     private final Set<String> _getRecordsOutputFormat = new HashSet<String>();
@@ -416,8 +417,16 @@ public class CatalogConfiguration {
         return _increasePopularity;
     }
 
+    public void setDefaultSortField(String defaultSortField) {
+        this.defaultSortField = defaultSortField;
+    }
+
     public String getDefaultSortField() {
         return defaultSortField;
+    }
+
+    public void setDefaultSortOrder(String defaultSortOrder) {
+        this.defaultSortOrder = defaultSortOrder;
     }
 
     public String getDefaultSortOrder() {

--- a/csw-server/src/main/java/org/fao/geonet/kernel/csw/CatalogConfiguration.java
+++ b/csw-server/src/main/java/org/fao/geonet/kernel/csw/CatalogConfiguration.java
@@ -31,6 +31,7 @@ import org.fao.geonet.kernel.GeonetworkDataDirectory;
 import org.fao.geonet.kernel.SchemaManager;
 import org.fao.geonet.utils.Log;
 import org.fao.geonet.utils.Xml;
+import org.jdom.Attribute;
 import org.jdom.Element;
 import org.jdom.Namespace;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -51,6 +52,8 @@ public class CatalogConfiguration {
     private final Set<String> _isoQueryables = new HashSet<String>();
     private final Set<String> _additionalQueryables = new HashSet<String>();
     private final Set<String> _getRecordsConstraintLanguage = new HashSet<String>();
+    private String defaultSortField = "_score";
+    private String defaultSortOrder = "DESC";
     private final Set<String> _getRecordsOutputFormat = new HashSet<String>();
     private final Set<String> _getRecordsOutputSchema = new HashSet<String>();
     private final Set<String> _getRecordsTypenames = new HashSet<String>();
@@ -199,6 +202,14 @@ public class CatalogConfiguration {
     }
 
     private void initGetRecordsConfig(Element operation) {
+        Attribute sortBy = operation.getAttribute("defaultSortField");
+        if (sortBy != null) {
+            defaultSortField = sortBy.getValue();
+        }
+        Attribute sortOrder = operation.getAttribute("defaultSortOrder");
+        if (sortOrder != null) {
+            defaultSortOrder = sortOrder.getValue();
+        }
         // Only one child parameters
         Element params = operation
             .getChild(Csw.ConfigFile.Operation.Child.PARAMETERS);
@@ -405,4 +416,11 @@ public class CatalogConfiguration {
         return _increasePopularity;
     }
 
+    public String getDefaultSortField() {
+        return defaultSortField;
+    }
+
+    public String getDefaultSortOrder() {
+        return defaultSortOrder;
+    }
 }

--- a/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/SortByParser.java
+++ b/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/SortByParser.java
@@ -28,6 +28,7 @@ import org.elasticsearch.search.sort.FieldSortBuilder;
 import org.elasticsearch.search.sort.SortBuilder;
 import org.elasticsearch.search.sort.SortOrder;
 import org.fao.geonet.csw.common.Csw;
+import org.fao.geonet.kernel.csw.CatalogConfiguration;
 import org.jdom.Element;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -40,15 +41,18 @@ public class SortByParser {
     @Autowired
     IFieldMapper fieldMapper;
 
+    @Autowired
+    private CatalogConfiguration _catalogConfig;
+
     public List<SortBuilder<FieldSortBuilder>> parseSortBy(Element request) {
         Element query = request.getChild("Query", Csw.NAMESPACE_CSW);
         if (query == null) {
-            return Collections.emptyList();
+            return getDefaultSort();
         }
 
         Element sortBy = query.getChild("SortBy", Csw.NAMESPACE_OGC);
         if (sortBy == null) {
-            return Collections.emptyList();
+            return getDefaultSort();
         }
 
         List<SortBuilder<FieldSortBuilder>> sortFields = new ArrayList<>();
@@ -61,6 +65,20 @@ public class SortByParser {
                 sortFields.add(new FieldSortBuilder(esSortFieldName).order(esSortOrder));
             }
         }
+
+        if (sortFields.size() == 0) {
+            sortFields = getDefaultSort();
+        }
+        return sortFields;
+    }
+
+    private List<SortBuilder<FieldSortBuilder>> getDefaultSort() {
+        List<SortBuilder<FieldSortBuilder>> sortFields = new ArrayList<>();
+        FieldSortBuilder defaultSortField =
+            new FieldSortBuilder(_catalogConfig.getDefaultSortField())
+                .order(SortOrder.fromString(_catalogConfig.getDefaultSortOrder()));
+
+        sortFields.add(defaultSortField);
         return sortFields;
     }
 

--- a/csw-server/src/test/java/org/fao/geonet/kernel/csw/services/getrecords/es/CswFilter2EsTestConfiguration.java
+++ b/csw-server/src/test/java/org/fao/geonet/kernel/csw/services/getrecords/es/CswFilter2EsTestConfiguration.java
@@ -23,6 +23,9 @@
 
 package org.fao.geonet.kernel.csw.services.getrecords.es;
 
+import org.fao.geonet.kernel.GeonetworkDataDirectory;
+import org.fao.geonet.kernel.SchemaManager;
+import org.fao.geonet.kernel.csw.CatalogConfiguration;
 import org.fao.geonet.kernel.csw.services.getrecords.IFieldMapper;
 import org.fao.geonet.kernel.csw.services.getrecords.IdentityFieldMapper;
 import org.springframework.context.annotation.Bean;
@@ -34,4 +37,18 @@ public class CswFilter2EsTestConfiguration {
         return new IdentityFieldMapper();
     }
 
+    @Bean
+    public CatalogConfiguration catalogConfiguration() {
+        return new CatalogConfiguration();
+    }
+
+    @Bean
+    public GeonetworkDataDirectory dataDirectory() {
+        return new GeonetworkDataDirectory();
+    }
+
+    @Bean
+    public SchemaManager schemaManager() {
+        return new SchemaManager();
+    }
 }

--- a/csw-server/src/test/java/org/fao/geonet/kernel/csw/services/getrecords/es/CswSortBy2EsTest.java
+++ b/csw-server/src/test/java/org/fao/geonet/kernel/csw/services/getrecords/es/CswSortBy2EsTest.java
@@ -25,10 +25,12 @@ package org.fao.geonet.kernel.csw.services.getrecords.es;
 
 import static junit.framework.TestCase.assertEquals;
 
+import org.checkerframework.checker.units.qual.A;
 import org.elasticsearch.search.sort.FieldSortBuilder;
 import org.elasticsearch.search.sort.SortBuilder;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.csw.common.Csw;
+import org.fao.geonet.kernel.csw.CatalogConfiguration;
 import org.fao.geonet.kernel.csw.services.getrecords.SortByParser;
 import org.jdom.Element;
 import org.junit.jupiter.api.Test;
@@ -57,6 +59,24 @@ class CswSortBy2EsTest {
 
     @Autowired
     SortByParser toTest;
+
+    @Autowired
+    CatalogConfiguration configuration;
+
+    @Test
+    void configureDefaultSort() {
+        configuration.setDefaultSortField("resourceTitleObject.default.keyword");
+        configuration.setDefaultSortOrder("DESC");
+        Element request =  createSortByBaseRequest(
+            new Element("Empty", Geonet.Namespaces.OGC));
+
+        List<SortBuilder<FieldSortBuilder>> sortFields = toTest.parseSortBy(request);
+
+        assertEquals(1, sortFields.size());
+        FieldSortBuilder sortField = (FieldSortBuilder)sortFields.get(0);
+        assertEquals(sortField.getFieldName(), "resourceTitleObject.default.keyword");
+        assertEquals(sortField.order().toString(), "desc");
+    }
 
     @Test
     void sortByRelevanceDESC() {

--- a/web/src/main/webapp/WEB-INF/config-csw.xml
+++ b/web/src/main/webapp/WEB-INF/config-csw.xml
@@ -34,7 +34,9 @@
       <!-- Defines the number of records that will be processed for any propertyname  -->
       <maxNumberOfRecordsForPropertyNames>1000</maxNumberOfRecordsForPropertyNames>
     </operation>
-    <operation name="GetRecords">
+    <operation name="GetRecords"
+               defaultSortField="_score"
+               defaultSortOrder="DESC">
       <parameters>
         <!-- - - - - - - - - - - - - - -->
         <!-- Core queryable properties -->


### PR DESCRIPTION
Add the possibility to configure the default sort option (ie. score) for GetRecords operation.

This can help solving issue when the catalogue is harvested with no sort order defined and record which may appear multiple times on various pages (due to index changes occuring during indexing).

Related to https://github.com/geonetwork/core-geonetwork/pull/6223