### PR TITLE
New metadata - improve the metadata template type display label when the template has no resource type defined

### DIFF
--- a/web-ui/src/main/resources/catalog/js/edit/NewMetadataController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/NewMetadataController.js
@@ -117,7 +117,7 @@
               terms: {
                 field: "resourceType",
                 exclude: ["map/static", "theme", "place"],
-                missing: "N/A"
+                missing: "other"
               }
             }
           };


### PR DESCRIPTION
Currently the new metadata page displays a label **N/A** for templates that have no resource type value.

![metadata-template-type-1](https://user-images.githubusercontent.com/1695003/205586339-cc5d4a22-3cbe-4638-ae7b-c8931d1266bd.png)


With the change a label **Other** is displayed, similar to `3.12.x` version.

![metadata-template-type-2](https://user-images.githubusercontent.com/1695003/205587204-030f9f79-b3fa-42a5-a5b1-79d893bef298.png)
