### PR TITLE
Formatter / Multilingual / Organisation name not translated.

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
@@ -1055,24 +1055,21 @@
 
   <!-- ########################## -->
   <!-- Render values for text ... -->
-   <xsl:template mode="render-value"
+  <xsl:template mode="render-value"
                 match="*[gco:CharacterString]">
-
      <xsl:variable name="txt">
        <xsl:apply-templates mode="localised" select=".">
          <xsl:with-param name="langId" select="$langId"/>
        </xsl:apply-templates>
      </xsl:variable>
      <span>
-      <xsl:choose>
-        <xsl:when test="name() = 'gmd:parentIdentifier'">
-          <a href="{$nodeUrl}api/records/{./gco:CharacterString}">
-            <i class="fa fa-fw fa-link"><xsl:comment select="'link'"/></i>
-            <xsl:value-of select="gn-fn-render:getMetadataTitle(./gco:CharacterString, $langId)"/>
-          </a>
-        </xsl:when>
-
-      </xsl:choose><xsl:comment select="name()"/>
+      <xsl:if test="name() = 'gmd:parentIdentifier'">
+        <a href="{$nodeUrl}api/records/{./gco:CharacterString}">
+          <i class="fa fa-fw fa-link"><xsl:comment select="'link'"/></i>
+          <xsl:value-of select="gn-fn-render:getMetadataTitle(./gco:CharacterString, $langId)"/>
+        </a>
+      </xsl:if>
+       <xsl:comment select="name()"/>
       <xsl:call-template name="addLineBreaksAndHyperlinks">
         <xsl:with-param name="txt" select="$txt"/>
       </xsl:call-template>
@@ -1081,25 +1078,17 @@
 
   <xsl:template mode="render-value-no-breaklines"
                 match="*[gco:CharacterString]">
-
-    <xsl:variable name="txtNonNormalized">
+    <span>
+      <xsl:if test="name() = 'gmd:parentIdentifier'">
+        <a href="{$nodeUrl}api/records/{./gco:CharacterString}">
+          <i class="fa fa-fw fa-link"><xsl:comment select="'link'"/></i>
+          <xsl:value-of select="gn-fn-render:getMetadataTitle(./gco:CharacterString, $langId)"/>
+        </a>
+      </xsl:if>
+      <xsl:comment select="name()"/>
       <xsl:apply-templates mode="localised" select=".">
         <xsl:with-param name="langId" select="$langId"/>
       </xsl:apply-templates>
-    </xsl:variable>
-
-    <xsl:variable name="txt" select="normalize-space($txtNonNormalized)" />
-    <span>
-      <xsl:choose>
-        <xsl:when test="name() = 'gmd:parentIdentifier'">
-          <a href="{$nodeUrl}api/records/{./gco:CharacterString}">
-            <i class="fa fa-fw fa-link"><xsl:comment select="'link'"/></i>
-            <xsl:value-of select="gn-fn-render:getMetadataTitle(./gco:CharacterString, $langId)"/>
-          </a>
-        </xsl:when>
-
-      </xsl:choose><xsl:comment select="name()"/>
-      <xsl:value-of select="$txt" />
     </span>
   </xsl:template>
 


### PR DESCRIPTION
eg. load this multilingual record https://sextant.ifremer.fr/Donnees/Catalogue#/metadata/59403137-7fc9-45b7-9b1b-e63883f3c4b8

Turn off table rendering for CI_ResponsibleParty in config-editor.

Check the formatter http://localhost:8080/geonetwork/srv/api/records/59403137-7fc9-45b7-9b1b-e63883f3c4b8/formatters/xsl-view?language=all&tab=default. Organisation name and address are displayed in both languages as text instead of `div`s with `xml:lang` attribute

![image](https://user-images.githubusercontent.com/1701393/205918421-2662704c-ef79-4081-8029-4482507e5dbe.png)


After

![image](https://user-images.githubusercontent.com/1701393/205918539-90e86c4d-ee43-45bf-a8fb-efcd0c434df0.png)
