### PR TITLE
Formatter / ISO19115-3 / DOI / Fix invalid variable name

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/datacite/view.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/datacite/view.xsl
@@ -162,7 +162,7 @@
         </xsl:when>
         <xsl:otherwise>
           <!-- Build a new one -->
-          <xsl:value-of select="$$doiId"/>
+          <xsl:value-of select="$doiId"/>
         </xsl:otherwise>
       </xsl:choose>
     </datacite:identifier>


### PR DESCRIPTION
On Datacite formatter http://localhost:8080/geonetwork/srv/api/records/ce6234fe-783b-405d-ad2e-c65a32f06fc8/formatters/datacite?output=xml

Error reported:

```
Error at xsl:value-of on line 165 column 43 of view.xsl:
  XPST0003: XPath syntax error at char 1 on line 165 in {$$doiId}:
    expected "<name>", found "$"
```

Related to https://github.com/geonetwork/core-geonetwork/pull/6347