### PR TITLE
Standard / ISO19115-3 / Index properly multiple characterSet

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
@@ -391,13 +391,11 @@
 
         <xsl:copy-of select="gn-fn-index:add-multilingual-field('resourceAbstract', mri:abstract, $allLanguages)"/>
 
-
-
-        <!-- # Characterset -->
-        <xsl:if test="mri:defaultLocale/lan:PT_Locale/lan:characterEncoding/lan:MD_CharacterSetCode">
+        <xsl:for-each-group select="mri:defaultLocale/*/lan:characterEncoding/*[@codeListValue != '']" 
+                            group-by="@codeListValue">
           <xsl:copy-of select="gn-fn-index:add-codelist-field(
-                                  'cl_resourceCharacterSet', mri:defaultLocale/lan:PT_Locale/lan:characterEncoding/lan:MD_CharacterSetCode, $allLanguages)"/>
-        </xsl:if>
+                                'cl_resourceCharacterSet', ., $allLanguages)"/>
+        </xsl:for-each-group>
 
         <!-- Indexing resource contact -->
         <xsl:apply-templates mode="index-contact"


### PR DESCRIPTION
Indexing was failing when more than one default language was defined for the resource

Error reported:
```
Error on line 395 of index.xsl:
  XTTE0790: A sequence of more than one item is not allowed as the second argument of
  gn-fn-index:add-codelist-field() (<lan:MD_CharacterSetCode/>, <lan:MD_CharacterSetCode/>) 
```

eg. when importing https://sextant.ifremer.fr/Donnees/Catalogue#/metadata/ff8d8cd6-c753-4581-99a3-af23fe4c996b and converting it to ISO19115-3.