### PR TITLE
API / Batch edit / Delete with a non matching XPath can remove unwanted elements

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/AddElemValue.java
+++ b/core/src/main/java/org/fao/geonet/kernel/AddElemValue.java
@@ -40,7 +40,7 @@ public class AddElemValue {
 
     public AddElemValue(String stringValue) throws JDOMException, IOException {
         Element finalNodeVal = null;
-        String finalStringVal = stringValue.replaceAll("</?gn_(add|replace|delete)>", "");
+        String finalStringVal = stringValue.replaceAll("</?gn_(add|replace)>", "");
         if (Xml.isXMLLike(finalStringVal)) {
             try {
                 finalNodeVal = Xml.loadString(stringValue, false);

--- a/core/src/test/java/org/fao/geonet/kernel/EditLibIntegrationTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/EditLibIntegrationTest.java
@@ -478,14 +478,6 @@ public class EditLibIntegrationTest extends AbstractCoreIntegrationTest {
             refSysElemName, new AddElemValue(newRefSystems), true);
 
         assertEquals(0, Xml.selectNodes(metadataElement, "gmd:referenceSystemInfo", Arrays.asList(GMD, GCO)).size());
-
-        Element deleteNotExistinElement = new Element(EditLib.SpecialUpdateTags.DELETE);
-        final String elementName = "gmd:referenceSystemInfo[test = false()]";
-        new EditLib(_schemaManager)
-            .addElementOrFragmentFromXpath(metadataElement, schema,
-                elementName, new AddElemValue(deleteNotExistinElement), true);
-
-        assertEquals(0, Xml.selectNodes(metadataElement, "gmd:referenceSystemInfo", Arrays.asList(GMD, GCO)).size());
     }
 
     @Test

--- a/core/src/test/java/org/fao/geonet/kernel/EditLibIntegrationTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/EditLibIntegrationTest.java
@@ -389,11 +389,11 @@ public class EditLibIntegrationTest extends AbstractCoreIntegrationTest {
         assertEquals(3, Xml.selectNodes(metadataElement, "gmd:referenceSystemInfo", Arrays.asList(GMD, GCO)).size());
 
 
-        Element deleteNotExistinElement = new Element(EditLib.SpecialUpdateTags.DELETE);
+        Element deleteNotExistingElement = new Element(EditLib.SpecialUpdateTags.DELETE);
         final String xpathWithNoMatch = "gmd:referenceSystemInfo[*/referenceSystemIdentifier/*/gmd:code/*/text() = 'XYZ']";
         new EditLib(_schemaManager)
             .addElementOrFragmentFromXpath(metadataElement, schema,
-                xpathWithNoMatch, new AddElemValue(deleteNotExistinElement), true);
+                xpathWithNoMatch, new AddElemValue(deleteNotExistingElement), true);
 
         assertEquals(3, Xml.selectNodes(metadataElement, "gmd:referenceSystemInfo", Arrays.asList(GMD, GCO)).size());
 

--- a/core/src/test/java/org/fao/geonet/kernel/EditLibIntegrationTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/EditLibIntegrationTest.java
@@ -388,6 +388,28 @@ public class EditLibIntegrationTest extends AbstractCoreIntegrationTest {
         ));
         assertEquals(3, Xml.selectNodes(metadataElement, "gmd:referenceSystemInfo", Arrays.asList(GMD, GCO)).size());
 
+
+        Element deleteNotExistinElement = new Element(EditLib.SpecialUpdateTags.DELETE);
+        final String xpathWithNoMatch = "gmd:referenceSystemInfo[*/referenceSystemIdentifier/*/gmd:code/*/text() = 'XYZ']";
+        new EditLib(_schemaManager)
+            .addElementOrFragmentFromXpath(metadataElement, schema,
+                xpathWithNoMatch, new AddElemValue(deleteNotExistinElement), true);
+
+        assertEquals(3, Xml.selectNodes(metadataElement, "gmd:referenceSystemInfo", Arrays.asList(GMD, GCO)).size());
+
+        new EditLib(_schemaManager)
+            .addElementOrFragmentFromXpath(metadataElement, schema,
+                xpathWithNoMatch, new AddElemValue("<gn_delete/>"), true);
+
+        assertEquals(3, Xml.selectNodes(metadataElement, "gmd:referenceSystemInfo", Arrays.asList(GMD, GCO)).size());
+
+        new EditLib(_schemaManager)
+            .addElementOrFragmentFromXpath(metadataElement, schema,
+                xpathWithNoMatch, new AddElemValue("<gn_delete></gn_delete>"), true);
+
+        assertEquals(3, Xml.selectNodes(metadataElement, "gmd:referenceSystemInfo", Arrays.asList(GMD, GCO)).size());
+
+
         Element newRefSystems = new Element(EditLib.SpecialUpdateTags.DELETE);
         final String refSysElemName = "gmd:referenceSystemInfo";
         // Delete first node
@@ -404,14 +426,6 @@ public class EditLibIntegrationTest extends AbstractCoreIntegrationTest {
 
         new EditLib(_schemaManager).addElementOrFragmentFromXpath(metadataElement, schema,
             refSysElemName, new AddElemValue(newRefSystems), true);
-
-        assertEquals(0, Xml.selectNodes(metadataElement, "gmd:referenceSystemInfo", Arrays.asList(GMD, GCO)).size());
-
-        Element deleteNotExistinElement = new Element(EditLib.SpecialUpdateTags.DELETE);
-        final String elementName = "gmd:referenceSystemInfo[test = false()]";
-        new EditLib(_schemaManager)
-            .addElementOrFragmentFromXpath(metadataElement, schema,
-                elementName, new AddElemValue(deleteNotExistinElement), true);
 
         assertEquals(0, Xml.selectNodes(metadataElement, "gmd:referenceSystemInfo", Arrays.asList(GMD, GCO)).size());
     }
@@ -462,6 +476,14 @@ public class EditLibIntegrationTest extends AbstractCoreIntegrationTest {
         // Delete all nodes of this type
         new EditLib(_schemaManager).addElementOrFragmentFromXpath(metadataElement, schema,
             refSysElemName, new AddElemValue(newRefSystems), true);
+
+        assertEquals(0, Xml.selectNodes(metadataElement, "gmd:referenceSystemInfo", Arrays.asList(GMD, GCO)).size());
+
+        Element deleteNotExistinElement = new Element(EditLib.SpecialUpdateTags.DELETE);
+        final String elementName = "gmd:referenceSystemInfo[test = false()]";
+        new EditLib(_schemaManager)
+            .addElementOrFragmentFromXpath(metadataElement, schema,
+                elementName, new AddElemValue(deleteNotExistinElement), true);
 
         assertEquals(0, Xml.selectNodes(metadataElement, "gmd:referenceSystemInfo", Arrays.asList(GMD, GCO)).size());
     }

--- a/core/src/test/resources/WEB-INF/config.properties
+++ b/core/src/test/resources/WEB-INF/config.properties
@@ -17,3 +17,5 @@ es.index.records=records
 es.index.searchlogs=searchlogs
 
 es.index.checker.interval=0/5 * * * * ?
+
+thesaurus.cache.maxsize=400000


### PR DESCRIPTION


When using `gn_delete` tag, always consider it as an XML mode to properly check that we are in deletion mode in EditLib.

Fix wrong test and test various type of config can be self closing tag or not `<gn_delete/>` or `<gn_delete></gn_delete>`.

Issue was noticed using the following config

```json
{"field":"Distribution / Remove an online resource by URL","insertMode":"gn_delete","xpath":"/gmd:MD_Metadata/gmd:distributionInfo/*/gmd:transferOptions/*/gmd:onLine[starts-with(*/gmd:linkage/gmd:URL, \"http://www.eea.europa.eu/data-and-maps/data\") or starts-with(*/gmd:linkage/gmd:URL, \"https://cmshare.eea.europa.eu/\")]","value":"","isXpath":true}
```

which was removing the first `gmd:onLine` when none were matching because it was not detecting deletion mode.