### PR TITLE
Editor board / Remove create child action

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/editor.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/editor.html
@@ -105,14 +105,6 @@
             </a>
             <a
               class="btn btn-default"
-              data-ng-show="user.canEditRecord(md) && md.isTemplate != 's'"
-              data-ng-href="#/create?childOf={{md.id}}"
-              title="{{'createChild' | translate}}"
-            >
-              <i class="fa fa-sitemap text-muted"></i>
-            </a>
-            <a
-              class="btn btn-default"
               data-ng-class="user.canEditRecord(md) ? '' : 'btn-single'"
               data-ng-show="md.isTemplate != 's'"
               data-ng-href="#/create?from={{md.id}}"


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/1701393/206394323-86a6066a-fc0f-425f-8c9a-260d5f599d14.png)

The current create child action displayed for all records (except template) really only applies, as it is now, to ISO19139 records which in `update-fixed-info` add an element `gmd:parentIdentifier` to the new record created. 

When a child/parent relation is defined between records (sometimes named groups/series/collections/products, ...), current practice is to mainly use `aggregationInfo` in ISO19139 and `associatedResource` in ISO19115-3 instead of the `parentIdentifier`. Also when creating links, some users prefer to link in direction:
* from series `isComposedOf` dataset
* from dataset `partOfSeamlessDatabase` series

Also most of the time, when user creates a new child in a series they often simply copy/paste an existing one which will probably share most of the descriptors.

So this action is not really useful (and is more misleading for users not using the ISO19139 `parentIdentifier` encoding rule for this type of links). Using the associated panel in the editor is a more consistent way of linking records with the various encoding rules users can have.

![image](https://user-images.githubusercontent.com/1701393/206394352-18e852f3-50a0-4248-af6f-27be78c3d3ca.png)
