### PR TITLE
Record view / Associated resources / Remote records may have null as title

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/MetadataUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataUtils.java
@@ -391,9 +391,10 @@ public class MetadataUtils {
     }
 
     private static String buildRemoteRecord(Map<String, String> props) {
-        return props == null ? "{}" : String.format(
-            "{\"resourceTitleObject\": {\"default\": \"%s\"}}",
-            StringEscapeUtils.escapeJson(props.get("resourceTitle")));
+        return props == null || props.get("resourceTitle") == null
+            ? "{}"
+            : String.format("{\"resourceTitleObject\": {\"default\": \"%s\"}}",
+                StringEscapeUtils.escapeJson(props.get("resourceTitle")));
     }
 
     @Deprecated


### PR DESCRIPTION

Avoid to display "null" as title.

eg. when a relation is set with the following encoding
```xml
<gmd:aggregationInfo>
<gmd:MD_AggregateInformation>
<gmd:aggregateDataSetIdentifier>
<gmd:MD_Identifier>
<gmd:code>
<gmx:Anchor xlink:href="http://www.eea.europa.eu/publications/trends-and-projections-in-the">http://www.eea.europa.eu/publications/trends-and-projections-in-the</gmx:Anchor>
</gmd:code>
</gmd:MD_Identifier>
</gmd:aggregateDataSetIdentifier>
<gmd:associationType>
<gmd:DS_AssociationTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#DS_AssociationTypeCode" codeListValue="crossReference"/>
</gmd:associationType>
</gmd:MD_AggregateInformation>
</gmd:aggregationInfo>
```

Use the link as title instead.


Before

![image](https://user-images.githubusercontent.com/1701393/206436030-6cac79ac-cb8d-4986-b805-de16580f4b5c.png)


After

![image](https://user-images.githubusercontent.com/1701393/206436054-2f87e942-e3ee-4221-9e66-0278e721caab.png)
