### PR TITLE
Allow for null passwords when creating user via api.

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/security/GeonetworkAuthenticationProvider.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/GeonetworkAuthenticationProvider.java
@@ -22,6 +22,7 @@
 //==============================================================================
 package org.fao.geonet.kernel.security;
 
+import org.apache.commons.lang3.StringUtils;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.domain.User;
 import org.fao.geonet.repository.UserRepository;
@@ -66,6 +67,7 @@ public class GeonetworkAuthenticationProvider extends AbstractUserDetailsAuthent
         }
 
         if (authentication.getCredentials().toString().isEmpty() ||
+            StringUtils.isEmpty(gnDetails.getPassword()) ||
             !encoder.matches(authentication.getCredentials().toString(), gnDetails.getPassword())) {
             Log.warning(Log.JEEVES, "Authentication failed: wrong password provided");
             throw new BadCredentialsException("Authentication failed: wrong password provided");

--- a/services/src/main/java/org/fao/geonet/api/users/UsersApi.java
+++ b/services/src/main/java/org/fao/geonet/api/users/UsersApi.java
@@ -465,9 +465,11 @@ public class UsersApi {
         groups.addAll(processGroups(userDto.getGroupsUserAdmin(), Profile.UserAdmin));
 
         User user = new User();
-        user.getSecurity().setPassword(
-            PasswordUtil.encoder(ApplicationContextHolder.get()).encode(
-                userDto.getPassword()));
+        if (userDto.getPassword() != null) {
+            user.getSecurity().setPassword(
+                PasswordUtil.encoder(ApplicationContextHolder.get()).encode(
+                    userDto.getPassword()));
+        }
 
         fillUserFromParams(user, userDto);
 

--- a/services/src/main/java/org/fao/geonet/api/users/UsersApi.java
+++ b/services/src/main/java/org/fao/geonet/api/users/UsersApi.java
@@ -451,6 +451,13 @@ public class UsersApi {
             throw new IllegalArgumentException(errorMessage);
         }
 
+        // If userProfileUpdateEnabled is not enabled, the user password are managed by the security provider so allow null passwords.
+        // Otherwise the password cannot be null.
+        if (userDto.getPassword() == null
+            && (securityProviderConfiguration == null || securityProviderConfiguration.isUserProfileUpdateEnabled())) {
+            throw new IllegalArgumentException("Users password must be supplied");
+        }
+
         List<User> existingUsers = userRepository.findByUsernameIgnoreCase(userDto.getUsername());
         if (!existingUsers.isEmpty()) {
             throw new IllegalArgumentException("Users with username "

--- a/services/src/main/java/org/fao/geonet/api/users/validation/UserDtoValidator.java
+++ b/services/src/main/java/org/fao/geonet/api/users/validation/UserDtoValidator.java
@@ -62,7 +62,8 @@ public class UserDtoValidator implements Validator {
                 "Users with username "
                     + user.getUsername() + " ignore case already exists");
         }
-
-        PasswordValidationUtils.rejectIfInvalid(errors, user.getPassword());
+        if (user.getPassword() != null) {
+            PasswordValidationUtils.rejectIfInvalid(errors, user.getPassword());
+        }
     }
 }


### PR DESCRIPTION
When pre-creating users for other authentication methods such as keycloak, passwords are not required so we should allow null passwords.