### PR TITLE
ISO19139 / Indexing / Subtemplate / Avoid warning

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/index-subtemplate.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/index-subtemplate.xsl
@@ -161,7 +161,7 @@
   <!-- Indexing constraints -->
   <xsl:template mode="index" match="gmd:resourceConstraints[count(ancestor::node()) =  1]">
     <xsl:variable name="constraint" select="concat(
-                        string-join(gmd:MD_LegalConstraints/*/gmd:MD_RestrictionCode/@codeListValue[@codeListValue != 'otherConstraints'], ', '),
+                        string-join(gmd:MD_LegalConstraints/*/gmd:MD_RestrictionCode/@codeListValue[. != 'otherConstraints'], ', '),
                         ' ',
                         string-join(gmd:MD_LegalConstraints/gmd:otherConstraints/*/text(), ', '))"/>
 


### PR DESCRIPTION
```
Warning: on line 166 of index-subtemplate.xsl:
  The attribute axis starting at an attribute node will never select anything
```