### PR TITLE
url harvester: add org for resource if none

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/fromJsonLdEsri.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/fromJsonLdEsri.xsl
@@ -193,6 +193,37 @@
               <mcc:MD_ProgressCode codeList="codeListLocation#MD_ProgressCode" codeListValue="{state}"/>
             </mri:status>-->
 
+            <!-- add publisher to resource organisation as well-->
+            <xsl:if test="not(organization)">
+              <cit:CI_Responsibility>
+                <cit:role>
+                  <cit:CI_RoleCode codeList="codeListLocation#CI_RoleCode" codeListValue="publisher"/>
+                </cit:role>
+                <cit:party>
+                  <cit:CI_Organisation>
+                    <cit:name>
+                      <gco:CharacterString>
+                        <xsl:value-of select="publisher"/>
+                      </gco:CharacterString>
+                    </cit:name>
+                    <cit:contactInfo>
+                      <cit:CI_Contact>
+                        <cit:address>
+                          <cit:CI_Address>
+                            <cit:electronicMailAddress>
+                              <gco:CharacterString>
+                                <xsl:value-of select="contactPoint/hasEmail"/>
+                              </gco:CharacterString>
+                            </cit:electronicMailAddress>
+                          </cit:CI_Address>
+                        </cit:address>
+                      </cit:CI_Contact>
+                    </cit:contactInfo>
+                  </cit:CI_Organisation>
+                </cit:party>
+              </cit:CI_Responsibility>
+            </xsl:if>
+
             <xsl:for-each select="organization">
               <mri:pointOfContact>
                 <cit:CI_Responsibility>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/fromJsonOpenDataSoft.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/fromJsonOpenDataSoft.xsl
@@ -196,6 +196,39 @@
               <mcc:MD_ProgressCode codeList="codeListLocation#MD_ProgressCode" codeListValue="{state}"/>
             </mri:status>-->
 
+            <!-- add publisher to resource organisation as well-->
+            <xsl:if test="not(organization)">
+              <mri:pointOfContact>
+                <cit:CI_Responsibility>
+                  <cit:role>
+                    <cit:CI_RoleCode codeList="codeListLocation#CI_RoleCode" codeListValue="originator">publisher</cit:CI_RoleCode>
+                  </cit:role>
+                  <cit:party>
+                    <cit:CI_Organisation>
+                      <cit:name>
+                        <gco:CharacterString>
+                          <xsl:value-of select="metas/publisher"/>
+                        </gco:CharacterString>
+                      </cit:name>
+                      <cit:contactInfo>
+                        <cit:CI_Contact>
+                          <cit:address>
+                            <cit:CI_Address>
+                              <cit:electronicMailAddress>
+                                <gco:CharacterString>
+                                  <xsl:value-of select="author_email"/>
+                                </gco:CharacterString>
+                              </cit:electronicMailAddress>
+                            </cit:CI_Address>
+                          </cit:address>
+                        </cit:CI_Contact>
+                      </cit:contactInfo>
+                    </cit:CI_Organisation>
+                  </cit:party>
+                </cit:CI_Responsibility>
+              </mri:pointOfContact>
+            </xsl:if>
+
             <xsl:for-each select="organization">
               <mri:pointOfContact>
                 <cit:CI_Responsibility>


### PR DESCRIPTION
For ODS and ESRI, it often happens that there is no resource contact, probably because it's the same that for the metadata.
In that case, we use the same contact for `org` and `orgForResource`