### PR TITLE
[a11y] Make the record link button in the record view accessible

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/recordLinkButton.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/recordLinkButton.html
@@ -1,5 +1,6 @@
 <a
   type="button"
+  href=""
   data-ng-show="hasAction"
   data-ng-disabled="::btnDisabled"
   data-ng-class="{'btn btn-default btn-sm': !isDropDown || iconMode === 'only'}"


### PR DESCRIPTION
The link button in the 'related' part of the detail view wasn't accessible by keyboard (using the `TAB` button). This PR fixes this by adding a `href` attribute

<img width="722" alt="gn-linkbutton" src="https://user-images.githubusercontent.com/19608667/207362661-48586114-a964-4416-9640-623d00a8af7d.png">

