### PR TITLE
Report file download - check if related file upload is available

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/reports/ReportDownloads.java
+++ b/services/src/main/java/org/fao/geonet/api/reports/ReportDownloads.java
@@ -91,11 +91,11 @@ public class ReportDownloads implements IReport {
             for (MetadataFileDownload fileDownload : records) {
                 // User should be the user that uploaded the file
                 int fileUploadId = fileDownload.getFileUploadId();
-                MetadataFileUpload metadataFileUpload =
+                Optional<MetadataFileUpload> metadataFileUpload =
                     uploadRepo.findOne(
-                        MetadataFileUploadSpecs.hasId(fileUploadId)).get();
+                        MetadataFileUploadSpecs.hasId(fileUploadId));
 
-                String username = metadataFileUpload.getUserName();
+                String username = metadataFileUpload.isPresent() ? metadataFileUpload.get().getUserName() : "";
                 String name = "";
                 String surname = "";
                 String email = "";
@@ -159,7 +159,7 @@ public class ReportDownloads implements IReport {
                 record.add(name);
                 record.add(email);
                 record.add(profile);
-                record.add(metadataFileUpload.getDeletedDate());
+                record.add(metadataFileUpload.isPresent() ? metadataFileUpload.get().getDeletedDate() : "");
 
                 csvFilePrinter.printRecord(record);
             }


### PR DESCRIPTION
The file download report displays some information about the related file upload, but if the file was uploaded to a metadata before the feature to track file uploads / downloads was implemented, can happen that there is no file upload.

This code change, checks if the file upload is present to retrieve the related information instead of causing an exception.