### PR TITLE
[FP] INSPIRE Atom fixes

### DIFF
--- a/domain/src/main/java/org/fao/geonet/domain/InspireAtomFeed.java
+++ b/domain/src/main/java/org/fao/geonet/domain/InspireAtomFeed.java
@@ -73,21 +73,23 @@ public class InspireAtomFeed extends GeonetEntity implements Serializable {
         Namespace ns = Namespace.getNamespace("f", "http://www.w3.org/2005/Atom");
         Namespace nsXml = Namespace.getNamespace("xml", "http://www.w3.org/XML/1998/namespace");
 
-        inspireAtomFeed.setTitle(atomDoc.getChildText("title", ns));
+        inspireAtomFeed.setTitle(StringUtils.left(atomDoc.getChildText("title", ns), 255));
 
         if (atomDoc.getChildText("subtitle", ns) != null) {
-            inspireAtomFeed.setSubtitle(atomDoc.getChildText("subtitle", ns));
+            inspireAtomFeed.setSubtitle(StringUtils.left(atomDoc.getChildText("subtitle", ns), 255));
         }
 
         if (atomDoc.getChildText("rights", ns) != null) {
-            inspireAtomFeed.setRights(atomDoc.getChildText("rights", ns));
+            inspireAtomFeed.setRights(StringUtils.left(atomDoc.getChildText("rights", ns), 255));
         }
 
         inspireAtomFeed.setLang(atomDoc.getAttributeValue("lang", ns, ""));
         Element authorEl = atomDoc.getChild("author", ns);
         if (authorEl != null) {
-            inspireAtomFeed.setAuthorName(atomDoc.getChild("author", ns).getChildText("name", ns));
-            inspireAtomFeed.setAuthorEmail(atomDoc.getChild("author", ns).getChildText("email", ns));
+            inspireAtomFeed.setAuthorName(
+                StringUtils.left(atomDoc.getChild("author", ns).getChildText("name", ns), 255));
+            inspireAtomFeed.setAuthorEmail(
+                StringUtils.left(atomDoc.getChild("author", ns).getChildText("email", ns), 255));
         }
         inspireAtomFeed.setLang(atomDoc.getAttributeValue("lang", nsXml, ""));
 
@@ -101,7 +103,7 @@ public class InspireAtomFeed extends GeonetEntity implements Serializable {
                     linkEl.getAttributeValue("rel", "").equals("section")) {
                     InspireAtomFeedEntry inspireAtomFeedEntry = new InspireAtomFeedEntry();
 
-                    inspireAtomFeedEntry.setTitle(entry.getChildText("title", ns));
+                    inspireAtomFeedEntry.setTitle(StringUtils.left(entry.getChildText("title", ns), 255));
 
                     if (entry.getChildText("category", ns) != null) {
                         inspireAtomFeedEntry.setCrs(entry.getChild("category", ns).getAttributeValue("term"));

--- a/domain/src/main/java/org/fao/geonet/domain/InspireAtomFeed.java
+++ b/domain/src/main/java/org/fao/geonet/domain/InspireAtomFeed.java
@@ -23,6 +23,7 @@
 package org.fao.geonet.domain;
 
 
+import org.apache.commons.lang.StringUtils;
 import org.hibernate.annotations.Type;
 import org.jdom.Element;
 import org.jdom.Namespace;

--- a/domain/src/main/java/org/fao/geonet/repository/specification/MetadataSpecs.java
+++ b/domain/src/main/java/org/fao/geonet/repository/specification/MetadataSpecs.java
@@ -215,7 +215,7 @@ public final class MetadataSpecs {
             @Override
             public Predicate toPredicate(Root<AbstractMetadata> root, CriteriaQuery<?> query, CriteriaBuilder cb) {
                 Path<String> schemaIdAttributePath = root.get(AbstractMetadata_.dataInfo).get(MetadataDataInfo_.schemaId);
-                Predicate likeSchemaIdPredicate = cb.like(schemaIdAttributePath, cb.literal("iso19139"));
+                Predicate likeSchemaIdPredicate = cb.like(schemaIdAttributePath, cb.literal("iso19139%"));
                 return likeSchemaIdPredicate;
             }
         };


### PR DESCRIPTION
- Update JPA specification to filter metadata with schemas based on iso19139 also.
- Atom feed parse: truncate fields longer than the database related fields.

Related to https://github.com/geonetwork/core-geonetwork/pull/5472