### PR TITLE
WRO4J / Do not chain filters on exception

### DIFF
--- a/wro4j/src/main/java/org/fao/geonet/wro4j/GeonetWro4jFilter.java
+++ b/wro4j/src/main/java/org/fao/geonet/wro4j/GeonetWro4jFilter.java
@@ -1,15 +1,14 @@
 package org.fao.geonet.wro4j;
 
 import org.fao.geonet.utils.Log;
-
 import ro.isdc.wro.http.WroFilter;
-
-import java.net.SocketException;
 
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.net.SocketException;
 
 /**
  * @author Jesse on 2/1/2015.
@@ -30,7 +29,13 @@ public class GeonetWro4jFilter extends WroFilter {
             // ignore this because it means that a client closed the socket while data was being written to it.
         } else {
             Log.error(GeonetworkWrojManagerFactory.WRO4J_LOG, "Error occurred during a wro4j request handling", e);
-            super.onException(e, response, chain);
+            // Do not call super to avoid having WRO4J chaining
+            // to other filters.
+            try {
+                response.sendError(HttpServletResponse.SC_NOT_FOUND, e.getMessage());
+            } catch (IOException ex) {
+                // Ignore
+            }
         }
     }
 }


### PR DESCRIPTION
Some bots are spamming application with calls like `/geonetwork/static/dut/qi?....`

In such case, WRO4J log the exception about the invalid cache key
```
2022-12-15T09:28:56,639 ERROR [ro.isdc.wro.http.WroFilter] - Exception occured
ro.isdc.wro.WroRuntimeException: Cannot build valid CacheKey from request: /geonetwork/static/dut/qi
at ro.isdc.wro.manager.ResourceBundleProcessor.getSafeCacheKey(ResourceBundleProcessor
```

But it also chain to other filters by default "The default implementation proceeds with filter chaining when exception is thrown." which in the above URL may also match the `GenericFilter` which tries to do something. Also raised in https://github.com/wro4j/wro4j/issues/1013, it does not make sense to chain filter in case of exception in our case. Return 404.

![image](https://user-images.githubusercontent.com/1701393/207832814-cbc1c429-e1c1-4680-83bf-2c695a1483fe.png)
