### PR TITLE
Index / Force linkProtocol to be an array

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/search/EsSearchManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/EsSearchManager.java
@@ -553,6 +553,7 @@ public class EsSearchManager implements ISearchManager {
             .add("type")
             .add("resourceDate")
             .add("link")
+            .add("linkProtocol")
             .add("crsDetails")
             .add("format")
             .add("orderingInstructionsObject")


### PR DESCRIPTION
When a field only contains one value, Elasticsearch makes it a string by default. Force it to always be indexed as array (some client apps don't want to rework the response).