### PR TITLE
Record view / Display bounding polygon if set

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -570,7 +570,10 @@
            */
           getBboxFeatureFromMd: function (md, proj) {
             var feat = new ol.Feature();
-            var wkts = md.geom;
+            var wkts = md.shape || md.geom;
+            if (!angular.isArray(wkts)) {
+              wkts = [wkts];
+            }
             var projExtent = proj.getExtent();
             if (wkts && wkts.length) {
               var geometry;


### PR DESCRIPTION
Most of the time only a bounding box is provided in metadata records but sometimes bounding polygons are also used. Add the possibility to return the bounding polygon if available for a metadata record. For the time being, this is only rendered in the record view. 

![image](https://user-images.githubusercontent.com/1701393/208482454-a3e079e3-13e4-4a78-a52d-d849f95675f8.png)

For search results, only the bounding box is rendered (as bounding polygon can increase a lot the search response size). If some user wants to highlight polygons in the small map, they can add the `shape` field in the `gnESFacet` include list.

Test record https://www.geocat.ch/geonetwork/srv/api/records/3ff2557b-5465-460f-958a-7b1c7eb4058d/formatters/iso19139?output=xml&approved=true