### PR TITLE
Indexing / Multilingual records / Ensure default field contains a value

### DIFF
--- a/web/src/main/webapp/xslt/common/index-utils.xsl
+++ b/web/src/main/webapp/xslt/common/index-utils.xsl
@@ -218,8 +218,8 @@
 
     <!--<xsl:message>gn-fn-index:add-field <xsl:value-of select="$fieldName"/></xsl:message>
     <xsl:message>gn-fn-index:add-field elements <xsl:copy-of select="$elements"/></xsl:message>
-    <xsl:message>gn-fn-index:add-field languages <xsl:copy-of select="$languages"/></xsl:message>
--->
+    <xsl:message>gn-fn-index:add-field languages <xsl:copy-of select="$languages"/></xsl:message>-->
+
     <xsl:variable name="isArray"
                   select="count($elements[not(@xml:lang)]) > 1"/>
     <xsl:for-each select="$elements">
@@ -242,11 +242,27 @@
             <xsl:for-each select="$element//(*:CharacterString|*:Anchor)[. != '']">
               <value><xsl:value-of select="concat($doubleQuote, 'default', $doubleQuote, ':',
                                            $doubleQuote, gn-fn-index:json-escape(.), $doubleQuote)"/></value>
-            <value><xsl:value-of select="concat($doubleQuote, 'lang', $mainLanguage, $doubleQuote, ':',
+              <value><xsl:value-of select="concat($doubleQuote, 'lang', $mainLanguage, $doubleQuote, ':',
                                            $doubleQuote, gn-fn-index:json-escape(.), $doubleQuote)"/></value>
             </xsl:for-each>
 
-            <xsl:for-each select="$element//*:LocalisedCharacterString[. != '']">
+            <xsl:variable name="translations"
+                          select="$element//*:LocalisedCharacterString[. != '']"/>
+
+            <xsl:if test="count($element//(*:CharacterString|*:Anchor)[. != '']) = 0
+                          and count($translations) > 0">
+
+              <xsl:variable name="mainLanguageId"
+                            select="concat('#', $languages/lang[@id != 'default' and @value = $mainLanguage]/@id)"/>
+
+              <value><xsl:value-of select="concat($doubleQuote, 'default', $doubleQuote, ':',
+                                           $doubleQuote, gn-fn-index:json-escape(
+                                           if ($translations[@local = $mainLanguageId])
+                                           then $translations[@local = $mainLanguageId]
+                                           else $translations[1]), $doubleQuote)"/></value>
+            </xsl:if>
+
+            <xsl:for-each select="$translations">
               <xsl:variable name="elementLanguage"
                             select="replace(@locale, '#', '')"/>
               <xsl:variable name="elementLanguage3LetterCode"


### PR DESCRIPTION
Some metadata producers encode multilingual content without using `gco:CharacterString` or `gcx:Anchor` for the main language. eg.

```xml
               <gmd:title xsi:type="gmd:PT_FreeText_PropertyType">
                  <gmd:PT_FreeText>
                     <gmd:textGroup>
                        <gmd:LocalisedCharacterString locale="#FR">GEOLOGIE DES SONDAGES</gmd:LocalisedCharacterString>
                     </gmd:textGroup>
                     <gmd:textGroup>
                        <gmd:LocalisedCharacterString locale="#EN">GEOLOGIE DES SONDAGES</gmd:LocalisedCharacterString>
                     </gmd:textGroup>
                     <gmd:textGroup>
                        <gmd:LocalisedCharacterString locale="#DE">GEOLOGIE DES SONDAGES</gmd:LocalisedCharacterString>
                     </gmd:textGroup>
                     <gmd:textGroup>
                        <gmd:LocalisedCharacterString locale="#IT">GEOLOGIE DES SONDAGES</gmd:LocalisedCharacterString>
                     </gmd:textGroup>
                     <gmd:textGroup>
                        <gmd:LocalisedCharacterString locale="#RM">GEOLOGIE DES SONDAGES</gmd:LocalisedCharacterString>
                     </gmd:textGroup>
                  </gmd:PT_FreeText>
               </gmd:title>
```

In that case, multilingual field object does not contain the `default` element and records are displayed without title (unless user interface is in one of the metadata language.

This change ensure that a default property is set with the translation in the main language of the record or fallback on the first translation if main language can't be found.

Test record https://www.geocat.ch/geonetwork/srv/api/records/SITG_2998/formatters/iso19139?output=xml&approved=true