### PR TITLE
Record view / PDF export based on browser capability

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/directives/partials/mdactionmenu.html
+++ b/web-ui/src/main/resources/catalog/views/default/directives/partials/mdactionmenu.html
@@ -331,10 +331,15 @@
         </a>
       </li>
       <li role="menuitem" data-ng-repeat="f in formatterList">
-        <a
+        <a data-ng-if="!!f.url"
           data-ng-href="{{::buildFormatter(f.url, md.uuid, mdView.current.record.draft)}}"
           target="_blank"
         >
+          <span class="fa fa-fw {{f.class}}"></span>&nbsp;
+          <span data-translate="">{{f.label | translate}}</span>
+        </a>
+        <a data-ng-if="!!f.url === false && f.label.indexOf('PDF') !== -1"
+           href="javascript:print();">
           <span class="fa fa-fw {{f.class}}"></span>&nbsp;
           <span data-translate="">{{f.label | translate}}</span>
         </a>

--- a/web-ui/src/main/resources/catalog/views/default/directives/partials/mdactionmenu.html
+++ b/web-ui/src/main/resources/catalog/views/default/directives/partials/mdactionmenu.html
@@ -331,15 +331,18 @@
         </a>
       </li>
       <li role="menuitem" data-ng-repeat="f in formatterList">
-        <a data-ng-if="!!f.url"
+        <a
+          data-ng-if="!!f.url"
           data-ng-href="{{::buildFormatter(f.url, md.uuid, mdView.current.record.draft)}}"
           target="_blank"
         >
           <span class="fa fa-fw {{f.class}}"></span>&nbsp;
           <span data-translate="">{{f.label | translate}}</span>
         </a>
-        <a data-ng-if="!!f.url === false && f.label.indexOf('PDF') !== -1"
-           href="javascript:print();">
+        <a
+          data-ng-if="!!f.url === false && f.label.indexOf('PDF') !== -1"
+          href="javascript:print();"
+        >
           <span class="fa fa-fw {{f.class}}"></span>&nbsp;
           <span data-translate="">{{f.label | translate}}</span>
         </a>


### PR DESCRIPTION
Follow up of https://github.com/geonetwork/core-geonetwork/pull/6517

If user want to configure the default PDF export based on the browser print capability, configure the downloadFormatter for PDF without URL:

```js
downloadFormatter: [
              {
                label: "exportMEF",
                url: "/formatters/zip?withRelated=false",
                class: "fa-file-zip-o"
              },
              {
                label: "exportPDF",
                class: "fa-file-pdf-o"
              },
```

To be discussed: this should be the default ?