### PR TITLE
CSW / Improve search on multilingual content.

### DIFF
--- a/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/es/CswFilter2Es.java
+++ b/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/es/CswFilter2Es.java
@@ -133,11 +133,10 @@ public class CswFilter2Es extends AbstractFilterVisitor {
         "            ]\n" +
         "          ,\"filter\":{\"query_string\":{\"query\":\"%s\"}}, \"minimum_should_match\" : 1}";
 
-    private final String templateMatch = " {\n" +
-        "            \"match\": {\n" +
-        "             \"%s\": \"%s\"\n" +
-        "            }\n" +
-        "          }";
+    private final String templateMatch = "{\"query_string\": {\n" +
+        "        \"fields\": [\"%s\"],\n" +
+        "        \"query\": \"%s\"\n" +
+        "    }}";
 
     private final String templatePropertyIsNot = " {\"bool\": {\n" +
         "            \"must_not\": " + templateMatch +
@@ -160,13 +159,10 @@ public class CswFilter2Es extends AbstractFilterVisitor {
         "        }\n" +
         "    }";
 
-    private final String templateIsLike = "{\n" +
-        "    \"wildcard\": {\n" +
-        "      \"%s\": {\n" +
-        "        \"value\": \"%s\"\n" +
-        "      }\n" +
-        "    }\n" +
-        "}";
+    private final String templateIsLike = "{\"query_string\": {\n" +
+        "        \"fields\": [\"%s\"],\n" +
+        "        \"query\": \"%s\"\n" +
+        "    }}";
 
     private final String templateSpatial = "{ \"geo_shape\": {\"geom\": {\n" +
         "                        \t\"shape\": {\n" +

--- a/web/src/main/webapp/WEB-INF/config-csw.xml
+++ b/web/src/main/webapp/WEB-INF/config-csw.xml
@@ -41,21 +41,21 @@
         <!-- - - - - - - - - - - - - - -->
         <!-- Core queryable properties -->
         <!-- - - - - - - - - - - - - - -->
-        <parameter name="Subject" field="tag.default" type="SupportedISOQueryables">
+        <parameter name="Subject" field="tag.*" type="SupportedISOQueryables">
           <xpath schema="iso19139" path="*/gmd:MD_Keywords/gmd:keyword/gco:CharacterString"/>
         </parameter>
 
-        <parameter name="Title" field="resourceTitleObject.default" sortField="resourceTitleObject.default.keyword" type="SupportedISOQueryables">
+        <parameter name="Title" field="resourceTitleObject.*" sortField="resourceTitleObject.default.keyword" type="SupportedISOQueryables">
           <xpath schema="iso19139"
                  path="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:title/gco:CharacterString"/>
         </parameter>
 
-        <parameter name="Abstract" field="resourceAbstractObject.default" sortField="resourceAbstractObject.default.keyword" type="SupportedISOQueryables">
+        <parameter name="Abstract" field="resourceAbstractObject.*" sortField="resourceAbstractObject.default.keyword" type="SupportedISOQueryables">
           <xpath schema="iso19139"
                  path="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:abstract/gco:CharacterString"/>
         </parameter>
 
-        <parameter name="AnyText" field="any.default" type="SupportedISOQueryables"/>
+        <parameter name="AnyText" field="any.*" type="SupportedISOQueryables"/>
 
         <parameter name="Format" field="format" type="SupportedISOQueryables">
           <xpath schema="iso19139"
@@ -85,7 +85,7 @@
                  path="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:date/gmd:CI_Date[gmd:dateType/gmd:CI_DateTypeCode/@codeListValue='revision']/gmd:date/gco:Date|gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:citation/gmd:CI_Citation/gmd:date/gmd:CI_Date[gmd:dateType/gmd:CI_DateTypeCode/@codeListValue='revision']/gmd:date/gco:Date"/>
         </parameter>
 
-        <parameter name="AlternateTitle" field="resourceAltTitle" sortField="resourceAltTitle.keyword" type="SupportedISOQueryables">
+        <parameter name="AlternateTitle" field="resourceAltTitleObject.*" sortField="resourceAltTitleObject.default.keyword" type="SupportedISOQueryables">
           <xpath schema="iso19139"
                  path="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:alternateTitle/gco:CharacterString"/>
         </parameter>
@@ -115,7 +115,7 @@
                  path="gmd:language/gco:CharacterString|gmd:language/gmd:LanguageCode/@codeListValue"/>
         </parameter>
 
-        <parameter name="ResourceIdentifier" field="resourceIdentifier" type="SupportedISOQueryables">
+        <parameter name="ResourceIdentifier" field="resourceIdentifier.code" type="SupportedISOQueryables">
           <xpath schema="iso19139"
                  path="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:identifier/gmd:MD_Identifier/gmd:code/gco:CharacterString|gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:identifier/gmd:MD_Identifier/gmd:code/gco:CharacterString"/>
         </parameter>
@@ -124,8 +124,7 @@
           <xpath schema="iso19139" path="gmd:parentIdentifier/gco:CharacterString"/>
         </parameter>
 
-        <!-- TODO: Check ES index field -->
-        <parameter name="KeywordType" field="keywordType" type="SupportedISOQueryables">
+        <parameter name="KeywordType" field="cl_type.key" type="SupportedISOQueryables">
           <xpath schema="iso19139"
                  path="*/gmd:MD_Keywords/gmd:type/gmd:MD_KeywordTypeCode/@codeListValue"/>
         </parameter>
@@ -135,7 +134,7 @@
         <!-- (both services and datasets)    -->
         <!-- - - - - - - - - - - - - - - - - -->
 
-        <parameter name="GeographicDescriptionCode" field="geoTag"
+        <parameter name="GeographicDescriptionCode" field="keywordType-place.*"
                    type="SupportedISOQueryables">
           <xpath schema="iso19139"
                  path="*/gmd:EX_Extent/gmd:geographicElement/gmd:EX_GeographicDescription/gmd:geographicIdentifier/gmd:MD_Identifier/gmd:code/gco:CharacterString"/>
@@ -146,7 +145,7 @@
         <!-- (dataset, datasetcollection, application ...)   -->
         <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
 
-        <parameter name="TopicCategory" field="topic" type="SupportedISOQueryables">
+        <parameter name="TopicCategory" field="cl_topic.key" type="SupportedISOQueryables">
           <xpath schema="iso19139"
                  path="gmd:identificationInfo//gmd:MD_DataIdentification/gmd:topicCategory/gmd:MD_TopicCategoryCode|gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:topicCategory/gmd:MD_TopicCategoryCode"/>
         </parameter>
@@ -174,13 +173,13 @@
                  path="gmd:spatialResolution/gmd:MD_Resolution/gmd:distance/gco:Distance/@uom"/>
         </parameter>
 
-        <parameter name="TempExtent_begin" field="resourceTemporalDateRange" type="SupportedISOQueryables"
+        <parameter name="TempExtent_begin" field="resourceTemporalDateRange.gte" type="SupportedISOQueryables"
                    range="true">
           <xpath schema="iso19139"
                  path="gmd:identificationInfo/gmd:MD_DataIdentification|gmd:identificationInfo/*/gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:TimePeriod/gml:beginPosition|gmd:identificationInfo/gmd:MD_DataIdentification|gmd:identificationInfo/*/gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:TimePeriod/gml:beginPosition/gml:begin/gml:TimeInstant/gml:timePosition"/>
         </parameter>
 
-        <parameter name="TempExtent_end" field="resourceTemporalDateRange" type="SupportedISOQueryables"
+        <parameter name="TempExtent_end" field="resourceTemporalDateRange.lte" type="SupportedISOQueryables"
                    range="true">
           <xpath schema="iso19139"
                  path="gmd:identificationInfo/gmd:MD_DataIdentification|gmd:identificationInfo/*/gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:TimePeriod/gml:endPosition|gmd:identificationInfo/gmd:MD_DataIdentification|gmd:identificationInfo/*/gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent/gmd:extent/gml:TimePeriod/gml:endPosition/gml:end/gml:TimeInstant/gml:timePosition"/>
@@ -241,12 +240,12 @@
                  path="gmd:dataQualityInfo/*/gmd:report/*/gmd:result//gmd:pass/gco:Boolean"/>
         </parameter>
 
-        <parameter name="SpecificationTitle" field="specificationTitle" type="AdditionalQueryables">
+        <parameter name="SpecificationTitle" field="specificationConformance.title" type="AdditionalQueryables">
           <xpath schema="iso19139"
                  path="gmd:dataQualityInfo/*/gmd:report/*/gmd:result//gmd:specification/*/gmd:title/gco:CharacterString"/>
         </parameter>
 
-        <parameter name="SpecificationDate" field="specificationDate" type="AdditionalQueryables">
+        <parameter name="SpecificationDate" field="specificationConformance.date" type="AdditionalQueryables">
           <xpath schema="iso19139"
                  path="gmd:dataQualityInfo/*/gmd:report/*/gmd:result//gmd:specification/*/gmd:date/*/gmd:date/gco:DateTime"/>
         </parameter>
@@ -257,29 +256,29 @@
                  path="gmd:dataQualityInfo/*/gmd:report/*/gmd:result//gmd:specification/*/gmd:date/*/gmd:dateType/gmd:CI_DateTypeCode/@codeListValue"/>
         </parameter>
 
-        <parameter name="AccessConstraints" field="accessConstr" type="AdditionalQueryables">
+        <parameter name="AccessConstraints" field="cl_accessConstraints.key" type="AdditionalQueryables">
           <xpath schema="iso19139"
                  path="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:resourceConstraints//gmd:accessConstraints/gmd:MD_RestrictionCode/@codeListValueClassification|gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:resourceConstraints//gmd:accessConstraints/gmd:MD_RestrictionCode/@codeListValueClassification"/>
         </parameter>
 
-        <parameter name="OtherConstraints" field="otherConstr" type="AdditionalQueryables">
+        <parameter name="OtherConstraints" field="MD_LegalConstraintsOtherConstraintsObject.*" type="AdditionalQueryables">
           <xpath schema="iso19139"
                  path="[gmd:identificationInfo//gmd:MD_DataIdentification/gmd:resourceConstraints//gmd:otherConstraints/gco:CharacterString|gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:resourceConstraints//gmd:otherConstraints/gco:CharacterString"/>
         </parameter>
 
-        <parameter name="Classification" field="cl_classification" type="AdditionalQueryables">
+        <parameter name="Classification" field="cl_classification.key" type="AdditionalQueryables">
           <xpath schema="iso19139"
                  path="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:resourceConstraints/gmd:classification/gmd:MD_ClassificationCode/@codeListValue|gmd:identificationInfo/srv:SV_ServiceIdentification/gmd:resourceConstraints/gmd:classification/gmd:MD_ClassificationCode/@codeListValue"/>
         </parameter>
 
-        <parameter name="ConditionApplyingToAccessAndUse" field="conditionApplyingToAccessAndUse"
+        <parameter name="ConditionApplyingToAccessAndUse" field="MD_ConstraintsUseLimitationObject.*"
                    type="AdditionalQueryables"/>
 
         <parameter name="MetadataPointOfContact" field="Org" type="AdditionalQueryables">
           <xpath schema="iso19139" path="gmd:contact/*/gmd:organisationName/gco:CharacterString"/>
         </parameter>
 
-        <parameter name="Lineage" field="lineage" type="AdditionalQueryables">
+        <parameter name="Lineage" field="lineageObject.*" type="AdditionalQueryables">
           <xpath schema="iso19139"
                  path="gmd:dataQualityInfo/*/gmd:lineage/*/gmd:statement/gco:CharacterString"/>
         </parameter>


### PR DESCRIPTION
Most of the mapping done between OGC CSW queryable to Elasticsearch index fields was targeting `.default` properties (which means the default record language).

eg. Loading https://www.geocat.ch/geonetwork/srv/api/records/87380db7-36c1-4ae6-b9fe-2fe49799707a/formatters/iso19139?output=xml&approved=true

and using query like

```xml
<csw:GetRecords xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" service="CSW" version="2.0.2" maxRecords="10" startPosition="1" outputFormat="application/xml" outputSchema="http://www.opengis.net/cat/csw/2.0.2" resultType="results">
    <csw:Query typeNames="csw:Record">
        <csw:ElementSetName>summary</csw:ElementSetName>
        <csw:Constraint version="1.1.0">
            <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
                <ogc:PropertyIsLike escapeChar="\" singleChar="_" wildCard="%">
                    <ogc:PropertyName>AnyText</ogc:PropertyName>
                    <ogc:Literal>eau</ogc:Literal>
                </ogc:PropertyIsLike>
            </ogc:Filter>
        </csw:Constraint>
    </csw:Query>
</csw:GetRecords>
```

Searching for "wasser" or "eau" will not match the record.

A workaround is to use `any.langfre` or `any.langger` instead of `AnyText` and making a OR query to search on all languages.

By default, it makes more sens to change the mapping to use all fields (which will means search in all languages). Replace the wildcard query type by query_string to be able to search on multiple fields.