### PR TITLE
Aggregation improvements

### DIFF
--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/FacetDirective.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/FacetDirective.js
@@ -389,7 +389,34 @@
   module.filter("facetBgUrlBuilder", [
     function () {
       return function (key, decorator) {
-        return decorator.path ? decorator.path.replace("{key}", key) : decorator.map[key];
+        if (decorator && decorator.path) {
+          return "background-image:url('" + decorator.path.replace("{key}", key) + "')";
+        } else if (decorator && decorator.map) {
+          return "background-image:url('" + decorator.map[key] + "');";
+        }
+        return "";
+      };
+    }
+  ]);
+
+  module.filter("facetSearchUrlBuilder", [
+    function () {
+      return function (facetValue, key, response, config, missingValue) {
+        var field = (response.meta && response.meta.field) || key,
+          filter = config.filters
+            ? config.filters.filters[facetValue].query_string.query
+            : undefined,
+          value = response.meta && response.meta.wildcard ? facetValue + "*" : facetValue;
+
+        return (
+          '#/search?query_string={"' +
+          field +
+          '": {"' +
+          (value === missingValue ? "%23MISSING%23" : value) +
+          '": ' +
+          (filter ? '"' + filter + '"' : "true") +
+          "}}"
+        );
       };
     }
   ]);
@@ -397,9 +424,13 @@
   module.filter("facetCssClassCode", [
     function () {
       return function (key, isInspire) {
-        return isInspire
-          ? key.slice(key.lastIndexOf("/") + 1)
-          : key.replace("/", "").replace(" ", "");
+        if (key) {
+          return isInspire
+            ? key.slice(key.lastIndexOf("/") + 1)
+            : key.replace("/", "").replace(" ", "");
+        } else {
+          return "";
+        }
       };
     }
   ]);
@@ -821,7 +852,10 @@
               scope.vl.view.addEventListener("click", function (event, item) {
                 if (item.datum && item.datum.$$hashKey) {
                   $timeout(function () {
-                    scope.updateCallback({ facet: scope.facet, item: item.datum });
+                    scope.updateCallback({
+                      facet: scope.facet,
+                      item: item.datum
+                    });
                   }, 10);
                 }
               });

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facet-cards.html
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facet-cards.html
@@ -31,7 +31,8 @@
         </h2>
         <h2 data-ng-hide="isInspire">
           <span class="clamp-2"
-            >{{::facetValue | facetTranslator: key | capitalize}}</span
+            >{{::facetValue | facetTranslator: (response.meta && response.meta.field) ||
+            key | capitalize}}</span
           >
         </h2>
       </a>

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facet-cards.html
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facet-cards.html
@@ -1,44 +1,43 @@
 <div
   data-ng-repeat="(k, facet) in searchInfo.aggregations[key].buckets"
-  data-ng-show="facet.key"
+  data-ng-init="facetValue = facet.key || k;"
+  data-ng-show="facetValue"
   data-ng-class="isInspire ? ('bg-iti-' + (facet.key | facetCssClassCode: isInspire)) : ''"
   class="col-xs-6 col-sm-4 col-md-3 col-lg-2 gn-topic"
 >
   <div
-    class="panel panel-default gn-facet-{{facet.key}} gn-facet-type-{{decorator.type}}"
-    style="background-image:url('{{facet.key | facetBgUrlBuilder:decorator}}')"
+    class="panel panel-default gn-facet-{{::facetValue}} gn-facet-type-{{::decorator.type}}"
+    style="{{::facetValue | facetBgUrlBuilder:decorator}}"
   >
     <div class="panel-body">
       <a
         class="clearfix"
-        title="{{facet.key}}"
+        title="{{::facetValue}}"
         role="link"
-        data-ng-init="aggResponse = searchInfo.aggregations[key];
-                       decorator = (aggResponse.meta && aggResponse.meta.decorator) || undefined;
-                       field = (aggResponse.meta && aggResponse.meta.field)
-                              || key;
-                       value = aggResponse.meta && aggResponse.meta.wildcard
-                              ? (facet.key + '*') : facet.key"
-        data-ng-href='#/search?query_string={"{{field}}": {"{{value === missingValue ? "%23MISSING%23" : value}}": true} }'
+        data-ng-init="response = searchInfo.aggregations[key];
+                      decorator = (response.meta && response.meta.decorator) || undefined"
+        data-ng-href="{{::facetValue | facetSearchUrlBuilder:key:searchInfo.aggregations[key]:homeFacet.config[key]:missingValue}}"
       >
         <span
           data-ng-if="decorator"
           data-es-facet-decorator="decorator"
-          data-key="facet.key"
+          data-key="facetValue"
         />
         <h2
           data-ng-show="isInspire"
-          class="inspire-{{(facet.key | facetCssClassCode: isInspire)}}-{{iso2lang}}"
+          class="inspire-{{::(facetValue | facetCssClassCode: isInspire)}}-{{::iso2lang}}"
         >
           <span class="inspire-label clamp-2"></span>
         </h2>
         <h2 data-ng-hide="isInspire">
-          <span class="clamp-2">{{facet.key | facetTranslator: key | capitalize}}</span>
+          <span class="clamp-2"
+            >{{::facetValue | facetTranslator: key | capitalize}}</span
+          >
         </h2>
       </a>
     </div>
     <div class="panel-footer">
-      <i class="fa fa-fw fa-file-text-o"></i>{{facet.doc_count}}
+      <i class="fa fa-fw fa-file-text-o"></i>{{::facet.doc_count}}
     </div>
   </div>
 </div>

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facet-tab.html
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facet-tab.html
@@ -5,7 +5,7 @@
     title="{{::ctrl.item.value}}"
     ng-click="ctrl.filter(ctrl.facet, ctrl.item)"
   >
-    {{::ctrl.item.count}} {{::ctrl.item.value | facetTranslator: ctrl.facet.key |
-    capitalize}}
+    {{::ctrl.item.count}} {{::ctrl.item.value | facetTranslator: (ctrl.facet.meta &&
+    ctrl.facet.meta.field) || ctrl.facet.key | capitalize}}
   </a>
 </li>

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facet.html
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facet.html
@@ -31,7 +31,8 @@
         data-key="ctrl.item.value"
       />
       <span class="gn-facet-label flex-shrink text-ellipsis">
-        {{::ctrl.item.value | facetTranslator: ctrl.facet.key | capitalize}}
+        {{::ctrl.item.value | facetTranslator: (ctrl.facet.meta && ctrl.facet.meta.field)
+        || ctrl.facet.key | capitalize}}
       </span>
       <span
         ng-if="ctrl.item.count"

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -1915,7 +1915,10 @@
                   var keys = Object.keys(gnGlobalSettings.gnCfg.mods.home.facetConfig);
                   selectedFacet = keys[0];
                   for (var i = 0; i < keys.length; i++) {
-                    if ($scope.searchInfo.aggregations[keys[i]].buckets.length > 0) {
+                    if (
+                      $scope.searchInfo.aggregations[keys[i]].buckets.length > 0 ||
+                      Object.keys($scope.searchInfo.aggregations[keys[i]]).length > 0
+                    ) {
                       selectedFacet = keys[i];
                       break;
                     }

--- a/web-ui/src/main/resources/catalog/views/default/templates/home.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/home.html
@@ -120,7 +120,7 @@
           <label
             data-ng-repeat="facetKey in homeFacet.list"
             data-ng-init="agg = searchInfo.aggregations[facetKey]"
-            data-ng-show="agg.buckets.length > 0 && facetKey != homeFacet.lastKey"
+            data-ng-show="facetKey != homeFacet.lastKey"
           >
             <input
               type="radio"


### PR DESCRIPTION
## Home page / Add support for filter aggregation

Only terms aggregation was supported.

Example:

```json
{
  "mods": {
    "home": {
      "facetConfig": {
        "availableInServices": {
          "filters": {
            "filters": {
              "availableInViewService": {
                "query_string": {
                  "query": "+linkProtocol:/OGC:WMS.*/"
                }
              },
              "availableInDownloadService": {
                "query_string": {
                  "query": "+linkProtocol:/OGC:WFS.*/"
                }
              }
            }
          },
          "meta": {
            "decorator": {
              "type": "icon",
              "prefix": "fa fa-2x pull-left ",
              "map": {
                "availableInViewService": "fa-globe",
                "availableInDownloadService": "fa-download"
              }
            }
          }
        },
 ```

render as

![image](https://user-images.githubusercontent.com/1701393/208931696-e73449d6-c4f8-4740-9e39-4b6df912ce3e.png)



## Aggregation / Translate bucket value based on search field

 
User may configure a custom facet with some include/exclude config to
only collect statistics on some values eg.
  
  ```json
  {
    "onlySomeGroup": {
      "terms": {
        "field": "groupOwner",
        "include": "101|102"
      },
      "meta": {
        "orderByTranslation": true,
        "field": "groupOwner"
      }
    },
  ```

![image](https://user-images.githubusercontent.com/1701393/208939716-24fdb92d-0c03-46ca-af04-1399c28d2a58.png)

  
  In this case, values 101 and 102 are translated client side based on
  group labels. As the facet has a custom name (ie. `onlySomeGroup`)
  group id are not translated. The translation has to be based on the
  meta field name in this case.
