### PR TITLE
Permalink / Set link URL as in sitemap.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionService.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionService.js
@@ -42,6 +42,7 @@
     "gnMetadataManager",
     "gnAlertService",
     "gnSearchSettings",
+    "gnGlobalSettings",
     "gnUtilityService",
     "gnShareService",
     "gnPopup",
@@ -58,6 +59,7 @@
       gnMetadataManager,
       gnAlertService,
       gnSearchSettings,
+      gnGlobalSettings,
       gnUtilityService,
       gnShareService,
       gnPopup,
@@ -579,11 +581,22 @@
 
       /**
        * Get html formatter link for the given md
+       * and open the permalink modal.
+       *
+       * TODO: At some point we may use the point of truth URL
+       * provided in the metadata record (eg. DOI) if set.
+       *
        * @param {Object} md
        */
       this.getPermalink = function (md) {
-        var url = $location.absUrl().split("#")[0] + "#/metadata/" + md.uuid;
-        gnUtilityService.getPermalink(md.resourceTitle, url);
+        var permalinkBaseUrl = gnConfig["system.server.sitemapLinkUrl"],
+          url = gnGlobalSettings.nodeUrl + "api/records/" + md.uuid + "?language=all";
+
+        if (permalinkBaseUrl && permalinkBaseUrl.toUpperCase().indexOf("{{UUID}}")) {
+          url = permalinkBaseUrl.replace(/\{\{UUID\}\}/i, md.uuid);
+        }
+
+        gnUtilityService.displayPermalink(md.resourceTitle, url);
       };
 
       /**

--- a/web-ui/src/main/resources/catalog/components/utility/UtilityService.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityService.js
@@ -330,7 +330,7 @@
        * @param {String} title
        * @param {String} url
        */
-      function getPermalink(title, url) {
+      function displayPermalink(title, url) {
         gnPopup.createModal({
           title: $translate.instant("permalinkTo", { title: title }),
           content:
@@ -434,7 +434,7 @@
         CSVToArray: CSVToArray,
         getUrlParameter: getUrlParameter,
         randomUuid: randomUuid,
-        getPermalink: getPermalink,
+        displayPermalink: displayPermalink,
         openModal: openModal,
         goBack: goBack
       };

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -1256,10 +1256,17 @@
         isShowLoginAsLink: false,
         isUserProfileUpdateEnabled: true,
         isUserGroupUpdateEnabled: true,
-        init: function (configOverlay, gnUrl, gnViewerSettings, gnSearchSettings) {
+        init: function (
+          configOverlay,
+          gnUrl,
+          nodeUrl,
+          gnViewerSettings,
+          gnSearchSettings
+        ) {
           this.applyConfig(configOverlay !== null ? configOverlay : {});
           this.setLegacyOption(gnViewerSettings, gnSearchSettings);
           this.gnUrl = gnUrl || "../";
+          this.nodeUrl = nodeUrl || "../";
           this.proxyUrl = this.gnUrl + "../proxy?url=";
         },
         setLegacyOption: function (gnViewerSettings, gnSearchSettings) {

--- a/web-ui/src/main/resources/catalog/views/api/index.html
+++ b/web-ui/src/main/resources/catalog/views/api/index.html
@@ -42,6 +42,7 @@
           gnGlobalSettings.init(
             config,
             "http://localhost:8080/geonetwork/srv/",
+            "http://localhost:8080/geonetwork/srv/",
             gnViewerSettings,
             gnSearchSettings
           );

--- a/web-ui/src/main/resources/catalog/views/api/index_debug.html
+++ b/web-ui/src/main/resources/catalog/views/api/index_debug.html
@@ -243,6 +243,7 @@
           gnGlobalSettings.init(
             config,
             "http://localhost:8080/geonetwork/srv/",
+            "http://localhost:8080/geonetwork/srv/",
             gnViewerSettings,
             gnSearchSettings
           );

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
@@ -583,7 +583,7 @@ INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/server/port', '8080', 1, 230, 'n');
 INSERT INTO settings (name, value, datatype, position, internal) VALUES ('system/server/log','log4j2.xml', 0, 250, 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/server/timeZone', '', 0, 260, 'n');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/server/sitemapLinkUrl', NULL, 0, 270, 'y');
+INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/server/sitemapLinkUrl', NULL, 0, 270, 'n');
 
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/intranet/network', '127.0.0.1', 0, 310, 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/intranet/netmask', '255.0.0.0', 0, 320, 'y');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v423/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v423/migrate-default.sql
@@ -1,2 +1,4 @@
+UPDATE Settings SET internal = 'n' WHERE name = 'system/server/sitemapLinkUrl';
+
 UPDATE Settings SET value='4.2.3' WHERE name='system/platform/version';
 UPDATE Settings SET value='SNAPSHOT' WHERE name='system/platform/subVersion';

--- a/web/src/main/webapp/xslt/base-layout-cssjs-loader.xsl
+++ b/web/src/main/webapp/xslt/base-layout-cssjs-loader.xsl
@@ -311,7 +311,10 @@
       function(gnViewerSettings, gnSearchSettings, gnGlobalSettings) {
       gnGlobalSettings.init(
       <xsl:value-of select="if ($appConfig != '') then $appConfig else '{}'"/>,
-      null, gnViewerSettings, gnSearchSettings);
+      // Relative path is safer as even if settings are wrong, the client app works.
+      null,
+      <xsl:value-of select="if ($nodeUrl != '') then concat('&quot;', $nodeUrl, '&quot;') else 'null'"/>,
+      gnViewerSettings, gnSearchSettings);
       }]);
     </script>
   </xsl:template>


### PR DESCRIPTION
Follow up of https://github.com/geonetwork/core-geonetwork/pull/5579.

The same URL is used in sitemap and on client side permalink popup. Default permalink is a link pointing to the API (and not the client app with the UUID after the # which makes the information not available server side and no redirect easy to setup).

The permalink points to an HTML page containing the JSON-LD representation needed for structured data indexing for SEO.

Also relate to discussion in https://github.com/geonetwork/core-geonetwork/issues/6553


The next step is probably to use the point of truth defined in the metadata record if any instead (eg. DOI).