### PR TITLE
Record view / Series member statistics improvement

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/mdview/mdviewService.js
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/mdviewService.js
@@ -119,7 +119,10 @@
                 docs: {
                   top_hits: {
                     // associated stats with UUIDs
-                    size: 100
+                    size: 100,
+                    _source: {
+                      includes: ["uuid"]
+                    }
                   }
                 }
               };
@@ -131,7 +134,7 @@
             var relatedRecordKeysWithValues = []; // keep track of the relations with values
 
             Object.keys(relatedRecords).forEach(function (k) {
-              if (relatedRecords[k] && relatedRecords[k].map) {
+              if (relatedRecords[k] && relatedRecords[k].length > 0) {
                 relatedRecordKeysWithValues.push(k);
 
                 body += '{"index": "records"}\n';


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1701393/210323314-4d81950c-36e8-4c28-b28e-7d7f242ad632.png)


* When computing stats on members, only return the UUID of each records in top_hits (https://www.elastic.co/guide/en/elasticsearch/reference/8.5/search-aggregations-metrics-top-hits-aggregation.html#_example_6)
* Only request stats when there is at least one record in an associated types

This reduce a lot response time and size for collecting statistics. Associated records details were already available using the search API (only the UUID is used to find which records are in which categories).

Example for a serie having 100 members
![image](https://user-images.githubusercontent.com/1701393/210992091-c965c111-b39f-44cc-a27d-d759ae047245.png)


