### PR TITLE
Standard / ISO19115-3 and editor config improvement

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/xsl-view/view.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/xsl-view/view.xsl
@@ -58,7 +58,9 @@
   <xsl:include href="../../layout/evaluate.xsl"/>
   <xsl:include href="../../layout/utility-tpl-multilingual.xsl"/>
   <xsl:include href="../../layout/utility-fn.xsl"/>
-  <xsl:include href="../../formatter/jsonld/iso19115-3.2018-to-jsonld.xsl"/>
+  <xsl:include href="../jsonld/iso19115-3.2018-to-jsonld.xsl"/>
+  <xsl:include href="../citation/base.xsl"/>
+  <xsl:include href="../citation/common.xsl"/>
 
   <!-- The core formatter XSL layout based on the editor configuration -->
   <xsl:include href="sharedFormatterDir/xslt/render-layout.xsl"/>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
@@ -391,7 +391,7 @@
 
         <xsl:copy-of select="gn-fn-index:add-multilingual-field('resourceAbstract', mri:abstract, $allLanguages)"/>
 
-        <xsl:for-each-group select="mri:defaultLocale/*/lan:characterEncoding/*[@codeListValue != '']" 
+        <xsl:for-each-group select="mri:defaultLocale/*/lan:characterEncoding/*[@codeListValue != '']"
                             group-by="@codeListValue">
           <xsl:copy-of select="gn-fn-index:add-codelist-field(
                                 'cl_resourceCharacterSet', ., $allLanguages)"/>
@@ -1128,8 +1128,7 @@
           <xsl:copy-of select="gn-fn-index:add-multilingual-field('orderingInstructions', ., $allLanguages)"/>
         </xsl:for-each>
 
-        <xsl:for-each select="mrd:transferOptions/*/
-                                mrd:onLine/*[cit:linkage/gco:CharacterString != '']">
+        <xsl:for-each select=".//mrd:onLine/*[cit:linkage/gco:CharacterString != '']">
           <xsl:variable name="transferGroup"
                         select="count(ancestor::mrd:transferOptions/preceding-sibling::mrd:transferOptions)"/>
 

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/dispatcher.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/dispatcher.xsl
@@ -37,7 +37,7 @@
   <!-- Dispatch to the current profile mode -->
   <xsl:template name="dispatch-iso19115-3.2018">
     <xsl:param name="base" as="node()"/>
-    <xsl:param name="overrideLabel" as="xs:string" required="no" select="''"/>
+    <xsl:param name="overrideLabel" as="xs:string?" required="no" select="''"/>
     <xsl:param name="refToDelete" as="node()?" required="no"/>
     <xsl:param name="config" as="node()?" required="no"/>
 

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/dispatcher.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/dispatcher.xsl
@@ -49,7 +49,7 @@
 
   <xsl:template name="dispatch-iso19139">
     <xsl:param name="base" as="node()"/>
-    <xsl:param name="overrideLabel" as="xs:string" required="no" select="''"/>
+    <xsl:param name="overrideLabel" as="xs:string?" required="no" select="''"/>
     <xsl:param name="refToDelete" as="node()?" required="no"/>
     <xsl:param name="config" as="node()?" required="no"/>
     <xsl:apply-templates mode="mode-iso19139" select="$base">

--- a/web/src/main/webapp/xslt/ui-metadata/form-configurator.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-configurator.xsl
@@ -672,9 +672,9 @@
       <xsl:variable name="btnOverrideName"
                     select="@name"/>
       <xsl:variable name="btnName"
-                    select="if ($btnOverrideName)
+                    select="if ($btnOverrideName and $strings/*[name() = $btnOverrideName] != '')
                             then $strings/*[name() = $btnOverrideName]
-                            else ''"/>
+                            else $btnOverrideName"/>
 
       <!-- If multiple elements $elementName contains multiple values. Use the first one in getLabel to avoid failure. -->
       <xsl:variable name="labelConfig"


### PR DESCRIPTION
* Standard / ISO19115-3 / Formatter / Fix citation
* Standard / ISO19115-3 / Indexing / Index also link which can be in a distributor.
* Editor / Configuration / Override label is optional.

Sample configuration:

```
          <action type="add" name=" " btnLabel="Add the resource identifier"
                  if="count(*/mdb:identificationInfo/*/mri:citation/*/cit:identifier) = 0"
                  or="identifier" in="/*/mdb:identificationInfo/*/mri:citation/*">
            <template>
              <snippet>
                <cit:identifier>
                  <mcc:MD_Identifier>
                    <mcc:code>
                      <gco:CharacterString>https://data.organisation.net/geo/code-year-edition</gco:CharacterString>
                    </mcc:code>
                  </mcc:MD_Identifier>
                </cit:identifier>
              </snippet>
            </template>
          </action>

          <field xpath="/*/mdb:identificationInfo/*/mri:citation/*/cit:identifier/*/mcc:code"
                 name="Resource identifier"
                 del="../.."/>

```

Error reported:
```
gn-fn-metadata:getLabel | missing translation in schema iso19115-3.2018 for cit:identifier.
Error on line 40 of dispatcher.xsl:
  XTTE0590: An empty sequence is not allowed as the value of parameter $overrideLabel
2023-01-03T15:53:25,038 ERROR [geonetwork] - An empty sequence is not allowed as the value of parameter $overrideLabel
```

OverrideLabel was maked as required=no but type was mandatory. Give more flexibility to configure label without translation files.

