### PR TITLE
Search / Aggregations minor improvements

### DIFF
--- a/web-ui/src/main/resources/catalog/components/elasticsearch/EsFacet.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/EsFacet.js
@@ -73,7 +73,7 @@
           track_total_hits: true
         },
         home: {
-          facets: gnGlobalSettings.gnCfg.mods.home.facetConfig,
+          facets: {},
           source: {
             includes: [
               "id",

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/LuceneQueryParser.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/LuceneQueryParser.js
@@ -122,32 +122,6 @@
         }
         return query_string;
       }
-
-      function parseAstNode(node, facets) {
-        if (!node) return;
-
-        var left = node.left;
-        var right = node.right;
-        var field = node.field;
-        var operator = node.operator;
-        var term = node.term;
-        var nextGroup = facets;
-
-        if (field) {
-          var indexKey = field.field;
-          facets[indexKey] = facets[indexKey] || [];
-          nextGroup = facets[indexKey];
-        }
-
-        if (Array.isArray(facets)) {
-          if (term) {
-            facets.push(term);
-          }
-        } else if (typeof facets == "object") {
-        }
-        parseAstNode(left, nextGroup);
-        parseAstNode(right, nextGroup);
-      }
     }
   ]);
 })();

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/FacetDirective.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/FacetDirective.js
@@ -276,7 +276,7 @@
     if (this.facet.type === "tree") {
       this.item.path = [this.facet.key, this.item.key];
       this.item.collapsed = !this.searchCtrl.hasChildInSearch(this.item.path);
-    } else if (this.facet.type === "filters" || this.facet.type === "histogram") {
+    } else {
       this.item.inverted = this.searchCtrl.isNegativeSearch(this.item.path);
     }
   };

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facet-tab.html
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facet-tab.html
@@ -5,6 +5,11 @@
     title="{{::ctrl.item.value}}"
     ng-click="ctrl.filter(ctrl.facet, ctrl.item)"
   >
+    <span
+      data-ng-if="ctrl.facet.meta && ctrl.facet.meta.decorator"
+      data-es-facet-decorator="ctrl.facet.meta.decorator"
+      data-key="ctrl.item.value"
+    />
     {{::ctrl.item.count}} {{::ctrl.item.value | facetTranslator: (ctrl.facet.meta &&
     ctrl.facet.meta.field) || ctrl.facet.key | capitalize}}
   </a>

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facet.html
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facet.html
@@ -44,13 +44,13 @@
     <a
       href
       class="facet-invert"
-      title="{{::(ctrl.item.inverted ? 'filterWithValue' : 'allValuesExcept') | translate}}"
+      title="{{(ctrl.item.inverted ? 'filterWithValue' : 'allValuesExcept') | translate}}"
       ng-click="ctrl.toggleInvert()"
     >
       <span class="fa" ng-class="ctrl.item.inverted ? 'fa-check' : 'fa-minus-circle'">
       </span>
       <span>
-        {{::(ctrl.item.inverted ? 'filterWithValue' : 'allValuesExcept') | translate}}
+        {{(ctrl.item.inverted ? 'filterWithValue' : 'allValuesExcept') | translate}}
       </span>
     </a>
   </div>

--- a/web-ui/src/main/resources/catalog/components/search/searchfiltertag/SearchFilterTagsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/searchfiltertag/SearchFilterTagsDirective.js
@@ -25,18 +25,20 @@
     "gnGlobalSettings",
     "gnHumanizeTimeService",
     function (gnGlobalSettings, gnHumanizeTimeService) {
-      return function (range) {
-        var tokens = range.split(/^[\[{](.*) TO (.*)[\]}]$/),
+      return function (range, key) {
+        var expression = "\\+?" + key + ":",
+          rangeValue = range.replace(new RegExp(expression), ""),
+          tokens = rangeValue.split(/^[\[{](.*) TO (.*)[\]}]$/),
           useFromNowSetting = gnGlobalSettings.gnCfg.mods.global.humanizeDates,
           format = gnGlobalSettings.gnCfg.mods.global.dateFormat;
 
-        return tokens.length === 4
+        return tokens.length === 4 && moment(tokens[1], moment.ISO_8601, true).isValid()
           ? gnHumanizeTimeService(tokens[1], format, useFromNowSetting !== undefined)
               .title +
               " > " +
               gnHumanizeTimeService(tokens[2], format, useFromNowSetting !== undefined)
                 .title
-          : range;
+          : rangeValue;
       };
     }
   ]);
@@ -249,7 +251,7 @@
             if (
               filter.value &&
               filter.value.match &&
-              filter.value.match(/\+\w+:[\[{].* TO .*[\]}]/)
+              filter.value.match(/\+?\w+:[\[{].* TO .*[\]}]/)
             ) {
               return "RANGE";
             } else if (filter.key === "geometry") {

--- a/web-ui/src/main/resources/catalog/components/search/searchfiltertag/partials/searchFilterTagsTemplate.html
+++ b/web-ui/src/main/resources/catalog/components/search/searchfiltertag/partials/searchFilterTagsTemplate.html
@@ -27,7 +27,7 @@
       <div class="flex-spacer"></div>
       <span ng-if="::specific"> {{::filter.value | characters:180}} </span>
       <span ng-if="::type === 'RANGE'">
-        {{::filter.value | renderRangeExpression:key}}
+        {{::filter.value | renderRangeExpression:filter.key}}
       </span>
       <span
         ng-if="::filter.label"

--- a/web-ui/src/main/resources/catalog/components/search/searchfiltertag/partials/searchFilterTagsTemplate.html
+++ b/web-ui/src/main/resources/catalog/components/search/searchfiltertag/partials/searchFilterTagsTemplate.html
@@ -27,7 +27,7 @@
       <div class="flex-spacer"></div>
       <span ng-if="::specific"> {{::filter.value | characters:180}} </span>
       <span ng-if="::type === 'RANGE'">
-        {{::filter.value.replace('+' + filter.key + ':', '') | renderRangeExpression}}
+        {{::filter.value | renderRangeExpression:key}}
       </span>
       <span
         ng-if="::filter.label"
@@ -38,10 +38,16 @@
       <span
         ng-if="::!specific && filter.label === undefined && type === undefined"
         ng-repeat="(key, value) in filter.value track by $index"
+        ng-init="type = getFilterType({value: value})"
         ng-class="{'gn-filter-negative': isNegative(value)}"
-        translate
-        >{{::key | facetTranslator: filter.key | capitalize}}</span
       >
+        <span ng-if="::type === 'RANGE'">
+          {{::value | renderRangeExpression:filter.key}}
+        </span>
+        <span ng-if="::type !== 'RANGE'">
+          {{::key | facetTranslator: filter.key | capitalize}}
+        </span>
+      </span>
       <!-- TODO: Nested aggs support -->
       <div class="flex-grow"></div>
       <span class="fa fa-times text-danger delete-icon pull-right"></span>

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -334,13 +334,6 @@
                 terms: {
                   field: "resourceType"
                 },
-                aggs: {
-                  format: {
-                    terms: {
-                      field: "format"
-                    }
-                  }
-                },
                 meta: {
                   decorator: {
                     type: "icon",
@@ -361,6 +354,14 @@
                 terms: {
                   field: "cl_spatialRepresentationType.key",
                   size: 10
+                }
+              },
+              format: {
+                terms: {
+                  field: "format"
+                },
+                meta: {
+                  collapsed: true
                 }
               },
               availableInServices: {

--- a/web-ui/src/main/resources/catalog/templates/admin/admin.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/admin.html
@@ -70,31 +70,11 @@
     <div data-gn-index-error-panel=""></div>
 
     <div class="row gn-row-admin-stats">
-      <div
-        class="col-lg-2 col-md-4 col-sm-4"
-        data-ng-repeat="type in searchInfo.facet.types"
-        data-ng-hide="searchInfo.facet.types.length === 0"
-      >
-        <div class="panel panel-default panel-primary1">
-          <div class="panel-heading">
-            <h5>{{(type['@label'] || type['@name']) | translate}}</h5>
-          </div>
-          <div class="panel-body">
-            <h2>{{type['@count']}}</h2>
-          </div>
-        </div>
-      </div>
-      <div class="col-md-4 col-sm-8" data-ng-hide="searchInfo.count == 0">
-        <div class="panel panel-default panel-success">
-          <div class="panel-heading">
-            <h5 data-translate="" title="{{'totalNumberOfRecordsHelp' | translate}}">
-              totalNumberOfRecords
-            </h5>
-          </div>
-          <div class="panel-body">
-            <h2>{{searchInfo.hits.total.value}}</h2>
-          </div>
-        </div>
+      <div class="well col-md-6" data-ng-hide="searchInfo.count == 0">
+        <h2 title="{{'totalNumberOfRecordsHelp' | translate}}">
+          {{searchInfo.hits.total.value}}
+          <span data-translate="">totalNumberOfRecords</span>
+        </h2>
       </div>
 
       <div

--- a/web-ui/src/main/resources/catalog/views/default/module.js
+++ b/web-ui/src/main/resources/catalog/views/default/module.js
@@ -74,6 +74,7 @@
         permalink: false,
         internal: true,
         filters: gnSearchSettings.filters,
+        configId: "home",
         params: {
           isTemplate: "n",
           sortBy: "popularity",
@@ -92,6 +93,7 @@
         permalink: false,
         internal: true,
         filters: gnSearchSettings.filters,
+        configId: "home",
         params: {
           isTemplate: "n",
           sortBy: "createDate",
@@ -120,6 +122,7 @@
             }
           }
         ],
+        configId: "home",
         params: {
           isTemplate: "n",
           sortBy: "changeDate",


### PR DESCRIPTION
- [x] Display decorator for the aggregation used as tab

![image](https://user-images.githubusercontent.com/1701393/210842874-d2925dd3-22d9-4d04-a024-13394fc62226.png)


- [x] No need to compute aggs for home page latest/most popular. This reduce response size (and time) eg. on a 2K records catalog

![image](https://user-images.githubusercontent.com/1701393/210515494-6b9cc495-6d2d-4e10-9fbd-b490998f8e73.png)

- [x] Update label based on inverted status (and not only the icon)

![image](https://user-images.githubusercontent.com/1701393/210578254-d2b0b70a-5844-42d7-bc6e-8ab3af5dfa7d.png)
![image](https://user-images.githubusercontent.com/1701393/210578335-3bd0c9a0-0b59-49b3-869d-b0a34795e222.png)


- [x] Move format to a dedicated facet. Nested facet does not provide option to see more values and filter - so only top 10 formats were displayed. Formats for series does not make much sense. For service, service type would be better so a field combining the 2 would be needed. 

![image](https://user-images.githubusercontent.com/1701393/210724275-af69adbf-d33b-4f03-abec-5948888ba26a.png)

- [x] Display range in list of filters (and not only the lower value of the range).

![image](https://user-images.githubusercontent.com/1701393/210971379-10c3f354-1c69-4cb1-bf47-89330961bcb7.png)



## Future work

Some inconsistencies which may require some more work:

* Histogram aggregation can also produce unexpected results. When clicking on a range, the histogram is computed for that range and the records on the set may be smaller or different depending on the interval. Maybe we should not reload histogram facet like for term agg ?

![image](https://user-images.githubusercontent.com/1701393/210600638-b821ca29-205f-4804-b27e-b4a27820e7e7.png)
 