### PR TITLE
create resource folder if missing during metadata loading.

### DIFF
--- a/core/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
@@ -501,21 +501,19 @@ public class CMISStore extends AbstractStore {
 
         final String key = getMetadataDir(context, metadataId);
 
-        try {
-            String folderRoot = cmisConfiguration.getExternalResourceManagementFolderRoot();
-            if (folderRoot == null) {
-                folderRoot = "";
-            }
-            Folder parentFolder = cmisUtils.getFolderCache(key + folderRoot, false, true);
-            MetadataResourceExternalManagementProperties metadataResourceExternalManagementProperties =
-                getMetadataResourceExternalManagementProperties(context, metadataId, metadataUuid, null, String.valueOf(metadataId), null, null, parentFolder.getId(), parentFolder.getType(), MetadataResourceExternalManagementProperties.ValidationStatus.UNKNOWN);
 
-            return new FilesystemStoreResourceContainer(metadataUuid, metadataId, metadataUuid,
-                settingManager.getNodeURL() + "api/records/", metadataResourceExternalManagementProperties, approved);
-
-        } catch (CmisObjectNotFoundException e) {
-            return null;
+        String folderRoot = cmisConfiguration.getExternalResourceManagementFolderRoot();
+        if (folderRoot == null) {
+            folderRoot = "";
         }
+        Folder parentFolder = cmisUtils.getFolderCache(key + folderRoot, false, true);
+        MetadataResourceExternalManagementProperties metadataResourceExternalManagementProperties =
+            getMetadataResourceExternalManagementProperties(context, metadataId, metadataUuid, null, String.valueOf(metadataId), null, null, parentFolder.getId(), parentFolder.getType(), MetadataResourceExternalManagementProperties.ValidationStatus.UNKNOWN);
+
+        return new FilesystemStoreResourceContainer(metadataUuid, metadataId, metadataUuid,
+            settingManager.getNodeURL() + "api/records/", metadataResourceExternalManagementProperties, approved);
+
+
     }
 
     @Override

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
@@ -506,7 +506,7 @@ public class CMISStore extends AbstractStore {
             if (folderRoot == null) {
                 folderRoot = "";
             }
-            Folder parentFolder = cmisUtils.getFolderCache(key + folderRoot);
+            Folder parentFolder = cmisUtils.getFolderCache(key + folderRoot, false, true);
             MetadataResourceExternalManagementProperties metadataResourceExternalManagementProperties =
                 getMetadataResourceExternalManagementProperties(context, metadataId, metadataUuid, null, String.valueOf(metadataId), null, null, parentFolder.getId(), parentFolder.getType(), MetadataResourceExternalManagementProperties.ValidationStatus.UNKNOWN);
 


### PR DESCRIPTION
When create a metadata in cmis mode, for error like this:

![image](https://user-images.githubusercontent.com/74916635/211404861-e458a7c2-45ac-4c16-91c9-1a2b278a4570.png)


The issue is backend cmis resource were not created.