### PR TITLE
Fix retrieve of  metadata bbox to display in the search map when the metadata doesn't have a bounding box

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -584,7 +584,9 @@
                   featureProjection: proj,
                   dataProjection: "EPSG:4326"
                 });
-                geoms.push(geom);
+                if (geom) {
+                  geoms.push(geom);
+                }
               });
               var geometryCollection = new ol.geom.GeometryCollection(geoms);
               feat.setGeometry(geometryCollection);


### PR DESCRIPTION
Test case:

1) Load the `iso19139` sample metadata
2) In the search page, do an empty search. In the Javascript console appears the following error and not all the metadata results bounding boxes are rendered in the search map:

```
lib.js?v=577a655b8e2174e205ebbb6e236357f799970a5c:133 TypeError: Cannot read properties of null (reading 'addEventListener')
    at q (lib.js?v=577a655b8e2174e205ebbb6e236357f799970a5c:669:25851)
    at e.listenGeometriesChange_ (lib.js?v=577a655b8e2174e205ebbb6e236357f799970a5c:669:474835)
    at new e (lib.js?v=577a655b8e2174e205ebbb6e236357f799970a5c:669:474535)
    at Object.getBboxFeatureFromMd (gn_search_default.js?v=577a655b8e2174e205ebbb6e236357f799970a5c&:604:44)
    at gn_search_default.js?v=577a655b8e2174e205ebbb6e236357f799970a5c&:1258:262
    at lib.js?v=577a655b8e2174e205ebbb6e236357f799970a5c:157:302
    at m.$digest (lib.js?v=577a655b8e2174e205ebbb6e236357f799970a5c:158:410)
    at m.$apply (lib.js?v=577a655b8e2174e205ebbb6e236357f799970a5c:161:363)
    at l (lib.js?v=577a655b8e2174e205ebbb6e236357f799970a5c:113:194)
    at K (lib.js?v=577a655b8e2174e205ebbb6e236357f799970a5c:117:376)
```

3) Same result  when hovering over the metadata `Geoscience Australia's Open Day Photographs 26th August 2007`
