### PR TITLE
Fix keyword badges filters with multilingual metadata

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/mdview/partials/keywordBadges.html
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/partials/keywordBadges.html
@@ -26,7 +26,7 @@
         </a>
         <br data-ng-if="::!!k.link" />
 
-        <div data-gn-search-filter-link="tag.default" data-filter="k.default">
+        <div data-gn-search-filter-link="tag.\\*" data-filter="k.default">
           {{k.default}}
         </div>
       </div>


### PR DESCRIPTION
Test case:

1) Create a multilingual iso19139 metadata with the main language as English and add a free-text keyword, filling the English and French entries with different values.
2) With the English UI, in the metadata detail page, filter by the keyword value --> Search results display the metadata (ok)

![filter-keyword](https://user-images.githubusercontent.com/1695003/212096714-8c34f48c-3e8b-4757-a9d2-2de4cb76730b.png)

3) With the French UI, in the metadata detail page, filter by the keyword value --> Search results doesn't display the metadata (no ok)
