### PR TITLE
Indexing / Build overview data also when commiting one document

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/search/EsSearchManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/EsSearchManager.java
@@ -421,6 +421,7 @@ public class EsSearchManager implements ISearchManager {
             document.put(id, jsonDocument);
             final BulkResponse bulkItemResponses = client.bulkRequest(defaultIndex, document);
             checkIndexResponse(bulkItemResponses, document);
+            overviewFieldUpdater.process(id);
         } else {
             listOfDocumentsToIndex.put(id, jsonDocument);
             if (listOfDocumentsToIndex.size() == commitInterval) {


### PR DESCRIPTION
Was done only when a batch of records was indexed.

To test: 
* import a document with overview, 
* check the doc in the index http://localhost:9200/gn-records/_doc/6244937d-1c2c-47f5-bdf1-33ca01ff1715 (it use to have only overview url and not the base64 encoded small image)

![image](https://user-images.githubusercontent.com/1701393/212099356-4f348b6c-4802-468e-ad65-9aa4b4f1e7ef.png)
