### PR TITLE
Aggregation / Add a refresh policy options.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/elasticsearch/EsClient.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/EsClient.js
@@ -39,11 +39,22 @@
         return ES_API_URL + service;
       };
 
-      this.search = function (params, selectionBucket, configId, types) {
+      this.search = function (
+        params,
+        selectionBucket,
+        configId,
+        types,
+        initialAggregationsValues
+      ) {
         return callApi("_search", params, selectionBucket, types).then(function (
           response
         ) {
-          return gnESFacet.getUIModel(response, params, configId);
+          return gnESFacet.getUIModel(
+            response,
+            params,
+            configId,
+            initialAggregationsValues
+          );
         });
       };
 
@@ -115,7 +126,7 @@
           facetConfig
         );
         return callApi("_search", params).then(function (response) {
-          var model = gnESFacet.getUIModel(response, params);
+          var model = gnESFacet.getUIModel(response, params, null);
           return model.facets[0];
         });
       };

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/FacetDirective.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/FacetDirective.js
@@ -52,22 +52,6 @@
             ? this.fLvlCollapse[this.list[i].key]
             : this.list[i].collapsed === true;
         }
-
-        var lastFacet = this.lastUpdatedFacet;
-
-        if (
-          this._isNotNestedFacet(lastFacet) &&
-          this.searchCtrl.hasFiltersForKey(lastFacet.path[0])
-        ) {
-          this.list.forEach(
-            function (f) {
-              if (f.key === lastFacet.key) {
-                f.items = lastFacet.items;
-              }
-            }.bind(this)
-          );
-          this.lastUpdatedFacet = null;
-        }
       }.bind(this)
     );
   };
@@ -285,16 +269,11 @@
     var value = !item.inverted;
     if (facet.type === "terms") {
       facet.include = "";
-      if (!item.isNested) {
-        this.facetsCtrl.lastUpdatedFacet = facet;
-      }
     } else if (facet.type === "filters" || facet.type === "histogram") {
       value = item.query_string.query_string.query;
       if (item.inverted) {
         value = "-(" + value + ")";
       }
-    } else if (facet.type === "tree") {
-      this.facetsCtrl.lastUpdatedFacet = facet;
     }
 
     this.searchCtrl.updateState(item.path, value);

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facet.html
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facet.html
@@ -35,8 +35,8 @@
         || ctrl.facet.key | capitalize}}
       </span>
       <span
-        ng-if="ctrl.item.count"
-        class="gn-facet-count flex-no-shrink gn-facet-count-{{ctrl.item.count}}"
+        ng-if="::ctrl.item.count"
+        class="gn-facet-count flex-no-shrink gn-facet-count-{{::ctrl.item.count}}"
         >{{::ctrl.item.count}}</span
       >
     </a>

--- a/web-ui/src/main/resources/catalog/components/search/searchmanager/LocationService.js
+++ b/web-ui/src/main/resources/catalog/components/search/searchmanager/LocationService.js
@@ -42,6 +42,7 @@
       gnExternalViewer
     ) {
       this.SEARCH = "/search";
+      this.EDITORBOARD = "/board";
       this.SEARCHPAGES = /\/search|\/board/;
       this.MAP = "/map";
       this.METADATA = "/metadata/";
@@ -74,6 +75,10 @@
 
       this.isMap = function () {
         return $location.path() == this.MAP;
+      };
+
+      this.isEditorBoard = function () {
+        return $location.path() == this.EDITORBOARD;
       };
 
       this.isHome = function () {

--- a/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchFormDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchFormDirective.js
@@ -184,6 +184,8 @@
       // Compute facet only if search is reset or new filters apply
       // When moving in pages or changing sort,
       // no need to compute aggregations again and again
+      // TODO: Some actions should invalidate search key.
+      //  eg. deletion, changing sharing
       var searchKey = buildSearchKey(esParams),
         dontComputeAggs = $scope.searchResults.searchKey === searchKey,
         lastSearchAggs = undefined;
@@ -208,7 +210,8 @@
           esParams,
           $scope.searchResults.selectionBucket || "metadata",
           $scope.searchObj.configId,
-          types
+          types,
+          $scope.searchInfo.aggregations
         )
         .then(
           function (data) {
@@ -235,6 +238,7 @@
             var records = data.hits.hits.map(function (r) {
               return new Metadata(r);
             });
+
             $scope.searchResults.records = records;
             $scope.searchResults.count = data.hits.total.value;
             $scope.searchResults.facets = dontComputeAggs

--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -1964,6 +1964,7 @@
       };
     }
   ]);
+
   module.filter("signInLink", [
     "$location",
     "gnLangs",
@@ -1980,6 +1981,7 @@
       };
     }
   ]);
+
   module.filter("getMailDomain", [
     function () {
       return function (mail) {
@@ -1987,6 +1989,7 @@
       };
     }
   ]);
+
   /**
    * Append size parameter to request a smaller thumbnail.
    */

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -335,6 +335,7 @@
                   field: "resourceType"
                 },
                 meta: {
+                  refreshAction: "displayAll",
                   decorator: {
                     type: "icon",
                     prefix: "fa fa-fw gn-icon-"
@@ -354,6 +355,9 @@
                 terms: {
                   field: "cl_spatialRepresentationType.key",
                   size: 10
+                },
+                meta: {
+                  refreshAction: "displayAll"
                 }
               },
               format: {
@@ -366,7 +370,7 @@
               },
               availableInServices: {
                 filters: {
-                  //"other_bucket_key": "others",
+                  // "other_bucket_key": "others",
                   // But does not support to click on it
                   filters: {
                     availableInViewService: {
@@ -460,6 +464,7 @@
                   size: 10
                 },
                 meta: {
+                  refreshAction: 'displayAll',
                   caseInsensitiveInclude: true
                 }
               },
@@ -532,6 +537,7 @@
                   size: 15
                 },
                 meta: {
+                  refreshAction: "displayAll",
                   // Always display filter even no more elements
                   // This can be used when all facet values are loaded
                   // with a large size and you want to provide filtering.
@@ -1506,6 +1512,7 @@
     "$cookies",
     "gnExternalViewer",
     "gnAlertService",
+    "gnSearchLocation",
     function (
       $scope,
       $http,
@@ -1525,7 +1532,8 @@
       gnSearchSettings,
       $cookies,
       gnExternalViewer,
-      gnAlertService
+      gnAlertService,
+      gnSearchLocation
     ) {
       $scope.version = "0.0.1";
       var defaultNode = "srv";
@@ -1911,12 +1919,21 @@
               if (gnGlobalSettings.gnCfg.mods.search.filters) {
                 query.bool.filter = gnGlobalSettings.gnCfg.mods.search.filters;
               }
+
+              var homeAndSearchAggs = angular.merge(
+                {},
+                gnGlobalSettings.gnCfg.mods[
+                  gnSearchLocation.isEditorBoard() ? "editor" : "search"
+                ].facetConfig,
+                gnGlobalSettings.gnCfg.mods.home.facetConfig
+              );
+
               return $http
                 .post("../api/search/records/_search", {
                   size: 0,
                   track_total_hits: true,
                   query: query,
-                  aggs: gnGlobalSettings.gnCfg.mods.home.facetConfig
+                  aggs: homeAndSearchAggs
                 })
                 .then(function (r) {
                   $scope.searchInfo = r.data;

--- a/web-ui/src/main/resources/catalog/style/gn_search.less
+++ b/web-ui/src/main/resources/catalog/style/gn_search.less
@@ -105,9 +105,6 @@
       &:after {
         content: ")";
       }
-      &.gn-facet-count-0 {
-        display: none;
-      }
     }
   }
   .gn-facet-header {

--- a/web-ui/src/main/resources/catalog/templates/editor/editorboard.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/editorboard.html
@@ -3,6 +3,7 @@
     <div data-ng-class="fluidEditorLayout ? 'container-fluid' : 'container'">
       <div
         class="col-sm-12"
+        data-ng-if="searchInfo.aggregations"
         data-ng-search-form=""
         data-runSearch="true"
         data-wait-for-user="true"

--- a/web-ui/src/main/resources/catalog/views/default/templates/results.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/results.html
@@ -1,4 +1,4 @@
-<div data-ng-search-form="" data-runSearch="true">
+<div data-ng-if="searchInfo.aggregations" data-ng-search-form="" data-runSearch="true">
   <div
     data-ng-if="!showHealthIndexError && searchOptions.fullText !== false"
     class="hidden-print"


### PR DESCRIPTION
Current general mechanism was to not refresh the last selected facets with some exception for nested facet and tree. But when selecting facet A, then B, then A again - both A and B have been refreshed and some users are not really convinced by that approach.

Current approach also has an issue when reloading the page with a facet selected, users would like for some important facet to display all values and not only the selected one. eg. select resource type = dataset, reload the page, only dataset is visible.

This is an experiment to turn off the last facet is not refreshed rule and adds a refresh policy property so that user can defined on a per facet basis the way it behaves. For now, all facets refresh others but if refreshPolicy is set to displayAll, the initial values are displayed (with no count). So user can continue selecting values in those facets and do an OR query on all selected values.

![image](https://user-images.githubusercontent.com/1701393/212252073-589dec36-7cff-4cd5-9d57-30967c9ecef6.png)

Other related feedback on facet is the filter aggregation type which always display bucket with 0 doc. Something to improve ?

![image](https://user-images.githubusercontent.com/1701393/212252413-f8abe234-34c0-4f8a-9d1b-03481ca9d962.png)


@MichelGabriel maybe you have ideas/feedbacks on this area too? Comments are welcomed.
