### PR TITLE
CORS Filter improvements

### DIFF
--- a/core/src/main/java/org/fao/geonet/web/CORSResponseFilter.java
+++ b/core/src/main/java/org/fao/geonet/web/CORSResponseFilter.java
@@ -22,6 +22,7 @@
  */
 package org.fao.geonet.web;
 
+import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.kernel.setting.SettingManager;
@@ -65,7 +66,7 @@ public class CORSResponseFilter
 
     public void init(FilterConfig config) {
         String allowedHosts = config.getInitParameter(ALLOWED_HOSTS);
-        if (allowedHosts != null) {
+        if (StringUtils.isNotEmpty(allowedHosts)) {
             if (allowedHosts.equals("db")) {
                 isUsingDb = true;
             } else if (allowedHosts.equals("*")) {
@@ -92,7 +93,10 @@ public class CORSResponseFilter
 
         if (isUsingDb) {
             String allowedHosts = settingManager.getValue(SYSTEM_CORS_ALLOWEDHOSTS);
-            if (allowedHosts != null) {
+            if (StringUtils.isEmpty(allowedHosts)) {
+                addHeaderForAllHosts = false;
+                allowedRemoteHosts = new ArrayList<>();
+            } else {
                 if (allowedHosts.equals("*")) {
                     addHeaderForAllHosts = true;
                 } else if (!allowedHosts.equals("")) {
@@ -102,7 +106,7 @@ public class CORSResponseFilter
             }
         }
 
-        if (addHeaderForAllHosts || allowedRemoteHosts.size() > 0) {
+        if (addHeaderForAllHosts || !allowedRemoteHosts.isEmpty()) {
             String clientOriginUrl = httpRequest.getHeader("origin");
             if (clientOriginUrl != null) {
                 try {

--- a/web/src/main/webResources/WEB-INF/web.xml
+++ b/web/src/main/webResources/WEB-INF/web.xml
@@ -94,6 +94,20 @@
     <url-pattern>/srv/*</url-pattern>
   </filter-mapping>
 
+  <!-- Add CORS Header -->
+  <filter>
+    <filter-name>cors</filter-name>
+    <filter-class>org.fao.geonet.web.CORSResponseFilter</filter-class>
+    <init-param>
+      <param-name>allowedHosts</param-name>
+      <param-value>${cors.allowedHosts}</param-value>
+    </init-param>
+  </filter>
+  <filter-mapping>
+    <filter-name>cors</filter-name>
+    <url-pattern>/*</url-pattern>
+  </filter-mapping>
+  
   <!-- url rewrite filter -->
   <filter>
     <filter-name>UrlRewriteFilter</filter-name>
@@ -169,15 +183,7 @@
     <filter-name>resources</filter-name>
     <filter-class>org.fao.geonet.resources.ResourceFilter</filter-class>
   </filter>
-  <!-- Add CORS Header -->
-  <filter>
-    <filter-name>cors</filter-name>
-    <filter-class>org.fao.geonet.web.CORSResponseFilter</filter-class>
-    <init-param>
-      <param-name>allowedHosts</param-name>
-      <param-value>${cors.allowedHosts}</param-value>
-    </init-param>
-  </filter>
+  
   <filter>
     <!--
         WebResourceOptimizer is a WRO4J Filter (https://code.google.com/p/wro4j/wiki/Introduction)
@@ -220,11 +226,6 @@
 
   <filter-mapping>
     <filter-name>webappMetricsFilter</filter-name>
-    <url-pattern>/*</url-pattern>
-  </filter-mapping>
-
-  <filter-mapping>
-    <filter-name>cors</filter-name>
     <url-pattern>/*</url-pattern>
   </filter-mapping>
 


### PR DESCRIPTION
* CORS Filter / Unset list of host when db settings is empty
 
When saving from the admin > settings, the value of the settings is set to "" and not null. Reset CORS config when list of hosts is cleared on db mode.

* CORS / Set headers before rewriting URL

We may have to rewrite old URL forwarding to new URLs and in such case we need to set CORS header first before the rewrite is made.

If not, website on another domain may get a CORS error due to unset header on rewritten resources.