### PR TITLE
Harvester / URL / Add RDF DCAT harvester.

### DIFF
--- a/common/src/main/java/org/fao/geonet/utils/Xml.java
+++ b/common/src/main/java/org/fao/geonet/utils/Xml.java
@@ -135,6 +135,7 @@ public final class Xml {
         + "\uE000-\uFFFD"
         + "\ud800\udc00-\udbff\udfff"
         + "]";
+    public static final String XML_VERSION_HEADER = "<\\?xml version='1.0' encoding='.*'\\?>\\s*";
 
     public static SAXBuilder getSAXBuilder(boolean validate) {
         SAXBuilder builder = getSAXBuilderWithPathXMLResolver(validate, null);
@@ -1128,6 +1129,8 @@ public final class Xml {
         Pattern pattern;
         Matcher matcher;
 
+        inXMLStr = inXMLStr.replaceFirst(XML_VERSION_HEADER, "");
+
         // Regular expression to see if it starts and ends with the same element or
         // it's a self-closing element.
         final String XML_PATTERN_STR = "<(\\S+?)(.*?)>(.*?)</\\1>|<(\\S+?)(.*?)/>";
@@ -1145,6 +1148,23 @@ public final class Xml {
 
         return retBool;
     }
+
+    /**
+     * Check if is XML and the first tag local name
+     * is rdf or something like a DCAT feed.
+     */
+    public static boolean isRDFLike(String inXMLStr) {
+        boolean retBool = false;
+        if (isXMLLike(inXMLStr)) {
+            String xml = inXMLStr.replaceFirst(XML_VERSION_HEADER, ""),
+            firstTag = xml
+                .substring(0, xml.indexOf(" "))
+                .toLowerCase();
+            retBool = firstTag.matches("<.*:(rdf|catalog|catalogrecord)");
+        }
+        return retBool;
+    }
+
 
     private static class JeevesURIResolver implements URIResolver {
 

--- a/common/src/main/java/org/fao/geonet/utils/Xml.java
+++ b/common/src/main/java/org/fao/geonet/utils/Xml.java
@@ -135,7 +135,7 @@ public final class Xml {
         + "\uE000-\uFFFD"
         + "\ud800\udc00-\udbff\udfff"
         + "]";
-    public static final String XML_VERSION_HEADER = "<\\?xml version='1.0' encoding='.*'\\?>\\s*";
+    public static final String XML_VERSION_HEADER = "<\\?xml version=['\"]1.0['\"] encoding=['\"].*['\"]\\?>\\s*";
 
     public static SAXBuilder getSAXBuilder(boolean validate) {
         SAXBuilder builder = getSAXBuilderWithPathXMLResolver(validate, null);

--- a/common/src/main/java/org/fao/geonet/utils/Xml.java
+++ b/common/src/main/java/org/fao/geonet/utils/Xml.java
@@ -1119,6 +1119,10 @@ public final class Xml {
 
     /**
      * return true if the String passed in is something like XML
+     * Check for XML header first.
+     * Then use a Regular expression to see if it starts and ends with
+     * the same element or it's a self-closing element.
+     * Regex can be slow on large document.
      *
      * @param inXMLStr a string that might be XML
      * @return true of the string is XML, false otherwise
@@ -1129,6 +1133,9 @@ public final class Xml {
         Pattern pattern;
         Matcher matcher;
 
+        if (inXMLStr.startsWith("<?xml")) {
+            return true;
+        }
         inXMLStr = inXMLStr.replaceFirst(XML_VERSION_HEADER, "");
 
         // Regular expression to see if it starts and ends with the same element or

--- a/common/src/test/java/org/fao/geonet/utils/XmlTest.java
+++ b/common/src/test/java/org/fao/geonet/utils/XmlTest.java
@@ -192,5 +192,16 @@ public class XmlTest {
         assertSame(attribute, actual.get(0));
     }
 
-
+    @Test
+    public void testIsXmlLike() {
+        assertEquals(true,
+            Xml.isXMLLike("<selfclosingtag attribute=\"\"/>"));
+        assertEquals(true,
+            Xml.isXMLLike("<tag attribute=\"\"></tag>"));
+        assertEquals(true,
+            Xml.isXMLLike("<?xml version='1.0' encoding='utf-8'?>\n<tag attribute=\"\"></tag>"));
+        assertEquals(true,
+            Xml.isRDFLike("<?xml version='1.0' encoding='utf-8'?>\n<rdf:RDF \n" +
+                "    xmlns:rdf=\"http://www.w3.org/1999/02/22-rdf-syntax-ns#\"/>"));
+    }
 }

--- a/core/src/main/java/org/fao/geonet/util/XslUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/XslUtil.java
@@ -761,6 +761,22 @@ public final class XslUtil {
         return ret;
     }
 
+    public static String geoJsonGeomToBbox(Object WKT) throws Exception {
+        String ret = "";
+        try {
+            Geometry geometry = new GeometryJSON().read(WKT);
+            if (geometry != null) {
+                final Envelope envelope = geometry.getEnvelopeInternal();
+                return
+                    String.format("%f|%f|%f|%f",
+                        envelope.getMinX(), envelope.getMinY(),
+                        envelope.getMaxX(), envelope.getMaxY());
+            }
+        } catch (Throwable e) {
+        }
+        return ret;
+    }
+
     /**
      * Get field value for metadata identified by uuid.
      *

--- a/harvesters/pom.xml
+++ b/harvesters/pom.xml
@@ -50,6 +50,11 @@
       <artifactId>sardine</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.jena</groupId>
+      <artifactId>apache-jena-libs</artifactId>
+      <type>pom</type>
+    </dependency>
+    <dependency>
       <groupId>org.jsoup</groupId>
       <artifactId>jsoup</artifactId>
     </dependency>

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/simpleurl/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/simpleurl/Aligner.java
@@ -21,7 +21,7 @@
 //===	Rome - Italy. email: geonetwork@osgeo.org
 //==============================================================================
 
-package org.fao.geonet.kernel.harvest.harvester.simpleUrl;
+package org.fao.geonet.kernel.harvest.harvester.simpleurl;
 
 import jeeves.server.context.ServiceContext;
 import org.fao.geonet.GeonetContext;

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/simpleurl/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/simpleurl/Aligner.java
@@ -56,6 +56,8 @@ import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.fao.geonet.kernel.harvest.harvester.csw.Aligner.applyBatchEdits;
+
 public class Aligner extends BaseAligner<SimpleUrlParams> {
 
     private ServiceContext context;
@@ -215,6 +217,7 @@ public class Aligner extends BaseAligner<SimpleUrlParams> {
             xml = dataMan.setUUID(schema, uuid, record.getValue());
         }
 
+        applyBatchEdits(uuid, xml, schema, params.getBatchEdits(), context, null);
 
         log.debug("  - Adding metadata with uuid:" + uuid + " schema:" + schema);
 
@@ -265,6 +268,8 @@ public class Aligner extends BaseAligner<SimpleUrlParams> {
         String language = context.getLanguage();
         String schema = dataMan.autodetectSchema(md, null);
         final String dateModified = dataMan.extractDateModified(schema, ri.getValue());
+
+        applyBatchEdits(ri.getKey(), md, schema, params.getBatchEdits(), context, null);
 
         final AbstractMetadata metadata = metadataManager.updateMetadata(context, id, md, validate, ufo,
             language, dateModified, true, IndexingMode.none);

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/simpleurl/RDFUtils.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/simpleurl/RDFUtils.java
@@ -1,0 +1,228 @@
+package org.fao.geonet.kernel.harvest.harvester.simpleurl;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.jena.query.*;
+import org.apache.jena.rdf.model.Model;
+import org.apache.jena.rdf.model.ModelFactory;
+import org.apache.jena.riot.Lang;
+import org.apache.jena.riot.RDFDataMgr;
+import org.fao.geonet.Constants;
+import org.fao.geonet.domain.ISODate;
+import org.fao.geonet.domain.Pair;
+import org.fao.geonet.utils.Log;
+import org.fao.geonet.utils.Xml;
+import org.jdom.Element;
+import org.jdom.JDOMException;
+
+import java.io.*;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * RDF utilities to query and process DCAT feeds.
+ */
+public class RDFUtils {
+    public static final String RESOURCE_FOLDER = "harvester-resources/simpleUrl/";
+
+    public static final String LOGGER_NAME = "geonetwork.harvester.simpleurl";
+
+    /**
+     * Retrieve all UUIDs from the RDF feed using a SPARQL query
+     *
+     * @return a map of UUID and the corresponding DCAT record.
+     */
+    public static HashMap<String, Element> getAllUuids(String feedUrl) throws Exception {
+        // Create an empty in-memory model and populate it from the graph
+        Model model = ModelFactory.createMemModelMaker().createDefaultModel();
+        RDFDataMgr.read(model, feedUrl);
+
+        Element rdfModel = Xml.loadStream(IOUtils.toInputStream(toRdfString(model), StandardCharsets.UTF_8.displayName()));
+
+        return getAllUuids(rdfModel);
+    }
+
+    /**
+     * Retrieve all UUIDs from the RDF feed using a SPARQL query.
+     * <p>
+     * The SPARQL results structure is:
+     * <pre>
+     * <sparql xmlns="http://www.w3.org/2005/sparql-results#">
+     *   <head>
+     *     <variable xmlns="" name="subject"/>
+     *     <variable xmlns="" name="predicate"/>
+     *     <variable xmlns="" name="object"/>
+     *     <variable xmlns="" name="pAsQName"/>
+     *   </head>
+     *   <results>
+     *     <result>
+     *       <binding xmlns="" name="subject">
+     *         <uri xmlns="http://www.w3.org/2005/sparql-results#">https://apps.titellus.net/geonetwork/api/collections/main/items/8698bf0b-fceb-4f0f-989b-111e7c4af0a4</uri>
+     *       </binding>
+     *       <binding xmlns="" name="predicate">
+     *         <uri xmlns="http://www.w3.org/2005/sparql-results#">http://www.w3.org/1999/02/22-rdf-syntax-ns#type</uri>
+     *       </binding>
+     *       <binding xmlns="" name="object">
+     *         <uri xmlns="http://www.w3.org/2005/sparql-results#">http://www.w3.org/ns/dcat#CatalogRecord</uri>
+     *       </binding>
+     *       <binding xmlns="" name="pAsQName">
+     *         <literal xmlns="http://www.w3.org/2005/sparql-results#">rdf:type</literal>
+     *       </binding>
+     *     </result>
+     *     ...
+     * </pre>
+     * and can be processed using XSLT to build a metadata supported by the catalogue.
+     *
+     * @return a map of UUID and the corresponding DCAT record.
+     */
+    public static HashMap<String, Element> getAllUuids(Element feed) throws Exception {
+        Element rdfDocument = checkForMissingRdfAbout(feed);
+
+        Model model = ModelFactory.createMemModelMaker().createDefaultModel();
+        RDFDataMgr.read(model,
+            IOUtils.toInputStream(Xml.getString(rdfDocument), StandardCharsets.UTF_8),
+            Lang.RDFXML);
+
+        model = checkAndCreateMissingCatalogRecords(model);
+
+        Query queryRecordIds = QueryFactory.create(getQueryString("extract-records-ids.rq"));
+        QueryExecution qe = QueryExecutionFactory.create(queryRecordIds, model);
+        ResultSet resultIds = qe.execSelect();
+
+        HashMap<String, Element> records = new HashMap<>();
+        while (resultIds.hasNext()) {
+            Pair<String, Element> recordInfo = getRecordInfo(resultIds.nextSolution(), model);
+            if (recordInfo != null) {
+                records.put(recordInfo.one(), recordInfo.two());
+            }
+        }
+
+        qe.close();
+        model.close();
+        return records;
+    }
+
+
+    private static Element checkForMissingRdfAbout(Element rdfModel) throws Exception {
+        List ns = rdfModel.getAdditionalNamespaces();
+        List<Element> nodeWithNoRdfAbout =
+            Xml.selectNodes(rdfModel,
+                ".//*[local-name() = 'Dataset' or local-name() = 'DataService'][not(@rdf:about)]", ns
+            );
+        nodeWithNoRdfAbout.forEach(n -> {
+            try {
+                Object httpIdentifier = Xml.selectSingle(n, "dct:identifier[matches(., '^http(s)://.*$')]/text()", ns);
+                if (httpIdentifier != null) {
+                    n.setAttribute("rdf:about", (String) httpIdentifier);
+                }
+            } catch (JDOMException e) {
+            }
+        });
+        return rdfModel;
+    }
+
+    private static Model checkAndCreateMissingCatalogRecords(Model model) throws IOException, URISyntaxException {
+        Query queryExtractNoRec = QueryFactory.create(getQueryString("extract-resources-no-records.rq"));
+        QueryExecution qe = QueryExecutionFactory.create(queryExtractNoRec, model);
+
+        Model newModel = model;
+        ResultSet resultIds = qe.execSelect();
+        while (resultIds.hasNext()) {
+            QuerySolution solution = resultIds.nextSolution();
+            newModel = createCatalogRecord(
+                newModel,
+                solution.get("resourceId").toString(),
+                solution.get("catalogId").toString()
+            );
+        }
+        return newModel;
+    }
+
+
+    private static InputStream getResourceAsStream(String resourcePath) {
+        return RDFUtils.class.getClassLoader().getResourceAsStream(resourcePath);
+    }
+
+    /**
+     * Convert a model back to RDF XML
+     * Only used for debugging
+     */
+    private static String toRdfString(Model model) {
+        StringWriter out = new StringWriter();
+        RDFDataMgr.write(out, model, Lang.RDFXML);
+        return out.toString();
+    }
+
+
+    private static String getQueryString(String queryFile) throws IOException, URISyntaxException {
+        return IOUtils.toString(getResourceAsStream(RESOURCE_FOLDER + "sparql/" + queryFile), Constants.CHARSET);
+    }
+
+    private static Model createCatalogRecord(Model model, String resourceId, String catalogId) throws IOException, URISyntaxException {
+        String recordUUID = resourceId;
+        Date now = new Date();
+        String localQuery = getQueryString("add-CatalogRecord.rq")
+            .replace("%recordID%", recordUUID)
+            .replace("%recordUUID%", recordUUID)
+            .replace("%resourceId%", resourceId)
+            // TODO: Should we set modified of catalog record to the date of publication?
+            // If not, they will be popup on top of search by date
+            .replace("%modifiedDate%", new ISODate(now.getTime(), false).toString())
+            .replace("%catalogId%", catalogId);
+
+        Query queryFixBlankNodes = QueryFactory.create(localQuery);
+        QueryExecution qe = QueryExecutionFactory.create(queryFixBlankNodes, model);
+        Model newModel = qe.execConstruct();
+        qe.close();
+        return newModel;
+    }
+
+
+    private static Pair<String, Element> getRecordInfo(QuerySolution solution, Model model) {
+        try {
+            String recordId = solution.get("recordId").toString();
+            String resourceId = solution.get("resourceId").toString();
+            String baseRecordUUID = solution.get("baseRecordUUID").toString();
+
+            String localQueryBuildRecord = getQueryString("build-record.rq")
+                .replace("%recordId%", recordId)
+                .replace("%resourceId%", resourceId);
+
+            Query queryRecord = QueryFactory.create(localQueryBuildRecord);
+            QueryExecution qe = QueryExecutionFactory.create(queryRecord, model);
+            ResultSet results = qe.execSelect();
+
+            if (results.hasNext()) {
+                ByteArrayOutputStream outxml = new ByteArrayOutputStream();
+                ResultSetFormatter.outputAsXML(outxml, results);
+                Element sparqlResults = Xml.loadStream(
+                    new ByteArrayInputStream(outxml.toByteArray()));
+                qe.close();
+
+                Map<String, Object> params = new HashMap<>();
+                params.put("recordUUID", baseRecordUUID);
+
+                // TODO: Update record only if modified is more recent than local
+//                Literal modifiedLiteral = solution.getLiteral("modified");
+//                String modified;
+//                if (modifiedLiteral != null) {
+//                    modified = DateUtil.convertToISOZuluDateTime(modifiedLiteral.getString());
+//                }
+
+                return Pair.read(baseRecordUUID, sparqlResults);
+            } else {
+                qe.close();
+            }
+
+        } catch (JDOMException | IOException | URISyntaxException e) {
+            Log.error(LOGGER_NAME, String.format(
+                "Error extracting record info using SPARQL. Error is: %s", e.getMessage()));
+        }
+
+        // we get here if we couldn't get the UUID or date modified
+        return null;
+    }
+}

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/simpleurl/SimpleUrlHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/simpleurl/SimpleUrlHarvester.java
@@ -21,25 +21,13 @@
 //===	Rome - Italy. email: geonetwork@osgeo.org
 //==============================================================================
 
-package org.fao.geonet.kernel.harvest.harvester.simpleUrl;
+package org.fao.geonet.kernel.harvest.harvester.simpleurl;
 
-import jeeves.server.context.ServiceContext;
 import org.fao.geonet.Logger;
-import org.fao.geonet.domain.Source;
-import org.fao.geonet.domain.SourceType;
-import org.fao.geonet.exceptions.BadInputEx;
 import org.fao.geonet.kernel.harvest.harvester.AbstractHarvester;
-import org.fao.geonet.kernel.harvest.harvester.AbstractParams;
 import org.fao.geonet.kernel.harvest.harvester.HarvestResult;
-import org.fao.geonet.kernel.harvest.harvester.csw.CswParams;
-import org.fao.geonet.repository.SourceRepository;
-import org.fao.geonet.resources.Resources;
-import org.jdom.Element;
-import org.springframework.beans.factory.annotation.Autowired;
 
-import java.io.File;
 import java.sql.SQLException;
-import java.util.UUID;
 
 /**
  * Harvest metadata from a JSON source.

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/simpleurl/SimpleUrlParams.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/simpleurl/SimpleUrlParams.java
@@ -21,7 +21,7 @@
 //===	Rome - Italy. email: geonetwork@osgeo.org
 //==============================================================================
 
-package org.fao.geonet.kernel.harvest.harvester.simpleUrl;
+package org.fao.geonet.kernel.harvest.harvester.simpleurl;
 
 import org.fao.geonet.Util;
 import org.fao.geonet.exceptions.BadInputEx;
@@ -44,7 +44,7 @@ public class SimpleUrlParams extends AbstractParams {
     }
 
     /**
-     * called when a new entry must be added. Reads values from the provided entry, providing
+     * called when a new entry must be added. Read values from the provided entry, providing
      * default values.
      */
     public void create(Element node) throws BadInputEx {
@@ -52,14 +52,14 @@ public class SimpleUrlParams extends AbstractParams {
 
         Element site = node.getChild("site");
 
-        url = Util.getParam(site, "url", "http://dados.gov.br/api/3/action/package_search?q=");
-        loopElement = Util.getParam(site, "loopElement", "/result/results");
-        numberOfRecordPath = Util.getParam(site, "numberOfRecordPath", "/result/count");
+        url = Util.getParam(site, "url", "");
+        loopElement = Util.getParam(site, "loopElement", "");
+        numberOfRecordPath = Util.getParam(site, "numberOfRecordPath", "");
         recordIdPath = Util.getParam(site, "recordIdPath", "id");
         pageSizeParam = Util.getParam(site, "pageSizeParam", "rows");
         pageFromParam = Util.getParam(site, "pageFromParam", "start");
-        toISOConversion = Util.getParam(site, "toISOConversion", "CKAN-to-ISO19115-3-2018");
-        icon = Util.getParam(site, "icon", "default.gif");
+        toISOConversion = Util.getParam(site, "toISOConversion", "");
+        icon = Util.getParam(site, "icon", "");
     }
 
     /**

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/simpleurl/SimpleUrlParams.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/simpleurl/SimpleUrlParams.java
@@ -55,9 +55,9 @@ public class SimpleUrlParams extends AbstractParams {
         url = Util.getParam(site, "url", "");
         loopElement = Util.getParam(site, "loopElement", "");
         numberOfRecordPath = Util.getParam(site, "numberOfRecordPath", "");
-        recordIdPath = Util.getParam(site, "recordIdPath", "id");
-        pageSizeParam = Util.getParam(site, "pageSizeParam", "rows");
-        pageFromParam = Util.getParam(site, "pageFromParam", "start");
+        recordIdPath = Util.getParam(site, "recordIdPath", "");
+        pageSizeParam = Util.getParam(site, "pageSizeParam", "");
+        pageFromParam = Util.getParam(site, "pageFromParam", "");
         toISOConversion = Util.getParam(site, "toISOConversion", "");
         icon = Util.getParam(site, "icon", "");
     }

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/simpleurl/SimpleUrlResourceType.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/simpleurl/SimpleUrlResourceType.java
@@ -1,4 +1,4 @@
-package org.fao.geonet.kernel.harvest.harvester.simpleUrl;
+package org.fao.geonet.kernel.harvest.harvester.simpleurl;
 
 public enum SimpleUrlResourceType {
     JSON,

--- a/harvesters/src/main/resources/config-spring-geonetwork.xml
+++ b/harvesters/src/main/resources/config-spring-geonetwork.xml
@@ -61,6 +61,6 @@
   <bean id="arcSDEConnectionFactory"
     class="org.fao.geonet.kernel.harvest.harvester.arcsde.ArcSDEConnectionFactory" />
   <bean id="simpleurl"
-        class="org.fao.geonet.kernel.harvest.harvester.simpleUrl.SimpleUrlHarvester"
+        class="org.fao.geonet.kernel.harvest.harvester.simpleurl.SimpleUrlHarvester"
         scope="prototype"/>
 </beans>

--- a/harvesters/src/main/resources/harvester-resources/simpleUrl/sparql/add-CatalogRecord.rq
+++ b/harvesters/src/main/resources/harvester-resources/simpleUrl/sparql/add-CatalogRecord.rq
@@ -1,0 +1,19 @@
+PREFIX dcat: <http://www.w3.org/ns/dcat#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+
+# Create a catalog record for the given resource
+CONSTRUCT {
+  ?recordId a dcat:CatalogRecord.
+  ?recordId dct:identifier "%recordUUID%".
+  ?recordId foaf:primaryTopic <%resourceId%>.
+  ?recordId dct:modified "%modifiedDate%".
+  <%catalogId%> dcat:record ?recordId.
+  ?s ?p ?o.
+} WHERE {
+  {
+    BIND (<%recordID%> as ?recordId)
+  } UNION {
+    ?s ?p ?o.
+  }
+}

--- a/harvesters/src/main/resources/harvester-resources/simpleUrl/sparql/build-record.rq
+++ b/harvesters/src/main/resources/harvester-resources/simpleUrl/sparql/build-record.rq
@@ -1,0 +1,94 @@
+PREFIX dcat: <http://www.w3.org/ns/dcat#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX vcard: <http://www.w3.org/2006/vcard/ns#>
+PREFIX apf: <http://jena.hpl.hp.com/ARQ/property#>
+PREFIX afn: <http://jena.hpl.hp.com/ARQ/function#>
+PREFIX skos: <http://www.w3.org/2004/02/skos/core#>
+
+# Retrieve all triples about a specific record URI.
+# Replace the string "%recordId%" with the record ID and
+# the string "%resourceId%" with the resource ID before executing
+SELECT DISTINCT ?subject ?predicate ?object ?pAsQName
+WHERE {
+  {
+    # Triples on a dct:Catalog instance
+    ?subject ?predicate ?object.
+    ?subject a dcat:Catalog.
+    ?subject dcat:dataset|dcat:service <%resourceId%>.
+    FILTER (?predicate != dcat:dataset && ?predicate != dcat:service && ?predicate != dcat:record)
+
+  } UNION {
+    # Triples on a dct:Catalog instance's child resources (publisher, distribution, ed.)
+    ?subject ?predicate ?object.
+    ?s a dcat:Catalog.
+    ?s dcat:dataset|dcat:service <%resourceId%>.
+    ?s ?p ?subject.
+    FILTER (?p != dcat:dataset && ?p != dcat:service && ?p != dcat:record).
+    FILTER (?predicate != dcat:dataset && ?predicate != dcat:service && ?predicate != dcat:record).
+
+  } UNION {
+    # Triples on a specific catalog record
+    ?subject ?predicate ?object.
+    FILTER (?subject = <%recordId%> || ?object = <%recordId%>)
+
+  } UNION {
+    # Triples on specific catalog record's child resources
+    ?subject ?predicate ?object.
+    <%recordId%> ?p ?subject
+
+  } UNION {
+    # Triples on specific catalog record's child of child
+    ?subject ?predicate ?object.
+    <%recordId%> ?p1 ?obj.
+    ?obj ?p2 ?subject.
+
+  } UNION {
+    # Triples on a specific resource
+    ?subject ?predicate ?object.
+    FILTER (?subject = <%resourceId%> || ?object = <%resourceId%>)
+
+  } UNION {
+    #Triples on a specific resource's child resources (publisher, distribution, ed.)
+    ?subject ?predicate ?object.
+    <%resourceId%> ?p ?subject.
+
+  } UNION {
+    # Triple on a specific distribution's child dct:license
+    ?subject ?predicate ?object.
+    <%resourceId%> dcat:distribution ?distribution.
+    ?distribution ?p ?subject.
+
+  } UNION {
+    # Triple on a specific contactPoint's child Address
+    ?subject ?predicate ?object.
+    <%resourceId%> dcat:contactPoint ?address.
+    ?address ?p ?subject.
+
+  } UNION {
+    # Triples on a skos:Concept instance
+    ?subject ?predicate ?object.
+    ?subject a skos:Concept.
+  }
+
+  BIND (afn:namespace(?predicate) as ?pns)
+
+  BIND (COALESCE(
+    IF(?pns = 'http://www.w3.org/ns/dcat#', 'dcat:', 1/0),
+    IF(?pns = 'http://purl.org/dc/terms/', 'dct:', 1/0),
+    IF(?pns = 'http://spdx.org/rdf/terms#', 'spdx:', 1/0),
+    IF(?pns = 'http://www.w3.org/2004/02/skos/core#', 'skos:', 1/0),
+    IF(?pns = 'http://www.w3.org/ns/adms#', 'adms:', 1/0),
+    IF(?pns = 'http://www.w3.org/1999/02/22-rdf-syntax-ns#', 'rdf:', 1/0),
+    IF(?pns = 'http://www.w3.org/2006/vcard/ns#', 'vcard:', 1/0),
+    IF(?pns = 'http://xmlns.com/foaf/0.1/', 'foaf:', 1/0),
+    IF(?pns = 'http://www.w3.org/2002/07/owl#', 'owl:', 1/0),
+    IF(?pns = 'http://schema.org/', 'schema:', 1/0),
+    IF(?pns = 'http://www.w3.org/2000/01/rdf-schema#', 'rdfs:', 1/0),
+    IF(?pns = 'http://www.w3.org/ns/locn#', 'locn:', 1/0),
+    IF(?pns = 'http://purl.org/dc/elements/1.1/', 'dc:', 1/0),
+    IF(?pns = 'http://data.vlaanderen.be/ns/metadata-dcat#', 'mdcat:', 1/0),
+    'unkown:'
+  ) AS ?pprefix)
+
+  BIND (CONCAT(?pprefix, afn:localname(?predicate)) AS ?pAsQName)
+}

--- a/harvesters/src/main/resources/harvester-resources/simpleUrl/sparql/extract-records-ids.rq
+++ b/harvesters/src/main/resources/harvester-resources/simpleUrl/sparql/extract-records-ids.rq
@@ -1,0 +1,21 @@
+PREFIX dcat: <http://www.w3.org/ns/dcat#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+
+# Extract all CatalogRecord ids, modified date and primary topic
+SELECT ?catalogId ?recordId ?modified ?resourceId ?baseRecordUUID ?baseResourceUUID
+WHERE {
+  VALUES ?type { dcat:Dataset dcat:DataService }
+  ?recordId a dcat:CatalogRecord .
+  ?recordId foaf:primaryTopic ?resourceId .
+  ?resourceId a ?type
+  OPTIONAL {
+    ?catalogId a dcat:Catalog .
+    ?catalogId dcat:record ?recordId .
+    ?recordId dct:modified ?modified .
+    ?recordId dct:identifier ?recordDctIdentifier .
+    ?resourceId dct:identifier ?resourceDctIdentifier .
+  }
+  BIND (if (bound(?recordDctIdentifier), ?recordDctIdentifier, ?recordId) as ?baseRecordUUID)
+  BIND (if (bound(?resourceDctIdentifier), ?resourceDctIdentifier, ?resourceId) as ?baseResourceUUID)
+}

--- a/harvesters/src/main/resources/harvester-resources/simpleUrl/sparql/extract-resources-no-records.rq
+++ b/harvesters/src/main/resources/harvester-resources/simpleUrl/sparql/extract-resources-no-records.rq
@@ -1,0 +1,41 @@
+PREFIX dcat: <http://www.w3.org/ns/dcat#>
+PREFIX dct: <http://purl.org/dc/terms/>
+PREFIX foaf: <http://xmlns.com/foaf/0.1/>
+
+# Extract list of resources ID that doesn't have a dcat:CatalogRecord.
+# It first check for the first resource dct:identifier.
+# If none, check on the resource about.
+# If none, ignore the resource.
+SELECT ?catalogId ?resourceId
+WHERE {
+  {
+    ?resourceId a dcat:Dataset .
+    ?catalogId dcat:dataset ?resourceId .
+    OPTIONAL {
+      ?catalogId a dcat:Catalog .
+      ?resourceId dct:identifier ?identifier
+    }
+    FILTER (NOT EXISTS {
+                         ?recordId a dcat:CatalogRecord .
+                         ?recordId foaf:primaryTopic ?resourceId .
+                       }
+    )
+    FILTER (bound(?identifier) || !isBlank(?resourceId))
+
+  } UNION {
+    ?catalogId a dcat:Catalog .
+    ?resourceId a dcat:DataService .
+    ?catalogId dcat:service ?resourceId .
+    OPTIONAL {
+      ?resourceId dct:identifier ?identifier .
+    }
+    BIND (if (bound(?identifier), ?identifier, ?resourceId) as ?brId)
+    FILTER (NOT EXISTS {
+                         ?recordId a dcat:CatalogRecord .
+                         ?recordId foaf:primaryTopic ?resourceId .
+                       }
+    )
+    FILTER (bound(?identifier) || !isBlank(?resourceId))
+  }
+}
+GROUP BY ?resourceId ?catalogId

--- a/harvesters/src/main/resources/harvester-resources/simpleUrl/sparql/fix-blank-node.rq
+++ b/harvesters/src/main/resources/harvester-resources/simpleUrl/sparql/fix-blank-node.rq
@@ -1,0 +1,46 @@
+PREFIX dcat: <http://www.w3.org/ns/dcat#>
+PREFIX dct: <http://purl.org/dc/terms/>
+
+# Set URIs of blank-node dcat:Dataset and dcat:DataService instances to a URN composed of the resource's first title.
+CONSTRUCT {
+  ?newResourceURI ?p1 ?o1 .
+  ?s2 ?p2 ?newResourceURI .
+  ?s3 ?p3 ?o3 .
+}
+WHERE {
+  {
+    ?oldResourceURI a dcat:Dataset .
+    ?oldResourceURI ?p1 ?o1 .
+    ?s2 ?p2 ?oldResourceURI .
+    FILTER (isBlank(?oldResourceURI)) .
+    {
+      SELECT ?oldResourceURI (UUID() AS ?uuid) (MIN(?t) AS ?title)
+      WHERE {
+        ?oldResourceURI dct:title ?t .
+      }
+      GROUP BY ?oldResourceURI
+    }
+    BIND (?uuid AS ?newResourceURI) .
+  } UNION {
+    ?s3 ?p3 ?o3 .
+    FILTER (NOT EXISTS {?s3 a dcat:Dataset . FILTER (isBlank(?s3)) .}) .
+    FILTER (NOT EXISTS {?o3 a dcat:Dataset . FILTER (isBlank(?o3)) .}) .
+  } UNION {
+    ?oldResourceURI a dcat:DataService .
+    ?oldResourceURI ?p1 ?o1 .
+    ?s2 ?p2 ?oldResourceURI .
+    FILTER (isBlank(?oldResourceURI)) .
+    {
+      SELECT ?oldResourceURI (UUID() AS ?uuid) (MIN(?t) AS ?title)
+      WHERE {
+        ?oldResourceURI dct:title ?t .
+      }
+      GROUP BY ?oldResourceURI
+    }
+    BIND (?uuid AS ?newResourceURI) .
+  } UNION {
+    ?s3 ?p3 ?o3 .
+    FILTER (NOT EXISTS {?s3 a dcat:DataService . FILTER (isBlank(?s3)) .}) .
+    FILTER (NOT EXISTS {?o3 a dcat:DataService . FILTER (isBlank(?o3)) .}) .
+  }
+}

--- a/harvesters/src/test/java/org/fao/geonet/kernel/harvest/harvester/simpleurl/HarvesterTest.java
+++ b/harvesters/src/test/java/org/fao/geonet/kernel/harvest/harvester/simpleurl/HarvesterTest.java
@@ -1,4 +1,4 @@
-package org.fao.geonet.kernel.harvest.harvester.simpleUrl;
+package org.fao.geonet.kernel.harvest.harvester.simpleurl;
 
 import org.fao.geonet.utils.Log;
 import org.junit.Test;

--- a/harvesters/src/test/java/org/fao/geonet/kernel/harvest/harvester/simpleurl/RDFUtilsTest.java
+++ b/harvesters/src/test/java/org/fao/geonet/kernel/harvest/harvester/simpleurl/RDFUtilsTest.java
@@ -1,0 +1,19 @@
+package org.fao.geonet.kernel.harvest.harvester.simpleurl;
+
+import org.jdom.Element;
+import org.junit.Test;
+
+import java.util.Map;
+
+import static junit.framework.Assert.assertEquals;
+
+public class RDFUtilsTest {
+    @Test
+    public void test_getAllUuidsFromFeed() throws Exception {
+        Map<String, Element> records = RDFUtils.getAllUuids(this.getClass().getResource("dcat-feed-mow.rdf").toString());
+        assertEquals(22, records.size());
+
+        records = RDFUtils.getAllUuids(this.getClass().getResource("ogcapirecords-dcat-output.rdf").toString());
+        assertEquals(1, records.size());
+    }
+}

--- a/harvesters/src/test/resources/META-INF/services/javax.xml.transform.TransformerFactory
+++ b/harvesters/src/test/resources/META-INF/services/javax.xml.transform.TransformerFactory
@@ -1,0 +1,1 @@
+net.sf.saxon.TransformerFactoryImpl

--- a/harvesters/src/test/resources/org/fao/geonet/kernel/harvest/harvester/simpleurl/dcat-feed-mow.rdf
+++ b/harvesters/src/test/resources/org/fao/geonet/kernel/harvest/harvester/simpleurl/dcat-feed-mow.rdf
@@ -1,0 +1,1246 @@
+<?xml version='1.0' encoding='utf-8'?>
+<rdf:RDF
+    xmlns:dcat="http://www.w3.org/ns/dcat#"
+    xmlns:dcterms="http://purl.org/dc/terms/"
+    xmlns:foaf="http://xmlns.com/foaf/0.1/"
+    xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+    xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#"
+    xmlns:store="http://mobielvlaanderen.be/store-x/man-dcat/"
+    xmlns:vcard="http://www.w3.org/2006/vcard/ns#">
+    <dcat:Catalog rdf:about="http://mobielvlaanderen.be/store-x/man-dcat/dr_catalog">
+        <dcterms:title xml:lang="nl">Dataroom Beleidsdomein Mobiliteit en Openbare Werken</dcterms:title>
+        <dcterms:description xml:lang="nl">Het beleidsdomein verzamelt indicatoren, die relevant zijn voor de beleidsvoorbereiding, -opvolging
+en -evaluatie, in deze databank voor intern gebruik en voor verdere verspreiding, onder meer als open data.
+De kwaliteit en betrouwbaarheid van de data is afhankelijk van de gebruikte meettechnieken
+en berekeningswijzen, die als metadata bij de indicatoren worden aangegeven.</dcterms:description>
+        <dcterms:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2016-02-03</dcterms:issued>
+        <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2023-01-18</dcterms:modified>
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:publisher>
+            <foaf:Agent rdf:about="http://data.vlaanderen.be/id/organisatie/OVO000096">
+                <foaf:name>Beleidsdomein Mobiliteit en Openbare Werken</foaf:name>
+                <dcterms:type>organization</dcterms:type>
+            </foaf:Agent>
+        </dcterms:publisher>
+        <dcterms:language rdf:resource="http://lexvo.org/id/iso639-3/nld" />
+        <foaf:homepage rdf:resource="http://opendata.mow.vlaanderen.be" />
+        <dcat:dataset rdf:resource="http://mobielvlaanderen.be/store-x/man-dcat/dataset_ind075" />
+        <dcat:dataset rdf:resource="http://mobielvlaanderen.be/store-x/man-dcat/dataset_ind087" />
+        <dcat:dataset rdf:resource="http://mobielvlaanderen.be/store-x/man-dcat/dataset_ind074" />
+        <dcat:dataset rdf:resource="http://mobielvlaanderen.be/store-x/man-dcat/dataset_ind071" />
+        <dcat:dataset rdf:resource="http://mobielvlaanderen.be/store-x/man-dcat/dataset_ind066" />
+        <dcat:dataset rdf:resource="http://mobielvlaanderen.be/store-x/man-dcat/dataset_ind067" />
+        <dcat:dataset rdf:resource="http://mobielvlaanderen.be/store-x/man-dcat/dataset_ind016" />
+        <dcat:dataset rdf:resource="http://mobielvlaanderen.be/store-x/man-dcat/dataset_ind077" />
+        <dcat:dataset rdf:resource="http://mobielvlaanderen.be/store-x/man-dcat/dataset_ind072" />
+        <dcat:dataset rdf:resource="http://mobielvlaanderen.be/store-x/man-dcat/dataset_ind068" />
+        <dcat:dataset rdf:resource="http://mobielvlaanderen.be/store-x/man-dcat/dataset_ind1080" />
+        <dcat:dataset rdf:resource="http://mobielvlaanderen.be/store-x/man-dcat/dataset_ind076" />
+        <dcat:dataset rdf:resource="http://mobielvlaanderen.be/store-x/man-dcat/dataset_ind003" />
+        <dcat:dataset rdf:resource="http://mobielvlaanderen.be/store-x/man-dcat/dataset_ind065" />
+        <dcat:dataset rdf:resource="http://mobielvlaanderen.be/store-x/man-dcat/dataset_ind1245" />
+        <dcat:dataset rdf:resource="http://mobielvlaanderen.be/store-x/man-dcat/dataset_ind011" />
+        <dcat:dataset rdf:resource="http://mobielvlaanderen.be/store-x/man-dcat/dataset_ind012" />
+        <dcat:dataset rdf:resource="http://mobielvlaanderen.be/store-x/man-dcat/dataset_ind1247" />
+        <dcat:dataset rdf:resource="http://mobielvlaanderen.be/store-x/man-dcat/dataset_ind1246" />
+        <dcat:dataset rdf:resource="http://mobielvlaanderen.be/store-x/man-dcat/dataset_ind1120" />
+        <dcat:dataset rdf:resource="http://mobielvlaanderen.be/store-x/man-dcat/dataset_ind073" />
+        <dcat:dataset rdf:resource="http://mobielvlaanderen.be/store-x/man-dcat/dataset_ind1100" />
+    </dcat:Catalog>
+    <dcat:Dataset rdf:about="http://mobielvlaanderen.be/store-x/man-dcat/dataset_ind075">
+        <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-04-28</dcterms:modified>
+        <dcterms:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-04-28</dcterms:issued>
+        <dcterms:title xml:lang="nl">aantal ton gelost op de waterwegen</dcterms:title>
+        <dcterms:description xml:lang="nl">hoeveelheid goederen gelost langs waterwegen beheerd door De Vlaamse Waterweg uitgedrukt in ton </dcterms:description>
+        <dcterms:publisher>
+            <foaf:Agent rdf:about="http://data.vlaanderen.be/id/organisatie/OVO000096">
+                <foaf:name>Beleidsdomein Mobiliteit en Openbare Werken</foaf:name>
+                <dcterms:type>organization</dcterms:type>
+            </foaf:Agent>
+        </dcterms:publisher>
+        <dcat:contactPoint>
+            <vcard:Kind rdf:about="https://www.mow-contact.be/">
+                <vcard:fn>https://www.mow-contact.be/</vcard:fn>
+            </vcard:Kind>
+        </dcat:contactPoint>
+        <dcterms:language rdf:resource="http://lexvo.org/id/iso639-3/nld" />
+        <dcat:landingPage rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/bijsluiter_075.html" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_075.xml" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_075.html" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/commentaar_075.xml" />
+        <dcat:distribution rdf:resource="https://app.powerbi.com/view?r=eyJrIjoiMmE3ODAxZWItOWNiMi00ZTU1LWJkNjEtODQ2ZDc4ZWNmZDRkIiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9" />
+    </dcat:Dataset>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_075.xml">
+        <dcterms:title xml:lang="nl">aantal ton gelost op de waterwegen - Cijfers (XML)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_075.xml" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>XML</dcterms:format>
+        <dcterms:description xml:lang="nl">Eventuele opmerkingen bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie)
+zijn terug te vinden in de commentaar file.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_075.html">
+        <dcterms:title xml:lang="nl">aantal ton gelost op de waterwegen - Cijfers (Tabel)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_075.html" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>HTML</dcterms:format>
+        <dcterms:description xml:lang="nl">Kies de URL hierboven om de cijfergegevens in een tabel te zien.
+
+De cijfergegevens in de tabel kunnen in MS Excel opgeladen worden via de 'Data' - 'From Web' functie. Gebruik de
+hierboven vermelde URL in het adres veld.
+
+Eventuele opmerkingen bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie) zijn terug te vinden
+in de commentaar file.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/commentaar_075.xml">
+        <dcterms:title xml:lang="nl">aantal ton gelost op de waterwegen - Commentaar</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/commentaar_075.xml" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>XML</dcterms:format>
+        <dcterms:description xml:lang="nl">Opmerkingen horend bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie).</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://app.powerbi.com/view?r=eyJrIjoiMmE3ODAxZWItOWNiMi00ZTU1LWJkNjEtODQ2ZDc4ZWNmZDRkIiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9">
+        <dcterms:title xml:lang="nl">aantal ton gelost op de waterwegen - Rapport (PowerBI)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://app.powerbi.com/view?r=eyJrIjoiMmE3ODAxZWItOWNiMi00ZTU1LWJkNjEtODQ2ZDc4ZWNmZDRkIiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>Rapport</dcterms:format>
+        <dcterms:description xml:lang="nl">Rapport met de cijfergegevens weergeven.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Dataset rdf:about="http://mobielvlaanderen.be/store-x/man-dcat/dataset_ind087">
+        <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-01-29</dcterms:modified>
+        <dcterms:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-01-29</dcterms:issued>
+        <dcterms:title xml:lang="nl">verdeling van woon-werkverplaatsingen volgens hoofdvervoerswijze (beroepsactieven)</dcterms:title>
+        <dcterms:description xml:lang="nl">percentage van de woon-werkverplaatsingen door beroepsactieven waarvoor gebruik wordt gemaakt van de betreffende vervoerswijze als hoofdvervoerswijze (d.w.z. voor het grootste deel van de af te leggen afstand)</dcterms:description>
+        <dcterms:publisher>
+            <foaf:Agent rdf:about="http://data.vlaanderen.be/id/organisatie/OVO000096">
+                <foaf:name>Beleidsdomein Mobiliteit en Openbare Werken</foaf:name>
+                <dcterms:type>organization</dcterms:type>
+            </foaf:Agent>
+        </dcterms:publisher>
+        <dcat:contactPoint>
+            <vcard:Kind rdf:about="https://www.mow-contact.be/">
+                <vcard:fn>https://www.mow-contact.be/</vcard:fn>
+            </vcard:Kind>
+        </dcat:contactPoint>
+        <dcterms:language rdf:resource="http://lexvo.org/id/iso639-3/nld" />
+        <dcat:landingPage rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/bijsluiter_087.html" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_087.xml" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_087.html" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/commentaar_087.xml" />
+        <dcat:distribution rdf:resource="https://app.powerbi.com/view?r=eyJrIjoiNTU4ZjRkMmEtYzRhOC00NWM5LTk4NDctZGU3MzE0ODIyNGQ5IiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9" />
+    </dcat:Dataset>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_087.xml">
+        <dcterms:title xml:lang="nl">verdeling van woon-werkverplaatsingen volgens hoofdvervoerswijze (beroepsactieven) - Cijfers (XML)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_087.xml" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>XML</dcterms:format>
+        <dcterms:description xml:lang="nl">Eventuele opmerkingen bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie)
+zijn terug te vinden in de commentaar file.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_087.html">
+        <dcterms:title xml:lang="nl">verdeling van woon-werkverplaatsingen volgens hoofdvervoerswijze (beroepsactieven) - Cijfers (Tabel)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_087.html" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>HTML</dcterms:format>
+        <dcterms:description xml:lang="nl">Kies de URL hierboven om de cijfergegevens in een tabel te zien.
+
+De cijfergegevens in de tabel kunnen in MS Excel opgeladen worden via de 'Data' - 'From Web' functie. Gebruik de
+hierboven vermelde URL in het adres veld.
+
+Eventuele opmerkingen bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie) zijn terug te vinden
+in de commentaar file.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/commentaar_087.xml">
+        <dcterms:title xml:lang="nl">verdeling van woon-werkverplaatsingen volgens hoofdvervoerswijze (beroepsactieven) - Commentaar</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/commentaar_087.xml" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>XML</dcterms:format>
+        <dcterms:description xml:lang="nl">Opmerkingen horend bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie).</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://app.powerbi.com/view?r=eyJrIjoiNTU4ZjRkMmEtYzRhOC00NWM5LTk4NDctZGU3MzE0ODIyNGQ5IiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9">
+        <dcterms:title xml:lang="nl">verdeling van woon-werkverplaatsingen volgens hoofdvervoerswijze (beroepsactieven) - Rapport (PowerBI)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://app.powerbi.com/view?r=eyJrIjoiNTU4ZjRkMmEtYzRhOC00NWM5LTk4NDctZGU3MzE0ODIyNGQ5IiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>Rapport</dcterms:format>
+        <dcterms:description xml:lang="nl">Rapport met de cijfergegevens weergeven.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Dataset rdf:about="http://mobielvlaanderen.be/store-x/man-dcat/dataset_ind074">
+        <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-08-26</dcterms:modified>
+        <dcterms:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-08-26</dcterms:issued>
+        <dcterms:title xml:lang="nl">aantal tonkilometer Albertkanaal</dcterms:title>
+        <dcterms:description xml:lang="nl">hoeveelheid goederen vervoerd op het Albertkanaal uitgedrukt in tonkilometer</dcterms:description>
+        <dcterms:publisher>
+            <foaf:Agent rdf:about="http://data.vlaanderen.be/id/organisatie/OVO000096">
+                <foaf:name>Beleidsdomein Mobiliteit en Openbare Werken</foaf:name>
+                <dcterms:type>organization</dcterms:type>
+            </foaf:Agent>
+        </dcterms:publisher>
+        <dcat:contactPoint>
+            <vcard:Kind rdf:about="https://www.mow-contact.be/">
+                <vcard:fn>https://www.mow-contact.be/</vcard:fn>
+            </vcard:Kind>
+        </dcat:contactPoint>
+        <dcterms:language rdf:resource="http://lexvo.org/id/iso639-3/nld" />
+        <dcat:landingPage rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/bijsluiter_074.html" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_074.xml" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_074.html" />
+        <dcat:distribution rdf:resource="https://app.powerbi.com/view?r=eyJrIjoiZmUwODYzNTctNzkyNi00YTg3LWI2ZTgtOGQxM2Y4YzNlODVhIiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9" />
+    </dcat:Dataset>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_074.xml">
+        <dcterms:title xml:lang="nl">aantal tonkilometer Albertkanaal - Cijfers (XML)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_074.xml" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>XML</dcterms:format>
+        <dcterms:description xml:lang="nl">Eventuele opmerkingen bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie)
+zijn terug te vinden in de commentaar file.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_074.html">
+        <dcterms:title xml:lang="nl">aantal tonkilometer Albertkanaal - Cijfers (Tabel)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_074.html" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>HTML</dcterms:format>
+        <dcterms:description xml:lang="nl">Kies de URL hierboven om de cijfergegevens in een tabel te zien.
+
+De cijfergegevens in de tabel kunnen in MS Excel opgeladen worden via de 'Data' - 'From Web' functie. Gebruik de
+hierboven vermelde URL in het adres veld.
+
+Eventuele opmerkingen bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie) zijn terug te vinden
+in de commentaar file.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://app.powerbi.com/view?r=eyJrIjoiZmUwODYzNTctNzkyNi00YTg3LWI2ZTgtOGQxM2Y4YzNlODVhIiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9">
+        <dcterms:title xml:lang="nl">aantal tonkilometer Albertkanaal - Rapport (PowerBI)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://app.powerbi.com/view?r=eyJrIjoiZmUwODYzNTctNzkyNi00YTg3LWI2ZTgtOGQxM2Y4YzNlODVhIiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>Rapport</dcterms:format>
+        <dcterms:description xml:lang="nl">Rapport met de cijfergegevens weergeven.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Dataset rdf:about="http://mobielvlaanderen.be/store-x/man-dcat/dataset_ind071">
+        <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-04-28</dcterms:modified>
+        <dcterms:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-04-28</dcterms:issued>
+        <dcterms:title xml:lang="nl">aantal vervoerde containers op de waterwegen</dcterms:title>
+        <dcterms:description xml:lang="nl">hoeveelheid vervoerde containers op waterwegen beheerd door De Vlaamse Waterweg uitgedrukt in twenty-foot equivalent units (TEU)</dcterms:description>
+        <dcterms:publisher>
+            <foaf:Agent rdf:about="http://data.vlaanderen.be/id/organisatie/OVO000096">
+                <foaf:name>Beleidsdomein Mobiliteit en Openbare Werken</foaf:name>
+                <dcterms:type>organization</dcterms:type>
+            </foaf:Agent>
+        </dcterms:publisher>
+        <dcat:contactPoint>
+            <vcard:Kind rdf:about="https://www.mow-contact.be/">
+                <vcard:fn>https://www.mow-contact.be/</vcard:fn>
+            </vcard:Kind>
+        </dcat:contactPoint>
+        <dcterms:language rdf:resource="http://lexvo.org/id/iso639-3/nld" />
+        <dcat:landingPage rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/bijsluiter_071.html" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_071.xml" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_071.html" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/commentaar_071.xml" />
+        <dcat:distribution rdf:resource="https://app.powerbi.com/view?r=eyJrIjoiMjUyODc1M2QtNjFjMy00NjhlLThhZTMtNzYzZDFhZGY5ZGY3IiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9" />
+    </dcat:Dataset>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_071.xml">
+        <dcterms:title xml:lang="nl">aantal vervoerde containers op de waterwegen - Cijfers (XML)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_071.xml" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>XML</dcterms:format>
+        <dcterms:description xml:lang="nl">Eventuele opmerkingen bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie)
+zijn terug te vinden in de commentaar file.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_071.html">
+        <dcterms:title xml:lang="nl">aantal vervoerde containers op de waterwegen - Cijfers (Tabel)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_071.html" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>HTML</dcterms:format>
+        <dcterms:description xml:lang="nl">Kies de URL hierboven om de cijfergegevens in een tabel te zien.
+
+De cijfergegevens in de tabel kunnen in MS Excel opgeladen worden via de 'Data' - 'From Web' functie. Gebruik de
+hierboven vermelde URL in het adres veld.
+
+Eventuele opmerkingen bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie) zijn terug te vinden
+in de commentaar file.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/commentaar_071.xml">
+        <dcterms:title xml:lang="nl">aantal vervoerde containers op de waterwegen - Commentaar</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/commentaar_071.xml" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>XML</dcterms:format>
+        <dcterms:description xml:lang="nl">Opmerkingen horend bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie).</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://app.powerbi.com/view?r=eyJrIjoiMjUyODc1M2QtNjFjMy00NjhlLThhZTMtNzYzZDFhZGY5ZGY3IiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9">
+        <dcterms:title xml:lang="nl">aantal vervoerde containers op de waterwegen - Rapport (PowerBI)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://app.powerbi.com/view?r=eyJrIjoiMjUyODc1M2QtNjFjMy00NjhlLThhZTMtNzYzZDFhZGY5ZGY3IiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>Rapport</dcterms:format>
+        <dcterms:description xml:lang="nl">Rapport met de cijfergegevens weergeven.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Dataset rdf:about="http://mobielvlaanderen.be/store-x/man-dcat/dataset_ind066">
+        <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-08-26</dcterms:modified>
+        <dcterms:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-08-26</dcterms:issued>
+        <dcterms:title xml:lang="nl">verdeling van personen (beroepsactieven) volgens hoofdvervoerswijze woon-werkverkeer</dcterms:title>
+        <dcterms:description xml:lang="nl">percentage van de beroepsactieven met een vast werkadres dat voor het woon-werkverkeer gebruikt maakt van de betreffende vervoerswijze als hoofdvervoerswijze (d.w.z. voor het grootste deel van de af te leggen afstand) </dcterms:description>
+        <dcterms:publisher>
+            <foaf:Agent rdf:about="http://data.vlaanderen.be/id/organisatie/OVO000096">
+                <foaf:name>Beleidsdomein Mobiliteit en Openbare Werken</foaf:name>
+                <dcterms:type>organization</dcterms:type>
+            </foaf:Agent>
+        </dcterms:publisher>
+        <dcat:contactPoint>
+            <vcard:Kind rdf:about="https://www.mow-contact.be/">
+                <vcard:fn>https://www.mow-contact.be/</vcard:fn>
+            </vcard:Kind>
+        </dcat:contactPoint>
+        <dcterms:language rdf:resource="http://lexvo.org/id/iso639-3/nld" />
+        <dcat:landingPage rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/bijsluiter_066.html" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_066.xml" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_066.html" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/commentaar_066.xml" />
+        <dcat:distribution rdf:resource="https://app.powerbi.com/view?r=eyJrIjoiMWU1MDNiNDUtYWFmNi00NjZlLTgzOWEtYjVkYmQxMDgwNTFjIiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9" />
+    </dcat:Dataset>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_066.xml">
+        <dcterms:title xml:lang="nl">verdeling van personen (beroepsactieven) volgens hoofdvervoerswijze woon-werkverkeer - Cijfers (XML)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_066.xml" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>XML</dcterms:format>
+        <dcterms:description xml:lang="nl">Eventuele opmerkingen bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie)
+zijn terug te vinden in de commentaar file.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_066.html">
+        <dcterms:title xml:lang="nl">verdeling van personen (beroepsactieven) volgens hoofdvervoerswijze woon-werkverkeer - Cijfers (Tabel)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_066.html" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>HTML</dcterms:format>
+        <dcterms:description xml:lang="nl">Kies de URL hierboven om de cijfergegevens in een tabel te zien.
+
+De cijfergegevens in de tabel kunnen in MS Excel opgeladen worden via de 'Data' - 'From Web' functie. Gebruik de
+hierboven vermelde URL in het adres veld.
+
+Eventuele opmerkingen bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie) zijn terug te vinden
+in de commentaar file.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/commentaar_066.xml">
+        <dcterms:title xml:lang="nl">verdeling van personen (beroepsactieven) volgens hoofdvervoerswijze woon-werkverkeer - Commentaar</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/commentaar_066.xml" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>XML</dcterms:format>
+        <dcterms:description xml:lang="nl">Opmerkingen horend bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie).</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://app.powerbi.com/view?r=eyJrIjoiMWU1MDNiNDUtYWFmNi00NjZlLTgzOWEtYjVkYmQxMDgwNTFjIiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9">
+        <dcterms:title xml:lang="nl">verdeling van personen (beroepsactieven) volgens hoofdvervoerswijze woon-werkverkeer - Rapport (PowerBI)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://app.powerbi.com/view?r=eyJrIjoiMWU1MDNiNDUtYWFmNi00NjZlLTgzOWEtYjVkYmQxMDgwNTFjIiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>Rapport</dcterms:format>
+        <dcterms:description xml:lang="nl">Rapport met de cijfergegevens weergeven.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Dataset rdf:about="http://mobielvlaanderen.be/store-x/man-dcat/dataset_ind067">
+        <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-02-10</dcterms:modified>
+        <dcterms:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-02-10</dcterms:issued>
+        <dcterms:title xml:lang="nl">verdeling van personen (scholieren en studenten) volgens hoofdvervoerswijze woon-schoolverkeer</dcterms:title>
+        <dcterms:description xml:lang="nl">percentage van de scholieren en studenten dat voor het woon-schoolverkeer gebruikt maakt van de betreffende vervoerswijze als hoofdvervoerswijze (d.w.z. voor het grootste deel van de af te leggen afstand)</dcterms:description>
+        <dcterms:publisher>
+            <foaf:Agent rdf:about="http://data.vlaanderen.be/id/organisatie/OVO000096">
+                <foaf:name>Beleidsdomein Mobiliteit en Openbare Werken</foaf:name>
+                <dcterms:type>organization</dcterms:type>
+            </foaf:Agent>
+        </dcterms:publisher>
+        <dcat:contactPoint>
+            <vcard:Kind rdf:about="https://www.mow-contact.be/">
+                <vcard:fn>https://www.mow-contact.be/</vcard:fn>
+            </vcard:Kind>
+        </dcat:contactPoint>
+        <dcterms:language rdf:resource="http://lexvo.org/id/iso639-3/nld" />
+        <dcat:landingPage rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/bijsluiter_067.html" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_067.xml" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_067.html" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/commentaar_067.xml" />
+        <dcat:distribution rdf:resource="https://app.powerbi.com/view?r=eyJrIjoiYzMzMjUwNWYtZGFlNi00MTBkLWFkODctY2UxMWQyZjkzY2ExIiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9" />
+    </dcat:Dataset>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_067.xml">
+        <dcterms:title xml:lang="nl">verdeling van personen (scholieren en studenten) volgens hoofdvervoerswijze woon-schoolverkeer - Cijfers (XML)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_067.xml" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>XML</dcterms:format>
+        <dcterms:description xml:lang="nl">Eventuele opmerkingen bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie)
+zijn terug te vinden in de commentaar file.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_067.html">
+        <dcterms:title xml:lang="nl">verdeling van personen (scholieren en studenten) volgens hoofdvervoerswijze woon-schoolverkeer - Cijfers (Tabel)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_067.html" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>HTML</dcterms:format>
+        <dcterms:description xml:lang="nl">Kies de URL hierboven om de cijfergegevens in een tabel te zien.
+
+De cijfergegevens in de tabel kunnen in MS Excel opgeladen worden via de 'Data' - 'From Web' functie. Gebruik de
+hierboven vermelde URL in het adres veld.
+
+Eventuele opmerkingen bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie) zijn terug te vinden
+in de commentaar file.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/commentaar_067.xml">
+        <dcterms:title xml:lang="nl">verdeling van personen (scholieren en studenten) volgens hoofdvervoerswijze woon-schoolverkeer - Commentaar</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/commentaar_067.xml" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>XML</dcterms:format>
+        <dcterms:description xml:lang="nl">Opmerkingen horend bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie).</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://app.powerbi.com/view?r=eyJrIjoiYzMzMjUwNWYtZGFlNi00MTBkLWFkODctY2UxMWQyZjkzY2ExIiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9">
+        <dcterms:title xml:lang="nl">verdeling van personen (scholieren en studenten) volgens hoofdvervoerswijze woon-schoolverkeer - Rapport (PowerBI)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://app.powerbi.com/view?r=eyJrIjoiYzMzMjUwNWYtZGFlNi00MTBkLWFkODctY2UxMWQyZjkzY2ExIiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>Rapport</dcterms:format>
+        <dcterms:description xml:lang="nl">Rapport met de cijfergegevens weergeven.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Dataset rdf:about="http://mobielvlaanderen.be/store-x/man-dcat/dataset_ind016">
+        <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-08-26</dcterms:modified>
+        <dcterms:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-08-26</dcterms:issued>
+        <dcterms:title xml:lang="nl">aantal ton zwerfvuil langs de gewestwegen</dcterms:title>
+        <dcterms:description xml:lang="nl">som van het aantal ton opgehaald zwerfvuil langs de autosnelwegen en gewestwegen</dcterms:description>
+        <dcterms:publisher>
+            <foaf:Agent rdf:about="http://data.vlaanderen.be/id/organisatie/OVO000096">
+                <foaf:name>Beleidsdomein Mobiliteit en Openbare Werken</foaf:name>
+                <dcterms:type>organization</dcterms:type>
+            </foaf:Agent>
+        </dcterms:publisher>
+        <dcat:contactPoint>
+            <vcard:Kind rdf:about="https://www.mow-contact.be/">
+                <vcard:fn>https://www.mow-contact.be/</vcard:fn>
+            </vcard:Kind>
+        </dcat:contactPoint>
+        <dcterms:language rdf:resource="http://lexvo.org/id/iso639-3/nld" />
+        <dcat:landingPage rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/bijsluiter_016.html" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_016.xml" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_016.html" />
+        <dcat:distribution rdf:resource="https://app.powerbi.com/view?r=eyJrIjoiNjgxY2MxNjMtN2EyMC00Y2IzLWJlYjQtNTQ3YTYxOTIzMmFkIiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9" />
+    </dcat:Dataset>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_016.xml">
+        <dcterms:title xml:lang="nl">aantal ton zwerfvuil langs de gewestwegen - Cijfers (XML)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_016.xml" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>XML</dcterms:format>
+        <dcterms:description xml:lang="nl">Eventuele opmerkingen bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie)
+zijn terug te vinden in de commentaar file.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_016.html">
+        <dcterms:title xml:lang="nl">aantal ton zwerfvuil langs de gewestwegen - Cijfers (Tabel)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_016.html" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>HTML</dcterms:format>
+        <dcterms:description xml:lang="nl">Kies de URL hierboven om de cijfergegevens in een tabel te zien.
+
+De cijfergegevens in de tabel kunnen in MS Excel opgeladen worden via de 'Data' - 'From Web' functie. Gebruik de
+hierboven vermelde URL in het adres veld.
+
+Eventuele opmerkingen bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie) zijn terug te vinden
+in de commentaar file.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://app.powerbi.com/view?r=eyJrIjoiNjgxY2MxNjMtN2EyMC00Y2IzLWJlYjQtNTQ3YTYxOTIzMmFkIiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9">
+        <dcterms:title xml:lang="nl">aantal ton zwerfvuil langs de gewestwegen - Rapport (PowerBI)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://app.powerbi.com/view?r=eyJrIjoiNjgxY2MxNjMtN2EyMC00Y2IzLWJlYjQtNTQ3YTYxOTIzMmFkIiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>Rapport</dcterms:format>
+        <dcterms:description xml:lang="nl">Rapport met de cijfergegevens weergeven.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Dataset rdf:about="http://mobielvlaanderen.be/store-x/man-dcat/dataset_ind077">
+        <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-04-28</dcterms:modified>
+        <dcterms:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-04-28</dcterms:issued>
+        <dcterms:title xml:lang="nl">aantal ton vervoerd op de waterwegen</dcterms:title>
+        <dcterms:description xml:lang="nl">hoeveelheid goederen vervoerd op waterwegen beheerd door De Vlaamse Waterweg uitgedrukt in ton</dcterms:description>
+        <dcterms:publisher>
+            <foaf:Agent rdf:about="http://data.vlaanderen.be/id/organisatie/OVO000096">
+                <foaf:name>Beleidsdomein Mobiliteit en Openbare Werken</foaf:name>
+                <dcterms:type>organization</dcterms:type>
+            </foaf:Agent>
+        </dcterms:publisher>
+        <dcat:contactPoint>
+            <vcard:Kind rdf:about="https://www.mow-contact.be/">
+                <vcard:fn>https://www.mow-contact.be/</vcard:fn>
+            </vcard:Kind>
+        </dcat:contactPoint>
+        <dcterms:language rdf:resource="http://lexvo.org/id/iso639-3/nld" />
+        <dcat:landingPage rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/bijsluiter_077.html" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_077.xml" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_077.html" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/commentaar_077.xml" />
+        <dcat:distribution rdf:resource="https://app.powerbi.com/view?r=eyJrIjoiZTg3ODI5MGItOGE4NC00ZjAyLThmZDItYjRiZDU1NzcyMGE5IiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9" />
+    </dcat:Dataset>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_077.xml">
+        <dcterms:title xml:lang="nl">aantal ton vervoerd op de waterwegen - Cijfers (XML)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_077.xml" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>XML</dcterms:format>
+        <dcterms:description xml:lang="nl">Eventuele opmerkingen bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie)
+zijn terug te vinden in de commentaar file.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_077.html">
+        <dcterms:title xml:lang="nl">aantal ton vervoerd op de waterwegen - Cijfers (Tabel)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_077.html" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>HTML</dcterms:format>
+        <dcterms:description xml:lang="nl">Kies de URL hierboven om de cijfergegevens in een tabel te zien.
+
+De cijfergegevens in de tabel kunnen in MS Excel opgeladen worden via de 'Data' - 'From Web' functie. Gebruik de
+hierboven vermelde URL in het adres veld.
+
+Eventuele opmerkingen bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie) zijn terug te vinden
+in de commentaar file.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/commentaar_077.xml">
+        <dcterms:title xml:lang="nl">aantal ton vervoerd op de waterwegen - Commentaar</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/commentaar_077.xml" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>XML</dcterms:format>
+        <dcterms:description xml:lang="nl">Opmerkingen horend bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie).</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://app.powerbi.com/view?r=eyJrIjoiZTg3ODI5MGItOGE4NC00ZjAyLThmZDItYjRiZDU1NzcyMGE5IiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9">
+        <dcterms:title xml:lang="nl">aantal ton vervoerd op de waterwegen - Rapport (PowerBI)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://app.powerbi.com/view?r=eyJrIjoiZTg3ODI5MGItOGE4NC00ZjAyLThmZDItYjRiZDU1NzcyMGE5IiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>Rapport</dcterms:format>
+        <dcterms:description xml:lang="nl">Rapport met de cijfergegevens weergeven.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Dataset rdf:about="http://mobielvlaanderen.be/store-x/man-dcat/dataset_ind072">
+        <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-08-26</dcterms:modified>
+        <dcterms:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-08-26</dcterms:issued>
+        <dcterms:title xml:lang="nl">aantal ton vervoerd Albertkanaal</dcterms:title>
+        <dcterms:description xml:lang="nl">hoeveelheid goederen vervoerd op het Albertkanaal uitgedrukt in ton</dcterms:description>
+        <dcterms:publisher>
+            <foaf:Agent rdf:about="http://data.vlaanderen.be/id/organisatie/OVO000096">
+                <foaf:name>Beleidsdomein Mobiliteit en Openbare Werken</foaf:name>
+                <dcterms:type>organization</dcterms:type>
+            </foaf:Agent>
+        </dcterms:publisher>
+        <dcat:contactPoint>
+            <vcard:Kind rdf:about="https://www.mow-contact.be/">
+                <vcard:fn>https://www.mow-contact.be/</vcard:fn>
+            </vcard:Kind>
+        </dcat:contactPoint>
+        <dcterms:language rdf:resource="http://lexvo.org/id/iso639-3/nld" />
+        <dcat:landingPage rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/bijsluiter_072.html" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_072.xml" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_072.html" />
+        <dcat:distribution rdf:resource="https://app.powerbi.com/view?r=eyJrIjoiNWQ5NmRmMjktN2IwZS00Mzg3LThlZjktN2FiOTdlOGIyZTk5IiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9" />
+    </dcat:Dataset>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_072.xml">
+        <dcterms:title xml:lang="nl">aantal ton vervoerd Albertkanaal - Cijfers (XML)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_072.xml" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>XML</dcterms:format>
+        <dcterms:description xml:lang="nl">Eventuele opmerkingen bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie)
+zijn terug te vinden in de commentaar file.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_072.html">
+        <dcterms:title xml:lang="nl">aantal ton vervoerd Albertkanaal - Cijfers (Tabel)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_072.html" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>HTML</dcterms:format>
+        <dcterms:description xml:lang="nl">Kies de URL hierboven om de cijfergegevens in een tabel te zien.
+
+De cijfergegevens in de tabel kunnen in MS Excel opgeladen worden via de 'Data' - 'From Web' functie. Gebruik de
+hierboven vermelde URL in het adres veld.
+
+Eventuele opmerkingen bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie) zijn terug te vinden
+in de commentaar file.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://app.powerbi.com/view?r=eyJrIjoiNWQ5NmRmMjktN2IwZS00Mzg3LThlZjktN2FiOTdlOGIyZTk5IiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9">
+        <dcterms:title xml:lang="nl">aantal ton vervoerd Albertkanaal - Rapport (PowerBI)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://app.powerbi.com/view?r=eyJrIjoiNWQ5NmRmMjktN2IwZS00Mzg3LThlZjktN2FiOTdlOGIyZTk5IiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>Rapport</dcterms:format>
+        <dcterms:description xml:lang="nl">Rapport met de cijfergegevens weergeven.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Dataset rdf:about="http://mobielvlaanderen.be/store-x/man-dcat/dataset_ind068">
+        <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-08-26</dcterms:modified>
+        <dcterms:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-08-26</dcterms:issued>
+        <dcterms:title xml:lang="nl">verdeling van verplaatsingen volgens verplaatsingsmotief</dcterms:title>
+        <dcterms:description xml:lang="nl">percentage van het gemiddeld aantal verplaatsingen per persoon, per dag dat wordt gemaakt voor het betreffende verplaatsingsmotief</dcterms:description>
+        <dcterms:publisher>
+            <foaf:Agent rdf:about="http://data.vlaanderen.be/id/organisatie/OVO000096">
+                <foaf:name>Beleidsdomein Mobiliteit en Openbare Werken</foaf:name>
+                <dcterms:type>organization</dcterms:type>
+            </foaf:Agent>
+        </dcterms:publisher>
+        <dcat:contactPoint>
+            <vcard:Kind rdf:about="https://www.mow-contact.be/">
+                <vcard:fn>https://www.mow-contact.be/</vcard:fn>
+            </vcard:Kind>
+        </dcat:contactPoint>
+        <dcterms:language rdf:resource="http://lexvo.org/id/iso639-3/nld" />
+        <dcat:landingPage rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/bijsluiter_068.html" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_068.xml" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_068.html" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/commentaar_068.xml" />
+        <dcat:distribution rdf:resource="https://app.powerbi.com/view?r=eyJrIjoiMDhjZDk0NTktZDNmNy00MjExLWJjMjEtNTI1ZmEzZjAyNjhiIiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9" />
+    </dcat:Dataset>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_068.xml">
+        <dcterms:title xml:lang="nl">verdeling van verplaatsingen volgens verplaatsingsmotief - Cijfers (XML)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_068.xml" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>XML</dcterms:format>
+        <dcterms:description xml:lang="nl">Eventuele opmerkingen bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie)
+zijn terug te vinden in de commentaar file.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_068.html">
+        <dcterms:title xml:lang="nl">verdeling van verplaatsingen volgens verplaatsingsmotief - Cijfers (Tabel)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_068.html" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>HTML</dcterms:format>
+        <dcterms:description xml:lang="nl">Kies de URL hierboven om de cijfergegevens in een tabel te zien.
+
+De cijfergegevens in de tabel kunnen in MS Excel opgeladen worden via de 'Data' - 'From Web' functie. Gebruik de
+hierboven vermelde URL in het adres veld.
+
+Eventuele opmerkingen bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie) zijn terug te vinden
+in de commentaar file.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/commentaar_068.xml">
+        <dcterms:title xml:lang="nl">verdeling van verplaatsingen volgens verplaatsingsmotief - Commentaar</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/commentaar_068.xml" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>XML</dcterms:format>
+        <dcterms:description xml:lang="nl">Opmerkingen horend bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie).</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://app.powerbi.com/view?r=eyJrIjoiMDhjZDk0NTktZDNmNy00MjExLWJjMjEtNTI1ZmEzZjAyNjhiIiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9">
+        <dcterms:title xml:lang="nl">verdeling van verplaatsingen volgens verplaatsingsmotief - Rapport (PowerBI)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://app.powerbi.com/view?r=eyJrIjoiMDhjZDk0NTktZDNmNy00MjExLWJjMjEtNTI1ZmEzZjAyNjhiIiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>Rapport</dcterms:format>
+        <dcterms:description xml:lang="nl">Rapport met de cijfergegevens weergeven.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Dataset rdf:about="http://mobielvlaanderen.be/store-x/man-dcat/dataset_ind1080">
+        <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-08-26</dcterms:modified>
+        <dcterms:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-08-26</dcterms:issued>
+        <dcterms:title xml:lang="nl">aantal fietsers op vaste telposten</dcterms:title>
+        <dcterms:description xml:lang="nl">aantal fietsers geregistreerd door vaste fietstelposten</dcterms:description>
+        <dcterms:publisher>
+            <foaf:Agent rdf:about="http://data.vlaanderen.be/id/organisatie/OVO000096">
+                <foaf:name>Beleidsdomein Mobiliteit en Openbare Werken</foaf:name>
+                <dcterms:type>organization</dcterms:type>
+            </foaf:Agent>
+        </dcterms:publisher>
+        <dcat:contactPoint>
+            <vcard:Kind rdf:about="https://www.mow-contact.be/">
+                <vcard:fn>https://www.mow-contact.be/</vcard:fn>
+            </vcard:Kind>
+        </dcat:contactPoint>
+        <dcterms:language rdf:resource="http://lexvo.org/id/iso639-3/nld" />
+        <dcat:landingPage rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/bijsluiter_1080.html" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_1080.xml" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_1080.html" />
+        <dcat:distribution rdf:resource="https://app.powerbi.com/view?r=eyJrIjoiMGE5YzI3NDAtYjc5OC00ZWI2LTg5ZWItMzU4ZGU3MjkzZjBhIiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9" />
+    </dcat:Dataset>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_1080.xml">
+        <dcterms:title xml:lang="nl">aantal fietsers op vaste telposten - Cijfers (XML)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_1080.xml" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>XML</dcterms:format>
+        <dcterms:description xml:lang="nl">Eventuele opmerkingen bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie)
+zijn terug te vinden in de commentaar file.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_1080.html">
+        <dcterms:title xml:lang="nl">aantal fietsers op vaste telposten - Cijfers (Tabel)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_1080.html" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>HTML</dcterms:format>
+        <dcterms:description xml:lang="nl">Kies de URL hierboven om de cijfergegevens in een tabel te zien.
+
+De cijfergegevens in de tabel kunnen in MS Excel opgeladen worden via de 'Data' - 'From Web' functie. Gebruik de
+hierboven vermelde URL in het adres veld.
+
+Eventuele opmerkingen bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie) zijn terug te vinden
+in de commentaar file.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://app.powerbi.com/view?r=eyJrIjoiMGE5YzI3NDAtYjc5OC00ZWI2LTg5ZWItMzU4ZGU3MjkzZjBhIiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9">
+        <dcterms:title xml:lang="nl">aantal fietsers op vaste telposten - Rapport (PowerBI)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://app.powerbi.com/view?r=eyJrIjoiMGE5YzI3NDAtYjc5OC00ZWI2LTg5ZWItMzU4ZGU3MjkzZjBhIiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>Rapport</dcterms:format>
+        <dcterms:description xml:lang="nl">Rapport met de cijfergegevens weergeven.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Dataset rdf:about="http://mobielvlaanderen.be/store-x/man-dcat/dataset_ind076">
+        <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-04-28</dcterms:modified>
+        <dcterms:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-04-28</dcterms:issued>
+        <dcterms:title xml:lang="nl">aantal ton geladen op de waterwegen</dcterms:title>
+        <dcterms:description xml:lang="nl">hoeveelheid goederen geladen langs waterwegen beheerd door De Vlaamse Waterweg uitgedrukt in ton</dcterms:description>
+        <dcterms:publisher>
+            <foaf:Agent rdf:about="http://data.vlaanderen.be/id/organisatie/OVO000096">
+                <foaf:name>Beleidsdomein Mobiliteit en Openbare Werken</foaf:name>
+                <dcterms:type>organization</dcterms:type>
+            </foaf:Agent>
+        </dcterms:publisher>
+        <dcat:contactPoint>
+            <vcard:Kind rdf:about="https://www.mow-contact.be/">
+                <vcard:fn>https://www.mow-contact.be/</vcard:fn>
+            </vcard:Kind>
+        </dcat:contactPoint>
+        <dcterms:language rdf:resource="http://lexvo.org/id/iso639-3/nld" />
+        <dcat:landingPage rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/bijsluiter_076.html" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_076.xml" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_076.html" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/commentaar_076.xml" />
+        <dcat:distribution rdf:resource="https://app.powerbi.com/view?r=eyJrIjoiNzliZTc0YTYtOWI1Zi00NTI0LWI0NDktNWIyNGQ1MGQwYjE2IiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9" />
+    </dcat:Dataset>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_076.xml">
+        <dcterms:title xml:lang="nl">aantal ton geladen op de waterwegen - Cijfers (XML)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_076.xml" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>XML</dcterms:format>
+        <dcterms:description xml:lang="nl">Eventuele opmerkingen bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie)
+zijn terug te vinden in de commentaar file.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_076.html">
+        <dcterms:title xml:lang="nl">aantal ton geladen op de waterwegen - Cijfers (Tabel)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_076.html" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>HTML</dcterms:format>
+        <dcterms:description xml:lang="nl">Kies de URL hierboven om de cijfergegevens in een tabel te zien.
+
+De cijfergegevens in de tabel kunnen in MS Excel opgeladen worden via de 'Data' - 'From Web' functie. Gebruik de
+hierboven vermelde URL in het adres veld.
+
+Eventuele opmerkingen bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie) zijn terug te vinden
+in de commentaar file.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/commentaar_076.xml">
+        <dcterms:title xml:lang="nl">aantal ton geladen op de waterwegen - Commentaar</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/commentaar_076.xml" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>XML</dcterms:format>
+        <dcterms:description xml:lang="nl">Opmerkingen horend bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie).</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://app.powerbi.com/view?r=eyJrIjoiNzliZTc0YTYtOWI1Zi00NTI0LWI0NDktNWIyNGQ1MGQwYjE2IiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9">
+        <dcterms:title xml:lang="nl">aantal ton geladen op de waterwegen - Rapport (PowerBI)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://app.powerbi.com/view?r=eyJrIjoiNzliZTc0YTYtOWI1Zi00NTI0LWI0NDktNWIyNGQ1MGQwYjE2IiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>Rapport</dcterms:format>
+        <dcterms:description xml:lang="nl">Rapport met de cijfergegevens weergeven.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Dataset rdf:about="http://mobielvlaanderen.be/store-x/man-dcat/dataset_ind003">
+        <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-08-26</dcterms:modified>
+        <dcterms:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-08-26</dcterms:issued>
+        <dcterms:title xml:lang="nl">filezwaarte op het hoofdwegennet - 2007 tot 2014 - oude berekeningswijze</dcterms:title>
+        <dcterms:description xml:lang="nl">product van filelengte en fileduur, cumulatief over de beschouwde periode, cumulatief over wegvakken van het hoofdwegennet</dcterms:description>
+        <dcterms:publisher>
+            <foaf:Agent rdf:about="http://data.vlaanderen.be/id/organisatie/OVO000096">
+                <foaf:name>Beleidsdomein Mobiliteit en Openbare Werken</foaf:name>
+                <dcterms:type>organization</dcterms:type>
+            </foaf:Agent>
+        </dcterms:publisher>
+        <dcat:contactPoint>
+            <vcard:Kind rdf:about="https://www.mow-contact.be/">
+                <vcard:fn>https://www.mow-contact.be/</vcard:fn>
+            </vcard:Kind>
+        </dcat:contactPoint>
+        <dcterms:language rdf:resource="http://lexvo.org/id/iso639-3/nld" />
+        <dcat:landingPage rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/bijsluiter_003.html" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_003.xml" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_003.html" />
+        <dcat:distribution rdf:resource="https://app.powerbi.com/view?r=eyJrIjoiNjEwNzVkNGUtOGUzNS00ODZjLWI5ZjgtN2UwMDc1NzZkNjUxIiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9" />
+    </dcat:Dataset>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_003.xml">
+        <dcterms:title xml:lang="nl">filezwaarte op het hoofdwegennet - 2007 tot 2014 - oude berekeningswijze - Cijfers (XML)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_003.xml" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>XML</dcterms:format>
+        <dcterms:description xml:lang="nl">Eventuele opmerkingen bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie)
+zijn terug te vinden in de commentaar file.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_003.html">
+        <dcterms:title xml:lang="nl">filezwaarte op het hoofdwegennet - 2007 tot 2014 - oude berekeningswijze - Cijfers (Tabel)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_003.html" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>HTML</dcterms:format>
+        <dcterms:description xml:lang="nl">Kies de URL hierboven om de cijfergegevens in een tabel te zien.
+
+De cijfergegevens in de tabel kunnen in MS Excel opgeladen worden via de 'Data' - 'From Web' functie. Gebruik de
+hierboven vermelde URL in het adres veld.
+
+Eventuele opmerkingen bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie) zijn terug te vinden
+in de commentaar file.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://app.powerbi.com/view?r=eyJrIjoiNjEwNzVkNGUtOGUzNS00ODZjLWI5ZjgtN2UwMDc1NzZkNjUxIiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9">
+        <dcterms:title xml:lang="nl">filezwaarte op het hoofdwegennet - 2007 tot 2014 - oude berekeningswijze - Rapport (PowerBI)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://app.powerbi.com/view?r=eyJrIjoiNjEwNzVkNGUtOGUzNS00ODZjLWI5ZjgtN2UwMDc1NzZkNjUxIiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>Rapport</dcterms:format>
+        <dcterms:description xml:lang="nl">Rapport met de cijfergegevens weergeven.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Dataset rdf:about="http://mobielvlaanderen.be/store-x/man-dcat/dataset_ind065">
+        <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-08-26</dcterms:modified>
+        <dcterms:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-08-26</dcterms:issued>
+        <dcterms:title xml:lang="nl">verdeling van verplaatsingen volgens hoofdvervoerswijze en afstandsklasse</dcterms:title>
+        <dcterms:description xml:lang="nl">percentage van het gemiddeld aantal verplaatsingen per persoon, per dag dat valt binnen de betreffende afstandsklasse en waarvoor gebruik gemaakt wordt van de betreffende vervoerswijze als hoofdvervoerswijze (d.w.z. voor het grootste deel van de af te leggen afstand)</dcterms:description>
+        <dcterms:publisher>
+            <foaf:Agent rdf:about="http://data.vlaanderen.be/id/organisatie/OVO000096">
+                <foaf:name>Beleidsdomein Mobiliteit en Openbare Werken</foaf:name>
+                <dcterms:type>organization</dcterms:type>
+            </foaf:Agent>
+        </dcterms:publisher>
+        <dcat:contactPoint>
+            <vcard:Kind rdf:about="https://www.mow-contact.be/">
+                <vcard:fn>https://www.mow-contact.be/</vcard:fn>
+            </vcard:Kind>
+        </dcat:contactPoint>
+        <dcterms:language rdf:resource="http://lexvo.org/id/iso639-3/nld" />
+        <dcat:landingPage rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/bijsluiter_065.html" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_065.xml" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_065.html" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/commentaar_065.xml" />
+        <dcat:distribution rdf:resource="https://app.powerbi.com/view?r=eyJrIjoiOGRlYTcyOTgtYTliNC00ZDgzLThmNzEtNjM4MTY1OTZmYzFkIiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9" />
+    </dcat:Dataset>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_065.xml">
+        <dcterms:title xml:lang="nl">verdeling van verplaatsingen volgens hoofdvervoerswijze en afstandsklasse - Cijfers (XML)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_065.xml" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>XML</dcterms:format>
+        <dcterms:description xml:lang="nl">Eventuele opmerkingen bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie)
+zijn terug te vinden in de commentaar file.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_065.html">
+        <dcterms:title xml:lang="nl">verdeling van verplaatsingen volgens hoofdvervoerswijze en afstandsklasse - Cijfers (Tabel)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_065.html" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>HTML</dcterms:format>
+        <dcterms:description xml:lang="nl">Kies de URL hierboven om de cijfergegevens in een tabel te zien.
+
+De cijfergegevens in de tabel kunnen in MS Excel opgeladen worden via de 'Data' - 'From Web' functie. Gebruik de
+hierboven vermelde URL in het adres veld.
+
+Eventuele opmerkingen bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie) zijn terug te vinden
+in de commentaar file.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/commentaar_065.xml">
+        <dcterms:title xml:lang="nl">verdeling van verplaatsingen volgens hoofdvervoerswijze en afstandsklasse - Commentaar</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/commentaar_065.xml" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>XML</dcterms:format>
+        <dcterms:description xml:lang="nl">Opmerkingen horend bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie).</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://app.powerbi.com/view?r=eyJrIjoiOGRlYTcyOTgtYTliNC00ZDgzLThmNzEtNjM4MTY1OTZmYzFkIiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9">
+        <dcterms:title xml:lang="nl">verdeling van verplaatsingen volgens hoofdvervoerswijze en afstandsklasse - Rapport (PowerBI)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://app.powerbi.com/view?r=eyJrIjoiOGRlYTcyOTgtYTliNC00ZDgzLThmNzEtNjM4MTY1OTZmYzFkIiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>Rapport</dcterms:format>
+        <dcterms:description xml:lang="nl">Rapport met de cijfergegevens weergeven.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Dataset rdf:about="http://mobielvlaanderen.be/store-x/man-dcat/dataset_ind1245">
+        <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-05-06</dcterms:modified>
+        <dcterms:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-05-06</dcterms:issued>
+        <dcterms:title xml:lang="nl">verdeling van woon-schoolverplaatsingen volgens hoofdvervoerswijze (scholieren en studenten) </dcterms:title>
+        <dcterms:description xml:lang="nl">percentage van de woon-schoolverplaatsingen door scholieren en studenten waarvoor gebruik wordt gemaakt van de betreffende vervoerswijze als hoofdvervoerswijze (d.w.z. voor het grootste deel van de af te leggen afstand)</dcterms:description>
+        <dcterms:publisher>
+            <foaf:Agent rdf:about="http://data.vlaanderen.be/id/organisatie/OVO000096">
+                <foaf:name>Beleidsdomein Mobiliteit en Openbare Werken</foaf:name>
+                <dcterms:type>organization</dcterms:type>
+            </foaf:Agent>
+        </dcterms:publisher>
+        <dcat:contactPoint>
+            <vcard:Kind rdf:about="https://www.mow-contact.be/">
+                <vcard:fn>https://www.mow-contact.be/</vcard:fn>
+            </vcard:Kind>
+        </dcat:contactPoint>
+        <dcterms:language rdf:resource="http://lexvo.org/id/iso639-3/nld" />
+        <dcat:landingPage rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/bijsluiter_1245.html" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_1245.xml" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_1245.html" />
+        <dcat:distribution rdf:resource="https://app.powerbi.com/view?r=eyJrIjoiMGRlYjEwY2ItNWU1OS00MTAzLTliZTQtNWZkYTBiYzMxMDc0IiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9" />
+    </dcat:Dataset>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_1245.xml">
+        <dcterms:title xml:lang="nl">verdeling van woon-schoolverplaatsingen volgens hoofdvervoerswijze (scholieren en studenten)  - Cijfers (XML)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_1245.xml" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>XML</dcterms:format>
+        <dcterms:description xml:lang="nl">Eventuele opmerkingen bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie)
+zijn terug te vinden in de commentaar file.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_1245.html">
+        <dcterms:title xml:lang="nl">verdeling van woon-schoolverplaatsingen volgens hoofdvervoerswijze (scholieren en studenten)  - Cijfers (Tabel)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_1245.html" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>HTML</dcterms:format>
+        <dcterms:description xml:lang="nl">Kies de URL hierboven om de cijfergegevens in een tabel te zien.
+
+De cijfergegevens in de tabel kunnen in MS Excel opgeladen worden via de 'Data' - 'From Web' functie. Gebruik de
+hierboven vermelde URL in het adres veld.
+
+Eventuele opmerkingen bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie) zijn terug te vinden
+in de commentaar file.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://app.powerbi.com/view?r=eyJrIjoiMGRlYjEwY2ItNWU1OS00MTAzLTliZTQtNWZkYTBiYzMxMDc0IiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9">
+        <dcterms:title xml:lang="nl">verdeling van woon-schoolverplaatsingen volgens hoofdvervoerswijze (scholieren en studenten)  - Rapport (PowerBI)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://app.powerbi.com/view?r=eyJrIjoiMGRlYjEwY2ItNWU1OS00MTAzLTliZTQtNWZkYTBiYzMxMDc0IiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>Rapport</dcterms:format>
+        <dcterms:description xml:lang="nl">Rapport met de cijfergegevens weergeven.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Dataset rdf:about="http://mobielvlaanderen.be/store-x/man-dcat/dataset_ind011">
+        <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-08-26</dcterms:modified>
+        <dcterms:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-08-26</dcterms:issued>
+        <dcterms:title xml:lang="nl">voertuigenpark (De Lijn)</dcterms:title>
+        <dcterms:description xml:lang="nl">wordt bijgehouden in de loop van het jaar door voertuigen uit dienst te verwijderen en nieuwe voertuigen in dienst te zetten</dcterms:description>
+        <dcterms:publisher>
+            <foaf:Agent rdf:about="http://data.vlaanderen.be/id/organisatie/OVO000096">
+                <foaf:name>Beleidsdomein Mobiliteit en Openbare Werken</foaf:name>
+                <dcterms:type>organization</dcterms:type>
+            </foaf:Agent>
+        </dcterms:publisher>
+        <dcat:contactPoint>
+            <vcard:Kind rdf:about="https://www.mow-contact.be/">
+                <vcard:fn>https://www.mow-contact.be/</vcard:fn>
+            </vcard:Kind>
+        </dcat:contactPoint>
+        <dcterms:language rdf:resource="http://lexvo.org/id/iso639-3/nld" />
+        <dcat:landingPage rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/bijsluiter_011.html" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_011.xml" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_011.html" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/commentaar_011.xml" />
+        <dcat:distribution rdf:resource="https://app.powerbi.com/view?r=eyJrIjoiZDg1NGNhNGUtNjI4Ny00NDVhLWJlNDktOTg0YWQ3NTRhM2FmIiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9" />
+    </dcat:Dataset>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_011.xml">
+        <dcterms:title xml:lang="nl">voertuigenpark (De Lijn) - Cijfers (XML)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_011.xml" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>XML</dcterms:format>
+        <dcterms:description xml:lang="nl">Eventuele opmerkingen bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie)
+zijn terug te vinden in de commentaar file.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_011.html">
+        <dcterms:title xml:lang="nl">voertuigenpark (De Lijn) - Cijfers (Tabel)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_011.html" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>HTML</dcterms:format>
+        <dcterms:description xml:lang="nl">Kies de URL hierboven om de cijfergegevens in een tabel te zien.
+
+De cijfergegevens in de tabel kunnen in MS Excel opgeladen worden via de 'Data' - 'From Web' functie. Gebruik de
+hierboven vermelde URL in het adres veld.
+
+Eventuele opmerkingen bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie) zijn terug te vinden
+in de commentaar file.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/commentaar_011.xml">
+        <dcterms:title xml:lang="nl">voertuigenpark (De Lijn) - Commentaar</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/commentaar_011.xml" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>XML</dcterms:format>
+        <dcterms:description xml:lang="nl">Opmerkingen horend bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie).</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://app.powerbi.com/view?r=eyJrIjoiZDg1NGNhNGUtNjI4Ny00NDVhLWJlNDktOTg0YWQ3NTRhM2FmIiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9">
+        <dcterms:title xml:lang="nl">voertuigenpark (De Lijn) - Rapport (PowerBI)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://app.powerbi.com/view?r=eyJrIjoiZDg1NGNhNGUtNjI4Ny00NDVhLWJlNDktOTg0YWQ3NTRhM2FmIiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>Rapport</dcterms:format>
+        <dcterms:description xml:lang="nl">Rapport met de cijfergegevens weergeven.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Dataset rdf:about="http://mobielvlaanderen.be/store-x/man-dcat/dataset_ind012">
+        <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-08-26</dcterms:modified>
+        <dcterms:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-08-26</dcterms:issued>
+        <dcterms:title xml:lang="nl">aantal reizigers per type vervoersbewijs (De Lijn)</dcterms:title>
+        <dcterms:description xml:lang="nl">aantal reizigers per type vervoersbewijs </dcterms:description>
+        <dcterms:publisher>
+            <foaf:Agent rdf:about="http://data.vlaanderen.be/id/organisatie/OVO000096">
+                <foaf:name>Beleidsdomein Mobiliteit en Openbare Werken</foaf:name>
+                <dcterms:type>organization</dcterms:type>
+            </foaf:Agent>
+        </dcterms:publisher>
+        <dcat:contactPoint>
+            <vcard:Kind rdf:about="https://www.mow-contact.be/">
+                <vcard:fn>https://www.mow-contact.be/</vcard:fn>
+            </vcard:Kind>
+        </dcat:contactPoint>
+        <dcterms:language rdf:resource="http://lexvo.org/id/iso639-3/nld" />
+        <dcat:landingPage rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/bijsluiter_012.html" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_012.xml" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_012.html" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/commentaar_012.xml" />
+        <dcat:distribution rdf:resource="https://app.powerbi.com/view?r=eyJrIjoiMjNjZjViNGUtYjc5OS00ZDhkLTlhOWUtZWZmNWZhMzY0MjI4IiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9" />
+    </dcat:Dataset>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_012.xml">
+        <dcterms:title xml:lang="nl">aantal reizigers per type vervoersbewijs (De Lijn) - Cijfers (XML)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_012.xml" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>XML</dcterms:format>
+        <dcterms:description xml:lang="nl">Eventuele opmerkingen bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie)
+zijn terug te vinden in de commentaar file.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_012.html">
+        <dcterms:title xml:lang="nl">aantal reizigers per type vervoersbewijs (De Lijn) - Cijfers (Tabel)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_012.html" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>HTML</dcterms:format>
+        <dcterms:description xml:lang="nl">Kies de URL hierboven om de cijfergegevens in een tabel te zien.
+
+De cijfergegevens in de tabel kunnen in MS Excel opgeladen worden via de 'Data' - 'From Web' functie. Gebruik de
+hierboven vermelde URL in het adres veld.
+
+Eventuele opmerkingen bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie) zijn terug te vinden
+in de commentaar file.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/commentaar_012.xml">
+        <dcterms:title xml:lang="nl">aantal reizigers per type vervoersbewijs (De Lijn) - Commentaar</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/commentaar_012.xml" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>XML</dcterms:format>
+        <dcterms:description xml:lang="nl">Opmerkingen horend bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie).</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://app.powerbi.com/view?r=eyJrIjoiMjNjZjViNGUtYjc5OS00ZDhkLTlhOWUtZWZmNWZhMzY0MjI4IiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9">
+        <dcterms:title xml:lang="nl">aantal reizigers per type vervoersbewijs (De Lijn) - Rapport (PowerBI)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://app.powerbi.com/view?r=eyJrIjoiMjNjZjViNGUtYjc5OS00ZDhkLTlhOWUtZWZmNWZhMzY0MjI4IiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>Rapport</dcterms:format>
+        <dcterms:description xml:lang="nl">Rapport met de cijfergegevens weergeven.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Dataset rdf:about="http://mobielvlaanderen.be/store-x/man-dcat/dataset_ind1247">
+        <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-12-23</dcterms:modified>
+        <dcterms:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-12-23</dcterms:issued>
+        <dcterms:title xml:lang="nl">kilometers per persoon per dag voor verplaatsingen met de fiets als hoofdvervoerswijze</dcterms:title>
+        <dcterms:description xml:lang="nl">gemiddeld aantal afgelegde kilometers per persoon per dag voor verplaatsingen waarvoor gebruik wordt gemaakt van de fiets of elektrische fiets als hoofdvervoerswijze</dcterms:description>
+        <dcterms:publisher>
+            <foaf:Agent rdf:about="http://data.vlaanderen.be/id/organisatie/OVO000096">
+                <foaf:name>Beleidsdomein Mobiliteit en Openbare Werken</foaf:name>
+                <dcterms:type>organization</dcterms:type>
+            </foaf:Agent>
+        </dcterms:publisher>
+        <dcat:contactPoint>
+            <vcard:Kind rdf:about="https://www.mow-contact.be/">
+                <vcard:fn>https://www.mow-contact.be/</vcard:fn>
+            </vcard:Kind>
+        </dcat:contactPoint>
+        <dcterms:language rdf:resource="http://lexvo.org/id/iso639-3/nld" />
+        <dcat:landingPage rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/bijsluiter_1247.html" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_1247.xml" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_1247.html" />
+        <dcat:distribution rdf:resource="https://app.powerbi.com/view?r=eyJrIjoiMGY3NmMwMTktZjFkNy00NGRmLWI1ZjYtZGQ4MTNmZDVkMDMzIiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9" />
+    </dcat:Dataset>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_1247.xml">
+        <dcterms:title xml:lang="nl">kilometers per persoon per dag voor verplaatsingen met de fiets als hoofdvervoerswijze - Cijfers (XML)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_1247.xml" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>XML</dcterms:format>
+        <dcterms:description xml:lang="nl">Eventuele opmerkingen bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie)
+zijn terug te vinden in de commentaar file.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_1247.html">
+        <dcterms:title xml:lang="nl">kilometers per persoon per dag voor verplaatsingen met de fiets als hoofdvervoerswijze - Cijfers (Tabel)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_1247.html" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>HTML</dcterms:format>
+        <dcterms:description xml:lang="nl">Kies de URL hierboven om de cijfergegevens in een tabel te zien.
+
+De cijfergegevens in de tabel kunnen in MS Excel opgeladen worden via de 'Data' - 'From Web' functie. Gebruik de
+hierboven vermelde URL in het adres veld.
+
+Eventuele opmerkingen bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie) zijn terug te vinden
+in de commentaar file.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://app.powerbi.com/view?r=eyJrIjoiMGY3NmMwMTktZjFkNy00NGRmLWI1ZjYtZGQ4MTNmZDVkMDMzIiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9">
+        <dcterms:title xml:lang="nl">kilometers per persoon per dag voor verplaatsingen met de fiets als hoofdvervoerswijze - Rapport (PowerBI)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://app.powerbi.com/view?r=eyJrIjoiMGY3NmMwMTktZjFkNy00NGRmLWI1ZjYtZGQ4MTNmZDVkMDMzIiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>Rapport</dcterms:format>
+        <dcterms:description xml:lang="nl">Rapport met de cijfergegevens weergeven.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Dataset rdf:about="http://mobielvlaanderen.be/store-x/man-dcat/dataset_ind1246">
+        <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-01-13</dcterms:modified>
+        <dcterms:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-01-13</dcterms:issued>
+        <dcterms:title xml:lang="nl">fietsbezit per gezin</dcterms:title>
+        <dcterms:description xml:lang="nl">Percentage gezinnen die x aantal fietsen bezitten, afzonderlijk voor gewone en voor elektrische fietsen. Waarbij x varieert van 0 tot 9.</dcterms:description>
+        <dcterms:publisher>
+            <foaf:Agent rdf:about="http://data.vlaanderen.be/id/organisatie/OVO000096">
+                <foaf:name>Beleidsdomein Mobiliteit en Openbare Werken</foaf:name>
+                <dcterms:type>organization</dcterms:type>
+            </foaf:Agent>
+        </dcterms:publisher>
+        <dcat:contactPoint>
+            <vcard:Kind rdf:about="https://www.mow-contact.be/">
+                <vcard:fn>https://www.mow-contact.be/</vcard:fn>
+            </vcard:Kind>
+        </dcat:contactPoint>
+        <dcterms:language rdf:resource="http://lexvo.org/id/iso639-3/nld" />
+        <dcat:landingPage rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/bijsluiter_1246.html" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_1246.xml" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_1246.html" />
+        <dcat:distribution rdf:resource="https://app.powerbi.com/view?r=eyJrIjoiMjA1OWM1MmMtNDgwNS00OTQxLThhOGYtZjRkYmM1MGJmOTg4IiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9" />
+    </dcat:Dataset>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_1246.xml">
+        <dcterms:title xml:lang="nl">fietsbezit per gezin - Cijfers (XML)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_1246.xml" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>XML</dcterms:format>
+        <dcterms:description xml:lang="nl">Eventuele opmerkingen bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie)
+zijn terug te vinden in de commentaar file.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_1246.html">
+        <dcterms:title xml:lang="nl">fietsbezit per gezin - Cijfers (Tabel)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_1246.html" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>HTML</dcterms:format>
+        <dcterms:description xml:lang="nl">Kies de URL hierboven om de cijfergegevens in een tabel te zien.
+
+De cijfergegevens in de tabel kunnen in MS Excel opgeladen worden via de 'Data' - 'From Web' functie. Gebruik de
+hierboven vermelde URL in het adres veld.
+
+Eventuele opmerkingen bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie) zijn terug te vinden
+in de commentaar file.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://app.powerbi.com/view?r=eyJrIjoiMjA1OWM1MmMtNDgwNS00OTQxLThhOGYtZjRkYmM1MGJmOTg4IiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9">
+        <dcterms:title xml:lang="nl">fietsbezit per gezin - Rapport (PowerBI)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://app.powerbi.com/view?r=eyJrIjoiMjA1OWM1MmMtNDgwNS00OTQxLThhOGYtZjRkYmM1MGJmOTg4IiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>Rapport</dcterms:format>
+        <dcterms:description xml:lang="nl">Rapport met de cijfergegevens weergeven.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Dataset rdf:about="http://mobielvlaanderen.be/store-x/man-dcat/dataset_ind1120">
+        <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-03-26</dcterms:modified>
+        <dcterms:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2021-03-26</dcterms:issued>
+        <dcterms:title xml:lang="nl">aantal voertuigkilometers per voertuigtype en wegennetwerk</dcterms:title>
+        <dcterms:description xml:lang="nl">jaarlijks aantal voertuigkilometers op snelwegen, andere gewestwegen en gemeentewegen per voertuigtype</dcterms:description>
+        <dcterms:publisher>
+            <foaf:Agent rdf:about="http://data.vlaanderen.be/id/organisatie/OVO000096">
+                <foaf:name>Beleidsdomein Mobiliteit en Openbare Werken</foaf:name>
+                <dcterms:type>organization</dcterms:type>
+            </foaf:Agent>
+        </dcterms:publisher>
+        <dcat:contactPoint>
+            <vcard:Kind rdf:about="https://www.mow-contact.be/">
+                <vcard:fn>https://www.mow-contact.be/</vcard:fn>
+            </vcard:Kind>
+        </dcat:contactPoint>
+        <dcterms:language rdf:resource="http://lexvo.org/id/iso639-3/nld" />
+        <dcat:landingPage rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/bijsluiter_1120.html" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_1120.xml" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_1120.html" />
+        <dcat:distribution rdf:resource="https://app.powerbi.com/view?r=eyJrIjoiMDAzNjczNTYtZmFiNy00ZGI0LThkMTYtNzI3NjM1YmJjMzgwIiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9" />
+    </dcat:Dataset>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_1120.xml">
+        <dcterms:title xml:lang="nl">aantal voertuigkilometers per voertuigtype en wegennetwerk - Cijfers (XML)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_1120.xml" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>XML</dcterms:format>
+        <dcterms:description xml:lang="nl">Eventuele opmerkingen bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie)
+zijn terug te vinden in de commentaar file.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_1120.html">
+        <dcterms:title xml:lang="nl">aantal voertuigkilometers per voertuigtype en wegennetwerk - Cijfers (Tabel)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_1120.html" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>HTML</dcterms:format>
+        <dcterms:description xml:lang="nl">Kies de URL hierboven om de cijfergegevens in een tabel te zien.
+
+De cijfergegevens in de tabel kunnen in MS Excel opgeladen worden via de 'Data' - 'From Web' functie. Gebruik de
+hierboven vermelde URL in het adres veld.
+
+Eventuele opmerkingen bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie) zijn terug te vinden
+in de commentaar file.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://app.powerbi.com/view?r=eyJrIjoiMDAzNjczNTYtZmFiNy00ZGI0LThkMTYtNzI3NjM1YmJjMzgwIiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9">
+        <dcterms:title xml:lang="nl">aantal voertuigkilometers per voertuigtype en wegennetwerk - Rapport (PowerBI)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://app.powerbi.com/view?r=eyJrIjoiMDAzNjczNTYtZmFiNy00ZGI0LThkMTYtNzI3NjM1YmJjMzgwIiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>Rapport</dcterms:format>
+        <dcterms:description xml:lang="nl">Rapport met de cijfergegevens weergeven.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Dataset rdf:about="http://mobielvlaanderen.be/store-x/man-dcat/dataset_ind073">
+        <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-09-22</dcterms:modified>
+        <dcterms:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2022-09-22</dcterms:issued>
+        <dcterms:title xml:lang="nl">aantal tonkilometer op de waterwegen</dcterms:title>
+        <dcterms:description xml:lang="nl">hoeveelheid goederen vervoerd op waterwegen beheerd door De Vlaamse Waterweg uitgedrukt in tonkilometer</dcterms:description>
+        <dcterms:publisher>
+            <foaf:Agent rdf:about="http://data.vlaanderen.be/id/organisatie/OVO000096">
+                <foaf:name>Beleidsdomein Mobiliteit en Openbare Werken</foaf:name>
+                <dcterms:type>organization</dcterms:type>
+            </foaf:Agent>
+        </dcterms:publisher>
+        <dcat:contactPoint>
+            <vcard:Kind rdf:about="https://www.mow-contact.be/">
+                <vcard:fn>https://www.mow-contact.be/</vcard:fn>
+            </vcard:Kind>
+        </dcat:contactPoint>
+        <dcterms:language rdf:resource="http://lexvo.org/id/iso639-3/nld" />
+        <dcat:landingPage rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/bijsluiter_073.html" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_073.xml" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_073.html" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/commentaar_073.xml" />
+        <dcat:distribution rdf:resource="https://app.powerbi.com/view?r=eyJrIjoiNmJiZjA0MmEtZDEwNi00NzgxLTg0ZGUtOWNjZGY5YjRlZjZjIiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9" />
+    </dcat:Dataset>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_073.xml">
+        <dcterms:title xml:lang="nl">aantal tonkilometer op de waterwegen - Cijfers (XML)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_073.xml" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>XML</dcterms:format>
+        <dcterms:description xml:lang="nl">Eventuele opmerkingen bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie)
+zijn terug te vinden in de commentaar file.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_073.html">
+        <dcterms:title xml:lang="nl">aantal tonkilometer op de waterwegen - Cijfers (Tabel)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_073.html" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>HTML</dcterms:format>
+        <dcterms:description xml:lang="nl">Kies de URL hierboven om de cijfergegevens in een tabel te zien.
+
+De cijfergegevens in de tabel kunnen in MS Excel opgeladen worden via de 'Data' - 'From Web' functie. Gebruik de
+hierboven vermelde URL in het adres veld.
+
+Eventuele opmerkingen bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie) zijn terug te vinden
+in de commentaar file.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/commentaar_073.xml">
+        <dcterms:title xml:lang="nl">aantal tonkilometer op de waterwegen - Commentaar</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/commentaar_073.xml" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>XML</dcterms:format>
+        <dcterms:description xml:lang="nl">Opmerkingen horend bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie).</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://app.powerbi.com/view?r=eyJrIjoiNmJiZjA0MmEtZDEwNi00NzgxLTg0ZGUtOWNjZGY5YjRlZjZjIiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9">
+        <dcterms:title xml:lang="nl">aantal tonkilometer op de waterwegen - Rapport (PowerBI)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://app.powerbi.com/view?r=eyJrIjoiNmJiZjA0MmEtZDEwNi00NzgxLTg0ZGUtOWNjZGY5YjRlZjZjIiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>Rapport</dcterms:format>
+        <dcterms:description xml:lang="nl">Rapport met de cijfergegevens weergeven.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Dataset rdf:about="http://mobielvlaanderen.be/store-x/man-dcat/dataset_ind1100">
+        <dcterms:modified rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-08-26</dcterms:modified>
+        <dcterms:issued rdf:datatype="http://www.w3.org/2001/XMLSchema#date">2019-08-26</dcterms:issued>
+        <dcterms:title xml:lang="nl">filezwaarte - nieuwe berekeningswijze</dcterms:title>
+        <dcterms:description xml:lang="nl">product van filelengte en fileduur, cumulatief over de beschouwde periode, cumulatief over wegvakken van het hoofdwegennet</dcterms:description>
+        <dcterms:publisher>
+            <foaf:Agent rdf:about="http://data.vlaanderen.be/id/organisatie/OVO000096">
+                <foaf:name>Beleidsdomein Mobiliteit en Openbare Werken</foaf:name>
+                <dcterms:type>organization</dcterms:type>
+            </foaf:Agent>
+        </dcterms:publisher>
+        <dcat:contactPoint>
+            <vcard:Kind rdf:about="https://www.mow-contact.be/">
+                <vcard:fn>https://www.mow-contact.be/</vcard:fn>
+            </vcard:Kind>
+        </dcat:contactPoint>
+        <dcterms:language rdf:resource="http://lexvo.org/id/iso639-3/nld" />
+        <dcat:landingPage rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/bijsluiter_1100.html" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_1100.xml" />
+        <dcat:distribution rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_1100.html" />
+        <dcat:distribution rdf:resource="https://app.powerbi.com/view?r=eyJrIjoiMWYwNDdiZDYtNjEwYi00YWM1LWIzYzgtZDcyZWQ0MWE1ZWE0IiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9" />
+    </dcat:Dataset>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_1100.xml">
+        <dcterms:title xml:lang="nl">filezwaarte - nieuwe berekeningswijze - Cijfers (XML)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersxml_1100.xml" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>XML</dcterms:format>
+        <dcterms:description xml:lang="nl">Eventuele opmerkingen bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie)
+zijn terug te vinden in de commentaar file.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_1100.html">
+        <dcterms:title xml:lang="nl">filezwaarte - nieuwe berekeningswijze - Cijfers (Tabel)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://mow-dataroom.s3-eu-west-1.amazonaws.com/cijfersTable_1100.html" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>HTML</dcterms:format>
+        <dcterms:description xml:lang="nl">Kies de URL hierboven om de cijfergegevens in een tabel te zien.
+
+De cijfergegevens in de tabel kunnen in MS Excel opgeladen worden via de 'Data' - 'From Web' functie. Gebruik de
+hierboven vermelde URL in het adres veld.
+
+Eventuele opmerkingen bij de cijferrecords voor een bepaalde periode (cfr. meetfrequentie) zijn terug te vinden
+in de commentaar file.</dcterms:description>
+    </dcat:Distribution>
+    <dcat:Distribution rdf:about="https://app.powerbi.com/view?r=eyJrIjoiMWYwNDdiZDYtNjEwYi00YWM1LWIzYzgtZDcyZWQ0MWE1ZWE0IiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9">
+        <dcterms:title xml:lang="nl">filezwaarte - nieuwe berekeningswijze - Rapport (PowerBI)</dcterms:title>
+        <dcat:accessURL rdf:resource="https://app.powerbi.com/view?r=eyJrIjoiMWYwNDdiZDYtNjEwYi00YWM1LWIzYzgtZDcyZWQ0MWE1ZWE0IiwidCI6IjBjMDMzOGE2LTk1NjEtNGVlOC1iOGQ2LTRlODljYmQ1MjBhMCIsImMiOjh9" />
+        <dcterms:license rdf:resource="https://data.vlaanderen.be/doc/licentie/modellicentie-gratis-hergebruik/v1.0" />
+        <dcterms:format>Rapport</dcterms:format>
+        <dcterms:description xml:lang="nl">Rapport met de cijfergegevens weergeven.</dcterms:description>
+    </dcat:Distribution>
+</rdf:RDF>

--- a/harvesters/src/test/resources/org/fao/geonet/kernel/harvest/harvester/simpleurl/ogcapirecords-dcat-output.rdf
+++ b/harvesters/src/test/resources/org/fao/geonet/kernel/harvest/harvester/simpleurl/ogcapirecords-dcat-output.rdf
@@ -1,0 +1,116 @@
+<?xml version='1.0' encoding='UTF-8'?><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><dcat:CatalogRecord rdf:about="https://apps.titellus.net/geonetwork/api/collections/main/items/8698bf0b-fceb-4f0f-989b-111e7c4af0a4" xmlns:adms="http://www.w3.org/ns/adms#" xmlns:dcatap="http://data.europa.eu/r5r/" xmlns:owl="http://www.w3.org/2002/07/owl#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdfs="http://www.w3.org/2000/01/rdf-schema#" xmlns:vcard="http://www.w3.org/2006/vcard/ns#" xmlns:dct="http://purl.org/dc/terms/" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:ns14="http://spdx.org/rdf/terms#" xmlns:locn="http://www.w3.org/ns/locn#" xmlns:dcat="http://www.w3.org/ns/dcat#" xmlns:prov="http://www.w3.org/ns/prov#" xmlns:foaf="http://xmlns.com/foaf/0.1/" xmlns:dc="http://purl.org/dc/elements/1.1/">
+    <dct:identifier>8698bf0b-fceb-4f0f-989b-111e7c4af0a4</dct:identifier>
+    <dct:created>2022-11-19T08:23:19.058Z</dct:created>
+    <dct:modified>2022-11-19T08:23:19.058Z</dct:modified>
+    <dct:language>
+        <skos:Concept rdf:about="http://publications.europa.eu/resource/authority/language/GER">
+            <skos:prefLabel>ger</skos:prefLabel>
+            <rdf:type rdf:resource="http://purl.org/dc/terms/LinguisticSystem"/>
+        </skos:Concept>
+    </dct:language>
+    <foaf:primaryTopic>
+        <dcat:Dataset rdf:about="https://apps.titellus.net/geonetwork/api/collections/main/items/8698bf0b-fceb-4f0f-989b-111e7c4af0a4#resource">
+            <dct:title>Alpenkonvention</dct:title>
+            <dct:description>Perimeter der Alpenkonvention in der Schweiz. Die Alpenkonvention ist ein völkerrechtlicher Vertrag zwischen den acht Alpenländern Deutschland, Frankreich, Italien, Liechtenstein, Monaco, Österreich, Schweiz, Slowenien sowie der Europäischen Union. Das Ziel des Übereinkommens ist der Schutz der Alpen durch eine sektorübergreifende, ganzheitliche und nachhaltige Politik.</dct:description>
+            <dct:identifier>ch.are.alpenkonvention</dct:identifier>
+            <dct:created>1999-01-01T00:00:00Z</dct:created>
+            <dct:modified>2009-01-01T00:00:00Z</dct:modified>
+            <dct:language>
+                <skos:Concept rdf:about="http://publications.europa.eu/resource/authority/language/GER">
+                    <skos:prefLabel>ger</skos:prefLabel>
+                    <rdf:type rdf:resource="http://purl.org/dc/terms/LinguisticSystem"/>
+                </skos:Concept>
+            </dct:language>
+            <dct:language>
+                <skos:Concept rdf:about="http://publications.europa.eu/resource/authority/language/FRE">
+                    <skos:prefLabel>fre</skos:prefLabel>
+                    <rdf:type rdf:resource="http://purl.org/dc/terms/LinguisticSystem"/>
+                </skos:Concept>
+            </dct:language>
+            <dct:language>
+                <skos:Concept rdf:about="http://publications.europa.eu/resource/authority/language/ITA">
+                    <skos:prefLabel>ita</skos:prefLabel>
+                    <rdf:type rdf:resource="http://purl.org/dc/terms/LinguisticSystem"/>
+                </skos:Concept>
+            </dct:language>
+            <dcat:contactPoint>
+                <vcard:Kind>
+                    <vcard:title>Bundesamt für Raumentwicklung</vcard:title>
+                    <vcard:role>pointOfContact</vcard:role>
+                    <vcard:hasEmail>rolf.giezendanner@are.admin.ch</vcard:hasEmail>
+                </vcard:Kind>
+            </dcat:contactPoint>
+            <dcat:contactPoint>
+                <vcard:Kind>
+                    <vcard:title>Bundesamt für Raumentwicklung</vcard:title>
+                    <vcard:role>owner</vcard:role>
+                    <vcard:hasEmail>info@are.admin.ch</vcard:hasEmail>
+                </vcard:Kind>
+            </dcat:contactPoint>
+            <dcat:theme>
+                <skos:Concept>
+                    <skos:prefLabel>Umweltüberwachung</skos:prefLabel>
+                </skos:Concept>
+            </dcat:theme>
+            <dcat:theme>
+                <skos:Concept>
+                    <skos:prefLabel>Nachhaltige Entwicklung</skos:prefLabel>
+                </skos:Concept>
+            </dcat:theme>
+            <dcat:theme>
+                <skos:Concept>
+                    <skos:prefLabel>Aufbewahrungs- und Archivierungsplanung AAP - Bund</skos:prefLabel>
+                </skos:Concept>
+            </dcat:theme>
+            <dcat:theme>
+                <skos:Concept>
+                    <skos:prefLabel>Alpenkonvention</skos:prefLabel>
+                </skos:Concept>
+            </dcat:theme>
+            <dcat:theme>
+                <skos:Concept>
+                    <skos:prefLabel>AK</skos:prefLabel>
+                </skos:Concept>
+            </dcat:theme>
+            <dct:type>
+                <skos:Concept>
+                    <skos:prefLabel>Dataset</skos:prefLabel>
+                </skos:Concept>
+            </dct:type>
+            <dcat:landingPage>
+                <foaf:Document rdf:about="https://apps.titellus.net/geonetwork/api/collections/main/items/8698bf0b-fceb-4f0f-989b-111e7c4af0a4">
+                    <dct:title>Alpenkonvention</dct:title>
+                </foaf:Document>
+            </dcat:landingPage>
+            <dcat:spatialResolutionInMeters>25000</dcat:spatialResolutionInMeters>
+            <dct:spatial>
+                <dct:Location>
+                    <locn:geometry>{"coordinates":[[[6.755991,45.788744],[10.541824,45.788744],[10.541824,47.517566],[6.755991,47.517566],[6.755991,45.788744]]],"type":"Polygon"}</locn:geometry>
+                </dct:Location>
+            </dct:spatial>
+            <dcat:distribution>
+                <dcat:Distribution>
+                    <dcat:accessURL rdf:resource="https://opendata.swiss/de/perma/8698bf0b-fceb-4f0f-989b-111e7c4af0a4@bundesamt-fur-raumentwicklung-are"/>
+                    <dct:title>Permalink opendata.swiss</dct:title>
+                    <dct:description>Permalink opendata.swiss</dct:description>
+                    <adms:representationTechnique>
+                        <skos:Concept>
+                            <skos:prefLabel>OPENDATA:SWISS</skos:prefLabel>
+                        </skos:Concept>
+                    </adms:representationTechnique>
+                </dcat:Distribution>
+            </dcat:distribution>
+            <dct:accrualPeriodicity>
+                <skos:Concept rdf:about="http://publications.europa.eu/resource/authority/frequency/asNeeded">
+                    <skos:prefLabel>asNeeded</skos:prefLabel>
+                    <rdf:type rdf:resource="http://purl.org/dc/terms/Frequency"/>
+                </skos:Concept>
+            </dct:accrualPeriodicity>
+            <dct:provenance>
+                <dct:ProvenanceStatement>
+                    <rdfs:label>Digitalisiert nach den administrativen Einheiten der Schweiz, die im Anhang des Übereinkommens erscheinen.</rdfs:label>
+                </dct:ProvenanceStatement>
+            </dct:provenance>
+        </dcat:Dataset>
+    </foaf:primaryTopic>
+</dcat:CatalogRecord></rdf:RDF>

--- a/pom.xml
+++ b/pom.xml
@@ -426,6 +426,12 @@
         <artifactId>rio</artifactId>
         <version>1.0.9</version>
       </dependency>
+      <dependency>
+        <groupId>org.apache.jena</groupId>
+        <artifactId>apache-jena-libs</artifactId>
+        <type>pom</type>
+        <version>3.17.0</version>
+      </dependency>
 
       <!-- PDF stuff: Managed by Mapfish -->
       <dependency>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/DCAT/sparql-to-iso19115-3.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/DCAT/sparql-to-iso19115-3.xsl
@@ -1,0 +1,671 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:sr="http://www.w3.org/2005/sparql-results#"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:spdx="http://spdx.org/rdf/terms#"
+                xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+                xmlns:adms="http://www.w3.org/ns/adms#"
+                xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                xmlns:dct="http://purl.org/dc/terms/"
+                xmlns:dcat="http://www.w3.org/ns/dcat#"
+                xmlns:vcard="http://www.w3.org/2006/vcard/ns#"
+                xmlns:foaf="http://xmlns.com/foaf/0.1/"
+                xmlns:owl="http://www.w3.org/2002/07/owl#"
+                xmlns:schema="http://schema.org/"
+                xmlns:locn="http://www.w3.org/ns/locn#"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xmlns:mdcat="http://data.vlaanderen.be/ns/metadata-dcat#"
+                xmlns:fn="http://www.w3.org/2005/xpath-functions"
+                xmlns:util="java:org.fao.geonet.util.XslUtil"
+                xmlns:cit="http://standards.iso.org/iso/19115/-3/cit/2.0"
+                xmlns:gex="http://standards.iso.org/iso/19115/-3/gex/1.0"
+                xmlns:lan="http://standards.iso.org/iso/19115/-3/lan/1.0"
+                xmlns:mcc="http://standards.iso.org/iso/19115/-3/mcc/1.0"
+                xmlns:mco="http://standards.iso.org/iso/19115/-3/mco/1.0"
+                xmlns:mdb="http://standards.iso.org/iso/19115/-3/mdb/2.0"
+                xmlns:mmi="http://standards.iso.org/iso/19115/-3/mmi/1.0"
+                xmlns:mrd="http://standards.iso.org/iso/19115/-3/mrd/1.0"
+                xmlns:mri="http://standards.iso.org/iso/19115/-3/mri/1.0"
+                xmlns:mrl="http://standards.iso.org/iso/19115/-3/mrl/2.0"
+                xmlns:mrs="http://standards.iso.org/iso/19115/-3/mrs/1.0"
+                xmlns:mrc="http://standards.iso.org/iso/19115/-3/mrc/2.0"
+                xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0"
+                xmlns:gfc="http://standards.iso.org/iso/19110/gfc/1.1"
+                xmlns:gml="http://www.opengis.net/gml/3.2"
+                xmlns:gn-fn-sparql="http://geonetwork-opensource.org/xsl/functions/sparql"
+                version="2.0"
+                exclude-result-prefixes="#all">
+
+  <xsl:import href="../ISO19139/utility/create19115-3Namespaces.xsl"/>
+  <xsl:import href="common/functions-sparql.xsl"/>
+
+  <xsl:output method="xml" indent="yes" encoding="UTF-8"/>
+
+  <xsl:param name="uuid" as="xs:string?"/>
+
+  <xsl:variable name="root"
+                select="/sr:sparql/sr:results"/>
+
+  <xsl:template match="/">
+    <xsl:variable name="catalogURIs"
+                  select="gn-fn-sparql:getSubject($root,
+                    'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
+                    'http://www.w3.org/ns/dcat#Catalog')"/>
+
+    <xsl:variable name="recordURIs"
+                  select="gn-fn-sparql:getSubject($root,
+                    'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
+                    'http://www.w3.org/ns/dcat#CatalogRecord')"/>
+
+    <xsl:variable name="datasetURIs"
+                  select="gn-fn-sparql:getSubject($root,
+                    'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
+                    'http://www.w3.org/ns/dcat#Dataset')"/>
+
+    <xsl:variable name="serviceURIs"
+                  select="gn-fn-sparql:getSubject($root,
+                    'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
+                    'http://www.w3.org/ns/dcat#DataService')"/>
+
+    <xsl:for-each select="$recordURIs">
+
+      <!-- We expect only one CatalogRecord containing on Dataset or DataService -->
+      <xsl:variable name="resource"
+                    select="($datasetURIs|$serviceURIs)"/>
+
+      <xsl:variable name="isService"
+                    select="ends-with($resource/binding[@name = 'object']/uri, 'DataService')"
+                    as="xs:boolean"/>
+
+      <xsl:variable name="recordUri"
+                    select="sr:uri"/>
+
+
+      <mdb:MD_Metadata>
+        <xsl:call-template name="add-iso19115-3.2018-namespaces"/>
+
+
+        <xsl:variable name="uuid"
+                      select="if ($uuid != '') then $uuid
+                              else gn-fn-sparql:getObject($root,
+                                'http://purl.org/dc/terms/identifier',
+                                $recordUri)/sr:literal"/>
+
+        <mdb:metadataIdentifier>
+          <mcc:MD_Identifier>
+            <mcc:code>
+              <gco:CharacterString>
+                <xsl:value-of select="$uuid"/>
+              </gco:CharacterString>
+            </mcc:code>
+          </mcc:MD_Identifier>
+        </mdb:metadataIdentifier>
+
+        <xsl:variable name="languages"
+                      select="gn-fn-sparql:getObject($root,
+                                'http://purl.org/dc/terms/language',
+                                $recordUri)/sr:uri"/>
+        <xsl:for-each select="$languages">
+         <xsl:call-template name="build-language">
+           <xsl:with-param name="element" select="'mdb:defaultLocale'"/>
+           <xsl:with-param name="languageUri" select="."/>
+         </xsl:call-template>
+        </xsl:for-each>
+
+        <mdb:metadataScope>
+          <mdb:MD_MetadataScope>
+            <mdb:resourceScope>
+              <mcc:MD_ScopeCode codeList=""
+                                codeListValue="{if ($isService)
+                                                then 'service'
+                                                else 'dataset'}"/>
+            </mdb:resourceScope>
+          </mdb:MD_MetadataScope>
+        </mdb:metadataScope>
+
+        <mdb:contact>
+          <cit:CI_Responsibility>
+            <cit:role>
+              <cit:CI_RoleCode codeList="codeListLocation#CI_RoleCode" codeListValue="pointOfContact">pointOfContact</cit:CI_RoleCode>
+            </cit:role>
+            <cit:party>
+              <cit:CI_Organisation>
+                <cit:name>
+                  <gco:CharacterString/>
+                </cit:name>
+                <cit:contactInfo>
+                  <cit:CI_Contact>
+                    <cit:address>
+                      <cit:CI_Address>
+                        <cit:electronicMailAddress>
+                          <gco:CharacterString/>
+                        </cit:electronicMailAddress>
+                      </cit:CI_Address>
+                    </cit:address>
+                  </cit:CI_Contact>
+                </cit:contactInfo>
+                <cit:individual>
+                  <cit:CI_Individual>
+                    <cit:name>
+                      <gco:CharacterString/>
+                    </cit:name>
+                    <cit:positionName>
+                      <gco:CharacterString/>
+                    </cit:positionName>
+                  </cit:CI_Individual>
+                </cit:individual>
+              </cit:CI_Organisation>
+            </cit:party>
+          </cit:CI_Responsibility>
+        </mdb:contact>
+
+        <xsl:variable name="dateTypes" as="node()*">
+          <type dcatType="created" isoType="creation"/>
+          <type dcatType="modified" isoType="revision"/>
+          <type dcatType="issued" isoType="publication"/>
+        </xsl:variable>
+        <xsl:for-each select="$dateTypes">
+          <xsl:variable name="dates"
+                        select="gn-fn-sparql:getObject($root,
+                                                  concat('http://purl.org/dc/terms/', @dcatType),
+                                                  $recordUri)/sr:literal"/>
+          <xsl:variable name="isoType" select="@isoType"/>
+          <xsl:for-each select="$dates">
+            <xsl:call-template name="build-date">
+              <xsl:with-param name="element" select="'mdb:dateInfo'"/>
+              <xsl:with-param name="date" select="."/>
+              <xsl:with-param name="dateType" select="$isoType"/>
+            </xsl:call-template>
+          </xsl:for-each>
+        </xsl:for-each>
+
+
+
+        <mdb:metadataStandard>
+          <cit:CI_Citation>
+            <cit:title>
+              <gco:CharacterString>ISO 19115-3</gco:CharacterString>
+            </cit:title>
+          </cit:CI_Citation>
+        </mdb:metadataStandard>
+
+
+        <mdb:metadataLinkage>
+          <cit:CI_OnlineResource>
+            <cit:linkage>
+              <gco:CharacterString><xsl:value-of select="$recordUri"/></gco:CharacterString>
+            </cit:linkage>
+            <cit:function>
+              <cit:CI_OnLineFunctionCode
+                codeList="http://standards.iso.org/iso/19139/resources/codelist/gmxCodelists.xml#CI_OnLineFunctionCode"
+                codeListValue="completeMetadata"/>
+            </cit:function>
+          </cit:CI_OnlineResource>
+        </mdb:metadataLinkage>
+
+
+        <xsl:for-each select="$resource">
+          <xsl:variable name="resourceUri"
+                        select="sr:uri"/>
+
+          <mdb:identificationInfo>
+            <xsl:choose>
+              <xsl:when test="$isService"></xsl:when>
+              <xsl:otherwise>
+                <mri:MD_DataIdentification>
+                  <mri:citation>
+                    <cit:CI_Citation>
+                      <cit:title>
+                        <gco:CharacterString>
+                          <xsl:value-of select="gn-fn-sparql:getObject($root,
+                                                  'http://purl.org/dc/terms/title',
+                                                  $resourceUri)/sr:literal"/>
+                        </gco:CharacterString>
+                      </cit:title>
+
+                      <xsl:for-each select="$dateTypes">
+                        <xsl:variable name="dates"
+                                      select="gn-fn-sparql:getObject($root,
+                                                  concat('http://purl.org/dc/terms/', @dcatType),
+                                                  $resourceUri)/sr:literal"/>
+                        <xsl:variable name="isoType" select="@isoType"/>
+                        <xsl:for-each select="$dates">
+                          <xsl:call-template name="build-date">
+                            <xsl:with-param name="element" select="'cit:date'"/>
+                            <xsl:with-param name="date" select="."/>
+                            <xsl:with-param name="dateType" select="$isoType"/>
+                          </xsl:call-template>
+                        </xsl:for-each>
+                      </xsl:for-each>
+
+
+                      <xsl:variable name="identifier"
+                                    select="gn-fn-sparql:getObject($root,
+                                                  'http://purl.org/dc/terms/identifier',
+                                                  $resourceUri)/sr:literal"/>
+                      <xsl:if test="$identifier != ''">
+                        <cit:identifier>
+                          <mcc:MD_Identifier>
+                            <mcc:code>
+                              <gco:CharacterString>
+                                <xsl:value-of select="$identifier"/>
+                              </gco:CharacterString>
+                            </mcc:code>
+                          </mcc:MD_Identifier>
+                        </cit:identifier>
+                      </xsl:if>
+                    </cit:CI_Citation>
+                  </mri:citation>
+                  <mri:abstract>
+                    <gco:CharacterString>
+                      <xsl:value-of select="gn-fn-sparql:getObject($root,
+                                                  'http://purl.org/dc/terms/description',
+                                                  $resourceUri)/sr:literal"/>
+                    </gco:CharacterString>
+                  </mri:abstract>
+
+
+
+                  <xsl:for-each select="gn-fn-sparql:getObject($root,
+                                                  'http://www.w3.org/ns/dcat#contactPoint',
+                                                  $resourceUri)/sr:bnode">
+                    <xsl:call-template name="build-contact">
+                      <xsl:with-param name="contactUri" select="."/>
+                    </xsl:call-template>
+                  </xsl:for-each>
+
+
+                  <!--
+                  <dcat:spatialResolutionInMeters>25000</dcat:spatialResolutionInMeters>
+                  -->
+                  <xsl:for-each select="gn-fn-sparql:getObject($root,
+                                                  'http://www.w3.org/ns/dcat#spatialResolutionInMeters',
+                                                  $resourceUri)/sr:literal">
+                    <mri:spatialResolution>
+                      <mri:MD_Resolution>
+                        <mri:equivalentScale>
+                          <mri:MD_RepresentativeFraction>
+                            <mri:denominator>
+                              <gco:Integer><xsl:value-of select="."/></gco:Integer>
+                            </mri:denominator>
+                          </mri:MD_RepresentativeFraction>
+                        </mri:equivalentScale>
+                      </mri:MD_Resolution>
+                    </mri:spatialResolution>
+                  </xsl:for-each>
+
+                  <!--
+                  <mri:topicCategory>
+                    <mri:MD_TopicCategoryCode>inlandWaters</mri:MD_TopicCategoryCode>
+                  </mri:topicCategory>
+                  -->
+
+                  <!--
+                    <dct:spatial>
+                        <dct:Location>
+                            <locn:geometry>{"coordinates":[[[6.755991,45.788744],[10.541824,45.788744],[10.541824,47.517566],[6.755991,47.517566],[6.755991,45.788744]]],"type":"Polygon"}</locn:geometry>
+                        </dct:Location>
+                    </dct:spatial>
+                   -->
+                  <xsl:for-each select="gn-fn-sparql:getObject($root,
+                                                  'http://purl.org/dc/terms/spatial',
+                                                  $resourceUri)/sr:bnode[. != '']">
+                    <xsl:for-each select="gn-fn-sparql:getObject($root,
+                                                  'http://www.w3.org/ns/locn#geometry',
+                                                  .)/sr:literal">
+                      <xsl:variable name="coordByPipe"
+                                    select="util:geoJsonGeomToBbox(string(.))"/>
+                      <xsl:if test="$coordByPipe != ''">
+                        <xsl:variable name="coords"
+                                      select="tokenize($coordByPipe, '\|')"/>
+                        <mri:extent>
+                          <gex:EX_Extent>
+                            <gex:geographicElement>
+                              <gex:EX_GeographicBoundingBox>
+                                <gex:westBoundLongitude>
+                                  <gco:Decimal><xsl:value-of select="$coords[1]"/></gco:Decimal>
+                                </gex:westBoundLongitude>
+                                <gex:eastBoundLongitude>
+                                  <gco:Decimal><xsl:value-of select="$coords[3]"/></gco:Decimal>
+                                </gex:eastBoundLongitude>
+                                <gex:southBoundLatitude>
+                                  <gco:Decimal><xsl:value-of select="$coords[2]"/></gco:Decimal>
+                                </gex:southBoundLatitude>
+                                <gex:northBoundLatitude>
+                                  <gco:Decimal><xsl:value-of select="$coords[4]"/></gco:Decimal>
+                                </gex:northBoundLatitude>
+                              </gex:EX_GeographicBoundingBox>
+                            </gex:geographicElement>
+                          </gex:EX_Extent>
+                        </mri:extent>
+                      </xsl:if>
+                    </xsl:for-each>
+                  </xsl:for-each>
+
+                  <!--
+                  <mri:extent>
+                    <gex:EX_Extent>
+                       <gex:temporalElement>
+                          <gex:EX_TemporalExtent>
+                             <gex:extent>
+                                <gml:TimePeriod gml:id="d36068e416a1053983">
+                                   <gml:beginPosition>1992-02-01</gml:beginPosition>
+                                   <gml:endPosition>2023-01-14</gml:endPosition>
+                                </gml:TimePeriod>
+                             </gex:extent>
+                          </gex:EX_TemporalExtent>
+                       </gex:temporalElement>
+                    </gex:EX_Extent>
+                 </mri:extent>
+                  -->
+
+                  <xsl:for-each select="gn-fn-sparql:getObject($root,
+                                                  'http://purl.org/dc/terms/accrualPeriodicity',
+                                                  $resourceUri)/sr:uri">
+
+                    <xsl:variable name="euPrefix"
+                                  select="'http://publications.europa.eu/resource/authority/frequency/'"/>
+                    <xsl:variable name="frequency"
+                                  select="if(starts-with(., $euPrefix))
+                                          then substring-after(., $euPrefix)
+                                          else ."/>
+                    <mri:resourceMaintenance>
+                      <mmi:MD_MaintenanceInformation>
+                        <mmi:maintenanceAndUpdateFrequency>
+                          <mmi:MD_MaintenanceFrequencyCode codeListValue="{$frequency}"
+                                                           codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_MaintenanceFrequencyCode"/>
+                        </mmi:maintenanceAndUpdateFrequency>
+                      </mmi:MD_MaintenanceInformation>
+                    </mri:resourceMaintenance>
+                  </xsl:for-each>
+
+                  <!--
+                  <mri:graphicOverview>
+                    <mcc:MD_BrowseGraphic>
+                       <mcc:fileName>
+                          <gco:CharacterString>https://metawal.wallonie.be/geonetwork/srv/api/records/b795de68-726c-4bdf-a62a-a42686aa5b6f/attachments/picc_vdiff_1.png</gco:CharacterString>
+                       </mcc:fileName>
+                       <mcc:fileDescription>
+                          <gco:CharacterString>picc_vdiff_1</gco:CharacterString>
+                       </mcc:fileDescription>
+                       <mcc:fileType>
+                          <gco:CharacterString>png</gco:CharacterString>
+                       </mcc:fileType>
+                    </mcc:MD_BrowseGraphic>
+                  </mri:graphicOverview>
+                  -->
+
+                  <!--
+                    <dcat:theme>
+                        <skos:Concept>
+                            <skos:prefLabel>Umweltüberwachung</skos:prefLabel>
+                        </skos:Concept>
+                    </dcat:theme>
+                  -->
+                  <mri:descriptiveKeywords>
+                    <mri:MD_Keywords>
+                      <xsl:for-each select="gn-fn-sparql:getObject($root,
+                                                      ('http://www.w3.org/ns/dcat#theme'),
+                                                      $resourceUri)/sr:bnode">
+                        <xsl:variable name="label"
+                                      select="gn-fn-sparql:getObject($root,
+                                                  'http://www.w3.org/2004/02/skos/core#prefLabel',
+                                                  .)/sr:literal"/>
+                        <mri:keyword>
+                          <gco:CharacterString><xsl:value-of select="$label"/></gco:CharacterString>
+                        </mri:keyword>
+                      </xsl:for-each>
+                    </mri:MD_Keywords>
+                  </mri:descriptiveKeywords>
+
+                  <!--<mri:resourceConstraints xsi:schemaLocation="http://www.isotc211.org/2005/gmd http://schemas.opengis.net/iso/19139/20060504/gmd/gmd.xsd">
+                    <mco:MD_LegalConstraints>
+                      <mco:useConstraints>
+                        <mco:MD_RestrictionCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode"
+                                                codeListValue="otherRestrictions"/>
+                      </mco:useConstraints>
+                      <mco:otherConstraints xsi:type="gmd:PT_FreeText_PropertyType">
+                        <gco:CharacterString>• Le gestionnaire du jeu de données tel qu’il est défini plus haut possède les droits de propriété (y compris les droits de propriété intellectuelle) se rapportant aux fichiers. • Le gestionnaire accorde au client le droit d’utiliser les données pour son usage interne. • L’usage des données à des fins commerciales, sous quelque forme que ce soit, est formellement interdit. • Le nom du gestionnaire doit apparaître lors de chaque utilisation publique des données.</gco:CharacterString>
+                      </mco:otherConstraints>
+                    </mco:MD_LegalConstraints>
+                  </mri:resourceConstraints>
+                  <mri:resourceConstraints xsi:schemaLocation="http://www.isotc211.org/2005/srv http://schemas.opengis.net/iso/19139/20060504/srv/srv.xsd">
+                    <mco:MD_LegalConstraints>
+                      <mco:accessConstraints>
+                        <mco:MD_RestrictionCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode"
+                                                codeListValue="otherRestrictions"/>
+                      </mco:accessConstraints>
+                      <mco:otherConstraints xsi:type="gmd:PT_FreeText_PropertyType">
+                        <gcx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess/noLimitations">Pas de restrictions concernant l'accès public</gcx:Anchor>
+                      </mco:otherConstraints>
+                    </mco:MD_LegalConstraints>
+                  </mri:resourceConstraints>-->
+
+
+                  <xsl:variable name="resourceLanguages"
+                                select="gn-fn-sparql:getObject($root,
+                                    'http://purl.org/dc/terms/language',
+                                    $resourceUri)/sr:uri"/>
+                  <xsl:for-each select="$resourceLanguages">
+                    <xsl:call-template name="build-language">
+                      <xsl:with-param name="element" select="'mri:defaultLocale'"/>
+                      <xsl:with-param name="languageUri" select="."/>
+                    </xsl:call-template>
+                  </xsl:for-each>
+
+                </mri:MD_DataIdentification>
+              </xsl:otherwise>
+            </xsl:choose>
+          </mdb:identificationInfo>
+
+
+          <xsl:variable name="lineage"
+                        select="gn-fn-sparql:getObject($root,
+                                    ('http://purl.org/dc/terms/provenance', 'http://www.w3.org/2000/01/rdf-schema#label'),
+                                    $resourceUri)/sr:literal"/>
+
+          <xsl:if test="$lineage != ''">
+            <mdb:resourceLineage>
+              <mrl:LI_Lineage>
+                <mrl:statement xsi:type="lan:PT_FreeText_PropertyType">
+                  <gco:CharacterString><xsl:value-of select="$lineage"/> </gco:CharacterString>
+                </mrl:statement>
+                <mrl:scope>
+                  <mcc:MD_Scope>
+                    <mcc:level>
+                      <mcc:MD_ScopeCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_ScopeCode"
+                                        codeListValue="dataset">dataset</mcc:MD_ScopeCode>
+                    </mcc:level>
+                  </mcc:MD_Scope>
+                </mrl:scope>
+              </mrl:LI_Lineage>
+            </mdb:resourceLineage>
+          </xsl:if>
+
+
+          <xsl:variable name="distributions"
+                        select="gn-fn-sparql:getObject($root,
+                                                  'http://www.w3.org/ns/dcat#distribution',
+                                                  $resourceUri)/sr:bnode[. != '']"/>
+
+          <xsl:if test="$distributions">
+            <mdb:distributionInfo>
+              <mrd:MD_Distribution>
+                <!--
+                <mrd:distributionFormat>
+                  <mrd:MD_Format>
+                     <mrd:formatSpecificationCitation>
+                        <cit:CI_Citation>
+                           <cit:title>
+                              <gcx:Anchor xlink:href="http://inspire.ec.europa.eu/media-types/application/x-shapefile">ESRI Shapefile (.shp)</gcx:Anchor>
+                           </cit:title>
+                           <cit:date gco:nilReason="unknown"/>
+                           <cit:edition>
+                              <gco:CharacterString>-</gco:CharacterString>
+                           </cit:edition>
+                        </cit:CI_Citation>
+                     </mrd:formatSpecificationCitation>
+                  </mrd:MD_Format>
+               </mrd:distributionFormat>
+                -->
+                <mrd:transferOptions>
+                  <mrd:MD_DigitalTransferOptions>
+                    <xsl:for-each select="$distributions">
+                      <xsl:variable name="accessUrl"
+                                    select="gn-fn-sparql:getObject($root,
+                                                        'http://www.w3.org/ns/dcat#accessURL',
+                                                        .)/sr:uri"/>
+                      <mrd:onLine>
+                        <cit:CI_OnlineResource>
+                          <cit:linkage>
+                            <gco:CharacterString>
+                              <xsl:value-of select="$accessUrl"/>
+                            </gco:CharacterString>
+                          </cit:linkage>
+
+                          <xsl:for-each select="gn-fn-sparql:getObject($root,
+                                                        'http://www.w3.org/ns/adms#representationTechnique',
+                                                        .)/sr:bnode[. != '']">
+                            <xsl:for-each select="gn-fn-sparql:getObject($root,
+                                                          'http://www.w3.org/2004/02/skos/core#prefLabel',
+                                                          .)/sr:literal[. != '']">
+                              <cit:protocol>
+                                <gco:CharacterString>
+                                  <xsl:value-of select="."/>
+                                </gco:CharacterString>
+                              </cit:protocol>
+                            </xsl:for-each>
+                          </xsl:for-each>
+
+                          <xsl:for-each select="gn-fn-sparql:getObject($root,
+                                                        'http://purl.org/dc/terms/title',
+                                                        .)/sr:literal">
+                            <cit:name>
+                              <gco:CharacterString>
+                                <xsl:value-of select="."/>
+                              </gco:CharacterString>
+                            </cit:name>
+                          </xsl:for-each>
+
+                          <xsl:for-each select="gn-fn-sparql:getObject($root,
+                                                        'http://purl.org/dc/terms/description',
+                                                        .)/sr:literal">
+                            <cit:description>
+                              <gco:CharacterString>
+                                <xsl:value-of select="."/>
+                              </gco:CharacterString>
+                            </cit:description>
+                          </xsl:for-each>
+                        </cit:CI_OnlineResource>
+                      </mrd:onLine>
+                    </xsl:for-each>
+                  </mrd:MD_DigitalTransferOptions>
+                </mrd:transferOptions>
+              </mrd:MD_Distribution>
+            </mdb:distributionInfo>
+          </xsl:if>
+        </xsl:for-each>
+      </mdb:MD_Metadata>
+    </xsl:for-each>
+  </xsl:template>
+
+
+  <xsl:template name="build-date">
+    <xsl:param name="element" as="xs:string"/>
+    <xsl:param name="date" as="xs:string"/>
+    <xsl:param name="dateType" as="xs:string"/>
+
+    <xsl:element name="{$element}">
+      <cit:CI_Date>
+        <cit:date>
+          <gco:DateTime><xsl:value-of select="$date"/></gco:DateTime>
+        </cit:date>
+        <cit:dateType>
+          <cit:CI_DateTypeCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_DateTypeCode"
+                               codeListValue="{$dateType}"></cit:CI_DateTypeCode>
+        </cit:dateType>
+      </cit:CI_Date>
+    </xsl:element>
+  </xsl:template>
+
+
+  <xsl:template name="build-language">
+    <xsl:param name="element" as="xs:string"/>
+    <xsl:param name="languageUri" as="xs:string"/>
+
+    <xsl:variable name="euPrefix"
+                  select="'(http://publications\.europa\.eu/resource/authority/language/|http://lexvo\.org/id/iso639-3/)([A-Za-z]+)'"/>
+
+    <xsl:element name="{$element}">
+      <lan:PT_Locale>
+        <lan:language>
+          <lan:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="{if (matches($languageUri, $euPrefix))
+                                then lower-case(replace($languageUri, $euPrefix, '$2'))
+                                else $languageUri}"/>
+        </lan:language>
+        <lan:characterEncoding>
+          <lan:MD_CharacterSetCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_CharacterSetCode"
+                                   codeListValue="utf8"/>
+        </lan:characterEncoding>
+      </lan:PT_Locale>
+    </xsl:element>
+  </xsl:template>
+
+
+  <!--
+  <dcat:contactPoint>
+      <vcard:Kind>
+          <vcard:title>Bundesamt für Raumentwicklung</vcard:title>
+          <vcard:role>pointOfContact</vcard:role>
+          <vcard:hasEmail>rolf.giezendanner@are.admin.ch</vcard:hasEmail>
+      </vcard:Kind>
+  </dcat:contactPoint>
+  -->
+  <xsl:template name="build-contact">
+    <xsl:param name="element" as="xs:string?" select="'mri:pointOfContact'"/>
+    <xsl:param name="contactUri" as="xs:string"/>
+
+    <xsl:variable name="role"
+                  select="gn-fn-sparql:getObject($root,
+                                    'http://www.w3.org/2006/vcard/ns#role',
+                                    $contactUri)/sr:literal"/>
+    <xsl:variable name="title"
+                  select="gn-fn-sparql:getObject($root,
+                                    'http://www.w3.org/2006/vcard/ns#title',
+                                    $contactUri)/sr:literal"/>
+    <xsl:variable name="email"
+                  select="gn-fn-sparql:getObject($root,
+                                    'http://www.w3.org/2006/vcard/ns#hasEmail',
+                                    $contactUri)/sr:literal"/>
+
+
+    <xsl:element name="{$element}">
+      <cit:CI_Responsibility>
+        <cit:role>
+          <cit:CI_RoleCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_RoleCode"
+                           codeListValue="{$role}"></cit:CI_RoleCode>
+        </cit:role>
+        <cit:party>
+          <cit:CI_Organisation>
+            <cit:name>
+              <gco:CharacterString>
+                <xsl:value-of select="$title"/>
+              </gco:CharacterString>
+            </cit:name>
+            <cit:contactInfo>
+              <cit:CI_Contact>
+                <cit:address>
+                  <cit:CI_Address>
+                    <cit:electronicMailAddress>
+                      <gco:CharacterString><xsl:value-of select="$email"/></gco:CharacterString>
+                    </cit:electronicMailAddress>
+                  </cit:CI_Address>
+                </cit:address>
+              </cit:CI_Contact>
+            </cit:contactInfo>
+          </cit:CI_Organisation>
+        </cit:party>
+      </cit:CI_Responsibility>
+    </xsl:element>
+  </xsl:template>
+</xsl:stylesheet>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/fromSPARQL-DCAT.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/fromSPARQL-DCAT.xsl
@@ -1,0 +1,671 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:sr="http://www.w3.org/2005/sparql-results#"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:spdx="http://spdx.org/rdf/terms#"
+                xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+                xmlns:adms="http://www.w3.org/ns/adms#"
+                xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                xmlns:dct="http://purl.org/dc/terms/"
+                xmlns:dcat="http://www.w3.org/ns/dcat#"
+                xmlns:vcard="http://www.w3.org/2006/vcard/ns#"
+                xmlns:foaf="http://xmlns.com/foaf/0.1/"
+                xmlns:owl="http://www.w3.org/2002/07/owl#"
+                xmlns:schema="http://schema.org/"
+                xmlns:locn="http://www.w3.org/ns/locn#"
+                xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                xmlns:mdcat="http://data.vlaanderen.be/ns/metadata-dcat#"
+                xmlns:fn="http://www.w3.org/2005/xpath-functions"
+                xmlns:util="java:org.fao.geonet.util.XslUtil"
+                xmlns:cit="http://standards.iso.org/iso/19115/-3/cit/2.0"
+                xmlns:gex="http://standards.iso.org/iso/19115/-3/gex/1.0"
+                xmlns:lan="http://standards.iso.org/iso/19115/-3/lan/1.0"
+                xmlns:mcc="http://standards.iso.org/iso/19115/-3/mcc/1.0"
+                xmlns:mco="http://standards.iso.org/iso/19115/-3/mco/1.0"
+                xmlns:mdb="http://standards.iso.org/iso/19115/-3/mdb/2.0"
+                xmlns:mmi="http://standards.iso.org/iso/19115/-3/mmi/1.0"
+                xmlns:mrd="http://standards.iso.org/iso/19115/-3/mrd/1.0"
+                xmlns:mri="http://standards.iso.org/iso/19115/-3/mri/1.0"
+                xmlns:mrl="http://standards.iso.org/iso/19115/-3/mrl/2.0"
+                xmlns:mrs="http://standards.iso.org/iso/19115/-3/mrs/1.0"
+                xmlns:mrc="http://standards.iso.org/iso/19115/-3/mrc/2.0"
+                xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0"
+                xmlns:gfc="http://standards.iso.org/iso/19110/gfc/1.1"
+                xmlns:gml="http://www.opengis.net/gml/3.2"
+                xmlns:gn-fn-sparql="http://geonetwork-opensource.org/xsl/functions/sparql"
+                version="2.0"
+                exclude-result-prefixes="#all">
+
+  <xsl:import href="ISO19139/utility/create19115-3Namespaces.xsl"/>
+  <xsl:import href="common/functions-sparql.xsl"/>
+
+  <xsl:output method="xml" indent="yes" encoding="UTF-8"/>
+
+  <xsl:param name="uuid" as="xs:string?"/>
+
+  <xsl:variable name="root"
+                select="/sr:sparql/sr:results"/>
+
+  <xsl:template match="/">
+    <xsl:variable name="catalogURIs"
+                  select="gn-fn-sparql:getSubject($root,
+                    'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
+                    'http://www.w3.org/ns/dcat#Catalog')"/>
+
+    <xsl:variable name="recordURIs"
+                  select="gn-fn-sparql:getSubject($root,
+                    'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
+                    'http://www.w3.org/ns/dcat#CatalogRecord')"/>
+
+    <xsl:variable name="datasetURIs"
+                  select="gn-fn-sparql:getSubject($root,
+                    'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
+                    'http://www.w3.org/ns/dcat#Dataset')"/>
+
+    <xsl:variable name="serviceURIs"
+                  select="gn-fn-sparql:getSubject($root,
+                    'http://www.w3.org/1999/02/22-rdf-syntax-ns#type',
+                    'http://www.w3.org/ns/dcat#DataService')"/>
+
+    <xsl:for-each select="$recordURIs">
+
+      <!-- We expect only one CatalogRecord containing on Dataset or DataService -->
+      <xsl:variable name="resource"
+                    select="($datasetURIs|$serviceURIs)"/>
+
+      <xsl:variable name="isService"
+                    select="ends-with($resource/binding[@name = 'object']/uri, 'DataService')"
+                    as="xs:boolean"/>
+
+      <xsl:variable name="recordUri"
+                    select="sr:uri"/>
+
+
+      <mdb:MD_Metadata>
+        <xsl:call-template name="add-iso19115-3.2018-namespaces"/>
+
+
+        <xsl:variable name="uuid"
+                      select="if ($uuid != '') then $uuid
+                              else gn-fn-sparql:getObject($root,
+                                'http://purl.org/dc/terms/identifier',
+                                $recordUri)/sr:literal"/>
+
+        <mdb:metadataIdentifier>
+          <mcc:MD_Identifier>
+            <mcc:code>
+              <gco:CharacterString>
+                <xsl:value-of select="$uuid"/>
+              </gco:CharacterString>
+            </mcc:code>
+          </mcc:MD_Identifier>
+        </mdb:metadataIdentifier>
+
+        <xsl:variable name="languages"
+                      select="gn-fn-sparql:getObject($root,
+                                'http://purl.org/dc/terms/language',
+                                $recordUri)/sr:uri"/>
+        <xsl:for-each select="$languages">
+          <xsl:call-template name="build-language">
+            <xsl:with-param name="element" select="'mdb:defaultLocale'"/>
+            <xsl:with-param name="languageUri" select="."/>
+          </xsl:call-template>
+        </xsl:for-each>
+
+        <mdb:metadataScope>
+          <mdb:MD_MetadataScope>
+            <mdb:resourceScope>
+              <mcc:MD_ScopeCode codeList=""
+                                codeListValue="{if ($isService)
+                                                then 'service'
+                                                else 'dataset'}"/>
+            </mdb:resourceScope>
+          </mdb:MD_MetadataScope>
+        </mdb:metadataScope>
+
+        <mdb:contact>
+          <cit:CI_Responsibility>
+            <cit:role>
+              <cit:CI_RoleCode codeList="codeListLocation#CI_RoleCode" codeListValue="pointOfContact">pointOfContact</cit:CI_RoleCode>
+            </cit:role>
+            <cit:party>
+              <cit:CI_Organisation>
+                <cit:name>
+                  <gco:CharacterString/>
+                </cit:name>
+                <cit:contactInfo>
+                  <cit:CI_Contact>
+                    <cit:address>
+                      <cit:CI_Address>
+                        <cit:electronicMailAddress>
+                          <gco:CharacterString/>
+                        </cit:electronicMailAddress>
+                      </cit:CI_Address>
+                    </cit:address>
+                  </cit:CI_Contact>
+                </cit:contactInfo>
+                <cit:individual>
+                  <cit:CI_Individual>
+                    <cit:name>
+                      <gco:CharacterString/>
+                    </cit:name>
+                    <cit:positionName>
+                      <gco:CharacterString/>
+                    </cit:positionName>
+                  </cit:CI_Individual>
+                </cit:individual>
+              </cit:CI_Organisation>
+            </cit:party>
+          </cit:CI_Responsibility>
+        </mdb:contact>
+
+        <xsl:variable name="dateTypes" as="node()*">
+          <type dcatType="created" isoType="creation"/>
+          <type dcatType="modified" isoType="revision"/>
+          <type dcatType="issued" isoType="publication"/>
+        </xsl:variable>
+        <xsl:for-each select="$dateTypes">
+          <xsl:variable name="dates"
+                        select="gn-fn-sparql:getObject($root,
+                                                  concat('http://purl.org/dc/terms/', @dcatType),
+                                                  $recordUri)/sr:literal"/>
+          <xsl:variable name="isoType" select="@isoType"/>
+          <xsl:for-each select="$dates">
+            <xsl:call-template name="build-date">
+              <xsl:with-param name="element" select="'mdb:dateInfo'"/>
+              <xsl:with-param name="date" select="."/>
+              <xsl:with-param name="dateType" select="$isoType"/>
+            </xsl:call-template>
+          </xsl:for-each>
+        </xsl:for-each>
+
+
+
+        <mdb:metadataStandard>
+          <cit:CI_Citation>
+            <cit:title>
+              <gco:CharacterString>ISO 19115-3</gco:CharacterString>
+            </cit:title>
+          </cit:CI_Citation>
+        </mdb:metadataStandard>
+
+
+        <mdb:metadataLinkage>
+          <cit:CI_OnlineResource>
+            <cit:linkage>
+              <gco:CharacterString><xsl:value-of select="$recordUri"/></gco:CharacterString>
+            </cit:linkage>
+            <cit:function>
+              <cit:CI_OnLineFunctionCode
+                codeList="http://standards.iso.org/iso/19139/resources/codelist/gmxCodelists.xml#CI_OnLineFunctionCode"
+                codeListValue="completeMetadata"/>
+            </cit:function>
+          </cit:CI_OnlineResource>
+        </mdb:metadataLinkage>
+
+
+        <xsl:for-each select="$resource">
+          <xsl:variable name="resourceUri"
+                        select="sr:uri"/>
+
+          <mdb:identificationInfo>
+            <xsl:choose>
+              <xsl:when test="$isService"></xsl:when>
+              <xsl:otherwise>
+                <mri:MD_DataIdentification>
+                  <mri:citation>
+                    <cit:CI_Citation>
+                      <cit:title>
+                        <gco:CharacterString>
+                          <xsl:value-of select="gn-fn-sparql:getObject($root,
+                                                  'http://purl.org/dc/terms/title',
+                                                  $resourceUri)/sr:literal"/>
+                        </gco:CharacterString>
+                      </cit:title>
+
+                      <xsl:for-each select="$dateTypes">
+                        <xsl:variable name="dates"
+                                      select="gn-fn-sparql:getObject($root,
+                                                  concat('http://purl.org/dc/terms/', @dcatType),
+                                                  $resourceUri)/sr:literal"/>
+                        <xsl:variable name="isoType" select="@isoType"/>
+                        <xsl:for-each select="$dates">
+                          <xsl:call-template name="build-date">
+                            <xsl:with-param name="element" select="'cit:date'"/>
+                            <xsl:with-param name="date" select="."/>
+                            <xsl:with-param name="dateType" select="$isoType"/>
+                          </xsl:call-template>
+                        </xsl:for-each>
+                      </xsl:for-each>
+
+
+                      <xsl:variable name="identifier"
+                                    select="gn-fn-sparql:getObject($root,
+                                                  'http://purl.org/dc/terms/identifier',
+                                                  $resourceUri)/sr:literal"/>
+                      <xsl:if test="$identifier != ''">
+                        <cit:identifier>
+                          <mcc:MD_Identifier>
+                            <mcc:code>
+                              <gco:CharacterString>
+                                <xsl:value-of select="$identifier"/>
+                              </gco:CharacterString>
+                            </mcc:code>
+                          </mcc:MD_Identifier>
+                        </cit:identifier>
+                      </xsl:if>
+                    </cit:CI_Citation>
+                  </mri:citation>
+                  <mri:abstract>
+                    <gco:CharacterString>
+                      <xsl:value-of select="gn-fn-sparql:getObject($root,
+                                                  'http://purl.org/dc/terms/description',
+                                                  $resourceUri)/sr:literal"/>
+                    </gco:CharacterString>
+                  </mri:abstract>
+
+
+
+                  <xsl:for-each select="gn-fn-sparql:getObject($root,
+                                                  'http://www.w3.org/ns/dcat#contactPoint',
+                                                  $resourceUri)/sr:bnode">
+                    <xsl:call-template name="build-contact">
+                      <xsl:with-param name="contactUri" select="."/>
+                    </xsl:call-template>
+                  </xsl:for-each>
+
+
+                  <!--
+                  <dcat:spatialResolutionInMeters>25000</dcat:spatialResolutionInMeters>
+                  -->
+                  <xsl:for-each select="gn-fn-sparql:getObject($root,
+                                                  'http://www.w3.org/ns/dcat#spatialResolutionInMeters',
+                                                  $resourceUri)/sr:literal">
+                    <mri:spatialResolution>
+                      <mri:MD_Resolution>
+                        <mri:equivalentScale>
+                          <mri:MD_RepresentativeFraction>
+                            <mri:denominator>
+                              <gco:Integer><xsl:value-of select="."/></gco:Integer>
+                            </mri:denominator>
+                          </mri:MD_RepresentativeFraction>
+                        </mri:equivalentScale>
+                      </mri:MD_Resolution>
+                    </mri:spatialResolution>
+                  </xsl:for-each>
+
+                  <!--
+                  <mri:topicCategory>
+                    <mri:MD_TopicCategoryCode>inlandWaters</mri:MD_TopicCategoryCode>
+                  </mri:topicCategory>
+                  -->
+
+                  <!--
+                    <dct:spatial>
+                        <dct:Location>
+                            <locn:geometry>{"coordinates":[[[6.755991,45.788744],[10.541824,45.788744],[10.541824,47.517566],[6.755991,47.517566],[6.755991,45.788744]]],"type":"Polygon"}</locn:geometry>
+                        </dct:Location>
+                    </dct:spatial>
+                   -->
+                  <xsl:for-each select="gn-fn-sparql:getObject($root,
+                                                  'http://purl.org/dc/terms/spatial',
+                                                  $resourceUri)/sr:bnode[. != '']">
+                    <xsl:for-each select="gn-fn-sparql:getObject($root,
+                                                  'http://www.w3.org/ns/locn#geometry',
+                                                  .)/sr:literal">
+                      <xsl:variable name="coordByPipe"
+                                    select="util:geoJsonGeomToBbox(string(.))"/>
+                      <xsl:if test="$coordByPipe != ''">
+                        <xsl:variable name="coords"
+                                      select="tokenize($coordByPipe, '\|')"/>
+                        <mri:extent>
+                          <gex:EX_Extent>
+                            <gex:geographicElement>
+                              <gex:EX_GeographicBoundingBox>
+                                <gex:westBoundLongitude>
+                                  <gco:Decimal><xsl:value-of select="$coords[1]"/></gco:Decimal>
+                                </gex:westBoundLongitude>
+                                <gex:eastBoundLongitude>
+                                  <gco:Decimal><xsl:value-of select="$coords[3]"/></gco:Decimal>
+                                </gex:eastBoundLongitude>
+                                <gex:southBoundLatitude>
+                                  <gco:Decimal><xsl:value-of select="$coords[2]"/></gco:Decimal>
+                                </gex:southBoundLatitude>
+                                <gex:northBoundLatitude>
+                                  <gco:Decimal><xsl:value-of select="$coords[4]"/></gco:Decimal>
+                                </gex:northBoundLatitude>
+                              </gex:EX_GeographicBoundingBox>
+                            </gex:geographicElement>
+                          </gex:EX_Extent>
+                        </mri:extent>
+                      </xsl:if>
+                    </xsl:for-each>
+                  </xsl:for-each>
+
+                  <!--
+                  <mri:extent>
+                    <gex:EX_Extent>
+                       <gex:temporalElement>
+                          <gex:EX_TemporalExtent>
+                             <gex:extent>
+                                <gml:TimePeriod gml:id="d36068e416a1053983">
+                                   <gml:beginPosition>1992-02-01</gml:beginPosition>
+                                   <gml:endPosition>2023-01-14</gml:endPosition>
+                                </gml:TimePeriod>
+                             </gex:extent>
+                          </gex:EX_TemporalExtent>
+                       </gex:temporalElement>
+                    </gex:EX_Extent>
+                 </mri:extent>
+                  -->
+
+                  <xsl:for-each select="gn-fn-sparql:getObject($root,
+                                                  'http://purl.org/dc/terms/accrualPeriodicity',
+                                                  $resourceUri)/sr:uri">
+
+                    <xsl:variable name="euPrefix"
+                                  select="'http://publications.europa.eu/resource/authority/frequency/'"/>
+                    <xsl:variable name="frequency"
+                                  select="if(starts-with(., $euPrefix))
+                                          then substring-after(., $euPrefix)
+                                          else ."/>
+                    <mri:resourceMaintenance>
+                      <mmi:MD_MaintenanceInformation>
+                        <mmi:maintenanceAndUpdateFrequency>
+                          <mmi:MD_MaintenanceFrequencyCode codeListValue="{$frequency}"
+                                                           codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_MaintenanceFrequencyCode"/>
+                        </mmi:maintenanceAndUpdateFrequency>
+                      </mmi:MD_MaintenanceInformation>
+                    </mri:resourceMaintenance>
+                  </xsl:for-each>
+
+                  <!--
+                  <mri:graphicOverview>
+                    <mcc:MD_BrowseGraphic>
+                       <mcc:fileName>
+                          <gco:CharacterString>https://metawal.wallonie.be/geonetwork/srv/api/records/b795de68-726c-4bdf-a62a-a42686aa5b6f/attachments/picc_vdiff_1.png</gco:CharacterString>
+                       </mcc:fileName>
+                       <mcc:fileDescription>
+                          <gco:CharacterString>picc_vdiff_1</gco:CharacterString>
+                       </mcc:fileDescription>
+                       <mcc:fileType>
+                          <gco:CharacterString>png</gco:CharacterString>
+                       </mcc:fileType>
+                    </mcc:MD_BrowseGraphic>
+                  </mri:graphicOverview>
+                  -->
+
+                  <!--
+                    <dcat:theme>
+                        <skos:Concept>
+                            <skos:prefLabel>Umweltüberwachung</skos:prefLabel>
+                        </skos:Concept>
+                    </dcat:theme>
+                  -->
+                  <mri:descriptiveKeywords>
+                    <mri:MD_Keywords>
+                      <xsl:for-each select="gn-fn-sparql:getObject($root,
+                                                      ('http://www.w3.org/ns/dcat#theme'),
+                                                      $resourceUri)/sr:bnode">
+                        <xsl:variable name="label"
+                                      select="gn-fn-sparql:getObject($root,
+                                                  'http://www.w3.org/2004/02/skos/core#prefLabel',
+                                                  .)/sr:literal"/>
+                        <mri:keyword>
+                          <gco:CharacterString><xsl:value-of select="$label"/></gco:CharacterString>
+                        </mri:keyword>
+                      </xsl:for-each>
+                    </mri:MD_Keywords>
+                  </mri:descriptiveKeywords>
+
+                  <!--<mri:resourceConstraints xsi:schemaLocation="http://www.isotc211.org/2005/gmd http://schemas.opengis.net/iso/19139/20060504/gmd/gmd.xsd">
+                    <mco:MD_LegalConstraints>
+                      <mco:useConstraints>
+                        <mco:MD_RestrictionCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode"
+                                                codeListValue="otherRestrictions"/>
+                      </mco:useConstraints>
+                      <mco:otherConstraints xsi:type="gmd:PT_FreeText_PropertyType">
+                        <gco:CharacterString>• Le gestionnaire du jeu de données tel qu’il est défini plus haut possède les droits de propriété (y compris les droits de propriété intellectuelle) se rapportant aux fichiers. • Le gestionnaire accorde au client le droit d’utiliser les données pour son usage interne. • L’usage des données à des fins commerciales, sous quelque forme que ce soit, est formellement interdit. • Le nom du gestionnaire doit apparaître lors de chaque utilisation publique des données.</gco:CharacterString>
+                      </mco:otherConstraints>
+                    </mco:MD_LegalConstraints>
+                  </mri:resourceConstraints>
+                  <mri:resourceConstraints xsi:schemaLocation="http://www.isotc211.org/2005/srv http://schemas.opengis.net/iso/19139/20060504/srv/srv.xsd">
+                    <mco:MD_LegalConstraints>
+                      <mco:accessConstraints>
+                        <mco:MD_RestrictionCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode"
+                                                codeListValue="otherRestrictions"/>
+                      </mco:accessConstraints>
+                      <mco:otherConstraints xsi:type="gmd:PT_FreeText_PropertyType">
+                        <gcx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess/noLimitations">Pas de restrictions concernant l'accès public</gcx:Anchor>
+                      </mco:otherConstraints>
+                    </mco:MD_LegalConstraints>
+                  </mri:resourceConstraints>-->
+
+
+                  <xsl:variable name="resourceLanguages"
+                                select="gn-fn-sparql:getObject($root,
+                                    'http://purl.org/dc/terms/language',
+                                    $resourceUri)/sr:uri"/>
+                  <xsl:for-each select="$resourceLanguages">
+                    <xsl:call-template name="build-language">
+                      <xsl:with-param name="element" select="'mri:defaultLocale'"/>
+                      <xsl:with-param name="languageUri" select="."/>
+                    </xsl:call-template>
+                  </xsl:for-each>
+
+                </mri:MD_DataIdentification>
+              </xsl:otherwise>
+            </xsl:choose>
+          </mdb:identificationInfo>
+
+
+          <xsl:variable name="lineage"
+                        select="gn-fn-sparql:getObject($root,
+                                    ('http://purl.org/dc/terms/provenance', 'http://www.w3.org/2000/01/rdf-schema#label'),
+                                    $resourceUri)/sr:literal"/>
+
+          <xsl:if test="$lineage != ''">
+            <mdb:resourceLineage>
+              <mrl:LI_Lineage>
+                <mrl:statement xsi:type="lan:PT_FreeText_PropertyType">
+                  <gco:CharacterString><xsl:value-of select="$lineage"/> </gco:CharacterString>
+                </mrl:statement>
+                <mrl:scope>
+                  <mcc:MD_Scope>
+                    <mcc:level>
+                      <mcc:MD_ScopeCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_ScopeCode"
+                                        codeListValue="dataset">dataset</mcc:MD_ScopeCode>
+                    </mcc:level>
+                  </mcc:MD_Scope>
+                </mrl:scope>
+              </mrl:LI_Lineage>
+            </mdb:resourceLineage>
+          </xsl:if>
+
+
+          <xsl:variable name="distributions"
+                        select="gn-fn-sparql:getObject($root,
+                                                  'http://www.w3.org/ns/dcat#distribution',
+                                                  $resourceUri)/sr:bnode[. != '']"/>
+
+          <xsl:if test="$distributions">
+            <mdb:distributionInfo>
+              <mrd:MD_Distribution>
+                <!--
+                <mrd:distributionFormat>
+                  <mrd:MD_Format>
+                     <mrd:formatSpecificationCitation>
+                        <cit:CI_Citation>
+                           <cit:title>
+                              <gcx:Anchor xlink:href="http://inspire.ec.europa.eu/media-types/application/x-shapefile">ESRI Shapefile (.shp)</gcx:Anchor>
+                           </cit:title>
+                           <cit:date gco:nilReason="unknown"/>
+                           <cit:edition>
+                              <gco:CharacterString>-</gco:CharacterString>
+                           </cit:edition>
+                        </cit:CI_Citation>
+                     </mrd:formatSpecificationCitation>
+                  </mrd:MD_Format>
+               </mrd:distributionFormat>
+                -->
+                <mrd:transferOptions>
+                  <mrd:MD_DigitalTransferOptions>
+                    <xsl:for-each select="$distributions">
+                      <xsl:variable name="accessUrl"
+                                    select="gn-fn-sparql:getObject($root,
+                                                        'http://www.w3.org/ns/dcat#accessURL',
+                                                        .)/sr:uri"/>
+                      <mrd:onLine>
+                        <cit:CI_OnlineResource>
+                          <cit:linkage>
+                            <gco:CharacterString>
+                              <xsl:value-of select="$accessUrl"/>
+                            </gco:CharacterString>
+                          </cit:linkage>
+
+                          <xsl:for-each select="gn-fn-sparql:getObject($root,
+                                                        'http://www.w3.org/ns/adms#representationTechnique',
+                                                        .)/sr:bnode[. != '']">
+                            <xsl:for-each select="gn-fn-sparql:getObject($root,
+                                                          'http://www.w3.org/2004/02/skos/core#prefLabel',
+                                                          .)/sr:literal[. != '']">
+                              <cit:protocol>
+                                <gco:CharacterString>
+                                  <xsl:value-of select="."/>
+                                </gco:CharacterString>
+                              </cit:protocol>
+                            </xsl:for-each>
+                          </xsl:for-each>
+
+                          <xsl:for-each select="gn-fn-sparql:getObject($root,
+                                                        'http://purl.org/dc/terms/title',
+                                                        .)/sr:literal">
+                            <cit:name>
+                              <gco:CharacterString>
+                                <xsl:value-of select="."/>
+                              </gco:CharacterString>
+                            </cit:name>
+                          </xsl:for-each>
+
+                          <xsl:for-each select="gn-fn-sparql:getObject($root,
+                                                        'http://purl.org/dc/terms/description',
+                                                        .)/sr:literal">
+                            <cit:description>
+                              <gco:CharacterString>
+                                <xsl:value-of select="."/>
+                              </gco:CharacterString>
+                            </cit:description>
+                          </xsl:for-each>
+                        </cit:CI_OnlineResource>
+                      </mrd:onLine>
+                    </xsl:for-each>
+                  </mrd:MD_DigitalTransferOptions>
+                </mrd:transferOptions>
+              </mrd:MD_Distribution>
+            </mdb:distributionInfo>
+          </xsl:if>
+        </xsl:for-each>
+      </mdb:MD_Metadata>
+    </xsl:for-each>
+  </xsl:template>
+
+
+  <xsl:template name="build-date">
+    <xsl:param name="element" as="xs:string"/>
+    <xsl:param name="date" as="xs:string"/>
+    <xsl:param name="dateType" as="xs:string"/>
+
+    <xsl:element name="{$element}">
+      <cit:CI_Date>
+        <cit:date>
+          <gco:DateTime><xsl:value-of select="$date"/></gco:DateTime>
+        </cit:date>
+        <cit:dateType>
+          <cit:CI_DateTypeCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_DateTypeCode"
+                               codeListValue="{$dateType}"></cit:CI_DateTypeCode>
+        </cit:dateType>
+      </cit:CI_Date>
+    </xsl:element>
+  </xsl:template>
+
+
+  <xsl:template name="build-language">
+    <xsl:param name="element" as="xs:string"/>
+    <xsl:param name="languageUri" as="xs:string"/>
+
+    <xsl:variable name="euPrefix"
+                  select="'(http://publications\.europa\.eu/resource/authority/language/|http://lexvo\.org/id/iso639-3/)([A-Za-z]+)'"/>
+
+    <xsl:element name="{$element}">
+      <lan:PT_Locale>
+        <lan:language>
+          <lan:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="{if (matches($languageUri, $euPrefix))
+                                then lower-case(replace($languageUri, $euPrefix, '$2'))
+                                else $languageUri}"/>
+        </lan:language>
+        <lan:characterEncoding>
+          <lan:MD_CharacterSetCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_CharacterSetCode"
+                                   codeListValue="utf8"/>
+        </lan:characterEncoding>
+      </lan:PT_Locale>
+    </xsl:element>
+  </xsl:template>
+
+
+  <!--
+  <dcat:contactPoint>
+      <vcard:Kind>
+          <vcard:title>Bundesamt für Raumentwicklung</vcard:title>
+          <vcard:role>pointOfContact</vcard:role>
+          <vcard:hasEmail>rolf.giezendanner@are.admin.ch</vcard:hasEmail>
+      </vcard:Kind>
+  </dcat:contactPoint>
+  -->
+  <xsl:template name="build-contact">
+    <xsl:param name="element" as="xs:string?" select="'mri:pointOfContact'"/>
+    <xsl:param name="contactUri" as="xs:string"/>
+
+    <xsl:variable name="role"
+                  select="gn-fn-sparql:getObject($root,
+                                    'http://www.w3.org/2006/vcard/ns#role',
+                                    $contactUri)/sr:literal"/>
+    <xsl:variable name="title"
+                  select="gn-fn-sparql:getObject($root,
+                                    'http://www.w3.org/2006/vcard/ns#title',
+                                    $contactUri)/sr:literal"/>
+    <xsl:variable name="email"
+                  select="gn-fn-sparql:getObject($root,
+                                    'http://www.w3.org/2006/vcard/ns#hasEmail',
+                                    $contactUri)/sr:literal"/>
+
+
+    <xsl:element name="{$element}">
+      <cit:CI_Responsibility>
+        <cit:role>
+          <cit:CI_RoleCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_RoleCode"
+                           codeListValue="{$role}"></cit:CI_RoleCode>
+        </cit:role>
+        <cit:party>
+          <cit:CI_Organisation>
+            <cit:name>
+              <gco:CharacterString>
+                <xsl:value-of select="$title"/>
+              </gco:CharacterString>
+            </cit:name>
+            <cit:contactInfo>
+              <cit:CI_Contact>
+                <cit:address>
+                  <cit:CI_Address>
+                    <cit:electronicMailAddress>
+                      <gco:CharacterString><xsl:value-of select="$email"/></gco:CharacterString>
+                    </cit:electronicMailAddress>
+                  </cit:CI_Address>
+                </cit:address>
+              </cit:CI_Contact>
+            </cit:contactInfo>
+          </cit:CI_Organisation>
+        </cit:party>
+      </cit:CI_Responsibility>
+    </xsl:element>
+  </xsl:template>
+</xsl:stylesheet>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/extract-date-modified.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/extract-date-modified.xsl
@@ -7,10 +7,10 @@
 
   <xsl:template
     match="mdb:MD_Metadata">
-    <xsl:variable name="revisionDate" 
-                  select="mdb:dateInfo/cit:CI_Date
+    <xsl:variable name="revisionDate"
+                  select="(mdb:dateInfo/cit:CI_Date
       [cit:dateType/cit:CI_DateTypeCode/@codeListValue='revision']
-      /cit:date/*"/>
+      /cit:date/*)[1]"/>
     <dateStamp>
       <xsl:choose>
         <xsl:when test="normalize-space($revisionDate)">

--- a/web-ui/src/main/resources/catalog/js/admin/HarvestSettingsController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/HarvestSettingsController.js
@@ -421,6 +421,9 @@
       };
 
       $scope.selectHarvester = function (h) {
+        $scope.activeTab.settings = true;
+        $scope.setSimpleUrlPagination();
+
         // TODO: Specific to thredds
         if (h["@type"] === "thredds") {
           $scope.threddsCollectionsMode =
@@ -617,10 +620,91 @@
 
       loadHarvesterTypes();
 
+      $scope.activeTab = {
+        settings: true,
+        history: false,
+        results: false
+      };
+
       // ---------------------------------------
       // Those function are harvester dependant and
       // should move in the harvester code
       // TODO
+      $scope.simpleUrlHarvesterHelperConfig = {
+        "DCAT feed > ISO": {
+          defaultValues: {
+            loopElement: "",
+            numberOfRecordPath: "",
+            pageSizeParam: "",
+            pageFromParam: "",
+            recordIdPath: "",
+            toISOConversion: "schema:iso19115-3.2018:convert/fromSPARQL-DCAT"
+          }
+        },
+        JSON: {
+          defaultValues: {
+            loopElement: "/datasets",
+            numberOfRecordPath: "/total_count",
+            pageSizeParam: "limit",
+            pageFromParam: "offset",
+            recordIdPath: "/dataset/dataset_id",
+            toISOConversion: "schema:iso19115-3.2018:convert/fromJsonOpenDataSoft"
+          }
+        },
+        "XML (ISO19115-3)": {
+          defaultValues: {
+            loopElement: ".",
+            numberOfRecordPath: "",
+            pageSizeParam: "",
+            pageFromParam: "",
+            recordIdPath: "mdb:metadataIdentifier/*/mcc:code/*/text()",
+            toISOConversion: ""
+          }
+        },
+        "XML (CSW-ISO19139)": {
+          defaultValues: {
+            loopElement: ".//csw:SearchResults/*",
+            numberOfRecordPath: "",
+            pageSizeParam: "",
+            pageFromParam: "",
+            recordIdPath: "gmd:fileIdentifier/*/text()",
+            toISOConversion: ""
+          }
+        }
+      };
+
+      $scope.getSimpleUrlConfigHelper = function (configKey) {
+        var helper = "";
+        angular.forEach(
+          $scope.simpleUrlHarvesterHelperConfig[configKey].defaultValues,
+          function (v, k) {
+            helper += $translate.instant(k) + " (" + k + "): " + v + "\n";
+          }
+        );
+        return helper;
+      };
+      $scope.setSimpleUrlConfig = function (configKey) {
+        angular.forEach(
+          $scope.simpleUrlHarvesterHelperConfig[configKey].defaultValues,
+          function (v, k) {
+            $scope.harvesterSelected.site[k] = v;
+          }
+        );
+        $scope.setSimpleUrlPagination();
+      };
+
+      $scope.setSimpleUrlPagination = function () {
+        if (
+          $scope.harvesterSelected &&
+          $scope.harvesterSelected.site &&
+          $scope.harvesterSelected.site.numberOfRecordPath
+        ) {
+          $scope.usePagination = {
+            enabled: $scope.harvesterSelected.site.numberOfRecordPath.length > 0
+          };
+        }
+      };
+
       $scope.geonetworkGetSources = function (url) {
         $http
           .get($scope.proxyUrl + encodeURIComponent(url + "/srv/eng/info?type=sources"))

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -261,6 +261,8 @@
     "geonetwork-xslfilterHelp": "The XSL filter is applied to each metadata record",
     "simpleurl-urlHelp": "URL pointing to JSON or XML documents. If harvesting more than one URL, add one line for each.",
     "loopElement": "Element to loop on",
+    "simpleurl-configHelper": "Sample configurations which can help setting up the harvester:",
+    "simpleurl-configHelper-help": "Depending on the target URL and the type of documents to harvest each configuration illustrate of to configure the harvester to extract the metadata records from the remote document.",
     "simpleurl-loopElementHelp": "For each element, one metadata record is created. For JSON document, points to a property. For XML document, points using XPath. eg. '.' if the element at the root of the XML document is a metadata document like 'mdb:MD_Metadata'.",
     "simpleurl-pagination": "Pagination parameters (optional)",
     "numberOfRecordPath": "Element for the number of records to collect",

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/harvest-settings.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/harvest-settings.html
@@ -171,10 +171,9 @@
 
     <div id="gn-harvest-select-help-button" data-gn-need-help="harvesting-home"></div>
   </div>
-
   <div class="col-lg-7" data-ng-hide="harvesterSelected['@id'] == null">
     <tabset id="harvester-tabset" type="pills" justified="false" role="tablist">
-      <tab heading="{{'settings' | translate}}" role="tab" active="true">
+      <tab heading="{{'settings' | translate}}" role="tab" active="activeTab.settings">
         <div id="gn-harvest-settings-panel" class="panel panel-default gn-margin-top">
           <div class="panel-heading clearfix">
             <span id="gn-harvest-settings-title">
@@ -288,7 +287,11 @@
           </div>
         </div>
       </tab>
-      <tab heading="{{'harvesterHistory'|translate}}" role="tab">
+      <tab
+        heading="{{'harvesterHistory'|translate}}"
+        role="tab"
+        active="activeTab.history"
+      >
         <div
           id="gn-harvest-history-panel"
           class="panel panel-default gn-margin-top"
@@ -460,6 +463,7 @@
                           || isLoadingOneHarvester
                           || deleting.indexOf(harvesterSelected['@id']) > -1"
         role="tab"
+        active="activeTab.results"
       >
         <div id="gn-harvest-records-panel" data-ng-search-form="" class="gn-margin-top">
           <div class="panel panel-default">

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/simpleurl.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/simpleurl.html
@@ -181,6 +181,22 @@
       <p class="help-block" data-translate="">applyXSLToRecordHelp</p>
     </div>
 
+    <div id="gn-harvest-settings-csw-advanced-batchEdits-row">
+      <label id="gn-harvest-settings-csw-advanced-batchEdits-label" class="control-label">
+        <span data-translate="">harvesterBatchEdits</span>
+      </label>
+
+      <div gn-batch-edit-examples-selector="addBatchEdits" />
+
+      <div
+        id="gn-harvest-settings-csw-advanced-batchEdits-list"
+        style="height: 300px"
+        ui-ace="{useWrapMode:true, showGutter:true, mode:'json'}"
+        data-ng-model="harvesterSelected.content.batchEdits"
+      />
+      <p class="help-block" data-translate="">harvesterBatchEditsHelp</p>
+    </div>
+
     <div
       id="gn-harvest-settings-simpleurl-advanced-category-row"
       data-gn-category="harvesterSelected.categories[0]['@id']"

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/simpleurl.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/simpleurl.html
@@ -44,6 +44,23 @@
       data-gn-harvester-account="harvesterSelected"
     />
 
+    <div class="well">
+      <span data-translate="">simpleurl-configHelper</span>
+      <div class="btn-group" role="group" aria-label="...">
+        <button
+          data-ng-repeat="(k, v) in simpleUrlHarvesterHelperConfig"
+          type="button"
+          class="btn btn-default"
+          data-ng-disabled="harvesterSelected['@id'] != ''"
+          title="{{::getSimpleUrlConfigHelper(k)}}"
+          data-ng-click="setSimpleUrlConfig(k)"
+        >
+          {{::k}}
+        </button>
+      </div>
+      <div data-translate="">simpleurl-configHelper-help</div>
+    </div>
+
     <div id="gn-harvest-settings-loopElement-row">
       <label
         id="gn-harvest-settings-loopElement-label"
@@ -76,9 +93,7 @@
       <p class="help-block" data-translate="">simpleurl-recordIdPathHelp</p>
     </div>
 
-    <div
-      data-ng-init="usePagination = {enabled: harvesterSelected.site.numberOfRecordPath.length > 0}"
-    >
+    <div>
       <label class="control-label">
         <input
           id="gn-harvest-settings-simpleurl-checkbox"

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/simpleurl.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/simpleurl.html
@@ -44,10 +44,7 @@
       data-gn-harvester-account="harvesterSelected"
     />
 
-    <div
-      id="gn-harvest-settings-loopElement-row"
-      data-ng-class="harvesterSelected.site.loopElement == '' ? 'has-error' : ''"
-    >
+    <div id="gn-harvest-settings-loopElement-row">
       <label
         id="gn-harvest-settings-loopElement-label"
         class="control-label"

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/simpleurl.js
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/simpleurl.js
@@ -26,7 +26,8 @@ var gnHarvestersimpleurl = {
         "toISOConversion": ""
       },
       "content" : {
-        "validate" : "NOVALIDATION"
+        "validate" : "NOVALIDATION",
+        "batchEdits" : ""
       },
       "options" : {
         "every" : "0 0 0 ? * *",
@@ -99,6 +100,7 @@ var gnHarvestersimpleurl = {
       + '  </options>'
       + '  <content>'
       + '    <validate>' + h.content.validate + '</validate>'
+      + '    <batchEdits><![CDATA[' + (h.content.batchEdits == '' ? '[]' : h.content.batchEdits) + ']]></batchEdits>'
       + '  </content>'
       + $scope.buildResponseGroup(h)
       + $scope.buildResponseCategory(h) + '</node>';

--- a/web/src/main/webapp/WEB-INF/oasis-catalog.xml
+++ b/web/src/main/webapp/WEB-INF/oasis-catalog.xml
@@ -77,4 +77,7 @@
 
   <uri name="common/functions-metadata.xsl"
        uri="../xslt/common/functions-metadata.xsl"/>
+
+  <uri name="common/functions-sparql.xsl"
+       uri="../xslt/common/functions-sparql.xsl"/>
 </catalog>

--- a/web/src/main/webapp/xsl/conversion/import/SPARQL-DCAT-to-ISO19115-3-2018.xsl
+++ b/web/src/main/webapp/xsl/conversion/import/SPARQL-DCAT-to-ISO19115-3-2018.xsl
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<xsl:stylesheet version="2.0"
-                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
-  <xsl:include href="../../../WEB-INF/data/config/schema_plugins/iso19115-3.2018/convert/DCAT/sparql-to-iso19115-3.xsl"/>
-</xsl:stylesheet>
-

--- a/web/src/main/webapp/xsl/conversion/import/SPARQL-DCAT-to-ISO19115-3-2018.xsl
+++ b/web/src/main/webapp/xsl/conversion/import/SPARQL-DCAT-to-ISO19115-3-2018.xsl
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet version="2.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:include href="../../../WEB-INF/data/config/schema_plugins/iso19115-3.2018/convert/DCAT/sparql-to-iso19115-3.xsl"/>
+</xsl:stylesheet>
+

--- a/web/src/main/webapp/xslt/common/functions-sparql.xsl
+++ b/web/src/main/webapp/xslt/common/functions-sparql.xsl
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:sr="http://www.w3.org/2005/sparql-results#"
+                xmlns:gn-fn-sparql="http://geonetwork-opensource.org/xsl/functions/sparql"
+                xmlns:saxon="http://saxon.sf.net/"
+                version="2.0" extension-element-prefixes="saxon"
+                exclude-result-prefixes="#all">
+
+
+  <xsl:function name="gn-fn-sparql:getSubject" as="node()*">
+    <xsl:param name="context" as="node()"/>
+    <xsl:param name="predicate" as="xs:string"/>
+    <xsl:param name="object" as="xs:string"/>
+
+    <xsl:copy-of select="$context/sr:result[
+                            sr:binding[@name = 'predicate']/sr:uri = $predicate
+                            and sr:binding[@name = 'object']/sr:uri = $object]
+                            /sr:binding[@name = 'subject']"/>
+  </xsl:function>
+
+
+  <xsl:function name="gn-fn-sparql:getObject" as="node()*">
+    <xsl:param name="context" as="node()"/>
+    <xsl:param name="predicate" as="xs:string*"/>
+    <xsl:param name="subject" as="xs:string"/>
+
+<!--    <xsl:message>For <xsl:value-of select="$subject"/> getObject <xsl:value-of select="$predicate"/></xsl:message>-->
+    <xsl:variable name="object"
+                  select="$context/sr:result[
+                            sr:binding[@name = 'subject']/(sr:uri|sr:bnode) = $subject
+                            and sr:binding[@name = 'predicate']/sr:uri = $predicate[1]]
+                          /sr:binding[@name = 'object']"/>
+    <xsl:choose>
+      <xsl:when test="count($predicate) > 1">
+        <xsl:if test="$object/sr:bnode">
+          <xsl:copy-of select="gn-fn-sparql:getObject($context,
+                                $predicate[position() > 1],
+                                $object/sr:bnode)/sr:literal"/>
+        </xsl:if>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:copy-of select="$object"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
+</xsl:stylesheet>


### PR DESCRIPTION
## Harvesting RDF feeds

The simpleurl harvester can already point to JSON or XML feed. It can also point to a RDF DCAT feed which will be loaded using Jena. SPARQL queries are applied to extract necessary information from the RDF graph.

This work was initially made by GIM team for [Metadata vlaanderen](https://metadata.vlaanderen.be/) in a DCAT-AP dedicated harvester (see https://github.com/metadata101/dcat-ap1.1/tree/master/src/main/java/org/fao/geonet/kernel/harvest/harvester/dcatap) but we considered that the simpleurl harvester can be a good candidate for simplification and provide DCAT feed support directly.

![image](https://user-images.githubusercontent.com/1701393/213636501-460deb3b-9840-4311-bb43-6c566ce1c20b.png)


The results can be converted using an XSL conversion. A conversion to ISO19115-3 is provided and custom plugins may provide other conversions (see https://github.com/geonetwork/core-geonetwork/pull/6772). The provided ISO19115-3 conversion support only Dataset and cover most of the mapping done in OGC API record (see https://github.com/geonetwork/geonetwork-microservices/blob/main/modules/library/common-index-model/src/main/java/org/fao/geonet/index/converter/DcatConverter.java#L188)

Tested with
* http://mow-dataroom.s3-eu-west-1.amazonaws.com/dr_dcat.rdf
* https://apps.titellus.net/geonetwork/api/collections/main/items?q=AlpenKonvention&f=dcat
* https://apps.titellus.net/geonetwork/api/collections/main/items/7bb33d95-7950-499a-9bd8-6f31d58b0b35?f=dcat


## Configuration improvements

* When creating the harvester, add an helper menu to more easily set up the configuration with some examples for loading:
  * DCAT feed converted to ISO
  * JSON
  * XML file containing one metadata record
  * CSW GetRecords response 

![image](https://user-images.githubusercontent.com/1701393/213726835-2a1d6922-7f07-4bd7-8bea-78e223a60873.png)


## Additional notes & improvements

* When selecting an harvester, select the settings tab by default (to not stay on history or results tab)

![image](https://user-images.githubusercontent.com/1701393/213728022-b321684d-0cdd-44a3-a415-8ff08461b784.png)


* Note that simple URL is a bit faster for harvesting CSW (but it requires to manually write the CSW GET query) eg. for 159 records

![image](https://user-images.githubusercontent.com/1701393/213726174-fd5f0178-fb70-46bd-b08e-57a4abf43a31.png)

* Add support for batch editing.


## Future work to be discussed

- Helper configuration can probably be improved (eg. hide useless fields depending on harvesting target, more detailed configuration for specific implementations)
- Add possibility to hash or not URI used for UUID (depends on https://github.com/geonetwork/core-geonetwork/pull/5736) - Add the possibility to use the `rdf:about` as UUID for the record (but require to support URL chars in UUID) or create a hash of the `rdf:about`
- RDF / Paging support for RDF feeds using Hydra
- RDF / Add support for multilingual DCAT feed
- RDF / Add support for turtle, JSON-LD



Co-authored-by: Mathieu Chaussier <mathieu.chaussier@gim.be>
Co-authored-by: Gustaaf Van de Boel <gustaaf.vandeboel@gim.be>
Co-authored-by: Stijn Goedertier <stijn.goedertier@gim.be>