### PR TITLE
Indexing / Add option to configure ignore_above.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1508,6 +1508,7 @@
     <es.index.max_result_window.limit>15000</es.index.max_result_window.limit>
 
     <es.index.mapping.total_fields.limit>4000</es.index.mapping.total_fields.limit>
+    <es.index.ignore_above>2000</es.index.ignore_above>
 
     <!-- If elasticsearch security is on,
     add a read/write user for index features and records: -->

--- a/web/src/main/webResources/WEB-INF/data/config/index/records.json
+++ b/web/src/main/webResources/WEB-INF/data/config/index/records.json
@@ -1081,7 +1081,7 @@
                 "fields": {
                   "keyword": {
                     "type": "keyword",
-                    "ignore_above": 256
+                    "ignore_above": ${es.index.ignore_above}
                   },
                   "trigram": {
                     "type": "text",
@@ -1100,7 +1100,7 @@
                 "fields": {
                   "keyword": {
                     "type": "keyword",
-                    "ignore_above": 256
+                    "ignore_above": ${es.index.ignore_above}
                   }
                 }
               },
@@ -1111,7 +1111,7 @@
                 "fields": {
                   "keyword": {
                     "type": "keyword",
-                    "ignore_above": 256
+                    "ignore_above": ${es.index.ignore_above}
                   }
                 }
               },
@@ -1122,7 +1122,7 @@
                 "fields": {
                   "keyword": {
                     "type": "keyword",
-                    "ignore_above": 256
+                    "ignore_above": ${es.index.ignore_above}
                   }
                 }
               },
@@ -1135,7 +1135,7 @@
                 "fields": {
                   "keyword": {
                     "type": "keyword",
-                    "ignore_above": 256
+                    "ignore_above": ${es.index.ignore_above}
                   }
                 }
               },
@@ -1146,7 +1146,7 @@
                 "fields": {
                   "keyword": {
                     "type": "keyword",
-                    "ignore_above": 256
+                    "ignore_above": ${es.index.ignore_above}
                   }
                 }
               },
@@ -1157,7 +1157,7 @@
                 "fields": {
                   "keyword": {
                     "type": "keyword",
-                    "ignore_above": 256
+                    "ignore_above": ${es.index.ignore_above}
                   }
                 }
               },
@@ -1168,7 +1168,7 @@
                 "fields": {
                   "keyword": {
                     "type": "keyword",
-                    "ignore_above": 256
+                    "ignore_above": ${es.index.ignore_above}
                   }
                 }
               },
@@ -1653,7 +1653,7 @@
         "fields": {
           "keyword": {
             "type": "keyword",
-            "ignore_above": 256
+            "ignore_above": ${es.index.ignore_above}
           }
         }
       },
@@ -1662,7 +1662,7 @@
         "fields": {
           "keyword": {
             "type": "keyword",
-            "ignore_above": 256
+            "ignore_above": ${es.index.ignore_above}
           }
         }
       },
@@ -1680,7 +1680,7 @@
         "fields": {
           "keyword": {
             "type": "keyword",
-            "ignore_above": 256
+            "ignore_above": ${es.index.ignore_above}
           }
         }
       },
@@ -1689,7 +1689,7 @@
         "fields": {
           "keyword": {
             "type": "keyword",
-            "ignore_above": 256
+            "ignore_above": ${es.index.ignore_above}
           }
         }
       },
@@ -1798,7 +1798,7 @@
         "fields": {
           "keyword": {
             "type": "keyword",
-            "ignore_above": 256
+            "ignore_above": ${es.index.ignore_above}
           }
         }
       },


### PR DESCRIPTION
Some request may not work on long abstract for example due to this parameter:

```
GET gn-records/_search
{
  "query": {
    "query_string": {
      "fields": ["resourceAbstractObject.langfre.keyword"],
      "query": "*bisse*"
    }
  },
  "_source": ["resourceAbstractObject.langfre"]
}
```

See https://www.elastic.co/guide/en/elasticsearch/reference/7.17/ignore-above.html.

It does not affect full text search which does analysis but more some advanced query on more precise fields like the one above.
