### PR TITLE
JS & CSS / Cache / Add a profile to prebuilt the wro4j-cache

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -80,6 +80,7 @@ web/src/main/webapp/WEB-INF/data/wro4j-cache*
 web/src/main/webapp/WEB-INF/data_*
 web/src/main/webapp/WEB-INF/metadata_subversion/
 web/src/main/webapp/WEB-INF/server.prop
+web/src/main/webapp/WEB-INF/prebuilt
 web/src/main/webapp/data/
 web/src/main/webapp/doc/en
 web/src/main/webapp/doc/fr

--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-resources-plugin</artifactId>
-          <version>3.1.0</version>
+          <version>3.3.0</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -276,6 +276,7 @@
         <artifactId>maven-resources-plugin</artifactId>
         <configuration>
           <encoding>UTF-8</encoding>
+          <propertiesEncoding>ISO-8859-1</propertiesEncoding>
         </configuration>
       </plugin>
 

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/oaipmh.js
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/oaipmh.js
@@ -21,7 +21,7 @@ var gnHarvesteroaipmh = {
               "icon" : "blank.png"
             },
             "content":   {
-              "validate": "NOVALIDATION",
+              "validate": "NOVALIDATION"
             },
             "options":   {
               "every": "0 0 0 ? * *",

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -905,25 +905,6 @@
               </resources>
             </configuration>
           </execution>
- <!--         <execution>
-            <id>copy-prebuilt-wro4j-db</id>
-            <phase>prepare-package</phase>
-            <goals>
-              <goal>copy-resources</goal>
-            </goals>
-            <configuration>
-              <outputDirectory>${project.build.outputDirectory}/geonetwork/WEB-INF/prebuilt/</outputDirectory>
-              <resources>
-                <resource>
-                  <directory>${project.build.directory}</directory>
-                  <filtering>false</filtering>
-                  <includes>
-                    <include>wro4j-cache.mv.db</include>
-                  </includes>
-                </resource>
-              </resources>
-            </configuration>
-          </execution>-->
         </executions>
       </plugin>
 
@@ -1069,6 +1050,7 @@
                   <extraConfigFile>${build.webapp.resources}/WEB-INF/wro-maven.properties</extraConfigFile>
                   <wroFile>${project.build.directory}/geonetwork/WEB-INF/wro-sources-maven.xml</wroFile>
                   <destinationFolder>${wro4jOutput}</destinationFolder>
+                  <targetGroups>lib,lib3d,gn_search,gn_search_default,gn_login,gn_login_default,gn_editor,gn_editor_default,gn_admin,gn_admin_default,nv.d3,gn_fonts,gn_inspire,gn_pickers,gn_print_default,ng-skos,bootstrap-table.min</targetGroups>
                 </configuration>
               </execution>
             </executions>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -886,6 +886,44 @@
               <overwrite>false</overwrite>
             </configuration>
           </execution>
+          <execution>
+            <id>copy-web-ui-wro-sources</id>
+            <phase>process-resources</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>${project.basedir}/../web-ui/src/main/resources/WEB-INF/classes</directory>
+                  <filtering>false</filtering>
+                  <includes>
+                    <include>web-ui-wro-sources.xml</include>
+                  </includes>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+ <!--         <execution>
+            <id>copy-prebuilt-wro4j-db</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <configuration>
+              <outputDirectory>${project.build.outputDirectory}/geonetwork/WEB-INF/prebuilt/</outputDirectory>
+              <resources>
+                <resource>
+                  <directory>${project.build.directory}</directory>
+                  <filtering>false</filtering>
+                  <includes>
+                    <include>wro4j-cache.mv.db</include>
+                  </includes>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>-->
         </executions>
       </plugin>
 
@@ -917,8 +955,16 @@
             <resource>
               <directory>${build.webapp.resources}</directory>
             </resource>
+            <resource>
+              <directory>${project.build.directory}</directory>
+              <includes>
+                <include>wro4j-cache.mv.db</include>
+              </includes>
+              <targetPath>WEB-INF/prebuilt</targetPath>
+            </resource>
           </webResources>
           <!-- <packagingExcludes>WEB-INF/data/**</packagingExcludes> -->
+
           <packagingExcludes>
             xml/schemas/**,
             WEB-INF/data/*.db,
@@ -990,10 +1036,46 @@
           <stopPort>${jetty.stop.port}</stopPort>
         </configuration>
       </plugin>
+
+
     </plugins>
   </build>
 
   <profiles>
+    <profile>
+      <id>wro4j-prebuild-cache</id>
+      <activation>
+        <property>
+          <name>prebuild-cache</name>
+          <value>true</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <!-- build WRO4J Cache during build time -->
+          <plugin>
+            <groupId>ro.isdc.wro4j</groupId>
+            <artifactId>wro4j-maven-plugin</artifactId>
+            <version>${wro.version}</version>
+            <executions>
+              <execution>
+                <id>wro4j-prebuild-cache</id>
+                <phase>prepare-package</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <wroManagerFactory>org.fao.geonet.wro4j.GeonetworkMavenNoTestsWrojManagerFactory</wroManagerFactory>
+                  <extraConfigFile>${build.webapp.resources}/WEB-INF/wro-maven.properties</extraConfigFile>
+                  <wroFile>${project.build.directory}/geonetwork/WEB-INF/wro-sources-maven.xml</wroFile>
+                  <destinationFolder>${wro4jOutput}</destinationFolder>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
 
     <!-- Unpack schema resources from maven artifacts -->
     <profile>

--- a/web/src/main/webResources/WEB-INF/web.xml
+++ b/web/src/main/webResources/WEB-INF/web.xml
@@ -185,10 +185,10 @@
 
         * Runtime as a Servlet Filter - at runtime WRO4J compiles, lints, minifies and compresses all javascript and css files.
                                         This allows a developer to be able to get instant feed back when he/she changes a file.
-                                        By Default the javascript and css is minimized.  To not have it minized use ?minimize=false
+                                        By Default the javascript and css is minimized.  To not have it minimized use ?minimize=false
         * Maven build - The same configuration is run on all javascript files during build time.  The artifacts are ignored
-                        because they are generated at runtime but it a check to verify that when deployed all artifacts can be
-                        correctly built when the .
+                        because they are generated at runtime, but it is a check to verify that when deployed all artifacts can be
+                        correctly built.
     -->
 
     <filter-name>WebResourceOptimizer</filter-name>

--- a/web/src/main/webResources/WEB-INF/wro-maven.properties
+++ b/web/src/main/webResources/WEB-INF/wro-maven.properties
@@ -1,0 +1,53 @@
+#
+# Copyright (C) 2001-2016 Food and Agriculture Organization of the
+# United Nations (FAO-UN), United Nations World Food Programme (WFP)
+# and United Nations Environment Programme (UNEP)
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or (at
+# your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+#
+# Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+# Rome - Italy. email: geonetwork@osgeo.org
+#
+
+managerFactoryClassName=org.fao.geonet.wro4j.GeonetworkWrojManagerFactory
+
+# debug should be false when in production.
+# This is the flag that allows: ?minimize=false to be added to get the normal unminimized code.
+debug=${wro.debug}
+gzipResources=true
+resourceWatcherUpdatePeriod=${wroRefresh}
+cacheUpdatePeriod=0
+modelUpdatePeriod=0
+disableCache=false
+parallelPreprocessing=false
+encoding=UTF-8
+ignoreMissingResources=false
+ignoreEmptyGroup=true
+ignoreFailingProcessor=${ignoreFailingProcessor}
+cacheGzippedContent=true
+jmxEnabled=true
+mbeanName=geonetwork-wro4j
+preProcessors=stripGoog,googleClosureSimple,geonetLessCompiler,cssMinJawr,removeSourceMapUrl${debugProcessors}
+postProcessors=
+uriLocators=servletContext,uri,classpath,closureDependencyURILocator,templateURILocator
+modelFactory=geonetwork
+
+#Note: GeonetworkWroModelFactory will ignore everything before WEB-INF so the
+#      fact that the build inserts complete path is not important
+wroSources=${project.basedir}/src/main/webapp/WEB-INF/wro-sources-maven.xml
+cacheStrategy=disk-memory
+lruSize=${lruSize}
+header=cache-control: public
+wroCacheLocation=${project.build.directory}/wro4j-cache

--- a/web/src/main/webapp/WEB-INF/wro-sources-maven.xml
+++ b/web/src/main/webapp/WEB-INF/wro-sources-maven.xml
@@ -20,16 +20,13 @@
   ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
   ~ Rome - Italy. email: geonetwork@osgeo.org
   -->
-
+<!-- This file is used when invoked mvn wro4j:run -Dminimize=false -DtargetGroup=all to generate wro4j database in
+build time
+ Main difference with wro-sources.xml is that {{schemaPluginDir}}... placeholders have been manually set to
+ their actual relative paths to web/target/geonetwork tree.-->
 <sources xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:noNamespaceSchemaLocation="wro-sources.xsd">
   <include file="classpath:web-ui-wro-sources.xml"/>
-  <require>
-    <!--pathOnDisk="web/target/geonetwork"-->
-
-    <jsSource webappPath="{{schemaPluginsDir}}"/>
-    <jsSource webappPath="{{formatterDir}}"/>
-    <cssSource webappPath="{{schemaPluginsDir}}"/>
-    <cssSource webappPath="{{formatterDir}}"/>
+  <require pathOnDisk="web/target/geonetwork">
   </require>
 </sources>

--- a/wro4j/Readme.md
+++ b/wro4j/Readme.md
@@ -1,31 +1,31 @@
 # Module Purpose
-[Web Resources Optimizer for Java (WRO4J)](https://code.google.com/p/wro4j/wiki/Introduction) is used by Geonetwork for javascript
-and css minification.  This module has several customization to the out-of-the-box implementation.  A few customizations are:
+[Web Resources Optimizer for Java (WRO4J)](https://code.google.com/p/wro4j/wiki/Introduction) is used by Geonetwork for Javascript
+and CSS minification.  This module has some customization to the out-of-the-box implementation.  A few customizations are:
 
 * Custom Wro Model Factory
- * The factory uses a custom xml model file called wro-sources.xml which is based on the wro-sources.xsd schema.  The documentation for
-   writing the xml file is in the xsd file.
- * This custom factory allows the javascript files and dependencies to be declared in the file using goog.provide and goog.require
-   declarations (see https://developers.google.com/closure/library/docs/introduction).
-   In WRO4J lingo, all requireJsSources javascript files found (see requireJsSourceType in wro-sources.xsd) are parsed for goog.provide
-   and goog.require files. The dependencies of each javascript file will be included in the WRO4J group.
-   All dependencies and the javascript file will be minified together as one group and the dependency order will be maintained.
- * The factory will create a closure_deps.js file which is needed by closure base.js for determining which javascript files to load.  This
-   is used when in debug mode.
- * The model factory also allows an explicit ordering of javascript files when that is required.
- * Finally the model factory allows wro-sources.xml files to be included in a root wro-sources.xml file.  This allows the wro-sources.xml
-   to be kept in the module it applies to and just be included from the web-app module.
-* A Less Compiler that can handle both css and less files.
-* A Processor that removes goog.provide and goog.require (because they are not needed in the minified javascript because all dependencies
+  * The factory uses a custom XML model file called `wro-sources.xml` which is based on the `wro-sources.xsd` schema.  The documentation for
+   writing the XML file is in the XSD file.
+  * This custom factory allows the Javascript files and dependencies to be declared in the file using `goog.provide` and `goog.require`
+    declarations (see https://developers.google.com/closure/library/docs/introduction).
+    In WRO4J lingo, all `requireJsSources` Javascript files found (see `requireJsSourceType` in `wro-sources.xsd`) are parsed for `goog.provide`
+    and `goog.require` files. The dependencies of each Javascript file will be included in the WRO4J group.
+    All dependencies and the Javascript file will be minified together as one group and the dependency order will be maintained.
+  * The factory will create a `closure_deps.js` file which is needed by closure `base.js` for determining which javascript files to load.  This
+    is used when in debug mode.
+  * The model factory also allows an explicit ordering of Javascript files when that is required.
+  * Finally, the model factory allows `wro-sources.xml` files to be included in a root `wro-sources.xml` file.  This allows the `wro-sources.xml`
+    to be kept in the module it applies to and just be included from the `web-app` module.
+* A Less Compiler that can handle both css and `less` files.
+* A Processor that removes `goog.provide` and `goog.require` (because they are not needed in the minified javascript because all dependencies
   are included)
-* Other support classes for Wro Model Factory are included in this module (like ClosureDependencyUriLocator)
+* Other support classes for Wro Model Factory are included in this module (like `ClosureDependencyUriLocator`)
 
 # Wro4j Configuration Files
 
-* __wro-sources.xml__ - Declares the javascript and css groups.  The _wro-sources.xsd_ contains information on how to write such a file.
-  At the time of this writing there is a root _wro-sources.xml_ file in web/src/main/webResources/WEB-INF/wro-sources.xml which includes:
-  * web-ui/src/main/resources/web-ui-wro-sources.xml
-* __wro.properties__ - The wro configuration. See https://code.google.com/p/wro4j/wiki/ConfigurationOptions for the list and
+* __`wro-sources.xml`__ - Declares the javascript and css groups.  The `wro-sources.xsd` contains information on how to write such a file.
+  At the time of this writing there is a root `wro-sources.xml` file in `web/src/main/webResources/WEB-INF/wro-sources.xml` which includes:
+   * `web-ui/src/main/resources/web-ui-wro-sources.xml`
+* __`wro.properties`__ - The wro configuration. See https://code.google.com/p/wro4j/wiki/ConfigurationOptions for the list and
   description of properties in the file.
-* __web/pom.xml__ - This file contains build/plugins/plugin plugin for wro4j which runs the minification and some minor checks on the wro4j
+* __`web/pom.xml`__ - This file contains `build/plugins/plugin` plugin for `wro4j` which runs the minification and some minor checks on the `wro4j`
   configuration during a build.  The intention is to catch any major configuration errors at build time.

--- a/wro4j/src/main/java/org/fao/geonet/wro4j/DiskbackedCache.java
+++ b/wro4j/src/main/java/org/fao/geonet/wro4j/DiskbackedCache.java
@@ -1,25 +1,40 @@
+//=============================================================================
+//===	Copyright (C) 2001-2023 Food and Agriculture Organization of the
+//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
+//===	and United Nations Environment Programme (UNEP)
+//===
+//===	This program is free software; you can redistribute it and/or modify
+//===	it under the terms of the GNU General Public License as published by
+//===	the Free Software Foundation; either version 2 of the License, or (at
+//===	your option) any later version.
+//===
+//===	This program is distributed in the hope that it will be useful, but
+//===	WITHOUT ANY WARRANTY; without even the implied warranty of
+//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//===	General Public License for more details.
+//===
+//===	You should have received a copy of the GNU General Public License
+//===	along with this program; if not, write to the Free Software
+//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+//===
+//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+//===	Rome - Italy. email: geonetwork@osgeo.org
+//==============================================================================
 package org.fao.geonet.wro4j;
 
-import java.io.Closeable;
-import java.io.IOException;
-import java.sql.Connection;
-import java.sql.DriverManager;
-import java.sql.PreparedStatement;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.sql.Statement;
-import java.util.UUID;
-
+import com.google.common.base.Joiner;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.kernel.GeonetworkDataDirectory;
-
-import com.google.common.base.Joiner;
-
 import ro.isdc.wro.WroRuntimeException;
 import ro.isdc.wro.cache.CacheKey;
 import ro.isdc.wro.cache.CacheStrategy;
 import ro.isdc.wro.cache.CacheValue;
 import ro.isdc.wro.cache.impl.LruMemoryCacheStrategy;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.sql.*;
+import java.util.UUID;
 
 /**
  * Wro4j caching strategy that in addition to using an in-memory cache, also writes to disk so that
@@ -32,6 +47,8 @@ public class DiskbackedCache implements CacheStrategy<CacheKey, CacheValue>, Clo
     public static final String DB_PROP_KEY = "cacheDB";
     private static final String TABLE = "cache";
     private static final String SQL_CLEAR = "DELETE FROM " + TABLE;
+
+    private static final String SQL_DELETE_CSS = "DELETE FROM " + TABLE + " WHERE TYPE='CSS'";
     private static final String SQL_SHUTDOWN = "SHUTDOWN";
     private static final String GROUPNAME = "groupname";
     private static final String TYPE = "type";
@@ -159,5 +176,17 @@ public class DiskbackedCache implements CacheStrategy<CacheKey, CacheValue>, Clo
     @Override
     public void close() throws IOException {
         destroy();
+    }
+
+    /**
+     * Deletes all the items of type CSS from the database.
+     */
+    public void deleteCSSItems() {
+        init();
+        try (Statement statement = dbConnection.createStatement()) {
+            statement.execute(SQL_DELETE_CSS);
+        } catch (SQLException e) {
+            throw new WroRuntimeException("Error deleting CSS items from cache", e);
+        }
     }
 }

--- a/wro4j/src/main/java/org/fao/geonet/wro4j/GeonetLessCompilerProcessor.java
+++ b/wro4j/src/main/java/org/fao/geonet/wro4j/GeonetLessCompilerProcessor.java
@@ -1,4 +1,50 @@
+//=============================================================================
+//===	Copyright (C) 2001-2023 Food and Agriculture Organization of the
+//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
+//===	and United Nations Environment Programme (UNEP)
+//===
+//===	This program is free software; you can redistribute it and/or modify
+//===	it under the terms of the GNU General Public License as published by
+//===	the Free Software Foundation; either version 2 of the License, or (at
+//===	your option) any later version.
+//===
+//===	This program is distributed in the hope that it will be useful, but
+//===	WITHOUT ANY WARRANTY; without even the implied warranty of
+//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//===	General Public License for more details.
+//===
+//===	You should have received a copy of the GNU General Public License
+//===	along with this program; if not, write to the Free Software
+//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+//===
+//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+//===	Rome - Italy. email: geonetwork@osgeo.org
+//==============================================================================
 package org.fao.geonet.wro4j;
+
+import com.github.sommeri.less4j.Less4jException;
+import com.github.sommeri.less4j.LessCompiler;
+import com.github.sommeri.less4j.LessCompiler.CompilationResult;
+import com.github.sommeri.less4j.LessCompiler.Problem;
+import com.github.sommeri.less4j.LessSource;
+import com.github.sommeri.less4j.core.DefaultLessCompiler;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.Validate;
+import org.fao.geonet.ApplicationContextHolder;
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.kernel.GeonetworkDataDirectory;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.context.ApplicationContext;
+import ro.isdc.wro.WroRuntimeException;
+import ro.isdc.wro.extensions.processor.css.Less4jProcessor;
+import ro.isdc.wro.model.group.Inject;
+import ro.isdc.wro.model.resource.Resource;
+import ro.isdc.wro.model.resource.ResourceType;
+import ro.isdc.wro.model.resource.SupportedResourceType;
+import ro.isdc.wro.model.resource.locator.factory.UriLocatorFactory;
+import ro.isdc.wro.util.WroUtil;
 
 import java.io.IOException;
 import java.io.Reader;
@@ -9,31 +55,6 @@ import java.nio.file.Paths;
 import java.util.Iterator;
 import java.util.logging.Logger;
 
-import org.apache.commons.io.IOUtils;
-import org.apache.commons.lang3.Validate;
-import org.fao.geonet.ApplicationContextHolder;
-import org.fao.geonet.constants.Geonet;
-import org.fao.geonet.kernel.GeonetworkDataDirectory;
-import org.json.JSONException;
-import org.json.JSONObject;
-import org.springframework.beans.factory.NoSuchBeanDefinitionException;
-
-import com.github.sommeri.less4j.Less4jException;
-import com.github.sommeri.less4j.LessCompiler;
-import com.github.sommeri.less4j.LessCompiler.CompilationResult;
-import com.github.sommeri.less4j.LessCompiler.Problem;
-import com.github.sommeri.less4j.LessSource;
-import com.github.sommeri.less4j.core.DefaultLessCompiler;
-
-import ro.isdc.wro.WroRuntimeException;
-import ro.isdc.wro.extensions.processor.css.Less4jProcessor;
-import ro.isdc.wro.model.group.Inject;
-import ro.isdc.wro.model.resource.Resource;
-import ro.isdc.wro.model.resource.ResourceType;
-import ro.isdc.wro.model.resource.SupportedResourceType;
-import ro.isdc.wro.model.resource.locator.factory.UriLocatorFactory;
-import ro.isdc.wro.util.WroUtil;
-
 /**
  * Custom Geonetwork implementation for importing stylesheets. Main factor is to make it more forgiving.
  * <p/>
@@ -42,91 +63,29 @@ import ro.isdc.wro.util.WroUtil;
 @SupportedResourceType(ResourceType.CSS)
 public class GeonetLessCompilerProcessor extends Less4jProcessor {
 
-    /** The Constant ALIAS. */
+    /**
+     * The Constant ALIAS.
+     */
     public static final String ALIAS = "geonetLessCompiler";
-    
-    /** The Constant LESS_EXT. */
-    private static final String LESS_EXT = ".less";
-
-    /** The Constant LOG. */
-    private static final Logger LOG = Logger.getLogger(GeonetLessCompilerProcessor.class.getPackage().getName());
 
     /**
-     * Required to use the less4j import mechanism.
+     * The Constant LESS_EXT.
      */
-    private static class RelativeAwareLessSource extends LessSource.StringSource {
-        
-        /** The resource. */
-        private final Resource resource;
-        
-        /** The locator factory. */
-        private final UriLocatorFactory locatorFactory;
+    private static final String LESS_EXT = ".less";
 
-        /**
-         * Instantiates a new relative aware less source.
-         *
-         * @param resource the resource
-         * @param content the content
-         * @param locatorFactory the locator factory
-         */
-        public RelativeAwareLessSource(final Resource resource, final String content, final UriLocatorFactory locatorFactory) {
-            super(content);
-            this.resource = resource;
-            Validate.notNull(locatorFactory);
-            this.locatorFactory = locatorFactory;
-        }
-
-        /**
-         * Relative source.
-         *
-         * @param relativePath the relative path
-         * @return the less source
-         * @throws StringSourceException the string source exception
-         */
-        @Override
-        public LessSource relativeSource(final String relativePath) throws StringSourceException {
-            return resource != null ? computeRelative(resource, relativePath) : super.relativeSource(relativePath);
-        }
-
-        /**
-         * Compute relative.
-         *
-         * @param resource the resource
-         * @param relativePath the relative path
-         * @return the less source
-         * @throws StringSourceException the string source exception
-         */
-        private LessSource computeRelative(final Resource resource, final String relativePath) throws StringSourceException {
-            try {
-                final String relativeResourceUri = computeRelativeResourceUri(resource.getUri(), relativePath);
-                final Resource relativeResource = Resource.create(relativeResourceUri, ResourceType.CSS);
-                final String relativeResourceContent = IOUtils.toString(locatorFactory.locate(relativeResourceUri), "UTF-8");
-                return new RelativeAwareLessSource(relativeResource, relativeResourceContent, locatorFactory);
-            } catch (final IOException e) {
-                GeonetLessCompilerProcessor.LOG.fine("Failed to compute relative resource: " + resource);
-                throw new StringSourceException();
-            }
-        }
-
-        /**
-         * Compute relative resource uri.
-         *
-         * @param originalResourceUri the original resource uri
-         * @param relativePath the relative path
-         * @return the string
-         */
-        public String computeRelativeResourceUri(final String originalResourceUri, final String relativePath) {
-            final String fullPath = WroUtil.getFullPath(originalResourceUri) + relativePath;
-            return WroUtil.normalize(fullPath);
-        }
-    }
-
-    /** The locator factory. */
+    /**
+     * The Constant LOG.
+     */
+    private static final Logger LOG = Logger.getLogger(GeonetLessCompilerProcessor.class.getPackage().getName());
+    /**
+     * The compiler.
+     */
+    private final LessCompiler compiler = new DefaultLessCompiler();
+    /**
+     * The locator factory.
+     */
     @Inject
     private UriLocatorFactory locatorFactory;
-
-    /** The compiler. */
-    private final LessCompiler compiler = new DefaultLessCompiler();
 
     /**
      * Process.
@@ -164,8 +123,8 @@ public class GeonetLessCompilerProcessor extends Less4jProcessor {
      * Process.
      *
      * @param resource the resource
-     * @param reader the reader
-     * @param writer the writer
+     * @param reader   the reader
+     * @param writer   the writer
      * @throws IOException Signals that an I/O exception has occurred.
      */
     @Override
@@ -210,12 +169,12 @@ public class GeonetLessCompilerProcessor extends Less4jProcessor {
      * Read custom less file.
      *
      * @param customLessFile the custom less file
-     * @return the string
+     * @return the content of the custom less file originally in JSON format transformed in a less file content.
      * @throws IOException Signals that an I/O exception has occurred.
      */
 
     private String readCustomLessFile(Path customLessFile) throws IOException {
-        String customLessVariables = new String();
+        StringBuilder customLessVariables = new StringBuilder();
         if (customLessFile != null) {
             final String content = new String(Files.readAllBytes(customLessFile));
             try {
@@ -224,39 +183,45 @@ public class GeonetLessCompilerProcessor extends Less4jProcessor {
                 while (iter.hasNext()) {
                     final String key = iter.next();
                     if (jObject.getString(key) != null && !jObject.getString(key).trim().equals("")) {
-                        customLessVariables += "\n @" + key.trim() + " : " + jObject.getString(key).trim() + ";";
+                        customLessVariables.append("\n @").append(key.trim()).append(" : ")
+                            .append(jObject.getString(key).trim()).append(";");
                     }
                 }
             } catch (final JSONException e) {
                 throw WroRuntimeException.wrap(e);
             }
         }
-        return customLessVariables;
+        return customLessVariables.toString();
     }
 
     /**
-     * Gets the custom less file.
+     * Gets the custom less file from the GeoNetwork data directory. Returns null if running from a maven build.
      *
-     * @return the custom less file
+     * @return the path to the custom less file.
      * @throws IOException Signals that an I/O exception has occurred.
      */
     private Path getCustomLessFile() throws IOException {
-        
+
+        Path customLessFile = null;
         try {
-            final GeonetworkDataDirectory geonetworkDataDirectory = ApplicationContextHolder.get().getBean(GeonetworkDataDirectory.class);
-            
-            if(geonetworkDataDirectory!=null && geonetworkDataDirectory.getSystemDataDir()!=null) {
-                final String path = geonetworkDataDirectory.getSystemDataDir().resolve(Geonet.Config.NODE_LESS_DIR).toString();
-                final Path customLessFile = openFileWithCustomStyle(path);
-                return customLessFile;
+            ApplicationContext applicationContext = ApplicationContextHolder.get();
+            if (applicationContext != null) {
+                final GeonetworkDataDirectory geonetworkDataDirectory = ApplicationContextHolder.get()
+                    .getBean(GeonetworkDataDirectory.class);
+
+                if (geonetworkDataDirectory.getSystemDataDir() != null) {
+                    final String path = geonetworkDataDirectory.getSystemDataDir().resolve(Geonet.Config.NODE_LESS_DIR).toString();
+                    customLessFile = openFileWithCustomStyle(path);
+                }
             } else {
-                return null;
+                LOG.warning("Executing Less Compiler from Maven. Cannot locate the custom less variable files at " +
+                    "$DATA_DIR/" + Geonet.Config.NODE_LESS_DIR);
             }
         } catch (NoSuchBeanDefinitionException e) {
-           LOG.fine("org.fao.geonet.kernel.GeonetworkDataDirectory bean not found"); 
+            LOG.severe("org.fao.geonet.kernel.GeonetworkDataDirectory bean not found");
         }
-        
-        return null;
+
+        return customLessFile;
     }
 
     /**
@@ -281,6 +246,80 @@ public class GeonetLessCompilerProcessor extends Less4jProcessor {
      */
     private String problemAsString(final Problem problem) {
         return String.format("%s:%s %s.", problem.getLine(), problem.getCharacter(), problem.getMessage());
+    }
+
+    /**
+     * Required to use the less4j import mechanism.
+     */
+    private static class RelativeAwareLessSource extends LessSource.StringSource {
+
+        /**
+         * The resource.
+         */
+        private final Resource resource;
+
+        /**
+         * The locator factory.
+         */
+        private final UriLocatorFactory locatorFactory;
+
+        /**
+         * Instantiates a new relative aware less source.
+         *
+         * @param resource       the resource
+         * @param content        the content
+         * @param locatorFactory the locator factory
+         */
+        public RelativeAwareLessSource(final Resource resource, final String content, final UriLocatorFactory locatorFactory) {
+            super(content);
+            this.resource = resource;
+            Validate.notNull(locatorFactory);
+            this.locatorFactory = locatorFactory;
+        }
+
+        /**
+         * Relative source.
+         *
+         * @param relativePath the relative path
+         * @return the less source
+         * @throws StringSourceException the string source exception
+         */
+        @Override
+        public LessSource relativeSource(final String relativePath) throws StringSourceException {
+            return resource != null ? computeRelative(resource, relativePath) : super.relativeSource(relativePath);
+        }
+
+        /**
+         * Compute relative.
+         *
+         * @param resource     the resource
+         * @param relativePath the relative path
+         * @return the less source
+         * @throws StringSourceException the string source exception
+         */
+        private LessSource computeRelative(final Resource resource, final String relativePath) throws StringSourceException {
+            try {
+                final String relativeResourceUri = computeRelativeResourceUri(resource.getUri(), relativePath);
+                final Resource relativeResource = Resource.create(relativeResourceUri, ResourceType.CSS);
+                final String relativeResourceContent = IOUtils.toString(locatorFactory.locate(relativeResourceUri), "UTF-8");
+                return new RelativeAwareLessSource(relativeResource, relativeResourceContent, locatorFactory);
+            } catch (final IOException e) {
+                GeonetLessCompilerProcessor.LOG.fine("Failed to compute relative resource: " + resource);
+                throw new StringSourceException();
+            }
+        }
+
+        /**
+         * Compute relative resource uri.
+         *
+         * @param originalResourceUri the original resource uri
+         * @param relativePath        the relative path
+         * @return the string
+         */
+        public String computeRelativeResourceUri(final String originalResourceUri, final String relativePath) {
+            final String fullPath = WroUtil.getFullPath(originalResourceUri) + relativePath;
+            return WroUtil.normalize(fullPath);
+        }
     }
 
 }

--- a/wro4j/src/main/java/org/fao/geonet/wro4j/GeonetLessCompilerProcessor.java
+++ b/wro4j/src/main/java/org/fao/geonet/wro4j/GeonetLessCompilerProcessor.java
@@ -138,13 +138,17 @@ public class GeonetLessCompilerProcessor extends Less4jProcessor {
                 logWarnings(result);
                 writer.write(result.getCss());
             } catch (final Less4jException e) {
-                GeonetLessCompilerProcessor.LOG.fine("Failed to compile less resource: {}.");
+                GeonetLessCompilerProcessor.LOG.warning(String.format(
+                    "Failed to compile less resource: %s.",
+                    resource.getUri()));
                 for (final Problem problem : e.getErrors()) {
-                    GeonetLessCompilerProcessor.LOG.fine(problemAsString(problem));
+                    GeonetLessCompilerProcessor.LOG.warning(problemAsString(problem));
                 }
                 throw WroRuntimeException.wrap(e);
             } catch (final Exception e) {
-                GeonetLessCompilerProcessor.LOG.fine("Exception while compiling less resource: {}.");
+                GeonetLessCompilerProcessor.LOG.warning(String.format(
+                    "Exception while compiling less resource: %s.",
+                    resource.getUri()));
                 throw WroRuntimeException.wrap(e);
             }
         } else {

--- a/wro4j/src/main/java/org/fao/geonet/wro4j/GeonetWro4jFilter.java
+++ b/wro4j/src/main/java/org/fao/geonet/wro4j/GeonetWro4jFilter.java
@@ -1,3 +1,25 @@
+//=============================================================================
+//===	Copyright (C) 2001-2023 Food and Agriculture Organization of the
+//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
+//===	and United Nations Environment Programme (UNEP)
+//===
+//===	This program is free software; you can redistribute it and/or modify
+//===	it under the terms of the GNU General Public License as published by
+//===	the Free Software Foundation; either version 2 of the License, or (at
+//===	your option) any later version.
+//===
+//===	This program is distributed in the hope that it will be useful, but
+//===	WITHOUT ANY WARRANTY; without even the implied warranty of
+//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//===	General Public License for more details.
+//===
+//===	You should have received a copy of the GNU General Public License
+//===	along with this program; if not, write to the Free Software
+//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+//===
+//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+//===	Rome - Italy. email: geonetwork@osgeo.org
+//==============================================================================
 package org.fao.geonet.wro4j;
 
 import org.fao.geonet.utils.Log;

--- a/wro4j/src/main/java/org/fao/geonet/wro4j/GeonetWroModelFactory.java
+++ b/wro4j/src/main/java/org/fao/geonet/wro4j/GeonetWroModelFactory.java
@@ -504,7 +504,7 @@ public class GeonetWroModelFactory implements WroModelFactory {
     private Map<String, Group> addJavascriptGroupsByRequireDependencies(final WroModel model, final ClosureRequireDependencyManager
         dependencyManager, Group closureDepsGroup) {
         final Set<String> moduleIds = dependencyManager.getAllModuleIds();
-        Map<String, Group> groupMap = new HashMap<String, Group>((int) (moduleIds.size() * 1.5));
+        Map<String, Group> groupMap = new HashMap<>((int) (moduleIds.size() * 1.5));
 
         for (String moduleId : moduleIds) {
             Group group = new Group(moduleId);
@@ -513,7 +513,7 @@ public class GeonetWroModelFactory implements WroModelFactory {
             closureDepsGroup.addResource(ClosureDependencyUriLocator.createClosureDepResource(dependencyManager.getNode(moduleId)));
             final Collection<ClosureRequireDependencyManager.Node> deps = dependencyManager.getTransitiveDependenciesFor(moduleId, true);
 
-            List<Resource> resources = new ArrayList<Resource>();
+            List<Resource> resources = new ArrayList<>();
             for (ClosureRequireDependencyManager.Node dep : deps) {
                 group.addResource(createResourceFrom(dep));
                 addTemplateResourceFrom(resources, dep);

--- a/wro4j/src/main/java/org/fao/geonet/wro4j/GeonetworkMavenNoTestsWrojManagerFactory.java
+++ b/wro4j/src/main/java/org/fao/geonet/wro4j/GeonetworkMavenNoTestsWrojManagerFactory.java
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2001-2023 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+package org.fao.geonet.wro4j;
+
+import ro.isdc.wro.cache.CacheKey;
+import ro.isdc.wro.cache.CacheStrategy;
+import ro.isdc.wro.cache.CacheValue;
+import ro.isdc.wro.maven.plugin.manager.factory.ConfigurableWroManagerFactory;
+import ro.isdc.wro.model.factory.WroModelFactory;
+import ro.isdc.wro.model.resource.locator.factory.UriLocatorFactory;
+
+import java.util.Properties;
+
+/**
+ * User: juanluisrp Date: 2023-01-18
+ */
+public class GeonetworkMavenNoTestsWrojManagerFactory extends GeonetworkMavenWrojManagerFactory {
+
+    private DiskbackedCache diskBackedCache = null;
+
+    @Override
+    protected WroModelFactory newModelFactory() {
+        return new GeonetWroModelFactory() {
+            @Override
+            protected Properties getConfigProperties() {
+                return createProperties();
+            }
+        };
+    }
+
+    @Override
+    protected UriLocatorFactory newUriLocatorFactory() {
+        return super.newUriLocatorFactory();
+    }
+
+    @Override
+    protected CacheStrategy<CacheKey, CacheValue> newCacheStrategy() {
+        Properties properties = createProperties();
+        String wroCacheLocation = properties.getProperty("wroCacheLocation");
+
+        diskBackedCache = new DiskbackedCache(5000, wroCacheLocation);
+        return diskBackedCache;
+    }
+
+    @Override
+    public void destroy() {
+        super.destroy();
+        if (this.diskBackedCache != null) {
+            diskBackedCache.destroy();
+        }
+    }
+
+}

--- a/wro4j/src/main/java/org/fao/geonet/wro4j/GeonetworkMavenNoTestsWrojManagerFactory.java
+++ b/wro4j/src/main/java/org/fao/geonet/wro4j/GeonetworkMavenNoTestsWrojManagerFactory.java
@@ -26,7 +26,6 @@ import ro.isdc.wro.cache.CacheKey;
 import ro.isdc.wro.cache.CacheStrategy;
 import ro.isdc.wro.cache.CacheValue;
 import ro.isdc.wro.model.factory.WroModelFactory;
-import ro.isdc.wro.model.resource.locator.factory.UriLocatorFactory;
 
 import java.util.Properties;
 

--- a/wro4j/src/main/java/org/fao/geonet/wro4j/GeonetworkMavenNoTestsWrojManagerFactory.java
+++ b/wro4j/src/main/java/org/fao/geonet/wro4j/GeonetworkMavenNoTestsWrojManagerFactory.java
@@ -25,7 +25,6 @@ package org.fao.geonet.wro4j;
 import ro.isdc.wro.cache.CacheKey;
 import ro.isdc.wro.cache.CacheStrategy;
 import ro.isdc.wro.cache.CacheValue;
-import ro.isdc.wro.maven.plugin.manager.factory.ConfigurableWroManagerFactory;
 import ro.isdc.wro.model.factory.WroModelFactory;
 import ro.isdc.wro.model.resource.locator.factory.UriLocatorFactory;
 
@@ -46,11 +45,6 @@ public class GeonetworkMavenNoTestsWrojManagerFactory extends GeonetworkMavenWro
                 return createProperties();
             }
         };
-    }
-
-    @Override
-    protected UriLocatorFactory newUriLocatorFactory() {
-        return super.newUriLocatorFactory();
     }
 
     @Override

--- a/wro4j/src/main/java/org/fao/geonet/wro4j/GeonetworkWrojManagerFactory.java
+++ b/wro4j/src/main/java/org/fao/geonet/wro4j/GeonetworkWrojManagerFactory.java
@@ -27,6 +27,7 @@ import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.kernel.GeonetworkDataDirectory;
 import org.fao.geonet.utils.Log;
 import org.springframework.web.context.support.XmlWebApplicationContext;
+import ro.isdc.wro.WroRuntimeException;
 import ro.isdc.wro.cache.CacheKey;
 import ro.isdc.wro.cache.CacheStrategy;
 import ro.isdc.wro.cache.CacheValue;
@@ -154,7 +155,7 @@ public class GeonetworkWrojManagerFactory extends ConfigurableWroManagerFactory 
         try (DiskbackedCache tempCache = new DiskbackedCache(50, dataDirPath.resolve("wro4j-cache").toString())) {
             tempCache.deleteCSSItems();
         } catch (IOException e) {
-            throw new RuntimeException(e);
+            throw new WroRuntimeException("Error removing CSS files from the wro4j cache", e);
         }
     }
 

--- a/wro4j/src/main/java/org/fao/geonet/wro4j/GeonetworkWrojManagerFactory.java
+++ b/wro4j/src/main/java/org/fao/geonet/wro4j/GeonetworkWrojManagerFactory.java
@@ -37,6 +37,7 @@ import ro.isdc.wro.model.factory.WroModelFactory;
 import javax.servlet.ServletContext;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -107,10 +108,14 @@ public class GeonetworkWrojManagerFactory extends ConfigurableWroManagerFactory 
                 Properties propInDataDir = new Properties();
                 Path propFileInDataDir = dataDirPath.resolve("git.properties");
                 if (Files.exists(propFileInDataDir)) {
-                    propInDataDir.load(Files.newInputStream(propFileInDataDir));
+                    try (InputStream propertiesInputStream = Files.newInputStream(propFileInDataDir)) {
+                        propInDataDir.load(propertiesInputStream);
+                    }
                 } else {
-                    bundledProperties.store(Files.newOutputStream(propFileInDataDir),
-                        "Copied from GN git.properties on " + DateTimeFormatter.ISO_DATE_TIME.format(OffsetDateTime.now()));
+                    try (OutputStream propertiesOutputStream = Files.newOutputStream(propFileInDataDir)) {
+                        bundledProperties.store(propertiesOutputStream,
+                            "Copied from GN git.properties on " + DateTimeFormatter.ISO_DATE_TIME.format(OffsetDateTime.now()));
+                    }
                 }
                 String dataDirGitVersion = propInDataDir.getProperty("git.commit.id");
                 gitVersionMatch = bundledGitRevision.equals(dataDirGitVersion);

--- a/wro4j/src/main/java/org/fao/geonet/wro4j/GeonetworkWrojManagerFactory.java
+++ b/wro4j/src/main/java/org/fao/geonet/wro4j/GeonetworkWrojManagerFactory.java
@@ -1,7 +1,32 @@
+//=============================================================================
+//===	Copyright (C) 2001-2023 Food and Agriculture Organization of the
+//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
+//===	and United Nations Environment Programme (UNEP)
+//===
+//===	This program is free software; you can redistribute it and/or modify
+//===	it under the terms of the GNU General Public License as published by
+//===	the Free Software Foundation; either version 2 of the License, or (at
+//===	your option) any later version.
+//===
+//===	This program is distributed in the hope that it will be useful, but
+//===	WITHOUT ANY WARRANTY; without even the implied warranty of
+//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//===	General Public License for more details.
+//===
+//===	You should have received a copy of the GNU General Public License
+//===	along with this program; if not, write to the Free Software
+//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+//===
+//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+//===	Rome - Italy. email: geonetwork@osgeo.org
+//==============================================================================
 package org.fao.geonet.wro4j;
 
-import java.util.Properties;
-
+import org.fao.geonet.ApplicationContextHolder;
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.kernel.GeonetworkDataDirectory;
+import org.fao.geonet.utils.Log;
+import org.springframework.web.context.support.XmlWebApplicationContext;
 import ro.isdc.wro.cache.CacheKey;
 import ro.isdc.wro.cache.CacheStrategy;
 import ro.isdc.wro.cache.CacheValue;
@@ -9,15 +34,26 @@ import ro.isdc.wro.cache.impl.LruMemoryCacheStrategy;
 import ro.isdc.wro.manager.factory.ConfigurableWroManagerFactory;
 import ro.isdc.wro.model.factory.WroModelFactory;
 
+import javax.servlet.ServletContext;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.OffsetDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Properties;
+
 /**
  * User: Jesse Date: 11/25/13 Time: 8:35 AM
  */
 public class GeonetworkWrojManagerFactory extends ConfigurableWroManagerFactory {
     public static final String WRO4J_LOG = "geonetwork.wro4j";
     private static final String CACHE_PROP_KEY = "cacheStrategy";
-    private static final java.lang.String SIZE_PROP_KEY = "lruSize";
+    private static final String SIZE_PROP_KEY = "lruSize";
 
-    private DiskbackedCache diskBackedCache = null;
+    private CacheStrategy<CacheKey, CacheValue> cacheStrategy = null;
+    private ServletContext servletContext;
+
 
     @Override
     protected WroModelFactory newModelFactory() {
@@ -35,20 +71,101 @@ public class GeonetworkWrojManagerFactory extends ConfigurableWroManagerFactory 
         int lruSize = Integer.parseInt(properties.getProperty(SIZE_PROP_KEY, "128"));
         switch (properties.getProperty(CACHE_PROP_KEY, "lru")) {
             case DiskbackedCache.NAME:
-                if (diskBackedCache == null) {
-                    diskBackedCache = new DiskbackedCache(lruSize, null);
+                if (cacheStrategy == null) {
+                    cacheStrategy = initDiskbackedCache(lruSize);
                 }
-                return diskBackedCache;
+                break;
             default:
-                return new LruMemoryCacheStrategy<>(lruSize);
+                cacheStrategy = new LruMemoryCacheStrategy<>(lruSize);
         }
+        return cacheStrategy;
     }
 
     @Override
     public void destroy() {
         super.destroy();
-        if (this.diskBackedCache != null) {
-            diskBackedCache.destroy();
+        if (this.cacheStrategy != null) {
+            cacheStrategy.destroy();
         }
+    }
+
+    private DiskbackedCache initDiskbackedCache(int lruSize) {
+        Properties bundledProperties = readPropertiesFile("/git.properties");
+        String bundledGitRevision = bundledProperties.getProperty("git.commit.id", "");
+        Path dataDirPath = null;
+        boolean gitVersionMatch = false;
+        try {
+            if (ApplicationContextHolder.get() != null) {
+                GeonetworkDataDirectory geonetworkDataDirectory = ApplicationContextHolder.get().getBean(GeonetworkDataDirectory.class);
+                if (ApplicationContextHolder.get() instanceof XmlWebApplicationContext) {
+                    servletContext = ((XmlWebApplicationContext) ApplicationContextHolder.get()).getServletContext();
+                }
+                dataDirPath = geonetworkDataDirectory.getSystemDataDir();
+            }
+            if (dataDirPath != null) {
+                Properties propInDataDir = new Properties();
+                Path propFileInDataDir = dataDirPath.resolve("git.properties");
+                if (Files.exists(propFileInDataDir)) {
+                    propInDataDir.load(Files.newInputStream(propFileInDataDir));
+                } else {
+                    bundledProperties.store(Files.newOutputStream(propFileInDataDir),
+                        "Copied from GN git.properties on " + DateTimeFormatter.ISO_DATE_TIME.format(OffsetDateTime.now()));
+                }
+                String dataDirGitVersion = propInDataDir.getProperty("git.commit.id");
+                gitVersionMatch = bundledGitRevision.equals(dataDirGitVersion);
+
+                if (servletContext != null) {
+                    // getResource() returns null if no resource with this name is found
+                    try (InputStream bundledPrebuiltCacheStream = servletContext.getResourceAsStream("/WEB-INF/prebuilt/wro4j-cache.mv.db")) {
+                        if (bundledPrebuiltCacheStream != null) {
+                            // The prebuilt cache exists
+                            Path dataWroCache = dataDirPath.resolve("wro4j-cache.mv.db");
+                            // Copy the prebuilt cache if it doesn't exist in the data directory or if the version in data
+                            // directory doesn't match the current GN git version
+                            if (!gitVersionMatch || Files.notExists(dataWroCache)) {
+                                Files.copy(bundledPrebuiltCacheStream, dataWroCache);
+                                Path customLessFiles = dataDirPath.resolve(Geonet.Config.NODE_LESS_DIR).resolve("gn_dynamic_style.json");
+                                if (Files.exists(customLessFiles)) {
+                                    removeCSSFromCache(dataDirPath);
+                                }
+                            }
+
+
+                        }
+                    }
+                }
+            }
+        } catch (IOException e) {
+            Log.error(WRO4J_LOG, "Error trying to initialize pre-populated wro4j-cache", e);
+        }
+
+
+        return new DiskbackedCache(lruSize, null);
+    }
+
+    private void removeCSSFromCache(Path dataDirPath) {
+
+        try (DiskbackedCache tempCache = new DiskbackedCache(50, dataDirPath.resolve("wro4j-cache").toString())) {
+            tempCache.deleteCSSItems();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    /**
+     * Reads a .properties file and load its content in a {@link Properties} object. Uses the classloader to retrieve
+     * the file.
+     *
+     * @param propertiesFile the file to load from the classpath.
+     * @return a {@link Properties} object with the contents of the file or empty if it can't be read.
+     */
+    private Properties readPropertiesFile(String propertiesFile) {
+        Properties properties = new Properties();
+        try (InputStream input = getClass().getResourceAsStream(propertiesFile)) {
+            properties.load(input);
+        } catch (IOException e) {
+            Log.error(WRO4J_LOG, "Cannot read " + propertiesFile + " file", e);
+        }
+        return properties;
     }
 }

--- a/wro4j/src/main/java/org/fao/geonet/wro4j/GeonetworkWrojManagerFactory.java
+++ b/wro4j/src/main/java/org/fao/geonet/wro4j/GeonetworkWrojManagerFactory.java
@@ -39,6 +39,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.time.OffsetDateTime;
 import java.time.format.DateTimeFormatter;
 import java.util.Properties;
@@ -123,7 +124,7 @@ public class GeonetworkWrojManagerFactory extends ConfigurableWroManagerFactory 
                             // Copy the prebuilt cache if it doesn't exist in the data directory or if the version in data
                             // directory doesn't match the current GN git version
                             if (!gitVersionMatch || Files.notExists(dataWroCache)) {
-                                Files.copy(bundledPrebuiltCacheStream, dataWroCache);
+                                Files.copy(bundledPrebuiltCacheStream, dataWroCache, StandardCopyOption.REPLACE_EXISTING);
                                 Path customLessFiles = dataDirPath.resolve(Geonet.Config.NODE_LESS_DIR).resolve("gn_dynamic_style.json");
                                 if (Files.exists(customLessFiles)) {
                                     removeCSSFromCache(dataDirPath);


### PR DESCRIPTION
WRO4J cache is store in an H2 database in the data directory of the catalogue. It is populated on demand when clients (ie. browser) request CSS or JS resources. Building the resources can take a bit of time on first load. To improve user experience on first load of the application, this proposal build the main resources and populate a prebuilt cache for the current version.

Use the `wro4j-prebuild-cache` maven profile for building the WRO4J cache in build time:

```shell
mvn clean install -Pwro4j-prebuild-cache
```

When the catalog starts, the prebuilt cache (stored in `WEB-INF/prebuilt`) is replaced in the data directory if:
* the data directory doesn't contain a wro4j-cache database
* or the git version stored in the data directory (in `git.properties`) doesn't match the GeoNetwork's git commit hash
Then, if the catalog configured custom CSS settings in the database then all the CSS resources from the cache are removed to allow the LESS compiler to take it on runtime.

For developper testing, the cache is available in `target` folder but does not apply while running `jetty:run`. Manually copy the prebuilt folder in the source for testing.  

