### PR TITLE
Map / PDF / Extent not always correct

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/print/PrintMapDirective.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/print/PrintMapDirective.js
@@ -125,6 +125,7 @@
       $scope.unsupportedLayers = gnPrint.getUnsupportedLayerTypes($scope.map);
 
       var initMapEvents = function () {
+        var currZoom = $scope.map.getView().getZoom();
         deregister = [
           $scope.map.on("moveend", function (event) {
             var newZoom = $scope.map.getView().getZoom();

--- a/web-ui/src/main/resources/catalog/components/common/map/print/PrintMapDirective.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/print/PrintMapDirective.js
@@ -126,15 +126,16 @@
 
       var initMapEvents = function () {
         deregister = [
-          $scope.map.getView().on("change:resolution", function (event) {
-            if ($scope.map.getView().getAnimating()) {
-              return;
-            }
-            if ($scope.auto) {
-              fitRectangleToView();
-              $scope.$apply();
-            } else {
-              updatePrintRectanglePixels($scope.config.scale);
+          $scope.map.on("moveend", function (event) {
+            var newZoom = $scope.map.getView().getZoom();
+            if (currZoom != newZoom) {
+              currZoom = newZoom;
+              if ($scope.auto) {
+                fitRectangleToView();
+                $scope.$apply();
+              } else {
+                updatePrintRectanglePixels($scope.config.scale);
+              }
             }
           }),
           $scope.$watch("auto", function (v) {


### PR DESCRIPTION
Using the `moveend` event instead of `change:resolution` which is triggered during animation but not at the end (cf. https://github.com/openlayers/openlayers/issues/7402#issuecomment-340776170).

The scale of the PDF was not updated.

Test:
* map > print the map
* zoom in
* print the map - both maps have same extent.