### PR TITLE
Fix status workflow facet labels

### DIFF
--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/FacetDirective.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/FacetDirective.js
@@ -161,7 +161,8 @@
     ["isTemplate", "recordType"],
     ["groupOwner", "group"],
     ["groupPublishedId", "group"],
-    ["sourceCatalogue", "source"]
+    ["sourceCatalogue", "source"],
+    ["statusWorkflow", "mdStatus"]
   ]);
 
   module.service("gnFacetSorter", [


### PR DESCRIPTION
Currently the status workflow facet in the Editor board displays the codes instead of the labels.

![image_2023_01_25T08_19_33_904Z](https://user-images.githubusercontent.com/1695003/214523383-b0c07208-18e4-424e-8622-1a32a98d53fd.png)

With this change, the correct labels are displayed:

<img width="289" alt="statusworkflow-facet-values" src="https://user-images.githubusercontent.com/1695003/214523592-9b5744dc-78ed-4c03-92f0-7d8af9cd76ab.png">
