### PR TITLE
Admin / Indexing errors / Add copy uuids to clipboard.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/utility/UtilityService.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityService.js
@@ -81,7 +81,9 @@
     "$rootScope",
     "$timeout",
     "$window",
-    function (gnPopup, $translate, $location, $rootScope, $timeout, $window) {
+    "$q",
+    "$http",
+    function (gnPopup, $translate, $location, $rootScope, $timeout, $window, $q, $http) {
       /**
        * Scroll page to element.
        */
@@ -421,6 +423,19 @@
         }
       };
 
+      var getSelectionListOfUuids = function (bucket, separator) {
+        var url = "../api/selections/" + bucket,
+          defer = $q.defer();
+        $http.delete(url).then(function () {
+          $http.put(url).then(function () {
+            $http.get(url).then(function (response) {
+              defer.resolve(response.data.join(separator || "\n"));
+            });
+          });
+        });
+        return defer.promise;
+      };
+
       return {
         scrollTo: scrollTo,
         isInView: isInView,
@@ -433,6 +448,7 @@
         toCsv: toCsv,
         CSVToArray: CSVToArray,
         getUrlParameter: getUrlParameter,
+        getSelectionListOfUuids: getSelectionListOfUuids,
         randomUuid: randomUuid,
         displayPermalink: displayPermalink,
         openModal: openModal,

--- a/web-ui/src/main/resources/catalog/js/admin/DashboardStatusController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/DashboardStatusController.js
@@ -51,7 +51,16 @@
     "$rootScope",
     "$translate",
     "gnESFacet",
-    function ($scope, $routeParams, $http, $rootScope, $translate, gnESFacet) {
+    "gnUtilityService",
+    function (
+      $scope,
+      $routeParams,
+      $http,
+      $rootScope,
+      $translate,
+      gnESFacet,
+      gnUtilityService
+    ) {
       $scope.healthy = undefined;
       $scope.nowarnings = undefined;
       $scope.threadSortField = undefined;
@@ -246,6 +255,10 @@
         });
       };
 
+      $scope.getListOfUuids = function () {
+        return gnUtilityService.getSelectionListOfUuids("ies");
+      };
+
       $scope.indexMessages = function (md) {
         if (angular.isArray(md.indexingErrorMsg)) {
           return md.indexingErrorMsg;
@@ -309,6 +322,7 @@
       };
       $scope.searchObj = {
         configId: "recordsWithErrors",
+        selectionBucket: "ies",
         defaultParams: {
           indexingErrorMsg: "*",
           sortBy: "changeDate",

--- a/web-ui/src/main/resources/catalog/locales/en-v4.json
+++ b/web-ui/src/main/resources/catalog/locales/en-v4.json
@@ -334,6 +334,7 @@
   "copyToClipboard": "Copy to clipboard.",
   "copyUrlToClipboard": "Copy URL to clipboard.",
   "copyHarvesterConfig": "Copy harvester config",
+  "copyListOfUuids": "Copy list of UUIDs",
   "addHarvesterFromClipboard": "Paste harvester config",
   "harvesterConfigIsNotJson": "The harvester config must be a JSON configuration.",
   "harvesterConfigIsNotValid": "The harvester config does not look to be a valid configuration.",

--- a/web-ui/src/main/resources/catalog/templates/admin/dashboard/status.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/dashboard/status.html
@@ -214,6 +214,16 @@
                 </tr>
               </thead>
               <tbody>
+                <tr>
+                  <td>
+                    <button
+                      gn-copy-to-clipboard-button=""
+                      get-text-fn="getListOfUuids()"
+                      btn-class="btn btn-xs pull-right"
+                      tooltip="copyListOfUuids"
+                    ></button>
+                  </td>
+                </tr>
                 <tr data-ng-repeat="md in searchResults.records">
                   <td>
                     <div class="dropdown">


### PR DESCRIPTION
While fixing indexing errors, user may need to easily get the UUID of affected records. Add a button to easily copy the list of UUID in current search.

![image](https://user-images.githubusercontent.com/1701393/214571984-eaebf1a4-6078-46aa-b685-00353e150fdf.png)
