### PR TITLE
Standard / ISO19115-3 / Indexing multiple quality reports

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/link-utility.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/link-utility.xsl
@@ -137,7 +137,7 @@
             <xsl:variable name="desc"
                           select="if (cit:description)
                                         then cit:description
-                                        else ../../mdq:abstract"/>
+                                        else ../../../../mdq:abstract"/>
             <xsl:choose>
               <xsl:when test="$forIndexing">
                 <xsl:copy-of select="$desc"/>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/link-utility.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/link-utility.xsl
@@ -104,37 +104,39 @@
                     select="current()"/>
       <xsl:for-each select="$root/descendant::*[
                               local-name() = $docType/element/text()
-                              ]/*[cit:onlineResource/*/cit:linkage/gco:CharacterString != '']">
+                              ]/*/cit:onlineResource/*[cit:linkage/gco:CharacterString != '']">
         <item>
           <id>
-            <xsl:value-of select="cit:onlineResource/cit:CI_OnlineResource/cit:linkage/gco:CharacterString"/>
+            <xsl:value-of select="cit:linkage/gco:CharacterString"/>
           </id>
           <url>
             <xsl:choose>
               <xsl:when test="$forIndexing">
-                <xsl:copy-of select="cit:onlineResource/*/cit:linkage"/>
+                <xsl:copy-of select="cit:linkage"/>
               </xsl:when>
               <xsl:otherwise>
                 <xsl:apply-templates mode="get-iso19115-3.2018-localized-string"
-                                     select="cit:onlineResource/*/cit:linkage"/>
+                                     select="cit:linkage"/>
               </xsl:otherwise>
             </xsl:choose>
           </url>
           <title>
+            <xsl:variable name="name"
+                          select="if (cit:name) then cit:name else ../../cit:title"/>
             <xsl:choose>
               <xsl:when test="$forIndexing">
-                <xsl:copy-of select="cit:title"/>
+                <xsl:copy-of select="$name"/>
               </xsl:when>
               <xsl:otherwise>
                 <xsl:apply-templates mode="get-iso19115-3.2018-localized-string"
-                                     select="cit:title"/>
+                                     select="$name"/>
               </xsl:otherwise>
             </xsl:choose>
           </title>
           <description>
             <xsl:variable name="desc"
-                          select="if (cit:onlineResource/*/cit:description)
-                                        then cit:onlineResource/*/cit:description
+                          select="if (cit:description)
+                                        then cit:description
                                         else ../../mdq:abstract"/>
             <xsl:choose>
               <xsl:when test="$forIndexing">


### PR DESCRIPTION
If records contains multiple quality reports, indexing error are reported

eg.
```xml
  <mdb:dataQualityInfo>
      <mdq:DQ_DataQuality>
         <mdq:scope>
            <mcc:MD_Scope>
               <mcc:level>
                  <mcc:MD_ScopeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_ScopeCode"
                                    codeListValue="series"/>
               </mcc:level>
            </mcc:MD_Scope>
         </mdq:scope>
         <mdq:standaloneQualityReport>
            <mdq:DQ_StandaloneQualityReportInformation>
               <mdq:reportReference>
                  <cit:CI_Citation>
                     <cit:onlineResource>
                        <cit:CI_OnlineResource>
                           <cit:linkage>
                              <gco:CharacterString>http://www.osi-saf.org/</gco:CharacterString>
                           </cit:linkage>
                           <cit:protocol>
                              <gco:CharacterString>WWW:LINK</gco:CharacterString>
                           </cit:protocol>
                           <cit:name>
                              <gco:CharacterString>Radiative fluxes over Indian Ocean from METEOSAT-8 data, validation report</gco:CharacterString>
                           </cit:name>
                           <cit:description>
                              <gco:CharacterString>Validation report for OSI SAF Meteosat Radiatives fluxes</gco:CharacterString>
                           </cit:description>
                           <cit:function>
                              <cit:CI_OnLineFunctionCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_OnLineFunctionCode"
                                                         codeListValue="information"/>
                           </cit:function>
                        </cit:CI_OnlineResource>
                     </cit:onlineResource>
                     <cit:onlineResource>
                        <cit:CI_OnlineResource>
                           <cit:linkage>
                              <gco:CharacterString>http://www.osi-saf.org/lml/#qkl_FLX%DLI_meteosat_Daily</gco:CharacterString>
                           </cit:linkage>
                           <cit:protocol>
                              <gco:CharacterString>WWW:LINK</gco:CharacterString>
                           </cit:protocol>
                           <cit:name>
                              <gco:CharacterString>Online SST quality assessment tool</gco:CharacterString>
                           </cit:name>
                           <cit:description>
                              <gco:CharacterString>Online SST quality assessment tool</gco:CharacterString>
                           </cit:description>
                           <cit:function>
                              <cit:CI_OnLineFunctionCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_OnLineFunctionCode"
                                                         codeListValue="information"/>
                           </cit:function>
                        </cit:CI_OnlineResource>
                     </cit:onlineResource>
                  </cit:CI_Citation>
               </mdq:reportReference>
            </mdq:DQ_StandaloneQualityReportInformation>
         </mdq:standaloneQualityReport>
      </mdq:DQ_DataQuality>
  </mdb:dataQualityInfo>
```

was failing with

```
2023-01-26T17:07:55,730 ERROR [geonetwork.index] - Parsing invalid JSON node { "protocol": "WWW:LINK", "function": "dataQualityReport", "urlObject": {"default":"http://www.osi-saf.org/", "langeng":"http://www.osi-saf.org/lml/doc/osisaf_cdop3_ss1_svr_meteosat08_io_flx.pdf"} {"default":"http://www.osi-saf.org/lml/#qkl_FLX%DLI_meteosat_Daily", "langeng":"http://www.osi-saf.org/lml/#qkl_FLX%DLI_meteosat_Daily"} , "descriptionObject": {"default":"Validation report for OSI SAF Meteosat Radiatives fluxes", "langeng":"Validation report for OSI SAF Meteosat Radiatives fluxes"} {"default":"Online SST quality assessment tool", "langeng":"Online SST quality assessment tool"} , "applicationProfile": "" } for property link. Error is: Unexpected character ('{' (code 123)): was expecting comma to separate Object entries
 at [Source: (String)"{
```