### PR TITLE
Editor / Online links / Display full URL.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/fileUploader.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/fileUploader.html
@@ -17,10 +17,10 @@
           data-ng-src="{{onlinesrcService.getApprovedUrl(f.lUrl || f.id)}}"
         />
 
-        <span class="flex-row" data-ng-if="!isOverview">
-          <div class="width-25" data-gn-link-icon="f" data-mode="gn-icon-inline"></div>
-          <div class="width-75" data-gn-link-label="f" />
-        </span>
+        <div data-ng-if="!isOverview">
+          <div data-gn-link-icon="f" data-mode="gn-icon-inline"></div>
+          <div data-gn-link-label="f"></div>
+        </div>
 
         <a
           href=""

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/onlinesrcList.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/onlinesrcList.html
@@ -170,14 +170,17 @@
           >
             <div class="row">
               <div class="col-md-11">
-                <span data-gn-link-icon="resource" data-mode="gn-icon-inline"></span>
-                <span data-gn-link-label="resource" />
-                <br data-ng-if="resource.locTitle" />
+                <span
+                  data-gn-link-icon="resource"
+                  titel="{{resource.protocol || ''}}"
+                  data-mode="gn-icon-inline"
+                ></span>
                 <strong>{{resource.locTitle}}</strong>
-                <br data-ng-if="resource.locDescription" />
+                <br data-ng-if="resource.locTitle" />
                 {{resource.locDescription}}
+                <br data-ng-if="resource.locDescription" />
+                <span data-gn-link-label="resource" />
                 <br />
-                <em data-ng-if="resource.protocol">{{resource.protocol || ''}}</em>
 
                 <div
                   data-ng-if="canPublishDoiForResource(resource)"

--- a/web-ui/src/main/resources/catalog/components/utility/partials/linklabel.html
+++ b/web-ui/src/main/resources/catalog/components/utility/partials/linklabel.html
@@ -4,6 +4,6 @@
   data-ng-if="link.lUrl.match('^http|ftp') !== null"
   target="_blank"
 >
-  {{link.lUrl.split('/').pop()}}
+  {{link.lUrl}}
 </a>
 <span data-ng-if="link.lUrl.match('^http|ftp') === null"> {{link.lUrl}} </span>

--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -214,6 +214,7 @@ div[gn-transfer-ownership] * .list-group {
 
 a {
   word-wrap: break-word;
+  word-break: break-all;
 }
 .gn-break {
   word-wrap: break-word;

--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -488,9 +488,6 @@ div.thumb-small {
 }
 .gn-list-file {
   position: relative;
-  white-space: nowrap;
-  text-overflow: ellipsis;
-  overflow: hidden;
   width: 100%;
   text-align: left;
   margin-bottom: 5px !important;

--- a/web-ui/src/main/resources/catalog/style/gn_editor.less
+++ b/web-ui/src/main/resources/catalog/style/gn_editor.less
@@ -531,6 +531,11 @@ form.gn-tab-inspire {
   .list-group-item {
     padding-left: 10px;
     padding-right: 5px;
+
+    [data-gn-link-icon] .label {
+      display: inline;
+    }
+
     // background-color: #fbfcfb;
     .row > div.col-md-10 {
       white-space: nowrap;

--- a/web-ui/src/main/resources/catalog/style/gn_editor.less
+++ b/web-ui/src/main/resources/catalog/style/gn_editor.less
@@ -523,6 +523,12 @@ form.gn-tab-inspire {
   }
 }
 
+[data-gn-file-uploader] {
+  [data-gn-link-icon] .label {
+    display: inline;
+  }
+}
+
 /* Onlinesrc styles */
 .gn-onlinesrc-panel {
   h2 {

--- a/web-ui/src/main/resources/catalog/style/gn_editor.less
+++ b/web-ui/src/main/resources/catalog/style/gn_editor.less
@@ -536,6 +536,12 @@ form.gn-tab-inspire {
       display: inline;
     }
 
+    [data-gn-link-icon] {
+      display: inline-block;
+      float: left;
+      width: 100%;
+    }
+
     // background-color: #fbfcfb;
     .row > div.col-md-10 {
       white-space: nowrap;


### PR DESCRIPTION
Some users are reporting that it is hard to find link as we don't display the full URL (only in tooltip). Also if the URL ends with a "/" the URL is not displayed as we were displaying the last token after the last "/". So it may be more relevant to display the full URL ? @MichelGabriel any advices ?


Before
![image](https://user-images.githubusercontent.com/1701393/215074642-3eed3bdc-4a05-459a-b57c-0ea14a68b991.png)


After 
![image](https://user-images.githubusercontent.com/1701393/215074662-ce89b791-4a6b-486c-9447-bb687637d3aa.png)

We used to display it in one line expanding the item on hover which was also not optimal ...
