### PR TITLE
Harvester / WFS features / Debug, Instant NPE, cleanup.

### DIFF
--- a/web/src/main/webapp/WEB-INF/classes/log4j2.xml
+++ b/web/src/main/webapp/WEB-INF/classes/log4j2.xml
@@ -55,7 +55,7 @@
     <Logger name="geonetwork.formatter" level="error"/>
     <Logger name="geonetwork.geoserver.publisher" level="error"/>
     <Logger name="geonetwork.geoserver.rest" level="error"/>
-    <Logger name="geonetwork.harvest.wfs.features"/>
+    <Logger name="geonetwork.harvest.wfs.features" level="debug"/>
     <Logger name="geonetwork.harvester" level="info"/>
     <Logger name="geonetwork.harvester" level="info"/>
     <Logger name="geonetwork.index" level="error"/>

--- a/workers/wfsfeature-harvester/src/main/java/org/fao/geonet/harvester/wfsfeatures/worker/EsWFSFeatureIndexer.java
+++ b/workers/wfsfeature-harvester/src/main/java/org/fao/geonet/harvester/wfsfeatures/worker/EsWFSFeatureIndexer.java
@@ -392,7 +392,7 @@ public class EsWFSFeatureIndexer {
                             } else if (attributeValue instanceof Instant) {
                                 try {
                                     Position position = ((DefaultInstant) attributeValue).getPosition();
-                                    if (position != null) {
+                                    if (position != null && position.getDate() != null) {
                                         rootNode.put(getDocumentFieldName(attributeName),
                                             position.getDate().toInstant().toString());
                                     }

--- a/workers/wfsfeature-harvester/src/main/java/org/fao/geonet/harvester/wfsfeatures/worker/EsWFSFeatureIndexer.java
+++ b/workers/wfsfeature-harvester/src/main/java/org/fao/geonet/harvester/wfsfeatures/worker/EsWFSFeatureIndexer.java
@@ -61,6 +61,7 @@ import org.locationtech.jts.precision.GeometryPrecisionReducer;
 import org.opengis.feature.simple.SimpleFeature;
 import org.opengis.geometry.BoundingBox;
 import org.opengis.temporal.Instant;
+import org.opengis.temporal.Position;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -390,8 +391,11 @@ public class EsWFSFeatureIndexer {
                                 rootNode.put("bbox_ymax", bbox.getMaxY());
                             } else if (attributeValue instanceof Instant) {
                                 try {
-                                    rootNode.put(getDocumentFieldName(attributeName),
-                                        ((DefaultInstant) attributeValue).getPosition().getDate().toInstant().toString());
+                                    Position position = ((DefaultInstant) attributeValue).getPosition();
+                                    if (position != null) {
+                                        rootNode.put(getDocumentFieldName(attributeName),
+                                            position.getDate().toInstant().toString());
+                                    }
                                 } catch (Exception instantException) {
                                     String msg = String.format(
                                         "Feature %s: Cannot read attribute %s, value %s. Exception is: %s",

--- a/workers/wfsfeature-harvester/src/main/java/org/fao/geonet/harvester/wfsfeatures/worker/WFSClientWithStrategyInvestigator.java
+++ b/workers/wfsfeature-harvester/src/main/java/org/fao/geonet/harvester/wfsfeatures/worker/WFSClientWithStrategyInvestigator.java
@@ -39,6 +39,9 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 
+import static org.fao.geonet.harvester.wfsfeatures.worker.WFSHarvesterExchangeState.MAPSERVER_STRATEGY;
+import static org.fao.geonet.harvester.wfsfeatures.worker.WFSHarvesterExchangeState.QGIS_STRATEGY;
+
 /**
  * WFSClient which use the DescribeFeatureType request to determine
  * which WFSStrategy to user.
@@ -84,10 +87,10 @@ public class WFSClientWithStrategyInvestigator extends WFSClient {
             String responsePayload = out.toString("UTF-8");
             if (responsePayload.contains("targetNamespace=\"http://www.qgis.org/gml\"")) {
                 strategy = new QgisStrategy();
-                strategyId = "qgis";
+                strategyId = QGIS_STRATEGY;
             } else if (responsePayload.contains("targetNamespace=\"http://mapserver.gis.umn.edu/mapserver\"")) {
                 strategy = new MapServerWFSStrategy(capabilities.getRawDocument());
-                strategyId = "mapserver";
+                strategyId = MAPSERVER_STRATEGY;
             }
         } catch (Exception e) {
             e.printStackTrace();

--- a/workers/wfsfeature-harvester/src/main/java/org/fao/geonet/harvester/wfsfeatures/worker/WFSClientWithStrategyInvestigator.java
+++ b/workers/wfsfeature-harvester/src/main/java/org/fao/geonet/harvester/wfsfeatures/worker/WFSClientWithStrategyInvestigator.java
@@ -25,13 +25,13 @@ package org.fao.geonet.harvester.wfsfeatures.worker;
 
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
-import org.geotools.http.HTTPClient;
-import org.geotools.http.HTTPResponse;
 import org.geotools.data.wfs.internal.WFSClient;
 import org.geotools.data.wfs.internal.WFSConfig;
 import org.geotools.data.wfs.internal.WFSGetCapabilities;
 import org.geotools.data.wfs.internal.WFSStrategy;
 import org.geotools.data.wfs.internal.v1_x.MapServerWFSStrategy;
+import org.geotools.http.HTTPClient;
+import org.geotools.http.HTTPResponse;
 import org.geotools.ows.ServiceException;
 
 import java.io.ByteArrayOutputStream;
@@ -45,7 +45,8 @@ import java.net.URL;
  */
 public class WFSClientWithStrategyInvestigator extends WFSClient {
     private String describeFeatureTypeUrl;
-    private transient Logger logger = LogManager.getLogger(WFSHarvesterRouteBuilder.LOGGER_NAME);
+    private String strategyId;
+    private Logger logger = LogManager.getLogger(WFSHarvesterRouteBuilder.LOGGER_NAME);
 
     public WFSClientWithStrategyInvestigator(URL capabilitiesURL, HTTPClient httpClient, WFSConfig config, String describeFeatureTypeUrl) throws IOException, ServiceException {
         this(capabilitiesURL, httpClient, config, (WFSGetCapabilities) null, describeFeatureTypeUrl);
@@ -54,12 +55,12 @@ public class WFSClientWithStrategyInvestigator extends WFSClient {
     public WFSClientWithStrategyInvestigator(URL capabilitiesURL, HTTPClient httpClient, WFSConfig config, WFSGetCapabilities capabilities, String describeFeatureTypeUrl) throws IOException, ServiceException {
         super(capabilitiesURL, httpClient, config, capabilities);
         this.describeFeatureTypeUrl = describeFeatureTypeUrl;
-        logger.debug(String.format(
-            "WFS client default strategy is %s", getStrategy()));
+        logger.debug(
+            "WFS client default strategy is {}", getStrategy());
         WFSStrategy targetNsBasedStrategy = this.determineCorrectStrategy(httpClient);
         if (targetNsBasedStrategy != null) {
-            logger.debug(String.format(
-                "Overriding WFS client strategy with GFI target namespace strategy: %s", targetNsBasedStrategy.getClass().getName()));
+            logger.debug(
+                "Overriding WFS client strategy with GFI target namespace strategy: {}", targetNsBasedStrategy.getClass().getName());
             super.specification = targetNsBasedStrategy;
             ((WFSStrategy) specification).setCapabilities(super.capabilities);
         }
@@ -70,7 +71,7 @@ public class WFSClientWithStrategyInvestigator extends WFSClient {
         WFSStrategy strategy = null;
 
         try {
-            logger.debug(String.format("Determining strategy based on %s", describeFeatureTypeUrl));
+            logger.debug("Determining strategy based on {}", describeFeatureTypeUrl);
             HTTPResponse httpResponse = httpClient.get(new URL(describeFeatureTypeUrl));
             InputStream inputStream = httpResponse.getResponseStream();
 
@@ -83,12 +84,18 @@ public class WFSClientWithStrategyInvestigator extends WFSClient {
             String responsePayload = out.toString("UTF-8");
             if (responsePayload.contains("targetNamespace=\"http://www.qgis.org/gml\"")) {
                 strategy = new QgisStrategy();
+                strategyId = "qgis";
             } else if (responsePayload.contains("targetNamespace=\"http://mapserver.gis.umn.edu/mapserver\"")) {
                 strategy = new MapServerWFSStrategy(capabilities.getRawDocument());
+                strategyId = "mapserver";
             }
         } catch (Exception e) {
             e.printStackTrace();
         }
         return strategy;
+    }
+
+    public String getStrategyId() {
+        return strategyId;
     }
 }

--- a/workers/wfsfeature-harvester/src/main/java/org/fao/geonet/harvester/wfsfeatures/worker/WFSHarvesterExchangeState.java
+++ b/workers/wfsfeature-harvester/src/main/java/org/fao/geonet/harvester/wfsfeatures/worker/WFSHarvesterExchangeState.java
@@ -27,8 +27,10 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.fao.geonet.harvester.wfsfeatures.model.WFSHarvesterParameter;
+import org.geotools.data.DataStoreFinder;
 import org.geotools.data.wfs.WFSDataStore;
 import org.geotools.data.wfs.WFSDataStoreFactory;
+import org.geotools.data.wfs.impl.WFSDataAccessFactory;
 import org.opengis.feature.simple.SimpleFeatureType;
 import org.opengis.feature.type.AttributeDescriptor;
 
@@ -43,9 +45,15 @@ import java.util.stream.Collectors;
 public class WFSHarvesterExchangeState implements Serializable {
     private WFSHarvesterParameter parameters;
     private transient Logger logger = LogManager.getLogger(WFSHarvesterRouteBuilder.LOGGER_NAME);
-    private transient Map<String, String> fields = new LinkedHashMap<String, String>();
+    private transient Map<String, String> fields = new LinkedHashMap<>();
     private transient WFSDataStore wfsDatastore = null;
     private String resolvedTypeName = null;
+
+    private String strategyId = null;
+
+    public String getStrategyId() {
+        return strategyId;
+    }
 
     public WFSHarvesterParameter getParameters() {
         return parameters;
@@ -82,18 +90,16 @@ public class WFSHarvesterExchangeState implements Serializable {
 
 
     private void checkTaskParameters() {
-        logger.info("Checking parameters ...");
         if (StringUtils.isEmpty(parameters.getUrl())) {
             String errorMsg = "Empty WFS server URL is not allowed.";
             logger.error(errorMsg);
             throw new IllegalArgumentException(errorMsg);
         }
         if (StringUtils.isEmpty(parameters.getTypeName())) {
-            String errorMsg = "Empty WFS type name is not allowed.";
-            logger.error(errorMsg);
+            String errorMsg = "Check configuration for WFS {}. Empty type name is not allowed.";
+            logger.error(errorMsg, parameters.getUrl());
             throw new IllegalArgumentException(errorMsg);
         }
-        logger.info("Parameters are accepted.");
     }
 
     /**
@@ -111,84 +117,87 @@ public class WFSHarvesterExchangeState implements Serializable {
             factory = new WFSDataStoreFactory();
         }
 
-        Map m = new HashMap();
+        Map<String, Object> m = new HashMap<>();
 
         try {
             String getCapUrl = OwsUtils.getGetCapabilitiesUrl(
-                    parameters.getUrl(), parameters.getVersion());
-            logger.info(String.format(
-                    "Connecting using GetCatapbilities URL '%s'.",
-                    getCapUrl));
+                parameters.getUrl(), parameters.getVersion());
+            logger.info("Connecting using GetCatapbilities URL '{}'.", getCapUrl);
 
-            m.put(WFSDataStoreFactory.URL.key, getCapUrl);
-            m.put(WFSDataStoreFactory.TIMEOUT.key, parameters.getTimeOut());
-            m.put(WFSDataStoreFactory.TRY_GZIP.key, true);
-            m.put(WFSDataStoreFactory.ENCODING.key, parameters.getEncoding());
-            m.put(WFSDataStoreFactory.USEDEFAULTSRS.key, true);
-            m.put(WFSDataStoreFactory.OUTPUTFORMAT.key, "GML3"); // seems to be mandatory with wfs 1.1.0 sources
-            m.put(WFSDataStoreFactory.LENIENT.key, true);
+            m.put(WFSDataAccessFactory.URL.key, getCapUrl);
+            m.put(WFSDataAccessFactory.TIMEOUT.key, parameters.getTimeOut());
+            m.put(WFSDataAccessFactory.TRY_GZIP.key, true);
+            m.put(WFSDataAccessFactory.ENCODING.key, parameters.getEncoding());
+            m.put(WFSDataAccessFactory.USEDEFAULTSRS.key, true);
+            m.put(WFSDataAccessFactory.OUTPUTFORMAT.key, "GML3"); // seems to be mandatory with wfs 1.1.0 sources
+            m.put(WFSDataAccessFactory.LENIENT.key, true);
             if(!"investigator".equals(parameters.getStrategy())
                 && StringUtils.isNotEmpty(parameters.getStrategy())) {
-                m.put(WFSDataStoreFactory.WFS_STRATEGY.key, parameters.getStrategy());
+                m.put(WFSDataAccessFactory.WFS_STRATEGY.key, parameters.getStrategy());
             }
 
             if (parameters.getMaxFeatures() != -1) {
-                m.put(WFSDataStoreFactory.MAXFEATURES.key, parameters.getMaxFeatures());
+                m.put(WFSDataAccessFactory.MAXFEATURES.key, parameters.getMaxFeatures());
             }
 
             wfsDatastore = factory.createDataStore(m);
-
-            logger.info(String.format(
-                    "Reading feature type '%s' schema structure.",
-                    parameters.getTypeName()));
-            SimpleFeatureType sft = null;
-            try {
-                sft = wfsDatastore.getSchema(parameters.getTypeName());
-                resolvedTypeName = parameters.getTypeName();
-            } catch (IOException e) {
-                String[] typeNames = wfsDatastore.getTypeNames();
-                String typeNamesList = Arrays.stream(typeNames).collect(Collectors.joining(", "));
-                logger.info(String.format(
-                    "Type '%s' not found in data store. Available types are %s. Trying to found a match ignoring namespace.",
-                    parameters.getTypeName(),
-                    typeNamesList
-                   ));
-                Optional<String> typeFound = Arrays.stream(typeNames)
-                    .filter(t -> t.endsWith(parameters.getTypeName())).findFirst();
-                if (typeFound.isPresent()) {
-                    resolvedTypeName = typeFound.get();
-                    logger.info(String.format(
-                        "Found a type '%s'.",
-                        resolvedTypeName
-                    ));
-                    sft = wfsDatastore.getSchema(resolvedTypeName);
-                } else {
-                    throw new NoSuchElementException(String.format(
-                        "No type found for '%s' (with or without namespace match).",
-                        parameters.getTypeName()
-                    ));
+            // Default to GeoTools auto mode for MapServer.
+            if(factory instanceof WFSDataStoreWithStrategyInvestigator) {
+                WFSClientWithStrategyInvestigator wfsClientWithStrategyInvestigator = (WFSClientWithStrategyInvestigator) wfsDatastore.getWfsClient();
+                this.strategyId = wfsClientWithStrategyInvestigator.getStrategyId();
+                if ("mapserver".equals(wfsClientWithStrategyInvestigator.getStrategyId())) {
+                    Map<String, Object> connectionParameters = new HashMap<>();
+                    connectionParameters.put("WFSDataStoreFactory:GET_CAPABILITIES_URL", parameters.getUrl());
+                    wfsDatastore = (WFSDataStore) DataStoreFinder.getDataStore(connectionParameters);
                 }
             }
-
-            List<AttributeDescriptor> attributesDesc = sft.getAttributeDescriptors();
-
-            for (AttributeDescriptor desc : attributesDesc) {
-                fields.put(desc.getName().getLocalPart(), OwsUtils.getTypeFromFeatureType(desc));
-            }
-
-            logger.info(String.format(
-                    "Successfully analyzed %d attributes in schema.", fields.size()));
         } catch (IOException e) {
             String errorMsg = String.format(
-                    "Failed to create datastore from service using URL '%s'. Error is %s.", parameters.getUrl(), e.getMessage());
+                "Failed to create datastore from service using URL '%s'. Error is %s.", parameters.getUrl(), e.getMessage());
             logger.error(errorMsg);
             throw e;
         } catch (Exception e) {
             String errorMsg = String.format(
-                    "Failed to GetCapabilities from service using URL '%s'. Error is %s.",
-                    parameters.getUrl(), e.getMessage());
+                "Failed to GetCapabilities from service using URL '%s'. Error is %s.",
+                parameters.getUrl(), e.getMessage());
             logger.error(errorMsg);
             throw e;
         }
+
+        logger.info("Reading feature type '{}' schema structure.",
+            parameters.getTypeName());
+        SimpleFeatureType sft = null;
+        try {
+            sft = wfsDatastore.getSchema(parameters.getTypeName());
+            resolvedTypeName = parameters.getTypeName();
+        } catch (IOException e) {
+            String[] typeNames = wfsDatastore.getTypeNames();
+            String typeNamesList = Arrays.stream(typeNames).collect(Collectors.joining(", "));
+            logger.info(String.format(
+                "Type '%s' not found in data store. Available types are %s. Trying to found a match ignoring namespace.",
+                parameters.getTypeName(),
+                typeNamesList
+            ));
+            Optional<String> typeFound = Arrays.stream(typeNames)
+                .filter(t -> t.endsWith(parameters.getTypeName())).findFirst();
+            if (typeFound.isPresent()) {
+                resolvedTypeName = typeFound.get();
+                logger.info("Found a type '{}'.", resolvedTypeName);
+                sft = wfsDatastore.getSchema(resolvedTypeName);
+            } else {
+                throw new NoSuchElementException(String.format(
+                    "No type found for '%s' (with or without namespace match).",
+                    parameters.getTypeName()
+                ));
+            }
+        }
+
+        List<AttributeDescriptor> attributesDesc = sft.getAttributeDescriptors();
+
+        for (AttributeDescriptor desc : attributesDesc) {
+            fields.put(desc.getName().getLocalPart(), OwsUtils.getTypeFromFeatureType(desc));
+        }
+
+        logger.info("Successfully analyzed {} attributes in schema.", fields.size());
     }
 }

--- a/workers/wfsfeature-harvester/src/main/java/org/fao/geonet/harvester/wfsfeatures/worker/WFSHarvesterExchangeState.java
+++ b/workers/wfsfeature-harvester/src/main/java/org/fao/geonet/harvester/wfsfeatures/worker/WFSHarvesterExchangeState.java
@@ -43,6 +43,10 @@ import java.util.stream.Collectors;
  * Created by fgravin on 11/5/15.
  */
 public class WFSHarvesterExchangeState implements Serializable {
+    public static final String MAPSERVER_STRATEGY = "mapserver";
+
+    public static final String QGIS_STRATEGY = "qgis";
+    public static final String INVESTIGATOR_STRATEGY = "investigator";
     private WFSHarvesterParameter parameters;
     private transient Logger logger = LogManager.getLogger(WFSHarvesterRouteBuilder.LOGGER_NAME);
     private transient Map<String, String> fields = new LinkedHashMap<>();
@@ -109,7 +113,7 @@ public class WFSHarvesterExchangeState implements Serializable {
     public void initDataStore() throws Exception {
         // Used to manage QGIS-Server based WFS
         WFSDataStoreFactory factory = null;
-        if ("investigator".equals(parameters.getStrategy())) {
+        if (INVESTIGATOR_STRATEGY.equals(parameters.getStrategy())) {
             factory = new WFSDataStoreWithStrategyInvestigator();
             ((WFSDataStoreWithStrategyInvestigator) factory).init(
                 parameters.getUrl(), parameters.getTypeName());
@@ -131,7 +135,7 @@ public class WFSHarvesterExchangeState implements Serializable {
             m.put(WFSDataAccessFactory.USEDEFAULTSRS.key, true);
             m.put(WFSDataAccessFactory.OUTPUTFORMAT.key, "GML3"); // seems to be mandatory with wfs 1.1.0 sources
             m.put(WFSDataAccessFactory.LENIENT.key, true);
-            if(!"investigator".equals(parameters.getStrategy())
+            if(!INVESTIGATOR_STRATEGY.equals(parameters.getStrategy())
                 && StringUtils.isNotEmpty(parameters.getStrategy())) {
                 m.put(WFSDataAccessFactory.WFS_STRATEGY.key, parameters.getStrategy());
             }
@@ -145,7 +149,7 @@ public class WFSHarvesterExchangeState implements Serializable {
             if(factory instanceof WFSDataStoreWithStrategyInvestigator) {
                 WFSClientWithStrategyInvestigator wfsClientWithStrategyInvestigator = (WFSClientWithStrategyInvestigator) wfsDatastore.getWfsClient();
                 this.strategyId = wfsClientWithStrategyInvestigator.getStrategyId();
-                if ("mapserver".equals(wfsClientWithStrategyInvestigator.getStrategyId())) {
+                if (MAPSERVER_STRATEGY.equals(wfsClientWithStrategyInvestigator.getStrategyId())) {
                     Map<String, Object> connectionParameters = new HashMap<>();
                     connectionParameters.put("WFSDataStoreFactory:GET_CAPABILITIES_URL", parameters.getUrl());
                     wfsDatastore = (WFSDataStore) DataStoreFinder.getDataStore(connectionParameters);


### PR DESCRIPTION
* Avoid NPE on Instant type - set field value to null
```
"Feature BIGOOD_prelevements#45581/id:fid-65ee4ab8_185f3393a14_3211: 
Cannot read attribute SAMPLING_DATE, value Instant{}.
Exception is: null"
```
* Set log level to debug so that user can get some info in the log about the progress (at some point we may make dedicated log file like in other harvester)
* Fix sonarlint reports