### PR TITLE
Skip indexing empty topic categories values

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
@@ -647,7 +647,7 @@
         </xsl:call-template>
 
 
-        <xsl:for-each select="mri:topicCategory/mri:MD_TopicCategoryCode">
+        <xsl:for-each select="mri:topicCategory/mri:MD_TopicCategoryCode[string(.)]">
           <xsl:variable name="value" as="node()">
             <xsl:copy>
               <xsl:attribute name="codeListValue" select="."/>

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
@@ -602,7 +602,7 @@
         </xsl:call-template>
 
 
-        <xsl:for-each select="gmd:topicCategory/gmd:MD_TopicCategoryCode">
+        <xsl:for-each select="gmd:topicCategory/gmd:MD_TopicCategoryCode[string(.)]">
           <xsl:variable name="value" as="node()">
             <xsl:copy>
               <xsl:attribute name="codeListValue" select="."/>


### PR DESCRIPTION
Avoid indexing empty values for topic categories, otherwise depending on the ElasticSearch response the empty values are displayed in the home page facets. See the item on the right, displaying an internal key (13) and 4 metadata with empty topic categories:

![home-topics](https://user-images.githubusercontent.com/1695003/215737847-114c00c7-534d-4c50-b608-7a818d31f977.png)
