### PR TITLE
[a11y] Make the toolbar on the editor dashboard accessible by keyboard

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/editor.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/editor.html
@@ -71,7 +71,7 @@
           <div class="btn-group">
             <a
               class="btn btn-default"
-              data-ng-href=""
+              href=""
               data-ng-if="user.canManagePrivileges(md) && user.isEditorOrMore() && md.draft != 'y'"
               data-ng-click="mdService.openPrivilegesPanel(md, getCatScope())"
               title="{{'privileges' | translate}}"
@@ -93,6 +93,7 @@
             </a>
             <a
               class="btn btn-default"
+              href=""
               data-ng-show="(!md.isPublished() || (md.isPublished() && user.canDeletePublishedMetadata())) && user.canEditRecord(md) && md.isTemplate != 's'
                              && (user.isReviewerOrMore() || md.mdStatus != 4 || !isMdWorkflowEnable)
                              && md.draft != 'e'"


### PR DESCRIPTION
This PR makes the toolbar on the editor dashboard accessible by keyboard. The `privileges` and `delete` button didn't get the keyboard focus when using the `TAB` key on the page

<img width="923" alt="gn-editor-toolbar" src="https://user-images.githubusercontent.com/19608667/216065067-a33199de-916a-4a19-8dad-ee264d9058b3.png">


Done:
Add `href` to the `<a>` element to make the link accessible by keyboard