### PR TITLE
Standard / ISO19139 / Indexing distribution format encoded using Anchor

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
@@ -988,9 +988,10 @@
 
       <xsl:for-each select="gmd:distributionInfo/*">
         <xsl:for-each
-          select="gmd:distributionFormat/*/gmd:name/gco:CharacterString[. != '']">
+          select="gmd:distributionFormat/*/gmd:name/*[. != '']">
           <xsl:copy-of select="gn-fn-index:add-field('format', .)"/>
         </xsl:for-each>
+
 
         <!-- Indexing distributor contact -->
         <xsl:for-each select="gmd:distributor/*[gmd:distributorContact]">


### PR DESCRIPTION
eg. https://beta.metadata.vlaanderen.be/srv/dut/catalog.search#/metadata/9f0ef2ea-49a3-454e-9685-8cace422cd11

```xml
<gmd:distributionFormat>
  <gmd:MD_Format>
    <gmd:name>
      <gmx:Anchor xlink:href="http://publications.europa.eu/resource/authority/file-type/SHP">Esri Shape</gmx:Anchor>
    </gmd:name>
    <gmd:version gco:nilReason="unknown">
      <gco:CharacterString/>
    </gmd:version>
  </gmd:MD_Format>
</gmd:distributionFormat>
```


![image](https://user-images.githubusercontent.com/1701393/216910352-2462c681-c8d2-45ad-91e9-96ae9f2ad93b.png)
