### PR TITLE
When identifying on a layer from a metadata with a linked feature catalog record, use case insensitive comparison between the feature catalog column definitions and the WMS FeatureInfo response.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/viewer/gfi/FeaturesLoader.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/gfi/FeaturesLoader.js
@@ -252,7 +252,7 @@
 
       var columns = Object.keys(features[0].getProperties()).map(function (x) {
         return {
-          field: x,
+          field: x.toLowerCase(),
           title: x,
           titleTooltip: x,
           sortable: true,
@@ -264,8 +264,8 @@
         for (var i = 0; i < columns.length; i++) {
           var fieldSpec = dictionary[columns[i]["field"]];
           if (angular.isDefined(fieldSpec)) {
-            columns[i]["title"] = fieldSpec.name;
-            columns[i]["titleTooltip"] = fieldSpec.definition || fieldSpec.code;
+            columns[i]["title"] = fieldSpec.code;
+            columns[i]["titleTooltip"] = fieldSpec.name || fieldSpec.code;
           }
         }
       }

--- a/web-ui/src/main/resources/catalog/components/viewer/gfi/FeaturesLoader.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/gfi/FeaturesLoader.js
@@ -264,8 +264,8 @@
         for (var i = 0; i < columns.length; i++) {
           var fieldSpec = dictionary[columns[i]["field"]];
           if (angular.isDefined(fieldSpec)) {
-            columns[i]["title"] = fieldSpec.code;
-            columns[i]["titleTooltip"] = fieldSpec.name || fieldSpec.code;
+            columns[i]["title"] = fieldSpec.name;
+            columns[i]["titleTooltip"] = fieldSpec.definition || fieldSpec.name;
           }
         }
       }

--- a/web-ui/src/main/resources/catalog/components/viewer/gfi/FeaturesTableService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/gfi/FeaturesTableService.js
@@ -41,7 +41,7 @@
     if (record && record.featureTypes && record.featureTypes[0]) {
       var dictionary = {};
       record.featureTypes[0].attributeTable.map(function (col) {
-        dictionary[col.code] = col;
+        dictionary[col.code.toLowerCase()] = col;
       });
       deferred.resolve(dictionary);
       return deferred.promise;

--- a/web-ui/src/main/resources/catalog/components/viewer/gfi/FeaturesTableService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/gfi/FeaturesTableService.js
@@ -63,7 +63,7 @@
           if (response.data["decodeMap"] != null) {
             var dictionary = {};
             Object.keys(response.data["decodeMap"]).map(function (key) {
-              dictionary[key] = {
+              dictionary[key.toLowerCase()] = {
                 code: response.data["decodeMap"][key][0],
                 name: response.data["decodeMap"][key][1]
               };

--- a/web-ui/src/main/resources/catalog/components/viewer/gfi/FeaturesTableService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/gfi/FeaturesTableService.js
@@ -64,8 +64,8 @@
             var dictionary = {};
             Object.keys(response.data["decodeMap"]).map(function (key) {
               dictionary[key.toLowerCase()] = {
-                code: response.data["decodeMap"][key][0],
-                name: response.data["decodeMap"][key][1]
+                name: response.data["decodeMap"][key][0],
+                definition: response.data["decodeMap"][key][1]
               };
             });
             deferred.resolve(dictionary);


### PR DESCRIPTION
This allows to display the column titles from the feature catalog metadata instead of the column identifiers, if defined the columns codes in the feature catalog and the WMS FeatureInfo with different case.

Test case:

1) Create an iso19139 linking to a WMS layer that supports FeatureInfo.
2) Create an iso19110 describing the dataset. In the attributes table use for the `code` values the column names defined in the WMS layer, but with different case.
3) Link the metadata from 1) and 2)
4) From the metadata detail page of the iso19139 metadata add the WMS layer to the map.
5) Zoom to the layer content and click in a feature.

Before the change:

![featureinfo-before](https://user-images.githubusercontent.com/1695003/216986102-6f56cd2f-05e5-4f86-a06f-01301c8ff5ef.png)

After the change:

![featureinfo-after](https://user-images.githubusercontent.com/1695003/216986135-a2cd6099-ffee-4a77-82ca-195354072945.png)

Fixed also the column values of the dictionary object created with the feature catalog metadata.
