### PR TITLE
[BP] When identifying on a layer from a metadata with a linked feature catalog record, use case insensitive comparison between the feature catalog column definitions and the WMS FeatureInfo response.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/viewer/gfi/FeaturesLoader.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/gfi/FeaturesLoader.js
@@ -190,7 +190,10 @@
           this.dictionary = this.$http.get('../api/records/'+uuid+'/featureCatalog?_content_type=json')
           .then(function(response) {
             if(response.data['decodeMap']!=null) {
-              return response.data['decodeMap'];
+              return Object.keys(response.data['decodeMap']).reduce((acc, key) => {
+                acc[key.toLowerCase()] = response.data['decodeMap'][key];
+                return acc;
+              }, {});
             } else {
               return null;
         	}
@@ -258,7 +261,7 @@
 
       var columns = Object.keys(features[0].getProperties()).map(function(x) {
         return {
-          field: x,
+          field: x.toLowerCase(),
           title: x,
           titleTooltip: x,
           sortable: true,

--- a/web-ui/src/main/resources/catalog/components/viewer/gfi/FeaturesTable.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/gfi/FeaturesTable.js
@@ -145,7 +145,6 @@
           },bstConfig)
       );
       scope.$watch('ctrl.active', function() {
-        element.bootstrapTable('resetWidth');
         element.bootstrapTable('resetView');
       });
     }.bind(this));


### PR DESCRIPTION
This allows to display the column titles from the feature catalog metadata instead of the column identifiers, if defined the columns codes in the feature catalog and the WMS FeatureInfo with different case.

Backport to `3.12.x` of https://github.com/geonetwork/core-geonetwork/pull/6801