### PR TITLE
Export / CSV / Add resource identifier.

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/tpl-csv.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/tpl-csv.xsl
@@ -47,6 +47,12 @@
         </xsl:apply-templates>
       </abstract>
 
+      <xsl:for-each select="mdb:identificationInfo/*/mri:citation/*/cit:identifier/*/mcc:code/*[. != '']">
+        <resourceIdentifier>
+          <xsl:value-of select="."/>
+        </resourceIdentifier>
+      </xsl:for-each>
+
       <category>
         <xsl:value-of select="mdb:metadataScope/*/mdb:resourceScope/*/@codeListValue"/>
       </category>

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/tpl-csv.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/tpl-csv.xsl
@@ -56,6 +56,12 @@
         </xsl:apply-templates>
       </abstract>
 
+      <xsl:for-each select="gmd:identificationInfo/*/gmd:citation/*/gmd:identifier/*/gmd:code/*[. != '']">
+        <resourceIdentifier>
+          <xsl:value-of select="."/>
+        </resourceIdentifier>
+      </xsl:for-each>
+
       <category>
         <xsl:choose>
           <xsl:when test="gmd:identificationInfo/srv:SV_ServiceIdentification">service</xsl:when>


### PR DESCRIPTION
Resource identifier is quite often used by end users for managing datasets and frequently ask for them in the CSV export for further analysis.