### PR TITLE
Standard / ISO19115-3 / Index main resource type first

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/xsl-view/view.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/xsl-view/view.xsl
@@ -204,7 +204,9 @@
   </xsl:template>
 
   <xsl:template mode="getMetadataHierarchyLevel" match="mdb:MD_Metadata">
-    <xsl:value-of select="mdb:metadataScope/*/mdb:resourceScope/mcc:MD_ScopeCode/@codeListValue"/>
+    <xsl:value-of select="if ($isOnlyFeatureCatalog)
+                          then 'featureCatalog'
+                          else mdb:metadataScope/*/mdb:resourceScope/mcc:MD_ScopeCode/@codeListValue"/>
   </xsl:template>
 
   <xsl:template mode="getMetadataThumbnail" match="mdb:MD_Metadata">

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
@@ -961,13 +961,15 @@
         </xsl:element>
       </xsl:for-each-group>
 
-
       <xsl:if test="$isOnlyFeatureCatalog">
         <resourceType>featureCatalog</resourceType>
 
         <xsl:for-each select="mdb:contentInfo/*/mrc:featureCatalogue/*">
-          <xsl:copy-of select="gn-fn-index:add-multilingual-field('resourceTitle',
-                                cat:name, $allLanguages)"/>
+          <xsl:for-each select="(cat:name[*/text() != '']
+                        |gfc:featureType/*/gfc:typeName[text() != ''])[1]">
+            <xsl:copy-of select="gn-fn-index:add-multilingual-field('resourceTitle',
+                               ., $allLanguages)"/>
+          </xsl:for-each>
 
           <xsl:for-each select="cat:versionNumber/*">
             <xsl:copy-of select="gn-fn-index:add-field('resourceEdition', .)"/>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
@@ -228,6 +228,7 @@
       </xsl:for-each>
 
 
+
       <!-- ISO19115-3 records can be only a feature catalogue description.
        In this case,
        * add the resourceType=featureCatalog to enable search when linking records
@@ -239,10 +240,9 @@
                             and exists(mdb:contentInfo/*/mrc:featureCatalogue)"
                     as="xs:boolean"/>
 
-      <xsl:if test="exists(mdb:contentInfo/*/mrc:featureCatalogue//gfc:FC_FeatureCatalogue/gfc:featureType)">
+      <xsl:if test="$isOnlyFeatureCatalog">
         <resourceType>featureCatalog</resourceType>
       </xsl:if>
-
 
       <xsl:choose>
         <xsl:when test="$isDataset">
@@ -259,6 +259,11 @@
       <xsl:for-each select="mdb:metadataScope/*/mdb:name">
         <xsl:copy-of select="gn-fn-index:add-multilingual-field('resourceTypeName', ., $allLanguages)"/>
       </xsl:for-each>
+
+      <xsl:if test="not($isOnlyFeatureCatalog)
+                    and exists(mdb:contentInfo/*/mrc:featureCatalogue//gfc:FC_FeatureCatalogue/gfc:featureType)">
+        <resourceType>featureCatalog</resourceType>
+      </xsl:if>
 
 
       <!-- Indexing metadata contact -->

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/utility-tpl.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/utility-tpl.xsl
@@ -11,10 +11,13 @@
   xmlns:msr="http://standards.iso.org/iso/19115/-3/msr/2.0"
   xmlns:lan="http://standards.iso.org/iso/19115/-3/lan/1.0"
   xmlns:gcx="http://standards.iso.org/iso/19115/-3/gcx/1.0"
+  xmlns:mrc="http://standards.iso.org/iso/19115/-3/mrc/2.0"
+  xmlns:cat="http://standards.iso.org/iso/19115/-3/cat/1.0"
   xmlns:gex="http://standards.iso.org/iso/19115/-3/gex/1.0"
   xmlns:dqm="http://standards.iso.org/iso/19157/-2/dqm/1.0"
   xmlns:cit="http://standards.iso.org/iso/19115/-3/cit/2.0"
   xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0"
+  xmlns:gfc="http://standards.iso.org/iso/19110/gfc/1.1"
   xmlns:gn-fn-index="http://geonetwork-opensource.org/xsl/functions/index"
   xmlns:gn="http://www.fao.org/geonetwork"
   xmlns:xs="http://www.w3.org/2001/XMLSchema" exclude-result-prefixes="#all">
@@ -28,7 +31,10 @@
   </xsl:template>
 
   <xsl:template name="get-iso19115-3.2018-title">
-    <xsl:value-of select="$metadata/mdb:identificationInfo/*/mri:citation/*/cit:title/gco:CharacterString"/>
+    <xsl:value-of select="($metadata/mdb:identificationInfo/*/mri:citation/*/cit:title/gco:CharacterString
+                          |$metadata/mdb:contentInfo/*/mrc:featureCatalogue/*/cat:name[*/text() != '']
+                          |$metadata/mdb:contentInfo/*/mrc:featureCatalogue/*/gfc:featureType/*/gfc:typeName[text() != ''])[1]
+"/>
   </xsl:template>
 
   <xsl:template mode="get-formats-as-json" match="mdb:MD_Metadata">


### PR DESCRIPTION
ISO19115-3 record may contain a feature catalogue embedded. Be sure the main resource type is indexed first as we use it for the main icon cf. https://github.com/geonetwork/core-geonetwork/blob/main/web-ui/src/main/resources/catalog/views/default/templates/recordView/title.html#L3
and we may use other resource   types in search (eg. when linking a feature catalogue)

![image](https://user-images.githubusercontent.com/1701393/217199200-9cfbfe95-cd00-483f-a3e2-201011da0792.png)


Also fix display of title in the editor toolbar for feature catalogue

![image](https://user-images.githubusercontent.com/1701393/217283126-4b37e341-0fb9-4279-ba7c-247047e389fd.png)

And fallback to first typename if no `cat:name` element.


Test record:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<mdb:MD_Metadata xmlns:mdb="http://standards.iso.org/iso/19115/-3/mdb/2.0"
                 xmlns:cat="http://standards.iso.org/iso/19115/-3/cat/1.0"
                 xmlns:gfc="http://standards.iso.org/iso/19110/gfc/1.1"
                 xmlns:cit="http://standards.iso.org/iso/19115/-3/cit/2.0"
                 xmlns:gcx="http://standards.iso.org/iso/19115/-3/gcx/1.0"
                 xmlns:gex="http://standards.iso.org/iso/19115/-3/gex/1.0"
                 xmlns:lan="http://standards.iso.org/iso/19115/-3/lan/1.0"
                 xmlns:srv="http://standards.iso.org/iso/19115/-3/srv/2.1"
                 xmlns:mas="http://standards.iso.org/iso/19115/-3/mas/1.0"
                 xmlns:mcc="http://standards.iso.org/iso/19115/-3/mcc/1.0"
                 xmlns:mco="http://standards.iso.org/iso/19115/-3/mco/1.0"
                 xmlns:mda="http://standards.iso.org/iso/19115/-3/mda/1.0"
                 xmlns:mds="http://standards.iso.org/iso/19115/-3/mds/2.0"
                 xmlns:mdt="http://standards.iso.org/iso/19115/-3/mdt/2.0"
                 xmlns:mex="http://standards.iso.org/iso/19115/-3/mex/1.0"
                 xmlns:mmi="http://standards.iso.org/iso/19115/-3/mmi/1.0"
                 xmlns:mpc="http://standards.iso.org/iso/19115/-3/mpc/1.0"
                 xmlns:mrc="http://standards.iso.org/iso/19115/-3/mrc/2.0"
                 xmlns:mrd="http://standards.iso.org/iso/19115/-3/mrd/1.0"
                 xmlns:mri="http://standards.iso.org/iso/19115/-3/mri/1.0"
                 xmlns:mrl="http://standards.iso.org/iso/19115/-3/mrl/2.0"
                 xmlns:mrs="http://standards.iso.org/iso/19115/-3/mrs/1.0"
                 xmlns:msr="http://standards.iso.org/iso/19115/-3/msr/2.0"
                 xmlns:mdq="http://standards.iso.org/iso/19157/-2/mdq/1.0"
                 xmlns:mac="http://standards.iso.org/iso/19115/-3/mac/2.0"
                 xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0"
                 xmlns:gml="http://www.opengis.net/gml/3.2"
                 xmlns:xlink="http://www.w3.org/1999/xlink"
                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                 xsi:schemaLocation="http://standards.iso.org/iso/19115/-3/mdb/2.0 https://schemas.isotc211.org/19115/-3/mdb/2.0/mdb.xsd">
  <mdb:metadataIdentifier>
      <mcc:MD_Identifier>
         <mcc:code>
            <gco:CharacterString>e8eeb8ef-7bc9-4925-8bc5-2ca08adc80fa</gco:CharacterString>
         </mcc:code>
         <mcc:codeSpace>
            <gco:CharacterString>urn:uuid</gco:CharacterString>
         </mcc:codeSpace>
      </mcc:MD_Identifier>
  </mdb:metadataIdentifier>
  <mdb:defaultLocale>
      <lan:PT_Locale id="EN">
         <lan:language>
            <lan:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="eng"/>
         </lan:language>
         <lan:characterEncoding>
            <lan:MD_CharacterSetCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_CharacterSetCode"
                                     codeListValue="utf8"/>
         </lan:characterEncoding>
      </lan:PT_Locale>
  </mdb:defaultLocale>
  <mdb:metadataScope>
      <mdb:MD_MetadataScope>
         <mdb:resourceScope>
            <mcc:MD_ScopeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_ScopeCode"
                              codeListValue="dataset"/>
         </mdb:resourceScope>
      </mdb:MD_MetadataScope>
  </mdb:metadataScope>
  <mdb:dateInfo>
      <cit:CI_Date>
         <cit:date>
            <gco:DateTime>2023-02-07T08:37:09.568Z</gco:DateTime>
         </cit:date>
         <cit:dateType>
            <cit:CI_DateTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_DateTypeCode"
                                 codeListValue="creation"/>
         </cit:dateType>
      </cit:CI_Date>
  </mdb:dateInfo>
  <mdb:dateInfo>
      <cit:CI_Date>
         <cit:date>
            <gco:DateTime>2023-02-07T08:55:49.417Z</gco:DateTime>
         </cit:date>
         <cit:dateType>
            <cit:CI_DateTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_DateTypeCode"
                                 codeListValue="revision"/>
         </cit:dateType>
      </cit:CI_Date>
  </mdb:dateInfo>
  <mdb:metadataStandard>
      <cit:CI_Citation>
         <cit:title>
            <gco:CharacterString>ISO 19115-3:2018</gco:CharacterString>
         </cit:title>
         <cit:edition>
            <gco:CharacterString>1.0</gco:CharacterString>
         </cit:edition>
      </cit:CI_Citation>
  </mdb:metadataStandard>
  <mdb:metadataLinkage>
      <cit:CI_OnlineResource>
         <cit:linkage>
            <gco:CharacterString>http://localhost:8080/geonetwork/srv/api/records/e8eeb8ef-7bc9-4925-8bc5-2ca08adc80fa</gco:CharacterString>
         </cit:linkage>
         <cit:function>
            <cit:CI_OnLineFunctionCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_OnLineFunctionCode"
                                       codeListValue="completeMetadata"/>
         </cit:function>
      </cit:CI_OnlineResource>
  </mdb:metadataLinkage>
  <mdb:spatialRepresentationInfo/>
  <mdb:referenceSystemInfo>
      <mrs:MD_ReferenceSystem>
         <mrs:referenceSystemIdentifier>
            <mcc:MD_Identifier>
               <mcc:code>
                  <gco:CharacterString>WGS 1984</gco:CharacterString>
               </mcc:code>
            </mcc:MD_Identifier>
         </mrs:referenceSystemIdentifier>
      </mrs:MD_ReferenceSystem>
  </mdb:referenceSystemInfo>
  <mdb:identificationInfo>
      <mri:MD_DataIdentification>
         <mri:citation>
            <cit:CI_Citation>
               <cit:title>
                  <gco:CharacterString>Hydrological Basins in Africa (Feature catalogue test)</gco:CharacterString>
               </cit:title>
               <cit:date>
                  <cit:CI_Date>
                     <cit:date>
                        <gco:DateTime>2000-07-19T14:45:00</gco:DateTime>
                     </cit:date>
                     <cit:dateType>
                        <cit:CI_DateTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_DateTypeCode"
                                             codeListValue="creation"/>
                     </cit:dateType>
                  </cit:CI_Date>
               </cit:date>
               <cit:edition>
                  <gco:CharacterString>First</gco:CharacterString>
               </cit:edition>
               <cit:presentationForm>
                  <cit:CI_PresentationFormCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_PresentationFormCode"
                                               codeListValue="mapDigital"/>
               </cit:presentationForm>
            </cit:CI_Citation>
         </mri:citation>
         <mri:abstract>
            <gco:CharacterString>Major hydrological basins and their sub-basins. This dataset divides the African continent according to its hydrological characteristics.
The dataset consists of the following information:- numerical code and name of the major basin (MAJ_BAS and MAJ_NAME); - area of the major basin in square km (MAJ_AREA); - numerical code and name of the sub-basin (SUB_BAS and SUB_NAME); - area of the sub-basin in square km (SUB_AREA); - numerical code of the sub-basin towards which the sub-basin flows (TO_SUBBAS) (the codes -888 and -999 have been assigned respectively to internal sub-basins and to sub-basins draining into the sea)</gco:CharacterString>
         </mri:abstract>
         <mri:purpose>
            <gco:CharacterString>This dataset is developed as part of a GIS-based information system on water resources for the African continent. It has been published in the framework of the AQUASTAT - programme of the Land and Water Division of the Food and Agriculture Organization of the United Nations, as part of FAO Land and Water Digital Media Series #13: "Atlas of Water Resources and Irrigation in Africa".

For a wider distribution and to support other projects at FAO this map is also distributed in a DVD as part of a publication entitled: "Jenness, J.; Dooley, J.; Aguilar-Manjarrez, J.; Riva, C. African Water Resource Database. GIS-based tools for inland aquatic resource management. 2. Technical manual and workbook. CIFA Technical Paper. No. 33, Part 2. Rome, FAO. 2007. 308 p."</gco:CharacterString>
         </mri:purpose>
         <mri:status>
            <mcc:MD_ProgressCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_ProgressCode"
                                 codeListValue="completed"/>
         </mri:status>
         <mri:spatialRepresentationType>
            <mcc:MD_SpatialRepresentationTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_SpatialRepresentationTypeCode"
                                                  codeListValue="vector"/>
         </mri:spatialRepresentationType>
         <mri:spatialResolution>
            <mri:MD_Resolution>
               <mri:equivalentScale>
                  <mri:MD_RepresentativeFraction>
                     <mri:denominator>
                        <gco:Integer>5000000</gco:Integer>
                     </mri:denominator>
                  </mri:MD_RepresentativeFraction>
               </mri:equivalentScale>
            </mri:MD_Resolution>
         </mri:spatialResolution>
         <mri:topicCategory>
            <mri:MD_TopicCategoryCode>inlandWaters</mri:MD_TopicCategoryCode>
         </mri:topicCategory>
         <mri:extent>
            <gex:EX_Extent>
               <gex:temporalElement>
                  <gex:EX_TemporalExtent>
                     <gex:extent>
                        <gml:TimePeriod gml:id="timeperiod1">
                           <gml:beginPosition>2006-01-01T04:29:00</gml:beginPosition>
                           <gml:endPosition>2008-01-08T04:29:00</gml:endPosition>
                        </gml:TimePeriod>
                     </gex:extent>
                  </gex:EX_TemporalExtent>
               </gex:temporalElement>
            </gex:EX_Extent>
         </mri:extent>
         <mri:extent>
            <gex:EX_Extent>
               <gex:geographicElement>
                  <gex:EX_GeographicBoundingBox>
                     <gex:westBoundLongitude>
                        <gco:Decimal>-17.30</gco:Decimal>
                     </gex:westBoundLongitude>
                     <gex:eastBoundLongitude>
                        <gco:Decimal>51.10</gco:Decimal>
                     </gex:eastBoundLongitude>
                     <gex:southBoundLatitude>
                        <gco:Decimal>-34.60</gco:Decimal>
                     </gex:southBoundLatitude>
                     <gex:northBoundLatitude>
                        <gco:Decimal>38.20</gco:Decimal>
                     </gex:northBoundLatitude>
                  </gex:EX_GeographicBoundingBox>
               </gex:geographicElement>
            </gex:EX_Extent>
         </mri:extent>
         <mri:resourceMaintenance>
            <mmi:MD_MaintenanceInformation>
               <mmi:maintenanceAndUpdateFrequency>
                  <mmi:MD_MaintenanceFrequencyCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_MaintenanceFrequencyCode"
                                                   codeListValue="asNeeded"/>
               </mmi:maintenanceAndUpdateFrequency>
            </mmi:MD_MaintenanceInformation>
         </mri:resourceMaintenance>
         <mri:graphicOverview>
            <mcc:MD_BrowseGraphic>
               <mcc:fileName>
                  <gco:CharacterString>http://localhost:8080/geonetwork/srv/api/records/da165110-88fd-11da-a88f-000d939bc5d8/attachments/thumbnail_s.gif</gco:CharacterString>
               </mcc:fileName>
               <mcc:fileDescription>
                  <gco:CharacterString>Hydrological Basins in Africa (small preview)</gco:CharacterString>
               </mcc:fileDescription>
            </mcc:MD_BrowseGraphic>
         </mri:graphicOverview>
         <mri:graphicOverview>
            <mcc:MD_BrowseGraphic>
               <mcc:fileName>
                  <gco:CharacterString>http://localhost:8080/geonetwork/srv/api/records/da165110-88fd-11da-a88f-000d939bc5d8/attachments/thumbnail.gif</gco:CharacterString>
               </mcc:fileName>
               <mcc:fileDescription>
                  <gco:CharacterString>Hydrological Basins in Africa</gco:CharacterString>
               </mcc:fileDescription>
            </mcc:MD_BrowseGraphic>
         </mri:graphicOverview>
         <mri:descriptiveKeywords>
            <mri:MD_Keywords>
               <mri:keyword>
                  <gco:CharacterString>watersheds</gco:CharacterString>
               </mri:keyword>
               <mri:keyword>
                  <gco:CharacterString>river basins</gco:CharacterString>
               </mri:keyword>
               <mri:keyword>
                  <gco:CharacterString>water resources</gco:CharacterString>
               </mri:keyword>
               <mri:keyword>
                  <gco:CharacterString>hydrology</gco:CharacterString>
               </mri:keyword>
               <mri:keyword>
                  <gco:CharacterString>AQUASTAT</gco:CharacterString>
               </mri:keyword>
               <mri:keyword>
                  <gco:CharacterString>AWRD</gco:CharacterString>
               </mri:keyword>
               <mri:type>
                  <mri:MD_KeywordTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_KeywordTypeCode"
                                          codeListValue="theme"/>
               </mri:type>
            </mri:MD_Keywords>
         </mri:descriptiveKeywords>
         <mri:descriptiveKeywords>
            <mri:MD_Keywords>
               <mri:keyword>
                  <gco:CharacterString>Africa</gco:CharacterString>
               </mri:keyword>
               <mri:type>
                  <mri:MD_KeywordTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_KeywordTypeCode"
                                          codeListValue="place"/>
               </mri:type>
            </mri:MD_Keywords>
         </mri:descriptiveKeywords>
         <mri:resourceConstraints>
            <mco:MD_Constraints>
               <mco:useLimitation gco:nilReason="missing">
                  <gco:CharacterString/>
               </mco:useLimitation>
            </mco:MD_Constraints>
         </mri:resourceConstraints>
         <mri:defaultLocale>
            <lan:PT_Locale>
               <lan:language>
                  <lan:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="eng"/>
               </lan:language>
               <lan:characterEncoding>
                  <lan:MD_CharacterSetCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_CharacterSetCode"
                                           codeListValue="utf8"/>
               </lan:characterEncoding>
            </lan:PT_Locale>
         </mri:defaultLocale>
         <mri:supplementalInformation>
            <gco:CharacterString>You can customize the template to suit your needs. You can add and remove fields and fill out default information (e.g. contact details). Fields you can not change in the default view may be accessible in the more comprehensive (and more complex) advanced view. You can even use the XML editor to create custom structures, but they have to be validated by the system, so know what you do :-)</gco:CharacterString>
         </mri:supplementalInformation>
      </mri:MD_DataIdentification>
  </mdb:identificationInfo>
  <mdb:contentInfo>
      <mrc:MD_FeatureCatalogue>
         <mrc:featureCatalogue>
            <gfc:FC_FeatureCatalogue>
               <gfc:producer/>
               <gfc:featureType>
                  <gfc:FC_FeatureType>
                     <gfc:typeName>Basins</gfc:typeName>
                     <gfc:isAbstract>
                        <gco:Boolean>false</gco:Boolean>
                     </gfc:isAbstract>
                     <gfc:carrierOfCharacteristics>
                        <gfc:FC_FeatureAttribute>
                           <gfc:memberName>MAJ Basin</gfc:memberName>
                           <gfc:definition gco:nilReason="missing">
                              <gco:CharacterString/>
                           </gfc:definition>
                           <gfc:cardinality>
                              <gco:CharacterString>0..1</gco:CharacterString>
                           </gfc:cardinality>
                           <gfc:code>
                              <gco:CharacterString>MAJ_bas</gco:CharacterString>
                           </gfc:code>
                           <gfc:valueType>
                              <gco:TypeName>
                                 <gco:aName>
                                    <gco:CharacterString>xsd:double</gco:CharacterString>
                                 </gco:aName>
                              </gco:TypeName>
                           </gfc:valueType>
                        </gfc:FC_FeatureAttribute>
                     </gfc:carrierOfCharacteristics>
                     <gfc:carrierOfCharacteristics>
                        <gfc:FC_FeatureAttribute>
                           <gfc:memberName>Sub-basin</gfc:memberName>
                           <gfc:definition gco:nilReason="missing">
                              <gco:CharacterString/>
                           </gfc:definition>
                           <gfc:cardinality>
                              <gco:CharacterString>0..1</gco:CharacterString>
                           </gfc:cardinality>
                           <gfc:code>
                              <gco:CharacterString>sub_bas</gco:CharacterString>
                           </gfc:code>
                           <gfc:valueType>
                              <gco:TypeName>
                                 <gco:aName>
                                    <gco:CharacterString>xsd:double</gco:CharacterString>
                                 </gco:aName>
                              </gco:TypeName>
                           </gfc:valueType>
                        </gfc:FC_FeatureAttribute>
                     </gfc:carrierOfCharacteristics>
                     <gfc:carrierOfCharacteristics>
                        <gfc:FC_FeatureAttribute>
                           <gfc:memberName>Name</gfc:memberName>
                           <gfc:definition gco:nilReason="missing">
                              <gco:CharacterString/>
                           </gfc:definition>
                           <gfc:cardinality>
                              <gco:CharacterString>0..1</gco:CharacterString>
                           </gfc:cardinality>
                           <gfc:code>
                              <gco:CharacterString>maj_name</gco:CharacterString>
                           </gfc:code>
                           <gfc:valueType>
                              <gco:TypeName>
                                 <gco:aName>
                                    <gco:CharacterString>xsd:string</gco:CharacterString>
                                 </gco:aName>
                              </gco:TypeName>
                           </gfc:valueType>
                        </gfc:FC_FeatureAttribute>
                     </gfc:carrierOfCharacteristics>
                     <gfc:carrierOfCharacteristics>
                        <gfc:FC_FeatureAttribute>
                           <gfc:memberName>Sub-basin name</gfc:memberName>
                           <gfc:definition gco:nilReason="missing">
                              <gco:CharacterString/>
                           </gfc:definition>
                           <gfc:cardinality>
                              <gco:CharacterString>0..1</gco:CharacterString>
                           </gfc:cardinality>
                           <gfc:code>
                              <gco:CharacterString>sub_name</gco:CharacterString>
                           </gfc:code>
                           <gfc:valueType>
                              <gco:TypeName>
                                 <gco:aName>
                                    <gco:CharacterString>xsd:string</gco:CharacterString>
                                 </gco:aName>
                              </gco:TypeName>
                           </gfc:valueType>
                        </gfc:FC_FeatureAttribute>
                     </gfc:carrierOfCharacteristics>
                     <gfc:carrierOfCharacteristics>
                        <gfc:FC_FeatureAttribute>
                           <gfc:memberName/>
                           <gfc:definition gco:nilReason="missing">
                              <gco:CharacterString/>
                           </gfc:definition>
                           <gfc:cardinality>
                              <gco:CharacterString>0..1</gco:CharacterString>
                           </gfc:cardinality>
                           <gfc:code>
                              <gco:CharacterString>to_subbas</gco:CharacterString>
                           </gfc:code>
                           <gfc:valueType>
                              <gco:TypeName>
                                 <gco:aName>
                                    <gco:CharacterString>xsd:double</gco:CharacterString>
                                 </gco:aName>
                              </gco:TypeName>
                           </gfc:valueType>
                        </gfc:FC_FeatureAttribute>
                     </gfc:carrierOfCharacteristics>
                     <gfc:carrierOfCharacteristics>
                        <gfc:FC_FeatureAttribute>
                           <gfc:memberName>Area</gfc:memberName>
                           <gfc:definition gco:nilReason="missing">
                              <gco:CharacterString/>
                           </gfc:definition>
                           <gfc:cardinality>
                              <gco:CharacterString>0..1</gco:CharacterString>
                           </gfc:cardinality>
                           <gfc:code>
                              <gco:CharacterString>maj_area</gco:CharacterString>
                           </gfc:code>
                           <gfc:valueType>
                              <gco:TypeName>
                                 <gco:aName>
                                    <gco:CharacterString>xsd:double</gco:CharacterString>
                                 </gco:aName>
                              </gco:TypeName>
                           </gfc:valueType>
                        </gfc:FC_FeatureAttribute>
                     </gfc:carrierOfCharacteristics>
                     <gfc:carrierOfCharacteristics>
                        <gfc:FC_FeatureAttribute>
                           <gfc:memberName>Sub basin area</gfc:memberName>
                           <gfc:definition gco:nilReason="missing">
                              <gco:CharacterString/>
                           </gfc:definition>
                           <gfc:cardinality>
                              <gco:CharacterString>0..1</gco:CharacterString>
                           </gfc:cardinality>
                           <gfc:code>
                              <gco:CharacterString>sub_area</gco:CharacterString>
                           </gfc:code>
                           <gfc:valueType>
                              <gco:TypeName>
                                 <gco:aName>
                                    <gco:CharacterString>xsd:double</gco:CharacterString>
                                 </gco:aName>
                              </gco:TypeName>
                           </gfc:valueType>
                        </gfc:FC_FeatureAttribute>
                     </gfc:carrierOfCharacteristics>
                     <gfc:carrierOfCharacteristics>
                        <gfc:FC_FeatureAttribute>
                           <gfc:memberName/>
                           <gfc:definition gco:nilReason="missing">
                              <gco:CharacterString/>
                           </gfc:definition>
                           <gfc:cardinality>
                              <gco:CharacterString>0..1</gco:CharacterString>
                           </gfc:cardinality>
                           <gfc:code>
                              <gco:CharacterString>geom</gco:CharacterString>
                           </gfc:code>
                           <gfc:valueType>
                              <gco:TypeName>
                                 <gco:aName>
                                    <gco:CharacterString>gml:MultiPolygonPropertyType</gco:CharacterString>
                                 </gco:aName>
                              </gco:TypeName>
                           </gfc:valueType>
                        </gfc:FC_FeatureAttribute>
                     </gfc:carrierOfCharacteristics>
                     <gfc:featureCatalogue/>
                  </gfc:FC_FeatureType>
               </gfc:featureType>
            </gfc:FC_FeatureCatalogue>
         </mrc:featureCatalogue>
      </mrc:MD_FeatureCatalogue>
  </mdb:contentInfo>
  <mdb:distributionInfo>
      <mrd:MD_Distribution>
         <mrd:distributionFormat>
            <mrd:MD_Format>
               <mrd:formatSpecificationCitation>
                  <cit:CI_Citation>
                     <cit:title>
                        <gco:CharacterString>ShapeFile</gco:CharacterString>
                     </cit:title>
                     <cit:date gco:nilReason="unknown"/>
                     <cit:edition>
                        <gco:CharacterString>Grass Version 6.1</gco:CharacterString>
                     </cit:edition>
                  </cit:CI_Citation>
               </mrd:formatSpecificationCitation>
            </mrd:MD_Format>
         </mrd:distributionFormat>
         <mrd:transferOptions>
            <mrd:MD_DigitalTransferOptions>
               <mrd:onLine>
                  <cit:CI_OnlineResource>
                     <cit:linkage>
                        <gco:CharacterString>http://www.fao.org/ag/AGL/aglw/aquastat/watresafrica/index.stm</gco:CharacterString>
                     </cit:linkage>
                     <cit:protocol>
                        <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
                     </cit:protocol>
                     <cit:name gco:nilReason="missing">
                        <gco:CharacterString/>
                     </cit:name>
                     <cit:description>
                        <gco:CharacterString>Online link to the  'Water Resources and Irrigation in Africa'- website</gco:CharacterString>
                     </cit:description>
                  </cit:CI_OnlineResource>
               </mrd:onLine>
               <mrd:onLine>
                  <cit:CI_OnlineResource>
                     <cit:linkage>
                        <gco:CharacterString>http://localhost:8080/geonetwork/srv/api/records/da165110-88fd-11da-a88f-000d939bc5d8/attachments/basins.zip</gco:CharacterString>
                     </cit:linkage>
                     <cit:protocol>
                        <gco:CharacterString>WWW:DOWNLOAD-1.0-http--download</gco:CharacterString>
                     </cit:protocol>
                     <cit:name>
                        <gco:CharacterString>basins.zip</gco:CharacterString>
                     </cit:name>
                     <cit:description>
                        <gco:CharacterString>Hydrological basins in Africa (Shapefile Format)</gco:CharacterString>
                     </cit:description>
                  </cit:CI_OnlineResource>
               </mrd:onLine>
               <mrd:onLine>
                  <cit:CI_OnlineResource>
                     <cit:linkage>
                        <gco:CharacterString>https://data.apps.fao.org/map/gsrv/gsrv1/geonetwork/wms</gco:CharacterString>
                     </cit:linkage>
                     <cit:protocol>
                        <gco:CharacterString>OGC:WMS</gco:CharacterString>
                     </cit:protocol>
                     <cit:name>
                        <gco:CharacterString>geonetwork:basins_296</gco:CharacterString>
                     </cit:name>
                     <cit:description>
                        <gco:CharacterString>Hydrological basins in Africa</gco:CharacterString>
                     </cit:description>
                  </cit:CI_OnlineResource>
               </mrd:onLine>
               <mrd:onLine>
                  <cit:CI_OnlineResource>
                     <cit:linkage>
                        <gco:CharacterString>https://data.apps.fao.org/map/gsrv/gsrv1/geonetwork/wms</gco:CharacterString>
                     </cit:linkage>
                     <cit:protocol>
                        <gco:CharacterString>OGC:WFS</gco:CharacterString>
                     </cit:protocol>
                     <cit:name>
                        <gco:CharacterString>geonetwork:basins_296</gco:CharacterString>
                     </cit:name>
                     <cit:description>
                        <gco:CharacterString>basins_296</gco:CharacterString>
                     </cit:description>
                     <cit:function>
                        <cit:CI_OnLineFunctionCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_OnLineFunctionCode"
                                                   codeListValue="download"/>
                     </cit:function>
                  </cit:CI_OnlineResource>
               </mrd:onLine>
            </mrd:MD_DigitalTransferOptions>
         </mrd:transferOptions>
      </mrd:MD_Distribution>
  </mdb:distributionInfo>
  <mdb:resourceLineage>
      <mrl:LI_Lineage>
         <mrl:statement>
            <gco:CharacterString>The linework of the map is obtained by delineating drainage basin boundaries from an hydrologically corrected digital elevation model with a resolution of 1 * 1 km.</gco:CharacterString>
         </mrl:statement>
         <mrl:scope>
            <mcc:MD_Scope>
               <mcc:level>
                  <mcc:MD_ScopeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_ScopeCode"
                                    codeListValue="dataset"/>
               </mcc:level>
            </mcc:MD_Scope>
         </mrl:scope>
      </mrl:LI_Lineage>
  </mdb:resourceLineage>
</mdb:MD_Metadata>
```
