### PR TITLE
ISO19115-3 / Metadata editor / Support gex:EX_BoundingPolygon with multiple gex:polygon elements

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/layout-custom-fields.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/layout-custom-fields.xsl
@@ -290,29 +290,32 @@
     <xsl:variable name="isoType" select="if (../@gco:isoType) then ../@gco:isoType else ''"/>
     <xsl:variable name="labelConfig" select="gn-fn-metadata:getLabel($schema, name(), $labels, name(..), $isoType, $xpath)"/>
 
-    <xsl:call-template name="render-boxed-element">
-      <xsl:with-param name="label"
-                      select="$labelConfig/label"/>
-      <xsl:with-param name="editInfo" select="../gn:element"/>
-      <xsl:with-param name="cls" select="local-name()"/>
-      <xsl:with-param name="subTreeSnippet">
+    <xsl:variable name="readonly" select="ancestor-or-self::node()[@xlink:href] != ''"/>
 
-        <xsl:variable name="geometry">
-          <xsl:apply-templates select="gex:polygon/gml:MultiSurface|gex:polygon/gml:LineString"
-                               mode="gn-element-cleaner"/>
-        </xsl:variable>
+    <xsl:for-each select="gex:polygon">
+      <xsl:call-template name="render-boxed-element">
+        <xsl:with-param name="label"
+                        select="$labelConfig/label"/>
+        <xsl:with-param name="editInfo" select="../../gn:element"/>
+        <xsl:with-param name="cls" select="local-name()"/>
+        <xsl:with-param name="subTreeSnippet">
 
-        <xsl:variable name="identifier"
-                      select="concat('_X', gex:polygon/gn:element/@ref, '_replace')"/>
-        <xsl:variable name="readonly" select="ancestor-or-self::node()[@xlink:href] != ''"/>
+          <xsl:variable name="geometry">
+            <xsl:apply-templates select="gml:MultiSurface|gml:LineString|gml:Point|gml:Polygon"
+                                 mode="gn-element-cleaner"/>
+          </xsl:variable>
 
-        <br />
-        <gn-bounding-polygon polygon-xml="{saxon:serialize($geometry, 'default-serialize-mode')}"
-                             identifier="{$identifier}"
-                             read-only="{$readonly}">
-        </gn-bounding-polygon>
-      </xsl:with-param>
-    </xsl:call-template>
+          <xsl:variable name="identifier"
+                        select="concat('_X', ./gn:element/@ref, '_replace')"/>
+
+          <br />
+          <gn-bounding-polygon polygon-xml="{saxon:serialize($geometry, 'default-serialize-mode')}"
+                               identifier="{$identifier}"
+                               read-only="{$readonly}">
+          </gn-bounding-polygon>
+        </xsl:with-param>
+      </xsl:call-template>
+    </xsl:for-each>
   </xsl:template>
 
   <!-- Those elements MUST be ignored in the editor layout -->

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/schematron/schematron-rules-iso.sch
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/schematron/schematron-rules-iso.sch
@@ -232,7 +232,7 @@
                value="gex:geographicElement/                          gex:EX_GeographicBoundingBox[                          normalize-space(gex:westBoundLongitude/gco:Decimal) != '' and                          normalize-space(gex:eastBoundLongitude/gco:Decimal) != '' and                          normalize-space(gex:southBoundLatitude/gco:Decimal) != '' and                          normalize-space(gex:northBoundLatitude/gco:Decimal) != ''                          ]"/>
 
       <sch:let name="geographicPoly"
-               value="gex:geographicElement/gex:EX_BoundingPolygon[                          normalize-space(gex:polygon) != '']"/>
+               value="gex:geographicElement/gex:EX_BoundingPolygon[                          count(gex:polygon[normalize-space() != '']) > 0]"/>
 
       <sch:let name="temporal"
                value="gex:temporalElement/gex:EX_TemporalExtent[                          normalize-space(gex:extent) != '']"/>


### PR DESCRIPTION
Editing an ISO19115-3 metadata with multiple `gex:polygon` inside the element `gex:geographicElement/gex:EX_BoundingPolygon` (what is valid according to the xsd):

https://github.com/geonetwork/core-geonetwork/blob/41a435f181177021ff1d7b2bd80d4eb3b73ab7b5/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/schema/standards.iso.org/19115/-3/gex/1.0/extent.xsd#L20-L32

```
<gex:geographicElement>
    <gex:EX_BoundingPolygon>
        <gex:polygon>
            <gml:MultiSurface srsName="urn:ogc:def:crs:EPSG:6.6:4326">
                <gml:surfaceMember>
                    <gml:Polygon srsName="urn:ogc:def:crs:EPSG:6.6:4326">
                        <gml:exterior>
                            <gml:LinearRing srsName="urn:ogc:def:crs:EPSG:6.6:4326">
                                <gml:posList srsDimension="2">21.736539949711826 5.635986328125005 -14.271037745292759 22.73895263671875 -5.453326108568561 53.779449462890604 29.549566573947914 35.682220458984375 21.736539949711826 5.635986328125005</gml:posList>
                            </gml:LinearRing>
                        </gml:exterior>
                    </gml:Polygon>
                </gml:surfaceMember>
            </gml:MultiSurface>
        </gex:polygon>
        <gex:polygon>
            <gml:MultiSurface srsName="urn:ogc:def:crs:EPSG:6.6:4326">
                <gml:surfaceMember>
                    <gml:Polygon srsName="urn:ogc:def:crs:EPSG:6.6:4326">
                        <gml:exterior>
                            <gml:LinearRing srsName="urn:ogc:def:crs:EPSG:6.6:4326">
                                <gml:posList srsDimension="2">7.849777801375154 -36.506195068359375 4.308068740318973 42.07419316406246 24.050226275705995 -24.508448437500043 28.97690931341242 -68.11043818359379 7.849777801375154 -36.506195068359375</gml:posList>
                            </gml:LinearRing>
                        </gml:exterior>
                    </gml:Polygon>
                </gml:surfaceMember>
            </gml:MultiSurface>
        </gex:polygon>
    </gex:EX_BoundingPolygon>
</gex:geographicElement>
```

reports the following error:

```
Error at xsl:attribute on line 312 of layout-custom-fields.xsl:
  XPTY0004: A sequence of more than one item is not allowed as the second argument of concat()
2023-02-10T08:35:28,502 ERROR [geonetwork] - A sequence of more than one item is not allowed as the second argument of concat()
net.sf.saxon.trans.XPathException: A sequence of more than one item is not allowed as the second argument of concat()
    at net.sf.saxon.expr.Expression.typeError(Expression.java:981) ~[saxon-9.1.0.8b-patch.jar:?]
    at net.sf.saxon.expr.SingletonAtomizer.evaluateItem(SingletonAtomizer.java:152) ~[saxon-9.1.0.8b-patch.
```

Also the validation rules `schematron-rules-iso.sch` fail.

![schematron-fail](https://user-images.githubusercontent.com/1695003/218038230-87c074c1-6efb-4654-809e-8ee014aefd3f.png)


Adding the polygons from the metadata editor UI, adds each polygon in a different `gex:geographicElement`, not having the reported problem. But can happen if the metadata was created originally in other systems:

---

Test metadata: [test-iso191153-polygons.txt](https://github.com/geonetwork/core-geonetwork/files/10705087/test-iso191153-polygons.txt)

Test case:

1) Import the metadata provided.
2) Edit it --> Expected the metadata editor is displayed, no errors reported. 2 polygon sections are displayed.
3) Validate it --> schematron rules are executed reporting validation errors in the xml, but no failure in the schematron execution.


