### PR TITLE
Admin / Thesaurus / Fix navigation between keywords

### DIFF
--- a/web-ui/src/main/resources/catalog/templates/admin/classification/thesaurus.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/classification/thesaurus.html
@@ -768,7 +768,7 @@
                 </h3>
                 <ul>
                   <li data-ng-repeat="k in value">
-                    <a data-ng-click="editKeyword(k.uri)">{{k.value['#text']}}</a>
+                    <a data-ng-click="editKeyword(k)">{{k.value['#text']}}</a>
                   </li>
                 </ul>
               </div>


### PR DESCRIPTION
When clicking related keywords, popup was not updated properly

![image](https://user-images.githubusercontent.com/1701393/219606432-64548af4-370d-46ba-b864-9fbb328dcc92.png)
