### PR TITLE
CSW harvester - migrate to ElasticSearch the found duplicated resource feature

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
@@ -23,9 +23,12 @@
 
 package org.fao.geonet.kernel.harvest.harvester.csw;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import jeeves.server.context.ServiceContext;
 import org.apache.commons.lang.StringUtils;
+import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.search.SearchHit;
 import org.fao.geonet.GeonetContext;
 import org.fao.geonet.Logger;
 import org.fao.geonet.constants.Geonet;
@@ -52,12 +55,12 @@ import org.fao.geonet.kernel.harvest.harvester.HarvesterUtil;
 import org.fao.geonet.kernel.harvest.harvester.RecordInfo;
 import org.fao.geonet.kernel.harvest.harvester.UUIDMapper;
 import org.fao.geonet.kernel.schema.MetadataSchema;
+import org.fao.geonet.kernel.search.EsSearchManager;
 import org.fao.geonet.kernel.search.IndexingMode;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.utils.Xml;
 import org.jdom.Element;
 import org.jdom.JDOMException;
-import org.jdom.Namespace;
 import org.jdom.xpath.XPath;
 
 import javax.transaction.Transactional;
@@ -65,17 +68,10 @@ import javax.transaction.Transactional.TxType;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static org.fao.geonet.kernel.search.EsSearchManager.FIELDLIST_CORE;
 import static org.fao.geonet.kernel.setting.Settings.SYSTEM_CSW_TRANSACTION_XPATH_UPDATE_CREATE_NEW_ELEMENTS;
 import static org.fao.geonet.utils.AbstractHttpRequest.Method.GET;
 import static org.fao.geonet.utils.AbstractHttpRequest.Method.POST;
@@ -98,8 +94,9 @@ public class Aligner extends BaseAligner<CswParams> {
     private HarvestResult result;
     private GetRecordByIdRequest request;
     private String processName;
-    private Map<String, Object> processParams = new HashMap<String, Object>();
+    private Map<String, Object> processParams = new HashMap<>();
     private Logger log;
+    private EsSearchManager searchManager;
 
     public Aligner(AtomicBoolean cancelMonitor, ServiceContext sc, CswServer server, CswParams params, Logger log) throws OperationAbortedEx {
         super(cancelMonitor);
@@ -112,6 +109,7 @@ public class Aligner extends BaseAligner<CswParams> {
         metadataUtils = gc.getBean(IMetadataUtils.class);
         metadataManager = gc.getBean(IMetadataManager.class);
         metadataIndexer = gc.getBean(IMetadataIndexer.class);
+        searchManager = gc.getBean(EsSearchManager.class);
         result = new HarvestResult();
         result.unretrievable = 0;
         result.uuidSkipped = 0;
@@ -219,6 +217,7 @@ public class Aligner extends BaseAligner<CswParams> {
                         case SKIP:
                             log.debug("Skipping record with uuid " + ri.uuid);
                             result.uuidSkipped++;
+                            break;
                         default:
                             break;
                     }
@@ -291,7 +290,7 @@ public class Aligner extends BaseAligner<CswParams> {
         }
 
         if (StringUtils.isNotEmpty(params.xpathFilter)) {
-            Object xpathResult = Xml.selectSingle(md, params.xpathFilter, new ArrayList<Namespace>(dataMan.getSchema(schema).getNamespaces()));
+            Object xpathResult = Xml.selectSingle(md, params.xpathFilter, new ArrayList<>(dataMan.getSchema(schema).getNamespaces()));
             boolean match = xpathResult instanceof Boolean && ((Boolean) xpathResult).booleanValue();
             if(!match) {
                 result.xpathFilterExcluded ++;
@@ -359,12 +358,12 @@ public class Aligner extends BaseAligner<CswParams> {
 
             BatchEditParameter[] listOfUpdates = mapper.readValue(batchEdits, BatchEditParameter[].class);
             if (listOfUpdates.length > 0) {
-                SchemaManager _schemaManager = context.getBean(SchemaManager.class);
-                EditLib editLib = new EditLib(_schemaManager);
+                SchemaManager schemaManager = context.getBean(SchemaManager.class);
+                EditLib editLib = new EditLib(schemaManager);
                 boolean metadataChanged = false;
                 boolean createXpathNodeIfNotExists =
                     context.getBean(SettingManager.class).getValueAsBool(SYSTEM_CSW_TRANSACTION_XPATH_UPDATE_CREATE_NEW_ELEMENTS);
-                MetadataSchema metadataSchema = _schemaManager.getSchema(schema);
+                MetadataSchema metadataSchema = schemaManager.getSchema(schema);
 
                 Iterator<BatchEditParameter> listOfUpdatesIterator =
                     Arrays.asList(listOfUpdates).iterator();
@@ -430,7 +429,7 @@ public class Aligner extends BaseAligner<CswParams> {
         String schema = dataMan.autodetectSchema(md, null);
 
         if (StringUtils.isNotEmpty(params.xpathFilter)) {
-            Object xpathResult = Xml.selectSingle(md, params.xpathFilter, new ArrayList<Namespace>(dataMan.getSchema(schema).getNamespaces()));
+            Object xpathResult = Xml.selectSingle(md, params.xpathFilter, new ArrayList<>(dataMan.getSchema(schema).getNamespaces()));
             boolean match = xpathResult instanceof Boolean && ((Boolean) xpathResult).booleanValue();
             if(!match) {
                 result.xpathFilterExcluded ++;
@@ -498,7 +497,7 @@ public class Aligner extends BaseAligner<CswParams> {
 
             //--- maybe the metadata has been removed
 
-            if (list.size() == 0) {
+            if (list.isEmpty()) {
                 return null;
             }
 
@@ -558,8 +557,6 @@ public class Aligner extends BaseAligner<CswParams> {
 
         if (schema != null && schema.startsWith("iso19139")) {
             String resourceIdentifierXPath = "gmd:identificationInfo/*/gmd:citation/gmd:CI_Citation/gmd:identifier/*/gmd:code/gco:CharacterString";
-            String resourceIdentifierLuceneIndexField = "identifier";
-            String defaultLanguage = "eng";
 
             try {
                 // Extract resource identifier
@@ -568,7 +565,7 @@ public class Aligner extends BaseAligner<CswParams> {
                 xp.addNamespace("gco", "http://www.isotc211.org/2005/gco");
                 @SuppressWarnings("unchecked")
                 List<Element> resourceIdentifiers = xp.selectNodes(response);
-                if (resourceIdentifiers.size() > 0) {
+                if (!resourceIdentifiers.isEmpty()) {
                     // Check if the metadata to import has a resource identifier
                     // existing in current catalog for a record with a different UUID
 
@@ -578,13 +575,9 @@ public class Aligner extends BaseAligner<CswParams> {
                         String identifier = identifierNode.getTextTrim();
                         log.debug("    - Searching for duplicates for resource identifier: " + identifier);
 
-                        // TODOES
-                        Map<String, Map<String, String>> values = new HashMap<>();
-//                        Map<String, Map<String, String>> values = LuceneSearcher.getAllMetadataFromIndexFor(defaultLanguage, resourceIdentifierLuceneIndexField,
-//                            identifier, Collections.singleton("_uuid"), true);
+                        Set<String> values = retrieveMetadataUuidsFromIdentifier(searchManager, identifier);
                         log.debug("    - Number of resources with same identifier: " + values.size());
-                        for (Map<String, String> recordFieldValues : values.values()) {
-                            String indexRecordUuid = recordFieldValues.get("_uuid");
+                        for (String indexRecordUuid : values) {
                             if (!indexRecordUuid.equals(uuid)) {
                                 log.debug("      - UUID " + indexRecordUuid + " in index does not match harvested record UUID " + uuid);
                                 log.warning("      - Duplicates found. Skipping record with UUID " + uuid + " and resource identifier " + identifier);
@@ -630,5 +623,44 @@ public class Aligner extends BaseAligner<CswParams> {
             }
         }
         return md;
+    }
+
+    /**
+     * Retrieves the list of metadata uuids that have the same dataset identifier.
+     *
+     * @param searchMan         ES search manager.
+     * @param datasetIdCode     Dataset identifier.
+     * @return  A list of metadata uuids that have the same dataset identifier.
+     */
+    private Set<String> retrieveMetadataUuidsFromIdentifier(EsSearchManager searchMan,
+                                                            String datasetIdCode) {
+
+        Set<String> metadataUuids = new HashSet<>();
+
+        String jsonQuery = "{" +
+            "          \"term\": {" +
+            "            \"resourceIdentifier.code\": {" +
+            "              \"value\": \"%s\"" +
+            "            }" +
+            "          }" +
+            "}";
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            JsonNode esJsonQuery = objectMapper.readTree(String.format(jsonQuery, datasetIdCode));
+
+            final SearchResponse queryResult = searchMan.query(
+                esJsonQuery,
+                FIELDLIST_CORE,
+                0, 1000);
+
+            for (SearchHit hit : queryResult.getHits()) {
+                String uuid = hit.getSourceAsMap().get(Geonet.IndexFieldNames.UUID).toString();
+                metadataUuids.add(uuid);
+            }
+
+        } catch (Exception ex) {
+            log.error("     retrieve metadata uuids from identifier  " + datasetIdCode + ".");
+        }
+        return metadataUuids;
     }
 }

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
@@ -650,7 +650,7 @@ public class Aligner extends BaseAligner<CswParams> {
 
             final SearchResponse queryResult = searchMan.query(
                 esJsonQuery,
-                FIELDLIST_CORE,
+                FIELDLIST_UUID,
                 0, 1000);
 
             for (SearchHit hit : queryResult.getHits()) {

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
@@ -639,7 +639,7 @@ public class Aligner extends BaseAligner<CswParams> {
 
         String jsonQuery = " {" +
             "       \"query_string\": {" +
-            "       \"query\": \"+resourceIdentifier.code:%s -uuid:%s\"" +
+            "       \"query\": \"+resourceIdentifier.code:\\\"%s\\\" -uuid:\\\"%s\\\"\"" +
             "       }" +
             "}";
         ObjectMapper objectMapper = new ObjectMapper();


### PR DESCRIPTION
The code was commented, pending to migrate it to use ElasticSearch to find the metadata identifiers that have an specific resource identifier.