### PR TITLE
Update OnlineSrcDirective.js

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -1556,7 +1556,7 @@
               scope.selectUploadedResource = function (res) {
                 if (res && res.url) {
                   var o = {
-                    name: res.id.split("/").splice(2).join("/"),
+                    name: decodeURI(res.id.split("/").splice(2).join("/")),
                     url: res.url
                   };
                   ["url", "name"].forEach(function (pName) {


### PR DESCRIPTION
decode unwanted resource character from URI format.

The UI copy paste the url substring into the resource name without decoding. Therefore, some unwanted character will be saved into the metadata xml.

![image](https://user-images.githubusercontent.com/74916635/219796838-2a4e51a5-f4e1-4b89-8b74-10b160593fc3.png)
