### PR TITLE
fix bug where LocalFileSystemHarvester does not update metadata

### DIFF
--- a/domain/src/main/java/org/fao/geonet/repository/GeonetRepositoryImpl.java
+++ b/domain/src/main/java/org/fao/geonet/repository/GeonetRepositoryImpl.java
@@ -110,6 +110,7 @@ public class GeonetRepositoryImpl<T extends GeonetEntity, ID extends Serializabl
         return rootEl;
     }
 
+    @Transactional
     public T update(ID id, Updater<T> updater) {
         final T entity = _entityManager.find(this._entityClass, id);
 


### PR DESCRIPTION
https://github.com/geonetwork/core-geonetwork/blob/main/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFsHarvesterFileVisitor.java#L443 has to conclude with a commit, so the proposed fix is to add a transaction around it.

The solution was to make GeonetRepositoryImpl::update transactionnal just like superclass (SimpleJpaRepository) write operations.

To reproduce the bug:
1. add an md
2. export this md as mef/zip
3. declare a local file system harvester asking for metadataoverriding overriding when uuid clash: set harvester settings -> identification -> user to someone else
4. update mef/zip embedded md (just to be sure harvesting took place)
5. make harvester import the mef/zip
6. check that, despite of the initial md has been updated:
- admin console -> catalog harvesters -> < your new harvester > -> metadata records has disappeared, or shows 0 (next to settings, harvester history),
- the owner has NOT been updated (editor board can be used to check this),
- md harvested status is "local".