### PR TITLE
Update GH Actions base image to Ubuntu 22.04

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - os: ubuntu-18.04
+          - os: ubuntu-22.04
             jdk: 8
     steps:
     - uses: actions/checkout@v3
@@ -21,7 +21,7 @@ jobs:
         fetch-depth: 500
         submodules: 'recursive'
     - name: Set up JDK
-      uses: actions/setup-java@v3.8.0
+      uses: actions/setup-java@v3.9.0
       with:
         distribution: 'temurin'
         java-version: ${{ matrix.jdk }}
@@ -40,7 +40,7 @@ jobs:
         find ~/.m2/repository -name "*3.8*" -type d | xargs rm -rf {}
 
   QA:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v3
       with:
@@ -48,7 +48,7 @@ jobs:
         fetch-depth: 500
         submodules: 'recursive'
     - name: Set up JDK
-      uses: actions/setup-java@v3.8.0
+      uses: actions/setup-java@v3.9.0
       with:
         distribution: 'temurin'
         java-version: 8


### PR DESCRIPTION
Ubuntu 18.04 is deprecated and it will be removed from Github actions.
This commit repaces it by Ubuntu 22.04.

See https://github.com/actions/runner-images/issues/6002 for more info.
