### PR TITLE
Update metadata schemas xpath filters to avoid skipping the elements at the first level

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/schema-ident.xml
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/schema-ident.xml
@@ -134,7 +134,7 @@ Ce schéma est également composé des normes :
     the information. When filtered the element is
     preserved but with no content in.
     -->
-    <filter xpath="*//*[@gco:nilReason='withheld']"
+    <filter xpath=".//*[@gco:nilReason='withheld']"
             ifNotOperation="editing">
       <keepMarkedElement gco:nilReason="withheld"/>
     </filter>
@@ -144,7 +144,7 @@ Ce schéma est également composé des normes :
     are filtered when user does not have download
     privilege.
     -->
-    <filter xpath="*//mrd:onLine[contains(*/cit:protocol/gco:CharacterString, 'DOWNLOAD') or
+    <filter xpath=".//mrd:onLine[contains(*/cit:protocol/gco:CharacterString, 'DOWNLOAD') or
                                   */cit:protocol/gco:CharacterString = 'FILE' or
                                   */cit:protocol/gco:CharacterString = 'DB' or
                                   */cit:protocol/gco:CharacterString = 'COPYFILE']"
@@ -155,7 +155,7 @@ Ce schéma est également composé des normes :
     to user not having dynamic privilege.
     TODO: other type of services ?
     -->
-    <filter xpath="*//mrd:onLine[starts-with(*/cit:protocol/gco:CharacterString, 'OGC:WMS')]"
+    <filter xpath=".//mrd:onLine[starts-with(*/cit:protocol/gco:CharacterString, 'OGC:WMS')]"
             ifNotOperation="dynamic"/>
   </filters>
 </schema>

--- a/schemas/iso19139/src/main/plugin/iso19139/schema-ident.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/schema-ident.xml
@@ -84,14 +84,14 @@
     </elements>
   </autodetect>
   <filters xmlns:gco="http://www.isotc211.org/2005/gco">
-    <filter xpath="*//*[@gco:nilReason='withheld']"
+    <filter xpath=".//*[@gco:nilReason='withheld']"
             ifNotOperation="editing">
       <keepMarkedElement gco:nilReason="withheld"/>
     </filter>
     <filter
-      xpath="*//gmd:onLine[*/gmd:protocol/gco:CharacterString = 'WWW:DOWNLOAD-1.0-http--download']"
+      xpath=".//gmd:onLine[*/gmd:protocol/gco:CharacterString = 'WWW:DOWNLOAD-1.0-http--download']"
       ifNotOperation="download"/>
-    <filter xpath="*//gmd:onLine[starts-with(*/gmd:protocol/gco:CharacterString, 'OGC:WMS')]"
+    <filter xpath=".//gmd:onLine[starts-with(*/gmd:protocol/gco:CharacterString, 'OGC:WMS')]"
             ifNotOperation="dynamic"/>
   </filters>
 </schema>


### PR DESCRIPTION
Test case:

1) Import the provided metadata containing 

```
<mdb:contact gco:nilReason="withheld">
```

2) Publish it

3) With a logged user, request the XML document and check that the metadata contains the element and it's content.

4) With an unlogged user request the XML document and check that the metadata does not contain the element and it's content --> NO OK: without the fix, this is not the case.

---

Test metadata: [contact-withheld.txt](https://github.com/geonetwork/core-geonetwork/files/10802123/contact-withheld.txt)
