### PR TITLE
Record view / Related records / Status badge.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/RelatedDirective.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/RelatedDirective.js
@@ -692,7 +692,8 @@
   ]);
 
   module.directive("gnMetadataCard", [
-    function () {
+    "gnGlobalSettings",
+    function (gnGlobalSettings) {
       return {
         restrict: "E",
         transclude: true,
@@ -708,6 +709,8 @@
         },
         link: function (scope, element, attrs, controller) {
           scope.lang = scope.lang || scope.$parent.lang;
+          scope.showStatusFooterFor =
+            gnGlobalSettings.gnCfg.mods.search.showStatusFooterFor;
         }
       };
     }

--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/metadataCard.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/metadataCard.html
@@ -30,6 +30,14 @@
         </h1>
       </a>
     </div>
+    <div
+      data-ng-repeat="c in md.cl_status track by $index"
+      data-ng-show="showStatusFooterFor.indexOf(md.cl_status[0].key) !== -1"
+      title="{{c.key | translate}}"
+      class="gn-status gn-status-md gn-status-bottomright gn-status-{{c.key}}"
+    >
+      {{c.key | translate}}
+    </div>
   </div>
   <!-- /.gn-card-heading -->
   <div class="panel-body gn-card-body">

--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -910,6 +910,15 @@ i.fa-times.delete:hover {
     margin-right: -8px;
     bottom: auto;
   }
+  .gn-status-bottomright {
+    position: absolute;
+    left: auto;
+    right: 0;
+    float: right;
+    margin-right: -8px;
+    bottom: 10px;
+    line-height: 1.6em;
+  }
   .gn-status-table {
     position: relative;
     bottom: unset;

--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -864,6 +864,7 @@ i.fa-times.delete:hover {
   .gn-status-stamp {
     position: absolute;
     margin: 100px;
+    right: 0;
     overflow: hidden;
     transform: rotate(-15deg);
     font-size: 4rem;

--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -938,6 +938,16 @@ i.fa-times.delete:hover {
   .gn-status-lg {
     font-size: 1.6em;
   }
+
+  // ----- Keep the text size inside card panels for related metadata
+  .gn-card-heading {
+    .gn-status-md {
+      font-size: inherit !important;
+    }
+    .gn-status-lg {
+      font-size: inherit !important;
+    }
+  }
 }
 
 // Language specific layout


### PR DESCRIPTION
Add badge to card layout so that it is similar to search results.


![image](https://user-images.githubusercontent.com/1701393/220653195-fdb99f9b-e9ae-4e8e-93db-8425db9a94c0.png)

Avoid overlapping watermark on title - move it to the right side

![image](https://user-images.githubusercontent.com/1701393/220978193-44334fbc-1b19-4a8d-b535-b1e58a17d8c3.png)

when using config:

```
recordview: {
            showStatusWatermarkFor: "obsolete",
```