### PR TITLE
Index / Feature catalogue / Add type and column names in full text search.

### DIFF
--- a/web/src/main/webResources/WEB-INF/data/config/index/records.json
+++ b/web/src/main/webResources/WEB-INF/data/config/index/records.json
@@ -1772,6 +1772,66 @@
           }
         }
       },
+      "featureTypes": {
+        "type": "object",
+        "properties": {
+          "aliases": {
+            "type": "keyword",
+            "copy_to": "any.common"
+          },
+          "code": {
+            "type": "keyword"
+          },
+          "definition": {
+            "type": "text"
+          },
+          "typeName": {
+            "type": "keyword",
+            "copy_to": "any.common"
+          },
+          "isAbstract": {
+            "type": "boolean"
+          },
+          "attributeTable": {
+            "type": "object",
+            "properties": {
+              "code": {
+                "type": "keyword",
+                "copy_to": "any.common"
+              },
+              "definition": {
+                "type": "text"
+              },
+              "link": {
+                "type": "keyword"
+              },
+              "name": {
+                "type": "keyword",
+                "copy_to": "any.common"
+              },
+              "type": {
+                "type": "keyword"
+              },
+              "values": {
+                "type": "object",
+                "properties": {
+                  "code": {
+                    "type": "keyword",
+                    "copy_to": "any.common"
+                  },
+                  "definition": {
+                    "type": "text"
+                  },
+                  "label": {
+                    "type": "keyword",
+                    "copy_to": "any.common"
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
       "serviceType": {
         "type": "keyword"
       },


### PR DESCRIPTION
Add possibility to search by feature type or column name in full text search

![image](https://user-images.githubusercontent.com/1701393/220893924-bace5206-5064-44db-be75-652dfa5da880.png)


eg. Load a feature catalogue from https://sdi.eea.europa.eu/catalogue/srv/eng/catalog.search#/search?query_string=%7B%22resourceType%22:%20%7B%22featureCatalog%22:%20true%7D%7D and search for a column or a type