### PR TITLE
Advanced search form: reset date filter fields

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/directives/directive.js
+++ b/web-ui/src/main/resources/catalog/views/default/directives/directive.js
@@ -337,7 +337,7 @@
             }
           });
 
-          scope.$on("resetSelection", function () {
+          scope.$on("beforeSearchReset", function () {
             scope.dateFrom = null;
             scope.dateTo = null;
             scope.relation = scope.relations[0];

--- a/web-ui/src/main/resources/catalog/views/default/directives/directive.js
+++ b/web-ui/src/main/resources/catalog/views/default/directives/directive.js
@@ -336,6 +336,12 @@
               scope.setRange();
             }
           });
+
+          scope.$on("resetSelection", function () {
+            scope.dateFrom = null;
+            scope.dateTo = null;
+            scope.relation = scope.relations[0];
+          });
         }
       };
     }


### PR DESCRIPTION
The reset search fields was not resetting the values of the date filters in the advanced search form.

![advanced-searchform-reset-datefields-1](https://user-images.githubusercontent.com/1695003/220900604-7eb75d53-8a53-4d85-be2b-a4398a806a9e.png)

Update the directive to listen to the `resetSelection` event and clear the date fields:

![advanced-searchform-reset-datefields-2](https://user-images.githubusercontent.com/1695003/220900614-cefa63a6-042c-42df-afc5-cd5eaa0b65f7.png)
