### PR TITLE
Schema plugins / iso19139 / Fix alt title indexing

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
@@ -269,7 +269,7 @@
         <xsl:for-each select="gmd:citation/gmd:CI_Citation">
 
           <xsl:copy-of select="gn-fn-index:add-multilingual-field('resourceTitle', gmd:title, $allLanguages)"/>
-          <xsl:copy-of select="gn-fn-index:add-multilingual-field('resourceAltTitle', gmd:resourceAltTitle, $allLanguages)"/>
+          <xsl:copy-of select="gn-fn-index:add-multilingual-field('resourceAltTitle', gmd:alternateTitle, $allLanguages)"/>
 
           <xsl:for-each select="gmd:date/gmd:CI_Date[gn-fn-index:is-isoDate(gmd:date/*/text())]">
             <xsl:variable name="dateType"


### PR DESCRIPTION
Fix the indexing of the alternate title for a resource.

Fixes #6859.