### PR TITLE
Extend ElasticSearch proxy to filter out elements defined in the schema filters configurations

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/SchemaManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/SchemaManager.java
@@ -1,29 +1,25 @@
-//=============================================================================
-//===
-//=== SchemaManager
-//===
-//=============================================================================
-//=== Copyright (C) 2001-2011 Food and Agriculture Organization of the
-//=== United Nations (FAO-UN), United Nations World Food Programme (WFP)
-//=== and United Nations Environment Programme (UNEP)
-//===
-//===	This program is free software; you can redistribute it and/or modify
-//===	it under the terms of the GNU General Public License as published by
-//===	the Free Software Foundation; either version 2 of the License, or (at
-//===	your option) any later version.
-//===
-//===	This program is distributed in the hope that it will be useful, but
-//===	WITHOUT ANY WARRANTY; without even the implied warranty of
-//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-//===	General Public License for more details.
-//===
-//===	You should have received a copy of the GNU General Public License
-//===	along with this program; if not, write to the Free Software
-//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
-//===
-//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
-//===	Rome - Italy. email: geonetwork@osgeo.org
-//==============================================================================
+/*
+ * Copyright (C) 2001-2023 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
 
 package org.fao.geonet.kernel;
 
@@ -42,6 +38,7 @@ import org.fao.geonet.exceptions.NoSchemaMatchesException;
 import org.fao.geonet.exceptions.OperationAbortedEx;
 import org.fao.geonet.exceptions.SchemaMatchConflictException;
 import org.fao.geonet.kernel.schema.MetadataSchema;
+import org.fao.geonet.kernel.schema.MetadataSchemaOperationFilter;
 import org.fao.geonet.kernel.schema.SchemaLoader;
 import org.fao.geonet.kernel.schema.SchemaPlugin;
 import org.fao.geonet.kernel.setting.SettingInfo;
@@ -107,8 +104,8 @@ public class SchemaManager {
      * Active writers count
      */
     private static int activeWriters = 0;
-    private Map<String, Schema> hmSchemas = new HashMap<String, Schema>();
-    private Map<String, Namespace> hmSchemasTypenames = new HashMap<String, Namespace>();
+    private Map<String, Schema> hmSchemas = new HashMap<>();
+    private Map<String, Namespace> hmSchemasTypenames = new HashMap<>();
     private String[] fnames = {"labels.xml", "codelists.xml", "strings.xml"};
     private Path schemaPluginsDir;
     private Path schemaPluginsCat;
@@ -271,11 +268,11 @@ public class SchemaManager {
         try {
             Schema schema = hmSchemas.get(name);
 
-            if (schema == null)
+            if (schema == null) {
                 throw new IllegalArgumentException("Schema not registered : " + name);
+            }
 
-            final MetadataSchema mds = schema.getMetadataSchema();
-            return mds;
+            return schema.getMetadataSchema();
         } finally {
             afterRead();
         }
@@ -288,7 +285,7 @@ public class SchemaManager {
      */
     public Set<String> getDependencies(String name) {
 
-        Set<String> dependencies = new HashSet<String>();
+        Set<String> dependencies = new HashSet<>();
 
         beforeRead();
         try {
@@ -541,7 +538,7 @@ public class SchemaManager {
         try {
             Schema schema = hmSchemas.get(name);
             List<Element> childs = schema.getConversionElements();
-            List<Element> dChilds = new ArrayList<Element>();
+            List<Element> dChilds = new ArrayList<>();
             for (Element child : childs) {
                 if (child != null) dChilds.add((Element) child.clone());
             }
@@ -712,40 +709,35 @@ public class SchemaManager {
             // -- specific test first, then in order of increasing generality,
             // -- first match wins
             schema = compareElementsAndAttributes(md, MODE_ATTRIBUTEWITHVALUE);
-            if (schema != null) {
-                if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER))
-                    Log.debug(Geonet.SCHEMA_MANAGER, "  => Found schema " + schema + " using AUTODETECT(attributes) examination");
+            if (schema != null && Log.isDebugEnabled(Geonet.SCHEMA_MANAGER)) {
+                Log.debug(Geonet.SCHEMA_MANAGER, "  => Found schema " + schema + " using AUTODETECT(attributes) examination");
             }
 
             if (schema == null) {
                 schema = compareElementsAndAttributes(md, MODE_NEEDLEWITHVALUE);
-                if (schema != null) {
-                    if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER))
-                        Log.debug(Geonet.SCHEMA_MANAGER, "  => Found schema " + schema + " using AUTODETECT(elements with value) examination");
+                if (schema != null && Log.isDebugEnabled(Geonet.SCHEMA_MANAGER)) {
+                    Log.debug(Geonet.SCHEMA_MANAGER, "  => Found schema " + schema + " using AUTODETECT(elements with value) examination");
                 }
             }
 
             if (schema == null) {
                 schema = compareElementsAndAttributes(md, MODE_NEEDLE);
-                if (schema != null) {
-                    if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER))
-                        Log.debug(Geonet.SCHEMA_MANAGER, "  => Found schema " + schema + " using AUTODETECT(elements) examination");
+                if (schema != null && Log.isDebugEnabled(Geonet.SCHEMA_MANAGER)) {
+                    Log.debug(Geonet.SCHEMA_MANAGER, "  => Found schema " + schema + " using AUTODETECT(elements) examination");
                 }
             }
 
             if (schema == null) {
                 schema = compareElementsAndAttributes(md, MODE_ROOT);
-                if (schema != null) {
-                    if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER))
-                        Log.debug(Geonet.SCHEMA_MANAGER, "  => Found schema " + schema + " using AUTODETECT(elements with root) examination");
+                if (schema != null && Log.isDebugEnabled(Geonet.SCHEMA_MANAGER)) {
+                    Log.debug(Geonet.SCHEMA_MANAGER, "  => Found schema " + schema + " using AUTODETECT(elements with root) examination");
                 }
             }
 
             if (schema == null) {
                 schema = compareElementsAndAttributes(md, MODE_NAMESPACE);
-                if (schema != null) {
-                    if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER))
-                        Log.debug(Geonet.SCHEMA_MANAGER, "  => Found schema " + schema + " using AUTODETECT(namespaces) examination");
+                if (schema != null && Log.isDebugEnabled(Geonet.SCHEMA_MANAGER)) {
+                    Log.debug(Geonet.SCHEMA_MANAGER, "  => Found schema " + schema + " using AUTODETECT(namespaces) examination");
                 }
             }
 
@@ -789,8 +781,9 @@ public class SchemaManager {
             MetadataSchema mds = getSchema(schema);
             if (mds != null) {
                 String primeNs = mds.getPrimeNS();
-                if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER))
+                if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER)) {
                     Log.debug(Geonet.SCHEMA_MANAGER, "  primeNs " + primeNs + " for schema " + schema);
+                }
                 if (md.getNamespace().getURI().equals(primeNs)) {
                     result = schema;
                 } else {
@@ -800,8 +793,9 @@ public class SchemaManager {
                     Schema sch = hmSchemas.get(schema);
                     List<Element> dependsList = sch.getDependElements();
                     for (Element depends : dependsList) {
-                        if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER))
+                        if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER)) {
                             Log.debug(Geonet.SCHEMA_MANAGER, "  checkNamespace for dependency: " + depends.getText());
+                        }
                         return checkNamespace(md, depends.getText());
                     }
                 }
@@ -869,7 +863,7 @@ public class SchemaManager {
         if (schema != null) {
             if (doDependencies) {
                 List<String> dependsOnMe = getSchemasThatDependOnMe(name);
-                if (dependsOnMe.size() > 0) {
+                if (!dependsOnMe.isEmpty()) {
                     String errStr = "Cannot remove schema " + name + " because the following schemas list it as a dependency: " + dependsOnMe;
                     Log.error(Geonet.SCHEMA_MANAGER, errStr);
                     throw new OperationAbortedEx(errStr);
@@ -959,19 +953,21 @@ public class SchemaManager {
 
         final String schemaName = schemaDir.getFileName().toString();
         Path locBase = schemaDir.resolve("loc");
-        Map<String, XmlFile> xfMap = new HashMap<String, XmlFile>();
+        Map<String, XmlFile> xfMap = new HashMap<>();
 
         for (String fname : fnames) {
             Path filePath = path.resolve("loc").resolve(defaultLang).resolve(fname);
-            if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER))
+            if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER)) {
                 Log.debug(Geonet.SCHEMA_MANAGER, "Searching for " + filePath);
+            }
             if (Files.exists(filePath)) {
                 Element config = new Element("xml");
                 config.setAttribute("name", schemaName);
                 config.setAttribute("base", locBase.toUri().toString());
                 config.setAttribute("file", fname);
-                if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER))
+                if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER)) {
                     Log.debug(Geonet.SCHEMA_MANAGER, "Adding XmlFile " + Xml.getString(config));
+                }
                 XmlFile xf = new XmlFile(config, defaultLang, true);
                 xfMap.put(fname, xf);
             } else {
@@ -1078,8 +1074,9 @@ public class SchemaManager {
             else continue; // skip this
 
             if (!uri.getName().equals("uri") || !uri.getNamespace().equals(Namespaces.OASIS_CATALOG)) {
-                if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER))
+                if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER)) {
                     Log.debug(Geonet.SCHEMA_MANAGER, "Skipping element " + uri.getQualifiedName() + ":" + uri.getNamespace());
+                }
                 continue;
             }
 
@@ -1113,8 +1110,9 @@ public class SchemaManager {
             else continue; // skip this
 
             if (!uri.getName().equals("rewriteURI") || !uri.getNamespace().equals(Namespaces.OASIS_CATALOG)) {
-                if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER))
+                if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER)) {
                     Log.debug(Geonet.SCHEMA_MANAGER, "Skipping element " + uri.getQualifiedName() + ":" + uri.getNamespace());
+                }
                 continue;
             }
 
@@ -1122,8 +1120,9 @@ public class SchemaManager {
             if (uri.getAttributeValue("rewritePrefix").equals(ourUri.toString())) return -1;
 
             String nameAttr = uri.getAttributeValue("uriStartString");
-            if (nameAttr.startsWith(Geonet.File.METADATA_BLANK)) {
-                if (nameAttr.compareTo(baseBlank) > 0) baseBlank = nameAttr;
+            if (nameAttr.startsWith(Geonet.File.METADATA_BLANK) &&
+                nameAttr.compareTo(baseBlank) > 0) {
+                baseBlank = nameAttr;
             }
         }
 
@@ -1318,17 +1317,17 @@ public class SchemaManager {
      * Check dependencies for all schemas - remove those that fail.
      */
     private void checkDependencies(Element schemaPluginCatRoot) throws Exception {
-        List<String> removes = new ArrayList<String>();
+        List<String> removes = new ArrayList<>();
 
         // process each schema to see whether its dependencies are present
-        for (String schemaName : hmSchemas.keySet()) {
-            Schema schema = hmSchemas.get(schemaName);
+        for (Map.Entry<String, Schema> schemaInfo : hmSchemas.entrySet()) {
+            Schema schema = schemaInfo.getValue();
             try {
-                checkDepends(schemaName, schema.getDependElements());
+                checkDepends(schemaInfo.getKey(), schema.getDependElements());
             } catch (Exception e) {
                 Log.error(Geonet.SCHEMA_MANAGER, "check dependencies failed: " + e.getMessage());
                 // add the schema to list for removal
-                removes.add(schemaName);
+                removes.add(schemaInfo.getKey());
             }
         }
 
@@ -1341,7 +1340,7 @@ public class SchemaManager {
     }
 
     private void checkAppSupported(Element schemaPluginCatRoot) throws Exception {
-        List<String> removes = new ArrayList<String>();
+        List<String> removes = new ArrayList<>();
 
         final SystemInfo systemInfo = ApplicationContextHolder.get().getBean(SystemInfo.class);
 
@@ -1349,17 +1348,17 @@ public class SchemaManager {
         Version appVersion = Version.parseVersionNumber(version);
 
         // process each schema to see whether its dependencies are present
-        for (String schemaName : hmSchemas.keySet()) {
-            Schema schema = hmSchemas.get(schemaName);
+        for (Map.Entry<String, Schema> schemaInfo : hmSchemas.entrySet()) {
+            Schema schema = schemaInfo.getValue();
             String minorAppVersionSupported = schema.getMetadataSchema().getAppMinorVersionSupported();
 
             Version schemaMinorAppVersion = Version.parseVersionNumber(minorAppVersionSupported);
 
             if (appVersion.compareTo(schemaMinorAppVersion) < 0) {
-                Log.error(Geonet.SCHEMA_MANAGER, "Schema " + schemaName +
+                Log.error(Geonet.SCHEMA_MANAGER, "Schema " + schemaInfo.getKey() +
                     " requires min Geonetwork version: " + minorAppVersionSupported + ", current is: " +
                     version + ". Skip load schema.");
-                removes.add(schemaName);
+                removes.add(schemaInfo.getKey());
                 continue;
             }
 
@@ -1368,10 +1367,10 @@ public class SchemaManager {
                 Version schemaMajorAppVersion = Version.parseVersionNumber(majorAppVersionSupported);
 
                 if (appVersion.compareTo(schemaMajorAppVersion) > 0) {
-                    Log.error(Geonet.SCHEMA_MANAGER, "Schema " + schemaName +
+                    Log.error(Geonet.SCHEMA_MANAGER, "Schema " + schemaInfo.getKey() +
                         " requires max Geonetwork version: " + majorAppVersionSupported + ", current is: " +
                         version + ". Skip load schema.");
-                    removes.add(schemaName);
+                    removes.add(schemaInfo.getKey());
                     continue;
                 }
             }
@@ -1396,17 +1395,17 @@ public class SchemaManager {
      */
     public List<String> getSchemasThatDependOnMe(String schemaName) {
 
-        List<String> myDepends = new ArrayList<String>();
+        List<String> myDepends = new ArrayList<>();
 
         // process each schema to see whether its dependencies are present
-        for (String schemaNameToTest : hmSchemas.keySet()) {
-            if (schemaNameToTest.equals(schemaName)) continue;
+        for (Map.Entry<String, Schema> schemaInfoToTest : hmSchemas.entrySet()) {
+            if (schemaInfoToTest.getKey().equals(schemaName)) continue;
 
-            Schema schema = hmSchemas.get(schemaNameToTest);
+            Schema schema = schemaInfoToTest.getValue();
             List<Element> dependsList = schema.getDependElements();
             for (Element depends : dependsList) {
                 if (depends.getText().equals(schemaName)) {
-                    myDepends.add(schemaNameToTest);
+                    myDepends.add(schemaInfoToTest.getKey());
                 }
             }
         }
@@ -1424,7 +1423,7 @@ public class SchemaManager {
         // process each dependency to see whether it is present
         for (Element depends : dependsList) {
             String schema = depends.getText();
-            if (schema.length() > 0) {
+            if (StringUtils.isNotBlank(schema)) {
                 if (!hmSchemas.containsKey(schema)) {
                     throw new IllegalArgumentException("Schema " + thisSchema + " depends on " + schema + ", but that schema is not loaded");
                 }
@@ -1444,7 +1443,7 @@ public class SchemaManager {
 
         // get list of depends elements from schema-ident.xml
         List<Element> dependsList = root.getChildren("depends", GEONET_SCHEMA_NS);
-        if (dependsList.size() == 0) {
+        if (dependsList.isEmpty()) {
             dependsList = root.getChildren("depends", GEONET_SCHEMA_PREFIX_NS);
         }
         return dependsList;
@@ -1502,11 +1501,11 @@ public class SchemaManager {
      * true if schema requires to synch the uuid column schema info with the uuid in the metadata
      * record (updated on editing or in UFO).
      */
-    private Map<String, Pair<String, Element>> extractOperationFilters(Path xmlIdFile) throws Exception {
+    private Map<String, MetadataSchemaOperationFilter> extractOperationFilters(Path xmlIdFile) throws Exception {
         Element root = Xml.loadFile(xmlIdFile);
         Element filters = root.getChild("filters", GEONET_SCHEMA_NS);
-        Map<String, Pair<String, Element>> filterRules =
-            new HashMap<String, Pair<String, Element>>();
+        Map<String, MetadataSchemaOperationFilter> filterRules =
+            new HashMap<>();
         if (filters == null) {
             return filterRules;
         } else {
@@ -1514,11 +1513,14 @@ public class SchemaManager {
                 if (rule instanceof Element) {
                     Element ruleElement = (Element) rule;
                     String xpath = ruleElement.getAttributeValue("xpath");
+                    String jsonpath = ruleElement.getAttributeValue("jsonpath");
                     String ifNotOperation = ruleElement.getAttributeValue("ifNotOperation");
                     Element markedElement = ruleElement.getChild("keepMarkedElement", GEONET_SCHEMA_NS);
+
                     if (StringUtils.isNotBlank(ifNotOperation) &&
                         StringUtils.isNotBlank(xpath)) {
-                        filterRules.put(ifNotOperation, Pair.read(xpath, markedElement));
+                        MetadataSchemaOperationFilter filter = new MetadataSchemaOperationFilter(xpath, jsonpath, ifNotOperation, markedElement);
+                        filterRules.put(ifNotOperation, filter);
                     }
                 }
             }
@@ -1574,11 +1576,12 @@ public class SchemaManager {
         if (!Files.exists(xmlConvFile)) {
             if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER))
                 Log.debug(Geonet.SCHEMA_MANAGER, "Schema conversions file not present");
-            return new ArrayList<Element>();
+            return new ArrayList<>();
         } else {
             Element root = Xml.loadFile(xmlConvFile);
-            if (root.getName() != "conversions")
+            if (!root.getName().equals("conversions")) {
                 throw new IllegalArgumentException("Schema conversions file " + xmlConvFile + " is invalid, no <conversions> root element");
+            }
             @SuppressWarnings("unchecked")
             List<Element> result = root.getChildren();
             return result;
@@ -1609,8 +1612,9 @@ public class SchemaManager {
         Set<String> allSchemas = getSchemas();
         List<String> matches = new ArrayList<>();
 
-        if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER))
+        if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER)) {
             Log.debug(Geonet.SCHEMA_MANAGER, "Schema autodetection starting on " + md.getName() + " (Namespace: " + md.getNamespace() + ") using mode: " + mode + "...");
+        }
 
         for (String schemaName : allSchemas) {
             if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER))
@@ -1619,8 +1623,9 @@ public class SchemaManager {
             List<Element> adElems = schema.getAutodetectElements();
 
             for (Element elem : adElems) {
-                if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER))
+                if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER)) {
                     Log.debug(Geonet.SCHEMA_MANAGER, "		Checking autodetect element " + Xml.getString(elem) + " with name " + elem.getName());
+                }
 
                 @SuppressWarnings("unchecked")
                 List<Element> elemKids = elem.getChildren();
@@ -1629,12 +1634,13 @@ public class SchemaManager {
                 Attribute type = elem.getAttribute("type");
 
                 // --- try and find the attribute and value in md
-                if (mode == MODE_ATTRIBUTEWITHVALUE && elem.getName() == "attributes") {
+                if (mode == MODE_ATTRIBUTEWITHVALUE && elem.getName().equals("attributes")) {
                     @SuppressWarnings("unchecked")
                     List<Attribute> atts = elem.getAttributes();
                     for (Attribute searchAtt : atts) {
-                        if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER))
+                        if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER)) {
                             Log.debug(Geonet.SCHEMA_MANAGER, "				Finding attribute " + searchAtt.toString());
+                        }
 
                         if (isMatchingAttributeInMetadata(searchAtt, md)) {
                             match = true;
@@ -1649,8 +1655,9 @@ public class SchemaManager {
                     @SuppressWarnings("unchecked")
                     List<Namespace> nss = elem.getAdditionalNamespaces();
                     for (Namespace ns : nss) {
-                        if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER))
+                        if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER)) {
                             Log.debug(Geonet.SCHEMA_MANAGER, "				Finding namespace " + ns.toString());
+                        }
 
                         if (isMatchingNamespaceInMetadata(ns, md)) {
                             match = true;
@@ -1664,8 +1671,9 @@ public class SchemaManager {
 
                         // --- is the kid the same as the root of the md
                         if (mode == MODE_ROOT && type != null && "root".equals(type.getValue())) {
-                            if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER))
+                            if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER)) {
                                 Log.debug(Geonet.SCHEMA_MANAGER, "				Comparing " + Xml.getString(kid) + " with " + md.getName() + " with namespace " + md.getNamespace() + " : " + (kid.getName().equals(md.getName()) && kid.getNamespace().equals(md.getNamespace())));
+                            }
                             if (kid.getName().equals(md.getName()) &&
                                 kid.getNamespace().equals(md.getNamespace())) {
                                 match = true;
@@ -1675,8 +1683,9 @@ public class SchemaManager {
                             }
                             // --- try and find the kid in the md (kid only, not value)
                         } else if (mode == MODE_NEEDLE && type != null && "search".equals(type.getValue())) {
-                            if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER))
+                            if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER)) {
                                 Log.debug(Geonet.SCHEMA_MANAGER, "				Comparing " + Xml.getString(kid) + " with " + md.getName() + " with namespace " + md.getNamespace() + " : " + (kid.getName().equals(md.getName()) && kid.getNamespace().equals(md.getNamespace())));
+                            }
 
                             if (isMatchingElementInMetadata(kid, md, false)) {
                                 match = true;
@@ -1720,8 +1729,9 @@ public class SchemaManager {
         @SuppressWarnings("unchecked")
         Iterator<Element> haystackIterator = haystack.getDescendants(new ElementFilter());
 
-        if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER))
+        if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER)) {
             Log.debug(Geonet.SCHEMA_MANAGER, "Matching " + needle.toString());
+        }
 
         while (haystackIterator.hasNext()) {
             Element tempElement = haystackIterator.next();
@@ -1742,8 +1752,9 @@ public class SchemaManager {
      * @param haystack the XML metadata record we are searching
      */
     private boolean isMatchingNamespaceInMetadata(Namespace needle, Element haystack) {
-        if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER))
+        if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER)) {
             Log.debug(Geonet.SCHEMA_MANAGER, "Matching " + needle.toString());
+        }
 
         if (checkNamespacesOnElement(needle, haystack)) return true;
 
@@ -1797,8 +1808,9 @@ public class SchemaManager {
 
             if (tempElement.getName().equals(needleName) && tempElement.getNamespace().equals(needleNS)) {
                 if (checkValue) {
-                    if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER))
+                    if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER)) {
                         Log.debug(Geonet.SCHEMA_MANAGER, "  Searching value for element: " + tempElement.getName());
+                    }
 
                     String needleVal = StringUtils.deleteWhitespace(needle.getValue());
                     String tempVal = StringUtils.deleteWhitespace(tempElement.getValue());
@@ -1923,7 +1935,6 @@ public class SchemaManager {
         List<String> listOfTypenames = new ArrayList<>();
         while (iterator.hasNext()) {
             String typeName = iterator.next();
-            Namespace ns = hmSchemasTypenames.get(typeName);
             listOfTypenames.add(typeName);
         }
         return listOfTypenames;

--- a/core/src/main/java/org/fao/geonet/kernel/XmlSerializer.java
+++ b/core/src/main/java/org/fao/geonet/kernel/XmlSerializer.java
@@ -183,33 +183,42 @@ public abstract class XmlSerializer {
             // Check if a filter is defined for this schema
             // for the editing operation ie. user who can not edit
             // will not see those elements.
-            MetadataSchemaOperationFilter editXpathFilter = mds.getOperationFilter(ReservedOperation.editing);
-            boolean filterEditOperationElements = editXpathFilter != null;
+            MetadataSchemaOperationFilter editFilter = mds.getOperationFilter(ReservedOperation.editing);
+            boolean filterEditOperationElements = editFilter != null;
             List<Namespace> namespaces = mds.getNamespaces();
             if (context != null) {
-                if (editXpathFilter != null) {
+                if (editFilter != null) {
                     boolean canEdit = accessManager.canEdit(context, id);
                     if (canEdit) {
                         filterEditOperationElements = false;
                     }
                 }
-                MetadataSchemaOperationFilter downloadXpathFilter = mds.getOperationFilter(ReservedOperation.download);
-                if (downloadXpathFilter != null) {
-                    boolean canDownload = accessManager.canDownload(context, id);
-                    if (!canDownload) {
-                        removeFilteredElement(metadataXml, downloadXpathFilter, namespaces);
+
+                MetadataSchemaOperationFilter authenticatedFilter = mds.getOperationFilter("authenticated");
+                if (authenticatedFilter != null) {
+                    boolean isAuthenticated = context.getUserSession().isAuthenticated();
+                    if (!isAuthenticated) {
+                        removeFilteredElement(metadataXml, authenticatedFilter, namespaces);
                     }
                 }
-                MetadataSchemaOperationFilter dynamicXpathFilter = mds.getOperationFilter(ReservedOperation.dynamic);
-                if (dynamicXpathFilter != null) {
+
+                MetadataSchemaOperationFilter downloadFilter = mds.getOperationFilter(ReservedOperation.download);
+                if (downloadFilter != null) {
+                    boolean canDownload = accessManager.canDownload(context, id);
+                    if (!canDownload) {
+                        removeFilteredElement(metadataXml, downloadFilter, namespaces);
+                    }
+                }
+                MetadataSchemaOperationFilter dynamicFilter = mds.getOperationFilter(ReservedOperation.dynamic);
+                if (dynamicFilter != null) {
                     boolean canDynamic = accessManager.canDynamic(context, id);
                     if (!canDynamic) {
-                        removeFilteredElement(metadataXml, dynamicXpathFilter, namespaces);
+                        removeFilteredElement(metadataXml, dynamicFilter, namespaces);
                     }
                 }
             }
             if (filterEditOperationElements || (getThreadLocal(false) != null && getThreadLocal(false).forceFilterEditOperation)) {
-                removeFilteredElement(metadataXml, editXpathFilter, namespaces);
+                removeFilteredElement(metadataXml, editFilter, namespaces);
             }
         }
         return metadataXml;

--- a/core/src/main/java/org/fao/geonet/kernel/mef/ExportFormat.java
+++ b/core/src/main/java/org/fao/geonet/kernel/mef/ExportFormat.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.fao.geonet.GeonetContext;
+import org.fao.geonet.constants.Edit;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.AbstractMetadata;
 import org.fao.geonet.domain.Metadata;
@@ -72,7 +73,7 @@ public class ExportFormat implements GeonetworkExtension {
                 String outputFileName = entry.getValue();
                 Path path = metadataSchema.getSchemaDir().resolve(xslFileName);
                 if (Files.isRegularFile(path)) {
-                    String outputData = formatData(metadata, true, path);
+                    String outputData = formatData(context, metadata, true, path);
                     allExports.add(Pair.read(outputFileName, outputData));
                 } else {
                     // A conversion that does not exist
@@ -96,10 +97,9 @@ public class ExportFormat implements GeonetworkExtension {
      *
      * @return ByteArrayInputStream
      */
-    public static String formatData(AbstractMetadata metadata, boolean transform, Path stylePath) throws Exception {
-        String xmlData = metadata.getData();
-
-        Element md = Xml.loadString(xmlData, false);
+    public static String formatData(ServiceContext context, AbstractMetadata metadata, boolean transform, Path stylePath) throws Exception {
+        Element md = context.getBean(DataManager.class).getMetadata(context, metadata.getId() + "", false, false, true);
+        md.removeChild("info", Edit.NAMESPACE);
 
         // Apply a stylesheet transformation when schema is ISO profil
         if (transform) {

--- a/core/src/main/java/org/fao/geonet/kernel/schema/MetadataSchema.java
+++ b/core/src/main/java/org/fao/geonet/kernel/schema/MetadataSchema.java
@@ -1,29 +1,25 @@
-//==============================================================================
-//===
-//===   MetadataSchema
-//===
-//==============================================================================
-//===	Copyright (C) 2001-2007 Food and Agriculture Organization of the
-//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
-//===	and United Nations Environment Programme (UNEP)
-//===
-//===	This program is free software; you can redistribute it and/or modify
-//===	it under the terms of the GNU General Public License as published by
-//===	the Free Software Foundation; either version 2 of the License, or (at
-//===	your option) any later version.
-//===
-//===	This program is distributed in the hope that it will be useful, but
-//===	WITHOUT ANY WARRANTY; without even the implied warranty of
-//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-//===	General Public License for more details.
-//===
-//===	You should have received a copy of the GNU General Public License
-//===	along with this program; if not, write to the Free Software
-//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
-//===
-//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
-//===	Rome - Italy. email: geonetwork@osgeo.org
-//==============================================================================
+/*
+ * Copyright (C) 2001-2023 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
 
 package org.fao.geonet.kernel.schema;
 
@@ -34,9 +30,9 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 
+import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.api.exception.ResourceNotFoundException;
 import org.fao.geonet.constants.Geonet;
-import org.fao.geonet.domain.Pair;
 import org.fao.geonet.domain.ReservedOperation;
 import org.fao.geonet.domain.Schematron;
 import org.fao.geonet.domain.SchematronCriteria;
@@ -82,15 +78,15 @@ public class MetadataSchema {
     private static final String XSL_FILE_EXTENSION = ".xsl";
     private static final String SCH_FILE_EXTENSION = ".sch";
     private static final String SCHEMATRON_RULE_FILE_PREFIX = "schematron-rules";
-    private Map<String, List<String>> hmElements = new HashMap<String, List<String>>();
-    private Map<String, List<List<String>>> hmRestric = new HashMap<String, List<List<String>>>();
-    private Map<String, MetadataType> hmTypes = new HashMap<String, MetadataType>();
-    private Map<String, List<String>> hmSubs = new HashMap<String, List<String>>();
-    private Map<String, String> hmSubsLink = new HashMap<String, String>();
-    private Map<String, Namespace> hmNameSpaces = new HashMap<String, Namespace>();
-    private Map<String, Namespace> hmPrefixes = new HashMap<String, Namespace>();
-    private Map<String, Pair<String, Element>> hmOperationFilters =
-        new HashMap<String, Pair<String, Element>>();
+    private Map<String, List<String>> hmElements = new HashMap<>();
+    private Map<String, List<List<String>>> hmRestric = new HashMap<>();
+    private Map<String, MetadataType> hmTypes = new HashMap<>();
+    private Map<String, List<String>> hmSubs = new HashMap<>();
+    private Map<String, String> hmSubsLink = new HashMap<>();
+    private Map<String, Namespace> hmNameSpaces = new HashMap<>();
+    private Map<String, Namespace> hmPrefixes = new HashMap<>();
+    private Map<String, MetadataSchemaOperationFilter> hmOperationFilters =
+        new HashMap<>();
     private String schemaName;
     private Path schemaDir;
     private String standardUrl;
@@ -294,8 +290,8 @@ public class MetadataSchema {
         // first just add the subs - because these are for global elements we
         // never have a clash because global elements are all in the same scope
         // and are thus unique
-        if (alSubs != null && alSubs.size() > 0) hmSubs.put(name, alSubs);
-        if (subLink != null && subLink.length() > 0) hmSubsLink.put(name, subLink);
+        if (alSubs != null && !alSubs.isEmpty()) hmSubs.put(name, alSubs);
+        if (subLink != null && StringUtils.isNotBlank(subLink)) hmSubsLink.put(name, subLink);
 
         List<String> exType = hmElements.get(name);
 
@@ -309,7 +305,8 @@ public class MetadataSchema {
 
             // it's not there so add a new list
         } else {
-            hmElements.put(name, exType = new ArrayList<String>());
+            exType = new ArrayList<>();
+            hmElements.put(name, exType);
         }
         exType.add(type);
 
@@ -323,7 +320,8 @@ public class MetadataSchema {
 
             // it's not there so add a new list of lists
         } else {
-            hmRestric.put(restricName, exValues = new ArrayList<List<String>>());
+            exValues = new ArrayList<>();
+            hmRestric.put(restricName, exValues);
         }
         exValues.add(alValues);
     }
@@ -361,7 +359,7 @@ public class MetadataSchema {
      */
     @JsonIgnore
     public List<Namespace> getNamespaces() {
-        List<Namespace> list = new ArrayList<Namespace>(hmNameSpaces.size());
+        List<Namespace> list = new ArrayList<>(hmNameSpaces.size());
         for (Namespace ns : hmNameSpaces.values()) {
             list.add(ns);
         }
@@ -382,12 +380,12 @@ public class MetadataSchema {
     //---------------------------------------------------------------------------
     @JsonIgnore
     public List<Namespace> getSchemaNS() {
-        return new ArrayList<Namespace>(hmPrefixes.values());
+        return new ArrayList<>(hmPrefixes.values());
     }
 
     @JsonProperty(value = "namespaces")
     public Map<String, String> getSchemaNSWithPrefix() {
-        Map<String, String> mapNs = new HashMap<String, String>();
+        Map<String, String> mapNs = new HashMap<>();
         List<Namespace> schemaNsList = getSchemaNS();
 
         for (Namespace ns : schemaNsList) {
@@ -518,7 +516,7 @@ public class MetadataSchema {
         this.schemaRepo.saveAll(updated);
     }
 
-    public void setOperationFilters(Map<String, Pair<String, Element>> operationFilters) {
+    public void setOperationFilters(Map<String, MetadataSchemaOperationFilter> operationFilters) {
         this.hmOperationFilters = operationFilters;
     }
 
@@ -527,8 +525,12 @@ public class MetadataSchema {
      *
      * @return The XPath to select element to filter or null
      */
-    public Pair<String, Element> getOperationFilter(ReservedOperation operation) {
+    public MetadataSchemaOperationFilter getOperationFilter(ReservedOperation operation) {
         return hmOperationFilters.get(operation.name());
+    }
+
+    public MetadataSchemaOperationFilter getOperationFilter(String operation) {
+        return hmOperationFilters.get(operation);
     }
 
     @JsonIgnore

--- a/core/src/main/java/org/fao/geonet/kernel/schema/MetadataSchemaOperationFilter.java
+++ b/core/src/main/java/org/fao/geonet/kernel/schema/MetadataSchemaOperationFilter.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2001-2023 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+package org.fao.geonet.kernel.schema;
+
+import org.jdom.Element;
+
+public class MetadataSchemaOperationFilter {
+    private String xpath;
+    private String jsonpath;
+    private String ifNotOperation;
+    private Element markedElement;
+
+
+    public MetadataSchemaOperationFilter(String xpath, String jsonpath, String ifNotOperation) {
+        this(xpath, jsonpath, ifNotOperation, null);
+    }
+
+    public MetadataSchemaOperationFilter(String xpath, String jsonpath, String ifNotOperation, Element markedElement) {
+        this.xpath = xpath;
+        this.jsonpath = jsonpath;
+        this.ifNotOperation = ifNotOperation;
+        this.markedElement = markedElement;
+
+    }
+
+    public String getXpath() {
+        return xpath;
+    }
+
+    public String getJsonpath() {
+        return jsonpath;
+    }
+
+    public String getIfNotOperation() {
+        return ifNotOperation;
+    }
+
+    public Element getMarkedElement() {
+        return markedElement;
+    }
+}

--- a/core/src/test/java/org/fao/geonet/kernel/XmlSerializerIntegrationTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/XmlSerializerIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2023 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -45,6 +45,7 @@ import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.Pair;
 import org.fao.geonet.kernel.datamanager.IMetadataManager;
 import org.fao.geonet.kernel.schema.MetadataSchema;
+import org.fao.geonet.kernel.schema.MetadataSchemaOperationFilter;
 import org.fao.geonet.utils.Xml;
 import org.jdom.Element;
 import org.jdom.Namespace;
@@ -101,23 +102,31 @@ public class XmlSerializerIntegrationTest extends AbstractCoreIntegrationTest {
 
     public void setSchemaFilters(boolean withHeld, boolean keepMarkedElement) {
         MetadataSchema mds = _dataManager.getSchema(metadata.getDataInfo().getSchemaId());
-        Map<String, Pair<String, Element>> filters = new HashMap<String, Pair<String, Element>>();
+        Map<String, MetadataSchemaOperationFilter> filters = new HashMap<>();
         if (withHeld) {
             if (keepMarkedElement) {
                 Element mark = new Element("keepMarkedElement");
                 mark.setAttribute("nilReason", "withheld", Geonet.Namespaces.GCO);
-                filters.put("editing",
-                    Pair.read(XPATH_WITHHELD, mark));
+
+                MetadataSchemaOperationFilter editFilter = new MetadataSchemaOperationFilter(XPATH_WITHHELD, "", "editing", mark);
+
+                filters.put(editFilter.getIfNotOperation(),
+                    editFilter);
             } else {
-                filters.put("editing",
-                    Pair.<String, Element>read(XPATH_WITHHELD, null));
+                MetadataSchemaOperationFilter editFilter = new MetadataSchemaOperationFilter(XPATH_WITHHELD, "", "editing", null);
+
+                filters.put(editFilter.getIfNotOperation(),
+                    editFilter);
             }
         }
 
-        filters.put("download",
-            Pair.<String, Element>read(XPATH_DOWNLOAD, null));
-        filters.put("dynamic",
-            Pair.<String, Element>read(XPATH_DYNAMIC, null));
+        MetadataSchemaOperationFilter downloadFilter = new MetadataSchemaOperationFilter(XPATH_DOWNLOAD, "", "download", null);
+        filters.put(downloadFilter.getIfNotOperation(),
+            downloadFilter);
+
+        MetadataSchemaOperationFilter dynamicFilter = new MetadataSchemaOperationFilter(XPATH_DYNAMIC, "", "dynamic", null);
+        filters.put(dynamicFilter.getIfNotOperation(),
+            dynamicFilter);
 
         mds.setOperationFilters(filters);
     }

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
@@ -1067,6 +1067,9 @@
             "descriptionObject": <xsl:value-of select="gn-fn-index:add-multilingual-field(
                                 'description', description/*, $allLanguages)"/>,
           </xsl:if>
+          <xsl:if test="nilReason">
+            "nilReason": "<xsl:value-of select="nilReason"/>",
+          </xsl:if>
           "applicationProfile": "<xsl:value-of select="gn-fn-index:json-escape(
                                         applicationProfile/text())"/>"
           }
@@ -1178,6 +1181,9 @@
             <xsl:if test="normalize-space(cit:description) != ''">
               "descriptionObject": <xsl:value-of select="gn-fn-index:add-multilingual-field(
                                 'description', cit:description, $allLanguages)"/>,
+            </xsl:if>
+            <xsl:if test="../@gco:nilReason">
+              "nilReason": "<xsl:value-of select="../@gco:nilReason"/>",
             </xsl:if>
             "function":"<xsl:value-of select="cit:function/cit:CI_OnLineFunctionCode/@codeListValue"/>",
             "applicationProfile":"<xsl:value-of select="gn-fn-index:json-escape(cit:applicationProfile/gco:CharacterString/text())"/>",
@@ -1331,9 +1337,6 @@
     <xsl:variable name="identifiers"
                   select=".//cit:partyIdentifier/*"/>
 
-
-    <xsl:variable name="hasWithheld" select="@gco:nilReason = 'withheld'" as="xs:boolean" />
-
     <xsl:element name="contact{$fieldSuffix}">
       <!-- TODO: Can be multilingual -->
       <xsl:attribute name="type" select="'object'"/>{
@@ -1349,8 +1352,8 @@
       "position":"<xsl:value-of select="gn-fn-index:json-escape($positionName)"/>",
       "phone":"<xsl:value-of select="gn-fn-index:json-escape($phone)"/>",
       "address":"<xsl:value-of select="gn-fn-index:json-escape($address)"/>"
-      <xsl:if test="$hasWithheld">
-        ,"nilReason": "withheld"
+      <xsl:if test="@gco:nilReason">
+        ,"nilReason": "<xsl:value-of select="@gco:nilReason"/>"
       </xsl:if>
       <xsl:if test="count($identifiers) > 0">
         ,"identifiers":[

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
@@ -1330,6 +1330,10 @@
 
     <xsl:variable name="identifiers"
                   select=".//cit:partyIdentifier/*"/>
+
+
+    <xsl:variable name="hasWithheld" select="@gco:nilReason = 'withheld'" as="xs:boolean" />
+
     <xsl:element name="contact{$fieldSuffix}">
       <!-- TODO: Can be multilingual -->
       <xsl:attribute name="type" select="'object'"/>{
@@ -1345,6 +1349,9 @@
       "position":"<xsl:value-of select="gn-fn-index:json-escape($positionName)"/>",
       "phone":"<xsl:value-of select="gn-fn-index:json-escape($phone)"/>",
       "address":"<xsl:value-of select="gn-fn-index:json-escape($address)"/>"
+      <xsl:if test="$hasWithheld">
+        ,"nilReason": "withheld"
+      </xsl:if>
       <xsl:if test="count($identifiers) > 0">
         ,"identifiers":[
         <xsl:for-each select="$identifiers">

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/link-utility.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/link-utility.xsl
@@ -151,6 +151,9 @@
           <protocol><xsl:value-of select="$docType/@protocol"/></protocol>
           <function><xsl:value-of select="$docType/@function"/></function>
           <type><xsl:value-of select="$docType/@type"/></type>
+          <xsl:if test="$forIndexing and ../../../@gco:nilReason">
+            <nilReason><xsl:value-of select="../../../@gco:nilReason"/></nilReason>
+          </xsl:if>
         </item>
       </xsl:for-each>
     </xsl:for-each>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/schema-ident.xml
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/schema-ident.xml
@@ -128,13 +128,14 @@ Ce schéma est également composé des normes :
   -->
   <filters xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0">
     <!--
-    All elemenets having a nilReason attribute
+    All elements having a nilReason attribute
     set to withheld, then users needs to have
     the edit privilege in order to be able to see
     the information. When filtered the element is
     preserved but with no content in.
     -->
     <filter xpath=".//*[@gco:nilReason='withheld']"
+            jsonpath="$.*[?(@.nilReason == 'withheld')]"
             ifNotOperation="editing">
       <keepMarkedElement gco:nilReason="withheld"/>
     </filter>
@@ -158,4 +159,8 @@ Ce schéma est également composé des normes :
     <filter xpath=".//mrd:onLine[starts-with(*/cit:protocol/gco:CharacterString, 'OGC:WMS')]"
             ifNotOperation="dynamic"/>
   </filters>
+
+  <!--<withheldElements>
+    <withheld esFieldName="contact" xpath="//mdb:contact"/>
+  </withheldElements>-->
 </schema>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/schema-ident.xml
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/schema-ident.xml
@@ -134,7 +134,7 @@ Ce schéma est également composé des normes :
     the information. When filtered the element is
     preserved but with no content in.
     -->
-    <filter xpath=".//*[@gco:nilReason='withheld']"
+    <filter xpath=".//*[@gco:nilReason = 'withheld']"
             jsonpath="$.*[?(@.nilReason == 'withheld')]"
             ifNotOperation="editing">
       <keepMarkedElement gco:nilReason="withheld"/>
@@ -159,8 +159,4 @@ Ce schéma est également composé des normes :
     <filter xpath=".//mrd:onLine[starts-with(*/cit:protocol/gco:CharacterString, 'OGC:WMS')]"
             ifNotOperation="dynamic"/>
   </filters>
-
-  <!--<withheldElements>
-    <withheld esFieldName="contact" xpath="//mdb:contact"/>
-  </withheldElements>-->
 </schema>

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
@@ -1006,7 +1006,7 @@
                                   /gmd:distributionOrderProcess/*/gmd:orderingInstructions">
           <xsl:copy-of select="gn-fn-index:add-multilingual-field('orderingInstructions', ., $allLanguages)"/>
         </xsl:for-each>
-        
+
         <xsl:for-each select="gmd:transferOptions/*/
                                 gmd:onLine/*[gmd:linkage/gmd:URL != '']">
 
@@ -1192,6 +1192,9 @@
       <xsl:copy-of select="gn-fn-index:add-multilingual-field(
                             $roleField, $organisationName, $languages)"/>
     </xsl:if>
+
+    <xsl:variable name="hasWithheld" select="@gco:nilReason = 'withheld'" as="xs:boolean" />
+
     <xsl:element name="contact{$fieldSuffix}">
       <xsl:attribute name="type" select="'object'"/>{
       <xsl:if test="$organisationName">
@@ -1206,6 +1209,9 @@
       "position":"<xsl:value-of select="gn-fn-index:json-escape($positionName)"/>",
       "phone":"<xsl:value-of select="gn-fn-index:json-escape($phone[1])"/>",
       "address":"<xsl:value-of select="gn-fn-index:json-escape($address)"/>"
+      <xsl:if test="$hasWithheld">
+        ,"nilReason": "withheld"
+      </xsl:if>
       }
     </xsl:element>
   </xsl:template>

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
@@ -1045,6 +1045,9 @@
               "descriptionObject": <xsl:value-of select="gn-fn-index:add-multilingual-field(
                                 'description', gmd:description, $allLanguages)"/>,
             </xsl:if>
+            <xsl:if test="../@gco:nilReason">
+              "nilReason": "<xsl:value-of select="../@gco:nilReason"/>",
+            </xsl:if>
             "function":"<xsl:value-of select="gmd:function/gmd:CI_OnLineFunctionCode/@codeListValue"/>",
             "applicationProfile":"<xsl:value-of select="gn-fn-index:json-escape(gmd:applicationProfile/gco:CharacterString/text())"/>",
             "group": <xsl:value-of select="$transferGroup"/>
@@ -1193,8 +1196,6 @@
                             $roleField, $organisationName, $languages)"/>
     </xsl:if>
 
-    <xsl:variable name="hasWithheld" select="@gco:nilReason = 'withheld'" as="xs:boolean" />
-
     <xsl:element name="contact{$fieldSuffix}">
       <xsl:attribute name="type" select="'object'"/>{
       <xsl:if test="$organisationName">
@@ -1209,8 +1210,8 @@
       "position":"<xsl:value-of select="gn-fn-index:json-escape($positionName)"/>",
       "phone":"<xsl:value-of select="gn-fn-index:json-escape($phone[1])"/>",
       "address":"<xsl:value-of select="gn-fn-index:json-escape($address)"/>"
-      <xsl:if test="$hasWithheld">
-        ,"nilReason": "withheld"
+      <xsl:if test="@gco:nilReason">
+        ,"nilReason": "<xsl:value-of select="@gco:nilReason"/>"
       </xsl:if>
       }
     </xsl:element>

--- a/schemas/iso19139/src/main/plugin/iso19139/schema-ident.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/schema-ident.xml
@@ -85,6 +85,7 @@
   </autodetect>
   <filters xmlns:gco="http://www.isotc211.org/2005/gco">
     <filter xpath=".//*[@gco:nilReason='withheld']"
+            jsonpath="$.*[?(@.nilReason == 'withheld')]"
             ifNotOperation="editing">
       <keepMarkedElement gco:nilReason="withheld"/>
     </filter>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -136,7 +136,6 @@
       <groupId>com.jayway.jsonpath</groupId>
       <artifactId>json-path</artifactId>
       <version>2.4.0</version>
-      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.jayway.jsonpath</groupId>

--- a/services/src/main/java/org/fao/geonet/api/es/EsHTTPProxy.java
+++ b/services/src/main/java/org/fao/geonet/api/es/EsHTTPProxy.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2023 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -26,12 +26,15 @@ package org.fao.geonet.api.es;
 
 import com.fasterxml.jackson.core.JsonGenerator;
 import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.MappingIterator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.Sets;
+import com.jayway.jsonpath.DocumentContext;
+import com.jayway.jsonpath.JsonPath;
 import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.parameters.RequestBody;
@@ -43,18 +46,19 @@ import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.Constants;
 import org.fao.geonet.NodeInfo;
 import org.fao.geonet.api.ApiUtils;
-import org.fao.geonet.api.records.MetadataApi;
 import org.fao.geonet.api.records.MetadataUtils;
 import org.fao.geonet.api.records.model.related.AssociatedRecord;
 import org.fao.geonet.api.records.model.related.RelatedItemType;
-import org.fao.geonet.api.records.model.related.RelatedResponse;
 import org.fao.geonet.constants.Edit;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.*;
 import org.fao.geonet.index.es.EsRestClient;
 import org.fao.geonet.kernel.AccessManager;
+import org.fao.geonet.kernel.SchemaManager;
 import org.fao.geonet.kernel.SelectionManager;
 import org.fao.geonet.kernel.datamanager.IMetadataUtils;
+import org.fao.geonet.kernel.schema.MetadataSchema;
+import org.fao.geonet.kernel.schema.MetadataSchemaOperationFilter;
 import org.fao.geonet.kernel.search.EsFilterBuilder;
 import org.fao.geonet.repository.SourceRepository;
 import org.slf4j.Logger;
@@ -77,7 +81,6 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
-import java.util.stream.Collectors;
 import java.util.zip.DeflaterInputStream;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.GZIPInputStream;
@@ -129,6 +132,9 @@ public class EsHTTPProxy {
     @Autowired
     private EsRestClient client;
 
+    @Autowired
+    private SchemaManager schemaManager;
+
     public EsHTTPProxy() {
     }
 
@@ -171,7 +177,7 @@ public class EsHTTPProxy {
             LOGGER.warn("Failed to load related types for {}. Error is: {}",
                 getSourceString(doc, Geonet.IndexFieldNames.UUID),
                 e.getMessage()
-                );
+            );
         }
         doc.putPOJO("related", related);
     }
@@ -274,20 +280,20 @@ public class EsHTTPProxy {
     @ResponseBody
     public void search(
         @RequestParam(defaultValue = SelectionManager.SELECTION_METADATA)
-            String bucket,
+        String bucket,
         @Parameter(description = "Type of related resource. If none, no associated resource returned.",
             required = false
         )
         @RequestParam(name = "relatedType", defaultValue = "")
-            RelatedItemType[] relatedTypes,
+        RelatedItemType[] relatedTypes,
         @Parameter(hidden = true)
-            HttpSession httpSession,
+        HttpSession httpSession,
         @Parameter(hidden = true)
-            HttpServletRequest request,
+        HttpServletRequest request,
         @Parameter(hidden = true)
-            HttpServletResponse response,
+        HttpServletResponse response,
         @RequestBody(description = "JSON request based on Elasticsearch API.")
-            String body,
+        String body,
         @Parameter(hidden = true)
         HttpEntity<String> httpEntity) throws Exception {
         ServiceContext context = ApiUtils.createServiceContext(request);
@@ -306,20 +312,20 @@ public class EsHTTPProxy {
     @ResponseBody
     public void msearch(
         @RequestParam(defaultValue = SelectionManager.SELECTION_METADATA)
-            String bucket,
+        String bucket,
         @Parameter(description = "Type of related resource. If none, no associated resource returned.",
             required = false
         )
         @RequestParam(name = "relatedType", defaultValue = "")
-            RelatedItemType[] relatedTypes,
+        RelatedItemType[] relatedTypes,
         @Parameter(hidden = true)
-            HttpSession httpSession,
+        HttpSession httpSession,
         @Parameter(hidden = true)
-            HttpServletRequest request,
+        HttpServletRequest request,
         @Parameter(hidden = true)
-            HttpServletResponse response,
+        HttpServletResponse response,
         @RequestBody(description = "JSON request based on Elasticsearch API.")
-            String body,
+        String body,
         @Parameter(hidden = true)
         HttpEntity<String> httpEntity) throws Exception {
         ServiceContext context = ApiUtils.createServiceContext(request);
@@ -336,25 +342,25 @@ public class EsHTTPProxy {
     @RequestMapping(value = "/search/records/{endPoint}",
         method = {
             RequestMethod.POST, RequestMethod.GET
-    })
+        })
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("hasAuthority('Administrator')")
     @ResponseBody
     public void call(
         @RequestParam(defaultValue = SelectionManager.SELECTION_METADATA)
-            String bucket,
+        String bucket,
         @Parameter(description = "'_search' for search service.")
         @PathVariable String endPoint,
         @Parameter(hidden = true)
-            HttpSession httpSession,
+        HttpSession httpSession,
         @Parameter(hidden = true)
-            HttpServletRequest request,
+        HttpServletRequest request,
         @Parameter(hidden = true)
-            HttpServletResponse response,
+        HttpServletResponse response,
         @RequestBody(description = "JSON request based on Elasticsearch API.")
-            String body,
+        String body,
         @Parameter(hidden = true)
-            HttpEntity<String> httpEntity) throws Exception {
+        HttpEntity<String> httpEntity) throws Exception {
 
         ServiceContext context = ApiUtils.createServiceContext(request);
         call(context, httpSession, request, response, endPoint, httpEntity.getBody(), bucket, null);
@@ -430,8 +436,8 @@ public class EsHTTPProxy {
 
         // Build filter node
         String esFilter = buildQueryFilter(context,
-                                            "",
-                                            esQuery.toString().contains("\"draft\":"));
+            "",
+            esQuery.toString().contains("\"draft\":"));
         JsonNode nodeFilter = objectMapper.readTree(esFilter);
 
         JsonNode queryNode = esQuery.get("query");
@@ -639,13 +645,20 @@ public class EsHTTPProxy {
                     addRelatedTypes(doc, relatedTypes, context);
                 }
 
-                // Remove fields with privileges info
                 if (doc.has("_source")) {
                     ObjectNode sourceNode = (ObjectNode) doc.get("_source");
 
+                    String metadataSchema = doc.get("_source").get("documentStandard").asText();
+                    MetadataSchema mds = schemaManager.getSchema(metadataSchema);
+
+                    // Apply metadata schema filters to remove non-allowed fields
+                    processMetadataSchemaFilters(context, mds, doc);
+
+                    // Remove fields with privileges info
                     for (ReservedOperation o : ReservedOperation.values()) {
                         sourceNode.remove("op" + o.getId());
                     }
+
                 }
             });
         } else {
@@ -778,4 +791,96 @@ public class EsHTTPProxy {
         return false;
     }
 
+
+    /**
+     * Process the metadata schema filters to filter out from the ElasticSearch response
+     * the elements defined in the metadata schema filters.
+     *
+     * It uses a jsonpath to filter the elements, typically is configured with the following jsonpath, to
+     * filter the ES object elements with an attribute nilReason = 'withheld'.
+     *
+     *  $.*[?(@.nilReason == 'withheld')]
+     *
+     * The metadata index process, has to define this attribute. Any element that requires to be filtered, should be
+     * defined as an object in ElasticSearch.
+     *
+     * Example for contacts:
+     *
+     *  <xsl:template mode="index-contact" match="*[cit:CI_Responsibility]">
+     *      ...
+     *      <!-- Check if the contact has an attribute @gco:nilReason = 'withheld', added by update-fixed-info.xsl process -->
+     *      <xsl:variable name="hasWithheld" select="@gco:nilReason = 'withheld'" as="xs:boolean" />
+     *
+     *      <xsl:element name="contact{$fieldSuffix}">
+     *        <xsl:attribute name="type" select="'object'"/>{
+     *        ...
+     *        "address":"<xsl:value-of select="gn-fn-index:json-escape($address)"/>"
+     *        <xsl:if test="$hasWithheld">
+     *         ,"nilReason": "withheld"
+     *        </xsl:if>
+     *
+     * @param mds
+     * @param doc
+     * @throws JsonProcessingException
+     */
+    private void processMetadataSchemaFilters(ServiceContext context, MetadataSchema mds, ObjectNode doc) throws JsonProcessingException {
+        if (!doc.has("_source")) {
+            return;
+        }
+
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectNode sourceNode = (ObjectNode) doc.get("_source");
+
+        MetadataSchemaOperationFilter authenticatedXpathFilter = mds.getOperationFilter("authenticated");
+
+        List<String> jsonpathFilters = new ArrayList<>();
+
+        if (authenticatedXpathFilter != null && !context.getUserSession().isAuthenticated()) {
+            jsonpathFilters.add(authenticatedXpathFilter.getJsonpath());
+        }
+
+        MetadataSchemaOperationFilter editXpathFilter = mds.getOperationFilter(ReservedOperation.editing);
+
+        if (editXpathFilter != null) {
+            boolean canEdit = doc.get("edit").asBoolean();
+
+            if (!canEdit) {
+                jsonpathFilters.add(editXpathFilter.getJsonpath());
+            }
+        }
+
+        MetadataSchemaOperationFilter downloadXpathFilter = mds.getOperationFilter(ReservedOperation.download);
+        if (downloadXpathFilter != null) {
+            boolean canDownload = doc.get("download").asBoolean();
+
+            if (!canDownload) {
+                jsonpathFilters.add(downloadXpathFilter.getJsonpath());
+            }
+        }
+
+        MetadataSchemaOperationFilter dynamicXpathFilter = mds.getOperationFilter(ReservedOperation.dynamic);
+        if (dynamicXpathFilter != null) {
+            boolean canDynamic = doc.get("dynamic").asBoolean();
+
+            if (!canDynamic) {
+                jsonpathFilters.add(dynamicXpathFilter.getJsonpath());
+            }
+        }
+
+        JsonNode actualObj = filterResponseElements(mapper, sourceNode, jsonpathFilters);
+        if (actualObj != null) {
+            doc.set("_source", actualObj);
+        }
+    }
+    private JsonNode filterResponseElements(ObjectMapper mapper, ObjectNode sourceNode, List<String> jsonPathFilters) throws JsonProcessingException {
+        DocumentContext jsonContext = JsonPath.parse(sourceNode.toPrettyString());
+
+        for(String jsonPath : jsonPathFilters) {
+            if (StringUtils.isNotBlank(jsonPath)) {
+                jsonContext = jsonContext.delete(jsonPath);
+            }
+        }
+
+        return mapper.readTree(jsonContext.jsonString());
+    }
 }

--- a/services/src/main/java/org/fao/geonet/api/es/EsHTTPProxy.java
+++ b/services/src/main/java/org/fao/geonet/api/es/EsHTTPProxy.java
@@ -831,39 +831,39 @@ public class EsHTTPProxy {
         ObjectMapper mapper = new ObjectMapper();
         ObjectNode sourceNode = (ObjectNode) doc.get("_source");
 
-        MetadataSchemaOperationFilter authenticatedXpathFilter = mds.getOperationFilter("authenticated");
+        MetadataSchemaOperationFilter authenticatedFilter = mds.getOperationFilter("authenticated");
 
         List<String> jsonpathFilters = new ArrayList<>();
 
-        if (authenticatedXpathFilter != null && !context.getUserSession().isAuthenticated()) {
-            jsonpathFilters.add(authenticatedXpathFilter.getJsonpath());
+        if (authenticatedFilter != null && !context.getUserSession().isAuthenticated()) {
+            jsonpathFilters.add(authenticatedFilter.getJsonpath());
         }
 
-        MetadataSchemaOperationFilter editXpathFilter = mds.getOperationFilter(ReservedOperation.editing);
+        MetadataSchemaOperationFilter editFilter = mds.getOperationFilter(ReservedOperation.editing);
 
-        if (editXpathFilter != null) {
+        if (editFilter != null) {
             boolean canEdit = doc.get("edit").asBoolean();
 
             if (!canEdit) {
-                jsonpathFilters.add(editXpathFilter.getJsonpath());
+                jsonpathFilters.add(editFilter.getJsonpath());
             }
         }
 
-        MetadataSchemaOperationFilter downloadXpathFilter = mds.getOperationFilter(ReservedOperation.download);
-        if (downloadXpathFilter != null) {
+        MetadataSchemaOperationFilter downloadFilter = mds.getOperationFilter(ReservedOperation.download);
+        if (downloadFilter != null) {
             boolean canDownload = doc.get("download").asBoolean();
 
             if (!canDownload) {
-                jsonpathFilters.add(downloadXpathFilter.getJsonpath());
+                jsonpathFilters.add(downloadFilter.getJsonpath());
             }
         }
 
-        MetadataSchemaOperationFilter dynamicXpathFilter = mds.getOperationFilter(ReservedOperation.dynamic);
-        if (dynamicXpathFilter != null) {
+        MetadataSchemaOperationFilter dynamicFilter = mds.getOperationFilter(ReservedOperation.dynamic);
+        if (dynamicFilter != null) {
             boolean canDynamic = doc.get("dynamic").asBoolean();
 
             if (!canDynamic) {
-                jsonpathFilters.add(dynamicXpathFilter.getJsonpath());
+                jsonpathFilters.add(dynamicFilter.getJsonpath());
             }
         }
 

--- a/services/src/main/java/org/fao/geonet/api/es/EsHTTPProxy.java
+++ b/services/src/main/java/org/fao/geonet/api/es/EsHTTPProxy.java
@@ -425,6 +425,7 @@ public class EsHTTPProxy {
      */
     private void addRequiredField(ArrayNode source) {
         source.add("op*");
+        source.add(Geonet.IndexFieldNames.SCHEMA);
         source.add(Geonet.IndexFieldNames.GROUP_OWNER);
         source.add(Geonet.IndexFieldNames.OWNER);
         source.add(Geonet.IndexFieldNames.ID);

--- a/web/src/main/webapp/xml/validation/schemaPlugins/schema-ident.xsd
+++ b/web/src/main/webapp/xml/validation/schemaPlugins/schema-ident.xsd
@@ -22,8 +22,9 @@
   ~ Rome - Italy. email: geonetwork@osgeo.org
   -->
 
-<xs:schema xmlns:gns="http://geonetwork-opensource.org/schemas/schema-ident" xmlns:xml="http://www.w3.org/XML/1998/namespace"
-           xmlns:xs="http://www.w3.org/2001/XMLSchema"
+<xs:schema xmlns:gns="http://geonetwork-opensource.org/schemas/schema-ident"
+           xmlns:xml="http://www.w3.org/XML/1998/namespace"
+           xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsl="http://www.w3.org/2001/XMLSchema"
            version="1.0"
            elementFormDefault="qualified"
            attributeFormDefault="unqualified"
@@ -247,6 +248,13 @@
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>
+    <xs:attribute name="jsonpath">
+      <xs:annotation>
+        <xs:documentation>
+          An JSON path to select elements to filter in the ElasticSearch index.
+        </xs:documentation>
+      </xs:annotation>
+    </xs:attribute>
     <xs:attribute name="ifNotOperation" use="required">
       <xs:annotation>
         <xs:documentation>
@@ -258,6 +266,7 @@
           <xs:enumeration value="editing"/>
           <xs:enumeration value="download"/>
           <xs:enumeration value="dynamic"/>
+          <xsl:enumeration value="authenticated" />
         </xs:restriction>
       </xs:simpleType>
     </xs:attribute>

--- a/web/src/main/webapp/xml/validation/schemaPlugins/schema-ident.xsd
+++ b/web/src/main/webapp/xml/validation/schemaPlugins/schema-ident.xsd
@@ -266,7 +266,7 @@
           <xs:enumeration value="editing"/>
           <xs:enumeration value="download"/>
           <xs:enumeration value="dynamic"/>
-          <xsl:enumeration value="authenticated" />
+          <xs:enumeration value="authenticated" />
         </xs:restriction>
       </xs:simpleType>
     </xs:attribute>


### PR DESCRIPTION
Currently the metadata schemas allow to define filters defined in `schema-ident.xml` file, to remove certain information from the metadata documents if certain conditions apply. 

For example in `iso19139`, if the user has no editing permission the elements with the attribute `@gco:nilReason='withheld'` are removed from the XML output and the full view formatter:

https://github.com/geonetwork/core-geonetwork/blob/fdd7536ac11b3ec8d648fc3e1923797bfe045b62/schemas/iso19139/src/main/plugin/iso19139/schema-ident.xml#L86-L90

The attribute `@gco:nilReason='withheld'` should be added in `update-fixed-info.xsl`  process of each metadata schema to mark which elements should be removed. A typical usage is to remove certain type of contacts for users that can't not edit the metadata record.

This pull request extends this support to filter out these elements from the ElasticSearch response. The indexing process has to be extended to handle the `@gco:nilReason='withheld'` for the related ElasticSearch fields (these fields should be object fields). An example for contacts is part of the pull request:


https://github.com/geonetwork/core-geonetwork/compare/withheld-es?expand=1#diff-e5443fc6e8489ecc9eb314b5c9f9a3e2e9c4bb0c85888bade22d731edf0f08ea



A new type of operation has been added (`authenticated`) to allow to remove information only for non-authenticated users. For example, if defined the following in `schema-ident.xml` file, the elements with `@gco:nilReason='withheld'` will be removed for non authenticated users that can view the metadata, but will be preserved for authenticated users that can view the metadata :

```
<filter xpath=".//*[@gco:nilReason='withheld']"
           jsonpath="$.*[?(@.nilReason == 'withheld')]"
           ifNotOperation="authenticated">
    <keepMarkedElement gco:nilReason="withheld"/>
</filter>
```