### PR TITLE
KeyCloak / Use the user profile configured locally if the configuration option KEYCLOACK_UPDATEPROFILE is disabled

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/security/keycloak/KeycloakUserUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/keycloak/KeycloakUserUtils.java
@@ -165,7 +165,9 @@ public class KeycloakUserUtils {
 
             // Assign the highest profile available
             Map<Profile, List<String>> profileGroups = getProfileGroups(accessToken);
-            user.setProfile(getMaxProfile(baselUser.getProfile(), profileGroups));
+            if (newUserFlag || keycloakConfiguration.isUpdateProfile()) {
+                user.setProfile(getMaxProfile(baselUser.getProfile(), profileGroups));
+            }
 
             //Apply changes to database is required.
             if (withDbUpdate) {


### PR DESCRIPTION
When the configuration option `KEYCLOACK_UPDATEPROFILE=false`, the user profile should be retrieved from the local database.

Currently the code to calculate the user profile ignores the previous configuration option and tries to retrieve this information from KeyCloak and if not available, the user gets assigned the `GUEST` profile, ignoring what is stored in the local database.

With this code change when `KEYCLOACK_UPDATEPROFILE=false` the user profile is retrieved from the database.