### PR TITLE
Fix language in the directive to display facet cards

### DIFF
--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/FacetDirective.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/FacetDirective.js
@@ -461,7 +461,7 @@
           );
         },
         link: function (scope, element, attrs) {
-          scope.iso2lang = gnLangs.getIso2Lang();
+          scope.iso2lang = gnLangs.getIso2Lang(gnLangs.getCurrent());
 
           function init() {
             scope.missingValue =


### PR DESCRIPTION
Previously, the INSPIRE Themes in the Home page were displayed always in English:

![inspire-themes-1](https://user-images.githubusercontent.com/1695003/221907494-2bb15dab-a20f-4ff2-8cee-ca0ed72c03b9.png)

With the fix, the INSPIRE Themes in the Home page were displayed in the UI language:

![inspire-themes-2](https://user-images.githubusercontent.com/1695003/221907806-2b6c5d63-a1ae-4d11-bf4c-827592398f2c.png)
