### PR TITLE
Fix indexing of resource date month / year in iso19139 and iso19115.3-2008 schemas (3.12.x)

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/common.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/common.xsl
@@ -285,10 +285,10 @@
           <Field name="revisionDate"
                  string="{string(gco:Date[.!='']|gco:DateTime[.!=''])}"
                  store="true" index="true"/>
-          <Field name="createDateMonth"
+          <Field name="revisionDateMonth"
                  string="{substring(gco:Date[.!='']|gco:DateTime[.!=''], 0, 8)}"
                  store="true" index="true"/>
-          <Field name="createDateYear"
+          <Field name="revisionDateYear"
                  string="{substring(gco:Date[.!='']|gco:DateTime[.!=''], 0, 5)}"
                  store="true" index="true"/>
           <xsl:if test="$useDateAsTemporalExtent">
@@ -320,6 +320,12 @@
         <xsl:for-each select="cit:date/cit:CI_Date[cit:dateType/cit:CI_DateTypeCode/@codeListValue='publication']/cit:date">
           <Field name="publicationDate"
                  string="{string(gco:Date[.!='']|gco:DateTime[.!=''])}"
+                 store="true" index="true"/>
+          <Field name="publicationDateMonth"
+                 string="{substring(gco:Date[.!='']|gco:DateTime[.!=''], 0, 8)}"
+                 store="true" index="true"/>
+          <Field name="publicationDateYear"
+                 string="{substring(gco:Date[.!='']|gco:DateTime[.!=''], 0, 5)}"
                  store="true" index="true"/>
           <xsl:if test="$useDateAsTemporalExtent">
             <Field name="tempExtentBegin"
@@ -832,11 +838,11 @@
         <xsl:if test="count($attributes) > 0">
           "attributeTable" : [
           <xsl:for-each select="$attributes">
-            {"name": "<xsl:apply-templates mode="localised" 
-                  select="*/gfc:memberName"><xsl:with-param name="langId" 
+            {"name": "<xsl:apply-templates mode="localised"
+                  select="*/gfc:memberName"><xsl:with-param name="langId"
                   select="concat('#', $langId)"/></xsl:apply-templates>",
-            "definition": "<xsl:apply-templates mode="localised" 
-                  select="*/gfc:definition"><xsl:with-param name="langId" 
+            "definition": "<xsl:apply-templates mode="localised"
+                  select="*/gfc:definition"><xsl:with-param name="langId"
                   select="concat('#', $langId)"/></xsl:apply-templates>",
             "code": "<xsl:value-of select="*/gfc:code/*/text()"/>",
             "link": "<xsl:value-of select="*/gfc:code/*/@xlink:href"/>",
@@ -844,12 +850,12 @@
             <xsl:if test="*/gfc:listedValue">
               ,"values": [
               <xsl:for-each select="*/gfc:listedValue">{
-                "label": "<xsl:apply-templates mode="localised" 
-                  select="*/gfc:label"><xsl:with-param name="langId" 
+                "label": "<xsl:apply-templates mode="localised"
+                  select="*/gfc:label"><xsl:with-param name="langId"
                   select="concat('#', $langId)"/></xsl:apply-templates>",
                 "code": "<xsl:value-of select="*/gfc:code/*/text()"/>",
-                "definition": "<xsl:apply-templates mode="localised" 
-                  select="*/gfc:definition"><xsl:with-param name="langId" 
+                "definition": "<xsl:apply-templates mode="localised"
+                  select="*/gfc:definition"><xsl:with-param name="langId"
                   select="concat('#', $langId)"/></xsl:apply-templates>"
                 }
                 <xsl:if test="position() != last()">,</xsl:if>

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/default.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/default.xsl
@@ -208,10 +208,10 @@
           select="gmd:date/gmd:CI_Date[gmd:dateType/gmd:CI_DateTypeCode/@codeListValue='revision']/gmd:date">
           <Field name="revisionDate" string="{string(gco:Date[.!='']|gco:DateTime[.!=''])}"
                  store="true" index="true"/>
-          <Field name="createDateMonth"
+          <Field name="revisionDateMonth"
                  string="{substring(gco:Date[.!='']|gco:DateTime[.!=''], 0, 8)}" store="true"
                  index="true"/>
-          <Field name="createDateYear"
+          <Field name="revisionDateYear"
                  string="{substring(gco:Date[.!='']|gco:DateTime[.!=''], 0, 5)}" store="true"
                  index="true"/>
           <xsl:if test="$useDateAsTemporalExtent">
@@ -240,6 +240,12 @@
           select="gmd:date/gmd:CI_Date[gmd:dateType/gmd:CI_DateTypeCode/@codeListValue='publication']/gmd:date">
           <Field name="publicationDate" string="{string(gco:Date[.!='']|gco:DateTime[.!=''])}"
                  store="true" index="true"/>
+          <Field name="publicationDateMonth"
+                 string="{substring(gco:Date[.!='']|gco:DateTime[.!=''], 0, 8)}" store="true"
+                 index="true"/>
+          <Field name="publicationDateYear"
+                 string="{substring(gco:Date[.!='']|gco:DateTime[.!=''], 0, 5)}" store="true"
+                 index="true"/>
           <xsl:if test="$useDateAsTemporalExtent">
             <Field name="tempExtentBegin" string="{string(gco:Date[.!='']|gco:DateTime[.!=''])}"
                    store="true" index="true"/>


### PR DESCRIPTION
For some unclear reason the resources `revision` date month and year were indexed in the fields `createDateMonth` and `createDateYear`. 

The `publication` date month and year were not indexed.

This code changes updates the indexing of iso19139 and iso19115.3-2008 schemas to fix previous issues.