### PR TITLE
Metadata full view - fix display of related metadata titles

### DIFF
--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-functions.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-functions.xsl
@@ -121,7 +121,7 @@
                   select="util:getIndexField(
                   $language,
                   $uuid,
-                  'resourceTitle',
+                  'resourceTitleObject',
                   $language)"/>
     <xsl:choose>
       <xsl:when test="$metadataTitle=''">
@@ -129,7 +129,7 @@
                       select="util:getIndexField(
                       $language,
                       $uuid,
-                      'resourceTitle',
+                      'resourceTitleObject',
                       $language)"/>
         <xsl:choose>
           <xsl:when test="$metadataDefaultTitle=''">


### PR DESCRIPTION
**Previously:**

The metadata full view relations doesn't display the metadata related titles.
![relations-1](https://user-images.githubusercontent.com/1695003/222350511-32b30f55-9181-4037-ae09-c4d8af63b0a6.png)

**With the change:**

![relations-2](https://user-images.githubusercontent.com/1695003/222350642-e7aeeca8-101d-498a-b386-7944ceac74aa.png)

---

@fxprunayre the fallback call to `util:getIndexField` to get the `metadataDefaultTitle` it seems exactly the same as the original one to get the title. That's not related to the pull request, but something we should check to fix.