### PR TITLE
fix related template if resource has no name

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/RelatedResourcesService.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/RelatedResourcesService.js
@@ -460,7 +460,7 @@
           ? $filter("gnLocalized")(resource.name)
           : (angular.isObject(resource.title)
               ? $filter("gnLocalized")(resource.title)
-              : resource.title) || resource.name;
+              : resource.title) || resource.name || '';
         resource.locDescription = angular.isObject(resource.description)
           ? $filter("gnLocalized")(resource.description)
           : resource.description;


### PR DESCRIPTION
was causing a template error in the console because of the name used for translation