### PR TITLE
subtemplate search, improve query

### DIFF
--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -1133,7 +1133,7 @@
             // Add some fuzziness when search on directory entries
             // but boost exact match.
             queryBase:
-              'any.${searchLang}:(${any}) OR any.common:(${any}) OR resourceTitleObject.${searchLang}:"${any}"^10 OR resourceTitleObject.${searchLang}:(${any})^5 OR resourceTitleObject.${searchLang}:(${any}~2)'
+              'any.${searchLang}:(${any}) OR any.default:(${any}) OR resourceTitleObject.${searchLang}:"${any}"^10 OR resourceTitleObject.${searchLang}:(${any}~2) OR resourceTitleObject.${searchLang}:(${any}*)'
           },
           admin: {
             enabled: true,


### PR DESCRIPTION
default instead of common
no need to consider resourceTitleObject twice
wilcard on resourceTitleObject besides fuzziness