### PR TITLE
Workflow / Restrict search by status to record that user can edit

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java
@@ -601,12 +601,14 @@ public class MetadataWorkflowApi {
                     "Non administrator user must use a id or uuid parameter to search for status.");
             }
 
-            for(Integer recordId : record) {
-                AbstractMetadata md;
-                try {
-                    md = ApiUtils.canEditRecord(recordId + "", request);
-                } catch (SecurityException e) {
-                    throw new NotAllowedException(ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_EDIT);
+            if (!CollectionUtils.isEmpty(record)) {
+                for(Integer recordId : record) {
+                    AbstractMetadata md;
+                    try {
+                        md = ApiUtils.canEditRecord(recordId + "", request);
+                    } catch (SecurityException e) {
+                        throw new NotAllowedException(ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_EDIT);
+                    }
                 }
             }
             for(String recordId : uuid) {

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java
@@ -611,12 +611,14 @@ public class MetadataWorkflowApi {
                     }
                 }
             }
-            for(String recordId : uuid) {
-                AbstractMetadata md;
-                try {
-                    md = ApiUtils.canEditRecord(recordId, request);
-                } catch (SecurityException e) {
-                    throw new NotAllowedException(ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_EDIT);
+            if (!CollectionUtils.isEmpty(uuid)) {
+                for(String recordId : uuid) {
+                    AbstractMetadata md;
+                    try {
+                        md = ApiUtils.canEditRecord(recordId, request);
+                    } catch (SecurityException e) {
+                        throw new NotAllowedException(ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_EDIT);
+                    }
                 }
             }
         }


### PR DESCRIPTION
* User has to be at least Editor to search status
* Administrator can search for all
* Other users must use `record` or `uuid` parameters on record they can edit.
