### PR TITLE
Get metadata bbox to display in search map: fix for metadata when the extent is defined by a point

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -564,7 +564,8 @@
                 }
               }
               // no valid bbox was found: clear geometry
-              if (!geometry.getPolygons().length) {
+              if (geometry.getType() === 'MultiPolygon' &&
+                !geometry.getPolygons().length) {
                 geometry = null;
               }
               feat.setGeometry(geometry);


### PR DESCRIPTION
Test case:

1) Create an iso19139 metadata.

2) In the XML view add this extent snippet:

```
          <gmd:extent>
            <gmd:EX_Extent>
               <gmd:geographicElement>
                  <gmd:EX_GeographicBoundingBox>
                     <gmd:westBoundLongitude>
                        <gco:Decimal>-70.216</gco:Decimal>
                     </gmd:westBoundLongitude>
                     <gmd:eastBoundLongitude>
                        <gco:Decimal>-70.216</gco:Decimal>
                     </gmd:eastBoundLongitude>
                     <gmd:southBoundLatitude>
                        <gco:Decimal>-39.50</gco:Decimal>
                     </gmd:southBoundLatitude>
                     <gmd:northBoundLatitude>
                        <gco:Decimal>-39.50</gco:Decimal>
                     </gmd:northBoundLatitude>
                  </gmd:EX_GeographicBoundingBox>
               </gmd:geographicElement>
            </gmd:EX_Extent>
         </gmd:extent>
```

3) Go to the search page.

Without the fix the following error is displayed in the javascript console:

```
lib.js?v=30eefcafe4365ddb39e4942f70324f2c19276cde:128 TypeError: f.getPolygons is not a function
    at Object.getBboxFeatureFromMd (gn_search_minimal.js:596:247)
    at gn_search_minimal.js:1178:214
    at lib.js:152:30
    at m.$digest (lib.js:153:119)
    at m.$apply (lib.js:156:35)
    at g (lib.js:108:281)
    at x (lib.js:112:369)
    at u.onload (lib.js:113:397)
```