### PR TITLE
Cmis performance enhancements

### DIFF
--- a/core/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
@@ -235,10 +235,8 @@ public class CMISStore extends AbstractStore {
     protected void setCmisProperties(String metadataUuid, Map<String, Object> properties, Document doc, Map<String, Object> additionalProperties) {
 
         // Add additional properties if exists.
-        if (additionalProperties != null) {
-            if (MapUtils.isNotEmpty(additionalProperties)) {
-                properties.putAll(additionalProperties);
-            }
+        if (MapUtils.isNotEmpty(additionalProperties)) {
+            properties.putAll(additionalProperties);
         }
 
         // now update metadata uuid and status within primary cmis fields if needed.

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
@@ -545,7 +545,7 @@ public class CMISStore extends AbstractStore {
 
         for (Property<?> property:document.getProperties()) {
            // Add secondary properties if exists.
-           if (aspectId != null && property.getId().startsWith(aspectId) && property.getValue()!=null) {
+           if (aspectId != null && property.getId().startsWith(aspectId) && property.getValue() != null) {
                properties.put(property.getId(), property.getValue());
            }
            // Add other common cmis properties.

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
@@ -214,75 +214,66 @@ public class CMISStore extends AbstractStore {
         // Reset Filter from the default operationalContext to include all fields because we may need secondary properties.
         oc.setFilter(null);
 
-        CmisObject cmisObject;
-        try {
-            cmisObject = cmisConfiguration.getClient().getObjectByPath(key, oc);
-        } catch (Exception e) {
-            cmisObject = null;
-        }
-
         Map<String, Object> properties = new HashMap<String, Object>();
-        if (!StringUtils.isEmpty(cmisConfiguration.getCmisMetadataUUIDPropertyName()) && !cmisConfiguration.existMetadataUUIDSecondaryProperty()) {
-            setCmisMetadataUUIDPrimary(properties, metadataUuid);
-        }
+        Document doc;
+        try {
+            doc = (Document) cmisConfiguration.getClient().getObjectByPath(key, oc);
 
-        // If cmisObject is empty then it is a new record. With new records, we need to set the default value for the status.
-        MetadataResourceExternalManagementProperties.ValidationStatus defaultStatus = null;
-        // We only need to set the default if there is a status property supplied.
-        if (!StringUtils.isEmpty(cmisConfiguration.getExternalResourceManagementValidationStatusPropertyName())) {
-            if (cmisConfiguration.getExternalResourceManagementValidationStatusDefaultValue() != null) {
-                // If a default property name does exist then use it
-                defaultStatus = MetadataResourceExternalManagementProperties.ValidationStatus.valueOf(cmisConfiguration.getExternalResourceManagementValidationStatusDefaultValue());
-            } else {
-                // Otherwise lets default to incomplete.
-                // Reason - as the administrator decided to use the status, it most likely means that there are extra properties that need to be set after a file is uploaded so defaulting it to
-                // incomplete seems reasonable.
-                defaultStatus = MetadataResourceExternalManagementProperties.ValidationStatus.INCOMPLETE;
-            }
-            if (cmisObject==null &&
-                !cmisConfiguration.existExternalResourceManagementValidationStatusSecondaryProperty() &&
-                !properties.containsKey(cmisConfiguration.getExternalResourceManagementValidationStatusPropertyName())
-                ) {
-                setCmisExternalManagementResourceStatusPrimary(properties, defaultStatus);
-            }
-        }
-
-        Document doc = cmisUtils.saveDocument(key, cmisObject, properties, is, changeDate);
-
-        // The optional metadata UUID is assigned to a user-defined property in the content management system.
-        // In some content management systems, custom properties appear as CMIS Secondary properties.
-        // CMIS Secondary properties cannot be set in the same call that creates the document and sets it's properties,
-        // so this is done in the following call after the document is created
-        if (cmisConfiguration.existSecondaryProperty()) {
-            Map<String, Object> secondaryProperties = new HashMap<>();
-            if (MapUtils.isNotEmpty(additionalProperties)) {
-                secondaryProperties.putAll(additionalProperties);
-            }
-            if (cmisConfiguration.existMetadataUUIDSecondaryProperty()) {
-                setCmisMetadataUUIDSecondary(doc, secondaryProperties, metadataUuid);
-            }
-
-            // If cmisObject is empty and the property does not already exist as an additional secondary property then it is a new record.
-            // With new records, we need to set the default value for the status.
-            if (cmisObject==null &&
-                cmisConfiguration.existExternalResourceManagementValidationStatusSecondaryProperty() &&
-                !secondaryProperties.containsKey(cmisConfiguration.getExternalResourceManagementValidationStatusPropertyName().split(CMISConfiguration.CMIS_SECONDARY_PROPERTY_SEPARATOR)[1])) {
-                setCmisExternalManagementResourceStatusSecondary(doc, secondaryProperties, defaultStatus);
-            }
-
-            try {
-                doc.updateProperties(secondaryProperties);
-            } catch (Exception e) {
-                Log.error(Geonet.RESOURCES,
-                    String.format("Unable to update CMIS secondary property on metadata resource '%s' for metadata '%s'.", key, metadataUuid), e);
-                throw e;
-            }
+            // Update existing document
+            setCmisProperties(metadataUuid, properties, doc, additionalProperties);
+            doc = cmisUtils.saveDocument(key, doc, properties, is, changeDate);
+        } catch (CmisObjectNotFoundException e) {
+            // add new document
+            setCmisProperties(metadataUuid, properties, null, additionalProperties);
+            doc = cmisUtils.saveDocument(key, null, properties, is, changeDate);
         }
 
         return createResourceDescription(context, metadataUuid, visibility, filename,
             doc, metadataId, approved);
     }
 
+    protected void setCmisProperties(String metadataUuid, Map<String, Object> properties, Document doc, Map<String, Object> additionalProperties) {
+
+        // Add additional properties if exists.
+        if (additionalProperties != null) {
+            if (MapUtils.isNotEmpty(additionalProperties)) {
+                properties.putAll(additionalProperties);
+            }
+        }
+
+        // now update metadata uuid and status within primary cmis fields if needed.
+
+        // Don't allow users metadata uuid to be supplied as a property so let's overwrite any value that may exist.
+        if (!StringUtils.isEmpty(cmisConfiguration.getCmisMetadataUUIDPropertyName())) {
+            setCmisMetadataUUIDPrimary(properties, metadataUuid);
+        }
+        // If document is empty it is a new record so set the default status value property if it does not already exist as an additional property.
+        if (doc == null &&
+            !StringUtils.isEmpty(cmisConfiguration.getExternalResourceManagementValidationStatusPropertyName()) &&
+            !properties.containsKey(cmisConfiguration.getExternalResourceManagementValidationStatusPropertyName())) {
+            setCmisExternalManagementResourceStatusPrimary(properties, cmisConfiguration.getValidationStatusDefaultValue());
+        }
+
+        // If we have secondary properties then lets apply those changes as well.
+        if (cmisConfiguration.existSecondaryProperty()) {
+            Property secondaryProperties = null;
+            if (doc != null) {
+                secondaryProperties = doc.getProperty(PropertyIds.SECONDARY_OBJECT_TYPE_IDS);
+            }
+
+            // Don't allow users metadata uuid to be supplied as a property so let's overwrite any value that may exist.
+            if (cmisConfiguration.existMetadataUUIDSecondaryProperty()) {
+                setCmisMetadataUUIDSecondary(secondaryProperties, properties, metadataUuid);
+            }
+            // If document is empty it is a new record so set the default status value property if it does not already exist as an additional secondary property.
+            if (doc == null &&
+                cmisConfiguration.existExternalResourceManagementValidationStatusSecondaryProperty() &&
+                !properties.containsKey(cmisConfiguration.getExternalResourceManagementValidationStatusPropertyName().split(CMISConfiguration.CMIS_SECONDARY_PROPERTY_SEPARATOR)[1])) {
+                setCmisExternalManagementResourceStatusSecondary(secondaryProperties, properties, cmisConfiguration.getValidationStatusDefaultValue());
+            }
+        }
+
+    }
     protected void setCmisMetadataUUIDPrimary(Map<String, Object> properties, String metadataUuid) {
         setCmisPrimaryProperty(properties, cmisConfiguration.getCmisMetadataUUIDPropertyName(), metadataUuid);
     }
@@ -298,22 +289,21 @@ public class CMISStore extends AbstractStore {
         }
     }
 
-    protected void setCmisExternalManagementResourceStatusSecondary(Document doc, Map<String, Object> properties, MetadataResourceExternalManagementProperties.ValidationStatus status) {
-        setCmisSecondaryProperty(doc, properties, cmisConfiguration.getExternalResourceManagementValidationStatusPropertyName(), status.getValue());
+    protected void setCmisExternalManagementResourceStatusSecondary(Property secondaryProperty, Map<String, Object> properties, MetadataResourceExternalManagementProperties.ValidationStatus status) {
+        setCmisSecondaryProperty(secondaryProperty, properties, cmisConfiguration.getExternalResourceManagementValidationStatusPropertyName(), status.getValue());
     }
 
-    protected void setCmisMetadataUUIDSecondary(Document doc, Map<String, Object> properties, String metadataUuid) {
-        setCmisSecondaryProperty(doc, properties, cmisConfiguration.getCmisMetadataUUIDPropertyName(), metadataUuid);
+    protected void setCmisMetadataUUIDSecondary(Property secondaryProperty, Map<String, Object> properties, String metadataUuid) {
+        setCmisSecondaryProperty(secondaryProperty, properties, cmisConfiguration.getCmisMetadataUUIDPropertyName(), metadataUuid);
     }
 
-    protected void setCmisSecondaryProperty(Document doc, Map<String, Object> properties, String propertyName, Object value) {
+    protected void setCmisSecondaryProperty(Property secondaryProperty, Map<String, Object> properties, String propertyName, Object value) {
         if (!StringUtils.isEmpty(propertyName) &&
             propertyName.contains(cmisConfiguration.getSecondaryPropertySeparator())) {
             String[] splitPropertyNames = propertyName.split(Pattern.quote(cmisConfiguration.getSecondaryPropertySeparator()));
             String aspectName = splitPropertyNames[0];
             String secondaryPropertyName = splitPropertyNames[1];
             List<Object> aspects = null;
-            Property secondaryProperty = doc.getProperty(PropertyIds.SECONDARY_OBJECT_TYPE_IDS);
             if (secondaryProperty != null) {
                 // It may return an unmodifiable list and we need to potentially modify the list so lets make a copy of the list.
                 aspects = new ArrayList<>(secondaryProperty.getValues());
@@ -534,29 +524,34 @@ public class CMISStore extends AbstractStore {
                 Document sourceDocument = sourceEntry.getValue();
 
                 // Get cmis properties from the source document
-                Map<String, Object> sourceProperties = getSecondaryProperties(sourceDocument);
+                Map<String, Object> sourceProperties = getProperties(sourceDocument);
                 putResource(context, targetUuid, sourceDocument.getName(), sourceDocument.getContentStream().getStream(), null, metadataResourceVisibility, targetApproved, sourceProperties);
 
             }
-        } catch (CmisObjectNotFoundException  e) {
-            Log.warning("Cannot find folder object from CMIS ... Abort copping resources from "+sourceResourceTypeDir, e);
+        } catch (CmisObjectNotFoundException | ResourceNotFoundException  e) {
+            Log.warning(Geonet.RESOURCES,"Cannot find folder object from CMIS ... Abort copping resources from " + sourceResourceTypeDir);
         }
     }
 
-    protected Map<String, Object> getSecondaryProperties(Document document) {
+    protected Map<String, Object> getProperties(Document document) {
+        Map<String, Object> properties = new HashMap<>();
+
+        // Get secondary properties aspect if it exists.
         String aspectId=null;
         Property aspectProperty = document.getProperty(PropertyIds.SECONDARY_OBJECT_TYPE_IDS);
-        if (aspectProperty != null) {
+        if (aspectProperty != null && !StringUtils.isEmpty(aspectProperty.getValueAsString())) {
             aspectId = aspectProperty.getValueAsString();
         }
 
-        Map<String, Object> properties = new HashMap<>();
-        if (!StringUtils.isEmpty(aspectId)) {
-            for (Property<?> property:document.getProperties()) {
-                if (property.getId().startsWith(aspectId) && property.getValue()!=null) {
-                    properties.put(property.getId(), property.getValue());
-                }
-            }
+        for (Property<?> property:document.getProperties()) {
+           // Add secondary properties if exists.
+           if (aspectId != null && property.getId().startsWith(aspectId) && property.getValue()!=null) {
+               properties.put(property.getId(), property.getValue());
+           }
+           // Add other common cmis properties.
+           if (property.getId().startsWith("cmis:") && property.getValue()!=null) {
+              properties.put(property.getId(), property.getValue());
+           }
         }
 
         return properties;

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
@@ -65,6 +65,8 @@ public class CMISStore extends AbstractStore {
 
     private Path baseMetadataDir = null;
 
+    private static final String CMIS_PROPERTY_PREFIX = "cmis:";
+
     @Autowired
     CMISConfiguration cmisConfiguration;
 
@@ -526,8 +528,8 @@ public class CMISStore extends AbstractStore {
                 putResource(context, targetUuid, sourceDocument.getName(), sourceDocument.getContentStream().getStream(), null, metadataResourceVisibility, targetApproved, sourceProperties);
 
             }
-        } catch (CmisObjectNotFoundException | ResourceNotFoundException  e) {
-            Log.warning(Geonet.RESOURCES,"Cannot find folder object from CMIS ... Abort copping resources from " + sourceResourceTypeDir);
+        } catch (CmisObjectNotFoundException | ResourceNotFoundException e) {
+            Log.warning(Geonet.RESOURCES, "Cannot find folder object from CMIS ... Abort copping resources from " + sourceResourceTypeDir);
         }
     }
 
@@ -535,21 +537,21 @@ public class CMISStore extends AbstractStore {
         Map<String, Object> properties = new HashMap<>();
 
         // Get secondary properties aspect if it exists.
-        String aspectId=null;
+        String aspectId = null;
         Property aspectProperty = document.getProperty(PropertyIds.SECONDARY_OBJECT_TYPE_IDS);
         if (aspectProperty != null && !StringUtils.isEmpty(aspectProperty.getValueAsString())) {
             aspectId = aspectProperty.getValueAsString();
         }
 
-        for (Property<?> property:document.getProperties()) {
-           // Add secondary properties if exists.
-           if (aspectId != null && property.getId().startsWith(aspectId) && property.getValue() != null) {
-               properties.put(property.getId(), property.getValue());
-           }
-           // Add other common cmis properties.
-           if (property.getId().startsWith("cmis:") && property.getValue()!=null) {
-              properties.put(property.getId(), property.getValue());
-           }
+        for (Property<?> property : document.getProperties()) {
+            // Add secondary properties if exists.
+            if (aspectId != null && property.getId().startsWith(aspectId) && property.getValue() != null) {
+                properties.put(property.getId(), property.getValue());
+            }
+            // Add other common cmis properties.
+            if (property.getId().startsWith(CMIS_PROPERTY_PREFIX) && property.getValue() != null) {
+                properties.put(property.getId(), property.getValue());
+            }
         }
 
         return properties;

--- a/core/src/main/java/org/fao/geonet/resources/CMISConfiguration.java
+++ b/core/src/main/java/org/fao/geonet/resources/CMISConfiguration.java
@@ -663,7 +663,7 @@ public class CMISConfiguration {
                     client.getDefaultContext().setIncludePolicies(false);
                 }
                 // IncludeRelationships should be NONE
-                if (! client.getDefaultContext().getIncludeRelationships().equals(IncludeRelationships.NONE)) {
+                if (!client.getDefaultContext().getIncludeRelationships().equals(IncludeRelationships.NONE)) {
                     Log.debug(Geonet.RESOURCES, "Changing default CMIS operational context to not include relationships.");
                     client.getDefaultContext().setIncludeRelationships(IncludeRelationships.NONE);
                 }

--- a/core/src/main/java/org/fao/geonet/resources/CMISConfiguration.java
+++ b/core/src/main/java/org/fao/geonet/resources/CMISConfiguration.java
@@ -59,6 +59,7 @@ import java.util.regex.Pattern;
 public class CMISConfiguration {
     private Session client = null;
 
+    public final static Integer CMIS_MAX_ITEMS_PER_PAGE = 1000;
     public final static String CMIS_FOLDER_DELIMITER = "/"; // Specs indicate that "/" is the folder delimiter/separator - not sure if other delimiter can be used?.
     public final static String CMIS_SECONDARY_PROPERTY_SEPARATOR = "->";
     private final String CMIS_DEFAULT_WEBSERVICES_ACL_SERVICE = "/services/ACLService?wsdl";
@@ -668,9 +669,9 @@ public class CMISConfiguration {
                     client.getDefaultContext().setIncludeRelationships(IncludeRelationships.NONE);
                 }
 
-                if (client.getDefaultContext().getMaxItemsPerPage() != 1000) {
-                    Log.debug(Geonet.RESOURCES, "Changing default CMIS max items per page to 1000.");
-                    client.getDefaultContext().setMaxItemsPerPage(1000);
+                if (client.getDefaultContext().getMaxItemsPerPage() != CMIS_MAX_ITEMS_PER_PAGE) {
+                    Log.debug(Geonet.RESOURCES, "Changing default CMIS max items per page to " + CMIS_MAX_ITEMS_PER_PAGE + ".");
+                    client.getDefaultContext().setMaxItemsPerPage(CMIS_MAX_ITEMS_PER_PAGE);
                 }
 
                 // Setup default filter. Only include properties that are used by the application.

--- a/core/src/main/java/org/fao/geonet/resources/CMISConfiguration.java
+++ b/core/src/main/java/org/fao/geonet/resources/CMISConfiguration.java
@@ -40,6 +40,7 @@ import org.apache.chemistry.opencmis.commons.exceptions.CmisRuntimeException;
 import org.apache.commons.lang.BooleanUtils;
 import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.domain.MetadataResourceExternalManagementProperties;
 import org.fao.geonet.utils.Log;
 
 import javax.annotation.Nonnull;
@@ -121,6 +122,7 @@ public class CMISConfiguration {
      */
     private String externalResourceManagementValidationStatusDefaultValue;
     private boolean externalResourceManagementValidationStatusSecondaryProperty = false;
+    private MetadataResourceExternalManagementProperties.ValidationStatus defaultStatus = null;
 
     /*
      * Enable option to add versioning in the link to the resource.
@@ -509,6 +511,21 @@ public class CMISConfiguration {
         }
     }
 
+    public MetadataResourceExternalManagementProperties.ValidationStatus getValidationStatusDefaultValue() {
+        // We only need to set the default if there is a status property supplied, and it is not already set
+        if (this.defaultStatus == null &&  !org.springframework.util.StringUtils.isEmpty(getExternalResourceManagementValidationStatusPropertyName())) {
+            if (getExternalResourceManagementValidationStatusDefaultValue() != null) {
+                // If a default property name does exist then use it
+                this.defaultStatus = MetadataResourceExternalManagementProperties.ValidationStatus.valueOf(getExternalResourceManagementValidationStatusDefaultValue());
+            } else {
+                // Otherwise let's default to incomplete.
+                // Reason - as the administrator decided to use the status, it most likely means that there are extra properties that need to be set after a file is uploaded so defaulting it to
+                // incomplete seems reasonable.
+                this.defaultStatus = MetadataResourceExternalManagementProperties.ValidationStatus.INCOMPLETE;
+            }
+        }
+        return this.defaultStatus;
+    }
 
     @PostConstruct
     public void init() {
@@ -646,9 +663,14 @@ public class CMISConfiguration {
                     client.getDefaultContext().setIncludePolicies(false);
                 }
                 // IncludeRelationships should be NONE
-                if (client.getDefaultContext().getIncludeRelationships().equals(IncludeRelationships.NONE)) {
+                if (! client.getDefaultContext().getIncludeRelationships().equals(IncludeRelationships.NONE)) {
                     Log.debug(Geonet.RESOURCES, "Changing default CMIS operational context to not include relationships.");
                     client.getDefaultContext().setIncludeRelationships(IncludeRelationships.NONE);
+                }
+
+                if (client.getDefaultContext().getMaxItemsPerPage() != 1000) {
+                    Log.debug(Geonet.RESOURCES, "Changing default CMIS max items per page to 1000.");
+                    client.getDefaultContext().setMaxItemsPerPage(1000);
                 }
 
                 // Setup default filter. Only include properties that are used by the application.


### PR DESCRIPTION
Cmis performance enhancements

- As CMIS calls are slow - reduce cmis calls when inserting and updating properties during adding and updating resources.
- Increase MaxItemsPerPage to 1000 to increase performance when there are over 100 attachments.
- Fix bug with setting IncludeRelationships to none
- Calculate default validation Status once and move to configuration.
- Fixed bug where primary properties were not being copied during resource copy.
- Other minor fixes.