### PR TITLE
reload4j drop-in replacement for Log4J 1.2 API use in 3.12.x branch

### DIFF
--- a/cachingxslt/pom.xml
+++ b/cachingxslt/pom.xml
@@ -56,8 +56,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
     </dependency>
     <dependency>
       <groupId>net.sf.saxon</groupId>

--- a/common/pom.xml
+++ b/common/pom.xml
@@ -74,8 +74,8 @@
       <artifactId>jdbm</artifactId>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.jcs</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -446,6 +446,10 @@
            <groupId>org.apache.pdfbox</groupId>
            <artifactId>pdfbox</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+       </exclusion>
       </exclusions>
     </dependency>
 
@@ -537,6 +541,12 @@
       <groupId>org.owasp.esapi</groupId>
       <artifactId>esapi</artifactId>
       <version>2.3.0.0</version>
+      <exclusions>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.xmlunit</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -323,7 +323,7 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <artifactId>slf4j-reload4j</artifactId>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -798,7 +798,7 @@
         <exclusions>
           <exclusion>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-reload4j</artifactId>
+            <artifactId>slf4j-log4j12</artifactId>
           </exclusion>
         </exclusions>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -893,8 +893,8 @@
         <version>${metrics.version}</version>
         <exclusions>
            <exclusion>
-             <groupId>ch.qos.reload4j</groupId>
-             <artifactId>reload4j</artifactId>
+             <groupId>log4j</groupId>
+             <artifactId>log4j</artifactId>
            </exclusion>
         </exclusions>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -545,23 +545,13 @@
       </dependency>
       <dependency>
         <groupId>org.slf4j</groupId>
-        <artifactId>slf4j-log4j12</artifactId>
+        <artifactId>slf4j-reload4j</artifactId>
         <version>${slf4j.version}</version>
       </dependency>
       <dependency>
-        <groupId>log4j</groupId>
-        <artifactId>log4j</artifactId>
-        <version>${log4j.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-api</artifactId>
-        <version>${log4j2.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-core</artifactId>
-        <version>${log4j2.version}</version>
+        <groupId>ch.qos.reload4j</groupId>
+        <artifactId>reload4j</artifactId>
+        <version>${reload4j.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
@@ -808,7 +798,7 @@
         <exclusions>
           <exclusion>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-log4j12</artifactId>
+            <artifactId>slf4j-reload4j</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
@@ -901,6 +891,12 @@
         <groupId>com.yammer.metrics</groupId>
         <artifactId>metrics-log4j</artifactId>
         <version>${metrics.version}</version>
+        <exclusions>
+           <exclusion>
+             <groupId>ch.qos.reload4j</groupId>
+             <artifactId>reload4j</artifactId>
+           </exclusion>
+        </exclusions>
       </dependency>
 
       <!-- Tests -->
@@ -1558,9 +1554,8 @@
     <jackson.version>2.10.3</jackson.version>
     <flying-saucer.version>9.1.22</flying-saucer.version>
     <camel.version>2.14.4</camel.version>
-    <log4j.version>1.2.17</log4j.version>
-    <log4j2.version>2.17.1</log4j2.version>
-    <slf4j.version>1.8.0-beta2</slf4j.version>
+    <reload4j.version>1.2.24</reload4j.version>
+    <slf4j.version>2.0.6</slf4j.version>
     <xbean.version>3.18</xbean.version>
     <jolokia.version>1.6.0</jolokia.version>
     <httpcomponents.version>4.5.9</httpcomponents.version>

--- a/pom.xml
+++ b/pom.xml
@@ -521,6 +521,10 @@
             <groupId>geronimo-spec</groupId>
             <artifactId>geronimo-spec-jms</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -800,6 +804,10 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-log4j12</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -860,6 +868,10 @@
           <exclusion>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-slf4j-impl</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
           </exclusion>
         </exclusions>
       </dependency>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -360,6 +360,10 @@
           <groupId>org.apache.xmlgraphics</groupId>
           <artifactId>batik-transcoder</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>log4j</groupId>
+          <artifactId>log4j</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
 

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -55,19 +55,11 @@
   <dependencies>
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <artifactId>slf4j-reload4j</artifactId>
     </dependency>
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-api</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-core</artifactId>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
     </dependency>
     <dependency>
       <groupId>org.tuckey</groupId>

--- a/workers/pom.xml
+++ b/workers/pom.xml
@@ -89,9 +89,9 @@
 
     <!--Log4j-->
     <dependency>
-      <groupId>log4j</groupId>
-      <artifactId>log4j</artifactId>
-      <version>${log4j.version}</version>
+      <groupId>ch.qos.reload4j</groupId>
+      <artifactId>reload4j</artifactId>
+      <version>${reload4j.version}</version>
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -110,7 +110,7 @@
     </dependency>
     <dependency>
       <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-log4j12</artifactId>
+      <artifactId>slf4j-reload4j</artifactId>
       <version>${slf4j.version}</version>
     </dependency>
 


### PR DESCRIPTION
While ``main`` has made the leap to Log4j 2.x series to work with a supported logging framework; the 3.12.x is presently using the Log4J 1.2 API which has reached end-of-life.

This pull request demonstrates that ``reload4j`` is a suitable drop-in replacement.

I encourage you to read about http://reload4j.qos.ch - the library is supported / maintained by the original author of Log4J 1.x series. Who is also the author of slf4j etc...