### PR TITLE
Support withheld to filter out elements defined in the schema filters configurations in Lucene query output

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/SchemaManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/SchemaManager.java
@@ -1,38 +1,32 @@
-//=============================================================================
-//===
-//=== SchemaManager
-//===
-//=============================================================================
-//=== Copyright (C) 2001-2011 Food and Agriculture Organization of the
-//=== United Nations (FAO-UN), United Nations World Food Programme (WFP)
-//=== and United Nations Environment Programme (UNEP)
-//===
-//===	This program is free software; you can redistribute it and/or modify
-//===	it under the terms of the GNU General Public License as published by
-//===	the Free Software Foundation; either version 2 of the License, or (at
-//===	your option) any later version.
-//===
-//===	This program is distributed in the hope that it will be useful, but
-//===	WITHOUT ANY WARRANTY; without even the implied warranty of
-//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-//===	General Public License for more details.
-//===
-//===	You should have received a copy of the GNU General Public License
-//===	along with this program; if not, write to the Free Software
-//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
-//===
-//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
-//===	Rome - Italy. email: geonetwork@osgeo.org
-//==============================================================================
+/*
+ * Copyright (C) 2001-2023 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
 
 package org.fao.geonet.kernel;
 
 import com.google.common.annotations.VisibleForTesting;
-
 import jeeves.server.context.ServiceContext;
 import jeeves.server.dispatchers.guiservices.XmlFile;
 import jeeves.server.overrides.ConfigurationOverrides;
-
 import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.Constants;
@@ -61,13 +55,7 @@ import org.springframework.context.ApplicationContext;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.*;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.regex.Pattern;
 
 /**

--- a/core/src/main/java/org/fao/geonet/kernel/SchemaManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/SchemaManager.java
@@ -45,6 +45,7 @@ import org.fao.geonet.exceptions.NoSchemaMatchesException;
 import org.fao.geonet.exceptions.OperationAbortedEx;
 import org.fao.geonet.exceptions.SchemaMatchConflictException;
 import org.fao.geonet.kernel.schema.MetadataSchema;
+import org.fao.geonet.kernel.schema.MetadataSchemaOperationFilter;
 import org.fao.geonet.kernel.schema.SchemaLoader;
 import org.fao.geonet.kernel.schema.SchemaPlugin;
 import org.fao.geonet.kernel.setting.SettingInfo;
@@ -96,8 +97,8 @@ public class SchemaManager {
      * Active writers count
      */
     private static int activeWriters = 0;
-    private Map<String, Schema> hmSchemas = new HashMap<String, Schema>();
-    private Map<String, Namespace> hmSchemasTypenames = new HashMap<String, Namespace>();
+    private Map<String, Schema> hmSchemas = new HashMap<>();
+    private Map<String, Namespace> hmSchemasTypenames = new HashMap<>();
     private String[] fnames = {"labels.xml", "codelists.xml", "strings.xml"};
     private Path schemaPluginsDir;
     private Path schemaPluginsCat;
@@ -277,7 +278,7 @@ public class SchemaManager {
      */
     public Set<String> getDependencies(String name) {
 
-        Set<String> dependencies = new HashSet<String>();
+        Set<String> dependencies = new HashSet<>();
 
         beforeRead();
         try {
@@ -530,7 +531,7 @@ public class SchemaManager {
         try {
             Schema schema = hmSchemas.get(name);
             List<Element> childs = schema.getConversionElements();
-            List<Element> dChilds = new ArrayList<Element>();
+            List<Element> dChilds = new ArrayList<>();
             for (Element child : childs) {
                 if (child != null) dChilds.add((Element) child.clone());
             }
@@ -858,7 +859,7 @@ public class SchemaManager {
         if (schema != null) {
             if (doDependencies) {
                 List<String> dependsOnMe = getSchemasThatDependOnMe(name);
-                if (dependsOnMe.size() > 0) {
+                if (!dependsOnMe.isEmpty()) {
                     String errStr = "Cannot remove schema " + name + " because the following schemas list it as a dependency: " + dependsOnMe;
                     Log.error(Geonet.SCHEMA_MANAGER, errStr);
                     throw new OperationAbortedEx(errStr);
@@ -948,7 +949,7 @@ public class SchemaManager {
 
         final String schemaName = schemaDir.getFileName().toString();
         Path locBase = schemaDir.resolve("loc");
-        Map<String, XmlFile> xfMap = new HashMap<String, XmlFile>();
+        Map<String, XmlFile> xfMap = new HashMap<>();
 
         for (String fname : fnames) {
             Path filePath = path.resolve("loc").resolve(defaultLang).resolve(fname);
@@ -1307,7 +1308,7 @@ public class SchemaManager {
      * Check dependencies for all schemas - remove those that fail.
      */
     private void checkDependencies(Element schemaPluginCatRoot) throws Exception {
-        List<String> removes = new ArrayList<String>();
+        List<String> removes = new ArrayList<>();
 
         // process each schema to see whether its dependencies are present
         for (String schemaName : hmSchemas.keySet()) {
@@ -1330,7 +1331,7 @@ public class SchemaManager {
     }
 
     private void checkAppSupported(Element schemaPluginCatRoot) throws Exception {
-        List<String> removes = new ArrayList<String>();
+        List<String> removes = new ArrayList<>();
 
         final SystemInfo systemInfo = ApplicationContextHolder.get().getBean(SystemInfo.class);
 
@@ -1385,7 +1386,7 @@ public class SchemaManager {
      */
     public List<String> getSchemasThatDependOnMe(String schemaName) {
 
-        List<String> myDepends = new ArrayList<String>();
+        List<String> myDepends = new ArrayList<>();
 
         // process each schema to see whether its dependencies are present
         for (String schemaNameToTest : hmSchemas.keySet()) {
@@ -1433,7 +1434,7 @@ public class SchemaManager {
 
         // get list of depends elements from schema-ident.xml
         List<Element> dependsList = root.getChildren("depends", GEONET_SCHEMA_NS);
-        if (dependsList.size() == 0) {
+        if (dependsList.isEmpty()) {
             dependsList = root.getChildren("depends", GEONET_SCHEMA_PREFIX_NS);
         }
         return dependsList;
@@ -1491,11 +1492,11 @@ public class SchemaManager {
      * true if schema requires to synch the uuid column schema info with the uuid in the metadata
      * record (updated on editing or in UFO).
      */
-    private Map<String, Pair<String, Element>> extractOperationFilters(Path xmlIdFile) throws Exception {
+    private Map<String, MetadataSchemaOperationFilter> extractOperationFilters(Path xmlIdFile) throws Exception {
         Element root = Xml.loadFile(xmlIdFile);
         Element filters = root.getChild("filters", GEONET_SCHEMA_NS);
-        Map<String, Pair<String, Element>> filterRules =
-            new HashMap<String, Pair<String, Element>>();
+        Map<String, MetadataSchemaOperationFilter> filterRules =
+            new HashMap<>();
         if (filters == null) {
             return filterRules;
         } else {
@@ -1507,7 +1508,8 @@ public class SchemaManager {
                     Element markedElement = ruleElement.getChild("keepMarkedElement", GEONET_SCHEMA_NS);
                     if (StringUtils.isNotBlank(ifNotOperation) &&
                         StringUtils.isNotBlank(xpath)) {
-                        filterRules.put(ifNotOperation, Pair.read(xpath, markedElement));
+                        MetadataSchemaOperationFilter filter = new MetadataSchemaOperationFilter(xpath, ifNotOperation, markedElement);
+                        filterRules.put(ifNotOperation, filter);
                     }
                 }
             }
@@ -1563,13 +1565,14 @@ public class SchemaManager {
         if (!Files.exists(xmlConvFile)) {
             if (Log.isDebugEnabled(Geonet.SCHEMA_MANAGER))
                 Log.debug(Geonet.SCHEMA_MANAGER, "Schema conversions file not present");
-            return new ArrayList<Element>();
+            return new ArrayList<>();
         } else {
             Element root = Xml.loadFile(xmlConvFile);
             ConfigurationOverrides.DEFAULT.updateWithOverrides(xmlConvFile.toString(), null, basePath, root);
 
-            if (root.getName() != "conversions")
+            if (!root.getName().equals("conversions")) {
                 throw new IllegalArgumentException("Schema conversions file " + xmlConvFile + " is invalid, no <conversions> root element");
+            }
             @SuppressWarnings("unchecked")
             List<Element> result = root.getChildren();
             return result;
@@ -1620,7 +1623,7 @@ public class SchemaManager {
                 Attribute type = elem.getAttribute("type");
 
                 // --- try and find the attribute and value in md
-                if (mode == MODE_ATTRIBUTEWITHVALUE && elem.getName() == "attributes") {
+                if (mode == MODE_ATTRIBUTEWITHVALUE && elem.getName().equals("attributes")) {
                     @SuppressWarnings("unchecked")
                     List<Attribute> atts = elem.getAttributes();
                     for (Attribute searchAtt : atts) {
@@ -1914,7 +1917,6 @@ public class SchemaManager {
         List<String> listOfTypenames = new ArrayList<>();
         while (iterator.hasNext()) {
             String typeName = iterator.next();
-            Namespace ns = hmSchemasTypenames.get(typeName);
             listOfTypenames.add(typeName);
         }
         return listOfTypenames;

--- a/core/src/main/java/org/fao/geonet/kernel/XmlSerializer.java
+++ b/core/src/main/java/org/fao/geonet/kernel/XmlSerializer.java
@@ -1,32 +1,30 @@
-//=============================================================================
-//===	Copyright (C) 2001-2007 Food and Agriculture Organization of the
-//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
-//===	and United Nations Environment Programme (UNEP)
-//===
-//===	This program is free software; you can redistribute it and/or modify
-//===	it under the terms of the GNU General Public License as published by
-//===	the Free Software Foundation; either version 2 of the License, or (at
-//===	your option) any later version.
-//===
-//===	This program is distributed in the hope that it will be useful, but
-//===	WITHOUT ANY WARRANTY; without even the implied warranty of
-//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-//===	General Public License for more details.
-//===
-//===	You should have received a copy of the GNU General Public License
-//===	along with this program; if not, write to the Free Software
-//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
-//===
-//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
-//===	Rome - Italy. email: geonetwork@osgeo.org
-//==============================================================================
+/*
+ * Copyright (C) 2001-2023 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
 
 package org.fao.geonet.kernel;
 
-import java.sql.SQLException;
-import java.util.ArrayList;
-import java.util.List;
-
+import jeeves.server.context.ServiceContext;
+import jeeves.xlink.Processor;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.AbstractMetadata;
@@ -45,15 +43,16 @@ import org.jdom.Element;
 import org.jdom.JDOMException;
 import org.jdom.Namespace;
 
-import jeeves.server.context.ServiceContext;
-import jeeves.xlink.Processor;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
- * This class is responsible of reading and writing xml on the database. It works on tables like
+ * This class is responsible for reading and writing xml on the database. It works on tables like
  * (id, data, lastChangeDate).
  */
 public abstract class XmlSerializer {
-    private static InheritableThreadLocal<ThreadLocalConfiguration> configThreadLocal = new InheritableThreadLocal<>();
+    private static final InheritableThreadLocal<ThreadLocalConfiguration> configThreadLocal = new InheritableThreadLocal<>();
 
     public static ThreadLocalConfiguration getThreadLocal(boolean setIfNotPresent) {
         ThreadLocalConfiguration config = configThreadLocal.get();
@@ -69,17 +68,24 @@ public abstract class XmlSerializer {
         configThreadLocal.set(null);
     }
 
+    /**
+     * Removed the specified XML elements from the passed documents.
+     * @param metadata original metadata. At the end of the process it won't contain the filtered elements.
+     * @param filter elements to remove depending on the operation done.
+     * @param namespaces list of the document namespaces.
+     * @throws JDOMException if any problem modifying the DOM occurs.
+     */
     public static void removeFilteredElement(Element metadata,
                                              final MetadataSchemaOperationFilter filter,
                                              List<Namespace> namespaces) throws JDOMException {
         // xPathAndMarkedElement seem can be null in some schemas like dublin core
         if (filter == null) return;
 
-        String xpath = filter.getXpath();
+        String xpathFilter = filter.getXpath();
         Element mark = filter.getMarkedElement();
 
         List<?> nodes = Xml.selectNodes(metadata,
-            xpath,
+            xpathFilter,
             namespaces);
         for (Object object : nodes) {
             if (object instanceof Element) {
@@ -89,13 +95,13 @@ public abstract class XmlSerializer {
 
                     // Remove attributes
                     @SuppressWarnings("unchecked")
-                    List<Attribute> atts = new ArrayList<>(element.getAttributes());
-                    for (Attribute attribute : atts) {
+                    List<Attribute> attributesList = new ArrayList<Attribute>(element.getAttributes());
+                    for (Attribute attribute : attributesList) {
                         attribute.detach();
                     }
 
                     // Insert attributes or children element of the mark
-                    List<Attribute> markAtts = new ArrayList<>(mark.getAttributes());
+                    List<Attribute> markAtts = new ArrayList<Attribute>(mark.getAttributes());
                     for (Attribute attribute : markAtts) {
                         element.setAttribute((Attribute) attribute.clone());
                     }
@@ -252,7 +258,7 @@ public abstract class XmlSerializer {
         IMetadataManager _metadataManager = ApplicationContextHolder.get().getBean(IMetadataManager.class);
         IMetadataUtils metadataUtils = ApplicationContextHolder.get().getBean(IMetadataUtils.class);
 
-        int metadataId = Integer.valueOf(id);
+        int metadataId = Integer.parseInt(id);
         AbstractMetadata md = metadataUtils.findOne(metadataId);
 
         md.setDataAndFixCR(xml);

--- a/core/src/main/java/org/fao/geonet/kernel/XmlSerializer.java
+++ b/core/src/main/java/org/fao/geonet/kernel/XmlSerializer.java
@@ -31,11 +31,11 @@ import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.AbstractMetadata;
 import org.fao.geonet.domain.ISODate;
-import org.fao.geonet.domain.Pair;
 import org.fao.geonet.domain.ReservedOperation;
 import org.fao.geonet.kernel.datamanager.IMetadataManager;
 import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.kernel.schema.MetadataSchema;
+import org.fao.geonet.kernel.schema.MetadataSchemaOperationFilter;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.kernel.setting.Settings;
 import org.fao.geonet.utils.Log;
@@ -53,7 +53,7 @@ import jeeves.xlink.Processor;
  * (id, data, lastChangeDate).
  */
 public abstract class XmlSerializer {
-    private static InheritableThreadLocal<ThreadLocalConfiguration> configThreadLocal = new InheritableThreadLocal<XmlSerializer.ThreadLocalConfiguration>();
+    private static InheritableThreadLocal<ThreadLocalConfiguration> configThreadLocal = new InheritableThreadLocal<>();
 
     public static ThreadLocalConfiguration getThreadLocal(boolean setIfNotPresent) {
         ThreadLocalConfiguration config = configThreadLocal.get();
@@ -70,13 +70,13 @@ public abstract class XmlSerializer {
     }
 
     public static void removeFilteredElement(Element metadata,
-                                             final Pair<String, Element> xPathAndMarkedElement,
+                                             final MetadataSchemaOperationFilter filter,
                                              List<Namespace> namespaces) throws JDOMException {
         // xPathAndMarkedElement seem can be null in some schemas like dublin core
-        if (xPathAndMarkedElement == null) return;
+        if (filter == null) return;
 
-        String xpath = xPathAndMarkedElement.one();
-        Element mark = xPathAndMarkedElement.two();
+        String xpath = filter.getXpath();
+        Element mark = filter.getMarkedElement();
 
         List<?> nodes = Xml.selectNodes(metadata,
             xpath,
@@ -89,13 +89,13 @@ public abstract class XmlSerializer {
 
                     // Remove attributes
                     @SuppressWarnings("unchecked")
-                    List<Attribute> atts = new ArrayList<Attribute>(element.getAttributes());
+                    List<Attribute> atts = new ArrayList<>(element.getAttributes());
                     for (Attribute attribute : atts) {
                         attribute.detach();
                     }
 
                     // Insert attributes or children element of the mark
-                    List<Attribute> markAtts = new ArrayList<Attribute>(mark.getAttributes());
+                    List<Attribute> markAtts = new ArrayList<>(mark.getAttributes());
                     for (Attribute attribute : markAtts) {
                         element.setAttribute((Attribute) attribute.clone());
                     }
@@ -182,33 +182,42 @@ public abstract class XmlSerializer {
             // Check if a filter is defined for this schema
             // for the editing operation ie. user who can not edit
             // will not see those elements.
-            Pair<String, Element> editXpathFilter = mds.getOperationFilter(ReservedOperation.editing);
-            boolean filterEditOperationElements = editXpathFilter != null;
+            MetadataSchemaOperationFilter editFilter = mds.getOperationFilter(ReservedOperation.editing);
+            boolean filterEditOperationElements = editFilter != null;
             List<Namespace> namespaces = mds.getNamespaces();
             if (context != null) {
-                if (editXpathFilter != null) {
+                if (editFilter != null) {
                     boolean canEdit = accessManager.canEdit(context, id);
                     if (canEdit) {
                         filterEditOperationElements = false;
                     }
                 }
-                Pair<String, Element> downloadXpathFilter = mds.getOperationFilter(ReservedOperation.download);
-                if (downloadXpathFilter != null) {
-                    boolean canDownload = accessManager.canDownload(context, id);
-                    if (!canDownload) {
-                        removeFilteredElement(metadataXml, downloadXpathFilter, namespaces);
+
+                MetadataSchemaOperationFilter authenticatedFilter = mds.getOperationFilter("authenticated");
+                if (authenticatedFilter != null) {
+                    boolean isAuthenticated = context.getUserSession().isAuthenticated();
+                    if (!isAuthenticated) {
+                        removeFilteredElement(metadataXml, authenticatedFilter, namespaces);
                     }
                 }
-                Pair<String, Element> dynamicXpathFilter = mds.getOperationFilter(ReservedOperation.dynamic);
-                if (dynamicXpathFilter != null) {
+
+                MetadataSchemaOperationFilter downloadFilter = mds.getOperationFilter(ReservedOperation.download);
+                if (downloadFilter != null) {
+                    boolean canDownload = accessManager.canDownload(context, id);
+                    if (!canDownload) {
+                        removeFilteredElement(metadataXml, downloadFilter, namespaces);
+                    }
+                }
+                MetadataSchemaOperationFilter dynamicFilter = mds.getOperationFilter(ReservedOperation.dynamic);
+                if (dynamicFilter != null) {
                     boolean canDynamic = accessManager.canDynamic(context, id);
                     if (!canDynamic) {
-                        removeFilteredElement(metadataXml, dynamicXpathFilter, namespaces);
+                        removeFilteredElement(metadataXml, dynamicFilter, namespaces);
                     }
                 }
             }
             if (filterEditOperationElements || (getThreadLocal(false) != null && getThreadLocal(false).forceFilterEditOperation)) {
-                removeFilteredElement(metadataXml, editXpathFilter, namespaces);
+                removeFilteredElement(metadataXml, editFilter, namespaces);
             }
         }
         return metadataXml;

--- a/core/src/main/java/org/fao/geonet/kernel/XmlSerializer.java
+++ b/core/src/main/java/org/fao/geonet/kernel/XmlSerializer.java
@@ -29,10 +29,10 @@ import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.AbstractMetadata;
 import org.fao.geonet.domain.ISODate;
-import org.fao.geonet.domain.ReservedOperation;
 import org.fao.geonet.kernel.datamanager.IMetadataManager;
 import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.kernel.schema.MetadataSchema;
+import org.fao.geonet.kernel.schema.MetadataSchemaOperation;
 import org.fao.geonet.kernel.schema.MetadataSchemaOperationFilter;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.kernel.setting.Settings;
@@ -188,7 +188,7 @@ public abstract class XmlSerializer {
             // Check if a filter is defined for this schema
             // for the editing operation ie. user who can not edit
             // will not see those elements.
-            MetadataSchemaOperationFilter editFilter = mds.getOperationFilter(ReservedOperation.editing);
+            MetadataSchemaOperationFilter editFilter = mds.getOperationFilter(MetadataSchemaOperation.editing);
             boolean filterEditOperationElements = editFilter != null;
             List<Namespace> namespaces = mds.getNamespaces();
             if (context != null) {
@@ -199,7 +199,7 @@ public abstract class XmlSerializer {
                     }
                 }
 
-                MetadataSchemaOperationFilter authenticatedFilter = mds.getOperationFilter("authenticated");
+                MetadataSchemaOperationFilter authenticatedFilter = mds.getOperationFilter(MetadataSchemaOperation.authenticated);
                 if (authenticatedFilter != null) {
                     boolean isAuthenticated = context.getUserSession().isAuthenticated();
                     if (!isAuthenticated) {
@@ -207,14 +207,14 @@ public abstract class XmlSerializer {
                     }
                 }
 
-                MetadataSchemaOperationFilter downloadFilter = mds.getOperationFilter(ReservedOperation.download);
+                MetadataSchemaOperationFilter downloadFilter = mds.getOperationFilter(MetadataSchemaOperation.download);
                 if (downloadFilter != null) {
                     boolean canDownload = accessManager.canDownload(context, id);
                     if (!canDownload) {
                         removeFilteredElement(metadataXml, downloadFilter, namespaces);
                     }
                 }
-                MetadataSchemaOperationFilter dynamicFilter = mds.getOperationFilter(ReservedOperation.dynamic);
+                MetadataSchemaOperationFilter dynamicFilter = mds.getOperationFilter(MetadataSchemaOperation.dynamic);
                 if (dynamicFilter != null) {
                     boolean canDynamic = accessManager.canDynamic(context, id);
                     if (!canDynamic) {

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataUtils.java
@@ -43,6 +43,7 @@ import org.fao.geonet.kernel.SchemaManager;
 import org.fao.geonet.kernel.XmlSerializer;
 import org.fao.geonet.kernel.datamanager.*;
 import org.fao.geonet.kernel.schema.MetadataSchema;
+import org.fao.geonet.kernel.schema.MetadataSchemaOperation;
 import org.fao.geonet.kernel.schema.MetadataSchemaOperationFilter;
 import org.fao.geonet.kernel.search.index.IndexingList;
 import org.fao.geonet.kernel.setting.SettingManager;
@@ -142,7 +143,7 @@ public class BaseMetadataUtils implements IMetadataUtils {
         final AbstractMetadata metadata = findOne(metadataId);
         if (metadata != null && metadata.getDataInfo().getType() == MetadataType.METADATA) {
             MetadataSchema mds = schemaManager.getSchema(metadata.getDataInfo().getSchemaId());
-            MetadataSchemaOperationFilter editFilter = mds.getOperationFilter(ReservedOperation.editing);
+            MetadataSchemaOperationFilter editFilter = mds.getOperationFilter(MetadataSchemaOperation.editing);
             XmlSerializer.removeFilteredElement(md, editFilter, mds.getNamespaces());
 
             String uuid = getMetadataUuid(metadataId);

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataUtils.java
@@ -43,6 +43,7 @@ import org.fao.geonet.kernel.SchemaManager;
 import org.fao.geonet.kernel.XmlSerializer;
 import org.fao.geonet.kernel.datamanager.*;
 import org.fao.geonet.kernel.schema.MetadataSchema;
+import org.fao.geonet.kernel.schema.MetadataSchemaOperationFilter;
 import org.fao.geonet.kernel.search.index.IndexingList;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.kernel.setting.Settings;
@@ -141,8 +142,8 @@ public class BaseMetadataUtils implements IMetadataUtils {
         final AbstractMetadata metadata = findOne(metadataId);
         if (metadata != null && metadata.getDataInfo().getType() == MetadataType.METADATA) {
             MetadataSchema mds = schemaManager.getSchema(metadata.getDataInfo().getSchemaId());
-            Pair<String, Element> editXpathFilter = mds.getOperationFilter(ReservedOperation.editing);
-            XmlSerializer.removeFilteredElement(md, editXpathFilter, mds.getNamespaces());
+            MetadataSchemaOperationFilter editFilter = mds.getOperationFilter(ReservedOperation.editing);
+            XmlSerializer.removeFilteredElement(md, editFilter, mds.getNamespaces());
 
             String uuid = getMetadataUuid(metadataId);
             metadataNotifierManager.updateMetadata(md, metadataId, uuid, getServiceContext());

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataUtils.java
@@ -1,25 +1,25 @@
-//=============================================================================
-//===	Copyright (C) 2001-2011 Food and Agriculture Organization of the
-//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
-//===	and United Nations Environment Programme (UNEP)
-//===
-//===	This program is free software; you can redistribute it and/or modify
-//===	it under the terms of the GNU General Public License as published by
-//===	the Free Software Foundation; either version 2 of the License, or (at
-//===	your option) any later version.
-//===
-//===	This program is distributed in the hope that it will be useful, but
-//===	WITHOUT ANY WARRANTY; without even the implied warranty of
-//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-//===	General Public License for more details.
-//===
-//===	You should have received a copy of the GNU General Public License
-//===	along with this program; if not, write to the Free Software
-//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
-//===
-//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
-//===	Rome - Italy. email: geonetwork@osgeo.org
-//==============================================================================
+/*
+ * Copyright (C) 2001-2023 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
 
 package org.fao.geonet.kernel.datamanager.base;
 

--- a/core/src/main/java/org/fao/geonet/kernel/mef/ExportFormat.java
+++ b/core/src/main/java/org/fao/geonet/kernel/mef/ExportFormat.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Set;
 
 import org.fao.geonet.GeonetContext;
+import org.fao.geonet.constants.Edit;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.AbstractMetadata;
 import org.fao.geonet.domain.Metadata;
@@ -72,7 +73,7 @@ public class ExportFormat implements GeonetworkExtension {
                 String outputFileName = entry.getValue();
                 Path path = metadataSchema.getSchemaDir().resolve(xslFileName);
                 if (Files.isRegularFile(path)) {
-                    String outputData = formatData(metadata, true, path);
+                    String outputData = formatData(context, metadata, true, path);
                     allExports.add(Pair.read(outputFileName, outputData));
                 } else {
                     // A conversion that does not exist
@@ -96,10 +97,9 @@ public class ExportFormat implements GeonetworkExtension {
      *
      * @return ByteArrayInputStream
      */
-    public static String formatData(AbstractMetadata metadata, boolean transform, Path stylePath) throws Exception {
-        String xmlData = metadata.getData();
-
-        Element md = Xml.loadString(xmlData, false);
+    public static String formatData(ServiceContext context, AbstractMetadata metadata, boolean transform, Path stylePath) throws Exception {
+        Element md = context.getBean(DataManager.class).getMetadata(context, metadata.getId() + "", false, false, true);
+        md.removeChild("info", Edit.NAMESPACE);
 
         // Apply a stylesheet transformation when schema is ISO profil
         if (transform) {

--- a/core/src/main/java/org/fao/geonet/kernel/mef/ExportFormat.java
+++ b/core/src/main/java/org/fao/geonet/kernel/mef/ExportFormat.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2023 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -23,18 +23,11 @@
 
 package org.fao.geonet.kernel.mef;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-
+import jeeves.server.context.ServiceContext;
 import org.fao.geonet.GeonetContext;
 import org.fao.geonet.constants.Edit;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.AbstractMetadata;
-import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.Pair;
 import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.GeonetworkExtension;
@@ -45,7 +38,12 @@ import org.fao.geonet.utils.Log;
 import org.fao.geonet.utils.Xml;
 import org.jdom.Element;
 
-import jeeves.server.context.ServiceContext;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 /**
  * An extension point called to create files to export as part of the MEF export.

--- a/core/src/main/java/org/fao/geonet/kernel/schema/MetadataSchema.java
+++ b/core/src/main/java/org/fao/geonet/kernel/schema/MetadataSchema.java
@@ -509,12 +509,8 @@ public class MetadataSchema {
      *
      * @return The XPath to select element to filter or null
      */
-    public MetadataSchemaOperationFilter getOperationFilter(ReservedOperation operation) {
+    public MetadataSchemaOperationFilter getOperationFilter(MetadataSchemaOperation operation) {
         return hmOperationFilters.get(operation.name());
-    }
-
-    public MetadataSchemaOperationFilter getOperationFilter(String operation) {
-        return hmOperationFilters.get(operation);
     }
 
     @JsonIgnore

--- a/core/src/main/java/org/fao/geonet/kernel/schema/MetadataSchema.java
+++ b/core/src/main/java/org/fao/geonet/kernel/schema/MetadataSchema.java
@@ -1,48 +1,36 @@
-//==============================================================================
-//===
-//===   MetadataSchema
-//===
-//==============================================================================
-//===	Copyright (C) 2001-2007 Food and Agriculture Organization of the
-//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
-//===	and United Nations Environment Programme (UNEP)
-//===
-//===	This program is free software; you can redistribute it and/or modify
-//===	it under the terms of the GNU General Public License as published by
-//===	the Free Software Foundation; either version 2 of the License, or (at
-//===	your option) any later version.
-//===
-//===	This program is distributed in the hope that it will be useful, but
-//===	WITHOUT ANY WARRANTY; without even the implied warranty of
-//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-//===	General Public License for more details.
-//===
-//===	You should have received a copy of the GNU General Public License
-//===	along with this program; if not, write to the Free Software
-//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
-//===
-//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
-//===	Rome - Italy. email: geonetwork@osgeo.org
-//==============================================================================
+/*
+ * Copyright (C) 2001-2023 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
 
 package org.fao.geonet.kernel.schema;
-
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
-
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
 import org.fao.geonet.api.exception.ResourceNotFoundException;
 import org.fao.geonet.constants.Geonet;
-import org.fao.geonet.domain.Pair;
-import org.fao.geonet.domain.ReservedOperation;
-import org.fao.geonet.domain.Schematron;
-import org.fao.geonet.domain.SchematronCriteria;
-import org.fao.geonet.domain.SchematronCriteriaGroup;
-import org.fao.geonet.domain.SchematronCriteriaGroupId;
-import org.fao.geonet.domain.SchematronCriteriaType;
+import org.fao.geonet.domain.*;
 import org.fao.geonet.kernel.SchemaManager;
 import org.fao.geonet.kernel.schema.editorconfig.Editor;
 import org.fao.geonet.repository.SchematronCriteriaGroupRepository;
@@ -53,21 +41,16 @@ import org.jdom.Element;
 import org.jdom.JDOMException;
 import org.jdom.Namespace;
 
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Unmarshaller;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Unmarshaller;
+import java.util.*;
 
 
 //==============================================================================

--- a/core/src/main/java/org/fao/geonet/kernel/schema/MetadataSchema.java
+++ b/core/src/main/java/org/fao/geonet/kernel/schema/MetadataSchema.java
@@ -81,15 +81,15 @@ public class MetadataSchema {
     private static final String XSL_FILE_EXTENSION = ".xsl";
     private static final String SCH_FILE_EXTENSION = ".sch";
     private static final String SCHEMATRON_RULE_FILE_PREFIX = "schematron-rules";
-    private Map<String, List<String>> hmElements = new HashMap<String, List<String>>();
-    private Map<String, List<List<String>>> hmRestric = new HashMap<String, List<List<String>>>();
-    private Map<String, MetadataType> hmTypes = new HashMap<String, MetadataType>();
-    private Map<String, List<String>> hmSubs = new HashMap<String, List<String>>();
-    private Map<String, String> hmSubsLink = new HashMap<String, String>();
-    private Map<String, Namespace> hmNameSpaces = new HashMap<String, Namespace>();
-    private Map<String, Namespace> hmPrefixes = new HashMap<String, Namespace>();
-    private Map<String, Pair<String, Element>> hmOperationFilters =
-        new HashMap<String, Pair<String, Element>>();
+    private Map<String, List<String>> hmElements = new HashMap<>();
+    private Map<String, List<List<String>>> hmRestric = new HashMap<>();
+    private Map<String, MetadataType> hmTypes = new HashMap<>();
+    private Map<String, List<String>> hmSubs = new HashMap<>();
+    private Map<String, String> hmSubsLink = new HashMap<>();
+    private Map<String, Namespace> hmNameSpaces = new HashMap<>();
+    private Map<String, Namespace> hmPrefixes = new HashMap<>();
+    private Map<String, MetadataSchemaOperationFilter> hmOperationFilters =
+        new HashMap<>();
     private String schemaName;
     private Path schemaDir;
     private String standardUrl;
@@ -517,7 +517,7 @@ public class MetadataSchema {
         this.schemaRepo.save(updated);
     }
 
-    public void setOperationFilters(Map<String, Pair<String, Element>> operationFilters) {
+    public void setOperationFilters(Map<String, MetadataSchemaOperationFilter> operationFilters) {
         this.hmOperationFilters = operationFilters;
     }
 
@@ -526,8 +526,12 @@ public class MetadataSchema {
      *
      * @return The XPath to select element to filter or null
      */
-    public Pair<String, Element> getOperationFilter(ReservedOperation operation) {
+    public MetadataSchemaOperationFilter getOperationFilter(ReservedOperation operation) {
         return hmOperationFilters.get(operation.name());
+    }
+
+    public MetadataSchemaOperationFilter getOperationFilter(String operation) {
+        return hmOperationFilters.get(operation);
     }
 
     @JsonIgnore

--- a/core/src/main/java/org/fao/geonet/kernel/schema/MetadataSchemaOperation.java
+++ b/core/src/main/java/org/fao/geonet/kernel/schema/MetadataSchemaOperation.java
@@ -22,29 +22,9 @@
  */
 package org.fao.geonet.kernel.schema;
 
-import org.jdom.Element;
-
-public class MetadataSchemaOperationFilter {
-    private final String xpath;
-    private final String ifNotOperation;
-    private final Element markedElement;
-
-    public MetadataSchemaOperationFilter(String xpath, String ifNotOperation, Element markedElement) {
-        this.xpath = xpath;
-        this.ifNotOperation = ifNotOperation;
-        this.markedElement = markedElement;
-
-    }
-
-    public String getXpath() {
-        return xpath;
-    }
-
-    public String getIfNotOperation() {
-        return ifNotOperation;
-    }
-
-    public Element getMarkedElement() {
-        return markedElement;
-    }
+public enum MetadataSchemaOperation {
+    authenticated,
+    editing,
+    download,
+    dynamic
 }

--- a/core/src/main/java/org/fao/geonet/kernel/schema/MetadataSchemaOperationFilter.java
+++ b/core/src/main/java/org/fao/geonet/kernel/schema/MetadataSchemaOperationFilter.java
@@ -25,9 +25,9 @@ package org.fao.geonet.kernel.schema;
 import org.jdom.Element;
 
 public class MetadataSchemaOperationFilter {
-    private String xpath;
-    private String ifNotOperation;
-    private Element markedElement;
+    private final String xpath;
+    private final String ifNotOperation;
+    private final Element markedElement;
 
 
     public MetadataSchemaOperationFilter(String xpath, String ifNotOperation) {

--- a/core/src/main/java/org/fao/geonet/kernel/schema/MetadataSchemaOperationFilter.java
+++ b/core/src/main/java/org/fao/geonet/kernel/schema/MetadataSchemaOperationFilter.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2001-2023 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+package org.fao.geonet.kernel.schema;
+
+import org.jdom.Element;
+
+public class MetadataSchemaOperationFilter {
+    private String xpath;
+    private String ifNotOperation;
+    private Element markedElement;
+
+
+    public MetadataSchemaOperationFilter(String xpath, String ifNotOperation) {
+        this(xpath, ifNotOperation, null);
+    }
+
+    public MetadataSchemaOperationFilter(String xpath, String ifNotOperation, Element markedElement) {
+        this.xpath = xpath;
+        this.ifNotOperation = ifNotOperation;
+        this.markedElement = markedElement;
+
+    }
+
+    public String getXpath() {
+        return xpath;
+    }
+
+    public String getIfNotOperation() {
+        return ifNotOperation;
+    }
+
+    public Element getMarkedElement() {
+        return markedElement;
+    }
+}

--- a/core/src/main/java/org/fao/geonet/kernel/search/LuceneSearcher.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/LuceneSearcher.java
@@ -27,6 +27,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.collect.Maps;
 import com.google.common.collect.Sets;
 import org.fao.geonet.kernel.schema.MetadataSchema;
+import org.fao.geonet.kernel.schema.MetadataSchemaOperation;
 import org.fao.geonet.kernel.schema.MetadataSchemaOperationFilter;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.io.WKTReader;
@@ -950,7 +951,7 @@ public class LuceneSearcher extends MetaSearcher implements MetadataRecordSelect
                 if (context != null) {
                     MetadataSchema mds = context.getBean(DataManager.class).getSchema(schema);
 
-                    MetadataSchemaOperationFilter editFilter = mds.getOperationFilter(ReservedOperation.editing);
+                    MetadataSchemaOperationFilter editFilter = mds.getOperationFilter(MetadataSchemaOperation.editing);
                     boolean filterEditOperationElements = false;
 
                     if (editFilter != null && editFilter.getXpath().contains(WITHHELD_VALUE)) {
@@ -958,20 +959,20 @@ public class LuceneSearcher extends MetaSearcher implements MetadataRecordSelect
                         filterEditOperationElements = !canEdit;
                     }
 
-                    MetadataSchemaOperationFilter authenticatedFilter = mds.getOperationFilter("authenticated");
+                    MetadataSchemaOperationFilter authenticatedFilter = mds.getOperationFilter(MetadataSchemaOperation.authenticated);
                     boolean filterAuthOperationElements = false;
                     if (authenticatedFilter != null && authenticatedFilter.getXpath().contains(WITHHELD_VALUE)) {
                         boolean isAuthenticated = context.getUserSession().isAuthenticated();
                         filterAuthOperationElements = !isAuthenticated;
                     }
 
-                    MetadataSchemaOperationFilter downloadFilter = mds.getOperationFilter(ReservedOperation.download);
+                    MetadataSchemaOperationFilter downloadFilter = mds.getOperationFilter(MetadataSchemaOperation.download);
                     boolean filterDownloadOperationElements = false;
                     if (downloadFilter != null && downloadFilter.getXpath().contains(WITHHELD_VALUE)) {
                         boolean canDownload = (Boolean.TRUE.toString().equals(info.getChildText(Edit.Info.Elem.DOWNLOAD)));
                         filterDownloadOperationElements = !canDownload;
                     }
-                    MetadataSchemaOperationFilter dynamicFilter = mds.getOperationFilter(ReservedOperation.dynamic);
+                    MetadataSchemaOperationFilter dynamicFilter = mds.getOperationFilter(MetadataSchemaOperation.dynamic);
                     boolean filterDynamicOperationElements = false;
                     if (dynamicFilter != null && dynamicFilter.getXpath().contains(WITHHELD_VALUE)) {
                         boolean canDynamic = (Boolean.TRUE.toString().equals(info.getChildText(Edit.Info.Elem.DYNAMIC)));

--- a/core/src/main/java/org/fao/geonet/kernel/search/LuceneSearcher.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/LuceneSearcher.java
@@ -1,25 +1,25 @@
-//==============================================================================
-//===	Copyright (C) 2001-2022 Food and Agriculture Organization of the
-//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
-//===	and United Nations Environment Programme (UNEP)
-//===
-//===	This program is free software; you can redistribute it and/or modify
-//===	it under the terms of the GNU General Public License as published by
-//===	the Free Software Foundation; either version 2 of the License, or (at
-//===	your option) any later version.
-//===
-//===	This program is distributed in the hope that it will be useful, but
-//===	WITHOUT ANY WARRANTY; without even the implied warranty of
-//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-//===	General Public License for more details.
-//===
-//===	You should have received a copy of the GNU General Public License
-//===	along with this program; if not, write to the Free Software
-//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
-//===
-//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
-//===	Rome - Italy. email: geonetwork@osgeo.org
-//==============================================================================
+/*
+ * Copyright (C) 2001-2023 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
 
 package org.fao.geonet.kernel.search;
 

--- a/core/src/test/java/org/fao/geonet/kernel/XmlSerializerIntegrationTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/XmlSerializerIntegrationTest.java
@@ -42,9 +42,9 @@ import org.fao.geonet.AbstractCoreIntegrationTest;
 import org.fao.geonet.GeonetContext;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.Metadata;
-import org.fao.geonet.domain.Pair;
 import org.fao.geonet.kernel.datamanager.IMetadataManager;
 import org.fao.geonet.kernel.schema.MetadataSchema;
+import org.fao.geonet.kernel.schema.MetadataSchemaOperationFilter;
 import org.fao.geonet.utils.Xml;
 import org.jdom.Element;
 import org.jdom.Namespace;
@@ -101,23 +101,30 @@ public class XmlSerializerIntegrationTest extends AbstractCoreIntegrationTest {
 
     public void setSchemaFilters(boolean withHeld, boolean keepMarkedElement) {
         MetadataSchema mds = _dataManager.getSchema(metadata.getDataInfo().getSchemaId());
-        Map<String, Pair<String, Element>> filters = new HashMap<String, Pair<String, Element>>();
+        Map<String, MetadataSchemaOperationFilter> filters = new HashMap<>();
         if (withHeld) {
             if (keepMarkedElement) {
                 Element mark = new Element("keepMarkedElement");
                 mark.setAttribute("nilReason", "withheld", Geonet.Namespaces.GCO);
-                filters.put("editing",
-                    Pair.read(XPATH_WITHHELD, mark));
+                MetadataSchemaOperationFilter editFilter = new MetadataSchemaOperationFilter(XPATH_WITHHELD, "editing", mark);
+
+                filters.put(editFilter.getIfNotOperation(),
+                    editFilter);
             } else {
-                filters.put("editing",
-                    Pair.<String, Element>read(XPATH_WITHHELD, null));
+                MetadataSchemaOperationFilter editFilter = new MetadataSchemaOperationFilter(XPATH_WITHHELD, "editing", null);
+
+                filters.put(editFilter.getIfNotOperation(),
+                    editFilter);
             }
         }
 
-        filters.put("download",
-            Pair.<String, Element>read(XPATH_DOWNLOAD, null));
-        filters.put("dynamic",
-            Pair.<String, Element>read(XPATH_DYNAMIC, null));
+        MetadataSchemaOperationFilter downloadFilter = new MetadataSchemaOperationFilter(XPATH_DOWNLOAD, "download", null);
+        filters.put(downloadFilter.getIfNotOperation(),
+            downloadFilter);
+
+        MetadataSchemaOperationFilter dynamicFilter = new MetadataSchemaOperationFilter(XPATH_DYNAMIC, "dynamic", null);
+        filters.put(dynamicFilter.getIfNotOperation(),
+            dynamicFilter);
 
         mds.setOperationFilters(filters);
     }

--- a/core/src/test/java/org/fao/geonet/kernel/XmlSerializerIntegrationTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/XmlSerializerIntegrationTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2023 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -23,20 +23,8 @@
 
 package org.fao.geonet.kernel;
 
-import static org.junit.Assert.assertEquals;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
-
-import java.io.Closeable;
-import java.io.InputStream;
-import java.lang.reflect.Field;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
+import com.google.common.collect.Maps;
+import jeeves.server.context.ServiceContext;
 import org.apache.commons.io.IOUtils;
 import org.fao.geonet.AbstractCoreIntegrationTest;
 import org.fao.geonet.GeonetContext;
@@ -55,9 +43,19 @@ import org.springframework.beans.factory.config.BeanDefinition;
 import org.springframework.beans.factory.support.DefaultListableBeanFactory;
 import org.springframework.context.ConfigurableApplicationContext;
 
-import com.google.common.collect.Maps;
+import java.io.Closeable;
+import java.io.InputStream;
+import java.lang.reflect.Field;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
-import jeeves.server.context.ServiceContext;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 public class XmlSerializerIntegrationTest extends AbstractCoreIntegrationTest {
     private static final String XPATH_WITHHELD = "*//*[@gco:nilReason = 'withheld']";

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/schema-ident.xml
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/schema-ident.xml
@@ -127,13 +127,13 @@ Ce schéma est également composé des normes :
   -->
   <filters xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0">
     <!--
-    All elemenets having a nilReason attribute
+    All elements having a nilReason attribute
     set to withheld, then users needs to have
     the edit privilege in order to be able to see
     the information. When filtered the element is
     preserved but with no content in.
     -->
-    <filter xpath="*//*[@gco:nilReason='withheld']"
+    <filter xpath=".//*[@gco:nilReason='withheld']"
             ifNotOperation="editing">
       <keepMarkedElement gco:nilReason="withheld"/>
     </filter>
@@ -143,7 +143,7 @@ Ce schéma est également composé des normes :
     are filtered when user does not have download
     privilege.
     -->
-    <filter xpath="*//mrd:onLine[contains(*/cit:protocol/gco:CharacterString, 'DOWNLOAD') or
+    <filter xpath=".//mrd:onLine[contains(*/cit:protocol/gco:CharacterString, 'DOWNLOAD') or
                                   */cit:protocol/gco:CharacterString = 'FILE' or
                                   */cit:protocol/gco:CharacterString = 'DB' or
                                   */cit:protocol/gco:CharacterString = 'COPYFILE']"
@@ -154,7 +154,7 @@ Ce schéma est également composé des normes :
     to user not having dynamic privilege.
     TODO: other type of services ?
     -->
-    <filter xpath="*//mrd:onLine[starts-with(*/cit:protocol/gco:CharacterString, 'OGC:WMS')]"
+    <filter xpath=".//mrd:onLine[starts-with(*/cit:protocol/gco:CharacterString, 'OGC:WMS')]"
             ifNotOperation="dynamic"/>
   </filters>
 </schema>

--- a/schemas/iso19139/src/main/plugin/iso19139/schema-ident.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/schema-ident.xml
@@ -84,12 +84,12 @@
     </elements>
   </autodetect>
   <filters xmlns:gco="http://www.isotc211.org/2005/gco">
-    <filter xpath="*//*[@gco:nilReason='withheld']"
+    <filter xpath=".//*[@gco:nilReason='withheld']"
             ifNotOperation="editing">
       <keepMarkedElement gco:nilReason="withheld"/>
     </filter>
     <filter
-      xpath="*//gmd:onLine[*/gmd:protocol/gco:CharacterString = 'WWW:DOWNLOAD-1.0-http--download']"
+      xpath=".//gmd:onLine[*/gmd:protocol/gco:CharacterString = 'WWW:DOWNLOAD-1.0-http--download']"
       ifNotOperation="download"/>
     <filter xpath="*//gmd:onLine[starts-with(*/gmd:protocol/gco:CharacterString, 'OGC:WMS')]"
             ifNotOperation="dynamic"/>

--- a/web/src/main/webapp/xml/validation/schemaPlugins/schema-ident.xsd
+++ b/web/src/main/webapp/xml/validation/schemaPlugins/schema-ident.xsd
@@ -258,6 +258,7 @@
           <xs:enumeration value="editing"/>
           <xs:enumeration value="download"/>
           <xs:enumeration value="dynamic"/>
+          <xs:enumeration value="authenticated" />
         </xs:restriction>
       </xs:simpleType>
     </xs:attribute>


### PR DESCRIPTION
Similar to https://github.com/geonetwork/core-geonetwork/pull/6869, but for `3.12.x` to support `withheld` filter elements in Lucene query output.

Also includes:
  
- Add support for `authenticated` operation in metadata operation filters.
- Fix in the metadata operation filters XPATH expressions in `iso19139` and `iso19115-3.2008` schemas.
- Fix in MEF export formats to withheld elements.


A test case:

1) Edit https://github.com/geonetwork/core-geonetwork/blob/3.12.x/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/update-fixed-info.xsl  and add the following template to withheld all contacts, except the Identification Info > Point of Contact (Contact for the resource).

```xml
  <!-- Withheld mdb:contact, cit:citedResponsibleParty, mrd:distributorContact elements -->
  <xsl:template match="mdb:contact|cit:citedResponsibleParty|mrd:distributorContact" priority="10">
    <xsl:copy>
      <xsl:copy-of select="@*[name() != 'gco:nilReason']" />
      <xsl:attribute name="gco:nilReason">withheld</xsl:attribute>

      <xsl:apply-templates select="*" />
    </xsl:copy>
  </xsl:template>
```

2) Create an ISO19115-3.2008 metadata with the template for geographical data.

3) Check the metadata default view, full view, pdf: all contacts should be displayed. The XML view should contain all the contact details.

4) Publish the metadata.

5) With an anonymous user or a logged user that can't edit the metadata, check the metadata default view, full view, pdf: only the Identification Info > Point of Contact (Contact for the resource) should be displayed. The XML view should contain the contact details for Identification Info > Point of Contact (Contact for the resource), for the others should contain the root element with the attribute `gco:nilReason=""withheld"` without containing the contact information.