### PR TITLE
OutOfMemory exception on tomcat / Change logging bridge dependency.

### DIFF
--- a/integration-test/pom.xml
+++ b/integration-test/pom.xml
@@ -60,7 +60,7 @@
 
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j18-impl</artifactId>
+      <artifactId>log4j-slf4j-impl</artifactId>
       <version>${log4j2.version}</version>
     </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -534,7 +534,7 @@
       <!-- logging -->
       <dependency> <!-- usedf for camel -->
         <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-slf4j18-impl</artifactId>
+        <artifactId>log4j-slf4j-impl</artifactId>
         <version>${log4j2.version}</version>
       </dependency>
       <dependency> <!-- used for LDAP test dependency in core -->

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -63,7 +63,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j18-impl</artifactId>
+      <artifactId>log4j-slf4j-impl</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>

--- a/workers/pom.xml
+++ b/workers/pom.xml
@@ -94,7 +94,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j18-impl</artifactId>
+      <artifactId>log4j-slf4j-impl</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
Tomcat (left) and Jetty (right) during indexing phase:

![image](https://user-images.githubusercontent.com/1701393/225274640-93948923-e821-40e8-ad00-4de7ad6f8c46.png)


A memory leak is observed on Tomcat related to logging.

![image](https://user-images.githubusercontent.com/1701393/225274957-83cddd36-7cc6-4748-9335-8afa42505121.png)

slf4j usage:

```shell
~/webapps/geonetwork/WEB-INF/lib$ find . -name "*slf4j*.jar"
./jcl-over-slf4j-1.7.5.jar
./log4j-slf4j18-impl-2.17.2.jar
./slf4j-api-1.7.36.jar
./jclouds-slf4j-2.2.1.jar
./log4j-slf4j-impl-2.17.2.jar
```

`slf4j-api-1.7.36` is used and should not contain memory leak observed on slf4j before 1.7.21 (https://www.slf4j.org/news.html#1.7.21).

We were using `log4j-slf4j18-impl` which is not the version recommended to use with version 1.7.x.

```
* log4j-slf4j-impl should be used with SLF4J 1.7.x releases or older.
* As of release 2.19.0 the log4j-slf4j18-impl module targetting the unreleased SLF4J 1.8.x series has been removed.
```

Changing the dependency version of the bridge looks to fix the memory leak observed on Tomcat.

Thanks to @cmangeat and @juanluisrp for giving ideas.

