### PR TITLE
Indexing / Add timeout when retrieving overview.

### DIFF
--- a/core/src/main/java/org/fao/geonet/util/XslUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/XslUtil.java
@@ -1189,6 +1189,7 @@ public final class XslUtil {
         String extension = Files.getFileExtension(url).toLowerCase();
         if (extension.matches(supportedExtension)) {
 
+            InputStream in = null;
             try {
                 SettingManager settingManager = ApplicationContextHolder.get().getBean(SettingManager.class);
                 Matcher m = Pattern.compile(settingManager.getNodeURL() + "api/records/(.*)/attachments/(.*)$").matcher(url);
@@ -1202,7 +1203,12 @@ public final class XslUtil {
                         image = ImageIO.read(file.getPath().toFile());
                     }
                 } else {
-                    image = ImageIO.read(new URL(url));
+                    URL imageUrl = new URL(url);
+                    URLConnection con = imageUrl.openConnection();
+                    con.setConnectTimeout(1000);
+                    con.setReadTimeout(10000);
+                    in = con.getInputStream();
+                    image = ImageIO.read(in);
                 }
 
                 if (image != null) {
@@ -1225,6 +1231,8 @@ public final class XslUtil {
                 Log.info(Geonet.GEONETWORK, String.format(
                     "Image '%s' is not accessible or can't be converted to Data URL. Error is: %s",
                     url, e.getMessage()));
+            } finally {
+                IOUtils.closeQuietly(in);
             }
         } else {
             Log.info(Geonet.GEONETWORK, String.format(


### PR DESCRIPTION
If URL is not available, this can slow down indexing. Adding a timeout to avoid to wait too long for downloading overview. If not available, the overview URL is used client side instead of the small overview added to the index document.