### PR TITLE
Editor / Configuration / Add for each support.

### DIFF
--- a/schemas/config-editor.xsd
+++ b/schemas/config-editor.xsd
@@ -1042,6 +1042,7 @@ The xpath of the element to loop on.
 If a for-each attribute is set for a section,
 then all children xpath will be relative to the current element.
 
+Note: Section with forEach does not support del attribute.
 
 .. code-block:: xml
 
@@ -1327,7 +1328,7 @@ This mode is used to hide the complexity of the XML element to edit. eg.
                  xpath="gmd:URL"
                  tooltip="gmd:linkage"/>
           </values>
-          <snippet>t
+          <snippet>
             <gmd:linkage>
               <gmd:URL>{{url}}</gmd:URL>
             </gmd:linkage>

--- a/schemas/config-editor.xsd
+++ b/schemas/config-editor.xsd
@@ -1035,6 +1035,28 @@ the mandatory section with no name and then the inner elements.
           </xs:documentation>
         </xs:annotation>
       </xs:attribute>
+      <xs:attribute name="forEach" type="xs:string">
+        <xs:annotation>
+          <xs:documentation><![CDATA[
+The xpath of the element to loop on.
+If a for-each attribute is set for a section,
+then all children xpath will be relative to the current element.
+
+
+.. code-block:: xml
+
+            <section forEach="/gmd:MD_Metadata/gmd:distributionInfo">
+              <text><h2>Distribution</h2></text>
+              <section forEach="*/gmd:transferOptions/*/gmd:onLine/gmd:CI_OnlineResource" name="A link">
+                <field xpath="gmd:linkage"/>
+                <field xpath="gmd:name" or="name" in="."/>
+              </section>
+              <text><hr/></text>
+            </section>
+
+          ]]></xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
       <xs:attribute ref="or"/>
       <xs:attribute ref="in"/>
       <xs:attribute ref="displayIfRecord"/>

--- a/schemas/config-editor.xsd
+++ b/schemas/config-editor.xsd
@@ -1042,7 +1042,7 @@ The xpath of the element to loop on.
 If a for-each attribute is set for a section,
 then all children xpath will be relative to the current element.
 
-Note: Section with forEach does not support del attribute.
+Note: Only sections with forEach support del attribute.
 
 .. code-block:: xml
 
@@ -1058,6 +1058,7 @@ Note: Section with forEach does not support del attribute.
           ]]></xs:documentation>
         </xs:annotation>
       </xs:attribute>
+      <xs:attribute ref="del"/>
       <xs:attribute ref="or"/>
       <xs:attribute ref="in"/>
       <xs:attribute ref="displayIfRecord"/>

--- a/web/src/main/webapp/xslt/ui-metadata/form-configurator.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-configurator.xsl
@@ -96,6 +96,66 @@
   </xsl:template>
 
 
+  <xsl:template mode="form-builder"
+                match="section[@forEach]">
+    <xsl:param name="base" as="node()"/>
+
+    <xsl:variable name="isDisplayed"
+                  as="xs:boolean"
+                  select="gn-fn-metadata:check-elementandsession-visibility(
+                  $schema, $metadata, $serviceInfo, @displayIfRecord, @displayIfServiceInfo)"/>
+
+    <xsl:variable name="xpathPrefix"
+                  select="if (starts-with(@forEach, '/'))
+                                    then '/..'
+                                    else '/'"/>
+    <xsl:if test="$isDisplayed">
+      <xsl:variable name="nodes">
+        <saxon:call-template name="{concat('evaluate-', $schema)}">
+          <xsl:with-param name="base" select="$base"/>
+          <xsl:with-param name="in" select="concat($xpathPrefix, @forEach)"/>
+        </saxon:call-template>
+      </xsl:variable>
+
+      <xsl:variable name="sectionName" select="@name"/>
+      <xsl:variable name="sectionConfig" select="."/>
+      <xsl:variable name="sectionContent" select="*"/>
+
+      <xsl:for-each select="$nodes/*">
+        <xsl:variable name="base" select="."/>
+        <xsl:choose>
+          <xsl:when test="$sectionName">
+            <fieldset data-gn-field-highlight="" class="gn-{$sectionName}">
+              <!-- Get translation for labels.
+              If labels contains ':', search into labels.xml. -->
+              <legend>
+                <xsl:if test="not($sectionConfig/@collapsible)">
+                  <xsl:attribute name="data-gn-slide-toggle" select="exists($sectionConfig/@collapsed)"/>
+                </xsl:if>
+                <xsl:value-of
+                  select="if (contains($sectionName, ':'))
+                    then gn-fn-metadata:getLabel($schema, $sectionName, $labels)/label
+                    else if ($strings/*[name() = $sectionName] != '')
+                    then $strings/*[name() = $sectionName]
+                    else $sectionName"
+                />
+              </legend>
+              <xsl:apply-templates mode="form-builder" select="$sectionContent">
+                <xsl:with-param name="base" select="$base"/>
+              </xsl:apply-templates>
+            </fieldset>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:apply-templates mode="form-builder" select="$sectionContent">
+              <xsl:with-param name="base" select="$base"/>
+            </xsl:apply-templates>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:for-each>
+    </xsl:if>
+  </xsl:template>
+
+
   <!-- Insert a HTML fragment in the editor from the
   localization files. -->
   <xsl:template mode="form-builder" match="text">
@@ -187,14 +247,25 @@
     is in the current document. In that case dispatch to the schema mode
     or create an XML snippet editor for non matching document based on the
     template element. -->
-  <xsl:template mode="form-builder" match="field|fieldset|section[@xpath]">
+  <xsl:template mode="form-builder"
+                match="field
+                      |fieldset
+                      |section[@xpath]">
     <!-- The XML document to edit -->
     <xsl:param name="base" as="node()"/>
 
     <xsl:if test="@xpath">
       <xsl:variable name="config" select="."/>
 
-      <!-- Seach any nodes in the metadata matching the XPath.
+      <!-- Depending on the context, we need to prefix the xpath
+      to work in evaluate function. If root element eg. /gmd:MD_Metadata...
+      then we prepend /.. if a child node, we use current. -->
+      <xsl:variable name="xpathPrefix"
+                    select="if (starts-with(@xpath, '/'))
+                                    then '/..'
+                                    else '/'"/>
+
+      <!-- Search any nodes in the metadata matching the XPath.
 
       We could have called saxon-evaluate from here like:
       <xsl:variable name="nodes"
@@ -208,7 +279,8 @@
       <xsl:variable name="nodes">
         <saxon:call-template name="{concat('evaluate-', $schema)}">
           <xsl:with-param name="base" select="$base"/>
-          <xsl:with-param name="in" select="concat('/../', @xpath)"/>
+          <xsl:with-param name="in"
+                          select="concat($xpathPrefix, @xpath)"/>
         </saxon:call-template>
       </xsl:variable>
 
@@ -219,7 +291,7 @@
           <saxon:call-template name="{concat('evaluate-', $schema)}">
             <xsl:with-param name="base" select="$base"/>
             <xsl:with-param name="in"
-                            select="concat('/../', @in, '[gn:child/@name=''', @or, ''']')"/>
+                            select="concat($xpathPrefix, @in, '[gn:child/@name=''', @or, ''']')"/>
           </saxon:call-template>
         </xsl:if>
       </xsl:variable>

--- a/web/src/main/webapp/xslt/ui-metadata/form-configurator.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-configurator.xsl
@@ -123,6 +123,7 @@
 
       <xsl:for-each select="$nodes/*">
         <xsl:variable name="base" select="."/>
+
         <xsl:choose>
           <xsl:when test="$sectionName">
             <fieldset data-gn-field-highlight="" class="gn-{$sectionName}">
@@ -436,7 +437,10 @@
             metadocument. This mode will probably take precedence over the others
             if defined in a view.
             -->
-          <xsl:variable name="name" select="@name"/>
+          <xsl:variable name="name"
+                        select="if (@name and $strings/*[name() = @name] != '')
+                                then $strings/*[name() = @name]
+                                else @name"/>
           <xsl:variable name="del" select="@del"/>
           <xsl:variable name="template" select="template"/>
           <xsl:variable name="forceLabel" select="@forceLabel"/>
@@ -516,7 +520,7 @@
                   correct location. -->
             <xsl:variable name="id" select="concat('_X', gn:element/@ref, '_replace')"/>
             <xsl:call-template name="render-element-template-field">
-              <xsl:with-param name="name" select="$strings/*[name() = $name]"/>
+              <xsl:with-param name="name" select="$name"/>
               <xsl:with-param name="id" select="$id"/>
               <xsl:with-param name="isExisting" select="true()"/>
               <xsl:with-param name="template" select="$templateCombinedWithNode"/>
@@ -700,13 +704,18 @@
     <xsl:param name="base" as="node()"/>
 
 
+    <xsl:variable name="xpathPrefix"
+                  select="if (starts-with(@in, '/'))
+                          then '/..'
+                          else '/'"/>
+
     <!-- Match any gn:child nodes from the metadocument which
       correspond to non existing node but available in the schema. -->
     <xsl:variable name="nonExistingChildParent">
       <xsl:if test="@or and @in">
         <saxon:call-template name="{concat('evaluate-', $schema)}">
           <xsl:with-param name="base" select="$base"/>
-          <xsl:with-param name="in" select="concat('/../', @in, '[gn:child/@name=''', @or, ''']')"/>
+          <xsl:with-param name="in" select="concat($xpathPrefix, @in, '[gn:child/@name=''', @or, ''']')"/>
         </saxon:call-template>
       </xsl:if>
     </xsl:variable>
@@ -716,7 +725,7 @@
         <saxon:call-template name="{concat('evaluate-', $schema)}">
           <xsl:with-param name="base" select="$base"/>
           <xsl:with-param name="in"
-                          select="concat('/../', @in,
+                          select="concat($xpathPrefix, @in,
                             '/*[local-name() = ''', @or, ''']')"/>
         </saxon:call-template>
       </xsl:if>

--- a/web/src/main/webapp/xslt/ui-metadata/form-configurator.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-configurator.xsl
@@ -110,6 +110,8 @@
                                     then '/..'
                                     else '/'"/>
     <xsl:if test="$isDisplayed">
+      <xsl:variable name="del" select="@del"/>
+
       <xsl:variable name="nodes">
         <saxon:call-template name="{concat('evaluate-', $schema)}">
           <xsl:with-param name="base" select="$base"/>
@@ -140,6 +142,22 @@
                     then $strings/*[name() = $sectionName]
                     else $sectionName"
                 />
+
+                <xsl:if test="$del != ''">
+                  <xsl:variable name="originalNode"
+                                select="gn-fn-metadata:getOriginalNode($metadata, .)"/>
+
+                  <xsl:variable name="refToDelete">
+                    <xsl:call-template name="get-ref-element-to-delete">
+                      <xsl:with-param name="node" select="$originalNode"/>
+                      <xsl:with-param name="delXpath" select="$del"/>
+                    </xsl:call-template>
+                  </xsl:variable>
+
+                  <xsl:call-template name="render-form-field-control-remove">
+                    <xsl:with-param name="editInfo" select="gn:element"/>
+                  </xsl:call-template>
+                </xsl:if>
               </legend>
               <xsl:apply-templates mode="form-builder" select="$sectionContent">
                 <xsl:with-param name="base" select="$base"/>

--- a/web/src/main/webapp/xslt/ui-metadata/menu-fn.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/menu-fn.xsl
@@ -36,8 +36,13 @@
 
     <xsl:choose>
       <xsl:when test="$condition">
+        <!-- Depending on the context, we need to prefix the xpath
+              to work in evaluate function. If root element eg. /gmd:MD_Metadata...
+              then we prepend /.. if 'gui' context or a child node, we use current. -->
         <xsl:variable name="prefixPath"
-                      select="if (local-name($base) = 'gui') then '/' else '/../'"/>
+                      select="if (local-name($base) = 'gui'
+                              or count($base/ancestor::*) = 0)
+                               then '/' else '/../'"/>
         <saxon:call-template name="{concat('evaluate-', $schema, '-boolean')}">
           <xsl:with-param name="base" select="$base"/>
           <xsl:with-param name="in" select="concat($prefixPath, $condition)"/>


### PR DESCRIPTION
Add the possibility to create one section per matching elements and then continue configuring some (or all) of the child elements.

eg.

```xml
        <section forEach="/gmd:MD_Metadata/gmd:distributionInfo">
          <text><h2>Distribution</h2></text>
          <section forEach="*/gmd:transferOptions/*/gmd:onLine" name="A link" del=".">
            <field xpath="*/gmd:linkage"/>
            <field xpath="*/gmd:name" or="name" in="*"/>
          </section>
          <text><hr/></text>
        </section>
```

creates:

![image](https://user-images.githubusercontent.com/1701393/225378462-bea96929-3712-49fc-8212-052f29b98e81.png)

This was only feasible previously for simple field using template mode (cf. https://geonetwork-opensource.org/manuals/4.0.x/en/customizing-application/editor-ui/creating-custom-editor.html#adding-a-template-based-field) and was not supporting nested context. 


Inspired by https://github.com/GIM-be/core-geonetwork/commit/f67a1bec22815633126e8ad1430cb30f5b83a2fd made by @CMath04 