### PR TITLE
Database / Add env variable to disable automatic migration.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1458,6 +1458,7 @@
     <db.username>#{systemEnvironment['GEONETWORK_DB_USERNAME']?:'www-data'}</db.username>
     <db.password>#{systemEnvironment['GEONETWORK_DB_PASSWORD']?:'www-data'}</db.password>
     <db.connectionProperties>#{systemEnvironment['GEONETWORK_DB_CONNECTION_PROPERTIES']}</db.connectionProperties>
+    <db.migration_onstartup>#{systemEnvironment['GEONETWORK_DB_MIGRATION_ONSTARTUP']?:'true'}</db.migration_onstartup>
 
     <db.pool.maxActive>30</db.pool.maxActive>
     <db.pool.maxIdle>10</db.pool.maxIdle>

--- a/web/src/main/java/org/fao/geonet/DatabaseMigration.java
+++ b/web/src/main/java/org/fao/geonet/DatabaseMigration.java
@@ -24,7 +24,6 @@
 package org.fao.geonet;
 
 import com.google.common.util.concurrent.Callables;
-import org.locationtech.jts.util.Assert;
 import jeeves.server.sources.http.ServletPathFinder;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.Pair;
@@ -33,6 +32,7 @@ import org.fao.geonet.lib.DatabaseType;
 import org.fao.geonet.lib.Lib;
 import org.fao.geonet.utils.Log;
 import org.fao.geonet.utils.Version;
+import org.locationtech.jts.util.Assert;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.config.BeanPostProcessor;
@@ -65,6 +65,8 @@ public class DatabaseMigration implements BeanPostProcessor {
     private static final int SUBVERSION_NUMBER_ID_BEFORE_2_11 = 16;
     private static final String JAVA_MIGRATION_PREFIX = "java:";
 
+    private boolean dbMigrationOnStartup = true;
+
     @Autowired
     private SystemInfo systemInfo;
     @Autowired
@@ -84,6 +86,9 @@ public class DatabaseMigration implements BeanPostProcessor {
 
     @Override
     public final Object postProcessAfterInitialization(final Object bean, final String beanName) {
+        if (!dbMigrationOnStartup) {
+            return bean;
+        }
         try {
             if (Class.forName(initAfter).isInstance(bean)) {
                 _logger.debug(String.format("DB Migration / Running '%s' after initialization of '%s'.", bean.getClass(), initAfter));
@@ -412,6 +417,14 @@ public class DatabaseMigration implements BeanPostProcessor {
 
     public boolean isFoundErrors() {
         return foundErrors;
+    }
+
+    public boolean isDbMigrationOnStartup() {
+        return dbMigrationOnStartup;
+    }
+
+    public void setDbMigrationOnStartup(boolean dbMigrationOnStartup) {
+        this.dbMigrationOnStartup = dbMigrationOnStartup;
     }
 
     public String getInitAfter() {

--- a/web/src/main/webResources/WEB-INF/config-db/database_migration.xml
+++ b/web/src/main/webResources/WEB-INF/config-db/database_migration.xml
@@ -33,10 +33,12 @@
   <bean id="database-migration-bean" class="org.fao.geonet.DatabaseMigration">
     <property name="migration" ref="migrationMap"/>
     <property name="initAfter" value="javax.sql.DataSource"/>
+    <property name="dbMigrationOnStartup" value="\${db.migration_onstartup}"/>
   </bean>
   <bean id="database-data-migration-bean" class="org.fao.geonet.DatabaseMigration">
     <property name="migration" ref="dataMigrationMap"/>
     <property name="initAfter" value="org.springframework.orm.jpa.JpaTransactionManager"/>
+    <property name="dbMigrationOnStartup" value="\${db.migration_onstartup}"/>
   </bean>
 
   <util:map id="migrationMap"

--- a/web/src/main/webResources/WEB-INF/config.properties
+++ b/web/src/main/webResources/WEB-INF/config.properties
@@ -11,6 +11,8 @@ usersavedselection.watchlist.searchurl=catalog.search#/search?_uuid={{filter}}
 # Define the link to each record sent by email by the watchlist notifier
 usersavedselection.watchlist.recordurl=api/records/{{index:uuid}}
 
+db.migration_onstartup=${db.migration_onstartup}
+
 es.protocol=${es.protocol}
 es.port=${es.port}
 es.host=${es.host}


### PR DESCRIPTION
In a number of situation, catalogue maintainer manage migration by themselves (eg. when community releases are not made at the same times as project releases). Add an env variable to disable the automatic migration startup phase using `GEONETWORK_DB_MIGRATION_ONSTARTUP=false`.