### PR TITLE
Build / git.properties file not created

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -654,7 +654,7 @@
             <includeOnlyProperty>^git.tags$</includeOnlyProperty>
             <includeOnlyProperty>^git.branch$</includeOnlyProperty>
             <includeOnlyProperty>^git.commit.id$</includeOnlyProperty>
-            <includeOnlyProperty>^git.commit.id.describe.short$</includeOnlyProperty>
+            <includeOnlyProperty>^git.commit.id.describe.*$</includeOnlyProperty>
             <includeOnlyProperty>^git.build.time$</includeOnlyProperty>
           </includeOnlyProperties>
           <replacementProperties>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -616,88 +616,86 @@
   </dependencies>
 
   <build>
-
     <plugins>
       <!-- Generate a properties file with the commit hash to be displayed on the admin.console -->
 	    <plugin>
-	        <groupId>pl.project13.maven</groupId>
-	        <artifactId>git-commit-id-plugin</artifactId>
-	        <version>2.2.6</version>
-	        <executions>
-                  <execution>
-                    <phase>initialize</phase>
-	                <id>get-the-git-infos</id>
-	                <goals>
-	                    <goal>revision</goal>
-	                </goals>
-	            </execution>
-	        </executions>
+        <groupId>io.github.git-commit-id</groupId>
+        <artifactId>git-commit-id-maven-plugin</artifactId>
+        <version>4.9.9</version>
+        <executions>
+          <execution>
+            <phase>initialize</phase>
+            <id>get-the-git-infos</id>
+            <goals>
+                <goal>revision</goal>
+            </goals>
+          </execution>
+        </executions>
 
-	        <configuration>
-	            <dotGitDirectory>${project.basedir}/../.git</dotGitDirectory>
-	            <prefix>git</prefix>
-	            <dateFormat>yyyy-MM-dd'T'HH:mm:ssZ</dateFormat>
-	            <dateFormatTimeZone>${user.timezone}</dateFormatTimeZone>
-	            <verbose>false</verbose>
-	            <generateGitPropertiesFile>true</generateGitPropertiesFile>
-	            <generateGitPropertiesFilename>src/main/webResources/WEB-INF/classes/git.properties</generateGitPropertiesFilename>
-	            <!-- Denotes the format to save properties in. Valid options are "properties" (default) and "json". Properties will be saved to the generateGitPropertiesFilename if generateGitPropertiesFile is set to `true`. -->
-	            <format>properties</format>
-	            <skipPoms>true</skipPoms>
-	            <injectAllReactorProjects>true</injectAllReactorProjects>
-	            <failOnNoGitDirectory>false</failOnNoGitDirectory>
-	            <failOnUnableToExtractRepoInfo>false</failOnUnableToExtractRepoInfo>
-	            <skip>false</skip>
-	            <runOnlyOnce>false</runOnlyOnce>
-	            <excludeProperties>
-	            </excludeProperties>
-							<includeOnlyProperties>
-								<includeOnlyProperty>^git.tags$</includeOnlyProperty>
-								<includeOnlyProperty>^git.branch$</includeOnlyProperty>
-								<includeOnlyProperty>^git.commit.id$</includeOnlyProperty>
-								<includeOnlyProperty>^git.commit.id.describe.short$</includeOnlyProperty>
-								<includeOnlyProperty>^git.build.time$</includeOnlyProperty>
-							</includeOnlyProperties>
-	            <replacementProperties>
-	            </replacementProperties>
-	            <useNativeGit>false</useNativeGit>
-	            <abbrevLength>7</abbrevLength>
-	            <commitIdGenerationMode>flat</commitIdGenerationMode>
-	            <gitDescribe>
-	                <skip>false</skip>
-	                <always>false</always>
-	                <abbrev>7</abbrev>
-	                <dirty>-dirty</dirty>
-	                <match>*</match>
-	                <tags>true</tags>
-	                <forceLongFormat>false</forceLongFormat>
-	            </gitDescribe>
-	            <!-- @since 2.2.2 -->
-	            <!--
-	                Since version **2.2.2** the maven-git-commit-id-plugin comes equipped with an additional validation utility which can be used to verify if your project properties are set as you would like to have them set.
-	                *Note*: This configuration will only be taken into account when the additional goal `validateRevision` is configured inside an execution.
-	            -->
-	            <validationProperties>
-	                <validationProperty>
-	                    <!--
-	                         A descriptive name that will be used to be able to identify the validation that does not match up (will be displayed in the error message).
-	                    -->
-	                    <name>validating project version</name>
-	                    <!--
-	                         the value that needs the validation
-	                         *Note* : In order to be able to validate the generated git-properties inside the pom itself you may need to set the configuration `<injectAllReactorProjects>true</injectAllReactorProjects>`.
-	                    -->
-	                    <value>${project.version}</value>
-	                    <!--
-	                        the expected value
-	                    -->
-	                    <shouldMatchTo><![CDATA[^.*(?<!-SNAPSHOT)$]]></shouldMatchTo>
-	                </validationProperty>
-	                <!-- the next validationProperty you would like to validate -->
-	            </validationProperties>
-	            <validationShouldFailIfNoMatch>false</validationShouldFailIfNoMatch>
-	        </configuration>
-
+        <configuration>
+          <dotGitDirectory>${project.basedir}/../.git</dotGitDirectory>
+          <prefix>git</prefix>
+          <dateFormat>yyyy-MM-dd'T'HH:mm:ssZ</dateFormat>
+          <dateFormatTimeZone>${user.timezone}</dateFormatTimeZone>
+          <verbose>false</verbose>
+          <generateGitPropertiesFile>true</generateGitPropertiesFile>
+          <generateGitPropertiesFilename>src/main/webResources/WEB-INF/classes/git.properties</generateGitPropertiesFilename>
+          <!-- Denotes the format to save properties in. Valid options are "properties" (default) and "json". Properties will be saved to the generateGitPropertiesFilename if generateGitPropertiesFile is set to `true`. -->
+          <format>properties</format>
+          <skipPoms>true</skipPoms>
+          <injectAllReactorProjects>true</injectAllReactorProjects>
+          <failOnNoGitDirectory>false</failOnNoGitDirectory>
+          <failOnUnableToExtractRepoInfo>false</failOnUnableToExtractRepoInfo>
+          <skip>false</skip>
+          <runOnlyOnce>false</runOnlyOnce>
+          <excludeProperties>
+          </excludeProperties>
+          <includeOnlyProperties>
+            <includeOnlyProperty>^git.tags$</includeOnlyProperty>
+            <includeOnlyProperty>^git.branch$</includeOnlyProperty>
+            <includeOnlyProperty>^git.commit.id$</includeOnlyProperty>
+            <includeOnlyProperty>^git.commit.id.describe.short$</includeOnlyProperty>
+            <includeOnlyProperty>^git.build.time$</includeOnlyProperty>
+          </includeOnlyProperties>
+          <replacementProperties>
+          </replacementProperties>
+          <useNativeGit>false</useNativeGit>
+          <abbrevLength>7</abbrevLength>
+          <commitIdGenerationMode>flat</commitIdGenerationMode>
+          <gitDescribe>
+            <skip>false</skip>
+            <always>false</always>
+            <abbrev>7</abbrev>
+            <dirty>-dirty</dirty>
+            <match>*</match>
+            <tags>true</tags>
+            <forceLongFormat>false</forceLongFormat>
+          </gitDescribe>
+          <!-- @since 2.2.2 -->
+          <!--
+              Since version **2.2.2** the maven-git-commit-id-plugin comes equipped with an additional validation utility which can be used to verify if your project properties are set as you would like to have them set.
+              *Note*: This configuration will only be taken into account when the additional goal `validateRevision` is configured inside an execution.
+          -->
+          <validationProperties>
+            <validationProperty>
+              <!--
+                   A descriptive name that will be used to be able to identify the validation that does not match up (will be displayed in the error message).
+              -->
+              <name>validating project version</name>
+              <!--
+                   the value that needs the validation
+                   *Note* : In order to be able to validate the generated git-properties inside the pom itself you may need to set the configuration `<injectAllReactorProjects>true</injectAllReactorProjects>`.
+              -->
+              <value>${project.version}</value>
+              <!--
+                  the expected value
+              -->
+              <shouldMatchTo><![CDATA[^.*(?<!-SNAPSHOT)$]]></shouldMatchTo>
+            </validationProperty>
+            <!-- the next validationProperty you would like to validate -->
+          </validationProperties>
+          <validationShouldFailIfNoMatch>false</validationShouldFailIfNoMatch>
+        </configuration>
 	    </plugin>
       <plugin>
         <artifactId>maven-clean-plugin</artifactId>


### PR DESCRIPTION
On some build environments `git.properties` was not created and wro4j cache initialization relying on it was triggerring a null pointer exception.

When building activating the `verbose` mode on those environments was also fixing the issue but sounds better to update. 

Updating the `git-commit-id-maven-plugin` fix the issue.