### PR TITLE
Extend date range filter directive to configure the date field to use

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/directives/directive.js
+++ b/web-ui/src/main/resources/catalog/views/default/directives/directive.js
@@ -263,26 +263,24 @@
           "../../catalog/views/default/directives/" + "partials/dateRangeFilter.html",
         scope: {
           label: "@gnDateRangeFilter",
-          field: "="
+          field: "=",
+          fieldName: "="
         },
         link: function linkFn(scope, element, attr) {
           var today = moment();
           scope.relations = ["intersects", "within", "contains"];
           scope.relation = scope.relations[0];
-          scope.field = {
-            range: {
-              resourceTemporalDateRange: {
-                gte: null,
-                lte: null,
-                relation: scope.relation
-              }
-            }
+          scope.field.range = scope.field.range || {};
+          scope.field.range[scope.fieldName] = {
+            gte: null,
+            lte: null,
+            relation: scope.relation
           };
 
           scope.setRange = function () {
-            scope.field.range.resourceTemporalDateRange.gte = scope.dateFrom;
-            scope.field.range.resourceTemporalDateRange.lte = scope.dateTo;
-            scope.field.range.resourceTemporalDateRange.relation = scope.relation;
+            scope.field.range[scope.fieldName].gte = scope.dateFrom;
+            scope.field.range[scope.fieldName].lte = scope.dateTo;
+            scope.field.range[scope.fieldName].relation = scope.relation;
           };
 
           scope.format = "YYYY-MM-DD";

--- a/web-ui/src/main/resources/catalog/views/default/templates/advancedSearchForm/defaultAdvancedSearchForm.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/advancedSearchForm/defaultAdvancedSearchForm.html
@@ -13,6 +13,7 @@
     data-ng-if="searchObj.params.resourceTemporalDateRange"
     data-gn-date-range-filter="resourceTemporalDateRange"
     data-field="searchObj.params.resourceTemporalDateRange"
+    data-field-name="'resourceTemporalDateRange'"
     class="gn-search-filter-datepicker"
   ></div>
 </div>


### PR DESCRIPTION
Currently only was supporting the field `resourceTemporalDateRange`. A new property `fieldName` should be specified with the date field name to query.

This change allows for example to extend the advanced search form to query ranges with other date fields like `creationDateForResource`:

```
<div
        data-ng-if="searchObj.params.creationDateForResource"
        data-gn-date-range-filter="creationDateForResource"
        data-field-name="'creationDateForResource'"
        data-field="searchObj.params.creationDateForResource"
        class="gn-search-filter-datepicker"
      ></div>
```
