### PR TITLE
Send Maven dependency tree to Github

### DIFF
--- a/.github/workflows/mvn-dep-tree.yml
+++ b/.github/workflows/mvn-dep-tree.yml
@@ -1,0 +1,31 @@
+# This job sends the maven dependency tree of the project to Github
+# for further security analysis.
+
+name: "MavenDepTreeSubmission"
+
+on:
+  push:
+    branches: [ main ]
+  schedule:
+    - cron: '44 22 * * 5'
+
+jobs:
+  update-maven-dep-tree:
+    runs-on: ubuntu-latest
+    
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+      
+      - name: Setup Java JDK
+        uses: actions/setup-java@v3.10.0
+        with:
+          java-version: 8
+          # Java distribution. See the list of supported distributions in README file
+          distribution: temurin
+          # The package type (jdk, jre, jdk+fx, jre+fx)
+          java-package: jdk
+          cache: maven
+    
+      - name: Submit Dependency Snapshot
+        uses: advanced-security/maven-dependency-submission-action@v3


### PR DESCRIPTION
This is a GitHub Action that will generate a complete dependency graph for a Maven project and submit the graph to the GitHub repository so that the graph is complete and includes all the transitive dependencies.