### PR TITLE
UI / Add a read more directive

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/related.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/related.html
@@ -33,6 +33,7 @@
           <p class="text-muted">
             <span
               data-translate="{{(mainType | lowercase) + 'LinkDetails'}}"
+              data-translate-default=""
               data-translate-values="{
                       url:{{r.locUrl | json}},
                       layer:{{r.locTitle | json}}
@@ -66,8 +67,10 @@
           data-ng-if="::r.locDescription.length > 0
                        && r.locDescription !== r.locTitle"
           title="{{::r.locDescription}}"
+          data-gn-read-more=""
+          data-line-number="3"
         >
-          {{::r.locDescription | striptags | characters:150}}
+          {{::r.locDescription | striptags}}
         </p>
         <div data-ng-switch on="mainType">
           <div data-ng-switch-when="WFS">

--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -204,6 +204,194 @@
     }
   ]);
 
+  module.directive("gnReadMore", [
+    "$timeout",
+    "$translate",
+    function ($timeout, $translate) {
+      return {
+        restrict: "A",
+        link: function (scope, el, attrs) {
+          var MAX_HEIGHT_LINE = 5,
+            element = el.get(0),
+            toggleButton = undefined,
+            expandLabel = attrs["expandLabel"]
+              ? $translate.instant(attrs["expandLabel"])
+              : "",
+            expandTooltip = attrs["expandTooltip"]
+              ? $translate.instant(attrs["expandTooltip"])
+              : $translate.instant("readMore"),
+            expandedLabel = attrs["expandedLabel"]
+              ? $translate.instant(attrs["expandedLabel"])
+              : "",
+            expandedTooltip = attrs["expandedTooltip"]
+              ? $translate.instant(attrs["expandedTooltip"])
+              : "",
+            expandIcon = attrs["expandIcon"] || "fa-plus-circle",
+            gradient = attrs["gradient"] || false,
+            expandedIcon = attrs["expandedIcon"] || "fa-minus-circle",
+            transparent = "rgba(0, 0, 0, 0)";
+
+          /**
+           * Returns the background style using the parent element color
+           * @param {string} background css value
+           */
+          function getParentBackgroundStyle(parentElement) {
+            var parentBgColor = getComputedStyle(parentElement).backgroundColor;
+            // Background color is not inherited
+            if (parentBgColor === transparent) {
+              return getParentBackgroundStyle(parentElement.parentElement);
+            }
+            var baseColor = "255, 255, 255";
+            var matches = /^rgba?\(([0-9]+, [0-9]+, [0-9]+)/.exec(parentBgColor);
+            if (matches && parentBgColor !== transparent) {
+              baseColor = matches[1];
+            }
+            if (gradient !== false) {
+              return (
+                "linear-gradient(0deg, rgba(" +
+                baseColor +
+                ", 1) 40%, rgba(" +
+                baseColor +
+                ", 0))"
+              );
+            } else {
+              return "rgba(" + baseColor + ")";
+            }
+          }
+
+          /**
+           * @param {HTMLElement} element
+           * @param {number} pxSize
+           */
+          function collapseElement(element, pxSize) {
+            var contentChild = element.querySelector(".gn-collapse-content");
+            contentChild.style.maxHeight = pxSize + "px";
+            contentChild.style.overflowY = "hidden";
+
+            toggleButton.innerHTML =
+              '<span class="fa fa-fw ' + expandIcon + '"></span>' + expandLabel;
+            toggleButton.setAttribute("title", expandTooltip);
+            element.setAttribute("data-collapsed", "");
+            toggleButton.style.background = getParentBackgroundStyle(element);
+            toggleButton.style.left = "0";
+          }
+
+          /**
+           * @param {HTMLElement} element
+           */
+          function expandElement(element) {
+            var contentChild = element.querySelector(".gn-collapse-content");
+            contentChild.style.removeProperty("max-height");
+            contentChild.style.removeProperty("overflow-y");
+
+            toggleButton.innerHTML =
+              '<span class="fa fa-fw ' + expandedIcon + '"></span>' + expandedLabel;
+            toggleButton.setAttribute("title", expandedTooltip);
+            toggleButton.style.removeProperty("left");
+            element.removeAttribute("data-collapsed");
+            toggleButton.style.removeProperty("background");
+          }
+
+          /**
+           * Returns the line height in px
+           * @param {HTMLElement} element
+           */
+          function measureLineHeight(element) {
+            var height = parseInt(
+              getComputedStyle(element).getPropertyValue("line-height"),
+              10
+            );
+            // make sure lineheight is not null;
+            if (!height) {
+              height = 10;
+            }
+            return height;
+          }
+
+          /**
+           * Returns the inner height (without padding) in px
+           * @param {HTMLElement} element
+           */
+          function measureInnerHeight(element) {
+            var height = parseInt(
+              getComputedStyle(element).getPropertyValue("height"),
+              10
+            );
+            var paddingTop = parseInt(
+              getComputedStyle(element).getPropertyValue("padding-top"),
+              10
+            );
+            var paddingBottom = parseInt(
+              getComputedStyle(element).getPropertyValue("padding-bottom"),
+              10
+            );
+            return height - paddingTop - paddingBottom;
+          }
+
+          /**
+           * Creates a toggle button and position it in the parent element
+           * @param {HTMLElement} parentElement
+           */
+          function createToggleButton(parentElement) {
+            toggleButton = document.createElement("a");
+            toggleButton.setAttribute("href", "");
+            toggleButton.classList.add("gn-collapse-toggle");
+            toggleButton.style.display = "block";
+            toggleButton.style.position = "absolute";
+            toggleButton.style.bottom = "0";
+            toggleButton.style.left = "0";
+            toggleButton.style.right = "0";
+            toggleButton.style.paddingRight = "0.5em";
+
+            // get parent background color to determine the gradient
+            toggleButton.style.background = getParentBackgroundStyle(parentElement);
+            parentElement.appendChild(toggleButton);
+          }
+
+          var init = function () {
+            var elHeightPx = measureInnerHeight(element);
+            var lineHeightPx = measureLineHeight(element);
+            var lineNumbers =
+              attrs["lineNumber"] != null
+                ? parseInt(attrs["lineNumber"], 10)
+                : MAX_HEIGHT_LINE;
+            if (elHeightPx < lineHeightPx * (lineNumbers + 1)) {
+              return;
+            }
+            var maxHeightPx = lineHeightPx * (lineNumbers + 1);
+
+            // put the element content in a child div
+            var contentChild = document.createElement("div");
+            contentChild.classList.add("gn-collapse-content");
+            contentChild.innerHTML = element.innerHTML;
+            contentChild.style.paddingBottom = "0";
+            element.innerHTML = "";
+            element.style.position = "relative";
+            element.appendChild(contentChild);
+            if (!getComputedStyle(element).position) {
+              element.style.position = "relative";
+            }
+
+            createToggleButton(element);
+            toggleButton.addEventListener("click", function (event) {
+              if (element.hasAttribute("data-collapsed")) {
+                expandElement(element);
+              } else {
+                collapseElement(element, maxHeightPx);
+              }
+              event.preventDefault();
+            });
+
+            // element is collapsed initially
+            collapseElement(element, maxHeightPx);
+          };
+
+          $timeout(init);
+        }
+      };
+    }
+  ]);
+
   /**
    * @ngdoc directive
    * @name gn_utility.directive:gnCountryPicker

--- a/web-ui/src/main/resources/catalog/locales/en-v4.json
+++ b/web-ui/src/main/resources/catalog/locales/en-v4.json
@@ -82,6 +82,7 @@
   "csw-sortByHelp": "Define sort option for GetRecords query. This can solve issue for large sets where some records may change on the remote node during harvesting and returned in different pages. Sorting by 'identifier:A' means by UUID with alphabetical order. Any CSW queryables can be used in combination with A or D for setting the ordering.",
   "moreLikeThis": "Similar records",
   "moreLikeType": "Similar ",
+  "readMore": "See more...",
   "onTheWeb": "More online information",
   "pdfReportTocTitle": "Contents",
   "loadMoreResults": "load more results...",


### PR DESCRIPTION
Based on an initial work made by @jahow on Ifremer Sextant project, and adapted to be used as a directive.

Usage:

```js
  <p data-ng-bind-html="(mdView.current.record.resourceAbstract) | linky | newlines"
     data-gn-read-more=""
     data-line-number="5"></p>
```

For now, used to display link description which can be quite long in some cases.

Before

![image](https://user-images.githubusercontent.com/1701393/227464176-96024ef5-cdad-484c-b4f8-3f775f179de0.png)

After

![image](https://user-images.githubusercontent.com/1701393/227464135-e2152189-9182-4355-9eae-b45466241338.png)


