### PR TITLE
Update CSW GetRecords samples. Fixes #6935

### DIFF
--- a/web/src/main/webapp/xml/csw/test/csw-GetRecordsFilterService.xml
+++ b/web/src/main/webapp/xml/csw/test/csw-GetRecordsFilterService.xml
@@ -29,7 +29,7 @@
       <Filter xmlns="http://www.opengis.net/ogc">
         <PropertyIsLike wildCard="%" singleChar="_" escapeChar="\">
           <PropertyName>AnyText</PropertyName>
-          <Literal>%service%</Literal>
+          <Literal>\%service\%</Literal>
         </PropertyIsLike>
       </Filter>
     </csw:Constraint>

--- a/web/src/main/webapp/xml/csw/test/csw-GetRecordsNoFilterValidate.xml
+++ b/web/src/main/webapp/xml/csw/test/csw-GetRecordsNoFilterValidate.xml
@@ -32,7 +32,7 @@
       <Filter xmlns="http://www.opengis.net/ogc">
         <PropertyIsLike wildCard="%" singleChar="_" escapeChar="\">
           <PropertyName>AnyText</PropertyName>
-          <Literal>%service%</Literal>
+          <Literal>\%service\%</Literal>
         </PropertyIsLike>
       </Filter>
     </csw:Constraint>


### PR DESCRIPTION
When using `escapeChar` with `PropertyIsLike`, the character should be used to escape the wildcards. 