### PR TITLE
Search results / List / Associated resource group by title.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/related.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/related.html
@@ -168,7 +168,8 @@
                     badge = config.getBadgeLabel(mainType, md);
                     icon = config.getClassIcon(mainType);"
   >
-    <h3 data-ng-if="groupSiblingsByType && items.length > 0">
+    <h3 data-ng-if="groupSiblingsByType && items.length > 0" class="gn-related-title">
+      <i class="fa fa-fw {{icon}}" />
       {{type.replace('siblings', '') | translate}}
     </h3>
 
@@ -181,7 +182,6 @@
           gn-metadata-open="md"
           gn-formatter="formatter.defaultUrl"
         >
-          <i class="fa {{icon}}" />
           {{md.resourceTitle}}
         </a>
         <a
@@ -191,7 +191,6 @@
           target="_blank"
           title="{{md.resourceTitle}}"
         >
-          <i class="fa {{icon}}" />
           {{md.resourceTitle}}
           <i
             data-ng-if="md.origin === 'remote'"

--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/relatedDropdown.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/relatedDropdown.html
@@ -9,11 +9,15 @@
     <span class="caret"></span>
   </button>
   <ul class="dropdown-menu">
-    <li
+    <span
       data-ng-repeat-start="(type, items) in md.related track by $index"
       data-ng-init="mainType = config.getType(md, type);
-                icon = config.getClassIcon(mainType);"
-    ></li>
+                    icon = config.getClassIcon(mainType);"
+    >
+    </span>
+    <li data-ng-if="items.length > 0" class="gn-related-title">
+      <i class="fa {{icon}}" /> {{('link-' + type) | translate}}
+    </li>
     <li data-ng-repeat="md in items | orderBy:getOrderBy">
       <a
         data-ng-hide="md.remoteUrl"
@@ -22,7 +26,6 @@
         gn-metadata-open="md"
         gn-formatter="formatter.defaultUrl"
       >
-        <i class="fa {{icon}}" />
         {{md.resourceTitle}}
       </a>
       <a
@@ -32,7 +35,6 @@
         target="_blank"
         title="{{md.resourceTitle}}"
       >
-        <i class="fa {{icon}}" />
         {{md.resourceTitle}}
         <i
           data-ng-if="md.origin === 'remote'"
@@ -41,6 +43,6 @@
         ></i>
       </a>
     </li>
-    <li data-ng-repeat-end=""></li>
+    <span data-ng-repeat-end=""></span>
   </ul>
 </div>

--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/relatedSimpleList.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/relatedSimpleList.html
@@ -5,6 +5,9 @@
   data-ng-init="mainType = config.getType(md, type);
                   icon = config.getClassIcon(mainType);"
 >
+  <li data-ng-if="items.length > 0" class="gn-related-title">
+    <i class="fa fa-fw {{icon}}" /> {{('link-' + type) | translate}}
+  </li>
   <li data-ng-repeat="md in items | orderBy:getOrderBy">
     <a
       data-ng-hide="md.remoteUrl"
@@ -13,7 +16,6 @@
       gn-metadata-open="md"
       gn-formatter="formatter.defaultUrl"
     >
-      <i class="fa {{icon}}" />
       {{md.resourceTitle}}
     </a>
     <a
@@ -23,7 +25,6 @@
       target="_blank"
       title="{{md.resourceTitle}}"
     >
-      <i class="fa {{icon}}" />
       {{md.resourceTitle}}
       <i
         data-ng-if="md.origin === 'remote'"

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid.html
@@ -86,10 +86,7 @@
       <div data-gn-status-badge="md" />
       <div class="gn-toolbar">
         <gn-links-btn class="pull-right"></gn-links-btn>
-
-        <!--<div data-gn-related-dropdown="md"
-             class="pull-right"></div>
-        </div>-->
+        <!-- <div data-gn-related-dropdown="md" data-user="user"></div>-->
       </div>
     </div>
     <!-- /.gn-card-footer -->

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/list.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/list.html
@@ -62,6 +62,7 @@
             </p>
 
             <div
+              class="gn-margin-top"
               data-gn-related-list="md"
               data-user="user"
               data-title="{{::('associatedResources' | translate)}}"

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/list.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/list.html
@@ -162,6 +162,7 @@
         </div>
 
         <gn-links-btn class="pull-right"></gn-links-btn>
+        <!-- <div class="pull-right" data-gn-related-dropdown="md" data-user="user"></div>-->
       </div>
     </div>
     <!-- /.gn-card-footer -->

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_card_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_card_default.less
@@ -298,9 +298,6 @@
       .col-md-3 {
         padding: 0px
       }
-      .col-md-6 {
-        padding-left: 0;
-      }
       .gn-md-abstract {
         margin-top: 15px;
         line-height: 1.5em;


### PR DESCRIPTION


![image](https://user-images.githubusercontent.com/1701393/227889971-1305d214-3f7d-4647-ab5f-e2249d9b66ff.png)
instead of one icon per records with type as tooltip (eg. https://metawal.wallonie.be/geonetwork/srv/eng/catalog.search#/search?query_string=%7B%22resourceType%22:%7B%22series%22:true%7D%7D).

Also applied to dropdown directive for users who use that directive eg.
![image](https://user-images.githubusercontent.com/1701393/227897627-12f08854-d7c3-4de5-93b8-afc1851d71c8.png)
