### PR TITLE
Empty error message when deleting metadata and an exeception occurs.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/mdview/mdviewModule.js
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/mdviewModule.js
@@ -196,7 +196,7 @@
             // Data needs improvements
             // See https://github.com/geonetwork/core-geonetwork/issues/723
             gnAlertService.addAlert({
-              msg: reason.data.description,
+              msg: reason.data.message || reason.data.description,
               type: "danger"
             });
           }

--- a/web-ui/src/main/resources/catalog/js/edit/EditorBoardController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/EditorBoardController.js
@@ -126,7 +126,7 @@
           },
           function (reason) {
             $rootScope.$broadcast("StatusUpdated", {
-              title: reason.data.description, //returned error JSON obj
+              title: reason.data.message || reason.data.description, //returned error JSON obj
               timeout: 0,
               type: "danger"
             });


### PR DESCRIPTION
When deleting the reason for the error may be in the description or the message so support both or it may display a empty reason.

Before the fix, if we attempt to delete a record that generates an error in the listener then we get the following 

![image](https://user-images.githubusercontent.com/1868233/227955609-6b30afc7-02ad-4210-8fff-73c1db911e4b.png)

After the fix, we get something like the following

![image](https://user-images.githubusercontent.com/1868233/227956279-1a4a85a2-4828-4365-982c-a263b79675a0.png)

Note that this fix depends on changes from 
#6850


