### PR TITLE
Add online resources from WMS layers with the 'resourcename' mode - improvements

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcService.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcService.js
@@ -113,22 +113,19 @@
       };
 
       /**
-       * Prepare name and description parameters
+       * Prepare name and url parameters
        * if we are adding resource with layers.
        *
        * Parse all selected layers, extract name
-       * and title to build name and desc params like
+       * and title to build name param like
        *   name : name1,name2,name3
-       *   desc : title1,title2,title3
        */
       var setLayersParams = function (params) {
         if (angular.isArray(params.selectedLayers) && params.selectedLayers.length > 0) {
-          var names = [],
-            descs = [];
+          var names = [];
 
           angular.forEach(params.selectedLayers, function (layer) {
             names.push(layer.Name || layer.name);
-            descs.push(layer.Title || layer.title);
           });
 
           var addLayersInUrl = params.addLayersInUrl;
@@ -143,8 +140,7 @@
 
           if (params.wmsResources.addLayerNamesMode == "resourcename") {
             angular.extend(params, {
-              name: names.join(","),
-              desc: descs.join(",")
+              name: names.join(",")
             });
           }
         }

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
@@ -259,7 +259,7 @@
                   id="gn-addonlinesrc-layers-row"
                   class="col-sm-9 col-md-offset-2"
                   data-ng-if="OGCProtocol != null  && isWMSProtocol()"
-                  data-selection-mode="(!isWMSProtocolWithLayersInUrl() && isEditing) ? 'single' : 'multiple'"
+                  data-selection-mode="(!isWMSProtocolWithLayersInUrl()) ? 'single' : 'multiple'"
                   data-layers="capabilitiesLayers"
                   data-selection="params.selectedLayers"
                 ></div>
@@ -270,7 +270,7 @@
                   id="gn-addonlinesrc-layers-row"
                   class="col-sm-9 col-md-offset-2"
                   data-ng-if="OGCProtocol != null && !isWMSProtocol()"
-                  data-gn-selection-mode="isEditing ? 'single' : 'multiple'"
+                  data-gn-selection-mode="'single'"
                   data-layers="layers"
                   data-selection="params.selectedLayers"
                 ></div>
@@ -307,6 +307,8 @@
                   type="text"
                   data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.name.tooltip}}"
                   placeholder="Name"
+                  data-ng-readonly='config.wmsResources.addLayerNamesMode ==
+                "resourcename" && OGCProtocol != null && isWMSProtocol()'
                 />
               </div>
               <div
@@ -325,6 +327,8 @@
                   lang="{{val}}"
                   data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.name.tooltip}}"
                   data-ng-model="params.name[val]"
+                  data-ng-readonly='config.wmsResources.addLayerNamesMode ==
+                "resourcename" && OGCProtocol != null && isWMSProtocol()'
                 />
               </div>
 


### PR DESCRIPTION
- Make the online resource name non-editable, as it must contain the WMS layer name to work properly with the Add to Map feature.
- Preserve online resource description changes. Previously, the description was always overridden with the WMS layer title, not keeping the user changes.
- Allow to select only 1  WMS layer when adding a new online resource, to make it consistent with the editing of the online resource.

Related to #6195