### PR TITLE
Record view / don't call records history when not authorised

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/footer.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/footer.html
@@ -6,7 +6,7 @@
 
 <div
   class="row gn-padding-top"
-  data-ng-show="isRecordHistoryEnabled
+  data-ng-if="isRecordHistoryEnabled
                  && user.isEditorOrMore()
                  && mdView.current.record.draft != 'y'"
 >


### PR DESCRIPTION
Currently accessing the metadata detail page for unlogged users, there is a failing request:

https://SERVER/geonetwork/srv/api/records/status/search?type=workflow&type=task&type=event&record=1782&from=0&size=5

```
{"message":"Access denied","code":"forbidden","description":"Access is denied. To access, try again with a user containing more priviledges."}
```

This is related to the record history, should not be requested for users not authorised to view that information.