### PR TITLE
Avoid retrieve metadata associated records aggregations when the metadata have no associated records

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/mdview/mdviewService.js
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/mdviewService.js
@@ -165,28 +165,30 @@
             });
 
             // Collect stats in main portal as some records may not be visible in subportal
-            $http
-              .post("../../srv/api/search/records/_msearch", body)
-              .then(function (data) {
-                gnMdViewObj.current.record.related = [];
+            if (Object.entries(recordsMap).length !== 0) {
+              $http
+                .post("../../srv/api/search/records/_msearch", body)
+                .then(function (data) {
+                  gnMdViewObj.current.record.related = [];
 
-                Object.keys(relatedRecords).map(function (k) {
-                  relatedRecords[k] &&
-                    relatedRecords[k].map(function (l, i) {
-                      var md = recordsMap[l._id];
-                      relatedRecords[k][i] = md;
-                    });
+                  Object.keys(relatedRecords).map(function (k) {
+                    relatedRecords[k] &&
+                      relatedRecords[k].map(function (l, i) {
+                        var md = recordsMap[l._id];
+                        relatedRecords[k][i] = md;
+                      });
+                  });
+
+                  gnMdViewObj.current.record.related = relatedRecords;
+                  gnMdViewObj.current.record.related.all = Object.values(recordsMap);
+                  gnMdViewObj.current.record.related.uuids = Object.keys(recordsMap);
+
+                  relatedRecordKeysWithValues.forEach(function (key, index) {
+                    gnMdViewObj.current.record.related["aggregations_" + key] =
+                      data.data.responses[index].aggregations;
+                  });
                 });
-
-                gnMdViewObj.current.record.related = relatedRecords;
-                gnMdViewObj.current.record.related.all = Object.values(recordsMap);
-                gnMdViewObj.current.record.related.uuids = Object.keys(recordsMap);
-
-                relatedRecordKeysWithValues.forEach(function (key, index) {
-                  gnMdViewObj.current.record.related["aggregations_" + key] =
-                    data.data.responses[index].aggregations;
-                });
-              });
+            }
           }
         }
 


### PR DESCRIPTION
When a record has no associated records the query to retrieve the associated records aggregations should not be sent, otherwise the request fails:

POST https://SERVER/geonetwork/srv/api/search/records/_msearch

```
{"message":"IllegalArgumentException","code":"unsatisfied_request_parameter","description":"argument \"content\" is null"}
```