### PR TITLE
change the method for the password's minLength

### DIFF
--- a/web-ui/src/main/resources/catalog/js/LoginController.js
+++ b/web-ui/src/main/resources/catalog/js/LoginController.js
@@ -84,7 +84,8 @@
       $scope.isShowLoginAsLink = gnGlobalSettings.isShowLoginAsLink;
       $scope.isUserProfileUpdateEnabled = gnGlobalSettings.isUserProfileUpdateEnabled;
 
-      $scope.passwordMinLength = Math.min(
+      // take the bigger of the two values
+      $scope.passwordMinLength = Math.max(
         gnConfig["system.security.passwordEnforcement.minLength"],
         6
       );

--- a/web-ui/src/main/resources/catalog/js/admin/UserGroupController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/UserGroupController.js
@@ -118,7 +118,8 @@
       $scope.isLoadingGroups = false;
 
       gnConfigService.load().then(function (c) {
-        $scope.passwordMinLength = Math.min(
+        // take the bigger of the two values 
+        $scope.passwordMinLength = Math.max(
           gnConfig["system.security.passwordEnforcement.minLength"],
           6
         );


### PR DESCRIPTION
change the method for the password's minLength to be max so if a bigger value than 6 is retrieved from "system.security.passwordEnforcement.minLength" this is taken into account. previously this was set to min, so if you wanted the user to have a password with a minimum length bigger than 6 you had to make code changes. also added a comment to highlight this.