### PR TITLE
Map accessibility setting

### DIFF
--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
@@ -749,7 +749,7 @@
                 <!-- boolean -->
                 <div
                   class="row"
-                  data-ng-switch-when="is3DModeAllowed|isVegaEnabled|isSaveMapInCatalogAllowed|isExportMapAsImageEnabled|useOSM|isUserRecordsOnly|isFilterTagsDisplayed|isFilterTagsDisplayedInSearch|showMapInFacet|autoFitOnLayer|showSocialBarInFooter|isSocialbarEnabled|isLogoInHeader|isHeaderFixed|isMenubarAccessible|fluidLayout|fluidHeaderLayout|fluidEditorLayout|showGNName|humanizeDates|sortKeywordsAlphabetically|showMosaic|showMaps|showApplicationInfoAndLinksInFooter|showBatchDropdown|moreLikeThisSameType|allowRemoteRecordLink"
+                  data-ng-switch-when="is3DModeAllowed|isVegaEnabled|isSaveMapInCatalogAllowed|isAccessible|isExportMapAsImageEnabled|useOSM|isUserRecordsOnly|isFilterTagsDisplayed|isFilterTagsDisplayedInSearch|showMapInFacet|autoFitOnLayer|isAccessible|showSocialBarInFooter|isSocialbarEnabled|isLogoInHeader|isHeaderFixed|isMenubarAccessible|fluidLayout|fluidHeaderLayout|fluidEditorLayout|showGNName|humanizeDates|sortKeywordsAlphabetically|showMosaic|showMaps|showApplicationInfoAndLinksInFooter|showBatchDropdown|moreLikeThisSameType|allowRemoteRecordLink"
                   data-ng-switch-when-separator="|"
                 >
                   <div class="col-lg-5 gn-nopadding-left">

--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
@@ -749,7 +749,7 @@
                 <!-- boolean -->
                 <div
                   class="row"
-                  data-ng-switch-when="is3DModeAllowed|isVegaEnabled|isSaveMapInCatalogAllowed|isAccessible|isExportMapAsImageEnabled|useOSM|isUserRecordsOnly|isFilterTagsDisplayed|isFilterTagsDisplayedInSearch|showMapInFacet|autoFitOnLayer|isAccessible|showSocialBarInFooter|isSocialbarEnabled|isLogoInHeader|isHeaderFixed|isMenubarAccessible|fluidLayout|fluidHeaderLayout|fluidEditorLayout|showGNName|humanizeDates|sortKeywordsAlphabetically|showMosaic|showMaps|showApplicationInfoAndLinksInFooter|showBatchDropdown|moreLikeThisSameType|allowRemoteRecordLink"
+                  data-ng-switch-when="is3DModeAllowed|isVegaEnabled|isSaveMapInCatalogAllowed|isAccessible|isExportMapAsImageEnabled|useOSM|isUserRecordsOnly|isFilterTagsDisplayed|isFilterTagsDisplayedInSearch|showMapInFacet|autoFitOnLayer|showSocialBarInFooter|isSocialbarEnabled|isLogoInHeader|isHeaderFixed|isMenubarAccessible|fluidLayout|fluidHeaderLayout|fluidEditorLayout|showGNName|humanizeDates|sortKeywordsAlphabetically|showMosaic|showMaps|showApplicationInfoAndLinksInFooter|showBatchDropdown|moreLikeThisSameType|allowRemoteRecordLink"
                   data-ng-switch-when-separator="|"
                 >
                   <div class="col-lg-5 gn-nopadding-left">

--- a/web-ui/src/main/resources/catalog/components/viewer/ViewerDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/ViewerDirective.js
@@ -140,6 +140,15 @@
               scope.is3DModeAllowed = gnViewerSettings.mapConfig.is3DModeAllowed || false;
               scope.is3dEnabled = gnConfig["is3dEnabled"] || false;
 
+              // map accessibility is disabled by default
+              scope.isAccessible = gnViewerSettings.mapConfig.isAccessible || false;
+              // add `tabindex="0"` so the map can get keyboard focus
+              //
+              // more info: https://openlayers.org/en/latest/examples/accessible.html
+              if (scope.isAccessible) {
+                iElement.find("#map").attr("tabindex", 0);
+              }
+
               // By default, sync only background layer
               // between main map and search map
               scope.syncAllLayers = false;

--- a/web-ui/src/main/resources/catalog/components/viewer/partials/mainviewer.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/partials/mainviewer.html
@@ -1,5 +1,11 @@
 <div class="wrapper" data-ng-controller="gnViewerController as ctrl">
-  <div id="map" ol-map="map" class="map" gn-vector-feature-tool-tip="map" onclick="focus(this)"></div>
+  <div
+    id="map"
+    ol-map="map"
+    class="map"
+    gn-vector-feature-tool-tip="map"
+    onclick="focus(this)"
+  ></div>
   <div gn-gfi="" map="map"></div>
   <gn-features-tables
     gn-features-tables-map="map"

--- a/web-ui/src/main/resources/catalog/components/viewer/partials/mainviewer.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/partials/mainviewer.html
@@ -1,13 +1,10 @@
 <div class="wrapper" data-ng-controller="gnViewerController as ctrl">
-  <div
-    id="map"
-    ol-map="map"
-    class="map"
-    tabindex="0"
-    gn-vector-feature-tool-tip="map"
-  ></div>
+  <div id="map" ol-map="map" class="map" gn-vector-feature-tool-tip="map" onclick="focus(this)"></div>
   <div gn-gfi="" map="map"></div>
-  <gn-features-tables gn-features-tables-map="map" data-height="300"></gn-features-tables>
+  <gn-features-tables
+    gn-features-tables-map="map"
+    data-height="300"
+  ></gn-features-tables>
 
   <div gn-localisation-input map="map"></div>
 
@@ -29,7 +26,10 @@
       <span class="label" ng-show="showToolLabels" translate="">addLayers</span>
       <span role="tooltip" translate="">addLayers</span>
     </button>
-    <div class="panel panel-default panel-tools" ng-show="activeTools.addLayers">
+    <div
+      class="panel panel-default panel-tools"
+      ng-show="activeTools.addLayers"
+    >
       <div class="panel-heading">
         <h3>{{'AddALayer' | translate}}</h3>
       </div>
@@ -117,8 +117,16 @@
         <h3>{{'ManageLayers' | translate}}</h3>
       </div>
       <div class="panel-body layers">
-        <div gn-layermanager="" gn-layermanager-map="map" class="gn-margin-bottom"></div>
-        <div gn-baselayerswitcher="" gn-baselayerswitcher-map="map" data-dropup=""></div>
+        <div
+          gn-layermanager=""
+          gn-layermanager-map="map"
+          class="gn-margin-bottom"
+        ></div>
+        <div
+          gn-baselayerswitcher=""
+          gn-baselayerswitcher-map="map"
+          data-dropup=""
+        ></div>
         <br data-ng-show="is3dEnabled" />
         <div
           data-gn-terrain-switcher="ol3d"
@@ -137,10 +145,15 @@
       ng-hide="disabledTools.projectionSwitcher"
     >
       <span class="fa fa-th-large"></span>
-      <span class="label" ng-show="showToolLabels" translate="">projectionSwitcher</span>
+      <span class="label" ng-show="showToolLabels" translate=""
+        >projectionSwitcher</span
+      >
       <span role="tooltip" translate="">projectionSwitcher</span>
     </button>
-    <div class="panel-default panel-tools" ng-show="activeTools.projectionSwitcher">
+    <div
+      class="panel-default panel-tools"
+      ng-show="activeTools.projectionSwitcher"
+    >
       <div gn-projection-switcher="map"></div>
     </div>
 
@@ -174,7 +187,9 @@
       aria-label="{{'filterData' | translate}}"
     >
       <span class="fa fa-filter"></span>
-      <span class="label" ng-show="showToolLabels" translate="">filterData</span>
+      <span class="label" ng-show="showToolLabels" translate=""
+        >filterData</span
+      >
       <span role="tooltip" translate="">filterData</span>
     </button>
     <div
@@ -200,21 +215,34 @@
       aria-label="{{'processesTool' | translate}}"
     >
       <span class="fa fa-cogs"></span>
-      <span class="label" ng-show="showToolLabels" translate="">processesTool</span>
+      <span class="label" ng-show="showToolLabels" translate=""
+        >processesTool</span
+      >
       <span role="tooltip" translate="">processesTool</span>
     </button>
-    <div class="panel panel-default panel-tools" ng-show="activeTools.processes">
+    <div
+      class="panel panel-default panel-tools"
+      ng-show="activeTools.processes"
+    >
       <div class="panel-heading">
         <h3>{{'processesTool' | translate}}</h3>
       </div>
       <div class="panel-body">
         <p translate="" class="text-muted">WPSDescription</p>
         <tabset class="info-tabset">
-          <tab heading="{{'wpsByUrl' | translate}}" active="wpsTabs.byUrl" role="tab">
+          <tab
+            heading="{{'wpsByUrl' | translate}}"
+            active="wpsTabs.byUrl"
+            role="tab"
+          >
             <br />
             <gn-wps-url-discovery wps-link="selectedWps" />
           </tab>
-          <tab heading="{{'wpsRecent' | translate}}" active="wpsTabs.recent" role="tab">
+          <tab
+            heading="{{'wpsRecent' | translate}}"
+            active="wpsTabs.recent"
+            role="tab"
+          >
             <br />
             <gn-wps-recent-list wps-link="selectedWps" />
           </tab>
@@ -293,7 +321,9 @@
       </div>
       <div class="panel-body">
         <div class="gn-measure-text">
-          <div class="text-muted hidden-print" translate>measure_instruction</div>
+          <div class="text-muted hidden-print" translate>
+            measure_instruction
+          </div>
           <dl class="dl-horizontal">
             <dt>{{'Distance' | translate}}</dt>
             <dd>{{measureObj.distance}}</dd>
@@ -314,7 +344,9 @@
       aria-label="{{'Annotations' | translate}}"
     >
       <span class="fa fa-pencil"></span>
-      <span class="label" ng-show="showToolLabels" translate="">Annotations</span>
+      <span class="label" ng-show="showToolLabels" translate=""
+        >Annotations</span
+      >
       <span role="tooltip" translate="">Annotations</span>
     </button>
     <div class="panel panel-default panel-tools" ng-show="drawVector.active">
@@ -322,7 +354,12 @@
         <h3>{{'Annotations' | translate}}</h3>
       </div>
       <div class="panel-body">
-        <div class="gn-draw-styleform" gn-draw="" map="map" vector="drawVector"></div>
+        <div
+          class="gn-draw-styleform"
+          gn-draw=""
+          map="map"
+          vector="drawVector"
+        ></div>
       </div>
     </div>
 
@@ -333,8 +370,13 @@
       ng-hide="disabledTools.syncAllLayers"
       aria-label="{{'syncAllLayers' | translate}}"
     >
-      <span class="fa fa-sync" ng-class="syncAllLayers ? 'fa-lock' : 'fa-unlock'" />
-      <span class="label" ng-show="showToolLabels" translate="">syncAllLayers</span>
+      <span
+        class="fa fa-sync"
+        ng-class="syncAllLayers ? 'fa-lock' : 'fa-unlock'"
+      />
+      <span class="label" ng-show="showToolLabels" translate=""
+        >syncAllLayers</span
+      >
       <span role="tooltip" translate="">syncAllLayers</span>
     </button>
   </div>
@@ -375,11 +417,19 @@
       data-ng-click="switch2D3D(map)"
       aria-label="{{'switchFrom2DTo3D' | translate}}"
     >
-      <span class="badge badge-left badge-2d" data-ng-hide="is3dEnabled">2D</span>
-      <span class="badge badge-left badge-3d" data-ng-show="is3dEnabled">3D</span>
+      <span class="badge badge-left badge-2d" data-ng-hide="is3dEnabled"
+        >2D</span
+      >
+      <span class="badge badge-left badge-3d" data-ng-show="is3dEnabled"
+        >3D</span
+      >
       <span class="fa fa-cube" />
-      <span class="badge badge-right badge-2d" data-ng-hide="is3dEnabled">2D</span>
-      <span class="badge badge-right badge-3d" data-ng-show="is3dEnabled">3D</span>
+      <span class="badge badge-right badge-2d" data-ng-hide="is3dEnabled"
+        >2D</span
+      >
+      <span class="badge badge-right badge-3d" data-ng-show="is3dEnabled"
+        >3D</span
+      >
       <span role="tooltip" data-translate="">switchFrom2DTo3D</span>
     </button>
     <button

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -760,6 +760,7 @@
             is3DModeAllowed: false,
             isSaveMapInCatalogAllowed: true,
             isExportMapAsImageEnabled: false,
+            isAccessible: false,
             storage: "sessionStorage",
             bingKey: "",
             listOfServices: {

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1118,6 +1118,8 @@
     "map/isMapViewerEnabled-help": "If unselected, the map tab will be disabled and will not be used.",
     "ui-isSaveMapInCatalogAllowed": "Allow users to save maps as metadata record",
     "ui-isSaveMapInCatalogAllowed-help": "From the map viewer, user can set the map title and abstract and save the map directly with the OWS context in the catalog as a metadata record.",
+    "ui-isAccessible": "Make the Map accessible",
+    "ui-isAccessible-help": "When the Map is accessible it can be used with a keyboard and will work when it has the focus. Note: when the Map is accessible zoom in and out with a mouse won't work until the map has the focus",
     "ui-advancedConfig": "JSON configuration",
     "ui-workflowAssistApps": "List of workflow assist apps",
     "ui-workflowAssistApps-help": "External Workflow assist applications. For example: App url: https://www.example.com/{isoLang}/{uuid} Label Key: WorkflowAssistApps-example-label. (this key should present in *-custom.json for translations.). URL can contain the following variables between '{' and '}': <ul><li><strong>uuid</strong> for the current metadata uuid</li><li><strong>lang</strong> for 3 letters language code</li><li> <strong>isoLang</strong> for 2 letters language code.</li></ul>",


### PR DESCRIPTION
This PR adds a setting to make the map accessible. The setting is off by default.

The accessible map caused some confusion to users because you first need the focus on the map before you can interact with it. Zooming in and out with the mouse doesn't work without the map having focus.

The new setting reverts the map to the old situation by default (direct interaction) and can be switched on to have keyboard interaction when the map has the focus.

<img width="693" alt="gn-a11y-map" src="https://user-images.githubusercontent.com/19608667/228759700-a7e4eb43-167a-408b-b32c-c9b316ca62cd.png">
