### PR TITLE
Changed the messages about existing users or emails to be identical, to make it harder to enumerate through users

### DIFF
--- a/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages.properties
+++ b/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages.properties
@@ -54,8 +54,8 @@ user_password_changed='%s' password was updated.
 user_password_notchanged=A problem occurred trying to change '%s' password. Contact the helpdesk.
 user_password_invalid_changekey='%s' is an invalid change key for '%s'. Change keys are only valid for one day.
 user_registered=User '%s' registered.
-user_with_that_email_found=A user with this email '%s' already exists.
-user_with_that_username_found=A user with this username '%s' already exists.
+user_with_that_email_found=A user with this email or username already exists.
+user_with_that_username_found=A user with this email or username already exists.
 register_email_admin_subject=%s / New account for %s as %s
 register_email_admin_message=Dear Admin,\n\
   Newly registered user %s has requested %s access for %s.\n\

--- a/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages_fre.properties
+++ b/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages_fre.properties
@@ -45,8 +45,8 @@ user_password_sent=Si l''utilisateur existe, vous recevrez un courriel contenant
 user_password_changed=Le mot de passe de %s a \u00E9t\u00E9 mis \u00E0 jour.
 user_password_notchanged=\u00C9chec lors du changement de mot de passe de %s. Contactez le support.
 user_password_invalid_changekey=%s est une cl\u00E9 invalide pour %s. Les cl\u00E9s ne sont valides que pendant une journ\u00E9e.
-user_with_that_email_found=Un utilisateur avec cette adresse email %s existe d\u00E9j\u00E0.
-user_with_that_username_found=Un utilisateur avec ce nom d''utilisateur %s existe d\u00E9j\u00E0.
+user_with_that_email_found=Un utilisateur avec cette adresse email ou ce nom d''utilisateur existe d\u00E9j\u00E0.
+user_with_that_username_found=Un utilisateur avec cette adresse email ou ce nom d''utilisateur existe d\u00E9j\u00E0.
 register_email_admin_subject=%s / Cr\u00E9ation de compte pour %s en tant que %s
 register_email_admin_message=Cher administrateur,\n\
   L'utilisateur %s vient de demander une cr\u00E9ation de compte pour %s.\n\


### PR DESCRIPTION
This PR relates to the messages that are triggered when creating a new user with an email or username that already exists. By making the message identical in both cases, and not including the actual value, it makes it much harder for bad actors to enumerate through the users.