### PR TITLE
Standard / ISO19115-3 / Editor / Reference system from EPSG database

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/config-editor.xml
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/config-editor.xml
@@ -321,14 +321,14 @@
               data-variables="cit:role/cit:CI_RoleCode/@codeListValue~{role}"/>
     </for>
 
-    <for name="mdb:referenceSystemInfo" addDirective="data-gn-directory-entry-selector">
+    <!--<for name="mdb:referenceSystemInfo" addDirective="data-gn-directory-entry-selector">
       <directiveAttributes
         data-template-add-action="true"
         data-search-action="true"
         data-template-type="CRS"
         data-filter='{"root": "mrs:MD_ReferenceSystem"}'
         data-insert-modes=""/>
-    </for>
+    </for>-->
 
 
     <for name="mri:extent" addDirective="data-gn-directory-entry-selector">


### PR DESCRIPTION
By default, do not configure usage of directory for reference system. Most of the users populate the reference system from the EPSG database (like in ISO19139 editor)

Before
![image](https://user-images.githubusercontent.com/1701393/229052425-a4e08485-920e-4a03-a986-38fa4d392760.png)

After 
![image](https://user-images.githubusercontent.com/1701393/229052451-7e8837b5-9581-45dc-a5db-a33ea312c6ba.png)
