### PR TITLE
Make local jetty run plugin context path configurable

### DIFF
--- a/web/pom.xml
+++ b/web/pom.xml
@@ -988,7 +988,7 @@
           <contextXml>${basedir}/jetty-context.xml</contextXml>
           <webAppSourceDirectory>${project.build.directory}/geonetwork</webAppSourceDirectory>
           <webApp>
-            <contextPath>/${application.name}</contextPath>
+            <contextPath>${geonetwork.webapp.contextpath}</contextPath>
             <descriptor>${project.build.directory}/WEB-INF/web.xml</descriptor>
             <baseResource implementation="org.eclipse.jetty.util.resource.ResourceCollection">
               <resourcesAsCSV>
@@ -1294,6 +1294,7 @@
     <geonetwork.webapp.dir>${basedir}/src/main/webapp</geonetwork.webapp.dir>
     <geonetwork.webapp.js.dir>${geonetwork.webapp.dir}/scripts</geonetwork.webapp.js.dir>
     <geonetwork.build.dir>${project.build.directory}/${project.build.finalName}</geonetwork.build.dir>
+    <geonetwork.webapp.contextpath>/${application.name}</geonetwork.webapp.contextpath>
     <schema-plugins.dir>${basedir}/src/main/webapp/WEB-INF/data/config/schema_plugins</schema-plugins.dir>
     <geonetwork.webapp.css.dir>${geonetwork.webapp.dir}</geonetwork.webapp.css.dir>
     <minify.verbose>false</minify.verbose>


### PR DESCRIPTION
When running jetty locally it was not apparently possible to configure the maven jetty plugin to run under the _root_ context  (`/`). This change allows passing the following variable to `mvn` to run under `/` (for example) instead of `/geonetwork`.

```
jetty:run -Dgeonetwork.webapp.contextpath=/
```

Question: should such change be documented in the docs?