### PR TITLE
Implement a more extendable openid connect security

### DIFF
--- a/core/src/main/java/jeeves/services/RegExpReplace.java
+++ b/core/src/main/java/jeeves/services/RegExpReplace.java
@@ -42,7 +42,7 @@ import java.util.regex.Pattern;
 //=============================================================================
 
 /**
- * This service reads a configuration xml file containint containing pattern-replacement pairs and
+ * This service reads a configuration xml file containing pattern-replacement pairs and
  * applies all the pairs to each text element of the output. The configuration is read from
  * xml/regexp.xml and is formatted: <regexp> <expr pattern="..." replacement="..."/> </regexp>
  */

--- a/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/OidcUser2GeonetworkUser.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/OidcUser2GeonetworkUser.java
@@ -52,21 +52,21 @@ import java.util.Map;
 public class OidcUser2GeonetworkUser {
 
     @Autowired
-    OIDCConfiguration oidcConfiguration;
+    protected OIDCConfiguration oidcConfiguration;
     @Autowired
-    OIDCRoleProcessor oidcRoleProcessor;
+    protected OIDCRoleProcessor oidcRoleProcessor;
     @Autowired
-    SimpleOidcUserFactory simpleOidcUserFactory;
+    protected SimpleOidcUserFactory simpleOidcUserFactory;
     @Autowired
-    private UserRepository userRepository;
+    protected UserRepository userRepository;
     @Autowired
-    private GroupRepository groupRepository;
+    protected GroupRepository groupRepository;
     @Autowired
-    private LanguageRepository langRepository;
+    protected LanguageRepository langRepository;
     @Autowired
-    private UserGroupRepository userGroupRepository;
+    protected UserGroupRepository userGroupRepository;
     @Autowired
-    private GeonetworkAuthenticationProvider geonetworkAuthenticationProvider;
+    protected GeonetworkAuthenticationProvider geonetworkAuthenticationProvider;
 
 
     public UserDetails getUserDetails(Map attributes, boolean withDbUpdate) throws Exception {
@@ -158,7 +158,7 @@ public class OidcUser2GeonetworkUser {
      * @param user          to apply the changes to.
      */
     //from keycloak
-    private void updateGroups(Map<Profile, List<String>> profileGroups, User user) {
+    protected void updateGroups(Map<Profile, List<String>> profileGroups, User user) {
         // First we remove all previous groups
         userGroupRepository.deleteAll(UserGroupSpecs.hasUserId(user.getId()));
 

--- a/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/SimpleOidcUser.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/SimpleOidcUser.java
@@ -42,7 +42,7 @@ import java.util.Map;
  * <p>
  * parts taken from BaselUser (GN keycloak plugin)
  */
-class SimpleOidcUser {
+public class SimpleOidcUser {
 
 
     private String username;
@@ -61,7 +61,7 @@ class SimpleOidcUser {
      * @param idToken  The User's ID token
      * @param attributes All the user's claims (ID Token claims + USERINFO claims)
      */
-    SimpleOidcUser(OIDCConfiguration oidcConfiguration, OIDCRoleProcessor oidcRoleProcessor, OidcIdToken idToken, Map userAttributes) throws Exception {
+    public SimpleOidcUser(OIDCConfiguration oidcConfiguration, OIDCRoleProcessor oidcRoleProcessor, OidcIdToken idToken, Map userAttributes) throws Exception {
         Map attributes = (userAttributes == null) ? new HashMap() : userAttributes;
 
         username = (String) idToken.getClaims().get(oidcConfiguration.getUserNameAttribute());
@@ -132,7 +132,7 @@ class SimpleOidcUser {
         }
     }
 
-    SimpleOidcUser(OIDCConfiguration oidcConfiguration, OIDCRoleProcessor oidcRoleProcessor, Map attributes) throws Exception {
+    public SimpleOidcUser(OIDCConfiguration oidcConfiguration, OIDCRoleProcessor oidcRoleProcessor, Map attributes) throws Exception {
         username = (String) attributes.get(oidcConfiguration.getUserNameAttribute());
         if (username == null) {
             username = (String) attributes.get(StandardClaimNames.PREFERRED_USERNAME);

--- a/domain/src/main/java/org/fao/geonet/domain/Group.java
+++ b/domain/src/main/java/org/fao/geonet/domain/Group.java
@@ -341,7 +341,7 @@ public class Group extends Localized implements Serializable {
      * Should we use the enableAllowedCategories list on this group? If false, we allow all
      * categories.
      *
-     * @param enableCategoriesRestriction
+     * @param enableAllowedCategories
      * @return this group entity object
      */
     public Group setEnableAllowedCategories(Boolean enableAllowedCategories) {


### PR DESCRIPTION
While integrating GeoNetwork with ACM/IDM, an OpenID connect flavor for Flanders/Belgium, we encountered some issues extending the default OpenID connect implementation of GeoNetwork.   

This PR is for enabling better extendability when it is needed to integrate OpenID with other implementations. 