### PR TITLE
Standard / ISO19115-3 / Do not alter creation date and allow editing of metadata identifier descriptors

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/extract-uuid.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/extract-uuid.xsl
@@ -1,7 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- FIXME: Which MD_Identifier do we select under mds:metadataIdentifier
-  probably should use some form of match on a particular codeSpace?
--->
 <xsl:stylesheet version="2.0" xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0"
   xmlns:mcc="http://standards.iso.org/iso/19115/-3/mcc/1.0"
   xmlns:mdb="http://standards.iso.org/iso/19115/-3/mdb/2.0"

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/layout-custom-fields.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/layout-custom-fields.xsl
@@ -18,16 +18,9 @@
   exclude-result-prefixes="#all">
 
 
-  <!-- Readonly elements
-  [parent::mds:metadataIdentifier and
-                        mcc:codeSpace/gco:CharacterString='urn:uuid']|
-                      mds:dateInfo/cit:CI_Date[cit:dateType/cit:CI_DateTypeCode
-                        /@codeListValue='revision']
--->
+  <!-- Readonly elements -->
   <xsl:template mode="mode-iso19115-3.2018"
                 match="mdb:metadataIdentifier/mcc:MD_Identifier/mcc:code|
-                       mdb:metadataIdentifier/mcc:MD_Identifier/mcc:codeSpace|
-                       mdb:metadataIdentifier/mcc:MD_Identifier/mcc:description|
                        mdb:dateInfo/cit:CI_Date[cit:dateType/cit:CI_DateTypeCode = 'revision']/cit:date|
                        mdb:dateInfo/cit:CI_Date[cit:dateType/cit:CI_DateTypeCode = 'revision']/cit:dateType"
                 priority="2000">

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/update-fixed-info.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/update-fixed-info.xsl
@@ -60,10 +60,6 @@
   <xsl:variable name="url" select="/root/env/siteURL"/>
   <xsl:variable name="uuid" select="/root/env/uuid"/>
 
-  <xsl:variable name="metadataIdentifierCodeSpace"
-                select="'urn:uuid'"
-                as="xs:string"/>
-
   <xsl:template match="/root">
     <xsl:apply-templates select="mdb:MD_Metadata"/>
   </xsl:template>
@@ -80,25 +76,28 @@
 
       <xsl:call-template name="add-iso19115-3.2018-namespaces"/>
 
-      <!-- Add metadataIdentifier if it doesn't exist
-      TODO: only if not harvested -->
-      <mdb:metadataIdentifier>
-        <mcc:MD_Identifier>
-          <!-- authority could be for this GeoNetwork node ?
-            <mcc:authority><cit:CI_Citation>etc</cit:CI_Citation></mcc:authority>
-          -->
-          <mcc:code>
-            <gco:CharacterString><xsl:value-of select="/root/env/uuid"/></gco:CharacterString>
-          </mcc:code>
-          <mcc:codeSpace>
-            <gco:CharacterString><xsl:value-of select="$metadataIdentifierCodeSpace"/></gco:CharacterString>
-          </mcc:codeSpace>
-        </mcc:MD_Identifier>
-      </mdb:metadataIdentifier>
+      <xsl:for-each select="mdb:metadataIdentifier">
+        <xsl:copy>
+          <mcc:MD_Identifier>
+            <xsl:apply-templates select="*/mcc:authority"/>
 
-  <!--    <xsl:apply-templates select="mdb:metadataIdentifier[
-                                    mcc:MD_Identifier/mcc:codeSpace/gco:CharacterString !=
-                                    $metadataIdentifierCodeSpace]"/>-->
+            <xsl:choose>
+              <xsl:when test="/root/env/uuid != ''">
+                <mcc:code>
+                  <gco:CharacterString><xsl:value-of select="/root/env/uuid"/></gco:CharacterString>
+                </mcc:code>
+              </xsl:when>
+              <xsl:otherwise>
+                <xsl:apply-templates select="*/mcc:code"/>
+              </xsl:otherwise>
+            </xsl:choose>
+
+            <xsl:apply-templates select="*/mcc:codeSpace"/>
+            <xsl:apply-templates select="*/mcc:version"/>
+            <xsl:apply-templates select="*/mcc:description"/>
+          </mcc:MD_Identifier>
+        </xsl:copy>
+      </xsl:for-each>
 
       <xsl:apply-templates select="mdb:defaultLocale"/>
       <xsl:apply-templates select="mdb:parentMetadata"/>


### PR DESCRIPTION
* Preserve creation date

eg. while running CSW transaction, the newRecord and createDate flag is not set. More carefully check creation and revision dates and avoid removal of creation date.


```xml
<csw:Transaction service="CSW" version="2.0.2" xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
                 xmlns:gml="http://www.opengis.net/gml" xmlns:mmi="http://standards.iso.org/iso/19115/-3/mmi/1.0"
                 xmlns:mcc="http://standards.iso.org/iso/19115/-3/mcc/1.0"
                 xmlns:msr="http://standards.iso.org/iso/19115/-3/msr/2.0"
                 xmlns:mac="http://standards.iso.org/iso/19115/-3/mac/2.0"
                 xmlns:cit="http://standards.iso.org/iso/19115/-3/cit/2.0"
                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                 xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0"
                 xmlns:cat="http://standards.iso.org/iso/19115/-3/cat/1.0"
                 xmlns:mco="http://standards.iso.org/iso/19115/-3/mco/1.0"
                 xmlns:lan="http://standards.iso.org/iso/19115/-3/lan/1.0"
                 xmlns:gex="http://standards.iso.org/iso/19115/-3/gex/1.0"
                 xmlns:gcx="http://standards.iso.org/iso/19115/-3/gcx/1.0"
                 xmlns:mas="http://standards.iso.org/iso/19115/-3/mas/1.0"
                 xmlns:mrd="http://standards.iso.org/iso/19115/-3/mrd/1.0"
                 xmlns:mrc="http://standards.iso.org/iso/19115/-3/mrc/2.0"
                 xmlns:mex="http://standards.iso.org/iso/19115/-3/mex/1.0"
                 xmlns:mpc="http://standards.iso.org/iso/19115/-3/mpc/1.0"
                 xmlns:mri="http://standards.iso.org/iso/19115/-3/mri/1.0"
                 xmlns:gfc="http://standards.iso.org/iso/19110/gfc/1.1"
                 xmlns:mrl="http://standards.iso.org/iso/19115/-3/mrl/2.0"
                 xmlns:mdb="http://standards.iso.org/iso/19115/-3/mdb/2.0"
                 xmlns:mda="http://standards.iso.org/iso/19115/-3/mda/1.0"
                 xmlns:mrs="http://standards.iso.org/iso/19115/-3/mrs/1.0"
                 xmlns:srv="http://standards.iso.org/iso/19115/-3/srv/2.1"
                 xmlns:mdq="http://standards.iso.org/iso/19157/-2/mdq/1.0"
                 xmlns:mdt="http://standards.iso.org/iso/19115/-3/mdt/2.0"
                 xmlns:mds="http://standards.iso.org/iso/19115/-3/mds/2.0" xmlns:xlink="http://www.w3.org/1999/xlink">
  <csw:Insert>
    <mdb:MD_Metadata>
      <mdb:metadataIdentifier>
        <mcc:MD_Identifier>
          <mcc:code>
            <gco:CharacterString>test--create</gco:CharacterString>
          </mcc:code>
        </mcc:MD_Identifier>
      </mdb:metadataIdentifier>
      <mdb:dateInfo>
        <cit:CI_Date>
          <cit:date>
            <gco:Date>2023-02-13</gco:Date>
          </cit:date>
          <cit:dateType>
            <cit:CI_DateTypeCode
              codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_DateTypeCode"
              codeListValue="creation"/>
          </cit:dateType>
        </cit:CI_Date>
      </mdb:dateInfo>
      <mdb:dateInfo>
        <cit:CI_Date>
          <cit:date>
            <gco:Date>2023-02-13</gco:Date>
          </cit:date>
          <cit:dateType>
            <cit:CI_DateTypeCode
              codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_DateTypeCode"
              codeListValue="revision"/>
          </cit:dateType>
        </cit:CI_Date>
      </mdb:dateInfo>
      <mdb:identificationInfo>
        <mri:MD_DataIdentification>
          <mri:citation>
            <cit:CI_Citation>
              <cit:title>
                <gco:CharacterString>TEST</gco:CharacterString>
              </cit:title>
            </cit:CI_Citation>
          </mri:citation>
        </mri:MD_DataIdentification>
      </mdb:identificationInfo>
    </mdb:MD_Metadata>
  </csw:Insert>
</csw:Transaction>
```


* Preserve metadataIdentifier descriptors (authority, codespace, version and description). Only the code is readonly.

![image](https://user-images.githubusercontent.com/1701393/229725041-9b02d321-ceac-48c7-810f-07874463da0b.png)

