### PR TITLE
Map / Feature table improvement.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/viewer/gfi/GetFeatureInfoDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/gfi/GetFeatureInfoDirective.js
@@ -26,7 +26,7 @@
 
   var module = angular.module("gn_gfi_directive", ["angular.filter"]);
 
-  var gfiTemplateURL = "../../catalog/components/viewer/gfi/partials/" + "gfi-popup.html";
+  var gfiTemplateURL = "../../catalog/components/viewer/gfi/partials/gfi-popup.html";
 
   module.value("gfiTemplateURL", gfiTemplateURL);
 
@@ -217,7 +217,13 @@
 
         this.gnFeaturesTableManager.addTable(
           {
-            name: layer.get("label") || layer.get("name"),
+            name:
+              (layer.get("label") || layer.get("name")) +
+              (layer.get("currentStyle")
+                ? " (" +
+                  (layer.get("currentStyle").Title || layer.get("currentStyle").Name) +
+                  ")"
+                : ""),
             type: type
           },
           {

--- a/web-ui/src/main/resources/catalog/components/viewer/gfi/partials/featurestables.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/gfi/partials/featurestables.html
@@ -35,7 +35,7 @@
         data-ng-click="ctrl.currentTable = 'summary'"
         title="{{'summary' | translate}}"
       >
-        <i class="fa fa-fw fa-info-circle" />
+        <i class="fa fa-fw fa-lg fa-info-circle" />
       </a>
     </li>
   </ul>
@@ -43,8 +43,18 @@
   <div class="tab-content" data-ng-show="ctrl.currentTable == 'summary'">
     <ul>
       <li data-ng-repeat="table in ctrl.tables">
-        <span>{{table.name}}</span>&nbsp; {{table.loader.getCount()}}
-        <span data-translate="">features</span>
+        <a
+          href=""
+          data-ng-show="!table.loader.isLoading() && table.loader.getCount() > 0"
+          data-ng-click="ctrl.currentTable = table"
+        >
+          <span>{{table.name}}</span>&nbsp; {{table.loader.getCount()}}
+          <span data-translate="">features</span>
+        </a>
+        <span data-ng-hide="!table.loader.isLoading() && table.loader.getCount() > 0">
+          <span>{{table.name}}</span>&nbsp; {{table.loader.getCount()}}
+          <span data-translate="">features</span>
+        </span>
       </li>
     </ul>
   </div>

--- a/web-ui/src/main/resources/catalog/components/viewer/gfi/partials/featurestables.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/gfi/partials/featurestables.html
@@ -10,6 +10,7 @@
   <ul class="nav nav-tabs" data-ng-show="ctrl.tables.length > 1">
     <li
       data-ng-repeat="table in ctrl.tables"
+      data-ng-show="table.loader.getCount() > 0"
       data-ng-class="{active: table == ctrl.currentTable}"
     >
       <a role="tab" data-ng-click="ctrl.currentTable = table" title="{{::table.name}}">
@@ -18,20 +19,46 @@
           <i class="fa fa-spin fa-spinner"></i>
         </span>
         <span
-          ng-init="ctrl.currentTable=table"
+          ng-init="ctrl.currentTable = table"
           ng-if="!table.loader.isLoading() && table.loader.getCount() > 0"
           class="badge"
           >{{table.loader.getCount()}}</span
         >
       </a>
     </li>
+    <li
+      data-ng-show="ctrl.tables.length > 1"
+      data-ng-class="{active: 'summary' == ctrl.currentTable}"
+    >
+      <a
+        role="tab"
+        data-ng-click="ctrl.currentTable = 'summary'"
+        title="{{'summary' | translate}}"
+      >
+        <i class="fa fa-fw fa-info-circle" />
+      </a>
+    </li>
   </ul>
 
+  <div class="tab-content" data-ng-show="ctrl.currentTable == 'summary'">
+    <ul>
+      <li data-ng-repeat="table in ctrl.tables">
+        <span>{{table.name}}</span>&nbsp; {{table.loader.getCount()}}
+        <span data-translate="">features</span>
+      </li>
+    </ul>
+  </div>
   <div
     class="tab-content"
     data-ng-show="ctrl.currentTable == table"
     ng-repeat="table in ctrl.tables"
   >
+    <div class="pull-left">
+      <strong>
+        <span>{{table.name}}</span>&nbsp; {{table.loader.getCount()}}
+        <span data-translate="">features</span>
+      </strong>
+    </div>
     <gn-features-table
       gn-features-table-loader="table.loader"
       gn-features-table-loader-map="ctrl.map"


### PR DESCRIPTION
Before, a map with many layers could create many tabs making results hard to read. Also tab was not displaying the same name as in layer manager (style was missing if set).

![image](https://user-images.githubusercontent.com/1701393/229841864-54ce0cd9-c0fc-4b4a-8d99-8d3ec0227795.png)


After:

* Do not display tab if layer has no match

* Add a tab with a summary

![image](https://user-images.githubusercontent.com/1701393/229841768-4d698ccc-a133-42f9-824c-7b6883ddbf07.png)

* Add a title with full layer name (including style - like in layer manager)

![image](https://user-images.githubusercontent.com/1701393/229841815-7e4c0fdf-ba80-4dcd-9006-e151d1accd94.png)
