### PR TITLE
add isFileSystemDate flag to thesaurus model

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/Thesaurus.java
+++ b/core/src/main/java/org/fao/geonet/kernel/Thesaurus.java
@@ -99,6 +99,8 @@ public class Thesaurus {
 
     private String date;
 
+    private boolean isFileSystemDate;
+
     private String defaultNamespace;
 
     private String downloadUrl;
@@ -256,6 +258,10 @@ public class Thesaurus {
 
     public String getDate() {
         return date;
+    }
+
+    public boolean isFileSystemDate() {
+        return isFileSystemDate;
     }
 
     @Nonnull
@@ -996,6 +1002,7 @@ public class Thesaurus {
                 }
                 if (this.date == null) {
                     this.date = new ISODate(lastModifiedTime.toMillis(), true).toString();
+                    this.isFileSystemDate = true;
                 }
             }
 

--- a/core/src/main/java/org/fao/geonet/kernel/ThesaurusManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/ThesaurusManager.java
@@ -551,6 +551,10 @@ public class ThesaurusManager implements ThesaurusFinder {
             String date = currentTh.getDate();
             elDate.addContent(date);
 
+            Element elIsFileSystemDate = new Element("isFileSystemDate");
+            boolean isFileSystemDate = currentTh.isFileSystemDate();
+            elIsFileSystemDate.addContent(Boolean.toString(isFileSystemDate));
+
             Element elUrl = new Element("url");
             String url = currentTh.getDownloadUrl();
             elUrl.addContent(url);
@@ -568,6 +572,7 @@ public class ThesaurusManager implements ThesaurusFinder {
             elLoop.addContent(elDublinCoreMultilingual);
             elLoop.addContent(elMultilingualDescriptions);
             elLoop.addContent(elDate);
+            elLoop.addContent(elIsFileSystemDate);
             elLoop.addContent(elUrl);
             elLoop.addContent(elDefaultURI);
             elLoop.addContent(elType);


### PR DESCRIPTION
This is to fix the issue https://github.com/metadata101/iso19139.ca.HNAP/issues/308

The issue is the schema transformation style sheet doesn't know if the date is from the thesaurus itself or from the file system last modified date. Therefore, it cannot adjust logic to render different XML template.