### PR TITLE
Standard / ISO19115-3 / Add same mechanism as ISO19139 for parentIdenfier

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/update-fixed-info.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/update-fixed-info.xsl
@@ -100,7 +100,16 @@
       </xsl:for-each>
 
       <xsl:apply-templates select="mdb:defaultLocale"/>
-      <xsl:apply-templates select="mdb:parentMetadata"/>
+      
+      <xsl:choose>
+        <xsl:when test="/root/env/parentUuid != ''">
+          <mdb:parentMetadata uuidref="{/root/env/parentUuid}"/>
+        </xsl:when>
+        <xsl:when test="mdb:parentMetadata">
+          <xsl:apply-templates select="mdb:parentMetadata"/>
+        </xsl:when>
+      </xsl:choose>
+      
       <xsl:apply-templates select="mdb:metadataScope"/>
       <xsl:apply-templates select="mdb:contact"/>
 


### PR DESCRIPTION

Same as https://github.com/geonetwork/core-geonetwork/blob/main/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl#L147-L158

Even if most of the users don't use the parentMetadata for collection/series/partOfSeamlessDatabase relation type and if create child record was removed in https://github.com/geonetwork/core-geonetwork/pull/6708, some users (eg. ifremer) still use this encoding.