### PR TITLE
Editor / Improve default tab configuration.

### DIFF
--- a/schemas/config-editor.xsd
+++ b/schemas/config-editor.xsd
@@ -620,6 +620,16 @@ The key of the view name stored in ``{schema}/loc/{lang}/strings.xml`` or the el
             ]]></xs:documentation>
         </xs:annotation>
       </xs:attribute>
+      <xs:attribute name="default" type="xs:boolean" fixed="true">
+        <xs:annotation>
+          <xs:documentation><![CDATA[
+One default view per schema can be configured. The default tab of the default
+view will be used if no tab parameter set. To customize the tab to use
+on a per metadata record basis, check the EditorController.js file schemaCustomConfig
+function.
+            ]]></xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
       <xs:attribute name="disabled" type="xs:boolean" fixed="true">
         <xs:annotation>
           <xs:documentation><![CDATA[

--- a/schemas/dublin-core/src/main/plugin/dublin-core/layout/config-editor.xml
+++ b/schemas/dublin-core/src/main/plugin/dublin-core/layout/config-editor.xml
@@ -50,7 +50,7 @@
 
   <!-- View configuration -->
   <views>
-    <view name="default" upAndDownControlHidden="true">
+    <view name="default" default="true" upAndDownControlHidden="true">
       <sidePanel>
         <directive data-gn-need-help="creating-metadata"/>
         <directive data-gn-validation-report=""/>

--- a/schemas/iso19110/src/main/plugin/iso19110/layout/config-editor.xml
+++ b/schemas/iso19110/src/main/plugin/iso19110/layout/config-editor.xml
@@ -23,7 +23,7 @@
   -->
 
 <editor xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="../../config-editor.xsd">
+        xsi:noNamespaceSchemaLocation="../../../../../../config-editor.xsd">
 
   <!-- Form field type configuration. Default is text. -->
   <fields>
@@ -65,7 +65,7 @@
 
   <!-- View configuration -->
   <views>
-    <view name="default">
+    <view name="default" default="true">
       <sidePanel>
         <directive data-gn-need-help="creating-metadata"/>
         <directive data-gn-onlinesrc-list=""

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/config-editor.xml
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/config-editor.xml
@@ -614,6 +614,7 @@
   <!-- View configuration -->
   <views>
     <view name="default"
+          default="true"
           class="gn-label-above-input gn-indent-bluescale">
       <sidePanel>
         <directive data-gn-need-help="creating-metadata"/>

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
@@ -3172,7 +3172,7 @@
     <!--
     Customize the editor layout by adding a class attribute
     <view name="default" class="gn-indent-bluescale gn-label-above-input">-->
-    <view name="default" 
+    <view name="default" default="true"
           class="gn-label-above-input gn-indent-bluescale">
       <sidePanel>
         <!-- Simple overview manager + online source manger for other types

--- a/services/src/main/java/org/fao/geonet/api/records/editing/MetadataEditingApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/editing/MetadataEditingApi.java
@@ -115,7 +115,7 @@ public class MetadataEditingApi {
         @ApiResponse(responseCode = "403", description = ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_EDIT)})
     public void startEditing(
         @Parameter(description = API_PARAM_RECORD_UUID, required = true) @PathVariable String metadataUuid,
-        @Parameter(description = "Tab") @RequestParam(defaultValue = "simple") String currTab,
+        @Parameter(description = "Tab") @RequestParam(defaultValue = "") String currTab,
         @RequestParam(defaultValue = "false") boolean withAttributes,
         @Parameter(hidden = true) HttpSession session,
         @Parameter(hidden = true) @RequestParam Map<String, String> allRequestParams,

--- a/web-ui/src/main/resources/catalog/components/metadatamanager/EditorService.js
+++ b/web-ui/src/main/resources/catalog/components/metadatamanager/EditorService.js
@@ -157,7 +157,7 @@
           ];
           gnCurrentEdit.tab
             ? params.push("&currTab=", gnCurrentEdit.tab)
-            : params.push("&currTab=", "default");
+            : params.push("&currTab=", "");
           gnCurrentEdit.withAttributes &&
             params.push("&withAttributes=", gnCurrentEdit.displayAttributes);
           return params.join("");

--- a/web-ui/src/main/resources/catalog/js/edit/EditorController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/EditorController.js
@@ -264,7 +264,7 @@
                 if ($scope.metadataFound) {
                   // Default view to display is default
                   // it may be overriden by route params or custom function
-                  var defaultTab = "default";
+                  var defaultTab = "";
 
                   // It may be overriden by an application
                   // settings. For example, you may have different

--- a/web/src/main/webapp/xslt/common/base-variables-metadata.xsl
+++ b/web/src/main/webapp/xslt/common/base-variables-metadata.xsl
@@ -101,11 +101,11 @@
 
 
   <xsl:variable name="tab"
-                select="if (/root/request/currTab)
+                select="if (/root/request/currTab != '')
                         then /root/request/currTab
-                        else if (/root/gui/currTab)
+                        else if (/root/gui/currTab != '')
                         then /root/gui/currTab
-                        else $editorConfig/editor/views/view/tab[@default]/@id"/>
+                        else $editorConfig/editor/views/view[@default]/tab[@default]/@id"/>
 
   <xsl:variable name="viewConfig"
                 select="$editorConfig/editor/views/view[tab/@id = $tab]"/>


### PR DESCRIPTION
In `config-editor.xml` add the possibility to define the default view to use (without naming it default). `currTab` parameter is not set to `simple` or `default` by default. Use the tab set as default in the view defined as default to create the default editor form.
Disable the default view if not used.

eg.

```xml
    <view name="vl"
          default="true"
          class="gn-label-above-input gn-indent-bluescale"
          displayTooltips="true">
    <tab id="vl-identificationTab" default="true" mode="flat">
      <section xpath="/gmd:MD_Metadata/gmd:identificationInfo/*/gmd:citation"/>
    </tab>
...
    <view name="default" disabled="true"
...
```