### PR TITLE
Editor / Thesaurus / Add option to display or not the SKOS browser.

### DIFF
--- a/schemas/config-editor.xsd
+++ b/schemas/config-editor.xsd
@@ -910,10 +910,12 @@ record, or if the field should be displayed to enable the user to add new occurr
 Customizing thesaurus
 ~~~~~~~~~~~~~~~~~~~~~
 
-To configure the type of transformations,
-or the number of keywords allowed, or if the widget
-has to be displayed in a fieldset, or as simple field for a
-thesaurus define a specific configuration:
+To configure:
+ * the type of transformations (eg. to-iso19139-keyword, to-iso19139-keyword-with-anchor - see convert/thesaurus-transformation.xsl in each plugins),
+ * the number of keywords allowed,
+ * if the widget has to be displayed in a fieldset or as simple field
+ * if the concept relationships are browsable (enable by default)
+
 
 e.g. only 2 INSPIRE themes:
 
@@ -938,6 +940,7 @@ e.g. only 2 INSPIRE themes:
             <xs:attribute name="maxtags" type="xs:integer" use="optional"/>
             <xs:attribute name="orderById" type="xs:boolean" use="optional"/>
             <xs:attribute name="fieldset" type="xs:string" use="optional" fixed="false"/>
+            <xs:attribute name="browsable" type="xs:string" use="optional" fixed="false"/>
             <xs:attribute name="transformations" type="xs:string" use="optional"/>
           </xs:complexType>
         </xs:element>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/layout-custom-fields-keywords.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/layout-custom-fields-keywords.xsl
@@ -237,6 +237,8 @@
              data-transformations="{$transformations}"
              data-current-transformation="{$transformation}"
              data-max-tags="{$maxTags}"
+             data-browsable="{not($thesaurusConfig/@browsable)
+                              or $thesaurusConfig/@browsable != 'false'}"
              data-order-by-id="{$orderById}"
              data-lang="{$metadataOtherLanguagesAsJson}"
              data-textgroup-only="false">

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields-keywords.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields-keywords.xsl
@@ -272,6 +272,8 @@
              data-transformations="{$transformations}"
              data-current-transformation="{$transformation}"
              data-max-tags="{$maxTags}"
+             data-browsable="{not($thesaurusConfig/@browsable)
+                              or $thesaurusConfig/@browsable != 'false'}"
              data-order-by-id="{$orderById}"
              data-lang="{$metadataOtherLanguagesAsJson}"
              data-textgroup-only="false">

--- a/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
+++ b/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
@@ -255,7 +255,8 @@
           // Max number of tags allowed. Use 1 to restrict to only
           // on keyword.
           maxTags: "@",
-          thesaurusTitle: "@"
+          thesaurusTitle: "@",
+          browsable: "@"
         },
         templateUrl:
           "../../catalog/components/thesaurus/" + "partials/keywordselector.html",
@@ -615,9 +616,11 @@
 
           if (scope.thesaurusKey) {
             init();
-            gnThesaurusService.getTopConcept(scope.thesaurusKey).then(function (c) {
-              scope.concept = c;
-            });
+            if (scope.browsable !== "false") {
+              gnThesaurusService.getTopConcept(scope.thesaurusKey).then(function (c) {
+                scope.concept = c;
+              });
+            }
           }
         }
       };


### PR DESCRIPTION
To disable navigation in GEMET use the `browsable` attribute for example, use:
```xml
<thesaurus key="external.theme.gemet"
           fieldset="false"
           browsable="false"
           transformations="to-iso19139-keyword-with-anchor"/>
```

By default, SKOS browser is displayed as before.

![image](https://user-images.githubusercontent.com/1701393/231755684-e6ac0656-6bb2-4508-95c6-8125448d37e8.png)
