### PR TITLE
Test / API / Page label null trigger error

### DIFF
--- a/services/src/test/java/org/fao/geonet/api/pages/PagesApiTest.java
+++ b/services/src/test/java/org/fao/geonet/api/pages/PagesApiTest.java
@@ -73,6 +73,7 @@ public class PagesApiTest extends AbstractServiceIntegrationTest {
         PageProperties newPage = new PageProperties();
         newPage.setPageId(pageId);
         newPage.setLanguage(language);
+        newPage.setLabel(pageId);
         newPage.setLink(link);
         ArrayList<Page.PageSection> sections = new ArrayList<>();
         sections.add(Page.PageSection.TOP);
@@ -94,6 +95,7 @@ public class PagesApiTest extends AbstractServiceIntegrationTest {
         page = pageRepository.findById(new PageIdentity(language, pageId));
         Assert.assertTrue(page.isPresent());
         Assert.assertEquals(link, page.get().getLink());
+        Assert.assertEquals(pageId, page.get().getLabel());
         Assert.assertTrue(page.get().getSections().contains(Page.PageSection.TOP));
 
         this.mockMvc.perform(createPageBuilder)
@@ -106,6 +108,7 @@ public class PagesApiTest extends AbstractServiceIntegrationTest {
         newPage.setLanguage(language);
         newPage.setPageId(pageId);
         newPage.setLink(link + "updated");
+        newPage.setLabel(pageId + "updated");
         newPage.getSections().add(Page.PageSection.FOOTER);
         MockHttpServletRequestBuilder updatePageBuilder = put("/srv/api/pages/eng/license")
             .content(gson.toJson(newPage))
@@ -119,6 +122,7 @@ public class PagesApiTest extends AbstractServiceIntegrationTest {
         page = pageRepository.findById(new PageIdentity(language, pageId));
         Assert.assertTrue(page.isPresent());
         Assert.assertEquals(link + "updated", page.get().getLink());
+        Assert.assertEquals(pageId + "updated", page.get().getLabel());
         Assert.assertTrue(page.get().getSections().contains(Page.PageSection.TOP));
         Assert.assertTrue(page.get().getSections().contains(Page.PageSection.FOOTER));
 


### PR DESCRIPTION
Error reported:

```
08:48:17.890 ERROR  [geonetwork] - not-null property references a null or transient value :
org.fao.geonet.domain.page.Page.label; nested exception is org.hibernate.PropertyValueException:
not-null property references a null or transient value :
org.fao.geonet.domain.page.Page.label
org.springframework.dao.DataIntegrityViolationException: not-null property references a null or transient value :
org.fao.geonet.domain.page.Page.label; nested exception is org.hibernate.PropertyValueException:
not-null property references a null or transient value : org.fao.geonet.domain.page.Page.label
```

Trigger the test:

```sh
mvn integration-test -Pit -DfailIfNoTests=false -DskipIntegrationTests=false -DskipTests=false -Dtest=None -Dit.test=PagesApiTest
```

Follow up of https://github.com/geonetwork/core-geonetwork/pull/6788