### PR TITLE
Fix related to #6946, scope.config is not ready when the metadata editor is being loaded

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -1479,7 +1479,10 @@
                * them to the record.
                */
               scope.$watchCollection("params.selectedLayers", function (n, o) {
-                if (scope.config.wmsResources.addLayerNamesMode != "resourcename") {
+                if (
+                  scope.config &&
+                  scope.config.wmsResources.addLayerNamesMode != "resourcename"
+                ) {
                   return;
                 }
 


### PR DESCRIPTION
When the metadata editor is loaded a javascript error is reported:

```
angular.js?v=09c9c07bf3c4d008d7fc2f9bb1db8d0b06d0346d:15763 TypeError: Cannot read properties of null (reading 'wmsResources')
    at OnlineSrcDirective.js:1482:34
    at $watchCollectionAction (angular.js?v=09c9c07bf3c4d008d7fc2f9bb1db8d0b06d0346d:19196:13)
    at Scope.$digest (angular.js?v=09c9c07bf3c4d008d7fc2f9bb1db8d0b06d0346d:19336:23)
    at Scope.$apply (angular.js?v=09c9c07bf3c4d008d7fc2f9bb1db8d0b06d0346d:19696:24)
    at done (angular.js?v=09c9c07bf3c4d008d7fc2f9bb1db8d0b06d0346d:13539:47)
    at completeRequest (angular.js?v=09c9c07bf3c4d008d7fc2f9bb1db8d0b06d0346d:13796:7)
    at XMLHttpRequest.requestLoaded (angular.js?v=09c9c07bf3c4d008d7fc2f9bb1db8d0b06d0346d:13701:9)
```

Related to #6946