### PR TITLE
Metadata editor / normalize the values provided to AngularJs directives

### DIFF
--- a/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
@@ -1236,7 +1236,7 @@
 
               <xsl:attribute name="{$type}">
                 <xsl:value-of
-                  select="."/>
+                  select="normalize-space($valueToEdit)"/>
               </xsl:attribute>
 
               <xsl:if test="$directiveAttributes instance of node()+">


### PR DESCRIPTION
This issue caused at least for the directive `gnCheckboxWithNilreason` to not select the proper value. 

The html contains breaklines in the supplied value, which causes the directive to not select the correct value:

![directive-1](https://user-images.githubusercontent.com/1695003/232051577-a2d599be-d3dc-40b8-9dad-800a9611fe09.png)

![directive-2](https://user-images.githubusercontent.com/1695003/232051753-e3c45794-7a91-4a28-a06e-eaaa0df2ffc5.png)

With the change, the value is selected correctly.
