### PR TITLE
Fix ui config html display

### DIFF
--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
@@ -1078,8 +1078,10 @@
                class="form-control"
                data-ng-model="mCfg[key]"/>
         <p class="help-block"
-           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
-          {{('ui-' + key + '-help') | translate}} </p>
+           data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')"
+           translate="">
+          {{'ui-' + key + '-help'}}
+        </p>
       </div>
 
       <div data-ng-switch-when="workflowAssistApps">


### PR DESCRIPTION
Before the fix, the ui config was display the url html help as follows

![image](https://user-images.githubusercontent.com/1868233/232132219-1982e3ce-954f-4f72-a470-5d52d7067dd2.png)

After the fix

![image](https://user-images.githubusercontent.com/1868233/232142963-008ca7da-215b-4862-b14b-43665d515e94.png)

Note: this issues does not seem to exists in the main branch.
