### PR TITLE
Map / WPS / Fixes and improvements

### DIFF
--- a/web-ui/src/main/resources/catalog/components/viewer/wps/WpsService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wps/WpsService.js
@@ -224,7 +224,7 @@
             });
           }
           if (input.complexData && data) {
-            var mimeType = input.complexData._default.format.mimeType;
+            var mimeType = input.mimeType || input.complexData._default.format.mimeType;
             request.value.dataInputs.input.push({
               identifier: {
                 value: input.identifier.value
@@ -317,18 +317,25 @@
        * @param {string} uri of the wps service
        * @param {string} processId of the process
        * @param {Object} inputs of the process
-       * @param {Object} output of the process
-       * @param {Object} options such as storeExecuteResponse,
-       * lineage and status
+       * @param {Object} responseDocument of the process
+       * @param {Object} formDescription Optional initial describe process processDescription (which contains form inputs and extra properties eg. preferred mimetype)
        * @return {defer} promise
        */
-      this.execute = function (uri, processId, inputs, responseDocument) {
+      this.execute = function (
+        uri,
+        processId,
+        inputs,
+        responseDocument,
+        formDescription
+      ) {
         var defer = $q.defer();
         var me = this;
 
+        // Not really sure why a describe process is required here
+        // as it was done already for creating the form.
         this.describeProcess(uri, processId).then(function (data) {
           // generate the XML message from the description
-          var description = data.processDescription[0];
+          var description = formDescription || data.processDescription[0];
           var message = me.printExecuteMessage(description, inputs, responseDocument);
 
           // do the post request

--- a/web-ui/src/main/resources/catalog/components/viewer/wps/partials/processform.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/wps/partials/processform.html
@@ -79,6 +79,7 @@
                 >
                   <input
                     ng-model="field.value"
+                    data-ng-click="desactivateGeometryTool()"
                     type="text"
                     ng-blur="onBlur($event)"
                     class="input-sm form-control"
@@ -87,8 +88,24 @@
                 </div>
               </div>
 
+              <div ng-if="isBoolean(input)">
+                <div
+                  ng-repeat="field in getInputsByName(input.identifier.value)"
+                  class="input-checkbox checkbox"
+                >
+                  <label>
+                    <input
+                      type="checkbox"
+                      id="field.value"
+                      data-ng-click="desactivateGeometryTool()"
+                      ng-model="field.value"
+                    />
+                  </label>
+                </div>
+              </div>
+
               <!-- Basic form field (combo box or text field) -->
-              <div ng-if="::input.literalData && !isDateTime(input)">
+              <div ng-if="::input.literalData && !isDateTime(input) && !isBoolean(input)">
                 <div
                   class="input-group"
                   ng-repeat="field in getInputsByName(input.identifier.value)"
@@ -97,6 +114,7 @@
                     class="form-control input-sm"
                     ng-if="::input.literalData.allowedValues && !getIsAllowedValuesRange(input.literalData.allowedValues)"
                     ng-model="field.value"
+                    data-ng-click="desactivateGeometryTool()"
                     ng-required="$index < input.minOccurs"
                     ng-disabled="inputWfsOverride[input.identifier.value] || isInputDisabled(input.identifier.value)"
                   >
@@ -114,6 +132,7 @@
                     min="{{::getMinValueFromAllowedValues(input.literalData.allowedValues) || ''}}"
                     max="{{::getMaxValueFromAllowedValues(input.literalData.allowedValues) || ''}}"
                     ng-model="field.value"
+                    data-ng-click="desactivateGeometryTool()"
                     ng-required="$index < input.minOccurs"
                     ng-disabled="inputWfsOverride[input.identifier.value] || isInputDisabled(input.identifier.value)"
                   />
@@ -144,6 +163,7 @@
                   value="field.value"
                   map="::map"
                   read-only="::inputWfsOverride[input.identifier.value] || isInputDisabled(input.identifier.value)"
+                  data-ng-click="desactivateGeometryTool()"
                   ng-required="$index < input.minOccurs"
                   watch-value-change="true"
                 />
@@ -158,10 +178,12 @@
                   output="field.value"
                   output-format="{{ input.outputFormat }}"
                   output-crs="{{ map.getView().getProjection().getCode() }}"
+                  name-type="{{ input.geometryType }}"
                   geometry-type="{{ input.geometryType }}"
                   output-crs="{{ map.getView().getProjection().getCode() }}"
                   output-as-features="true"
                   map="map"
+                  active-geometry-tool="activeGeometryTool"
                 />
               </div>
 


### PR DESCRIPTION
Improve geometry input types:

* Activate only one geometry type at the same time if process has multiple geometry inputs
* Fix controller initialization (related to https://github.com/geonetwork/core-geonetwork/pull/6693)
* Properly set mime type based on format of the features
* Multi geometry support (work done by @jahow for Ifremer)


Before
![image](https://user-images.githubusercontent.com/1701393/232549478-23d4fb73-9adf-450e-8984-7f5287158b73.png)


After
![image](https://user-images.githubusercontent.com/1701393/232549504-b704118f-879f-4b40-a492-4ac84f32b89a.png)


Unfortunately the QGIS WPS server used for testing all types of input is not public but should improve support for all WPS having geometry as inputs.