### PR TITLE
Fix display of user selections panel for logged users

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/savedselections/SavedSelectionsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/common/savedselections/SavedSelectionsDirective.js
@@ -441,14 +441,18 @@
           return;
         }
 
-        scope.$watch("user", function (n, o) {
-          if (n !== o || scope.selections === null) {
-            scope.selections = null;
-            controller.getSelections(scope.user).then(function (selections) {
-              scope.selections = selections;
-            });
-          }
-        });
+        scope.$watch(
+          "user",
+          function (n, o) {
+            if (n !== o || scope.selections === null) {
+              scope.selections = null;
+              controller.getSelections(scope.user).then(function (selections) {
+                scope.selections = selections;
+              });
+            }
+          },
+          true
+        );
 
         scope.remove = function (selection, uuid) {
           controller.remove(selection, scope.user, uuid);


### PR DESCRIPTION
For logged users, the user selections panel is not displayed:

![userselections-logged-users-missing](https://user-images.githubusercontent.com/1695003/232812463-e7c6ce26-c4bd-428a-abe1-8dbe17656dbd.png)

---

Test case:

1) Login as administrator and enable the `Saved selections` in the `Admin console` > `Settings` > `User interface`

![userselections-admin](https://user-images.githubusercontent.com/1695003/232813366-1546e8cc-20f9-45eb-9c00-87354b2bf1e5.png)


2) Go to the search page, the Basket panel is not displayed
3) Logout and go to the search page, the Basket panel is displayed

With this fix, case 2) is fixed.

![userselections-logged-users](https://user-images.githubusercontent.com/1695003/232812410-07d41337-e1bb-45b6-a9dc-dfe79a1b309f.png)
