### PR TITLE
Thesaurus / Virtual all thesaurus modifying Keyword bean in cache

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/AllThesaurus.java
+++ b/core/src/main/java/org/fao/geonet/kernel/AllThesaurus.java
@@ -27,15 +27,13 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-
-import org.locationtech.jts.util.Assert;
-
 import org.fao.geonet.Constants;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.exceptions.TermNotFoundException;
 import org.fao.geonet.kernel.search.keyword.KeywordRelation;
 import org.fao.geonet.languages.IsoLanguagesMapper;
 import org.fao.geonet.utils.Log;
+import org.locationtech.jts.util.Assert;
 import org.openrdf.model.GraphException;
 import org.openrdf.model.URI;
 import org.openrdf.sesame.config.AccessDeniedException;
@@ -46,6 +44,8 @@ import org.openrdf.sesame.query.QueryResultsTable;
 import org.openrdf.sesame.repository.local.LocalRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
@@ -58,9 +58,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 /**
  * @author Jesse on 2/27/2015.
@@ -297,7 +294,7 @@ public class AllThesaurus extends Thesaurus {
         final DecomposedAllUri decomposedAllUri = new DecomposedAllUri(uri);
         final Thesaurus thesaurus = this.thesaurusFinder.getThesaurusByName(decomposedAllUri.thesaurusKey);
 
-        final KeywordBean keyword = thesaurus.getKeyword(decomposedAllUri.keywordUri, languages);
+        final KeywordBean keyword = thesaurus.getKeywordWithoutCache(decomposedAllUri.keywordUri, languages);
         updateKeywordBeanThesaurusInfo(keyword);
         return keyword;
     }

--- a/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info-keywords.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info-keywords.xsl
@@ -306,11 +306,11 @@
             <gmd:descriptiveKeywords
                         xlink:href="{concat(
                                       $hrefPrefix,
-                                      'skipdescriptivekeywords=true&amp;thesaurus=', current-grouping-key(),
-                                      '&amp;id=',
-                                      string-join(
+                                      'thesaurus=', current-grouping-key(),
+                                      '&amp;id=', string-join(
                                         current-group()/id[. != ''],
                                         ','),
+                                      (if (contains($queryString, 'skipdescriptivekeywords=true')) then '' else '&amp;skipdescriptivekeywords=true'),
                                       $queryString)}"/>
           </xsl:if>
         </xsl:for-each-group>


### PR DESCRIPTION
When using virtual all thesaurus, keyword can be added with a reference to the virtual all thesaurus instead of the thesaurus of the keyword (ie. no thesaurus date and title set to All keywords).

Also when using XLinks, the dispatching of keywords based on their thesaurus of origin was building xlink URL with concept id as thesaurus parameter.

Remove unecessary duplicated skipdescriptivekeyword parameter when dispatching keyword from the all thesaurus.

For testing:
* enable virtual all thesaurus in settings and xlink
* try to add keywords (with xlink mode) Keywords are not added properly.

Workaround for previous version:
* set thesaurus.cache.maxsize=0 in config.properties.