### PR TITLE
Add migration for static pages

### DIFF
--- a/web/src/main/webResources/WEB-INF/config-db/database_migration.xml
+++ b/web/src/main/webResources/WEB-INF/config-db/database_migration.xml
@@ -155,7 +155,7 @@
     </entry>
     <entry key="4.2.4">
       <list>
-        <value>WEB-INF/classes/setup/sql/migrate/v400/migrate-db-</value>
+        <value>WEB-INF/classes/setup/sql/migrate/v424/migrate-db-</value>
       </list>
     </entry>
   </util:map>

--- a/web/src/main/webResources/WEB-INF/config-db/database_migration.xml
+++ b/web/src/main/webResources/WEB-INF/config-db/database_migration.xml
@@ -153,6 +153,11 @@
         <value>WEB-INF/classes/setup/sql/migrate/v400/migrate-db-</value>
       </list>
     </entry>
+    <entry key="4.2.4">
+      <list>
+        <value>WEB-INF/classes/setup/sql/migrate/v400/migrate-db-</value>
+      </list>
+    </entry>
   </util:map>
 
 

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v424/migrate-db-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v424/migrate-db-default.sql
@@ -1,0 +1,4 @@
+ALTER TABLE spg_page ADD COLUMN label VARCHAR(255);
+UPDATE spg_page SET label = linktext;
+DELETE FROM spg_sections WHERE section = 'DRAFT';
+ALTER TABLE spg_page ALTER COLUMN label SET NOT NULL;

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v424/migrate-db-mysql.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v424/migrate-db-mysql.sql
@@ -1,0 +1,4 @@
+ALTER TABLE spg_page ADD COLUMN label VARCHAR(255);
+UPDATE spg_page SET label = linktext;
+DELETE FROM spg_sections WHERE section = 'DRAFT';
+ALTER TABLE spg_page MODIFY label VARCHAR(255) NOT NULL;

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v424/migrate-db-oracle.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v424/migrate-db-oracle.sql
@@ -1,0 +1,4 @@
+ALTER TABLE spg_page ADD label VARCHAR(255);
+UPDATE spg_page SET label = linktext;
+DELETE FROM spg_sections WHERE section = 'DRAFT';
+ALTER TABLE spg_page MODIFY label VARCHAR(255) NOT NULL;

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v424/migrate-db-sqlserver.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v424/migrate-db-sqlserver.sql
@@ -1,0 +1,4 @@
+ALTER TABLE spg_page ADD label VARCHAR(255);
+UPDATE spg_page SET label = linktext;
+DELETE FROM spg_sections WHERE section = 'DRAFT';
+ALTER TABLE spg_page ALTER COLUMN label VARCHAR(255) NOT NULL;


### PR DESCRIPTION
Related to #6788.

If the database contains pages, the Hibernate update doesn't add the `label` column to the `spg_page` as it is defined as not nullable.

Also the section `DRAFT`  was added in the previous version, but no longer exists.