### PR TITLE
Import metadata / If workflow is enable hide publish option

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/MetadataInsertDeleteApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataInsertDeleteApi.java
@@ -299,7 +299,7 @@ public class MetadataInsertDeleteApi {
         @Parameter(description = "URL of a file to download and insert.", required = false) @RequestParam(required = false) String[] url,
         @Parameter(description = "Server folder where to look for files.", required = false) @RequestParam(required = false) String serverFolder,
         @Parameter(description = "(Server folder import only) Recursive search in folder.", required = false) @RequestParam(required = false, defaultValue = "false") final boolean recursiveSearch,
-        @Parameter(description = "(XML file only) Publish record.", required = false) @RequestParam(required = false, defaultValue = "false") final boolean publishToAll,
+        @Parameter(description = "(XML file only and if workflow is not enabled) Publish record.", required = false) @RequestParam(required = false, defaultValue = "false") boolean publishToAll,
         @Parameter(description = "(MEF file only) Assign to current catalog.", required = false) @RequestParam(required = false, defaultValue = "false") final boolean assignToCatalog,
         @Parameter(description = API_PARAM_RECORD_UUID_PROCESSING, required = false) @RequestParam(required = false, defaultValue = "NOTHING") final MEFLib.UuidAction uuidProcessing,
         @Parameter(description = API_PARAM_RECORD_GROUP, required = false) @RequestParam(required = false) final String group,
@@ -324,6 +324,11 @@ public class MetadataInsertDeleteApi {
         checkUserProfileToImportMetadata(userSession);
 
 
+        boolean isMdWorkflowEnable = settingManager.getValueAsBool(Settings.METADATA_WORKFLOW_ENABLE);
+        if (isMdWorkflowEnable) {
+            publishToAll = false;
+        }
+
         if (xml != null) {
             Element element = null;
             try {
@@ -332,6 +337,7 @@ public class MetadataInsertDeleteApi {
                 throw new IllegalArgumentException(
                     String.format(messages.getString("api.metadata.import.errorInvalidXMLFragment"), ex.getMessage()));
             }
+
             Pair<Integer, String> pair = loadRecord(metadataType, element, uuidProcessing, group, category,
                     rejectIfInvalid, publishToAll, allowEditGroupMembers, transformWith, schema, extra, request);
             report.addMetadataInfos(pair.one(), pair.two(), !publishToAll, false, String.format(messages.getString("api.metadata.import.importedFromXMLWithUuid"), pair.two()));

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataInsertDeleteApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataInsertDeleteApi.java
@@ -574,7 +574,7 @@ public class MetadataInsertDeleteApi {
         @Parameter(description = API_PARAM_RECORD_GROUP, required = false) @RequestParam(required = false) final String group,
         @Parameter(description = API_PARAM_RECORD_TAGS, required = false) @RequestParam(required = false) final String[] category,
         @Parameter(description = API_PARAM_RECORD_VALIDATE, required = false) @RequestParam(required = false, defaultValue = "false") final boolean rejectIfInvalid,
-        @Parameter(description = "(XML file only) Publish record.", required = false) @RequestParam(required = false, defaultValue = "false") final boolean publishToAll,
+        @Parameter(description = "(XML file only) Publish record.", required = false) @RequestParam(required = false, defaultValue = "false") boolean publishToAll,
         @Parameter(description = "(MEF file only) Assign to current catalog.", required = false) @RequestParam(required = false, defaultValue = "false") final boolean assignToCatalog,
         @Parameter(description = API_PARAM_RECORD_XSL, required = false) @RequestParam(required = false, defaultValue = "_none_") final String transformWith,
         @Parameter(description = API_PARAM_FORCE_SCHEMA, required = false) @RequestParam(required = false) String schema,
@@ -587,6 +587,11 @@ public class MetadataInsertDeleteApi {
 
         if (file == null) {
             throw new IllegalArgumentException(messages.getString("api.metadata.import.errorFileRequired"));
+        }
+
+        boolean isMdWorkflowEnable = settingManager.getValueAsBool(Settings.METADATA_WORKFLOW_ENABLE);
+        if (isMdWorkflowEnable) {
+            publishToAll = false;
         }
 
         SimpleMetadataProcessingReport report = new SimpleMetadataProcessingReport();
@@ -611,8 +616,9 @@ public class MetadataInsertDeleteApi {
                             //This is a catch-for-call for the case when there is no record is imported, to notify the user the import is not successful.
                             throw new BadFormatEx(messages.getString("api.metadata.import.errorInvalidMEF"));
                         }
+                        boolean finalPublishToAll = publishToAll;
                         ids.forEach(e -> {
-                            report.addMetadataInfos(Integer.parseInt(e), e, !publishToAll, false,
+                            report.addMetadataInfos(Integer.parseInt(e), e, !finalPublishToAll, false,
                                     String.format(messages.getString("api.metadata.import.importedWithId"), e));
 
                             try {

--- a/web-ui/src/main/resources/catalog/js/edit/ImportController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/ImportController.js
@@ -79,6 +79,7 @@
       $scope.importing = false;
 
       gnConfigService.load().then(function (c) {
+        $scope.isMdWorkflowEnable = gnConfig["metadata.workflow.enable"];
         $scope.params.group = gnConfig["system.metadatacreate.preferredGroup"];
       });
 

--- a/web-ui/src/main/resources/catalog/templates/editor/import.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/import.html
@@ -334,7 +334,8 @@
               </div>
             </div>
 
-            <div id="gn-import-validate-row" class="form-group gn-no">
+            <div id="gn-import-validate-row" class="form-group gn-no"
+                 data-ng-hide="isMdWorkflowEnable">
               <div class="col-sm-offset-4 col-sm-8">
                 <div class="checkbox">
                   <label>
@@ -350,7 +351,8 @@
               </div>
             </div>
 
-            <div id="gn-import-publish-row" class="form-group">
+            <div id="gn-import-publish-row" class="form-group"
+                 data-ng-hide="isMdWorkflowEnable">
               <div class="col-sm-offset-4 col-sm-8">
                 <div class="checkbox">
                   <label>

--- a/web-ui/src/main/resources/catalog/templates/editor/import.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/import.html
@@ -334,8 +334,7 @@
               </div>
             </div>
 
-            <div id="gn-import-validate-row" class="form-group gn-no"
-                 data-ng-hide="isMdWorkflowEnable">
+            <div id="gn-import-validate-row" class="form-group gn-no">
               <div class="col-sm-offset-4 col-sm-8">
                 <div class="checkbox">
                   <label>

--- a/web-ui/src/main/resources/catalog/templates/editor/import.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/import.html
@@ -350,8 +350,11 @@
               </div>
             </div>
 
-            <div id="gn-import-publish-row" class="form-group"
-                 data-ng-hide="isMdWorkflowEnable">
+            <div
+              id="gn-import-publish-row"
+              class="form-group"
+              data-ng-hide="isMdWorkflowEnable"
+            >
               <div class="col-sm-offset-4 col-sm-8">
                 <div class="checkbox">
                   <label>


### PR DESCRIPTION
When workflow is enabled, usually extra rules apply to publish records. So don't let the user set those option while importing a new record. Let the record enter the workflow and follow the proper steps.

![image](https://user-images.githubusercontent.com/1701393/233054970-9eabbbfa-bff9-4c29-a36c-5d77a5d6c128.png)
