### PR TITLE
Editing / dateStamp = changeDate on update

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
@@ -712,7 +712,7 @@ public class BaseMetadataManager implements IMetadataManager {
         final AbstractMetadata metadata = metadataUtils.findOne(metadataId);
 
         if (updateDateStamp) {
-            if (changeDate == null) {
+            if (StringUtils.isEmpty(changeDate)) {
                 changeDate = new ISODate().toString();
                 metadata.getDataInfo().setChangeDate(new ISODate());
             } else {

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
@@ -696,7 +696,7 @@ public class BaseMetadataManager implements IMetadataManager {
      */
     @Override
     public synchronized AbstractMetadata updateMetadata(final ServiceContext context, final String metadataId, final Element md,
-                                                        final boolean validate, final boolean ufo, final String lang, final String changeDate,
+                                                        final boolean validate, final boolean ufo, final String lang, String changeDate,
                                                         final boolean updateDateStamp, final IndexingMode indexingMode) throws Exception {
         Log.trace(Geonet.DATA_MANAGER, "Update record with id " + metadataId);
 
@@ -709,12 +709,21 @@ public class BaseMetadataManager implements IMetadataManager {
         }
         String schema = metadataSchemaUtils.getMetadataSchema(metadataId);
 
+        final AbstractMetadata metadata = metadataUtils.findOne(metadataId);
+
+        if (updateDateStamp) {
+            if (changeDate == null) {
+                changeDate = new ISODate().toString();
+                metadata.getDataInfo().setChangeDate(new ISODate());
+            } else {
+                metadata.getDataInfo().setChangeDate(new ISODate(changeDate));
+            }
+        }
+
         String uuidBeforeUfo = null;
         if (ufo) {
             String parentUuid = null;
             Integer intId = Integer.valueOf(metadataId);
-
-            final AbstractMetadata metadata = metadataUtils.findOne(metadataId);
 
             uuidBeforeUfo = findUuid(metadataXml, schema, metadata);
 
@@ -724,9 +733,6 @@ public class BaseMetadataManager implements IMetadataManager {
 
         // --- force namespace prefix for iso19139 metadata
         setNamespacePrefixUsingSchemas(schema, metadataXml);
-
-        // Notifies the metadata change to metatada notifier service
-        final AbstractMetadata metadata = metadataUtils.findOne(metadataId);
 
         String uuid = findUuid(metadataXml, schema, metadata);
 


### PR DESCRIPTION
On metadata update, `BaseMetadataManager` is calling `update-fixed-info` which set `dateStamp` from metadata table `changeDate` but the table is only updated after in `XmlSerializerDb`. The dateStamp is using the previous changeDate (usually a short time before last edit on an editing session with multiple actions). If user just open the editor and save and close directly, the dateStamp is set to the last editing date (which could be long time ago).

In the index, we expect to have `dateStamp` = `changeDate` but it was not the case.

For testing, edit a record and save and close then check the index fields.