### PR TITLE
Portal redirection / Search portal by uuid not by name.

### DIFF
--- a/core/src/main/java/org/fao/geonet/web/GeoNetworkPortalFilter.java
+++ b/core/src/main/java/org/fao/geonet/web/GeoNetworkPortalFilter.java
@@ -75,7 +75,7 @@ public class GeoNetworkPortalFilter implements javax.servlet.Filter {
             if (!NodeInfo.DEFAULT_NODE.equals(portal)) {
                 SourceRepository sourceRepository = ApplicationContextHolder.get().getBean(SourceRepository.class);
                 // Check the portal exists and it's of type subportal, otherwise redirect to the default portal
-                boolean redirectToDefaultPortal = !sourceRepository.existsByNameAndType(portal, SourceType.subportal);
+                boolean redirectToDefaultPortal = !sourceRepository.existsByUuidAndType(portal, SourceType.subportal);
 
                 if (redirectToDefaultPortal) {
                     String newPath = httpReq.getPathInfo().replace(URL_PATH_SEPARATOR + portal + URL_PATH_SEPARATOR,

--- a/domain/src/main/java/org/fao/geonet/repository/SourceRepository.java
+++ b/domain/src/main/java/org/fao/geonet/repository/SourceRepository.java
@@ -76,5 +76,5 @@ public interface SourceRepository extends GeonetRepository<Source, String>, JpaS
     @Nullable
     List<Source> findByGroupOwnerIn(Set<Integer> groupOwner);
 
-    boolean existsByNameAndType(String name, SourceType type);
+    boolean existsByUuidAndType(String name, SourceType type);
 }


### PR DESCRIPTION
Follow up of https://github.com/geonetwork/core-geonetwork/pull/6970.

Portal redirection was only working fine if name and portal uuid was the same. 