### PR TITLE
PDF / Report image URL in case of error

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/formatters/ImageReplacedElementFactory.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/ImageReplacedElementFactory.java
@@ -240,7 +240,10 @@ public class ImageReplacedElementFactory implements ReplacedElementFactory {
 
             return new ITextImageElement(fsImage);
         } catch (Exception e) {
-            Log.error(Geonet.GEONETWORK, "Error writing metadata to PDF", e);
+            Log.warning(Geonet.GEONETWORK,
+                String.format("Error loading image %s for PDF",
+                    imageLoader instanceof UrlImageLoader ?
+                        ((UrlImageLoader) imageLoader).url : ""), e);
 
             try {
                 return superFactory.createReplacedElement(layoutContext, box, userAgentCallback, cssWidth, cssHeight);

--- a/web/src/main/webapp/xslt/skin/default/skin.xsl
+++ b/web/src/main/webapp/xslt/skin/default/skin.xsl
@@ -34,7 +34,7 @@
               <a href="{/root/gui/nodeUrl}">
                 <img class="gn-logo"
                      alt="{$i18n/siteLogo}"
-                     src="{/root/gui/url}/images/logos/{$env//system/site/siteId}.png"></img>
+                     src="{/root/gui/nodeUrl}../images/logos/{$env//system/site/siteId}.png"></img>
                 <xsl:value-of select="$env//system/site/name"/>
               </a>
             </li>


### PR DESCRIPTION
Provide some more context to user about the error


```
2023-04-26T12:37:21,072 ERROR [geonetwork] - Error writing metadata to PDF
java.lang.IllegalArgumentException: URI is not absolute
	at java.net.URI.toURL(URI.java:1088) ~[?:1.8.0_362]
	at org.fao.geonet.api.records.formatters.ImageReplacedElementFactory$UrlImageLoader.loadImage(ImageReplacedElementFactory.java:289) ~[classes/:?]
```

replaced by
```
2023-04-26T12:46:31,470 ERROR [geonetwork] - Error loading image /images/logos/c9c5a394-882a-4520-8011-7f6c11ffaa5a.png for PDF
java.lang.IllegalArgumentException: URI is not absolute
	at java.net.URI.toURL(URI.java:1088) ~[?:1.8.0_362]
```

Logging as warning as it is not blocking PDF creation.