### PR TITLE
Verify the portal requested exists - configure servlet names to exclude

### DIFF
--- a/core/src/main/java/org/fao/geonet/web/GeoNetworkPortalFilter.java
+++ b/core/src/main/java/org/fao/geonet/web/GeoNetworkPortalFilter.java
@@ -23,11 +23,12 @@
 
 package org.fao.geonet.web;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.NodeInfo;
 import org.fao.geonet.domain.SourceType;
 import org.fao.geonet.repository.SourceRepository;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
@@ -36,36 +37,34 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * Filter to check that the portal requested is a valid one, otherwise redirects to the default portal:
- *
- *  - Default srv portal.
- *  - Valid portal defined in the sources table
+ * <p>
+ * - Default srv portal.
+ * - Valid portal defined in the sources table
  */
 public class GeoNetworkPortalFilter implements javax.servlet.Filter {
     private static final String EXCLUDED_URL_PATHS = "excludedPaths";
 
-    private static final String EXCLUDED_URL_SERVLET = "excludedServletPaths";
-
     private static final String URL_PATH_SEPARATOR = "/";
 
-    /** Ignored application paths **/
-    private List<String> excludedPaths = new ArrayList<>();
+    /**
+     * Ignored application paths.
+     **/
+    private List<AntPathRequestMatcher> excludedPathsMatchers = new ArrayList<>();
 
-    /** Ignored servlet paths **/
-    private List<String> excludedServletPaths = new ArrayList<>();
 
     @Override
     public void init(FilterConfig config) {
         String excludedPathsValue = config.getInitParameter(EXCLUDED_URL_PATHS);
         if (StringUtils.isNotEmpty(excludedPathsValue)) {
-            excludedPaths = Arrays.asList(excludedPathsValue.split(","));
-        }
-
-        String excludedServletPathsValue = config.getInitParameter(EXCLUDED_URL_SERVLET);
-        if (StringUtils.isNotEmpty(excludedServletPathsValue)) {
-            excludedServletPaths = Arrays.asList(excludedServletPathsValue.split(","));
+            excludedPathsMatchers = Arrays.stream(excludedPathsValue.split(","))
+                .map(StringUtils::trimToEmpty)
+                .filter(StringUtils::isNotEmpty)
+                .map(AntPathRequestMatcher::new)
+                .collect(Collectors.toList());
         }
     }
 
@@ -73,8 +72,7 @@ public class GeoNetworkPortalFilter implements javax.servlet.Filter {
         HttpServletResponse httpResp = (HttpServletResponse) resp;
         HttpServletRequest httpReq = (HttpServletRequest) req;
 
-        if (!ignoreServletPath(httpReq.getServletPath()) &&
-            !ignoreUrl(httpReq.getPathInfo())) {
+        if (!ignoreUrl(httpReq)) {
             String portal = "";
 
             // Check the url format: /portal/lang/service/..., /portal/api/service/...
@@ -91,10 +89,11 @@ public class GeoNetworkPortalFilter implements javax.servlet.Filter {
 
                 if (redirectToDefaultPortal) {
                     String newPath = httpReq.getPathInfo().replace(URL_PATH_SEPARATOR + portal + URL_PATH_SEPARATOR,
-                        URL_PATH_SEPARATOR + NodeInfo.DEFAULT_NODE +URL_PATH_SEPARATOR);
-                    if ( httpReq.getQueryString() != null) {
+                        URL_PATH_SEPARATOR + NodeInfo.DEFAULT_NODE + URL_PATH_SEPARATOR);
+                    if (httpReq.getQueryString() != null) {
                         newPath = newPath + "?" + httpReq.getQueryString();
                     }
+
                     httpResp.sendRedirect(httpReq.getContextPath() + newPath);
                     return;
                 }
@@ -109,19 +108,12 @@ public class GeoNetworkPortalFilter implements javax.servlet.Filter {
         // No cleanup required
     }
 
-    private boolean ignoreUrl(String urlPath) {
-        if (StringUtils.isEmpty(urlPath)) {
+    private boolean ignoreUrl(HttpServletRequest request) {
+        if (StringUtils.isEmpty(request.getPathInfo())) {
             return true;
         } else {
-            return excludedPaths.stream().anyMatch(urlPath::matches);
-        }
-    }
-
-    private boolean ignoreServletPath(String servletPath) {
-        if (StringUtils.isEmpty(servletPath)) {
-            return false;
-        } else {
-            return excludedServletPaths.stream().anyMatch(servletPath::matches);
+            return excludedPathsMatchers.stream()
+                .anyMatch(matcher -> matcher.matches(request));
         }
     }
 }

--- a/web/src/main/webResources/WEB-INF/web.xml
+++ b/web/src/main/webResources/WEB-INF/web.xml
@@ -93,11 +93,18 @@
     <filter-name>portalCheckFilter</filter-name>
     <filter-class>org.fao.geonet.web.GeoNetworkPortalFilter</filter-class>
     <init-param>
-      <!-- List of url regular expressions that should be not checked -->
+      <!-- List of url regular expressions that should be not checked for application url paths -->
       <param-name>excludedPaths</param-name>
-      <param-value>^/catalog/.*,^/jolokia/.*,^/dashboards/.*,^/doc/.*,^/api/.*,^/static/.*,^/images/.*,^/map/.*,^/htmlcache/.*,^/pdf/.*,^/xml/.*,^/xsl/.*,^/config/.*,^/read/.*,^/.*\.jsp,^/.*\.html,^/.*\.css</param-value>
+      <param-value>^/catalog/.*,^/doc/.*,^/static/.*,^/images/.*,^/map/.*,^/htmlcache/.*,^/pdf/.*,^/xml/.*,^/xsl/.*,^/config/.*,^/read/.*,^/.*\.jsp,^/.*\.html,^/.*\.css</param-value>
+    </init-param>
+
+    <init-param>
+      <!-- List of url regular expressions that should be not checked for servlet paths -->
+      <param-name>excludedServletPaths</param-name>
+      <param-value>^/api,^/jolokia,^/dashboards,^/index/features,^/criticalhealthcheck,^/warninghealthcheck,^/expensivehealthcheck,^/monitor</param-value>
     </init-param>
   </filter>
+
   <filter-mapping>
     <filter-name>portalCheckFilter</filter-name>
     <url-pattern>/*</url-pattern>

--- a/web/src/main/webResources/WEB-INF/web.xml
+++ b/web/src/main/webResources/WEB-INF/web.xml
@@ -86,22 +86,40 @@
     <url-pattern>/*</url-pattern>
   </filter-mapping>
 
-  <!-- Filter to verify the portal parameter in the url is a valid portal defined in GeoNetwork.
-       If a non-valid value is provided, it redirects to the same url in the default portal (srv).
+  <!-- Filter to verify the portal parameter in the URL is a valid portal defined in GeoNetwork.
+       If a non-valid value is provided, it redirects to the same URL in the default portal (srv).
   -->
   <filter>
     <filter-name>portalCheckFilter</filter-name>
     <filter-class>org.fao.geonet.web.GeoNetworkPortalFilter</filter-class>
     <init-param>
-      <!-- List of url regular expressions that should be not checked for application url paths -->
+      <!-- List of Ant style patterns that should be not checked for application URL paths -->
+      <!-- https://docs.spring.io/spring-security/site/docs/5.7.3/api/org/springframework/security/web/util/matcher/AntPathRequestMatcher.html -->
       <param-name>excludedPaths</param-name>
-      <param-value>^/catalog/.*,^/doc/.*,^/static/.*,^/images/.*,^/map/.*,^/htmlcache/.*,^/pdf/.*,^/xml/.*,^/xsl/.*,^/config/.*,^/read/.*,^/.*\.jsp,^/.*\.html,^/.*\.css</param-value>
-    </init-param>
-
-    <init-param>
-      <!-- List of url regular expressions that should be not checked for servlet paths -->
-      <param-name>excludedServletPaths</param-name>
-      <param-value>^/api,^/jolokia,^/dashboards,^/index/features,^/criticalhealthcheck,^/warninghealthcheck,^/expensivehealthcheck,^/monitor</param-value>
+      <param-value>
+        /catalog/**,
+        /api/**,
+        /static/**,
+        /images/**,
+        /index/features/**,
+        /htmlcache/**,
+        /config/**,
+        /jolokia/**,
+        /dashboards/**,
+        /criticalhealthcheck/**,
+        /warninghealthcheck/**,
+        /expensivehealthcheck/**,
+        /monitor/**
+        /doc/**,
+        /map/**,
+        /pdf/**,
+        /xml/**,
+        /xsl/**,
+        /read/**,
+        /.*.jsp,
+        /*.html,
+        /*.css
+      </param-value>
     </init-param>
   </filter>
 


### PR DESCRIPTION
 Related to #6970

Update the portal check filter to allow to configure servlet paths to exclude.