### PR TITLE
Add pagination to the footer of the search page

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/templates/results.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/results.html
@@ -78,7 +78,9 @@
             ></div>
           </div>
 
-          <div class="col-xs-6 col-sm-3 gn-nopadding-right text-right navbar-right">
+          <div
+            class="col-xs-6 col-sm-3 gn-nopadding-right text-right navbar-right"
+          >
             <div
               data-sortby-combo=""
               class="d-inline-block"
@@ -100,7 +102,10 @@
         </div>
         <div class="row">
           <div class="col-xs-12 gn-nopadding-left gn-nopadding-right">
-            <span class="loading fa fa-spinner fa-spin" data-ng-show="searching"></span>
+            <span
+              class="loading fa fa-spinner fa-spin"
+              data-ng-show="searching"
+            ></span>
 
             <div
               class="alert alert-warning"
@@ -118,7 +123,10 @@
               data-template-url="resultTemplate"
               data-map="searchObj.searchMap"
             ></div>
-
+          </div>
+        </div>
+        <div class="row gn-row-tools gn-noborder-bottom hidden-print">
+          <div class="col-sm-3">
             <button
               data-ng-show="searchResults.records.length > 9"
               class="btn btn-link hidden-print"
@@ -127,6 +135,15 @@
             >
               <i class="fa fa-fw fa-chevron-up" />
             </button>
+          </div>
+          <div class="col-xs-12 col-sm-6 text-center">
+            <div
+              class=""
+              data-gn-pagination="paginationInfo"
+              data-hits-values="searchObj.hitsperpageValues"
+              data-enable-hot-keys=""
+              data-enable-events=""
+            ></div>
           </div>
         </div>
       </div>
@@ -146,7 +163,9 @@
         class="gn-toggle gn-minimap-toggle btn btn-primary gn-minimap-button hidden-xs"
       >
         <i class="fa fa-angle-double-right"></i>
-        <strong class="gn-minimap-toggle gn-minimap-text" data-translate="">map</strong>
+        <strong class="gn-minimap-toggle gn-minimap-text" data-translate=""
+          >map</strong
+        >
       </button>
     </div>
   </div>


### PR DESCRIPTION
When you're scrolled all the way to the bottom of the search page, you need to scroll all the way back to the top to go to the next page. This PR also adds a pagination to the bottom of the page so there's no need to go to the top anymore.

<img width="870" alt="gn-search-pagination-footer" src="https://user-images.githubusercontent.com/19608667/234854418-09a1b591-a503-49d7-9066-adffd2c3613d.png">
