### PR TITLE
Prevent breaking of topic titles in middle of title

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/less/gn_topics_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_topics_default.less
@@ -73,7 +73,7 @@
           line-height: 1.3em;
           vertical-align: middle;
           font-weight: normal;
-          word-break: break-all;
+          word-break: break-word;
           border-top-left-radius: 4px;
           border-top-right-radius: 4px;
         }


### PR DESCRIPTION
Titles of the Topics on the homepage were breaking in the middle of the word, this PR fixes this by not breaking in the middle of a word anymore

**Before**
<img width="1026" alt="gn-topics-before" src="https://user-images.githubusercontent.com/19608667/234859027-b264d896-7baa-4030-94cb-4c3fd82a7473.png">

**After**
<img width="1028" alt="gn-topics-after" src="https://user-images.githubusercontent.com/19608667/234859347-d260aa14-8a97-4297-acc8-78e59d33409f.png">
