### PR TITLE
Move tooltip from reccusive input field to a single label

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
@@ -349,6 +349,7 @@
                 for="gn-addonlinesrc-description-single-textarea"
                 class="col-sm-2 control-label"
                 data-translate=""
+                data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.desc.tooltip}}"
                 >description</label
               >
               <div class="col-sm-9" data-ng-if="!params.linkType.fields.desc.directive">
@@ -364,7 +365,6 @@
                     data-ng-model="params.desc"
                     class="form-control input-sm"
                     placeholder="description"
-                    data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.desc.tooltip}}"
                     name="description"
                   />
                 </div>
@@ -384,7 +384,6 @@
                     data-ng-model="params.desc[val]"
                     class="form-control input-sm"
                     placeholder="description"
-                    data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.desc.tooltip}}"
                     name="description"
                   />
                 </div>

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
@@ -291,6 +291,7 @@
                 for="gn-addonlinesrc-name-single-input"
                 class="col-sm-2 control-label"
                 data-translate=""
+                data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.name.tooltip}}"
                 >onlineResourceName</label
               >
               <div
@@ -306,7 +307,6 @@
                   class="form-control input-sm"
                   type="text"
                   placeholder="Name"
-                  data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.name.tooltip}}"
                   data-ng-readonly='config.wmsResources.addLayerNamesMode ==
                 "resourcename" && OGCProtocol != null && isWMSProtocol()'
                 />
@@ -319,32 +319,16 @@
                 data-main-language="{{mdLang}}"
                 expanded="false"
               >
-                <span data-ng-repeat="(key, val) in mdLangs">
-                  <input
-                    data-ng-if="$index == 0"
-                    id="gn-addonlinesrc-name-multilingual-{{val}}"
-                    data-ng-required="params.linkType.fields.name.required"
-                    class="form-control input-sm"
-                    lang="{{val}}"
-                    data-ng-model="params.name[val]"
-                    data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.name.tooltip}}"
-                    data-ng-readonly='config.wmsResources.addLayerNamesMode ==
-                    "resourcename" && OGCProtocol != null && isWMSProtocol()'
-                    />
-
-                  <input
-                    data-ng-if="$index > 0"
-                    id="gn-addonlinesrc-name-multilingual-{{val}}"
-                    data-ng-required="params.linkType.fields.name.required"
-                    class="form-control input-sm"
-                    lang="{{val}}"
-                    data-ng-model="params.name[val]"
-                    data-ng-readonly='config.wmsResources.addLayerNamesMode ==
-                    "resourcename" && OGCProtocol != null && isWMSProtocol()'
-                  />
-
-                </span>
-
+                <input
+                  data-ng-repeat="(key, val) in mdLangs"
+                  id="gn-addonlinesrc-name-multilingual-{{val}}"
+                  data-ng-required="params.linkType.fields.name.required"
+                  class="form-control input-sm"
+                  lang="{{val}}"
+                  data-ng-model="params.name[val]"
+                  data-ng-readonly='config.wmsResources.addLayerNamesMode ==
+                "resourcename" && OGCProtocol != null && isWMSProtocol()'
+                />
               </div>
 
               <div class="col-sm-1 gn-control"></div>
@@ -365,6 +349,7 @@
                 for="gn-addonlinesrc-description-single-textarea"
                 class="col-sm-2 control-label"
                 data-translate=""
+                data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.desc.tooltip}}"
                 >description</label
               >
               <div class="col-sm-9" data-ng-if="!params.linkType.fields.desc.directive">
@@ -377,7 +362,6 @@
                     id="gn-addonlinesrc-description-single-textarea"
                     data-gn-autogrow=""
                     data-ng-required="params.linkType.fields.desc.required"
-                    data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.desc.tooltip}}"
                     data-ng-model="params.desc"
                     class="form-control input-sm"
                     placeholder="description"
@@ -391,32 +375,17 @@
                   data-main-language="{{mdLang}}"
                   expanded="false"
                 >
-                  <span data-ng-repeat="(key, val) in mdLangs">
-                    <textarea
-                      data-ng-if="$index == 0"
-                      id="gn-addonlinesrc-description-multilingual-{{val}}"
-                      rows="3"
-                      lang="{{val}}"
-                      data-ng-required="params.linkType.fields.applicationProfile.required"
-                      data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.desc.tooltip}}"
-                      data-ng-model="params.desc[val]"
-                      class="form-control input-sm"
-                      placeholder="description"
-                      name="description"
-                    />
-                    <textarea
-                      data-ng-if="$index > 0"
-                      id="gn-addonlinesrc-description-multilingual-{{val}}"
-                      rows="3"
-                      lang="{{val}}"
-                      data-ng-required="params.linkType.fields.applicationProfile.required"
-                      data-ng-model="params.desc[val]"
-                      class="form-control input-sm"
-                      placeholder="description"
-                      name="description"
-                    />
-                  </span>
-
+                  <textarea
+                    data-ng-repeat="(key, val) in mdLangs"
+                    id="gn-addonlinesrc-description-multilingual-{{val}}"
+                    rows="3"
+                    lang="{{val}}"
+                    data-ng-required="params.linkType.fields.applicationProfile.required"
+                    data-ng-model="params.desc[val]"
+                    class="form-control input-sm"
+                    placeholder="description"
+                    name="description"
+                  />
                 </div>
               </div>
               <div

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
@@ -64,7 +64,8 @@
               data-ng-if="key === 'function' &&
                              !params.linkType.fields.function.hidden"
             >
-              <label id="gn-addonlinesrc-function-label" class="col-sm-2 control-label">
+              <label id="gn-addonlinesrc-function-label" class="col-sm-2 control-label"
+                     data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.function.tooltip}}">
                 <span data-translate="">onlineFunction</span>
               </label>
               <div class="col-sm-9">
@@ -75,7 +76,6 @@
                   data-init-on-load="true"
                   data-allow-blank="true"
                   data-selected-info="params.function"
-                  data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.function.tooltip}}"
                   data-gn-schema-info="function"
                   lang="lang"
                 ></div>
@@ -93,7 +93,8 @@
               data-ng-if="key === 'protocol' &&
                              !params.linkType.fields.protocol.hidden"
             >
-              <label id="gn-addonlinesrc-protocol-label" class="col-sm-2 control-label">
+              <label id="gn-addonlinesrc-protocol-label" class="col-sm-2 control-label"
+                     data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.protocol.tooltip}}">
                 <span data-translate="">protocol</span>
               </label>
               <div class="col-sm-9">
@@ -103,7 +104,6 @@
                   data-init-on-load="true"
                   name="protocol"
                   data-selected-info="params.protocol"
-                  data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.protocol.tooltip}}"
                   data-gn-schema-info="protocol"
                   lang="lang"
                   data-extra-options="dataFormats"
@@ -120,7 +120,8 @@
               data-ng-if="key === 'mimeType' &&
                              !params.linkType.fields.mimeType.hidden"
             >
-              <label id="gn-addonlinesrc-mimeType-label" class="col-sm-2 control-label">
+              <label id="gn-addonlinesrc-mimeType-label" class="col-sm-2 control-label"
+                     data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.mimeType.tooltip}}">
                 <span data-translate="">mimeType</span>
               </label>
               <div class="col-sm-9">
@@ -129,7 +130,6 @@
                   type="text"
                   name="format"
                   data-ng-model="params.mimeType"
-                  data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.mimeType.tooltip}}"
                 />
               </div>
               <div class="col-sm-1 gn-control"></div>
@@ -148,6 +148,7 @@
                   for="gn-addonlinesrc-url-list-single-input"
                   class="col-sm-2 control-label"
                   data-translate=""
+                  data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.url.tooltip}}"
                   >url</label
                 >
 
@@ -166,7 +167,6 @@
                     class="form-control input-sm"
                     lang="{{val}}"
                     ng-model-options="{debounce: 500}"
-                    data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.url.tooltip}}"
                     data-ng-model="params.url[val]"
                   />
                 </div>
@@ -188,7 +188,6 @@
                       type="text"
                       data-ng-blur="loadCurrentLink()"
                       id="gn-addonlinesrc-url-list-single-input"
-                      data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.url.tooltip}}"
                       placeholder="{{params.linkType.fields.url.placeholder || 'https://...'}}"
                     />
                     <span class="input-group-btn" data-ng-show="OGCProtocol != null">
@@ -416,7 +415,7 @@
                 for="gn-addonlinesrc-profile-input"
                 class="col-sm-2 control-label"
                 data-translate=""
-                >applicationProfile</label
+                data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.applicationProfile.tooltip}}">applicationProfile</label
               >
               <div class="col-sm-9">
                 <input
@@ -425,7 +424,6 @@
                   data-ng-required="params.linkType.fields.applicationProfile.required"
                   name="applicationProfile"
                   class="form-control"
-                  data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.applicationProfile.tooltip}}"
                   type="text"
                 />
               </div>

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
@@ -291,6 +291,7 @@
                 for="gn-addonlinesrc-name-single-input"
                 class="col-sm-2 control-label"
                 data-translate=""
+                data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.name.tooltip}}"
                 >onlineResourceName</label
               >
               <div
@@ -305,7 +306,6 @@
                   name="name"
                   class="form-control input-sm"
                   type="text"
-                  data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.name.tooltip}}"
                   placeholder="Name"
                   data-ng-readonly='config.wmsResources.addLayerNamesMode ==
                 "resourcename" && OGCProtocol != null && isWMSProtocol()'
@@ -325,7 +325,6 @@
                   data-ng-required="params.linkType.fields.name.required"
                   class="form-control input-sm"
                   lang="{{val}}"
-                  data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.name.tooltip}}"
                   data-ng-model="params.name[val]"
                   data-ng-readonly='config.wmsResources.addLayerNamesMode ==
                 "resourcename" && OGCProtocol != null && isWMSProtocol()'
@@ -333,6 +332,7 @@
               </div>
 
               <div class="col-sm-1 gn-control"></div>
+
             </div>
 
             <!-- Description Text area -->

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
@@ -291,7 +291,6 @@
                 for="gn-addonlinesrc-name-single-input"
                 class="col-sm-2 control-label"
                 data-translate=""
-                data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.name.tooltip}}"
                 >onlineResourceName</label
               >
               <div
@@ -307,6 +306,7 @@
                   class="form-control input-sm"
                   type="text"
                   placeholder="Name"
+                  data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.name.tooltip}}"
                   data-ng-readonly='config.wmsResources.addLayerNamesMode ==
                 "resourcename" && OGCProtocol != null && isWMSProtocol()'
                 />
@@ -319,16 +319,32 @@
                 data-main-language="{{mdLang}}"
                 expanded="false"
               >
-                <input
-                  data-ng-repeat="(key, val) in mdLangs"
-                  id="gn-addonlinesrc-name-multilingual-{{val}}"
-                  data-ng-required="params.linkType.fields.name.required"
-                  class="form-control input-sm"
-                  lang="{{val}}"
-                  data-ng-model="params.name[val]"
-                  data-ng-readonly='config.wmsResources.addLayerNamesMode ==
-                "resourcename" && OGCProtocol != null && isWMSProtocol()'
-                />
+                <span data-ng-repeat="(key, val) in mdLangs">
+                  <input
+                    data-ng-if="$index == 0"
+                    id="gn-addonlinesrc-name-multilingual-{{val}}"
+                    data-ng-required="params.linkType.fields.name.required"
+                    class="form-control input-sm"
+                    lang="{{val}}"
+                    data-ng-model="params.name[val]"
+                    data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.name.tooltip}}"
+                    data-ng-readonly='config.wmsResources.addLayerNamesMode ==
+                    "resourcename" && OGCProtocol != null && isWMSProtocol()'
+                    />
+
+                  <input
+                    data-ng-if="$index > 0"
+                    id="gn-addonlinesrc-name-multilingual-{{val}}"
+                    data-ng-required="params.linkType.fields.name.required"
+                    class="form-control input-sm"
+                    lang="{{val}}"
+                    data-ng-model="params.name[val]"
+                    data-ng-readonly='config.wmsResources.addLayerNamesMode ==
+                    "resourcename" && OGCProtocol != null && isWMSProtocol()'
+                  />
+
+                </span>
+
               </div>
 
               <div class="col-sm-1 gn-control"></div>
@@ -349,7 +365,6 @@
                 for="gn-addonlinesrc-description-single-textarea"
                 class="col-sm-2 control-label"
                 data-translate=""
-                data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.desc.tooltip}}"
                 >description</label
               >
               <div class="col-sm-9" data-ng-if="!params.linkType.fields.desc.directive">
@@ -362,6 +377,7 @@
                     id="gn-addonlinesrc-description-single-textarea"
                     data-gn-autogrow=""
                     data-ng-required="params.linkType.fields.desc.required"
+                    data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.desc.tooltip}}"
                     data-ng-model="params.desc"
                     class="form-control input-sm"
                     placeholder="description"
@@ -375,17 +391,32 @@
                   data-main-language="{{mdLang}}"
                   expanded="false"
                 >
-                  <textarea
-                    data-ng-repeat="(key, val) in mdLangs"
-                    id="gn-addonlinesrc-description-multilingual-{{val}}"
-                    rows="3"
-                    lang="{{val}}"
-                    data-ng-required="params.linkType.fields.applicationProfile.required"
-                    data-ng-model="params.desc[val]"
-                    class="form-control input-sm"
-                    placeholder="description"
-                    name="description"
-                  />
+                  <span data-ng-repeat="(key, val) in mdLangs">
+                    <textarea
+                      data-ng-if="$index == 0"
+                      id="gn-addonlinesrc-description-multilingual-{{val}}"
+                      rows="3"
+                      lang="{{val}}"
+                      data-ng-required="params.linkType.fields.applicationProfile.required"
+                      data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.desc.tooltip}}"
+                      data-ng-model="params.desc[val]"
+                      class="form-control input-sm"
+                      placeholder="description"
+                      name="description"
+                    />
+                    <textarea
+                      data-ng-if="$index > 0"
+                      id="gn-addonlinesrc-description-multilingual-{{val}}"
+                      rows="3"
+                      lang="{{val}}"
+                      data-ng-required="params.linkType.fields.applicationProfile.required"
+                      data-ng-model="params.desc[val]"
+                      class="form-control input-sm"
+                      placeholder="description"
+                      name="description"
+                    />
+                  </span>
+
                 </div>
               </div>
               <div


### PR DESCRIPTION
This is to fix the issue of https://github.com/geonetwork/core-geonetwork/issues/7040

There are some duplicated of tool tip due to the tooltip was added to the recursive input fields instead of a single label. Therefore the tooltip will also be added multiple times.

![image](https://user-images.githubusercontent.com/74916635/235701751-4a7d703d-2008-4528-8777-a84a117c1e6b.png)
Here is the after fix look:

![image](https://user-images.githubusercontent.com/74916635/235166139-9f9e8300-d062-4ad8-ac2d-cd5cf63f223a.png)
