### PR TITLE
disable link to parent button to use ng-disabled

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/linkServiceToDataset.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/linkServiceToDataset.html
@@ -60,7 +60,7 @@
         type="button"
         class="btn navbar-btn btn-success"
         data-gn-click-and-spin="linkTo(addOnlineSrcInDataset)"
-        data-ng-class="{'disabled': (stateObj.selectRecords.length < 1)}"
+        ng-disabled="(stateObj.selectRecords.length < 1)"
       >
         <i class="fa gn-icon-service" />&nbsp;
         <span data-translate="" data-ng-show="mode == 'service'">linkToService</span>

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/linkToMd.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/linkToMd.html
@@ -35,7 +35,7 @@
         type="button"
         class="btn navbar-btn btn-success"
         data-gn-click-and-spin="gnOnlinesrc.linkToMd(mode, selectRecords[0], popupid)"
-        data-ng-class="{'disabled': (selectRecords.length < 1)}"
+        ng-disabled="(selectRecords.length < 1)"
       >
         <i class="fa gn-icon-{{mode}}" />
         <i class="icon-external-link"></i>&nbsp; {{btn.label}}


### PR DESCRIPTION
This issue can be tested from GN 4.0 (https://apps.titellus.net/geonetwork/srv/eng/catalog.search#/home).

Go to link to parent side panel when editing a metadata.

The button was initially disabled.
![image](https://user-images.githubusercontent.com/74916635/235695848-4e56e70a-76ef-4073-a29a-cd7bec9e7540.png)

If we click on it, it shows clickable and enabled.
![image](https://user-images.githubusercontent.com/74916635/235696046-4d3062a0-47d4-4683-9ad4-75f532a178af.png)


I placed ng-disabled which is same as adding resource panel to make the button disabled until records are selected.