### PR TITLE
Indexing / More robust on invalid thesaurus type

### DIFF
--- a/web/src/main/webapp/xslt/common/index-utils.xsl
+++ b/web/src/main/webapp/xslt/common/index-utils.xsl
@@ -388,17 +388,20 @@
 
     <!-- Build index field for type
     keywordType-place: [{default: France}]-->
-    <xsl:for-each-group select="$allKeywords" group-by="thesaurus/info/@type">
-      <xsl:element name="keywordType-{current-grouping-key()}">
-        <xsl:attribute name="type" select="'object'"/>
-        [<xsl:for-each select="$allKeywords/thesaurus[info/@type = current-grouping-key()]/keywords/keyword">
-        {
-        <xsl:value-of select="string-join(values/value, ', ')"/>
-        <xsl:if test="@uri != ''">, "link": "<xsl:value-of select="@uri"/>"</xsl:if>
-        }
-        <xsl:if test="position() != last()">,</xsl:if>
-      </xsl:for-each>]
-      </xsl:element>
+    <xsl:for-each-group select="$allKeywords"
+                        group-by="thesaurus/info/@type">
+      <xsl:if test="matches(current-grouping-key(), '^[A-Za-z\-_.]+$')">
+        <xsl:element name="keywordType-{current-grouping-key()}">
+          <xsl:attribute name="type" select="'object'"/>
+          [<xsl:for-each select="$allKeywords/thesaurus[info/@type = current-grouping-key()]/keywords/keyword">
+          {
+          <xsl:value-of select="string-join(values/value, ', ')"/>
+          <xsl:if test="@uri != ''">, "link": "<xsl:value-of select="@uri"/>"</xsl:if>
+          }
+          <xsl:if test="position() != last()">,</xsl:if>
+        </xsl:for-each>]
+        </xsl:element>
+      </xsl:if>
     </xsl:for-each-group>
 
     <!-- Fields with keywords and keyword count of a thesaurus, eg. th_regions, th_regionsNumber -->

--- a/web/src/main/webapp/xslt/common/index-utils.xsl
+++ b/web/src/main/webapp/xslt/common/index-utils.xsl
@@ -390,7 +390,7 @@
     keywordType-place: [{default: France}]-->
     <xsl:for-each-group select="$allKeywords"
                         group-by="thesaurus/info/@type">
-      <xsl:if test="matches(current-grouping-key(), '^[A-Za-z\-_.]+$')">
+      <xsl:if test="matches(current-grouping-key(), '^[A-Za-z\-_]+$')">
         <xsl:element name="keywordType-{current-grouping-key()}">
           <xsl:attribute name="type" select="'object'"/>
           [<xsl:for-each select="$allKeywords/thesaurus[info/@type = current-grouping-key()]/keywords/keyword">


### PR DESCRIPTION
Fixes for https://github.com/geonetwork/core-geonetwork/issues/7051.

ISO19139 and ISO19115-3 codelist for keyword type is only contains of letters eg. theme, place, discipline. Some users are reporting invalid metadata with keyword title in the keyword type (!) which cause an indexing error. 

Making the indexing more robust on this case only allowing letters and `-_` in codelist type.