### PR TITLE
Record view / Break keywords with long values

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/less/gn_result_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_result_default.less
@@ -310,6 +310,7 @@
     // keywords
     [data-gn-keyword-badges] {
       .btn {
+        word-break: break-word;
         white-space: normal;
         text-align: left;
       }


### PR DESCRIPTION
Some users are referencing CF standard names (https://cfconventions.org/Data/cf-standard-names/current/build/cf-standard-name-table.html) in keywords which can contains long values and display is not that nice. Improving it.

Create a record with 
```xml
         <gmd:descriptiveKeywords>
            <gmd:MD_Keywords>
               <gmd:keyword>
                  <gco:CharacterString>altitude_at_top_of_atmosphere_mixed_layer_defined_by_ambient_aerosol_particles_backwards_scattering_by_ranging_instrument</gco:CharacterString>
               </gmd:keyword>
               <gmd:type>
                  <gmd:MD_KeywordTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_KeywordTypeCode"
                                          codeListValue="cfstandardname"
                                          codeSpace="ISOTC211/19115"/>
               </gmd:type>
            </gmd:MD_Keywords>
         </gmd:descriptiveKeywords>
```
for testing.

Before
![image](https://user-images.githubusercontent.com/1701393/236281304-a1d0a4f1-7ee2-450d-a963-a6c1bd2686a5.png)


After
![image](https://user-images.githubusercontent.com/1701393/236281270-859feaad-c27f-4060-a310-f7c54a969c6c.png)
