### PR TITLE
Home page / Aggregations / Fix label for facet based on multilingual thesaurus

### DIFF
--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/FacetDirective.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/FacetDirective.js
@@ -449,9 +449,7 @@
         scope: {
           key: "=esFacetCards",
           homeFacet: "=homeFacet",
-          searchInfo: "=searchInfo",
-          aggResponse: "=aggResponse",
-          aggConfig: "=aggConfig"
+          searchInfo: "=searchInfo"
         },
         templateUrl: function (elem, attrs) {
           return (
@@ -468,6 +466,11 @@
               scope.homeFacet.config[scope.key].terms &&
               scope.homeFacet.config[scope.key].terms.missing;
             scope.isInspire = scope.key.indexOf("th_httpinspireeceuropaeutheme") === 0;
+
+            scope.aggregations = {};
+            scope.homeFacet.facets.forEach(function (facet) {
+              scope.aggregations[facet.key] = facet;
+            });
           }
 
           init();

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facet-cards.html
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facet-cards.html
@@ -1,6 +1,6 @@
 <div
-  data-ng-repeat="(k, facet) in searchInfo.aggregations[key].buckets"
-  data-ng-init="facetValue = facet.key || k;"
+  data-ng-repeat="(k, facet) in aggregations[key].items"
+  data-ng-init="facetValue = facet.value;"
   data-ng-show="facetValue"
   data-ng-class="isInspire ? ('bg-iti-' + (facet.key | facetCssClassCode: isInspire)) : ''"
   class="col-xs-6 col-sm-4 col-md-3 col-lg-2 gn-topic"
@@ -14,9 +14,9 @@
         class="clearfix"
         title="{{::facetValue}}"
         role="link"
-        data-ng-init="response = searchInfo.aggregations[key];
+        data-ng-init="response = aggregations[key];
                       decorator = (response.meta && response.meta.decorator) || undefined"
-        data-ng-href="{{::facetValue | facetSearchUrlBuilder:key:searchInfo.aggregations[key]:homeFacet.config[key]:missingValue}}"
+        data-ng-href="{{::facetValue | facetSearchUrlBuilder:key:aggregations[key]:homeFacet.config[key]:missingValue}}"
       >
         <span
           data-ng-if="decorator"
@@ -38,7 +38,7 @@
       </a>
     </div>
     <div class="panel-footer">
-      <i class="fa fa-fw fa-file-text-o"></i>{{::facet.doc_count}}
+      <i class="fa fa-fw fa-file-text-o"></i>{{::facet.count}}
     </div>
   </div>
 </div>

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -1517,6 +1517,7 @@
     "$cookies",
     "gnExternalViewer",
     "gnAlertService",
+    "gnESFacet",
     function (
       $scope,
       $http,
@@ -1536,7 +1537,8 @@
       gnSearchSettings,
       $cookies,
       gnExternalViewer,
-      gnAlertService
+      gnAlertService,
+      gnESFacet
     ) {
       $scope.version = "0.0.1";
       var defaultNode = "srv";
@@ -1952,6 +1954,7 @@
                   $scope.searchInfo = r.data;
                   var keys = Object.keys(gnGlobalSettings.gnCfg.mods.home.facetConfig);
                   selectedFacet = keys[0];
+
                   for (var i = 0; i < keys.length; i++) {
                     if (
                       $scope.searchInfo.aggregations[keys[i]].buckets.length > 0 ||
@@ -1965,7 +1968,13 @@
                     list: keys,
                     key: selectedFacet,
                     lastKey: keys.length > 1 ? keys[keys.length - 1] : undefined,
-                    config: gnGlobalSettings.gnCfg.mods.home.facetConfig
+                    config: gnGlobalSettings.gnCfg.mods.home.facetConfig,
+                    facets: gnESFacet.createFacetModel(
+                      gnGlobalSettings.gnCfg.mods.home.facetConfig,
+                      r.data.aggregations,
+                      undefined,
+                      undefined
+                    )
                   };
                 });
             }


### PR DESCRIPTION
Use the facet model for the facet cards as in the search facet component (which takes care of loading keyword translations from the thesaurus based on the key value).

eg. when adding GEMET on home page

```json
       "home": {
            "facetConfig": {
              "th_gemet_tree.key": {
                "terms": {
                  "field": "th_gemet_tree.key",
                  "size": 10
                }
              },
```

Before
![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/94f6cf78-65a6-421e-afdf-d4c68722a09d)

After
![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/1c12c54e-0c2c-41d0-844d-e8d1678c2094)
