### PR TITLE
Update documentation url

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/needhelp/NeedHelpDirective.js
+++ b/web-ui/src/main/resources/catalog/components/common/needhelp/NeedHelpDirective.js
@@ -55,7 +55,7 @@
         link: function(scope, element, attrs) {
           scope.iconOnly = attrs.iconOnly === 'true';
           var helpBaseUrl = gnGlobalSettings.docUrl ||
-              'https://geonetwork-opensource.org/manuals/trunk/';
+              'https://geonetwork-opensource.org/manuals/3.12.x/';
 
           var testAndOpen = function(url) {
             var defer = $q.defer();

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -333,7 +333,7 @@ goog.require('gn_alert');
       requireProxy: [],
       gnCfg: angular.copy(defaultConfig),
       gnUrl: '',
-      docUrl: 'https://geonetwork-opensource.org/manuals/trunk/',
+      docUrl: 'https://geonetwork-opensource.org/manuals/3.12.x/',
       //docUrl: '../../doc/',
       modelOptions: {
         updateOn: 'default blur',


### PR DESCRIPTION
Documentation for 3.12.x has been changed to https://geonetwork-opensource.org/manuals/3.12.x/en. 

For the time being there is a redirect configured from the old url https://geonetwork-opensource.org/manuals/trunk/en/, so previous installations of GeoNetwork work properly.