### PR TITLE
Fix multiple default tab in a single view

### DIFF
--- a/web/src/main/webapp/xslt/common/base-variables-metadata.xsl
+++ b/web/src/main/webapp/xslt/common/base-variables-metadata.xsl
@@ -26,6 +26,7 @@
                 xmlns:gn="http://www.fao.org/geonetwork"
                 xmlns:util="java:org.fao.geonet.util.XslUtil"
                 xmlns:saxon="http://saxon.sf.net/"
+                xmlns:gn-fn-metadata="http://geonetwork-opensource.org/xsl/functions/metadata"
                 version="2.0" extension-element-prefixes="saxon"
 >
   <!-- Global XSL variables about the metadata record. This should be included for
@@ -105,7 +106,10 @@
                         then /root/request/currTab
                         else if (/root/gui/currTab != '')
                         then /root/gui/currTab
-                        else $editorConfig/editor/views/view[@default]/tab[@default]/@id"/>
+                        else $editorConfig/editor/views/view[@default]/tab[
+                          @default and
+                          gn-fn-metadata:check-elementandsession-visibility($schema, $metadata, $serviceInfo, @displayIfRecord, @displayIfServiceInfo)
+                        ]/@id"/>
 
   <xsl:variable name="viewConfig"
                 select="$editorConfig/editor/views/view[tab/@id = $tab]"/>


### PR DESCRIPTION
@fxprunayre  

Declaring multiple default tabs in a single view, with a pre-condition to be displayed will cause issue and lead to multiple tabs being shown at once.

```xml
<tab id="tabDataset" default="true" mode="flat" displayIfRecord="count(//dcat:dataset) > 0" hideIfNotDisplayed="true">...</tab>
<tab id="tabDistribution" mode="flat" displayIfRecord="count(//dcat:dataset) > 0" hideIfNotDisplayed="true">...</tab>
<tab id="tabService" default="true" mode="flat" displayIfRecord="count(//dcat:service) > 0" hideIfNotDisplayed="true">...</tab>