### PR TITLE
Editor / Top bar / Avoid hiding editor tabs with tool bar actions.

### DIFF
--- a/web-ui/src/main/resources/catalog/templates/editor/top-toolbar.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/top-toolbar.html
@@ -12,9 +12,10 @@
       {{gnCurrentEdit.mdTitle | limitTo: 50 }} {{gnCurrentEdit.mdTitle.length > 50 ? '...'
       : ''}}
     </h1>
-    <br/>
-    <span class="label label-default"
-          data-ng-class="saveError ? 'text-danger' : ''">{{savedStatus}}</span>
+    <br />
+    <span class="label label-default" data-ng-class="saveError ? 'text-danger' : ''"
+      >{{savedStatus}}</span
+    >
   </div>
 
   <div class="gn-btn-toolbar navbar-right">

--- a/web-ui/src/main/resources/catalog/templates/editor/top-toolbar.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/top-toolbar.html
@@ -12,8 +12,9 @@
       {{gnCurrentEdit.mdTitle | limitTo: 50 }} {{gnCurrentEdit.mdTitle.length > 50 ? '...'
       : ''}}
     </h1>
-    <span data-ng-if="savedStatus">| </span>
-    <span data-ng-class="saveError ? 'text-danger' : ''">{{savedStatus}}</span>
+    <br/>
+    <span class="label label-default"
+          data-ng-class="saveError ? 'text-danger' : ''">{{savedStatus}}</span>
   </div>
 
   <div class="gn-btn-toolbar navbar-right">

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
@@ -26,7 +26,7 @@
     // status
     div.gn-tooltip {
       padding: 0;
-      margin: 15px 0;
+      margin: 10px 0;
       h1 {
         font-size: 14px;
         font-weight: 700;


### PR DESCRIPTION
Move the save status below title to avoid overlapping buttons and editor tabs. This depend on the size of translations and the zoom level.

Before

![Pasted image 2](https://github.com/geonetwork/core-geonetwork/assets/1701393/5d2cfcae-f8c9-4762-bed1-fc22380f5201)

After
![Pasted image 3](https://github.com/geonetwork/core-geonetwork/assets/1701393/8de39a46-542e-4c00-aab6-0d48c819f460)

