### PR TITLE
Send metadata mail notifications for public metadata when is re-approved

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/model/MetadataPublicationNotificationInfo.java
+++ b/services/src/main/java/org/fao/geonet/api/records/model/MetadataPublicationNotificationInfo.java
@@ -44,7 +44,6 @@ public class MetadataPublicationNotificationInfo {
      * When the metadata workflow is enabled and the metadata was already
      * published, but has been reapproved a working copy. To use a different
      * message for the mail.
-     *
      */
     private boolean reapproval = false;
 

--- a/services/src/main/java/org/fao/geonet/api/records/model/MetadataPublicationNotificationInfo.java
+++ b/services/src/main/java/org/fao/geonet/api/records/model/MetadataPublicationNotificationInfo.java
@@ -40,6 +40,14 @@ public class MetadataPublicationNotificationInfo {
     private String reviewerUser = "";
     private String submitterUser = "";
 
+    /**
+     * When the metadata workflow is enabled and the metadata was already
+     * published, but has been reapproved a working copy. To use a different
+     * message for the mail.
+     *
+     */
+    private boolean reapproval = false;
+
     public String getMetadataUuid() {
         return metadataUuid;
     }
@@ -102,5 +110,13 @@ public class MetadataPublicationNotificationInfo {
 
     public void setSubmitterUser(String submitterUser) {
         this.submitterUser = submitterUser;
+    }
+
+    public boolean isReapproval() {
+        return reapproval;
+    }
+
+    public void setReapproval(boolean reapproval) {
+        this.reapproval = reapproval;
     }
 }

--- a/services/src/main/java/org/fao/geonet/util/MetadataPublicationMailNotifier.java
+++ b/services/src/main/java/org/fao/geonet/util/MetadataPublicationMailNotifier.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright (C) 2001-2023 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+package org.fao.geonet.util;
+
+import org.apache.commons.lang3.StringUtils;
+import org.fao.geonet.api.API;
+import org.fao.geonet.api.records.model.MetadataPublicationNotificationInfo;
+import org.fao.geonet.domain.Group;
+import org.fao.geonet.domain.StatusValueNotificationLevel;
+import org.fao.geonet.domain.User;
+import org.fao.geonet.kernel.metadata.DefaultStatusActions;
+import org.fao.geonet.kernel.setting.SettingManager;
+import org.fao.geonet.repository.GroupRepository;
+import org.fao.geonet.util.MailUtil;
+import org.fao.geonet.utils.Log;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static org.fao.geonet.kernel.setting.Settings.SYSTEM_METADATAPRIVS_PUBLICATION_NOTIFICATIONGROUPS;
+import static org.fao.geonet.kernel.setting.Settings.SYSTEM_METADATAPRIVS_PUBLICATION_NOTIFICATIONLEVEL;
+
+@Component
+public class MetadataPublicationMailNotifier {
+    @Autowired
+    SettingManager sm;
+
+    @Autowired
+    GroupRepository groupRepository;
+
+    /**
+     * Notify a metadata publication by mail.
+     *
+     * Collects the email addresses to be notified based on the metadata publication
+     * notification level configured in the settings.
+     *
+     * @param messages                          Message bundle with the mail texts.
+     * @param mailLanguage                      Language to use for the mais.
+     * @param metadataListToNotifyPublication   List of notifications to send.
+     *
+     */
+    public void notifyPublication(ResourceBundle messages,
+                                  String mailLanguage,
+                                  List<MetadataPublicationNotificationInfo> metadataListToNotifyPublication) {
+        String notificationSetting = sm.getValue(SYSTEM_METADATAPRIVS_PUBLICATION_NOTIFICATIONLEVEL);
+        if (StringUtils.isNotEmpty(notificationSetting)) {
+            StatusValueNotificationLevel notificationLevel =
+                StatusValueNotificationLevel.valueOf(notificationSetting);
+            if (notificationLevel != null) {
+
+                if (notificationLevel == StatusValueNotificationLevel.recordProfileReviewer) {
+                    Map<Integer, List<MetadataPublicationNotificationInfo>> metadataListToNotifyPublicationPerGroup =
+                        metadataListToNotifyPublication.stream()
+                            .collect(Collectors.groupingBy(MetadataPublicationNotificationInfo::getGroupId));
+
+                    // Process the metadata published by group owner
+                    metadataListToNotifyPublicationPerGroup.forEach((groupId, metadataNotificationInfoList) -> {
+                        Set<Integer> metadataIds = metadataNotificationInfoList
+                            .stream().map(m -> m.getMetadataId()).collect(Collectors.toSet());
+
+                        List<User> userToNotify = DefaultStatusActions.getUserToNotify(notificationLevel,
+                            metadataIds,
+                            null);
+
+                        List<String> toAddress1 = userToNotify.stream()
+                            .filter(u -> StringUtils.isNotEmpty(u.getEmail()))
+                            .map(User::getEmail)
+                            .collect(Collectors.toList());
+
+                        sendMailPublicationNotification(messages, mailLanguage, toAddress1, metadataNotificationInfoList);
+                    });
+
+                } else {
+                    List<String> toAddress;
+
+                    if (notificationLevel == StatusValueNotificationLevel.recordGroupEmail) {
+                        List<Group> groupToNotify = DefaultStatusActions.getGroupToNotify(notificationLevel,
+                            Arrays.asList(sm.getValue(SYSTEM_METADATAPRIVS_PUBLICATION_NOTIFICATIONGROUPS).split("\\|")));
+
+                        toAddress = groupToNotify.stream()
+                            .filter(g -> StringUtils.isNotEmpty(g.getEmail()))
+                            .map(Group::getEmail)
+                            .collect(Collectors.toList());
+                    } else {
+                        Set<Integer> metadataIds = metadataListToNotifyPublication
+                            .stream().map(m -> m.getMetadataId()).collect(Collectors.toSet());
+
+                        List<User> userToNotify = DefaultStatusActions.getUserToNotify(notificationLevel,
+                            metadataIds,
+                            null);
+
+                        toAddress = userToNotify.stream()
+                            .filter(u -> StringUtils.isNotEmpty(u.getEmail()))
+                            .map(User::getEmail)
+                            .collect(Collectors.toList());
+
+                    }
+
+                    sendMailPublicationNotification(messages, mailLanguage, toAddress, metadataListToNotifyPublication);
+                }
+            }
+        }
+    }
+
+    private void sendMailPublicationNotification(ResourceBundle messages,
+                                                 String mailLanguage,
+                                                 List<String> toAddress,
+                                                 List<MetadataPublicationNotificationInfo> metadataListToNotifyPublication) {
+        if (toAddress.isEmpty()) {
+            return;
+        }
+
+        String subject = String.format(
+            messages.getString("metadata_published_subject"),
+            sm.getSiteName());
+        String message = messages.getString("metadata_published_text");
+
+        String linkRecordTemplate = "{{link}}";
+        String linkRecordUrlTemplate = sm.getNodeURL()+ "api/records/{{index:uuid}}";
+
+        String recordPublishedMessage = messages.getString("metadata_published_record_text")
+            .replace(linkRecordTemplate, linkRecordUrlTemplate);
+        String recordUnpublishedMessage  = messages.getString("metadata_unpublished_record_text")
+            .replace(linkRecordTemplate, linkRecordUrlTemplate);
+        String recordReapprovedPublishedMessage = messages.getString("metadata_approved_published_record_text")
+            .replace(linkRecordTemplate, linkRecordUrlTemplate);
+
+
+        StringBuilder listOfProcessedMetadataMessage = new StringBuilder();
+
+        metadataListToNotifyPublication.forEach( metadata -> {
+            java.util.Optional<Group> group = groupRepository.findById(metadata.getGroupId());
+
+            if (Boolean.TRUE.equals(metadata.getPublished())) {
+                String recordPublishedMessageAux;
+
+                if (!metadata.isReapproval()) {
+                    recordPublishedMessageAux = replaceMessageValues(recordPublishedMessage, metadata, group);
+                } else {
+                    recordPublishedMessageAux = replaceMessageValues(recordReapprovedPublishedMessage, metadata, group);
+                }
+
+                listOfProcessedMetadataMessage.append(
+                    MailUtil.compileMessageWithIndexFields(recordPublishedMessageAux, metadata.getMetadataUuid(), mailLanguage));
+            } else {
+                String recordUnpublishedMessageAux = replaceMessageValues(recordUnpublishedMessage, metadata, group);
+
+                listOfProcessedMetadataMessage.append(
+                    MailUtil.compileMessageWithIndexFields(recordUnpublishedMessageAux, metadata.getMetadataUuid(), mailLanguage));
+            }
+        });
+
+        String htmlMessage = String.format(message, listOfProcessedMetadataMessage);
+
+        // Send mail to notify about metadata publication / un-publication
+        try {
+            MailUtil.sendHtmlMail(toAddress, subject, htmlMessage, sm);
+        } catch (IllegalArgumentException ex) {
+            Log.warning(API.LOG_MODULE_NAME, ex.getMessage(), ex);
+        }
+    }
+
+
+    private String replaceMessageValues(String message, MetadataPublicationNotificationInfo metadata, Optional<Group> group) {
+        String messageAux = message
+            .replace("{{publisherUser}}", metadata.getPublisherUser())
+            .replace("{{submitterUser}}", metadata.getSubmitterUser())
+            .replace("{{reviewerUser}}", metadata.getReviewerUser())
+            .replace("{{timeStamp}}", metadata.getPublicationDateStamp().getDateAndTime());
+
+        if (group.isPresent()) {
+            messageAux = messageAux.replace("{{group}}", group.get().getName());
+        }
+
+        return messageAux;
+    }
+}

--- a/services/src/main/resources/config-spring-geonetwork.xml
+++ b/services/src/main/resources/config-spring-geonetwork.xml
@@ -42,6 +42,7 @@
   <context:component-scan base-package="org.fao.geonet.guiapi"/>
   <context:component-scan base-package="org.fao.geonet.guiservices"/>
   <context:component-scan base-package="org.fao.geonet.services"/>
+  <context:component-scan base-package="org.fao.geonet.util"/>
 
   <bean id="defaultLanguage" class="java.lang.String">
     <constructor-arg index="0" value="\${language.default}"/>

--- a/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages.properties
+++ b/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages.properties
@@ -120,6 +120,7 @@ metadata_published_text=The following records have been processed:\n\
     <ul>%s</ul>
 metadata_published_record_text=<li>The metadata <a href="{{link}}">{{index:resourceTitleObject}}</a> has been published.</li>
 metadata_unpublished_record_text=<li>The metadata <a href="{{link}}">{{index:resourceTitleObject}}</a> has been unpublished.</li>
+metadata_approved_published_record_text=<li>The metadata <a href="{{link}}">{{index:resourceTitleObject}}</a> has been published a new version.</li>
 
 api.groups.group_not_found=Group with ID ''{0}'' not found in this catalog.
 user_watchlist_subject=%s / %d updates in your watch list since %s

--- a/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages_fre.properties
+++ b/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages_fre.properties
@@ -109,6 +109,7 @@ metadata_published_text=Les fiches suivantes ont \u00E9t\u00E9 trait\u00E9es:\n\
     <ul>%s</ul>
 metadata_published_record_text=<li>La m\u00E9tadonn\u00E9e <a href="{{link}}">{{index:resourceTitleObject}}</a> a \u00E9t\u00E9 publi\u00E9e.</li>
 metadata_unpublished_record_text=<li>La m\u00E9tadonn\u00E9e <a href="{{link}}">{{index:resourceTitleObject}}</a> a \u00E9t\u00E9 d\u00E9publi\u00E9e.</li>
+metadata_approved_published_record_text=<li>La m\u00E9tadonn\u00E9e <a href="{{link}}">{{index:resourceTitleObject}}</a> a \u00E9t\u00E9 publi\u00E9e dans une nouvelle version.</li>
 
 api.groups.group_not_found=Le groupe avec l''identifiant ''{0}'' n''a pas \u00E9t\u00E9 trouv\u00E9 dans le catalogue.
 user_watchlist_subject=%s / %d mises \u00e0 jour dans vos fiches surveill\u00E9es %s


### PR DESCRIPTION
When a metadata is published / un-published it can be configured a mail notification.

When the metadata workflow is enabled, published metadata can be edited and re-approved. This change request expands the email notifications in this case, to send an email to let you know that a published metadata has been re-approved, with a new version published.

Related to https://github.com/geonetwork/core-geonetwork/pull/6457

The change request contains also Sonarlint code changes.