### PR TITLE
fixed links to debugging tomcat in eclipse and remote debugging

### DIFF
--- a/software_development/ECLIPSE.md
+++ b/software_development/ECLIPSE.md
@@ -86,8 +86,8 @@ Tomcat Plugin for controlling a Tomcat Service.
 
 ## Remote Debugging
 
-* [How do I configure Tomcat to support remote debugging?](http://wiki.apache.org/tomcat/FAQ/Developing#Q1)
-* [How do I remotely debug Tomcat using Eclipse?](http://wiki.apache.org/tomcat/FAQ/Developing#Q2)
+* [How do I configure Tomcat to support remote debugging?](https://cwiki.apache.org/confluence/display/TOMCAT/Developing#Developing-Q1)
+* [How do I remotely debug Tomcat using Eclipse?](https://cwiki.apache.org/confluence/display/TOMCAT/Developing#Developing-Q2)
 
 ## Code Quality Tools in Eclipse
 


### PR DESCRIPTION
Fixed the two URLs in https://github.com/geonetwork/core-geonetwork/blob/main/software_development/ECLIPSE.md#remote-debugging to use the correct cwiki.apache.org links