### PR TITLE
UI / Language picker / Display all entries on focus. Search by code and labels

### DIFF
--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -906,7 +906,11 @@
                   lang.tokens = [lang.name, lang.code, lang.english];
                 });
                 var source = new Bloodhound({
-                  datumTokenizer: Bloodhound.tokenizers.obj.whitespace("name", "code", "english"),
+                  datumTokenizer: Bloodhound.tokenizers.obj.whitespace(
+                    "name",
+                    "code",
+                    "english"
+                  ),
                   queryTokenizer: Bloodhound.tokenizers.whitespace,
                   local: data,
                   limit: 30

--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -900,18 +900,27 @@
                 // Compute default name and add a
                 // tokens element which is used for filter
                 angular.forEach(data, function (lang) {
-                  var defaultName = lang.label["eng"];
-                  lang.name = lang.label[scope.lang] || defaultName;
+                  lang.english = lang.label["eng"];
+                  lang.name = lang.label[scope.lang] || lang.english;
                   lang.code = scope.prefix + lang.code;
-                  lang.tokens = [lang.name, lang.code, defaultName];
+                  lang.tokens = [lang.name, lang.code, lang.english];
                 });
                 var source = new Bloodhound({
-                  datumTokenizer: Bloodhound.tokenizers.obj.whitespace("name"),
+                  datumTokenizer: Bloodhound.tokenizers.obj.whitespace("name", "code", "english"),
                   queryTokenizer: Bloodhound.tokenizers.whitespace,
                   local: data,
                   limit: 30
                 });
                 source.initialize();
+
+                function allOrSearchFn(q, sync) {
+                  if (q === "") {
+                    sync(source.all());
+                  } else {
+                    source.search(q, sync);
+                  }
+                }
+
                 $(element).typeahead(
                   {
                     minLength: 0,
@@ -920,7 +929,7 @@
                   {
                     name: "isoLanguages",
                     displayKey: "code",
-                    source: source.ttAdapter(),
+                    source: allOrSearchFn,
                     templates: {
                       suggestion: function (datum) {
                         return "<p>" + datum.name + " (" + datum.code + ")</p>";


### PR DESCRIPTION

![Pasted image 4](https://github.com/geonetwork/core-geonetwork/assets/1701393/2a9561c7-bda8-4fe6-9b36-f344cacf84dc)


Side note : The default list contains all languages, here is a sample SQL to limit languages to the list of languages defined in the app (if modified) 

```sql
DELETE FROM isolanguagesdes
    WHERE langid NOT IN (
        SELECT id FROM languages
    );
DELETE FROM isolanguagesdes
    WHERE iddes NOT IN (
        SELECT id FROM isolanguages WHERE code IN (
            SELECT id FROM languages));
DELETE FROM isolanguages
    WHERE code NOT IN (SELECT id FROM languages);
```
 