### PR TITLE
SEO / Set HTML head title and description

### DIFF
--- a/core/src/main/java/org/fao/geonet/util/XslUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/XslUtil.java
@@ -443,6 +443,17 @@ public final class XslUtil {
         return source.isPresent() ? source.get().getLogo() : "";
     }
 
+    public static String getDiscoveryServiceUuid(String key) {
+        Optional<Source> source = getSource(key);
+        if (source.isPresent() && source.get().getType() == SourceType.subportal) {
+            return source.get().getServiceRecord();
+        } else {
+            SettingManager settingsMan = ApplicationContextHolder.get().getBean(SettingManager.class);
+            String uuid = settingsMan.getValue(SYSTEM_CSW_CAPABILITY_RECORD_UUID);
+            return "-1".equals(uuid) ? "" : uuid;
+        }
+    }
+
     private static Optional<Source> getSource(String idOrUuid) {
         SettingManager settingsMan = ApplicationContextHolder.get().getBean(SettingManager.class);
         if (StringUtils.isEmpty(idOrUuid)) {

--- a/web/src/main/webapp/xslt/base-layout.xsl
+++ b/web/src/main/webapp/xslt/base-layout.xsl
@@ -41,14 +41,40 @@
   <xsl:template match="/">
     <html ng-app="{$angularModule}" lang="{$lang2chars}" id="ng-app">
       <head>
-        <title>
-            <xsl:value-of select="util:getNodeName('', $lang, true())"/>
-        </title>
+        <xsl:variable name="discoveryServiceRecordUuid"
+                      select="util:getDiscoveryServiceUuid('')"/>
+        <xsl:variable name="nodeName"
+                      select="util:getNodeName('', $lang, true())"/>
+
+        <xsl:variable name="htmlHeadTitle"
+                      select="if ($discoveryServiceRecordUuid != '')
+                              then util:getIndexField(
+                                        $lang,
+                                        $discoveryServiceRecordUuid,
+                                        'resourceTitleObject',
+                                        $lang)
+                              else if (contains($nodeName, '|'))
+                              then substring-before($nodeName, '|')
+                              else $nodeName"/>
+
+
+        <xsl:variable name="htmlHeadDescription"
+                      select="if ($discoveryServiceRecordUuid != '')
+                              then util:getIndexField(
+                                        $lang,
+                                        $discoveryServiceRecordUuid,
+                                        'resourceAbstractObject',
+                                        $lang)
+                              else if (contains($nodeName, '|'))
+                              then substring-after($nodeName, '|')
+                              else $nodeName"/>
+
+        <title><xsl:value-of select="$htmlHeadTitle"/></title>
         <meta charset="utf-8"/>
         <meta name="viewport" content="initial-scale=1.0"/>
         <meta name="apple-mobile-web-app-capable" content="yes"/>
 
-        <meta name="description" content=""/>
+        <meta name="description" content="{$htmlHeadDescription}"/>
         <meta name="keywords" content=""/>
 
 


### PR DESCRIPTION
Currently HTML head description is set to an empty value. Google is indexing a cookie warning in GeoNetwork case when no HTML head is found (probably because it is the first HTML text content found).

eg.
![Pasted image 6](https://github.com/geonetwork/core-geonetwork/assets/1701393/8da2e2b4-74de-4395-af7c-01df4a42c69c)


Use a service metadata record to configure the catalogue title and description:

* for the main node (see admin > settings > record to use for GetCapabilities) 

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/ff205bc6-6093-431e-857c-99ccd634712b)


* for portal.

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/68c515c9-8692-4808-9371-b4d727cc28c9)


If no service metadata record configured, default title and description to the node name (or site name for the main portal).

eg. home page with proper title and description:

![Pasted image](https://github.com/geonetwork/core-geonetwork/assets/1701393/e2ee6d47-d3e3-4c0e-b0c6-7dc4e6fd3894)

which can be customized in the service metadata describing the portal

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/454617cb-806f-4cb2-8499-a5cb851d9f09)



Follow up of:
* https://github.com/geonetwork/core-geonetwork/commit/611be2a0f5a514be9fa3b80a14b0dd785c94dba9
* https://github.com/geonetwork/core-geonetwork/pull/4758


Future improvements:
* Do not only support the default language of the service metadata record.