### PR TITLE
fix the issue of parsing comma delimited schamas

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
@@ -621,13 +621,16 @@ public class BaseMetadataManager implements IMetadataManager {
 
         // Check if the schema is allowed by settings
         String mdImportSetting = settingManager.getValue(Settings.METADATA_IMPORT_RESTRICT);
-        if (mdImportSetting != null && !mdImportSetting.equals("")) {
-            if (!newMetadata.getHarvestInfo().isHarvested() && !Arrays.asList(mdImportSetting.split(",")).contains(schema)) {
+        if (!StringUtils.isEmpty(mdImportSetting)) {
+            if (!newMetadata.getHarvestInfo().isHarvested() &&
+                !Arrays.asList(mdImportSetting.trim().split("\\s*,\\s*")).contains(schema)) {
                 throw new IllegalArgumentException("The system setting '" + Settings.METADATA_IMPORT_RESTRICT
-                    + "' doesn't allow to import " + schema
-                    + " metadata records (they can still be harvested). "
-                    + "Apply an import stylesheet to convert file to one of the allowed schemas: " + mdImportSetting);
+                    + "' doesn't allow to import '" + schema
+                    + "' metadata records (they can still be harvested). "
+                    + "Apply an import stylesheet to convert file to one of the allowed schemas: "
+                    + mdImportSetting + ".");
             }
+        }
         }
 
         // --- force namespace prefix for iso19139 metadata


### PR DESCRIPTION
Geonetwork in admin settings accepts multiple imported metadata schemas in a string delimited by commas, such as  "scheam1,schema2". However, it could not handle heading or tailing spaces around the schema names, e.g "schema1, schema2".
Because many users get used to add space following a comma, geonetwork gets trouble to recognize these schemas.
The fixes resolve the problem.