### PR TITLE
Metadata workflow / send mail notifications for metadata status change to DRAFT when doing a rejection, not when creating a working copy

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/metadata/DefaultStatusActions.java
+++ b/core/src/main/java/org/fao/geonet/kernel/metadata/DefaultStatusActions.java
@@ -268,6 +268,16 @@ public class DefaultStatusActions implements StatusActions {
      */
     protected List<User> getUserToNotify(MetadataStatus status) {
         StatusValueNotificationLevel notificationLevel = status.getStatusValue().getNotificationLevel();
+
+        // If new status is DRAFT and previous status is not SUBMITTED (which means a rejection),
+        // ignore notifications as the DRAFT status is used also when creating the working copy.
+        // We don't want to notify when creating a working copy.
+        if (status.getStatusValue().getId() == Integer.parseInt(StatusValue.Status.DRAFT) &&
+            ((StringUtils.isEmpty(status.getPreviousState())) ||
+                (Integer.parseInt(status.getPreviousState()) != Integer.parseInt(StatusValue.Status.SUBMITTED)))) {
+                return new ArrayList<>();
+        }
+
         // TODO: Status does not provide batch update
         // So taking care of one record at a time.
         // Currently the code could notify a mix of reviewers


### PR DESCRIPTION
When the metadata workflow is enabled, currently when a metadata status changes to `DRAFT` is send a mail to the metadata author:

https://github.com/geonetwork/core-geonetwork/blob/0f2f2db5e4472735e5b0fc61fb7ef6ca78c78ab4/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql#L527

There are 2 cases that changes the metadata status to `DRAFT`:

1. When a metadata was submitted and the approval is rejected.
2. When a metadata is approved and it's created a working copy that gets that status.

This change updates the code to only send mail notifications in the 1st case, as the 2on case doesn't make sense to notify when the metadata is edited.