### PR TITLE
Configuration / Externalize Kibana configuration

### DIFF
--- a/web/src/main/webResources/WEB-INF/web.xml
+++ b/web/src/main/webResources/WEB-INF/web.xml
@@ -484,7 +484,7 @@
 
   <servlet>
     <servlet-name>HttpDashboardProxy</servlet-name>
-    <servlet-class>org.mitre.dsmiley.httpproxy.ProxyServlet</servlet-class>
+    <servlet-class>org.fao.geonet.proxy.URITemplateProxyServlet</servlet-class>
     <init-param>
       <param-name>targetUri</param-name>
       <param-value>${kb.url}</param-value>


### PR DESCRIPTION
Add the possibility to configure Kibana URL using env variables

eg.
```
 -Dgeonetwork.HttpDashboardProxy.targetUri=http://kibana:5601

```
Follow up of https://github.com/geonetwork/core-geonetwork/pull/6356