### PR TITLE
DB / Only update schema on startup

### DIFF
--- a/web/src/main/webResources/WEB-INF/config-spring-geonetwork.xml
+++ b/web/src/main/webResources/WEB-INF/config-spring-geonetwork.xml
@@ -118,7 +118,7 @@
     <entry key="hibernate.enable_lazy_load_no_trans" value="true"/>
     <!-- If db migration is off, disable automatic updates, but notify changes using validate -->
     <!-- options: none, validate, update, create, create-drop, create-only -->
-    <entry key="hibernate.hbm2ddl.auto" value="#{'\${db.migration_onstartup}' ? 'create-drop' : 'validate'}"/>
+    <entry key="hibernate.hbm2ddl.auto" value="#{'\${db.migration_onstartup}' ? 'update' : 'validate'}"/>
 
     <!-- If a specific schema has to be used
     <entry key="hibernate.default_schema" value="catalog"/>


### PR DESCRIPTION
Follow up of https://github.com/geonetwork/core-geonetwork/pull/6954

Not sure what is the default value when not set, but changing to update (as create-drop cleanup the schema on startup).

- *validate*: validate that the schema matches, make no changes to the schema of the database, you probably want this for production.
- *update*: update the schema to reflect the entities being persisted
- *create*: creates the schema necessary for your entities, destroying any previous data.
- *create-drop*: create the schema as in create above, but also drop the schema at the end of the session.