### PR TITLE
Workflow / On Cancel / Properly remove draft from index

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/draft/DraftMetadataUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/draft/DraftMetadataUtils.java
@@ -643,7 +643,7 @@ public class DraftMetadataUtils extends BaseMetadataUtils {
 
                 // --- remove metadata
                 xmlSerializer.delete(id, ServiceContext.get());
-                searchManager.delete(id);
+                searchManager.delete(String.format("+id:%s", id));
 
                 // Unset METADATA_EDITING_CREATED_DRAFT flag
                 context.getUserSession().removeProperty(Geonet.Session.METADATA_EDITING_CREATED_DRAFT);


### PR DESCRIPTION
Follow up of https://github.com/geonetwork/core-geonetwork/pull/5006

Test.
* enable workflow
* create a record
* publish (and approve)
* edit will create a draft
* cancel
* open record view http://localhost:8080/srv/eng/catalog.search#/metadata/5692d7a3-949e-4f27-8fe0-0fa9efd3584e
* open draft view (even if not displayed in record view) http://localhost:8080/srv/eng/catalog.search#/metadraf/5692d7a3-949e-4f27-8fe0-0fa9efd3584e show a records which does not exist in db anymore (due to cancel) but was not properly removed from index.

Also note that if you make some edits in the new draft, the cancel will not remove it (looks to be expected in 5006).