### PR TITLE
Fix javascript error when creating / editing online resources

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -1392,7 +1392,8 @@
                     selectedLayersNames = params[scope.addLayersInUrl].split(",");
                   }
 
-                  scope.layers.forEach &&
+                  scope.layers &&
+                    scope.layers.forEach &&
                     scope.layers.forEach(function (l) {
                       if (selectedLayersNames.indexOf(l.Name) != -1) {
                         scope.params.selectedLayers.push(l);
@@ -1409,7 +1410,8 @@
                     ? []
                     : scope.params.name.split(",");
                   scope.params.selectedLayers = [];
-                  scope.layers.forEach &&
+                  scope.layers &&
+                    scope.layers.forEach &&
                     scope.layers.forEach(function (l) {
                       if (selectedLayersNames.indexOf(l.Name) != -1) {
                         scope.params.selectedLayers.push(l);


### PR DESCRIPTION
Fixes the following javascript error when creating / editing online resources in the metadata editor:

```
b.js?v=c45c5f19b136d829dbe12df67e688ce7fd491343:143 TypeError: Cannot read properties of undefined (reading 'forEach')
    at H (gn_editor.js?v=c45c5f19b136d829dbe12df67e688ce7fd491343&:2161:266)
    at gn_editor.js?v=c45c5f19b136d829dbe12df67e688ce7fd491343&:2162:399
    at lib.js?v=c45c5f19b136d829dbe12df67e688ce7fd491343:155:454
    at m.$digest (lib.js?v=c45c5f19b136d829dbe12df67e688ce7fd491343:167:67)
    at m.$apply (lib.js?v=c45c5f19b136d829dbe12df67e688ce7fd491343:170:484)
    at k (lib.js?v=c45c5f19b136d829dbe12df67e688ce7fd491343:121:445)
    at v (lib.js?v=c45c5f19b136d829dbe12df67e688ce7fd491343:127:40)
    at y.onload (lib.js?v=c45c5f19b136d829dbe12df67e688ce7fd491343:127:464) 'Possibly unhandled rejection: {}'
```

`scope.layers`  can be `undefined`.

@fxprunayre the original code was just checking `scope.layers.forEach`, what is the reason for that? `scope.layers` apart of `undefined` can contain also something else than an array? If not I think we should remove the check `scope.layers.forEach`.