### PR TITLE
Fix microservices proxy detection

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/site/SiteApi.java
+++ b/services/src/main/java/org/fao/geonet/api/site/SiteApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2021 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2023 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -32,7 +32,7 @@ import jeeves.config.springutil.ServerBeanPropertyUpdater;
 import jeeves.server.JeevesProxyInfo;
 import jeeves.server.UserSession;
 import jeeves.server.context.ServiceContext;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.elasticsearch.client.RequestOptions;
 import org.elasticsearch.client.core.CountRequest;
 import org.elasticsearch.client.core.CountResponse;
@@ -235,17 +235,11 @@ public class SiteApi {
         }
 
         // Setting for OGC API Records service enabled
-        String microservicesTargetUri = "";
-        ServletRegistration microServicesProxyServlet =
-            request.getServletContext().getServletRegistrations().get("MicroServicesProxy");
-
-        if (microServicesProxyServlet != null) {
-            microservicesTargetUri = microServicesProxyServlet.getInitParameter("targetUri");
-        }
+        String microservicesTargetUri = (String) request.getServletContext().getAttribute("MicroServicesProxy.targetUri");
 
         response.getSettings().add(
             new Setting().setName(Settings.MICROSERVICES_ENABLED)
-                .setValue(Boolean.toString(StringUtils.isNotEmpty(microservicesTargetUri)))
+                .setValue(Boolean.toString(StringUtils.isNotBlank(microservicesTargetUri)))
                 .setDataType(SettingDataType.BOOLEAN));
 
         return response;

--- a/services/src/main/java/org/fao/geonet/guiservices/util/Env.java
+++ b/services/src/main/java/org/fao/geonet/guiservices/util/Env.java
@@ -1,5 +1,5 @@
 //=============================================================================
-//===	Copyright (C) 2001-2007 Food and Agriculture Organization of the
+//===	Copyright (C) 2001-2023 Food and Agriculture Organization of the
 //===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
 //===	and United Nations Environment Programme (UNEP)
 //===
@@ -26,7 +26,7 @@ package org.fao.geonet.guiservices.util;
 import jeeves.interfaces.Service;
 import jeeves.server.ServiceConfig;
 import jeeves.server.context.ServiceContext;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.fao.geonet.GeonetContext;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.kernel.XmlSerializer;
@@ -71,17 +71,10 @@ public class Env implements Service {
         }
 
         // Setting for OGC API Records service enabled
-        String microservicesTargetUri = "";
-
-        ServletRegistration microServicesProxyServlet =
-            context.getServlet().getServletContext().getServletRegistrations().get("MicroServicesProxy");
-
-        if (microServicesProxyServlet != null) {
-            microservicesTargetUri = microServicesProxyServlet.getInitParameter("targetUri");
-        }
+        String microservicesTargetUri = (String) context.getServlet().getServletContext().getAttribute("MicroServicesProxy.targetUri");
 
         Element microservicesEnabled = new Element("microservicesEnabled");
-        microservicesEnabled.setText(Boolean.toString(StringUtils.isNotEmpty(microservicesTargetUri)));
+        microservicesEnabled.setText(Boolean.toString(StringUtils.isNotBlank(microservicesTargetUri)));
         system.addContent(microservicesEnabled);
 
         return (Element) system.clone();

--- a/web-ui/src/main/resources/catalog/views/default/directives/partials/mdactionmenu.html
+++ b/web-ui/src/main/resources/catalog/views/default/directives/partials/mdactionmenu.html
@@ -123,7 +123,6 @@
         </a>
       </li>
 
-
       <!--metadata workflow assistance external link(s)-->
       <li
         role="menuitem"

--- a/web/src/main/webResources/WEB-INF/web.xml
+++ b/web/src/main/webResources/WEB-INF/web.xml
@@ -436,6 +436,7 @@
       <param-name>log</param-name>
       <param-value>false</param-value>
     </init-param>
+    <load-on-startup>1</load-on-startup>
   </servlet>
   <servlet-mapping>
     <servlet-name>MicroServicesProxy</servlet-name>


### PR DESCRIPTION
Follow-up of https://github.com/geonetwork/core-geonetwork/pull/7094.

The targetUri property can be configured using multiple methods, not only as init parameter in `web.xml` servlet's config but also as environment variable, system property or `config.properties` entry. This change saves the targetUri value in a `ServletContext` attribute so it can be retrieved from other servlets to check its value. Added `<load-on-startup>` servlet property to init the attribute on server start.
