### PR TITLE
Metadata editor / include the metadata file store in the default configuration of the online resources.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -772,6 +772,9 @@
               };
 
               var DEFAULT_CONFIG = {
+                sources: {
+                  filestore: true
+                },
                 process: "onlinesrc-add",
                 fields: {
                   url: {


### PR DESCRIPTION
Fixes #7103

I notice when it is used the `DEFAULT_CONFIG` doesn't select the radio button in the dialog:

![online-resource-type-no-selected](https://github.com/geonetwork/core-geonetwork/assets/1695003/5ac29f61-084d-450b-a3c5-2f649fac825c)

It's related to this code, that uses the full configuration object for the value:

https://github.com/geonetwork/core-geonetwork/blob/1bd3d8b8cf1cf5cea2d67581fa14ac2cae140967/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html#L17-L26 

That will not match with any value from the schemas configurations when used `DEFAULT_CONFIG`.

1) Should not be enough to check `process` property only?

2) Maybe when editing an online resource, we don't need to show that section as it's read only? If we create an online resource of type `Add a thumbnail` it's never listed in the resources list, only in the `Overview` panel. So maybe this change makes sense.