### PR TITLE
Fix only my records filter when reset the search in the editor board or access to the editor board from other pages

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchFormDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchFormDirective.js
@@ -302,6 +302,9 @@
         facetsParams = gnFacetService.getParamsFromFacets($scope.currentFacets);
         $scope.$broadcast('beforesearch');
         var params = angular.copy($scope.searchObj.params);
+        if ($scope.onlyMyRecord && $scope.onlyMyRecord.is === true) {
+          params['_owner'] = $scope.user.id;
+        }
         cleanSearchParams(params);
         angular.extend(params, facetsParams);
 
@@ -351,6 +354,11 @@
       } else {
         $scope.searchObj.params = {};
       }
+
+      if ($scope.onlyMyRecord && $scope.onlyMyRecord.is === true) {
+        $scope.searchObj.params['_owner'] = $scope.user.id;
+      }
+      
       if ($scope.searchObj.sortbyDefault) {
         angular.extend($scope.searchObj.params, $scope.searchObj.sortbyDefault);
       }


### PR DESCRIPTION
A fix for `3.12.x`. In `main` there are issues with this setting also, but the code is different. A new pull request for `main` will be provided.

Test case:

1) Login as admin 
2) In the user interface settings. Enable the setting `Editor application` > `Only my records`
2) Create an editor user
3) Load the iso19139 samples
4) In the editor board transfer 1 of the records to the editor user

Without the changes:

1) Go to the Editor board (`Only my records` checkbox is enabled) do a search and reset the search --> `Only my records` checkbox is enabled, but the results are not applying the filter.

2) Go to the Import metadata page and select the Editor board page --> `Only my records checkbox` is enabled, but the results are not applying the filter.

The code change fixes these 2 issues.

