### PR TITLE
roll back ES version to 7.11.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1492,7 +1492,7 @@
     <jetty.port>8080</jetty.port>
     <jetty.stop.port>8090</jetty.stop.port>
 
-    <es.version>7.15.1</es.version>
+    <es.version>7.11.1</es.version>
     <es.platform>linux-x86_64</es.platform>
     <es.installer.extension>tar.gz</es.installer.extension>
     <es.protocol>http</es.protocol>


### PR DESCRIPTION
Upgrading ES past 7.11.1 is a breaking change for using the AWS managed OpenSearch service - `Error is Invalid or missing build flavor [oss]`.  I imagine this impacts other use cases as well. 

As a better long term solution, [moving to an OpenSearch client](https://aws.amazon.com/blogs/opensource/keeping-clients-of-opensearch-and-elasticsearch-compatible-with-open-source/) would help keep geonetwork compatible with open source. 