### PR TITLE
Update link type protocol values for map layers

### DIFF
--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -198,7 +198,7 @@ goog.require('gn_alert');
           'linkTypes': {
             'links': ['LINK', 'kml'],
             'downloads': ['DOWNLOAD'],
-            'layers': ['OGC', 'ESRI:REST'],
+            'layers': ['OGC:WMS', 'OGC:WMTS', 'ESRI:REST'],
             'maps': ['ows']
           },
           'isFilterTagsDisplayedInSearch': false,

--- a/web-ui/src/main/resources/catalog/views/api/index_debug.html
+++ b/web-ui/src/main/resources/catalog/views/api/index_debug.html
@@ -147,7 +147,7 @@
           "linkTypes": {
             "links": ["LINK", "kml"],
             "downloads": ["DOWNLOAD"],
-            "layers":["OGC"],
+            "layers":['OGC:WMS', 'OGC:WMTS', 'ESRI:REST'],
             "maps": ["ows"]
           },
           "addWMSLayersToMap": {


### PR DESCRIPTION
Change for `3.12.x` branch. In `main` branch was fixed.

Currently in `3.12.x` the metadata with any online resource related to `OGC`, for example `OGC:CSW` display in the search results the globe icon to add the "layer" to the map viewer. 

This code change, limits the values to `OGC:WMS` and `OGC:WMTS`.

To fix existing installations, go to Admin console > Settings > User interface. In Search application > List of link types update the map links to:

- `OGC:WMS`
- `OGC:WMTS`
- `ESRI:REST`

Removing the value `OGC`.