### PR TITLE
Index configuration / define dynamic template for conformTo_* fields pattern

### DIFF
--- a/web/src/main/webResources/WEB-INF/data/config/index/records.json
+++ b/web/src/main/webResources/WEB-INF/data/config/index/records.json
@@ -1025,6 +1025,14 @@
   "mappings": {
     "dynamic_templates": [
       {
+        "conformTo": {
+          "match": "conformTo_*",
+          "mapping": {
+            "type": "keyword"
+          }
+        }
+      },
+      {
         "numbers": {
           "match": "*Number",
           "mapping": {


### PR DESCRIPTION
For some metadata having a conformance title including the word `Date` another dynamic template for dates was matched, causing the following indexing error:

```
ElasticsearchException[Elasticsearch exception [type=mapper_parsing_exception, reason=failed to parse field
 [conformTo_INSPIREDatenspezifikationenfrBodennutzung] of type [date] in document with id 
'920eb3af-7e14-48d7-860b-44f6f3a7c1a5'. Preview of field's value: 'false']]; nested: 
ElasticsearchException[Elasticsearch exception [type=illegal_argument_exception, reason=failed to parse date 
field [false] with format [strict_date_optional_time||epoch_millis]]]; nested: ElasticsearchException[
Elasticsearch exception [type=date_time_parse_exception, reason=Failed to parse with all enclosed parsers]];
```

Test case:

1) Create an iso19139 and add the following data quality report:

```
<gmd:report>
    <gmd:DQ_DomainConsistency>
        <gmd:result>
            <gmd:DQ_ConformanceResult>
                <gmd:specification>
                    <gmd:CI_Citation>
                        <gmd:title>
                            <gco:CharacterString>INSPIRE Datenspezifikationen für Bodennutzung</gco:CharacterString>
                        </gmd:title>
                        <gmd:date>
                            <gmd:CI_Date>
                                <gmd:date>
                                    <gco:Date>2013-12-10</gco:Date>
                                </gmd:date>
                                <gmd:dateType>
                                    <gmd:CI_DateTypeCode codeList="https://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication"/>
                                </gmd:dateType>
                            </gmd:CI_Date>
                        </gmd:date>
                    </gmd:CI_Citation>
                </gmd:specification>
                <gmd:explanation gco:nilReason="missing"/>
                <gmd:pass>
                    <gco:Boolean >false</gco:Boolean>
                </gmd:pass>
            </gmd:DQ_ConformanceResult>
        </gmd:result>
    </gmd:DQ_DomainConsistency>
</gmd:report>
```

2) Without the fix, the previous indexing error is reported.

3) With the fix, no indexing error is reported.