### PR TITLE
Include the parent exception in the MetadataProcessingReport error

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/processing/report/MetadataProcessingReport.java
+++ b/services/src/main/java/org/fao/geonet/api/processing/report/MetadataProcessingReport.java
@@ -161,7 +161,7 @@ public abstract class MetadataProcessingReport extends ProcessingReport {
         try {
             metadataDraft = ApplicationContextHolder.get().getBean(IMetadataUtils.class).isMetadataDraft(metadataId);
         } catch (Exception e) {
-            throw new RuntimeException("Error detecting if metadata is draft");
+            throw new RuntimeException("Error detecting if metadata is draft", e);
         }
         return metadataDraft;
     }
@@ -171,7 +171,7 @@ public abstract class MetadataProcessingReport extends ProcessingReport {
         try {
             metadataApproved = ApplicationContextHolder.get().getBean(IMetadataUtils.class).isMetadataApproved(metadataId);
         } catch (Exception e) {
-            throw new RuntimeException("Error detecting if metadata is approved");
+            throw new RuntimeException("Error detecting if metadata is approved", e);
         }
         return metadataApproved;
     }


### PR DESCRIPTION
Include the parent exception in the MetadataProcessingReport error so that we can see the real error in the logs.