### PR TITLE
Return contact information in the search results, used in the results templates

### DIFF
--- a/web-ui/src/main/resources/catalog/components/elasticsearch/EsFacet.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/EsFacet.js
@@ -52,6 +52,7 @@
           "status*",
           "rating",
           "geom",
+          "contact*",
           "Org*",
           "isTemplate",
           "valid",


### PR DESCRIPTION
Test case: 

1) Load iso19139 samples

2) In the search page change to the List mode

Before:

![before-list-mode](https://github.com/geonetwork/core-geonetwork/assets/1695003/9095b8d1-5d19-41f7-8388-38ded0f20767)

After:

![after-list-mode](https://github.com/geonetwork/core-geonetwork/assets/1695003/edd85d48-b134-4022-b44f-c1f35a25af53)
