### PR TITLE
Map / Layer manager / Add support for multilingual layer title.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -1541,6 +1541,32 @@
           /**
            * @ngdoc method
            * @methodOf gn_map.service:gnMap
+           * @name gnMap#getLinkDescription
+           *
+           * @description
+           * Retrieve description of the link from the metadata
+           * record using the URL and layer name. The description
+           * may override GetCapabilities layer name and can also
+           * be multilingual.
+           */
+          getLinkDescription: function (md, url, name) {
+            if (md) {
+              var link = md.getLinksByFilter(
+                "protocol:OGC:WMS" +
+                  " AND url:" +
+                  url.replace("?", "\\?") +
+                  " AND name:" +
+                  name
+              );
+              if (link.length === 1) {
+                return link[0].description !== "" ? link[0].description : undefined;
+              }
+            }
+          },
+
+          /**
+           * @ngdoc method
+           * @methodOf gn_map.service:gnMap
            * @name gnMap#addWmsFromScratch
            *
            * @description
@@ -1615,6 +1641,12 @@
                           if (!createOnly) {
                             map.addLayer(olL);
                           }
+
+                          olL.set(
+                            "layerTitleFromMetadata",
+                            $this.getLinkDescription(olL.get("md"), url, name)
+                          );
+
                           gnWmsQueue.removeFromQueue(
                             url,
                             name,
@@ -1910,6 +1942,12 @@
                       if (!createOnly) {
                         map.addLayer(olL);
                       }
+
+                      olL.set(
+                        "layerTitleFromMetadata",
+                        $this.getLinkDescription(olL.get("md"), url, name)
+                      );
+
                       gnWmsQueue.removeFromQueue(url, name, map);
                       defer.resolve(olL);
                     };
@@ -2393,7 +2431,7 @@
           feedLayerWithRelated: function (layer, linkGroup) {
             var md = layer.get("md");
 
-            if (!linkGroup) {
+            if (!Number.isInteger(linkGroup)) {
               console.warn(
                 "The layer has not been found in any group: " +
                   layer.getSource().getParams().LAYERS

--- a/web-ui/src/main/resources/catalog/components/index/IndexDataViewDirective.js
+++ b/web-ui/src/main/resources/catalog/components/index/IndexDataViewDirective.js
@@ -42,7 +42,7 @@
             scope.currentLayer = l;
           };
           scope.getLabel = function (layer) {
-            return layer.get("label");
+            return layer.get("layerTitleFromMetadata") || layer.get("label");
           };
           scope.set = function () {
             if (scope.layer) {

--- a/web-ui/src/main/resources/catalog/components/viewer/layermanager/partials/layermanageritem.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/layermanager/partials/layermanageritem.html
@@ -66,15 +66,18 @@
           for="layer-{{$index}}"
           data-ng-class="{'gn-map-layer-selected': layer.showInfo}"
         >
-          <a data-ng-class="layer.get('errors').length > 0 ? 'text-danger' : ''">
-            {{layer.get('label')}}
+          <span class="clickable"
+                data-ng-class="layer.get('errors').length > 0 ? 'text-danger' : ''"
+                title="{{layer.get('label')}}"
+          >
+            {{layer.get('layerTitleFromMetadata') || layer.get('label')}}
             <span
               ><em>
                 {{layer.get('currentStyle') ? '(' + (layer.get('currentStyle').Title ||
                 layer.get('currentStyle').Name) + ')' : ''}}
               </em>
             </span>
-          </a>
+          </span>
         </label>
       </div>
     </div>

--- a/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
@@ -66,7 +66,6 @@
     "gnOwsCapabilities",
     "$http",
     "gnViewerSettings",
-    "gnViewerService",
     "$translate",
     "$q",
     "$filter",
@@ -79,7 +78,6 @@
       gnOwsCapabilities,
       $http,
       gnViewerSettings,
-      gnViewerService,
       $translate,
       $q,
       $filter,
@@ -359,7 +357,6 @@
             }
             firstLoad = false;
           }
-          gnViewerService.openTool("layers");
         }
       };
 

--- a/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
@@ -66,6 +66,7 @@
     "gnOwsCapabilities",
     "$http",
     "gnViewerSettings",
+    "gnViewerService",
     "$translate",
     "$q",
     "$filter",
@@ -78,6 +79,7 @@
       gnOwsCapabilities,
       $http,
       gnViewerSettings,
+      gnViewerService,
       $translate,
       $q,
       $filter,
@@ -357,6 +359,7 @@
             }
             firstLoad = false;
           }
+          gnViewerService.openTool("layers");
         }
       };
 

--- a/web-ui/src/main/resources/catalog/components/viewer/searchlayerformap/partials/searchlayerformap.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/searchlayerformap/partials/searchlayerformap.html
@@ -66,11 +66,11 @@
               <a
                 data-ng-click="addToMap(link, md)"
                 href=""
-                title="{{'addLayerPrefix' | translate}} {{link.desc || link.name}} {{'addLayerPostfix' | translate}}"
+                title="{{'addLayerPrefix' | translate}} {{link.name}} {{'addLayerPostfix' | translate}}"
                 class="flex-row"
               >
                 <span class="fa fa-fw fa-plus"></span>
-                <span>{{link.desc || link.name}}&nbsp;</span>
+                <span>{{link.description || link.name}}&nbsp;</span>
               </a>
             </li>
           </ul>


### PR DESCRIPTION
Metadata may be multilingual and provide multilingual layer name in the online source description field. GetCapabilities document do not provide multilingual support, so this adds the possibility to translate layer name in maps.

![Pasted image](https://github.com/geonetwork/core-geonetwork/assets/1701393/31d8f7a9-e92d-4b77-8ecc-758d08c875f3)


A multilingual description in a link:

```xml
<gmd:onLine>
  <gmd:CI_OnlineResource>
    <gmd:linkage>
      <gmd:URL>https://data.apps.fao.org/map/gsrv/gsrv1/geonetwork/ows?SERVICE=WMS&amp;</gmd:URL>
    </gmd:linkage>
    <gmd:protocol>
      <gmx:MimeFileType type="">OGC:WMS</gmx:MimeFileType>
    </gmd:protocol>
    <gmd:name xsi:type="gmd:PT_FreeText_PropertyType">
      <gco:CharacterString>geonetwork:basins_296</gco:CharacterString>
      <gmd:PT_FreeText>
        <gmd:textGroup>
          <gmd:LocalisedCharacterString locale="#EN">geonetwork:basins_296</gmd:LocalisedCharacterString>
        </gmd:textGroup>
        <gmd:textGroup>
          <gmd:LocalisedCharacterString locale="#FR" />
        </gmd:textGroup>
      </gmd:PT_FreeText>
    </gmd:name>
    <gmd:description xsi:type="gmd:PT_FreeText_PropertyType">
      <gco:CharacterString>Hydrological basins in Africa</gco:CharacterString>
      <gmd:PT_FreeText>
        <gmd:textGroup>
          <gmd:LocalisedCharacterString locale="#EN">Hydrological basins in Africa</gmd:LocalisedCharacterString>
        </gmd:textGroup>
        <gmd:textGroup>
          <gmd:LocalisedCharacterString locale="#FR">Bassins versants en Afrique</gmd:LocalisedCharacterString>
        </gmd:textGroup>
      </gmd:PT_FreeText>
    </gmd:description>
  </gmd:CI_OnlineResource>
</gmd:onLine>
```

The description is retrieved from the metadata on load from the metadata UUID which is attached to the layer (and saved in the OWS context extension of the layer) using the service URL and the layer name.

This also allows to override layer name when a group of layer (eg. `a,b,c`) is used in the online source name.


Layer title also displayed in layer search
![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/01781368-aa80-4607-9916-c27fba5ea56b)

and in filtering
![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/c9f03fd7-d292-4d66-b691-318b8e03c423)


Also fix/improve:
* group id can be 0 and (!0 was true always logging a message in this case)
* clicking layer title enable/disable the checkbox 
* after loading map, switch to layer manager panel