### PR TITLE
ISO19139 / Metadata editor / Fix display of contact individual name label in German

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/loc/ger/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/ger/labels.xml
@@ -2344,8 +2344,7 @@
       steht
     </description>
   </element>
-  <element name="gmd:individualName" context="gmd:CI_ResponsibleParty"
-           id="375">
+  <element name="gmd:individualName" id="375">
     <label>Person</label>
     <help>Als Trennzeichen wird Komma empfohlen</help>
     <condition>Es muss entweder ein Nachname, eine Organisation oder eine


### PR DESCRIPTION
Test case:

1) Create an iso19139 metadata with the default template

2) Without the change:

![german-label-individualname-before](https://github.com/geonetwork/core-geonetwork/assets/1695003/0810f365-fdb2-43ce-ba34-5607268348b8)

3) With the change:

![german-label-individualname-after](https://github.com/geonetwork/core-geonetwork/assets/1695003/823ca215-c339-4889-affa-3eeb8f86fa36)
