### PR TITLE
Allow multiple request matchers to decide if apply CSRF

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@ git*.properties
 */*/target/
 */target/
 .*/
-GeoNetwork*
+#GeoNetwork*
 /geonetwork*
 camel-harvesters/wfsfeature-harvester/logs
 changes-*

--- a/core/src/main/java/org/fao/geonet/kernel/security/keycloak/KeycloakPreAuthActionsLoginFilter.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/keycloak/KeycloakPreAuthActionsLoginFilter.java
@@ -74,11 +74,19 @@ public class KeycloakPreAuthActionsLoginFilter extends KeycloakPreAuthActionsFil
         //     - It does not match the default request matcher (which is mostly used to validate bearer tokens request for api's)
         //       No sign in page required for api calls.
         //     - and it is not an internal k_* request which should be processed by keycloak adapter and also don't required login page.
-        if (servletRequest.getPathInfo() != null && !KeycloakAuthenticationProcessingFilter.DEFAULT_REQUEST_MATCHER.matches(servletRequest) && !isAuthenticated() && !(servletRequest.getContextPath() + KeycloakUtil.getSigninPath()).equals(servletRequest.getRequestURI()) && !servletRequest.getRequestURI().endsWith(AdapterConstants.K_LOGOUT) && !servletRequest.getRequestURI().endsWith(AdapterConstants.K_PUSH_NOT_BEFORE) && !servletRequest.getRequestURI().endsWith(AdapterConstants.K_QUERY_BEARER_TOKEN) && !servletRequest.getRequestURI().endsWith(AdapterConstants.K_TEST_AVAILABLE) && !servletRequest.getRequestURI().endsWith(AdapterConstants.K_JWKS)) {
+        if (servletRequest.getPathInfo() != null
+            && !KeycloakAuthenticationProcessingFilter.DEFAULT_REQUEST_MATCHER.matches(servletRequest)
+            && !isAuthenticated() && !(servletRequest.getContextPath() + KeycloakUtil.getSigninPath()).equals(servletRequest.getRequestURI())
+            && !servletRequest.getRequestURI().endsWith(AdapterConstants.K_LOGOUT)
+            && !servletRequest.getRequestURI().endsWith(AdapterConstants.K_PUSH_NOT_BEFORE)
+            && !servletRequest.getRequestURI().endsWith(AdapterConstants.K_QUERY_BEARER_TOKEN)
+            && !servletRequest.getRequestURI().endsWith(AdapterConstants.K_TEST_AVAILABLE)
+            && !servletRequest.getRequestURI().endsWith(AdapterConstants.K_JWKS)) {
 
             // Get request uri which is a relative path. Absolute paths will be ignored if they are received as returning url.
             String returningUrl = servletRequest.getRequestURI() + (servletRequest.getQueryString() == null ? "" : "?" + servletRequest.getQueryString());
-            String encodedRedirectURL = ((HttpServletResponse) response).encodeRedirectURL(servletRequest.getContextPath() + KeycloakUtil.getSigninPath() + "?redirectUrl=" + URLEncoder.encode(returningUrl, Constants.ENCODING));
+            String encodedRedirectURL = ((HttpServletResponse) response).encodeRedirectURL(
+                servletRequest.getContextPath() + KeycloakUtil.getSigninPath() + "?redirectUrl=" + URLEncoder.encode(returningUrl, Constants.ENCODING));
             servletResponse.sendRedirect(encodedRedirectURL);
 
             // No further action required as we are redirecting to new page

--- a/core/src/main/java/org/fao/geonet/kernel/security/keycloak/KeycloakPreAuthActionsLoginFilter.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/keycloak/KeycloakPreAuthActionsLoginFilter.java
@@ -64,29 +64,34 @@ public class KeycloakPreAuthActionsLoginFilter extends KeycloakPreAuthActionsFil
     }
 
     @Override
-    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+        throws IOException, ServletException {
         HttpServletRequest servletRequest = (HttpServletRequest) request;
         HttpServletResponse servletResponse = (HttpServletResponse) response;
 
-        // Let's redirect the user to the signin page if
+        // Lets redirect the user to the signin page if
         //     - The session is not authenticate
         //     - This is not a request for the signin page (we don't want endless loop to sign in page)
         //     - It does not match the default request matcher (which is mostly used to validate bearer tokens request for api's)
         //       No sign in page required for api calls.
         //     - and it is not an internal k_* request which should be processed by keycloak adapter and also don't required login page.
-        if (servletRequest.getPathInfo() != null
-            && !KeycloakAuthenticationProcessingFilter.DEFAULT_REQUEST_MATCHER.matches(servletRequest)
-            && !isAuthenticated() && !(servletRequest.getContextPath() + KeycloakUtil.getSigninPath()).equals(servletRequest.getRequestURI())
-            && !servletRequest.getRequestURI().endsWith(AdapterConstants.K_LOGOUT)
-            && !servletRequest.getRequestURI().endsWith(AdapterConstants.K_PUSH_NOT_BEFORE)
-            && !servletRequest.getRequestURI().endsWith(AdapterConstants.K_QUERY_BEARER_TOKEN)
-            && !servletRequest.getRequestURI().endsWith(AdapterConstants.K_TEST_AVAILABLE)
-            && !servletRequest.getRequestURI().endsWith(AdapterConstants.K_JWKS)) {
+        if (servletRequest.getPathInfo() != null &&
+            !KeycloakAuthenticationProcessingFilter.DEFAULT_REQUEST_MATCHER.matches(servletRequest) &&
+            !isAuthenticated() &&
+            !(servletRequest.getContextPath() + KeycloakUtil.getSigninPath()).equals(servletRequest.getRequestURI()) &&
+            !servletRequest.getRequestURI().endsWith(AdapterConstants.K_LOGOUT) &&
+            !servletRequest.getRequestURI().endsWith(AdapterConstants.K_PUSH_NOT_BEFORE) &&
+            !servletRequest.getRequestURI().endsWith(AdapterConstants.K_QUERY_BEARER_TOKEN) &&
+            !servletRequest.getRequestURI().endsWith(AdapterConstants.K_TEST_AVAILABLE) &&
+            !servletRequest.getRequestURI().endsWith(AdapterConstants.K_JWKS)) {
 
             // Get request uri which is a relative path. Absolute paths will be ignored if they are received as returning url.
-            String returningUrl = servletRequest.getRequestURI() + (servletRequest.getQueryString() == null ? "" : "?" + servletRequest.getQueryString());
+            String returningUrl = servletRequest.getRequestURI() +
+                (servletRequest.getQueryString() == null ? "" : "?" + servletRequest.getQueryString());
+
             String encodedRedirectURL = ((HttpServletResponse) response).encodeRedirectURL(
                 servletRequest.getContextPath() + KeycloakUtil.getSigninPath() + "?redirectUrl=" + URLEncoder.encode(returningUrl, Constants.ENCODING));
+
             servletResponse.sendRedirect(encodedRedirectURL);
 
             // No further action required as we are redirecting to new page
@@ -98,7 +103,8 @@ public class KeycloakPreAuthActionsLoginFilter extends KeycloakPreAuthActionsFil
 
     private boolean isAuthenticated() {
         Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
-        if (authentication == null || AnonymousAuthenticationToken.class.isAssignableFrom(authentication.getClass())) {
+        if (authentication == null || AnonymousAuthenticationToken.class.
+            isAssignableFrom(authentication.getClass())) {
             return false;
         }
         return authentication.isAuthenticated();

--- a/core/src/test/java/org/fao/geonet/security/web/csrf/GeonetworkCsrfSecurityRequestMatcherTest.java
+++ b/core/src/test/java/org/fao/geonet/security/web/csrf/GeonetworkCsrfSecurityRequestMatcherTest.java
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) 2001-2023 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+package org.fao.geonet.security.web.csrf;
+
+import com.google.common.collect.Lists;
+import com.google.common.collect.Sets;
+import org.junit.Before;
+import org.junit.Test;
+import org.keycloak.adapters.springsecurity.filter.KeycloakCsrfRequestMatcher;
+import org.keycloak.constants.AdapterConstants;
+import org.springframework.http.HttpMethod;
+import org.springframework.mock.web.MockHttpServletRequest;
+
+import java.util.Set;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class GeonetworkCsrfSecurityRequestMatcherTest {
+
+    private static final String ROOT_CONTEXT_PATH = "";
+    private static final String SUB_CONTEXT_PATH = "/foo";
+
+    private GeonetworkCsrfSecurityRequestMatcher matcher;
+    private MockHttpServletRequest request;
+
+    @Before
+    public void setUp() {
+        request = new MockHttpServletRequest();
+        Set<String> notCorsPaths = Sets.newLinkedHashSet(Lists.newArrayList(
+            "/[a-zA-Z0-9_\\-]+/[a-z]{2,3}/csw-publication!?.*",
+            "/[a-zA-Z0-9_\\-]+/[a-z]{2,3}/csw-.*",
+            "/[a-zA-Z0-9_\\-]+/[a-z]{2,3}/csw!?.*",
+            "/[a-zA-Z0-9_\\-]+/api/search/.*",
+            "/[a-zA-Z0-9_\\-]+/api/site")
+        );
+        matcher = new GeonetworkCsrfSecurityRequestMatcher(notCorsPaths);
+    }
+
+    @Test
+    public void testDefaultConfigHttpMethods() {
+
+        request.setMethod(HttpMethod.GET.name());
+        assertFalse((matcher.matches(request)));
+
+        request.setMethod(HttpMethod.HEAD.name());
+        assertFalse((matcher.matches(request)));
+        request.setMethod(HttpMethod.TRACE.name());
+        assertFalse((matcher.matches(request)));
+        request.setMethod(HttpMethod.OPTIONS.name());
+        assertFalse((matcher.matches(request)));
+
+        request.setMethod(HttpMethod.PATCH.name());
+        assertTrue(matcher.matches(request));
+        request.setMethod(HttpMethod.POST.name());
+        assertTrue(matcher.matches(request));
+        request.setMethod(HttpMethod.PUT.name());
+        assertTrue(matcher.matches(request));
+        request.setMethod(HttpMethod.DELETE.name());
+        assertTrue(matcher.matches(request));
+    }
+
+    @Test
+    public void testDefaultMatchesMethodPost() throws Exception {
+        prepareRequest(HttpMethod.POST, ROOT_CONTEXT_PATH, "some/random/uri");
+        assertTrue(matcher.matches(request));
+        prepareRequest(HttpMethod.POST, SUB_CONTEXT_PATH, "some/random/uri");
+        assertTrue(matcher.matches(request));
+
+        prepareRequest(HttpMethod.POST, SUB_CONTEXT_PATH, "some/random/uri");
+        assertTrue(matcher.matches(request));
+        prepareRequest(HttpMethod.POST, SUB_CONTEXT_PATH, "some/random/uri");
+        assertTrue(matcher.matches(request));
+
+        prepareRequest(HttpMethod.POST, ROOT_CONTEXT_PATH, "srv/eng/csw-publication");
+        assertFalse(matcher.matches(request));
+        prepareRequest(HttpMethod.POST, SUB_CONTEXT_PATH, "srv/eng/csw-publication");
+        assertFalse(matcher.matches(request));
+
+        prepareRequest(HttpMethod.POST, ROOT_CONTEXT_PATH, "srv/eng/csw-foo");
+        assertFalse(matcher.matches(request));
+        prepareRequest(HttpMethod.POST, SUB_CONTEXT_PATH, "srv/eng/csw-foo");
+        assertFalse(matcher.matches(request));
+
+        prepareRequest(HttpMethod.POST, ROOT_CONTEXT_PATH, "srv/eng/csw");
+        assertFalse(matcher.matches(request));
+        prepareRequest(HttpMethod.POST, SUB_CONTEXT_PATH, "srv/eng/csw");
+        assertFalse(matcher.matches(request));
+
+        prepareRequest(HttpMethod.POST, ROOT_CONTEXT_PATH, "srv/api/search/foo");
+        assertFalse(matcher.matches(request));
+        prepareRequest(HttpMethod.POST, SUB_CONTEXT_PATH, "srv/api/search/foo");
+        assertFalse(matcher.matches(request));
+
+        prepareRequest(HttpMethod.POST, ROOT_CONTEXT_PATH, "srv/api/site");
+        assertFalse(matcher.matches(request));
+        prepareRequest(HttpMethod.POST, SUB_CONTEXT_PATH, "srv/api/site");
+        assertFalse(matcher.matches(request));
+
+        prepareRequest(HttpMethod.POST, ROOT_CONTEXT_PATH, "k_logout");
+        assertTrue(matcher.matches(request));
+        prepareRequest(HttpMethod.POST, SUB_CONTEXT_PATH, "k_logout");
+        assertTrue(matcher.matches(request));
+    }
+
+    @Test
+    public void testKeycloakCorsFilter() {
+        matcher.addRequestMatcher(new KeycloakCsrfRequestMatcher());
+
+        prepareRequest(HttpMethod.POST, ROOT_CONTEXT_PATH, "some/random/uri");
+        assertTrue(matcher.matches(request));
+        prepareRequest(HttpMethod.POST, SUB_CONTEXT_PATH, "some/random/uri");
+        assertTrue(matcher.matches(request));
+
+        prepareRequest(HttpMethod.POST, ROOT_CONTEXT_PATH, "srv/eng/csw-publication");
+        assertFalse(matcher.matches(request));
+        prepareRequest(HttpMethod.POST, SUB_CONTEXT_PATH, "srv/eng/csw-publication");
+        assertFalse(matcher.matches(request));
+
+        prepareRequest(HttpMethod.POST, ROOT_CONTEXT_PATH, "srv/eng/csw-foo");
+        assertFalse(matcher.matches(request));
+        prepareRequest(HttpMethod.POST, SUB_CONTEXT_PATH, "srv/eng/csw-foo");
+        assertFalse(matcher.matches(request));
+
+        prepareRequest(HttpMethod.POST, ROOT_CONTEXT_PATH, "srv/eng/csw");
+        assertFalse(matcher.matches(request));
+        prepareRequest(HttpMethod.POST, SUB_CONTEXT_PATH, "srv/eng/csw");
+        assertFalse(matcher.matches(request));
+
+        prepareRequest(HttpMethod.POST, ROOT_CONTEXT_PATH, "srv/api/search/foo");
+        assertFalse(matcher.matches(request));
+        prepareRequest(HttpMethod.POST, SUB_CONTEXT_PATH, "srv/api/search/foo");
+        assertFalse(matcher.matches(request));
+
+        prepareRequest(HttpMethod.POST, ROOT_CONTEXT_PATH, "srv/api/site");
+        assertFalse(matcher.matches(request));
+        prepareRequest(HttpMethod.POST, SUB_CONTEXT_PATH, "srv/api/site");
+        assertFalse(matcher.matches(request));
+
+        prepareRequest(HttpMethod.POST, ROOT_CONTEXT_PATH, AdapterConstants.K_LOGOUT);
+        assertFalse(matcher.matches(request));
+        prepareRequest(HttpMethod.POST, SUB_CONTEXT_PATH, AdapterConstants.K_LOGOUT);
+        assertFalse(matcher.matches(request));
+
+        prepareRequest(HttpMethod.POST, ROOT_CONTEXT_PATH, AdapterConstants.K_PUSH_NOT_BEFORE);
+        assertFalse(matcher.matches(request));
+        prepareRequest(HttpMethod.POST, SUB_CONTEXT_PATH, AdapterConstants.K_PUSH_NOT_BEFORE);
+        assertFalse(matcher.matches(request));
+
+        prepareRequest(HttpMethod.POST, ROOT_CONTEXT_PATH, AdapterConstants.K_QUERY_BEARER_TOKEN);
+        assertFalse(matcher.matches(request));
+        prepareRequest(HttpMethod.POST, SUB_CONTEXT_PATH, AdapterConstants.K_QUERY_BEARER_TOKEN);
+        assertFalse(matcher.matches(request));
+
+        prepareRequest(HttpMethod.POST, ROOT_CONTEXT_PATH, AdapterConstants.K_TEST_AVAILABLE);
+        assertFalse(matcher.matches(request));
+        prepareRequest(HttpMethod.POST, SUB_CONTEXT_PATH, AdapterConstants.K_TEST_AVAILABLE);
+        assertFalse(matcher.matches(request));
+
+    }
+
+    private void prepareRequest(HttpMethod method, String contextPath, String uri) {
+        request.setMethod(method.name());
+        request.setContextPath(contextPath);
+        request.setRequestURI(contextPath + "/" + uri);
+        request.setServletPath("/" + uri);
+    }
+}

--- a/web/src/main/webapp/WEB-INF/config-security/config-security-keycloak.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-keycloak.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 
 <!--
-  ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
+  ~ Copyright (C) 2001-2023 Food and Agriculture Organization of the
   ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
   ~ and United Nations Environment Programme (UNEP)
   ~
@@ -76,9 +76,10 @@
   <bean id="keycloakPreAuthActionsFilter" class="org.keycloak.adapters.springsecurity.filter.KeycloakPreAuthActionsFilter">
     <constructor-arg ref="userSessionManagement" />
   </bean>
-  <bean id="keycloakPreAuthActionsLoginFilter" class="org.fao.geonet.kernel.security.keycloak.keycloakPreAuthActionsLoginFilter" >
+  <bean id="keycloakPreAuthActionsLoginFilter" class="org.fao.geonet.kernel.security.keycloak.KeycloakPreAuthActionsLoginFilter" >
       <constructor-arg ref="userSessionManagement" />
       <constructor-arg ref="csrfFilter" />
+      <constructor-arg ref="geonetworkCsrfSecurityRequestMatcher" />
   </bean>
   <bean id="keycloakAuthenticationProcessingFilter" class="org.fao.geonet.kernel.security.keycloak.KeycloakAuthenticationProcessingFilter" depends-on="keycloakUtil">
     <constructor-arg name="authenticationManager" ref="authenticationManager" />


### PR DESCRIPTION
* Fix a problem with the Keycloak configuration that was making the server to request CSRF Token for GN URLs that shouldn't be protected by CSRF.
* To do this, now the `GeonetworkCsrfSecurityRequestMatcher` allows to be configured with additional `RequestMatcher` instances, for example the `KeycloakCsrfRequestMatcher`. If Keycloak security is enabled, then the `KeycloakCsrfRequestMatcher` is added to the original GeoNetwork patterns listed in `config-security-core.xml`
