### PR TITLE
Added some logic into JeevesNodeAwareLogoutSuccessHandler to deal with the case where no port is set in the settings manager

### DIFF
--- a/core/src/main/java/jeeves/config/springutil/JeevesNodeAwareLogoutSuccessHandler.java
+++ b/core/src/main/java/jeeves/config/springutil/JeevesNodeAwareLogoutSuccessHandler.java
@@ -90,10 +90,6 @@ public class JeevesNodeAwareLogoutSuccessHandler extends AbstractAuthenticationT
                     String siteProtocol = settingManager.getValue(Settings.SYSTEM_SERVER_PROTOCOL);
                     
                     // some conditional logic to handle the case where there's no port in the settings
-                    //int sitePort = Geonet.DefaultHttpPort.HTTP;
-                    //if (StringUtils.isNumeric(settingManager.getValue(Settings.SYSTEM_SERVER_PORT))) {
-                    //    sitePort = settingManager.getValueAsInt(Settings.SYSTEM_SERVER_PORT);
-                    //}
                     SettingInfo si = new SettingInfo();
                     int sitePort = si.getSitePort(); 
 

--- a/core/src/main/java/jeeves/config/springutil/JeevesNodeAwareLogoutSuccessHandler.java
+++ b/core/src/main/java/jeeves/config/springutil/JeevesNodeAwareLogoutSuccessHandler.java
@@ -90,7 +90,7 @@ public class JeevesNodeAwareLogoutSuccessHandler extends AbstractAuthenticationT
                     
                     // some conditional logic to handle the case where there's no port in the settings
                     int sitePort = Geonet.DefaultHttpPort.HTTP;
-                    if (StringUtils.isNumeric(Settings.SYSTEM_SERVER_PORT)) {
+                    if (StringUtils.isNumeric(settingManager.getValue(Settings.SYSTEM_SERVER_PORT))) {
                         sitePort = settingManager.getValueAsInt(Settings.SYSTEM_SERVER_PORT);
                     }
 

--- a/core/src/main/java/jeeves/config/springutil/JeevesNodeAwareLogoutSuccessHandler.java
+++ b/core/src/main/java/jeeves/config/springutil/JeevesNodeAwareLogoutSuccessHandler.java
@@ -31,6 +31,7 @@ import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AbstractAuthenticationTargetUrlRequestHandler;
 import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
+import org.apache.commons.lang.StringUtils;
 
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -84,8 +85,12 @@ public class JeevesNodeAwareLogoutSuccessHandler extends AbstractAuthenticationT
 
                     String siteHost = settingManager.getValue(Settings.SYSTEM_SERVER_HOST);
                     String siteProtocol = settingManager.getValue(Settings.SYSTEM_SERVER_PROTOCOL);
-                    int sitePort = settingManager.getValueAsInt(Settings.SYSTEM_SERVER_PORT);
-
+                    
+                    // some conditional logic to handle the case where there's no port in the settings
+                    int sitePort = 80;
+                    if (Settings.SYSTEM_SERVER_PORT != null && StringUtils.isNumeric(Settings.SYSTEM_SERVER_PORT)) {
+                        sitePort = settingManager.getValueAsInt(Settings.SYSTEM_SERVER_PORT);
+                    }
 
                     if (!hostName.equalsIgnoreCase(siteHost) ||
                         !protocol.equalsIgnoreCase(siteProtocol) ||

--- a/core/src/main/java/jeeves/config/springutil/JeevesNodeAwareLogoutSuccessHandler.java
+++ b/core/src/main/java/jeeves/config/springutil/JeevesNodeAwareLogoutSuccessHandler.java
@@ -33,6 +33,7 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AbstractAuthenticationTargetUrlRequestHandler;
 import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
 import org.apache.commons.lang3.StringUtils;
+import org.fao.geonet.kernel.setting.SettingInfo;
 
 
 import java.io.IOException;
@@ -89,10 +90,12 @@ public class JeevesNodeAwareLogoutSuccessHandler extends AbstractAuthenticationT
                     String siteProtocol = settingManager.getValue(Settings.SYSTEM_SERVER_PROTOCOL);
                     
                     // some conditional logic to handle the case where there's no port in the settings
-                    int sitePort = Geonet.DefaultHttpPort.HTTP;
-                    if (StringUtils.isNumeric(settingManager.getValue(Settings.SYSTEM_SERVER_PORT))) {
-                        sitePort = settingManager.getValueAsInt(Settings.SYSTEM_SERVER_PORT);
-                    }
+                    //int sitePort = Geonet.DefaultHttpPort.HTTP;
+                    //if (StringUtils.isNumeric(settingManager.getValue(Settings.SYSTEM_SERVER_PORT))) {
+                    //    sitePort = settingManager.getValueAsInt(Settings.SYSTEM_SERVER_PORT);
+                    //}
+                    SettingInfo si = new SettingInfo();
+                    int sitePort = si.getSitePort(); 
 
                     if (!hostName.equalsIgnoreCase(siteHost) ||
                         !protocol.equalsIgnoreCase(siteProtocol) ||

--- a/core/src/main/java/jeeves/config/springutil/JeevesNodeAwareLogoutSuccessHandler.java
+++ b/core/src/main/java/jeeves/config/springutil/JeevesNodeAwareLogoutSuccessHandler.java
@@ -26,12 +26,14 @@ package jeeves.config.springutil;
 import org.fao.geonet.NodeInfo;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.kernel.setting.Settings;
+import org.fao.geonet.constants.Geonet;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.web.authentication.AbstractAuthenticationTargetUrlRequestHandler;
 import org.springframework.security.web.authentication.logout.LogoutSuccessHandler;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
+
 
 import java.io.IOException;
 import java.net.MalformedURLException;
@@ -87,8 +89,8 @@ public class JeevesNodeAwareLogoutSuccessHandler extends AbstractAuthenticationT
                     String siteProtocol = settingManager.getValue(Settings.SYSTEM_SERVER_PROTOCOL);
                     
                     // some conditional logic to handle the case where there's no port in the settings
-                    int sitePort = 80;
-                    if (Settings.SYSTEM_SERVER_PORT != null && StringUtils.isNumeric(Settings.SYSTEM_SERVER_PORT)) {
+                    int sitePort = Geonet.DefaultHttpPort.HTTP;
+                    if (StringUtils.isNumeric(Settings.SYSTEM_SERVER_PORT)) {
                         sitePort = settingManager.getValueAsInt(Settings.SYSTEM_SERVER_PORT);
                     }
 

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
@@ -53,6 +53,7 @@ import org.fao.geonet.kernel.search.MetaSearcher;
 import org.fao.geonet.kernel.search.index.BatchOpsMetadataReindexer;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.kernel.setting.Settings;
+import org.fao.geonet.kernel.setting.SettingInfo;
 import org.fao.geonet.lib.Lib;
 import org.fao.geonet.repository.*;
 import org.fao.geonet.repository.specification.MetadataFileUploadSpecs;
@@ -917,12 +918,14 @@ public class BaseMetadataManager implements IMetadataManager {
         // add baseUrl of this site (from settings)
         String protocol = settingManager.getValue(Settings.SYSTEM_SERVER_PROTOCOL);
         String host = settingManager.getValue(Settings.SYSTEM_SERVER_HOST);
-        String port = settingManager.getValue(Settings.SYSTEM_SERVER_PORT);
-        if (port.equals("80")) {
-            port = "";
-        } else {
-            port = ":" + port;
-        }
+        SettingInfo si = new SettingInfo();
+        String port = Integer.toString(si.getSitePort());
+        //String port = settingManager.getValue(Settings.SYSTEM_SERVER_PORT);
+        //if (port.equals("80")) {
+        //    port = "";
+        //} else {
+        //    port = ":" + port;
+        //}
         addElement(info, Edit.Info.Elem.BASEURL, protocol + "://" + host + port + context.getBaseUrl());
         addElement(info, Edit.Info.Elem.LOCSERV, "/srv/en");
         return info;

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
@@ -920,12 +920,6 @@ public class BaseMetadataManager implements IMetadataManager {
         String host = settingManager.getValue(Settings.SYSTEM_SERVER_HOST);
         SettingInfo si = new SettingInfo();
         String port = Integer.toString(si.getSitePort());
-        //String port = settingManager.getValue(Settings.SYSTEM_SERVER_PORT);
-        //if (port.equals("80")) {
-        //    port = "";
-        //} else {
-        //    port = ":" + port;
-        //}
         addElement(info, Edit.Info.Elem.BASEURL, protocol + "://" + host + port + context.getBaseUrl());
         addElement(info, Edit.Info.Elem.LOCSERV, "/srv/en");
         return info;

--- a/core/src/main/java/org/fao/geonet/kernel/setting/SettingInfo.java
+++ b/core/src/main/java/org/fao/geonet/kernel/setting/SettingInfo.java
@@ -74,7 +74,7 @@ public class SettingInfo {
   */
 
     public Integer getSitePort() {
-             SettingManager settingManager = ApplicationContextHolder.get().getBean(SettingManager.class);
+        SettingManager settingManager = ApplicationContextHolder.get().getBean(SettingManager.class);
 
         // some conditional logic to handle the case where there's no port in the settings
         int sitePort = Geonet.DefaultHttpPort.HTTP;

--- a/core/src/main/java/org/fao/geonet/kernel/setting/SettingInfo.java
+++ b/core/src/main/java/org/fao/geonet/kernel/setting/SettingInfo.java
@@ -25,6 +25,7 @@ package org.fao.geonet.kernel.setting;
 
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.constants.Geonet;
+import org.apache.commons.lang3.StringUtils;
 
 import static org.fao.geonet.kernel.setting.SettingManager.isPortRequired;
 
@@ -66,6 +67,22 @@ public class SettingInfo {
 		}
 
         return sb.toString();
+    }
+
+    /**
+   * Handle the case where the port in Settings is empty
+  */
+
+    public Integer getSitePort() {
+             SettingManager settingManager = ApplicationContextHolder.get().getBean(SettingManager.class);
+
+        // some conditional logic to handle the case where there's no port in the settings
+        int sitePort = Geonet.DefaultHttpPort.HTTP;
+        if (StringUtils.isNumeric(settingManager.getValue(Settings.SYSTEM_SERVER_PORT))) {
+            sitePort = settingManager.getValueAsInt(Settings.SYSTEM_SERVER_PORT);
+        }
+
+        return sitePort;
     }
 
     //---------------------------------------------------------------------------


### PR DESCRIPTION
This PR handles the error on signout where there is no port set in the settings manager. Previously if no port was set (because it's not needed) logging out would produce a null pointer error (see below):

![Screenshot from 2023-05-31 12-08-13](https://github.com/geonetwork/core-geonetwork/assets/1544849/daf75739-1c54-470b-b607-b8460a17e52e)

This PR adds some logic to check for the value of the port in the settings and to set it to 80 if it is not included.
With this pull request, if no port is set the logout error no longer occurs.