### PR TITLE
ISO19139 / Fix indexing of CRS codespace when contains a multilingual value

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
@@ -857,7 +857,7 @@
 
           <crsDetails type="object">{
             "code": "<xsl:value-of select="gn-fn-index:json-escape((gmd:code/*/text())[1])"/>",
-            "codeSpace": "<xsl:value-of select="gn-fn-index:json-escape(gmd:codeSpace/*/text())"/>",
+            "codeSpace": "<xsl:value-of select="gn-fn-index:json-escape((gmd:codeSpace/*/text())[1])"/>",
             "name": "<xsl:value-of select="gn-fn-index:json-escape($crsLabel)"/>",
             "url": "<xsl:value-of select="gn-fn-index:json-escape(gmd:code/*/@xlink:href)"/>"
             }</crsDetails>


### PR DESCRIPTION
Test case:

1) Create an iso19139 multilingual metadata

2) Add the following snippet:

```
 <gmd:referenceSystemInfo>
    <gmd:MD_ReferenceSystem>
      <gmd:referenceSystemIdentifier>
        <gmd:RS_Identifier>
          <gmd:code gco:nilReason="missing" xsi:type="gmd:PT_FreeText_PropertyType">
            <gco:CharacterString>http://www.opengis.net/def/crs/EPSG/0/3794</gco:CharacterString>
            <gmd:PT_FreeText>
              <gmd:textGroup>
                <gmd:LocalisedCharacterString locale="#SL">http://www.opengis.net/def/crs/EPSG/0/3794</gmd:LocalisedCharacterString>
              </gmd:textGroup>
            </gmd:PT_FreeText>
          </gmd:code>
        </gmd:RS_Identifier>
      </gmd:referenceSystemIdentifier>
    </gmd:MD_ReferenceSystem>
  </gmd:referenceSystemInfo>
```

Without the change, the following error is displayed in the console and the metadata has an indexing error:

```
Error on line 860 of index.xsl:
  XTTE0790: A sequence of more than one item is not allowed as the first argument of
  gn-fn-index:json-escape() ("http://www.opengis.net/def/crs...", "") 
2023-05-31T13:45:51,378 ERROR [geonetwork.index] - Indexing stylesheet contains errors: A sequence of more than one item is not allowed as the first argument of gn-fn-index:json-escape() ("http://www.opengis.net/def/crs...", "")  
  Marking the metadata as _indexingError=1 in index
```