### PR TITLE
Fix check of harvester log file path

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/GeonetworkDataDirectory.java
+++ b/core/src/main/java/org/fao/geonet/kernel/GeonetworkDataDirectory.java
@@ -25,11 +25,6 @@ package org.fao.geonet.kernel;
 
 import jeeves.server.ServiceConfig;
 import jeeves.server.sources.http.JeevesServlet;
-import org.apache.log4j.Appender;
-import org.apache.log4j.Logger;
-import org.apache.log4j.bridge.AppenderWrapper;
-import org.apache.logging.log4j.core.appender.FileAppender;
-import org.apache.logging.log4j.core.appender.RollingFileAppender;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.utils.IO;
@@ -124,15 +119,6 @@ public class GeonetworkDataDirectory {
         this.init(webappName, webappDir, handlerConfig, jeevesServlet);
     }
 
-
-    /**
-     * This is the name of the RollingFileAppender in your log4j2.xml configuration file.
-     * <p>
-     * LogConfig uses this name to lookup RollingFileAppender to check configuration in
-     * case a custom log file location has been used.
-     */
-    private static final String FILE_APPENDER_NAME = "File";
-
     /**
      * Logfile location as determined from appender, or system property, or default.
      * <p>
@@ -141,62 +127,7 @@ public class GeonetworkDataDirectory {
      * @return logfile location, or {@code null} if unable to determine
      */
     public static File getLogfile() {
-        // Appender is supplied by LogUtils based on parsing log4j2.xml file indicated
-        // by database settings
-
-        // First, try the fileappender from the logger named "geonetwork"
-        Appender appender = Logger.getLogger(Geonet.GEONETWORK).getAppender(FILE_APPENDER_NAME);
-        // If still not found, try the one from the logger named "jeeves"
-        if (appender == null) {
-            appender = Logger.getLogger(Log.JEEVES).getAppender(FILE_APPENDER_NAME);
-        }
-        if (appender != null) {
-            if (appender instanceof AppenderWrapper) {
-                AppenderWrapper wrapper = (AppenderWrapper) appender;
-                org.apache.logging.log4j.core.Appender appender2 = wrapper.getAppender();
-
-                if (appender2 instanceof FileAppender) {
-                    FileAppender fileAppender = (FileAppender) appender2;
-                    String logFileName = fileAppender.getFileName();
-                    if (logFileName != null) {
-                        File logFile = new File(logFileName);
-                        if (logFile.exists()) {
-                            return logFile;
-                        }
-                    }
-                }
-                if (appender2 instanceof RollingFileAppender) {
-                    RollingFileAppender fileAppender = (RollingFileAppender) appender2;
-                    String logFileName = fileAppender.getFileName();
-                    if (logFileName != null) {
-                        File logFile = new File(logFileName);
-                        if (logFile.exists()) {
-                            return logFile;
-                        }
-                    }
-                }
-            }
-        }
-        Log.warning(Geonet.GEONETWORK, "Error when getting logger file for the " + "appender named '" + FILE_APPENDER_NAME + "'. "
-            + "Check your log configuration file. "
-            + "A FileAppender or RollingFileAppender is required to return last activity to the user interface."
-            + "Appender file not found.");
-
-        if (System.getProperties().containsKey("log_dir")) {
-            File logDir = new File(System.getProperty("log_dir"));
-            if (logDir.exists() && logDir.isDirectory()) {
-                File logFile = new File(logDir, "logs/geonetwork.log");
-                if (logFile.exists()) {
-                    return logFile;
-                }
-            }
-        } else {
-            File logFile = new File("logs/geonetwork.log");
-            if (logFile.exists()) {
-                return logFile;
-            }
-        }
-        return null; // unavailable
+        return Log.getLogfile();
     }
 
     /**

--- a/domain/src/main/java/org/fao/geonet/domain/HarvestHistory.java
+++ b/domain/src/main/java/org/fao/geonet/domain/HarvestHistory.java
@@ -36,6 +36,7 @@ import javax.annotation.Nullable;
 import javax.persistence.*;
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.IdentityHashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -307,7 +308,7 @@ public class HarvestHistory extends GeonetEntity {
            boolean isLogFileFound = false;
            for (Iterator iter = logfileElements.iterator(); iter.hasNext();) {
                Element logfile = (Element) iter.next();
-               String path = logfile.getText();
+               String path = Paths.get(Log.getLogfile().getParent()).resolve(logfile.getText()).toString();
                File file = new File(path);
                if (file.exists() && file.canRead()) {
                    if (isLogFileFound) {


### PR DESCRIPTION
The harvester history checks the log file path, but it was using the file name instead of the full path. 

This causes that the harvester history user interface doesn't show the button to download the log file.

With the fix the button is displayed again, allowing to download the log file.

![harvester-log-file](https://github.com/geonetwork/core-geonetwork/assets/1695003/6e72ff1c-e947-4bc8-9c37-ce839697fff4)

Thanks @fxprunayre for the hints to fix the issue.