### PR TITLE
Fixed broken link for Installing from source code

### DIFF
--- a/software_development/BUILDING.md
+++ b/software_development/BUILDING.md
@@ -1,6 +1,6 @@
 # Building
 
-See [Installing from source code](https://geonetwork-opensource.org/manuals/trunk/en/maintainer-guide/installing/installing-from-source-code.html) (Maintainer Guide)
+See [Installing from source code](https://geonetwork-opensource.org/manuals/4.0.x/en/install-guide/installing-from-source-code.html) (Installation Guide)
 
 Build GeoNetwork
 ----------------


### PR DESCRIPTION
The link for 'Installing from source code' is broken.  The label of Maintainer Guide is also incorrect and should be Installation Guide.