### PR TITLE
Related resources - fix the check to display association information

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/related.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/related.html
@@ -233,15 +233,15 @@
             }"
         >
           <i class="fa {{icon}}" />
-          <span data-ng-hide="md.properties && md.properties.associationType != ''">
+          <span data-ng-hide="md.properties && !md.properties.associationType">
             {{(config.getLabel(mainType, type)) | translate}}</span
           >
           <span
-            data-ng-show="md.properties && md.properties.associationType != ''"
+            data-ng-show="md.properties && md.properties.associationType"
             title="{{(config.getLabel(mainType, type)) | translate}}"
           >
             {{md.properties.associationType | translate}}
-            <span data-ng-if="md.properties && md.properties.initiativeType != ''">
+            <span data-ng-if="md.properties && md.properties.initiativeType">
               ({{md.properties.initiativeType | translate}})
             </span>
           </span>


### PR DESCRIPTION
For source datasets association properties are not returned, the current code displayed an empty block `()`:

![source-dataset-1](https://github.com/geonetwork/core-geonetwork/assets/1695003/cc407a97-acff-466a-b6f5-7de3a1725f5f)

With the change:

![source-dataset-2](https://github.com/geonetwork/core-geonetwork/assets/1695003/b7cd0655-1eb7-4948-93fb-7d7628308ae5)

@fxprunayre maybe we could display in this case a generic text `Associated resource` or similar instead of just the icon?
