### PR TITLE
Update status emails to contain link to metadata which does not contain in anchor

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/metadata/DefaultStatusActions.java
+++ b/core/src/main/java/org/fao/geonet/kernel/metadata/DefaultStatusActions.java
@@ -264,6 +264,11 @@ public class DefaultStatusActions implements StatusActions {
             textTemplate = messages.getString("status_change_default_email_text");
         }
 
+        // Replace link in message
+        ApplicationContext applicationContext = ApplicationContextHolder.get();
+        SettingManager sm = applicationContext.getBean(SettingManager.class);
+        textTemplate = textTemplate.replace("{{link}}", sm.getNodeURL()+ "api/records/{{index:uuid}}");
+
         UserRepository userRepository = context.getBean(UserRepository.class);
         User owner = userRepository.findById(status.getOwner()).orElse(null);
 

--- a/core/src/test/resources/org/fao/geonet/api/Messages.properties
+++ b/core/src/test/resources/org/fao/geonet/api/Messages.properties
@@ -101,7 +101,7 @@ Message: \n\
 {1} \n\
  \n\
 View record: \n\
-{7}
+{{link}}
 
 # SiteName / Task / recordTitle statusName by userName
 status_change_doiCreationTask_email_subject={0} / Task / {1} for '{{'index:resourceTitleObject'}}'
@@ -113,7 +113,7 @@ Message: \n\
 {1} \n\
 \n\
 View record: \n\
-{7}
+{{link}}
 # TODO: Link to DOI creation panel
 
 api.groups.group_not_found=Group with ID ''{0}'' not found in this catalog.

--- a/core/src/test/resources/org/fao/geonet/api/Messages_fre.properties
+++ b/core/src/test/resources/org/fao/geonet/api/Messages_fre.properties
@@ -89,7 +89,7 @@ Message: \n\
 {1} \n\
  \n\
 Consulter la fiche : \n\
-{7}
+{{link}}
 
 # SiteName / Task / recordTitle statusName by userName
 status_change_doiCreationTask_email_subject={0} / Action / {1} pour '{{'index:resourceTitleObject'}}'
@@ -102,7 +102,7 @@ Message: \n\
 {1} \n\
 \n\
 Consulter la fiche : \n\
-{7}
+{{link}}
 # TODO: Link to DOI creation panel
 metadata_published_subject=%s / Publication de m\u00E9tadonn\u00E9es
 metadata_published_text=Les fiches suivantes ont \u00E9t\u00E9 trait\u00E9es:\n\

--- a/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages.properties
+++ b/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages.properties
@@ -101,7 +101,7 @@ Message: \n\
 {1} \n\
  \n\
 View record: \n\
-{7}
+{{link}}
 
 # SiteName / Task / recordTitle statusName by userName
 status_change_doiCreationTask_email_subject={0} / Task / {1} for '{{'index:resourceTitleObject'}}'
@@ -113,7 +113,7 @@ Message: \n\
 {1} \n\
 \n\
 View record: \n\
-{7}
+{{link}}
 # TODO: Link to DOI creation panel
 metadata_published_subject=%s / Metadata publication
 metadata_published_text=The following records have been processed:\n\

--- a/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages_fre.properties
+++ b/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages_fre.properties
@@ -89,7 +89,7 @@ Message: \n\
 {1} \n\
  \n\
 Consulter la fiche : \n\
-{7}
+{{link}}
 
 # SiteName / Task / recordTitle statusName by userName
 status_change_doiCreationTask_email_subject={0} / Action / {1} pour '{{'index:resourceTitleObject'}}'
@@ -102,7 +102,7 @@ Message: \n\
 {1} \n\
 \n\
 Consulter la fiche : \n\
-{7}
+{{link}}
 # TODO: Link to DOI creation panel
 metadata_published_subject=%s / Publication de m\u00E9tadonn\u00E9es
 metadata_published_text=Les fiches suivantes ont \u00E9t\u00E9 trait\u00E9es:\n\


### PR DESCRIPTION
Update status emails to contain link to metadata which does not contain in anchor

This will make the link consistent with other emails such as publish/unpublish notifications.

Before this change the url in the link would be 
http://localhost:8080/geonetwork/srv/eng/catalog.search#/metadata/00000000-0000-0000-0000-000000000000

After this change, the url will be 
http://localhost:8080/geonetwork/srv/api/records/00000000-0000-0000-0000-000000000000

Related to issue #6934 
