### PR TITLE
Add missing translations for metadata workflow statuses

### DIFF
--- a/web-ui/src/main/resources/catalog/locales/en-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/en-editor.json
@@ -428,5 +428,7 @@
     "confirmCancelEdit": "Do you want to cancel all changes and close the editor?",
     "allowEditGroupMembers": "Allow group editors to edit",
     "wmsSelectedLayers": "Selected layers",
-    "wmsSelectedLayersNone": "No layers selected"
+    "wmsSelectedLayersNone": "No layers selected",
+    "approved-submitted": "Approved (Working copy is Submitted)",
+    "approved-draft": "Approved (Working copy is Draft)"
 }


### PR DESCRIPTION
Seems related to #7104

Labels in the results were ok, but not the facet values:

![workflow-facet-translations-wrong](https://github.com/geonetwork/core-geonetwork/assets/1695003/01b18ef6-bb4c-4959-95be-3d4bb4735fcc)

With the change:

![workflow-facet-translations-ok](https://github.com/geonetwork/core-geonetwork/assets/1695003/98d1956b-070c-4453-bf17-651aa872512b)
