### PR TITLE
Update xalan dependency (remove potential vuln)

### DIFF
--- a/common/pom.xml
+++ b/common/pom.xml
@@ -86,6 +86,10 @@
       <artifactId>jcs</artifactId>
     </dependency>
     <dependency>
+      <groupId>xalan</groupId>
+      <artifactId>serializer</artifactId>
+    </dependency>
+    <dependency>
       <groupId>net.sf.saxon</groupId>
       <artifactId>saxon</artifactId>
     </dependency>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -53,6 +53,10 @@
       <artifactId>xalan</artifactId>
     </dependency>
     <dependency>
+      <groupId>xalan</groupId>
+      <artifactId>serializer</artifactId>
+    </dependency>
+    <dependency>
       <groupId>net.sf.saxon</groupId>
       <artifactId>saxon-dom</artifactId>
     </dependency>
@@ -477,6 +481,10 @@
         <exclusion>
           <groupId>xalan</groupId>
           <artifactId>xalan</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>xalan</groupId>
+          <artifactId>serializer</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.apache.xmlgraphics</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -354,11 +354,30 @@
         <artifactId>jdom</artifactId>
         <version>1.1.2</version>
       </dependency>
+
       <dependency>
         <groupId>xalan</groupId>
         <artifactId>xalan</artifactId>
-        <version>2.7.1</version>
+        <version>2.7.3</version>
       </dependency>
+      <!-- because xalan 2.7.3 misses to declare its serializer dependency
+       we do it as an explicit dependency here and where it is declared
+       and needed, which is in:
+          core/pom.xml
+          web/pom.xml
+          common/pom.xml
+
+       This all can be removed once the following issue
+       has been resolved: https://issues.apache.org/jira/browse/XALANJ-2649
+       This is planned for the next xalan release. Note that xml-apis
+       and xercesImpl were already listed explicitly.
+      -->
+      <dependency>
+        <groupId>xalan</groupId>
+        <artifactId>serializer</artifactId>
+        <version>2.7.3</version>
+      </dependency>
+
       <dependency>
         <groupId>net.sf.saxon</groupId>
         <artifactId>saxon</artifactId>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -84,6 +84,10 @@
       <artifactId>xalan</artifactId>
     </dependency>
     <dependency>
+      <groupId>xalan</groupId>
+      <artifactId>serializer</artifactId>
+    </dependency>
+    <dependency>
       <groupId>net.sf.saxon</groupId>
       <artifactId>saxon-dom</artifactId>
     </dependency>
@@ -334,6 +338,10 @@
         <exclusion>
           <groupId>xalan</groupId>
           <artifactId>xalan</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>xalan</groupId>
+          <artifactId>serializer</artifactId>
         </exclusion>
         <exclusion>
           <groupId>org.apache.xmlgraphics</groupId>


### PR DESCRIPTION
 * Update Xalan from 2.7.1 to 2.7.3 to address CVE-2022-34169.
 * Use a workaround to address a shortcoming in xalan 2.7.3:The xalan serializer is declared as explicit dependency and the place marked for later reversal of this workaround.

This improves on #7057 and #7117 and supercedes those pull requests.

The security implication of  CVE-2022-34169 for core-geonetwork cannot be fully assessed, a malicious XSLT style sheet can be used for an _Arbitrary Code Execution_  and it cannot be ruled out that someone has build a solution where XSLT style sheet elements are supplied by external users and are not fully sanitized. So it makes sense to fix this at least as a precaution now and not wait for xalan 2.7.4. 
Reference: proof of concept description: https://bugs.chromium.org/p/project-zero/issues/detail?id=2290