### PR TITLE
FeatureInfo - lower case columns names to display the table information

### DIFF
--- a/web-ui/src/main/resources/catalog/components/viewer/gfi/FeaturesLoader.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/gfi/FeaturesLoader.js
@@ -247,6 +247,10 @@
             }
           }
         });
+
+        // Lower case the keys
+        obj = _.mapKeys(obj, function (v, k) { return k.toLowerCase(); });
+        
         return obj;
       });
 


### PR DESCRIPTION
Related to #6801, happens when the column names from the WMS GetFeatureInfo are not in lower case.
 
Test case:

1) Add this layer to the map: https://data.bev.gv.at/geoserver/INSdataAD/wms?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetCapabilities

2) Without the change:

![without-change](https://github.com/geonetwork/core-geonetwork/assets/1695003/9c452f01-4c62-4108-8cd5-95cd3d83a0c9)

3) With the change:

![with-change](https://github.com/geonetwork/core-geonetwork/assets/1695003/cf6a5a8c-be64-4512-94b1-8ec645861fb6)
