### PR TITLE
Update TESTING.md to include a hint to the it maven profile

### DIFF
--- a/software_development/TESTING.md
+++ b/software_development/TESTING.md
@@ -41,3 +41,5 @@ The following list provides a few tips:
 * **org.fao.geonet.utils.GeonetHttpRequestFactory*: When making Http requests you should use `org.fao.geonet.utils.GeonetHttpRequestFactory` instead
   of directly using `HttpClient`.  This is because there are mock instances of `org.fao.geonet.utils.GeonetHttpRequestFactory` that can
   be used to mock responses when performing tests.
+
+* Integration tests are disabled by default. Use the `it` maven profile to use them.


### PR DESCRIPTION
As the only hint to the integration test maven profile i could find is in the root pom.xml, this could make it easier for people to run the integration tests.