### PR TITLE
CSW / DCAT output / Fix for multilingual records

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/layout/tpl-rdf.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/tpl-rdf.xsl
@@ -170,9 +170,9 @@
         </dcat:accessURL>
         <!-- xpath: gmd:linkage/gmd:URL -->
 
-        <xsl:if test="gmd:name/gco:CharacterString!=''">
+        <xsl:if test="gmd:name/(gco:CharacterString|gmx:Anchor) != ''">
           <dct:title>
-            <xsl:value-of select="gmd:name/gco:CharacterString"/>
+            <xsl:value-of select="gmd:name/(gco:CharacterString|gmx:Anchor)"/>
           </dct:title>
         </xsl:if>
         <!-- xpath: gmd:name/gco:CharacterString -->

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/tpl-rdf.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/tpl-rdf.xsl
@@ -159,7 +159,7 @@
     <xsl:for-each-group
       select="//gmd:distributionInfo/*/gmd:transferOptions/*/gmd:onLine/gmd:CI_OnlineResource"
       group-by="gmd:linkage/gmd:URL">
-      <dcat:Distribution rdf:about="{iso19139:RecordUri($uuid)}#{encode-for-uri(gmd:protocol/*/text())}-{encode-for-uri(gmd:name/*/text())}">
+      <dcat:Distribution rdf:about="{iso19139:RecordUri($uuid)}#{encode-for-uri(gmd:protocol/*/text())}-{encode-for-uri(gmd:name/(gco:CharacterString|gmx:Anchor)/text())}">
         <!--
           "points to the location of a distribution. This can be a direct download link, a link
           to an HTML page containing a link to the actual data, Feed, Web Service etc.
@@ -448,7 +448,7 @@
     <!-- xpath: gmd:identificationInfo/*/gmd:resourceConstraints/??? -->
 
     <xsl:for-each select="../../gmd:distributionInfo/*/gmd:transferOptions/*/gmd:onLine">
-      <dcat:distribution rdf:resource="{iso19139:RecordUri($uuid)}#{encode-for-uri(gmd:CI_OnlineResource/gmd:protocol/*/text())}-{encode-for-uri(gmd:CI_OnlineResource/gmd:name/*/text())}"/>
+      <dcat:distribution rdf:resource="{iso19139:RecordUri($uuid)}#{encode-for-uri(gmd:CI_OnlineResource/gmd:protocol/*/text())}-{encode-for-uri(gmd:CI_OnlineResource/gmd:name/(gco:CharacterString|gmx:Anchor)/text())}"/>
     </xsl:for-each>
 
     <!-- xpath: gmd:distributionInfo/*/gmd:transferOptions/*/gmd:onLine/gmd:CI_OnlineResource -->


### PR DESCRIPTION
RDF about creation on Distribution class can fail on some multilingual records.

eg https://sextant.ifremer.fr/geonetwork/srv/api/records/8c8c52b3-4b00-4d11-9dad-37edf6395d82/formatters/xml

Test:
```xml
<csw:GetRecordById xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
                   service="CSW" version="2.0.2"
                   outputSchema="http://www.w3.org/ns/dcat#">
  <csw:Id>8c8c52b3-4b00-4d11-9dad-37edf6395d82</csw:Id>
</csw:GetRecordById>
```

