### PR TITLE
Do not make Danish language a default language.

### DIFF
--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-dan-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-dan-default.sql
@@ -1,4 +1,4 @@
-INSERT INTO Languages (id, name, isinspire, isdefault) VALUES ('dan','Dansk', 'y', 'y');
+INSERT INTO Languages (id, name, isinspire, isdefault) VALUES ('dan','Dansk', 'y', 'n');
 
 -- Take care to table ID (related to other loc files)
 INSERT INTO CategoriesDes (iddes, langid, label) VALUES (1,'dan','Kort & grafik');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v425/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v425/migrate-default.sql
@@ -35,6 +35,7 @@ UPDATE StatusValuesDes SET label = 'Retirado' WHERE iddes = 3 AND langid = 'spa'
 UPDATE StatusValuesDes SET label = 'Enviado' WHERE iddes = 4 AND langid = 'spa';
 UPDATE StatusValuesDes SET label = 'Rechazado' WHERE iddes = 5 AND langid = 'spa';
 
+UPDATE Languages SET isdefault = 'n' where id ='dan';
 
 UPDATE Settings SET value='4.2.5' WHERE name='system/platform/version';
 UPDATE Settings SET value='SNAPSHOT' WHERE name='system/platform/subVersion';


### PR DESCRIPTION
Regression from PR #6933

This was causing request to urls like /geonetwork/srv/api/records/5bc5b51a-f07f-4cb8-b08f-35fa4b3489b9?language=all to fail because a query would return multiple languages when it only expected one default.