### PR TITLE
When authenticating user, only update the usergroups in the database if they have changed

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/security/keycloak/KeycloakUserUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/keycloak/KeycloakUserUtils.java
@@ -299,16 +299,7 @@ public class KeycloakUserUtils {
             }
         }
 
-        List<UserGroup> dbUserGroupLists = userGroupRepository.findAll(UserGroupSpecs.hasUserId(user.getId()));
-        Set<UserGroup> dbUserGroups = new HashSet<>(dbUserGroupLists);
-
-        // If the user groups are not the same as what is in the database then update database so that they are the same.
-        if (! userGroups.equals(dbUserGroups)) {
-            userGroupRepository.deleteAll(UserGroupSpecs.hasUserId(user.getId()));
-            for (UserGroup ug: userGroups) {
-                userGroupRepository.save(ug);
-            }
-        }
+        userGroupRepository.updateUserGroups(user.getId(), userGroups);
     }
 
     /**

--- a/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/OidcUser2GeonetworkUser.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/OidcUser2GeonetworkUser.java
@@ -209,15 +209,6 @@ public class OidcUser2GeonetworkUser {
             }
         }
 
-        List<UserGroup> dbUserGroupLists = userGroupRepository.findAll(UserGroupSpecs.hasUserId(user.getId()));
-        Set<UserGroup> dbUserGroups = new HashSet<>(dbUserGroupLists);
-
-        // If the user groups are not the same as what is in the database then update database so that they are the same.
-        if (!userGroups.equals(dbUserGroups)) {
-            userGroupRepository.deleteAll(UserGroupSpecs.hasUserId(user.getId()));
-            for (UserGroup ug : userGroups) {
-                userGroupRepository.save(ug);
-            }
-        }
+        userGroupRepository.updateUserGroups(user.getId(), userGroups);
     }
 }

--- a/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/OidcUser2GeonetworkUser.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/OidcUser2GeonetworkUser.java
@@ -41,8 +41,10 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.oauth2.core.oidc.OidcIdToken;
 import org.springframework.util.StringUtils;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 /**
  * Class for handling Oidc User and the Geonetwork User.
@@ -159,8 +161,7 @@ public class OidcUser2GeonetworkUser {
      */
     //from keycloak
     protected void updateGroups(Map<Profile, List<String>> profileGroups, User user) {
-        // First we remove all previous groups
-        userGroupRepository.deleteAll(UserGroupSpecs.hasUserId(user.getId()));
+        Set<UserGroup> userGroups = new HashSet<>();
 
         // Now we add the groups
         for (Profile p : profileGroups.keySet()) {
@@ -201,13 +202,22 @@ public class OidcUser2GeonetworkUser {
                     ug.setGroup(group);
                     ug.setUser(user);
                     ug.setProfile(Profile.Editor);
-                    userGroupRepository.save(ug);
+                    userGroups.add(ug);
                 }
 
-                userGroupRepository.save(usergroup);
+                userGroups.add(usergroup);
+            }
+        }
+
+        List<UserGroup> dbUserGroupLists = userGroupRepository.findAll(UserGroupSpecs.hasUserId(user.getId()));
+        Set<UserGroup> dbUserGroups = new HashSet<>(dbUserGroupLists);
+
+        // If the user groups are not the same as what is in the database then update database so that they are the same.
+        if (!userGroups.equals(dbUserGroups)) {
+            userGroupRepository.deleteAll(UserGroupSpecs.hasUserId(user.getId()));
+            for (UserGroup ug : userGroups) {
+                userGroupRepository.save(ug);
             }
         }
     }
-
-
 }

--- a/core/src/main/java/org/fao/geonet/kernel/security/shibboleth/ShibbolethUserUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/shibboleth/ShibbolethUserUtils.java
@@ -269,16 +269,7 @@ public class ShibbolethUserUtils {
             userGroups.add(usergroup);
         }
 
-        List<UserGroup> dbUserGroupLists = userGroupRepository.findAll(UserGroupSpecs.hasUserId(user.getId()));
-        Set<UserGroup> dbUserGroups = new HashSet<>(dbUserGroupLists);
-
-        // If the user groups are not the same then update database so that they are the same.
-        if (! userGroups.equals(dbUserGroups)) {
-            userGroupRepository.deleteAll(UserGroupSpecs.hasUserId(user.getId()));
-            for (UserGroup ug: userGroups) {
-                userGroupRepository.save(ug);
-            }
-        }
+        userGroupRepository.updateUserGroups(user.getId(), userGroups);
     }
 
     private void assignProfile(String[] role_groups, String roleGroupSeparator, User user) {

--- a/domain/src/main/java/org/fao/geonet/domain/UserGroup.java
+++ b/domain/src/main/java/org/fao/geonet/domain/UserGroup.java
@@ -32,6 +32,7 @@ import javax.persistence.*;
 
 import java.io.Serializable;
 import java.util.IdentityHashMap;
+import java.util.Objects;
 
 /**
  * The mapping between user, the groups a user is a part of and the profiles the user has for each
@@ -144,5 +145,20 @@ public class UserGroup extends GeonetEntity implements Serializable {
             .addContent(new Element("group").setText("" + getId().getGroupId()))
             .addContent(new Element("user").setText("" + getId().getUserId()))
             .addContent(new Element("profile").setText(getProfile().name()));
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        UserGroup ug = (UserGroup) o;
+        return (getId().getGroupId() == (ug.getId().getGroupId()) &&
+            getId().getUserId() == (ug.getId().getUserId()) &&
+            getProfile().name().equals(ug.getProfile().name()));
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getProfile().name(), getId().getUserId(), getId().getGroupId());
     }
 }

--- a/domain/src/main/java/org/fao/geonet/repository/UserGroupRepositoryCustom.java
+++ b/domain/src/main/java/org/fao/geonet/repository/UserGroupRepositoryCustom.java
@@ -31,6 +31,7 @@ import javax.persistence.metamodel.SingularAttribute;
 
 import java.util.Collection;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Custom methods for loading {@link UserGroup} entities.
@@ -61,4 +62,13 @@ public interface UserGroupRepositoryCustom {
      * @return the number of entities deleted
      */
     int deleteAllByIdAttribute(SingularAttribute<UserGroupId, Integer> idAttribute, Collection<Integer> ids);
+
+    /**
+     * Update user with the new list of {@link UserGroup}. 
+     * If the user already has all the groups specified then no change will be made.
+     *
+     * @param userId        user id to have the groups updated
+     * @param newUserGroups the {@link UserGroup} to set
+     */
+    void updateUserGroups(int userId, Set<UserGroup> newUserGroups);
 }

--- a/domain/src/main/java/org/fao/geonet/repository/UserGroupRepositoryCustomImpl.java
+++ b/domain/src/main/java/org/fao/geonet/repository/UserGroupRepositoryCustomImpl.java
@@ -26,10 +26,12 @@
  */
 package org.fao.geonet.repository;
 
+import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.domain.UserGroup;
 import org.fao.geonet.domain.UserGroupId;
 import org.fao.geonet.domain.UserGroupId_;
 import org.fao.geonet.domain.UserGroup_;
+import org.fao.geonet.repository.specification.UserGroupSpecs;
 import org.springframework.data.jpa.domain.Specification;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -42,7 +44,9 @@ import javax.persistence.criteria.Root;
 import javax.persistence.metamodel.SingularAttribute;
 
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Implementation object for methods in {@link UserGroupRepositoryCustom}.
@@ -96,6 +100,21 @@ public class UserGroupRepositoryCustomImpl implements UserGroupRepositoryCustom 
         query.where(predicate);
         query.distinct(true);
         return _entityManager.createQuery(query).getResultList();
+    }
+
+     public void updateUserGroups(int userId, Set<UserGroup> newUserGroups) {
+         UserGroupRepository userGroupRepository = ApplicationContextHolder.get().getBean(UserGroupRepository.class);
+
+         List<UserGroup> currentUserGroupLists = userGroupRepository.findAll(UserGroupSpecs.hasUserId(userId));
+         Set<UserGroup> currentUserGroups = new HashSet<>(currentUserGroupLists);
+
+         // If the new user groups are not the same as what is in the database then update database so that they are the same.
+         if (!newUserGroups.equals(currentUserGroups)) {
+             userGroupRepository.deleteAll(UserGroupSpecs.hasUserId(userId));
+             for (UserGroup ug : newUserGroups) {
+                 userGroupRepository.save(ug);
+             }
+         }
     }
 
 }

--- a/domain/src/test/java/org/fao/geonet/repository/UserGroupRepositoryTest.java
+++ b/domain/src/test/java/org/fao/geonet/repository/UserGroupRepositoryTest.java
@@ -33,16 +33,16 @@ import org.fao.geonet.repository.specification.UserGroupSpecs;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.jpa.domain.Specification;
-import org.springframework.data.jpa.domain.Specification;
 
 import java.util.Arrays;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.springframework.data.jpa.domain.Specification.where;
 
@@ -199,6 +199,28 @@ public class UserGroupRepositoryTest extends AbstractSpringDataTest {
         assertTrue(_repo.existsById(ug4.getId()));
 
         assertFalse(_repo.findById(ug1.getId()).isPresent());
+    }
+
+    @Test
+    public void testUpdateUserGroups() {
+        UserGroup ug1 = _repo.save(newUserGroup());
+        User user = ug1.getUser();
+
+        UserGroup ug2 = newUserGroup();
+        ug2.setUser(user);
+
+        UserGroup ug3 = newUserGroup();
+        ug3.setUser(user);
+
+        Set<UserGroup> userGroups = new HashSet<>();
+        userGroups.add(ug2);
+        userGroups.add(ug3);
+
+        _repo.updateUserGroups(ug1.getUser().getId(), userGroups);
+
+        List<UserGroup> userGroups1 = _repo.findAll(UserGroupSpecs.hasUserId(user.getId()));
+
+        assertEquals(new HashSet<>(userGroups1), userGroups);
     }
 
     private UserGroup newUserGroup() {


### PR DESCRIPTION
When authenticating user, only update the usergroups in the database if they have changed. 

This will prevent database locks when multiple authentications from the same user are being done.

Fixes issue #7088
