### PR TITLE
Standard / ISO19115-3 / Preserve revision date type.

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/utility-fn.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/utility-fn.xsl
@@ -10,6 +10,28 @@
   exclude-result-prefixes="#all">
 
 
+  <xsl:function name="gn-fn-iso19115-3.2018:write-date-or-dateTime" as="node()">
+    <xsl:param name="date" as="xs:string"/>
+    <xsl:param name="dateType" as="xs:string"/>
+    <cit:CI_Date>
+      <cit:date>
+        <xsl:choose>
+          <xsl:when test="contains($date, 'T')">
+            <gco:DateTime><xsl:value-of select="$date"/></gco:DateTime>
+          </xsl:when>
+          <xsl:otherwise>
+            <gco:Date><xsl:value-of select="$date"/></gco:Date>
+          </xsl:otherwise>
+        </xsl:choose>
+      </cit:date>
+      <cit:dateType>
+        <cit:CI_DateTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_DateTypeCode" codeListValue="{$dateType}"/>
+      </cit:dateType>
+    </cit:CI_Date>
+  </xsl:function>
+
+
+
   <!-- Get language id attribute defined in
   the metadata PT_Locale section matching the lang
   parameter. If not found, return the lang parameter

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/update-fixed-info.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/update-fixed-info.xsl
@@ -100,7 +100,7 @@
       </xsl:for-each>
 
       <xsl:apply-templates select="mdb:defaultLocale"/>
-      
+
       <xsl:choose>
         <xsl:when test="/root/env/parentUuid != ''">
           <mdb:parentMetadata uuidref="{/root/env/parentUuid}"/>
@@ -109,7 +109,7 @@
           <xsl:apply-templates select="mdb:parentMetadata"/>
         </xsl:when>
       </xsl:choose>
-      
+
       <xsl:apply-templates select="mdb:metadataScope"/>
       <xsl:apply-templates select="mdb:contact"/>
 
@@ -128,29 +128,14 @@
                     or (/root/env/createDate != ''
                         and /root/env/newRecord = 'true')">
         <mdb:dateInfo>
-          <cit:CI_Date>
-            <cit:date>
-              <gco:DateTime><xsl:value-of select="/root/env/createDate"/></gco:DateTime>
-            </cit:date>
-            <cit:dateType>
-              <cit:CI_DateTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_DateTypeCode" codeListValue="creation"/>
-            </cit:dateType>
-          </cit:CI_Date>
+          <xsl:copy-of select="gn-fn-iso19115-3.2018:write-date-or-dateTime(/root/env/createDate, 'creation')"/>
         </mdb:dateInfo>
       </xsl:if>
       <xsl:if test="not($isRevisionDateAvailable)">
         <mdb:dateInfo>
-          <cit:CI_Date>
-            <cit:date>
-              <gco:DateTime><xsl:value-of select="/root/env/changeDate"/></gco:DateTime>
-            </cit:date>
-            <cit:dateType>
-              <cit:CI_DateTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_DateTypeCode" codeListValue="revision"/>
-            </cit:dateType>
-          </cit:CI_Date>
+          <xsl:copy-of select="gn-fn-iso19115-3.2018:write-date-or-dateTime(/root/env/changeDate, 'revision')"/>
         </mdb:dateInfo>
       </xsl:if>
-
 
       <!-- Preserve date order -->
       <xsl:for-each select="mdb:dateInfo">
@@ -159,14 +144,7 @@
         <xsl:choose>
           <xsl:when test="$currentDateType = 'revision' and /root/env/changeDate">
             <mdb:dateInfo>
-              <cit:CI_Date>
-                <cit:date>
-                  <gco:DateTime><xsl:value-of select="/root/env/changeDate"/></gco:DateTime>
-                </cit:date>
-                <cit:dateType>
-                  <cit:CI_DateTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_DateTypeCode" codeListValue="revision"/>
-                </cit:dateType>
-              </cit:CI_Date>
+              <xsl:copy-of select="gn-fn-iso19115-3.2018:write-date-or-dateTime(/root/env/changeDate, 'revision')"/>
             </mdb:dateInfo>
           </xsl:when>
           <xsl:when test="$currentDateType = 'creation'


### PR DESCRIPTION
When updating a metadata record using CSW, revision date could have invalid date type. GeoNetwork always write revision date as dateTime type (to properly order records by change date) but if using the API, user insert records using date type for dates, the wrong type may be introduced.


Test:
* Insert
```xml
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<csw:Transaction service="CSW" version="2.0.2" xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:mmi="http://standards.iso.org/iso/19115/-3/mmi/1.0" xmlns:mcc="http://standards.iso.org/iso/19115/-3/mcc/1.0" xmlns:msr="http://standards.iso.org/iso/19115/-3/msr/2.0" xmlns:mac="http://standards.iso.org/iso/19115/-3/mac/2.0" xmlns:cit="http://standards.iso.org/iso/19115/-3/cit/2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0" xmlns:cat="http://standards.iso.org/iso/19115/-3/cat/1.0" xmlns:mco="http://standards.iso.org/iso/19115/-3/mco/1.0" xmlns:lan="http://standards.iso.org/iso/19115/-3/lan/1.0" xmlns:gex="http://standards.iso.org/iso/19115/-3/gex/1.0" xmlns:gcx="http://standards.iso.org/iso/19115/-3/gcx/1.0" xmlns:mas="http://standards.iso.org/iso/19115/-3/mas/1.0" xmlns:mrd="http://standards.iso.org/iso/19115/-3/mrd/1.0" xmlns:mrc="http://standards.iso.org/iso/19115/-3/mrc/2.0" xmlns:mex="http://standards.iso.org/iso/19115/-3/mex/1.0" xmlns:mpc="http://standards.iso.org/iso/19115/-3/mpc/1.0" xmlns:mri="http://standards.iso.org/iso/19115/-3/mri/1.0" xmlns:gfc="http://standards.iso.org/iso/19110/gfc/1.1" xmlns:mrl="http://standards.iso.org/iso/19115/-3/mrl/2.0" xmlns:mdb="http://standards.iso.org/iso/19115/-3/mdb/2.0" xmlns:mda="http://standards.iso.org/iso/19115/-3/mda/1.0" xmlns:mrs="http://standards.iso.org/iso/19115/-3/mrs/1.0" xmlns:srv="http://standards.iso.org/iso/19115/-3/srv/2.1" xmlns:mdq="http://standards.iso.org/iso/19157/-2/mdq/1.0" xmlns:mdt="http://standards.iso.org/iso/19115/-3/mdt/2.0" xmlns:mds="http://standards.iso.org/iso/19115/-3/mds/2.0" xmlns:xlink="http://www.w3.org/1999/xlink">
    <csw:Insert>
        <mdb:MD_Metadata>
            <mdb:metadataIdentifier>
                <mcc:MD_Identifier>
                    <mcc:code>
                        <gco:CharacterString>AA</gco:CharacterString>
                    </mcc:code>
                </mcc:MD_Identifier>
            </mdb:metadataIdentifier>
            <mdb:dateInfo>
                <cit:CI_Date>
                    <cit:date>
                        <gco:Date>2023-06-19</gco:Date>
                    </cit:date>
                    <cit:dateType>
                        <cit:CI_DateTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_DateTypeCode" codeListValue="creation"/>
                    </cit:dateType>
                </cit:CI_Date>
            </mdb:dateInfo>
            <mdb:dateInfo>
                <cit:CI_Date>
                    <cit:date>
                        <gco:Date>2023-06-19</gco:Date>
                    </cit:date>
                    <cit:dateType>
                        <cit:CI_DateTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_DateTypeCode" codeListValue="revision"/>
                    </cit:dateType>
                </cit:CI_Date>
            </mdb:dateInfo>
            <mdb:identificationInfo>
                <mri:MD_DataIdentification>
                    <mri:citation>
                        <cit:CI_Citation>
                            <cit:title xsi:type="lan:PT_FreeText_PropertyType">
                                <gco:CharacterString>j4</gco:CharacterString>
                                <lan:PT_FreeText>
                                    <lan:textGroup>
                                        <lan:LocalisedCharacterString locale="#FR">j4</lan:LocalisedCharacterString>
                                    </lan:textGroup>
                                </lan:PT_FreeText>
                            </cit:title>
                        </cit:CI_Citation>
                    </mri:citation>
                </mri:MD_DataIdentification>
            </mdb:identificationInfo>
        </mdb:MD_Metadata>
    </csw:Insert>
</csw:Transaction>
```
* Then run the Update operation. Revision date is DateTime instead of Date

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/dbe3e1f8-8981-4249-83d4-3503fbbb4a9a)



Future improvements:
* Maybe we should add the possibility to configure if revision date should be written as Date or DateTime ? 