### PR TITLE
Remove Language table isdefault column and use DefaultLanguage bean instead

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataUtils.java
@@ -51,6 +51,7 @@ import org.fao.geonet.repository.reports.MetadataReportsQueries;
 import org.fao.geonet.repository.specification.OperationAllowedSpecs;
 import org.fao.geonet.utils.Log;
 import org.fao.geonet.utils.Xml;
+import org.fao.geonet.web.DefaultLanguage;
 import org.jdom.Element;
 import org.jdom.JDOMException;
 import org.jdom.Namespace;
@@ -106,6 +107,9 @@ public class BaseMetadataUtils implements IMetadataUtils {
 
     @Autowired(required = false)
     protected XmlSerializer xmlSerializer;
+
+    @Autowired
+    private DefaultLanguage defaultLanguage;
 
     private Path stylePath;
 
@@ -261,15 +265,15 @@ public class BaseMetadataUtils implements IMetadataUtils {
     @Override
     public String extractDefaultLanguage(String schema, Element md) throws Exception {
         Path styleSheet = metadataSchemaUtils.getSchemaDir(schema).resolve(Geonet.File.EXTRACT_DEFAULT_LANGUAGE);
-        String defaultLanguage = Xml.transform(md, styleSheet).getText().trim();
+        String defaultLanguageValue = Xml.transform(md, styleSheet).getText().trim();
 
         if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
-            Log.debug(Geonet.DATA_MANAGER, "Extracted default language '" + defaultLanguage + "' for schema '" + schema + "'");
+            Log.debug(Geonet.DATA_MANAGER, "Extracted default language '" + defaultLanguageValue + "' for schema '" + schema + "'");
 
         // --- needed to detach md from the document
         md.detach();
 
-        return defaultLanguage;
+        return defaultLanguageValue;
     }
 
     /**
@@ -347,10 +351,7 @@ public class BaseMetadataUtils implements IMetadataUtils {
     public String getDefaultUrl(String uuid, String language) {
         String dynamicAppLinkUrl = settingManager.getValue(METADATA_URL_DYNAMICAPPLINKURL);
         if ("all".equals(language)) {
-            Language defaultLanguage = languageRepository.findOneByDefaultLanguage();
-            if (defaultLanguage != null) {
-                language = defaultLanguage.getId();
-            }
+            language = defaultLanguage.getLanguage();
         }
         String defaultLink = settingManager.getNodeURL() + language + "/catalog.search#/metadata/" + uuid;
         String url = buildUrl(uuid, language, dynamicAppLinkUrl);
@@ -513,12 +514,9 @@ public class BaseMetadataUtils implements IMetadataUtils {
 
     @Override
     public void setTemplateExt(final int id, final MetadataType metadataType) throws Exception {
-        metadataRepository.update(id, new Updater<Metadata>() {
-            @Override
-            public void apply(@Nonnull Metadata metadata) {
-                final MetadataDataInfo dataInfo = metadata.getDataInfo();
-                dataInfo.setType(metadataType);
-            }
+        metadataRepository.update(id, metadata -> {
+            final MetadataDataInfo dataInfo = metadata.getDataInfo();
+            dataInfo.setType(metadataType);
         });
     }
 
@@ -538,14 +536,11 @@ public class BaseMetadataUtils implements IMetadataUtils {
      */
     @Override
     public void setSubtemplateTypeAndTitleExt(final int id, String title) throws Exception {
-        metadataRepository.update(id, new Updater<Metadata>() {
-            @Override
-            public void apply(@Nonnull Metadata metadata) {
-                final MetadataDataInfo dataInfo = metadata.getDataInfo();
-                dataInfo.setType(MetadataType.SUB_TEMPLATE);
-                if (title != null) {
-                    dataInfo.setTitle(title);
-                }
+        metadataRepository.update(id, metadata -> {
+            final MetadataDataInfo dataInfo = metadata.getDataInfo();
+            dataInfo.setType(MetadataType.SUB_TEMPLATE);
+            if (title != null) {
+                dataInfo.setTitle(title);
             }
         });
     }
@@ -558,14 +553,11 @@ public class BaseMetadataUtils implements IMetadataUtils {
     @Override
     public void setHarvestedExt(final int id, final String harvestUuid, final Optional<String> harvestUri)
         throws Exception {
-        metadataRepository.update(id, new Updater<Metadata>() {
-            @Override
-            public void apply(Metadata metadata) {
-                MetadataHarvestInfo harvestInfo = metadata.getHarvestInfo();
-                harvestInfo.setUuid(harvestUuid);
-                harvestInfo.setHarvested(harvestUuid != null);
-                harvestInfo.setUri(harvestUri.orNull());
-            }
+        metadataRepository.update(id, metadata -> {
+            MetadataHarvestInfo harvestInfo = metadata.getHarvestInfo();
+            harvestInfo.setUuid(harvestUuid);
+            harvestInfo.setHarvested(harvestUuid != null);
+            harvestInfo.setUri(harvestUri.orNull());
         });
     }
 
@@ -576,12 +568,7 @@ public class BaseMetadataUtils implements IMetadataUtils {
      */
     @Override
     public void updateDisplayOrder(final String id, final String displayOrder) throws Exception {
-        metadataRepository.update(Integer.valueOf(id), new Updater<Metadata>() {
-            @Override
-            public void apply(Metadata entity) {
-                entity.getDataInfo().setDisplayOrder(Integer.parseInt(displayOrder));
-            }
-        });
+        metadataRepository.update(Integer.valueOf(id), entity -> entity.getDataInfo().setDisplayOrder(Integer.parseInt(displayOrder)));
     }
 
     /**
@@ -592,14 +579,9 @@ public class BaseMetadataUtils implements IMetadataUtils {
         // READONLYMODE
         if (!srvContext.getBean(NodeInfo.class).isReadOnly()) {
             int iId = Integer.parseInt(id);
-            metadataRepository.update(iId, new Updater<Metadata>() {
-                @Override
-                public void apply(Metadata entity) {
-                    entity.getDataInfo().setPopularity(
-                        entity.getDataInfo().getPopularity() + 1
-                    );
-                }
-            });
+            metadataRepository.update(iId, entity -> entity.getDataInfo().setPopularity(
+                entity.getDataInfo().getPopularity() + 1
+            ));
             final java.util.Optional<Metadata> metadata = metadataRepository.findById(iId);
 
             if (metadata.isPresent()) {
@@ -639,12 +621,7 @@ public class BaseMetadataUtils implements IMetadataUtils {
         if (Log.isDebugEnabled(Geonet.DATA_MANAGER))
             Log.debug(Geonet.DATA_MANAGER, "Setting rating for id:" + metadataId + " --> rating is:" + newRating);
 
-        metadataRepository.update(metadataId, new Updater<Metadata>() {
-            @Override
-            public void apply(Metadata entity) {
-                entity.getDataInfo().setRating(newRating);
-            }
-        });
+        metadataRepository.update(metadataId, entity -> entity.getDataInfo().setRating(newRating));
         // And register the metadata to be indexed in the near future
         indexingList.add(metadataId);
 
@@ -671,7 +648,7 @@ public class BaseMetadataUtils implements IMetadataUtils {
 
         // Drop Geonet namespace declaration. It may be contained
         // multiple times, so loop on all.
-        final List<Namespace> additionalNamespaces = new ArrayList<Namespace>(md.getAdditionalNamespaces());
+        final List<Namespace> additionalNamespaces = new ArrayList<>(md.getAdditionalNamespaces());
         for (Namespace n : additionalNamespaces) {
             if (Edit.NAMESPACE.getURI().equals(n.getURI())) {
                 md.removeNamespaceDeclaration(Edit.NAMESPACE);

--- a/domain/src/main/java/org/fao/geonet/domain/Language.java
+++ b/domain/src/main/java/org/fao/geonet/domain/Language.java
@@ -47,7 +47,6 @@ public class Language extends GeonetEntity {
     String _id;
     String _name;
     char _inspire = Constants.YN_FALSE;
-    char _defaultLanguage = Constants.YN_FALSE;
 
     /**
      * Get the id of the language. This is a generated value and as such new instances should not
@@ -130,38 +129,5 @@ public class Language extends GeonetEntity {
      */
     public void setInspire(boolean inspire) {
         setInspire_JPAWorkaround(Constants.toYN_EnabledChar(inspire));
-    }
-
-    /**
-     * For backwards compatibility we need the isdefault column to be either 'n' or 'y'. This is a
-     * workaround to allow this until future versions of JPA that allow different ways of
-     * controlling how types are mapped to the database.
-     */
-    @Column(name = "isDefault", length = 1)
-    protected char getDefaultLanguage_JPAWorkaround() {
-        return _defaultLanguage;
-    }
-
-    protected void setDefaultLanguage_JPAWorkaround(char isdefault) {
-        _defaultLanguage = isdefault;
-    }
-
-    /**
-     * Get whether or not this language is the default system language.
-     *
-     * @return true is default language.
-     */
-    @Transient
-    public boolean isDefaultLanguage() {
-        return Constants.toBoolean_fromYNChar(getDefaultLanguage_JPAWorkaround());
-    }
-
-    /**
-     * set true if this is the default language.
-     *
-     * @param newDefault true if this language is the new default.
-     */
-    public void setDefaultLanguage(boolean newDefault) {
-        setDefaultLanguage_JPAWorkaround(Constants.toYN_EnabledChar(newDefault));
     }
 }

--- a/domain/src/main/java/org/fao/geonet/repository/LanguageRepositoryCustom.java
+++ b/domain/src/main/java/org/fao/geonet/repository/LanguageRepositoryCustom.java
@@ -42,10 +42,4 @@ public interface LanguageRepositoryCustom {
      */
     List<Language> findAllByInspireFlag(boolean inspire);
 
-    /**
-     * Find the default language.
-     *
-     * @return the default language.
-     */
-    Language findOneByDefaultLanguage();
 }

--- a/domain/src/main/java/org/fao/geonet/repository/LanguageRepositoryCustomImpl.java
+++ b/domain/src/main/java/org/fao/geonet/repository/LanguageRepositoryCustomImpl.java
@@ -53,14 +53,4 @@ public class LanguageRepositoryCustomImpl implements LanguageRepositoryCustom {
 
         return _entityManager.createQuery(query).getResultList();
     }
-
-    @Override
-    public Language findOneByDefaultLanguage() {
-        CriteriaBuilder cb = _entityManager.getCriteriaBuilder();
-        CriteriaQuery<Language> query = cb.createQuery(Language.class);
-        Root<Language> root = query.from(Language.class);
-        query.where(cb.equal(root.get(Language_.defaultLanguage_JPAWorkaround), Constants.YN_TRUE));
-
-        return _entityManager.createQuery(query).getSingleResult();
-    }
 }

--- a/domain/src/test/java/org/fao/geonet/repository/LanguageRepositoryTest.java
+++ b/domain/src/test/java/org/fao/geonet/repository/LanguageRepositoryTest.java
@@ -42,7 +42,6 @@ public class LanguageRepositoryTest extends AbstractSpringDataTest {
         int val = inc.incrementAndGet();
         Language lang = new Language();
         lang.setId("l-" + val);
-        lang.setDefaultLanguage(val % 2 == 0);
         lang.setInspire(val % 2 == 1);
         lang.setName("name" + val);
         return lang;
@@ -59,19 +58,6 @@ public class LanguageRepositoryTest extends AbstractSpringDataTest {
 
         assertEquals(language1, _repo.findById(language1.getId()).get());
         assertEquals(language, _repo.findById(language.getId()).get());
-    }
-
-    @Test
-    public void testFindOneByDefaultLanguage() {
-        Language language = newLanguage();
-        language.setDefaultLanguage(true);
-        language = _repo.save(language);
-
-        Language language1 = newLanguage();
-        language1.setDefaultLanguage(false);
-        _repo.save(language1);
-
-        assertEquals(language, _repo.findOneByDefaultLanguage());
     }
 
     @Test

--- a/services/src/main/java/org/fao/geonet/api/languages/LanguagesApi.java
+++ b/services/src/main/java/org/fao/geonet/api/languages/LanguagesApi.java
@@ -90,9 +90,6 @@ public class LanguagesApi {
         List<Language> list = applicationLanguages.stream().map(l -> {
             Language language = new Language();
             language.setId(l);
-            if (l.equals(defaultLanguage)) {
-                language.setDefaultLanguage(true);
-            }
             return language;
         }).collect(Collectors.toList());
         return list;

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-ara-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-ara-default.sql
@@ -1,4 +1,4 @@
-INSERT INTO Languages (id, name, isinspire, isdefault) VALUES ('ara','العربية', 'n', 'n');
+INSERT INTO Languages (id, name, isinspire) VALUES ('ara','العربية', 'n');
 
 -- Take care to table ID (related to other loc files)
 INSERT INTO CategoriesDes (iddes, langid, label) VALUES (1,'ara','Maps & graphics');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-cat-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-cat-default.sql
@@ -1,4 +1,4 @@
-INSERT INTO Languages (id, name, isinspire, isdefault) VALUES ('cat','català', 'n', 'n');
+INSERT INTO Languages (id, name, isinspire) VALUES ('cat','català', 'n');
 
 -- Take care to table ID (related to other loc files)
 INSERT INTO CategoriesDes (iddes, langid, label) VALUES (1,'cat','Mapes i gràfics');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-chi-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-chi-default.sql
@@ -1,4 +1,4 @@
-INSERT INTO Languages (id, name, isinspire, isdefault) VALUES ('chi','中文', 'n', 'n');
+INSERT INTO Languages (id, name, isinspire) VALUES ('chi','中文', 'n');
 
 -- Take care to table ID (related to other loc files)
 INSERT INTO CategoriesDes (iddes, langid, label) VALUES (1,'chi','Maps & graphics');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-dan-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-dan-default.sql
@@ -1,4 +1,4 @@
-INSERT INTO Languages (id, name, isinspire, isdefault) VALUES ('dan','Dansk', 'y', 'n');
+INSERT INTO Languages (id, name, isinspire) VALUES ('dan','Dansk', 'y');
 
 -- Take care to table ID (related to other loc files)
 INSERT INTO CategoriesDes (iddes, langid, label) VALUES (1,'dan','Kort & grafik');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-dut-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-dut-default.sql
@@ -1,4 +1,4 @@
-INSERT INTO Languages (id, name, isinspire, isdefault) VALUES ('dut','Nederlands', 'y', 'n');
+INSERT INTO Languages (id, name, isinspire) VALUES ('dut','Nederlands', 'y');
 
 -- Take care to table ID (related to other loc files)
 INSERT INTO CategoriesDes (iddes, langid, label) VALUES (1,'dut','Kaarten & afbeeldingen');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-eng-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-eng-default.sql
@@ -1,4 +1,4 @@
-INSERT INTO Languages (id, name, isinspire, isdefault) VALUES ('eng','English', 'y', 'y');
+INSERT INTO Languages (id, name, isinspire) VALUES ('eng','English', 'y');
 
 -- Take care to table ID (related to other loc files)
 INSERT INTO CategoriesDes (iddes, langid, label) VALUES (1,'eng','Maps & graphics');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-fin-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-fin-default.sql
@@ -1,4 +1,4 @@
-INSERT INTO Languages (id, name, isinspire, isdefault) VALUES ('fin','suomi', 'y', 'n');
+INSERT INTO Languages (id, name, isinspire) VALUES ('fin','suomi', 'y');
 
 -- Take care to table ID (related to other loc files)
 INSERT INTO CategoriesDes (iddes, langid, label) VALUES (1,'fin','Kartat & kuvat');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-fre-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-fre-default.sql
@@ -1,4 +1,4 @@
-INSERT INTO Languages (id, name, isinspire, isdefault) VALUES ('fre','Français', 'y', 'n');
+INSERT INTO Languages (id, name, isinspire) VALUES ('fre','Français', 'y');
 
 -- Take care to table ID (related to other loc files)
 INSERT INTO CategoriesDes (iddes, langid, label) VALUES (2,'fre','Jeux de données');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-ger-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-ger-default.sql
@@ -1,4 +1,4 @@
-INSERT INTO Languages (id, name, isinspire, isdefault) VALUES ('ger','Deutsch', 'y', 'n');
+INSERT INTO Languages (id, name, isinspire) VALUES ('ger','Deutsch', 'y');
 
 -- Take care to table ID (related to other loc files)
 INSERT INTO CategoriesDes (iddes, langid, label) VALUES (1,'ger','Karten & Grafiken');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-ita-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-ita-default.sql
@@ -1,4 +1,4 @@
-INSERT INTO Languages (id, name, isinspire, isdefault)  VALUES ('ita','Italiano', 'y', 'n');
+INSERT INTO Languages (id, name, isinspire)  VALUES ('ita','Italiano', 'y');
 
 -- Take care to table ID (related to other loc files)
 INSERT INTO CategoriesDes (iddes, langid, label) VALUES (1,'ita','Mappe e grafici');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-nor-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-nor-default.sql
@@ -1,4 +1,4 @@
-INSERT INTO Languages (id, name, isinspire, isdefault) VALUES ('nor','norsk', 'n', 'n');
+INSERT INTO Languages (id, name, isinspire) VALUES ('nor','norsk', 'n');
 
 -- Take care to table ID (related to other loc files)
 INSERT INTO CategoriesDes (iddes, langid, label) VALUES (1,'nor','Kart og grafikk');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-pol-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-pol-default.sql
@@ -1,4 +1,4 @@
-INSERT INTO Languages (id, name, isinspire, isdefault) VALUES ('pol','Polski', 'n', 'n');
+INSERT INTO Languages (id, name, isinspire) VALUES ('pol','Polski', 'n');
 
 -- Take care to table ID (related to other loc files)
 INSERT INTO CategoriesDes (iddes, langid, label) VALUES (1,'pol','Mapy i grafika');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-por-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-por-default.sql
@@ -1,4 +1,4 @@
-INSERT INTO Languages (id, name, isinspire, isdefault) VALUES ('por','português', 'y', 'n');
+INSERT INTO Languages (id, name, isinspire) VALUES ('por','português', 'y');
 
 -- Take care to table ID (related to other loc files)
 INSERT INTO CategoriesDes (iddes, langid, label) VALUES (1,'por','Mapas & Graficos');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-rus-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-rus-default.sql
@@ -1,4 +1,4 @@
-INSERT INTO Languages (id, name, isinspire, isdefault) VALUES ('rus','русский язык', 'n', 'n');
+INSERT INTO Languages (id, name, isinspire) VALUES ('rus','русский язык', 'n');
 
 -- Take care to table ID (related to other loc files)
 INSERT INTO CategoriesDes (iddes, langid, label) VALUES (1,'rus','Карты и графика');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-slo-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-slo-default.sql
@@ -1,4 +1,4 @@
-INSERT INTO Languages (id, name, isinspire, isdefault) VALUES ('slo','Slovenčina', 'n', 'n');
+INSERT INTO Languages (id, name, isinspire) VALUES ('slo','Slovenčina', 'n');
 
 -- Take care to table ID (related to other loc files)
 INSERT INTO CategoriesDes (iddes, langid, label) VALUES (1,'slo','Maps & graphics [SK]');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-spa-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-spa-default.sql
@@ -1,4 +1,4 @@
-INSERT INTO Languages (id, name, isinspire, isdefault) VALUES ('spa','español', 'y', 'n');
+INSERT INTO Languages (id, name, isinspire) VALUES ('spa','español', 'y');
 
 -- Take care to table ID (related to other loc files)
 INSERT INTO CategoriesDes (iddes, langid, label) VALUES (2,'spa','Conjuntos de datos');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-swe-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-swe-default.sql
@@ -1,4 +1,4 @@
-INSERT INTO Languages (id, name, isinspire, isdefault) VALUES ('swe','swedish', 'y', 'n');
+INSERT INTO Languages (id, name, isinspire) VALUES ('swe','swedish', 'y');
 
 -- Take care to table ID (related to other loc files)
 INSERT INTO CategoriesDes (iddes, langid, label) VALUES (1,'swe','Kartor och grafik');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-tur-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-tur-default.sql
@@ -1,4 +1,4 @@
-INSERT INTO Languages (id, name, isinspire, isdefault) VALUES ('tur','Türkçe', 'n', 'n');
+INSERT INTO Languages (id, name, isinspire) VALUES ('tur','Türkçe', 'n');
 
 -- Take care to table ID (related to other loc files)
 INSERT INTO CategoriesDes (iddes, langid, label) VALUES (1,'tur','Haritalar & grafikler');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-vie-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-vie-default.sql
@@ -1,4 +1,4 @@
-INSERT INTO Languages (id, name, isinspire, isdefault) VALUES ('vie','Tiếng Việt', 'n', 'n');
+INSERT INTO Languages (id, name, isinspire) VALUES ('vie','Tiếng Việt', 'n');
 
 -- Take care to table ID (related to other loc files)
 INSERT INTO CategoriesDes (iddes, langid, label) VALUES (1,'vie','Maps & graphics');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v425/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v425/migrate-default.sql
@@ -35,7 +35,7 @@ UPDATE StatusValuesDes SET label = 'Retirado' WHERE iddes = 3 AND langid = 'spa'
 UPDATE StatusValuesDes SET label = 'Enviado' WHERE iddes = 4 AND langid = 'spa';
 UPDATE StatusValuesDes SET label = 'Rechazado' WHERE iddes = 5 AND langid = 'spa';
 
-UPDATE Languages SET isdefault = 'n' where id ='dan';
+ALTER TABLE Languages DROP COLUMN isdefault;
 
 UPDATE Settings SET value='4.2.5' WHERE name='system/platform/version';
 UPDATE Settings SET value='SNAPSHOT' WHERE name='system/platform/subVersion';


### PR DESCRIPTION
The default language value was stored in the `Language` table and also in the `DefaultLanguage` bean.

This code change, removes the related column in the `Language` table, to use the `DefaultLanguage` bean as does other code in the application.

It includes also some Sonarlint improvements.