### PR TITLE
Editor / Template field label fix

### DIFF
--- a/web/src/main/webapp/xslt/ui-metadata/form-configurator.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-configurator.xsl
@@ -324,15 +324,15 @@
                     select="gn-fn-metadata:check-elementandsession-visibility(
                   $schema, $base, $serviceInfo, @if, @displayIfServiceInfo)"/>
 
-      <!--
+      <!-- 
       <xsl:message> Field: <xsl:value-of select="@name"/></xsl:message>
       <xsl:message>Xpath: <xsl:copy-of select="@xpath"/></xsl:message>
       <xsl:message>TemplateModeOnly: <xsl:value-of select="@templateModeOnly"/></xsl:message>
       <xsl:message>Display: <xsl:copy-of select="$isDisplayed"/></xsl:message>
       <xsl:message><xsl:value-of select="count($nodes/*)"/> matching nodes: <xsl:copy-of select="$nodes"/></xsl:message>
       <xsl:message>Non existing child path: <xsl:value-of select="concat(@in, '/gn:child[@name = ''', @or, ''']')"/></xsl:message>
-      <xsl:message>Non existing child: <xsl:copy-of select="$nonExistingChildParent"/></xsl:message>
-      -->
+      <xsl:message>Non existing child: <xsl:copy-of select="$nonExistingChildParent"/></xsl:message> -->
+
 
 
       <xsl:variable name="del" select="@del"/>
@@ -361,7 +361,6 @@
             <xsl:if test="$configName != '' and not($overrideLabel)">
               <xsl:message>Label not defined for field name <xsl:value-of select="$configName"/> in loc/{language}/strings.xml.</xsl:message>
             </xsl:if>
-
 
             <xsl:choose>
               <xsl:when test="count($nodes/*) = 1">
@@ -455,10 +454,14 @@
             metadocument. This mode will probably take precedence over the others
             if defined in a view.
             -->
+          <xsl:variable name="configName" select="@name"/>
+          <xsl:variable name="translation"
+                        select="$strings/*[name() = $configName]"/>
           <xsl:variable name="name"
-                        select="if (@name and $strings/*[name() = @name] != '')
-                                then $strings/*[name() = @name]
-                                else @name"/>
+                        select="if ($translation != '')
+                                then $translation
+                                else $configName"/>
+
           <xsl:variable name="del" select="@del"/>
           <xsl:variable name="template" select="template"/>
           <xsl:variable name="forceLabel" select="@forceLabel"/>
@@ -530,7 +533,6 @@
                 <xsl:with-param name="delXpath" select="$del"/>
               </xsl:call-template>
             </xsl:variable>
-
 
             <!-- If the element exist, use the _X<ref> mode which
                   insert the snippet for the element if not use the


### PR DESCRIPTION
When using template field, the label may not be retrieved from translation files.

eg. configuration
```xml
 <section>

          <field name="sextant-temporalRangeSection"
                 templateModeOnly="true"
                 notDisplayedIfMissing="true"
                 xpath="/mdb:MD_Metadata/mdb:identificationInfo/*/mri:extent/*/gex:temporalElement">
            <template>
              <values>
                <key label="beginPosition"
                     xpath="gex:EX_TemporalExtent/mri:extent/gml:TimePeriod/*/gml:beginPosition"
                     use="gn-date-picker"
                     tooltip="mri:extent|gex:EX_TemporalExtent">
                  <directiveAttributes data-tag-name="gml:beginPosition"/>
                </key>
                <key label="endPosition"
                     xpath="gex:EX_TemporalExtent/mri:extent/gml:TimePeriod/*/gml:endPosition"
                     use="gn-date-picker"
                     tooltip="mri:extent|gex:EX_TemporalExtent"
                >
                  <directiveAttributes
                    data-tag-name="gml:endPosition"
                    data-indeterminate-position="eval#gex:EX_TemporalExtent/mri:extent/gml:TimePeriod/*/gml:endPosition/@indeterminatePosition"/>
                </key>
              </values>
              <snippet>
                <gex:temporalElement>
                  <gex:EX_TemporalExtent>
                    <gex:extent>
                      <gml:TimePeriod gml:id="">
                        {{beginPosition}}
                        {{endPosition}}
                      </gml:TimePeriod>
                    </gex:extent>
                  </gex:EX_TemporalExtent>
                </gex:temporalElement>
              </snippet>
            </template>
          </field>
```

Translation in loc/eng/strings.xml
```xml
  <sextant-temporalRangeSection>Temporal extent</sextant-temporalRangeSection>
````

Display the label (instead of the translation key)

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/ca066adc-2eec-44fb-990a-a091f24fd65f)
