### PR TITLE
Standard / ISO19115-3 / Editor / Do not add default lang id

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/update-fixed-info.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/update-fixed-info.xsl
@@ -528,10 +528,10 @@
   <xsl:template match="mdb:MD_Metadata/*/lan:PT_Locale">
     <xsl:element name="lan:{local-name()}">
       <xsl:variable name="id"
-                    select="upper-case(java:twoCharLangCode(lan:language/lan:LanguageCode/@codeListValue))"/>
+                    select="upper-case(java:twoCharLangCode(lan:language/lan:LanguageCode/@codeListValue, ''))"/>
 
       <xsl:apply-templates select="@*"/>
-      <xsl:if test="normalize-space(@id)='' or normalize-space(@id)!=$id">
+      <xsl:if test="normalize-space(@id) = '' or normalize-space(@id) != $id">
         <xsl:attribute name="id">
           <xsl:value-of select="$id"/>
         </xsl:attribute>


### PR DESCRIPTION
Only define the language id once language code is defined. 

If not, we can have wrong multilingual widget.

Test:
* create new 115-3 record
* set default language to spanish
* add other language to english
* set title in both languages
* add other language without lang code (it will get the EN id) - and editor do not display title properly.
 
![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/09cb8dc1-4c01-4b3c-be61-f14a0145f9ed)

