### PR TITLE
API / Import record / Overwrite mode improvement.

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/mef/Importer.java
+++ b/core/src/main/java/org/fao/geonet/kernel/mef/Importer.java
@@ -65,7 +65,7 @@ import static org.fao.geonet.domain.Localized.translationXmlToLangMap;
 public class Importer {
     @Deprecated
     public static List<String> doImport(final Element params, final ServiceContext context, final Path mefFile,
-        final Path stylePath) throws Exception {
+                                        final Path stylePath) throws Exception {
         String fileType = Util.getParam(params, "file_type", "mef");
         String style = Util.getParam(params, Params.STYLESHEET, "_none_");
         String uuidAction = Util.getParam(params, Params.UUID_ACTION, Params.NOTHING);
@@ -81,8 +81,8 @@ public class Importer {
     }
 
     public static List<String> doImport(String fileType, final MEFLib.UuidAction uuidAction, final String style, final String source,
-        final MetadataType isTemplate, final String[] category, final String groupId, final boolean validate, final boolean assign,
-        final ServiceContext context, final Path mefFile) throws Exception {
+                                        final MetadataType isTemplate, final String[] category, final String groupId, final boolean validate, final boolean assign,
+                                        final ServiceContext context, final Path mefFile) throws Exception {
         ApplicationContext applicationContext = ApplicationContextHolder.get();
         final DataManager dm = applicationContext.getBean(DataManager.class);
         final SettingManager sm = applicationContext.getBean(SettingManager.class);
@@ -479,8 +479,8 @@ public class Importer {
     }
 
     public static void importRecord(String uuid, MEFLib.UuidAction uuidAction, List<Element> md, String schema, int index, String source,
-        String sourceName, Map<String, String> sourceTranslations, ServiceContext context, List<String> id, String createDate,
-        String changeDate, String groupId, MetadataType isTemplate) throws Exception {
+                                    String sourceName, Map<String, String> sourceTranslations, ServiceContext context, List<String> id, String createDate,
+                                    String changeDate, String groupId, MetadataType isTemplate) throws Exception {
 
         GeonetContext gc = (GeonetContext) context.getHandlerContext(Geonet.CONTEXT_NAME);
         DataManager dm = gc.getBean(DataManager.class);
@@ -512,31 +512,56 @@ public class Importer {
             }
         }
 
-        try {
-            if (dm.existsMetadataUuid(uuid) && uuidAction != MEFLib.UuidAction.NOTHING) {
-                // user has privileges to replace the existing metadata
+        boolean metadataExist = dm.existsMetadataUuid(uuid);
+        String metadataId = "";
+        if (metadataExist && uuidAction == MEFLib.UuidAction.NOTHING) {
+            throw new UnAuthorizedException("Record already exists. Change the import mode to overwrite or generating a new UUID.", null);
+        } else if (metadataExist && uuidAction == MEFLib.UuidAction.OVERWRITE){
+            String recordToUpdateId = dm.getMetadataId(uuid);
+            if (dm.getAccessManager().canEdit(context, recordToUpdateId)) {
+                MetadataValidationRepository metadataValidationRepository =
+                    context.getBean(MetadataValidationRepository.class);
+                List<MetadataValidation> validationStatus = metadataValidationRepository
+                    .findAllById_MetadataId(Integer.parseInt(recordToUpdateId));
+
+                // Refresh validation status if set
+                boolean validate = !validationStatus.isEmpty();
+                metadataManager.updateMetadata(
+                    context, recordToUpdateId, md.get(index),
+                    validate, true,
+                    context.getLanguage(),
+                    null, true, IndexingMode.full);
+                metadataId = recordToUpdateId;
+            } else {
+                throw new UnAuthorizedException("User has no privilege to overwrite existing metadata", null);
+            }
+        } else if (metadataExist && uuidAction == MEFLib.UuidAction.REMOVE_AND_REPLACE){
+            try {
                 if (dm.getAccessManager().canEdit(context, dm.getMetadataId(uuid))) {
                     if (Log.isDebugEnabled(Geonet.MEF)) {
                         Log.debug(Geonet.MEF, "Deleting existing metadata with UUID : " + uuid);
                     }
                     metadataManager.deleteMetadata(context, dm.getMetadataId(uuid));
                     metadataManager.flush();
-                }
-                // user does not hav privileges to replace the existing metadata
-                else {
+                } else {
                     throw new UnAuthorizedException("User has no privilege to replace existing metadata", null);
                 }
+            } catch (Exception e) {
+                throw new Exception(" Existing metadata with UUID " + uuid + " could not be deleted. Error is: " + e.getMessage());
             }
-        } catch (Exception e) {
-            throw new Exception(" Existing metadata with UUID " + uuid + " could not be deleted. Error is: " + e.getMessage());
+            metadataId = insertMetadata(uuid, md, schema, index, source, context, createDate, changeDate, groupId, isTemplate, dm, metadataManager);
+        } else {
+            metadataId = insertMetadata(uuid, md, schema, index, source, context, createDate, changeDate, groupId, isTemplate, dm, metadataManager);
         }
 
+        id.add(index, metadataId);
+
+    }
+
+    private static String insertMetadata(String uuid, List<Element> md, String schema, int index, String source, ServiceContext context, String createDate, String changeDate, String groupId, MetadataType isTemplate, DataManager dm, IMetadataManager metadataManager) throws Exception {
         if (Log.isDebugEnabled(Geonet.MEF))
             Log.debug(Geonet.MEF, "Adding metadata with uuid:" + uuid);
 
-        //
-        // insert metadata
-        //
         int userid = context.getUserSession().getUserIdAsInt();
         String docType = null, category = null;
         boolean ufo = false;
@@ -546,15 +571,11 @@ public class Importer {
                 createDate, changeDate, ufo, IndexingMode.none);
 
         dm.activateWorkflowIfConfigured(context, metadataId, groupId);
-
-        id.add(index, metadataId);
-
+        return metadataId;
     }
 
-    // --------------------------------------------------------------------------
-
     private static void saveFile(ServiceContext context, String id, MetadataResourceVisibility access, String file, String changeDate,
-        InputStream is) throws Exception {
+                                 InputStream is) throws Exception {
         final Store store = context.getBean("resourceStore", Store.class);
         final IMetadataUtils metadataUtils = context.getBean(IMetadataUtils.class);
         final String metadataUuid = metadataUtils.getMetadataUuid(id);
@@ -609,7 +630,7 @@ public class Importer {
      * Add operations according to information file.
      */
     private static Set<OperationAllowed> addOperations(final ServiceContext context, final DataManager dm, final Element group,
-        final int metadataId, final int grpId) {
+                                                       final int metadataId, final int grpId) {
         @SuppressWarnings("unchecked") List<Element> operations = group.getChildren("operation");
 
         Set<OperationAllowed> toAdd = new HashSet<OperationAllowed>();

--- a/core/src/main/java/org/fao/geonet/kernel/mef/MEFLib.java
+++ b/core/src/main/java/org/fao/geonet/kernel/mef/MEFLib.java
@@ -563,7 +563,17 @@ public class MEFLib {
     public enum UuidAction {
         GENERATEUUID("generateUUID"),
         NOTHING("nothing"),
-        OVERWRITE("overwrite");
+
+        /**
+         * Update the XML of the metadata record.
+         */
+        OVERWRITE("overwrite"),
+
+        /**
+         * Remove the metadata (and privileges, status, ...)
+         * and insert the new one with the same UUID.
+         */
+        REMOVE_AND_REPLACE("removeAndReplace");
         String name;
 
         UuidAction(String name) {
@@ -583,7 +593,7 @@ public class MEFLib {
 
     public enum Format {
         /**
-         * Only metadata record and infomation
+         * Only metadata record and information
          */
         SIMPLE,
         /**


### PR DESCRIPTION
Currently `OVERWRITE` mode is not really overwriting the record but remove it (including status, privileges, ...) and then replace it with the new XML and import parameters.

Users expect that overwrite is only updating the XML of the metadata record.

Change `OVERWRITE` mode to only update the XML and add a `REMOVE_AND_REPLACE` (not visible in the UI ?) mode to keep existing mechanism.


When workflow is enabled, `OVERWRITE` is not allowed

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/fb444418-5b67-41d7-92ad-3465b1d9dd0f)
