### PR TITLE
Site information - return ElasticSearch index information

### DIFF
--- a/index/src/main/java/org/fao/geonet/index/es/EsRestClient.java
+++ b/index/src/main/java/org/fao/geonet/index/es/EsRestClient.java
@@ -49,6 +49,7 @@ import org.elasticsearch.action.search.SearchRequest;
 import org.elasticsearch.action.search.SearchResponse;
 import org.elasticsearch.action.support.WriteRequest;
 import org.elasticsearch.client.*;
+import org.elasticsearch.client.core.MainResponse;
 import org.elasticsearch.client.indices.AnalyzeRequest;
 import org.elasticsearch.client.indices.AnalyzeResponse;
 import org.elasticsearch.common.xcontent.XContentType;
@@ -281,7 +282,7 @@ public class EsRestClient implements InitializingBean {
         final QueryBuilder query = QueryBuilders.wrapperQuery(String.valueOf(jsonQuery));
         return query(index, query, postFilterBuilder, includedFields, scriptedFields, from, size, sort);
     }
-    
+
     public SearchResponse query(String index, QueryBuilder queryBuilder, QueryBuilder postFilterBuilder,
                                 Set<String> includedFields, Map<String, String> scriptedFields,
                                 int from, int size, List<SortBuilder<FieldSortBuilder>> sort) throws Exception {
@@ -501,5 +502,11 @@ public class EsRestClient implements InitializingBean {
 
         return response.getStatus().toString();
 //        return getClient().ping(RequestOptions.DEFAULT);
+    }
+
+    public String getServerVersion() throws IOException {
+        MainResponse.Version version = client.info(RequestOptions.DEFAULT).getVersion();
+
+        return version.getNumber();
     }
 }

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1449,6 +1449,9 @@
     "ui-topCustomMenu": "Header custom menu items",
     "ui-topCustomMenu-help": "List of static page IDs associated with the header section to display: <ul><li>When a list is provided, the links are displayed in the order provided and only for the pages listed.</li><li>When a list is not provided, all static pages configured for the header section are displayed, with no guaranteed order.</li>",
     "ui-footerCustomMenu": "Footer custom menu items",
-    "ui-footerCustomMenu-help": "List of static page IDs associated with the footer section to display: <ul><li>When a list is provided, the links are displayed in the order provided and only for the pages listed.</li><li>When a list is not provided, all static pages configured for the footer section are displayed, with no guaranteed order.</li>"
+    "ui-footerCustomMenu-help": "List of static page IDs associated with the footer section to display: <ul><li>When a list is provided, the links are displayed in the order provided and only for the pages listed.</li><li>When a list is not provided, all static pages configured for the footer section are displayed, with no guaranteed order.</li>",
+    "es.url": "ElasticSearch server",
+    "es.version": "ElasticSearch version",
+    "es.index": "Index name"
 }
 


### PR DESCRIPTION
Currently the information page displays an empty section for the `Index`. 

![information-index-empty](https://github.com/geonetwork/core-geonetwork/assets/1695003/3f36118e-5be3-4090-b266-5a493d60a8dc)

This change adds some basic information:

- ElasticSearch server version
- ElasticSearch server URL
- Index name

![information-index](https://github.com/geonetwork/core-geonetwork/assets/1695003/955ea402-7f96-4152-9766-89a36a421f03)
