### PR TITLE
Standard / ISO19110 / Add cardinality in default view

### DIFF
--- a/schemas/iso19110/src/main/plugin/iso19110/index-fields/index.xsl
+++ b/schemas/iso19110/src/main/plugin/iso19110/index-fields/index.xsl
@@ -110,6 +110,9 @@
               "code": "<xsl:value-of select="gn-fn-index:json-escape(*/gfc:code/*/text())"/>",
               "link": "<xsl:value-of select="*/gfc:code/*/@xlink:href"/>",
               "type": "<xsl:value-of select="*/gfc:valueType/gco:TypeName/gco:aName/*/text()"/>"
+              <xsl:if test="*/gfc:cardinality">
+                ,"cardinality": "<xsl:value-of select="concat(*/gfc:cardinality//gco:lower/*/text(), '..', */gfc:cardinality//gco:upper/*/text())"/>"
+              </xsl:if>
               <xsl:if test="*/gfc:listedValue">
                 ,"values": [
                 <xsl:for-each select="*/gfc:listedValue">{

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
@@ -1013,6 +1013,9 @@
               "code": "<xsl:value-of select="gn-fn-index:json-escape(*/gfc:code/*/text())"/>",
               "link": "<xsl:value-of select="*/gfc:code/*/@xlink:href"/>",
               "type": "<xsl:value-of select="*/gfc:valueType/gco:TypeName/gco:aName/*/text()"/>"
+              <xsl:if test="*/gfc:cardinality">
+                ,"cardinality": "<xsl:value-of select="gn-fn-index:json-escape(*/gfc:cardinality/*/text())"/>"
+              </xsl:if>
               <xsl:if test="*/gfc:listedValue">
                 ,"values": [
                 <xsl:for-each select="*/gfc:listedValue">{

--- a/web-ui/src/main/resources/catalog/locales/en-core.json
+++ b/web-ui/src/main/resources/catalog/locales/en-core.json
@@ -398,6 +398,7 @@
     "featureAttributeTable": "Attribute table",
     "attributeName": "Name",
     "attributeDefinition": "Definition",
+    "attributeCardinality": "Cardinality:",
     "attributeValues": "List of values",
     "attributeType": "Type",
     "attributeCode": "Code",

--- a/web-ui/src/main/resources/catalog/locales/nl-core.json
+++ b/web-ui/src/main/resources/catalog/locales/nl-core.json
@@ -408,6 +408,7 @@
     "featureAttributeTable": "Attributen tabel",
     "attributeName": "naam",
     "attributeDefinition": "Definitie",
+    "attributeCardinality": "Cardinaliteit:",
     "attributeValues": "Lijst met waarden",
     "attributeType": "Soort",
     "attributeCode": "Code",

--- a/web-ui/src/main/resources/catalog/style/gn_metadata.less
+++ b/web-ui/src/main/resources/catalog/style/gn_metadata.less
@@ -60,7 +60,7 @@ header div.gn-abstract {
         border-bottom: 1px solid @table-border-color;
       }
       th {
-        width: 35%;
+        width: 30%;
       }
       @media (max-width: @screen-xs-max) {
         th,

--- a/web-ui/src/main/resources/catalog/views/default/directives/directive.js
+++ b/web-ui/src/main/resources/catalog/views/default/directives/directive.js
@@ -66,10 +66,12 @@
           ) {
             scope.attributeTable = [scope.attributeTable];
           }
-          scope.showCodeColumn = false;
+          scope.columnVisibility = {
+            code: false
+          };
           angular.forEach(scope.attributeTable, function (elem) {
             if (elem.code > "") {
-              scope.showCodeColumn = true;
+              scope.columnVisibility.code = true;
             }
           });
         }

--- a/web-ui/src/main/resources/catalog/views/default/directives/partials/attributetable.html
+++ b/web-ui/src/main/resources/catalog/views/default/directives/partials/attributetable.html
@@ -1,15 +1,25 @@
 <table class="table table-bordered">
   <tr>
     <th data-translate="">attributeName</th>
-    <th data-translate="" data-ng-show="showCodeColumn">attributeCode</th>
+    <th data-translate="" data-ng-show="::columnVisibility.code">attributeCode</th>
     <th data-translate="">attributeDefinition</th>
   </tr>
   <tr data-ng-repeat-start="attribute in attributeTable track by $index">
     <td>
       <strong>{{attribute.name}}</strong>
-      <span data-ng-show="attribute.type">&nbsp;({{attribute.type}})</span>
+      <div>
+        <span data-ng-if="attribute.type" title="{{'attributeType' | translate}}">
+          {{attribute.type}}
+        </span>
+        <span data-ng-if="attribute.type && attribute.cardinality"> - </span>
+        <span
+          data-ng-if="attribute.cardinality"
+          title="{{'attributeCardinality' | translate}}"
+          >{{'attributeCardinality' | translate}} {{attribute.cardinality}}
+        </span>
+      </div>
     </td>
-    <td data-ng-show="showCodeColumn">
+    <td data-ng-show="::columnVisibility.code">
       <strong data-ng-show="{{attribute.link == null || attribute.link == ''}}"
         >{{attribute.code}}</strong
       >

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/featurecatalogue.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/featurecatalogue.html
@@ -35,10 +35,6 @@
   </h3>
   <table class="table table-striped table-bordered gn-margin-left-lg gn-margin-top-lg">
     <tbody>
-      <tr data-ng-if="featureType.typeName">
-        <th></th>
-        <td>{{featureType.typeName}}</td>
-      </tr>
       <tr data-ng-if="featureType.definition">
         <th data-translate="">featureDefinition</th>
         <td>{{featureType.definition}}</td>

--- a/web/src/main/webResources/WEB-INF/data/config/index/records.json
+++ b/web/src/main/webResources/WEB-INF/data/config/index/records.json
@@ -1838,6 +1838,9 @@
               "type": {
                 "type": "keyword"
               },
+              "cardinality": {
+                "type": "keyword"
+              },
               "values": {
                 "type": "object",
                 "properties": {


### PR DESCRIPTION
In ISO19139, `gfc:cardinality` is a multiplicity element with lower/upper properties. In ISO19115-3, cardinality is a `CharacterString`.

Store it as text in the index with `lower..upper` value for ISO19139.

Display cardinality next to the type.

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/5ec2777f-d449-4780-af54-9be20fce8a22)

Do not display twice the type name (already the table header).