### PR TITLE
Bulk publish / Publish privileges should be assigned to the approved version, not to the working copy version.

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/MetadataSharingApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataSharingApi.java
@@ -552,12 +552,12 @@ public class MetadataSharingApi {
                 java.util.Optional<GroupPrivilege> allGroupPrivsBefore =
                     sharingBefore.getPrivileges().stream().filter(p -> p.getGroup() == ReservedGroup.all.getId()).findFirst();
 
-                boolean publishedBefore = allGroupPrivsBefore.get().getOperations().get(ReservedOperation.view.name());
+                boolean publishedBefore = allGroupPrivsBefore.isPresent() && allGroupPrivsBefore.get().getOperations().get(ReservedOperation.view.name());
 
                 java.util.Optional<GroupOperations> allGroupOpsAfter =
                     privileges.stream().filter(p -> p.getGroup() == ReservedGroup.all.getId()).findFirst();
 
-                boolean publishedAfter = allGroupOpsAfter.get().getOperations().get(ReservedOperation.view.name());
+                boolean publishedAfter = allGroupOpsAfter.isPresent() && allGroupOpsAfter.get().getOperations().get(ReservedOperation.view.name());
 
                 if (publishedBefore != publishedAfter) {
                     MetadataPublicationNotificationInfo metadataNotificationInfo = new MetadataPublicationNotificationInfo();
@@ -1296,9 +1296,10 @@ public class MetadataSharingApi {
                             }
 
                             if (!allGroupPrivileges.isEmpty()) {
-                                setOperations(sharing, dataMan, context, appContext, metadata, operationMap, privileges,
+                                setOperations(sharing, dataMan, context, appContext, md, operationMap, allGroupPrivileges,
                                     ApiUtils.getUserSession(session).getUserIdAsInt(), skipAllReservedGroup, report, request,
-                                    metadataListToNotifyPublication, notifyByEmail);                            }
+                                    metadataListToNotifyPublication, notifyByEmail);
+                            }
                         }
 
                         if (!privileges.isEmpty()) {


### PR DESCRIPTION
Fix related to #5557

Applies only to `3.12.x`, in `main` this FP contains the fix: https://github.com/geonetwork/core-geonetwork/pull/7183

Test case:

1) Enable the metadata workflow
2) Create an iso19139 metadata and approve it
3) Edit it to create a working copy
4) Publish it from the metadata detail page --> The metadata is published (OK)

5) Create a new iso19139 metadata and approve it
6) Edit it to create a working copy
7) In the editor board select it and use the Bulk Publish option 

Without the fix:

- The metadata is not published (NO OK)

With the fix:

- The metadata is not published (OK)
