### PR TITLE
Change line-height for username so that it is not truncated.

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -1260,7 +1260,7 @@ gn-md-type-inspire-validation-widget {
     vertical-align: middle;
     padding-left: 3px;
     margin: -6px 0px;
-    line-height: 1em;
+    line-height: normal;
     .gn-user-name {
       max-width: 200px;
       display: inline-block;


### PR DESCRIPTION
Letters like j, y, p are getting truncated when displaying the username.

![image](https://github.com/geonetwork/core-geonetwork/assets/1868233/0482e1f8-ed36-4cd5-bd23-38a7b5fdaa40)

Based on the following it seems like line-height should be normal

https://stackoverflow.com/questions/25470084/minimum-line-height-to-ensure-text-is-not-cut-off

After this change is looks like this

![image](https://github.com/geonetwork/core-geonetwork/assets/1868233/b8a5bed2-e8e0-4d3b-b304-0d4c898c9978)
