### PR TITLE
Standard / ISO19115-3 / Formatter / Layout improvements

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/xsl-view/view.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/xsl-view/view.xsl
@@ -1056,13 +1056,17 @@
 
   <!-- ########################## -->
   <!-- Render values for text ... -->
-
   <xsl:template mode="render-value"
                 match="*[gco:CharacterString]">
+    <xsl:variable name="txt">
+      <xsl:apply-templates mode="localised" select=".">
+        <xsl:with-param name="langId" select="$langId"/>
+      </xsl:apply-templates>
+    </xsl:variable>
 
-    <xsl:apply-templates mode="localised" select=".">
-      <xsl:with-param name="langId" select="$langId"/>
-    </xsl:apply-templates>
+    <xsl:call-template name="addLineBreaksAndHyperlinks">
+      <xsl:with-param name="txt" select="$txt"/>
+    </xsl:call-template>
   </xsl:template>
 
   <xsl:template mode="render-value"

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/xsl-view/view.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/xsl-view/view.xsl
@@ -50,7 +50,7 @@
   <xsl:variable name="configuration"
                 select="document('../../layout/config-editor.xml')"/>
 
- <!-- Required for utility-fn.xsl -->
+  <!-- Required for utility-fn.xsl -->
   <xsl:variable name="editorConfig"
                 select="document('../../layout/config-editor.xml')"/>
 
@@ -171,8 +171,9 @@
                     <span class="badge"><xsl:copy-of select="."/></span>
                   </xsl:when>
                   <xsl:otherwise>
-                    <a href='#/search?query_string=%7B"tag.\\*":%7B"{.}":true%7D%7D'>
-                      <span class="badge"><xsl:copy-of select="."/></span>
+                    <a class="btn btn-default btn-xs"
+                       href='#/search?query_string=%7B"tag.\\*":%7B"{.}":true%7D%7D'>
+                      <xsl:copy-of select="."/>
                     </a>
                   </xsl:otherwise>
                 </xsl:choose>
@@ -191,8 +192,9 @@
                   <span class="badge"><xsl:copy-of select="."/></span>
                 </xsl:when>
                 <xsl:otherwise>
-                  <a href='#/search?query_string=%7B"tag.\\*":%7B"{.}":true%7D%7D'>
-                    <span class="badge"><xsl:copy-of select="."/></span>
+                  <a class="btn btn-default btn-xs"
+                     href='#/search?query_string=%7B"tag.\\*":%7B"{.}":true%7D%7D'>
+                    <xsl:copy-of select="."/>
                   </a>
                 </xsl:otherwise>
               </xsl:choose>
@@ -309,7 +311,7 @@
       select="mdb:identificationInfo/*/mri:citation/*/cit:otherCitationDetails"/>
       -->
       <xsl:choose>
-      <!-- Landing page case -->
+        <!-- Landing page case -->
         <xsl:when test="$language = 'all'">
 
           <xsl:variable name="citationInfo">
@@ -414,7 +416,7 @@
     <xsl:param name="fieldName" select="''" as="xs:string"/>
 
     <xsl:variable name="elementName" select="if (@codeListValue) then name(..) else name(.)"/>
-    <dl>
+    <dl class="gn-{local-name()}">
       <dt>
         <xsl:call-template name="render-field-label">
           <xsl:with-param name="fieldName" select="$fieldName"/>
@@ -569,7 +571,6 @@
     <br/>
   </xsl:template>
 
-
   <xsl:template mode="render-field"
                 match="gex:EX_BoundingPolygon/gex:polygon"
                 priority="100">
@@ -586,16 +587,16 @@
                 match="gex:EX_Extent"
                 priority="100">
     <div class="entry name">
-    <h4>
-      <xsl:call-template name="render-field-label">
+      <h4>
+        <xsl:call-template name="render-field-label">
           <xsl:with-param name="languages" select="$allLanguages"/>
         </xsl:call-template>
-      <xsl:apply-templates mode="render-value"
-                           select="@*"/>
-    </h4>
-    <div class="target">
-      <xsl:apply-templates mode="render-field"
-                           select="gex:*"/>
+        <xsl:apply-templates mode="render-value"
+                             select="@*"/>
+      </h4>
+      <div class="target">
+        <xsl:apply-templates mode="render-field"
+                             select="gex:*"/>
       </div>
     </div>
   </xsl:template>
@@ -605,48 +606,96 @@
   <xsl:template mode="render-field"
                 match="*[cit:CI_Responsibility]"
                 priority="100">
-    <div class="gn-contact">
-      <h4>
-        <i class="fa fa-envelope"><xsl:comment select="'.'"/></i>
-        <xsl:apply-templates mode="render-value"
-                             select="*/cit:role/*/@codeListValue"/>
-      </h4>
+    <xsl:param name="layout"
+               required="no"/>
+
+    <xsl:choose>
+      <xsl:when test="$layout = 'short'">
+        <xsl:apply-templates mode="render-field"
+                             select="*/cit:party/(cit:CI_Organisation|cit:CI_Individual)">
+          <xsl:with-param name="layout" select="$layout"/>
+        </xsl:apply-templates>
+      </xsl:when>
+      <xsl:otherwise>
+        <div class="gn-contact">
+          <h4>
+            <i class="fa fa-envelope"><xsl:comment select="'.'"/></i>
+            <xsl:apply-templates mode="render-value"
+                                 select="*/cit:role/*/@codeListValue"/>
+          </h4>
+
+          <xsl:apply-templates mode="render-field"
+                               select="*/cit:party/(cit:CI_Organisation|cit:CI_Individual)">
+            <xsl:with-param name="layout" select="$layout"/>
+          </xsl:apply-templates>
+        </div>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
 
 
 
-      <xsl:for-each select="*/cit:party/(cit:CI_Organisation|cit:CI_Individual)">
-        <!-- Display name is <org name> - <individual name> (<position name>) -->
-        <xsl:variable name="displayName">
-          <xsl:choose>
-            <xsl:when
-              test="name(.) = 'cit:CI_Organisation'">
-              <!-- Org name may be multilingual -->
-              <xsl:apply-templates mode="render-value"
-                                   select="cit:name"/>
-              <xsl:if test="cit:individual">
-                <xsl:text> - </xsl:text>
-              </xsl:if>
-              <xsl:for-each select="cit:individual">
-                <xsl:apply-templates mode="get-display-name" select="cit:CI_Individual"/>
-                <xsl:if test="position() != last()">
-                  <xsl:text>, </xsl:text>
-                </xsl:if>
-              </xsl:for-each>
-            </xsl:when>
-            <xsl:otherwise>
-              <xsl:apply-templates mode="get-display-name" select="."/>
-            </xsl:otherwise>
-          </xsl:choose>
-        </xsl:variable>
+  <xsl:template mode="render-field"
+                match="*/cit:party/cit:CI_Organisation
+                      |*/cit:party/cit:CI_Individual"
+                priority="100">
+    <xsl:param name="layout"
+               required="no"/>
 
-        <xsl:variable name="email">
-          <xsl:for-each select=".//cit:electronicMailAddress[not(gco:nilReason)]">
-            <xsl:apply-templates mode="render-value" select="."/>
-            <xsl:if test="position() != last()">,<xsl:comment select="'.'"/></xsl:if>
+    <!-- Display name is <org name> - <individual name> (<position name>) -->
+    <xsl:variable name="displayName">
+      <xsl:choose>
+        <xsl:when
+          test="name(.) = 'cit:CI_Organisation'">
+          <!-- Org name may be multilingual -->
+          <xsl:apply-templates mode="render-value-no-breaklines"
+                               select="cit:name"/>
+          <xsl:for-each select="cit:individual[normalize-space(.) != '']">
+            <xsl:if test="position() = 1"> - </xsl:if>
+            <xsl:apply-templates mode="get-display-name"
+                                 select="cit:CI_Individual"/>
+            <xsl:if test="position() != last()">
+              <xsl:text>, </xsl:text>
+            </xsl:if>
           </xsl:for-each>
-        </xsl:variable>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:apply-templates mode="get-display-name"
+                               select="."/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:variable>
 
+    <xsl:variable name="email">
+      <xsl:for-each select=".//cit:electronicMailAddress[not(gco:nilReason)]">
+        <xsl:apply-templates mode="render-value-no-breaklines"
+                             select="."/>
+        <xsl:if test="position() != last()">,<xsl:comment select="'.'"/></xsl:if>
+      </xsl:for-each>
+    </xsl:variable>
 
+    <xsl:choose>
+      <xsl:when test="$layout = 'short'">
+        <xsl:variable name="url"
+                      select="(ancestor::cit:CI_Responsibility/@uuid[starts-with(., 'http')]
+                      |.//cit:onlineResource/*/cit:linkage/gco:CharacterString[normalize-space(.) != ''])[1]"/>
+
+        <xsl:choose>
+          <xsl:when test="$url != ''">
+            <a href="{$url}" target="_blank"><xsl:copy-of select="$displayName"/></a>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:copy-of select="$displayName"/>
+          </xsl:otherwise>
+        </xsl:choose>
+
+        <xsl:if test="$email != ''">
+          <a href="mailto:{normalize-space($email)}">
+            <sup class="fa fa-envelope">&#160;</sup>
+          </a>
+        </xsl:if>
+      </xsl:when>
+      <xsl:otherwise>
         <div class="row">
           <div class="col-md-6">
             <!-- Needs improvements as contact/org are more flexible in iso19115-3.2018 -->
@@ -669,7 +718,7 @@
                                             cit:administrativeArea|cit:postalCode|cit:country)">
                   <div>
                     <xsl:if test="normalize-space(.) != ''">
-                      <xsl:apply-templates mode="render-value" select="."/><br/>
+                      <xsl:apply-templates mode="render-value-no-breaklines" select="."/><br/>
                     </xsl:if>
                   </div>
                 </xsl:for-each>
@@ -682,7 +731,7 @@
                 <xsl:for-each select="cit:phone/*[cit:numberType/*/@codeListValue = 'voice']/cit:number[normalize-space(.) != '']">
                   <div>
                     <xsl:variable name="phoneNumber">
-                      <xsl:apply-templates mode="render-value" select="."/>
+                      <xsl:apply-templates mode="render-value-no-breaklines" select="."/>
                     </xsl:variable>
                     <i class="fa fa-phone"><xsl:comment select="'.'"/></i>
                     <a href="tel:{$phoneNumber}">
@@ -693,7 +742,7 @@
                 <xsl:for-each select="cit:phone/*[cit:numberType/*/@codeListValue != 'voice']/cit:number[normalize-space(.) != '']">
                   <div>
                     <xsl:variable name="phoneNumber">
-                      <xsl:apply-templates mode="render-value" select="."/>
+                      <xsl:apply-templates mode="render-value-no-breaklines" select="."/>
                     </xsl:variable>
                     <i class="fa fa-fax"><xsl:comment select="'.'"/></i>
                     <a href="tel:{normalize-space($phoneNumber)}">
@@ -702,22 +751,28 @@
                   </div>
                 </xsl:for-each>
                 <xsl:for-each select="cit:onlineResource/*/cit:linkage[normalize-space(.) != '']">
+                  <xsl:variable name="linkName">
+                    <xsl:apply-templates mode="render-value"
+                                         select="../cit:name"/>
+                  </xsl:variable>
                   <xsl:variable name="linkDescription">
                     <xsl:apply-templates mode="render-value"
                                          select="../cit:description"/>
                   </xsl:variable>
                   <xsl:variable name="linkage">
-                    <xsl:apply-templates mode="render-value" select="."/>
+                    <xsl:apply-templates mode="render-value-no-breaklines" select="."/>
                   </xsl:variable>
                   <i class="fa fa-link"><xsl:comment select="'.'"/></i>
                   <a href="{normalize-space($linkage)}" target="_blank">
-                    <xsl:value-of select="if (../cit:name)
-                                          then ../cit:name/* else
-                                          normalize-space(linkage)"/><xsl:comment select="'.'"/>
->                 </a>
-                  <p>
-                    <xsl:value-of select="normalize-space($linkDescription)"/>
-                  </p>
+                    <xsl:value-of select="if (normalize-space($linkName) != '')
+                                          then $linkName
+                                          else normalize-space($linkage)"/>
+                  </a>
+                  <xsl:if test="normalize-space($linkDescription) != ''">
+                    <p>
+                      <xsl:value-of select="normalize-space($linkDescription)"/>
+                    </p>
+                  </xsl:if>
                 </xsl:for-each>
                 <xsl:for-each select="cit:hoursOfService">
                   <span>
@@ -731,28 +786,33 @@
             </xsl:for-each>
           </div>
         </div>
-      </xsl:for-each>
-    </div>
+      </xsl:otherwise>
+    </xsl:choose>
+
   </xsl:template>
 
   <!-- Format CT_Individual element for display -->
   <!-- Display name is <individual name> (<position name>) -->
   <xsl:template mode="get-display-name" match="cit:CI_Individual">
     <xsl:if test="cit:name">
-      <xsl:apply-templates mode="render-value"
+      <xsl:apply-templates mode="render-value-no-breaklines"
                            select="cit:name"/>
     </xsl:if>
-    <xsl:if test="cit:positionName">
+
+    <xsl:variable name="position">
+      <xsl:apply-templates mode="render-value-no-breaklines"
+                           select="cit:positionName"/>
+    </xsl:variable>
+
+    <xsl:if test="normalize-space($position) != ''">
       <xsl:if test="cit:name">
         <xsl:text> (</xsl:text>
       </xsl:if>
-      <xsl:apply-templates mode="render-value"
-                            select="cit:positionName"/>
+      <xsl:copy-of select="$position"/>
       <xsl:if test="cit:name">
         <xsl:text>)</xsl:text>
       </xsl:if>
     </xsl:if>
-
   </xsl:template>
 
   <!-- Metadata linkage -->
@@ -817,13 +877,13 @@
       <dd>
         <xsl:if test="*/mcc:codeSpace">
           <xsl:variable name="prefix">
-            <xsl:apply-templates mode="render-value"
+            <xsl:apply-templates mode="render-value-no-breaklines"
                                  select="*/mcc:codeSpace"/>
           </xsl:variable>
           <xsl:value-of select="if(ends-with($prefix, '/')) then $prefix else concat($prefix, '/')"/>
         </xsl:if>
-        <xsl:apply-templates mode="render-value"
-                               select="*/mcc:code"/>
+        <xsl:apply-templates mode="render-value-no-breaklines"
+                             select="*/mcc:code"/>
         <p>
           <xsl:apply-templates mode="render-field"
                                select="*/mcc:authority"/>
@@ -839,6 +899,7 @@
                 match="mri:descriptiveKeywords[
                   normalize-space(string-join(*/mri:keyword//text(), '')) = ''
                   or count(*/mri:keyword) = 0]" priority="200"/>
+
   <xsl:template mode="render-field"
                 match="mri:descriptiveKeywords[
                         */mri:thesaurusName/cit:CI_Citation/cit:title]"
@@ -932,8 +993,8 @@
                                    select="*/mrd:formatSpecificationCitation/*/
                                     cit:title"/>
               <p>
-              <xsl:apply-templates mode="render-field"
-                      select="*/(mrd:amendmentNumber|
+                <xsl:apply-templates mode="render-field"
+                                     select="*/(mrd:amendmentNumber|
                               mrd:fileDecompressionTechnique|
                               mrd:medium|
                               mrd:formatDistributor)"/>
@@ -962,8 +1023,8 @@
         </xsl:call-template>
       </dt>
       <dd>
-          <xsl:apply-templates mode="render-value"
-                               select="*/cit:date/*"/>
+        <xsl:apply-templates mode="render-value"
+                             select="*/cit:date/*"/>
       </dd>
     </dl>
   </xsl:template>
@@ -989,8 +1050,8 @@
                 msr:MD_PixelOrientationCode|srv:SV_ParameterDirection|
                 reg:RE_AmendmentType)">
             <li>
-            <xsl:apply-templates mode="render-value"
-                                 select="*"/>
+              <xsl:apply-templates mode="render-value"
+                                   select="*"/>
             </li>
           </xsl:for-each>
         </ul>
@@ -1056,6 +1117,7 @@
 
   <!-- ########################## -->
   <!-- Render values for text ... -->
+
   <xsl:template mode="render-value"
                 match="*[gco:CharacterString]">
     <xsl:variable name="txt">
@@ -1068,6 +1130,21 @@
       <xsl:with-param name="txt" select="$txt"/>
     </xsl:call-template>
   </xsl:template>
+
+  <xsl:template mode="render-value-no-breaklines"
+                match="*[gco:CharacterString]">
+
+    <xsl:variable name="txtNonNormalized">
+      <xsl:apply-templates mode="localised" select=".">
+        <xsl:with-param name="langId" select="$langId"/>
+      </xsl:apply-templates>
+    </xsl:variable>
+
+    <xsl:variable name="txt" select="normalize-space($txtNonNormalized)" />
+    <xsl:value-of select="$txt" />
+  </xsl:template>
+
+
 
   <xsl:template mode="render-value"
                 match="gco:Integer|gco:Decimal|

--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
@@ -160,8 +160,9 @@
 
             <xsl:for-each select="current-group()">
               <xsl:sort select="."/>
-              <a href='#/search?query_string=%7B"tag.\\*":%7B"{.}":true%7D%7D'>
-                <span class="badge"><xsl:copy-of select="."/></span>
+              <a class="btn btn-default btn-xs"
+                 href='#/search?query_string=%7B"tag.\\*":%7B"{.}":true%7D%7D'>
+                <xsl:copy-of select="."/>
               </a>
             </xsl:for-each>
             <xsl:if test="position() != last()">
@@ -172,8 +173,9 @@
         <xsl:otherwise>
           <xsl:for-each select="$tags/tag">
             <xsl:sort select="."/>
-              <a href='#/search?query_string=%7B"tag.\\*":%7B"{.}":true%7D%7D'>
-              <span class="badge"><xsl:copy-of select="."/></span>
+            <a class="btn btn-default btn-xs"
+               href='#/search?query_string=%7B"tag.\\*":%7B"{.}":true%7D%7D'>
+              <xsl:copy-of select="."/>
             </a>
           </xsl:for-each>
         </xsl:otherwise>

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_result_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_result_default.less
@@ -36,7 +36,7 @@
   h3 {
     font-size: 18px;
   }
-  [data-gn-keyword-badges] {
+  [data-gn-keyword-badges], .gn-md-side-social {
     .col-md-12 {
       padding-left: 0px;
       padding-right: 0px;


### PR DESCRIPTION
In all `gco:CharacterString` add line breaks and hyperlinks eg. in lineage.


```xml
<mdb:resourceLineage>
<mrl:LI_Lineage>
<mrl:statement>
<gco:CharacterString>http://www.argodatamgt.org/Documentation</gco:CharacterString>
</mrl:statement>
```

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/187dd300-31dd-452c-b690-ee37ec64dfa7)


Backport https://github.com/geonetwork/core-geonetwork/pull/5446 to ISO19115-3

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/ce4a87a3-b72f-4840-b463-4a69b7ecfae0)

This is more consistent with ISO19139 and the default view.