### PR TITLE
Standard / ISO19115-3 / Do not declare main language in other languages

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/utility-fn.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/utility-fn.xsl
@@ -47,7 +47,7 @@
       <xsl:when
         test="$languageIdentifier">
         <xsl:value-of
-          select="concat('#', $languageIdentifier)"
+          select="concat('#', $languageIdentifier[1])"
         />
       </xsl:when>
       <xsl:otherwise>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/update-fixed-info.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/update-fixed-info.xsl
@@ -177,7 +177,7 @@
 
       <xsl:apply-templates select="mdb:metadataProfile"/>
       <xsl:apply-templates select="mdb:alternativeMetadataReference"/>
-      <xsl:apply-templates select="mdb:otherLocale"/>
+      <xsl:apply-templates select="mdb:otherLocale[*/lan:language/*/@codeListValue != $mainLanguage]"/>
       <xsl:apply-templates select="mdb:metadataLinkage"/>
 
       <xsl:variable name="pointOfTruthUrl" select="concat(/root/env/nodeURL, 'api/records/', $uuid)"/>


### PR DESCRIPTION
In ISO19139, the main language was also declared as a `locale` object in order to set the ID for the main language used for translations. See https://github.com/geonetwork/core-geonetwork/blob/main/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info.xsl#L169-L186

In ISO19115-3, `defaultLocale` and `otherLocale` are both locale object so there is no need to declare main language in 2 places like in ISO19139. The ID is already set in the `defaultLocale` element.

Avoid XSL error if a language is declared more than once.

This could happen when users migrate from ISO19139.