### PR TITLE
Remote INSPIRE ATOM Feed / code cleanup and optimisations for ATOM describe service

### DIFF
--- a/domain/src/main/java/org/fao/geonet/domain/InspireAtomFeed.java
+++ b/domain/src/main/java/org/fao/geonet/domain/InspireAtomFeed.java
@@ -1,25 +1,25 @@
-//=============================================================================
-//===	Copyright (C) 2001-2010 Food and Agriculture Organization of the
-//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
-//===	and United Nations Environment Programme (UNEP)
-//===
-//===	This program is free software; you can redistribute it and/or modify
-//===	it under the terms of the GNU General Public License as published by
-//===	the Free Software Foundation; either version 2 of the License, or (at
-//===	your option) any later version.
-//===
-//===	This program is distributed in the hope that it will be useful, but
-//===	WITHOUT ANY WARRANTY; without even the implied warranty of
-//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-//===	General Public License for more details.
-//===
-//===	You should have received a copy of the GNU General Public License
-//===	along with this program; if not, write to the Free Software
-//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
-//===
-//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
-//===	Rome - Italy. email: geonetwork@osgeo.org
-//==============================================================================
+/*
+ * Copyright (C) 2001-2023 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
 package org.fao.geonet.domain;
 
 
@@ -29,10 +29,10 @@ import org.jdom.Element;
 import org.jdom.Namespace;
 
 import javax.persistence.*;
-
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * INSPIRE Atom feed model class.
@@ -42,7 +42,9 @@ import java.util.List;
 @Entity
 @Access(AccessType.PROPERTY)
 @Table(name = "InspireAtomFeed",
-    indexes = { @Index(name = "idx_inspireatomfeed_metadataid", columnList = "metadataid") })
+    indexes = { @Index(name = "idx_inspireatomfeed_metadataid", columnList = "metadataid"),
+                @Index(name = "idx_inspireatomfeed_atomDatasetid", columnList = "atomDatasetid"),
+                @Index(name = "idx_inspireatomfeed_atomDatasetns", columnList = "atomDatasetns")})
 @SequenceGenerator(name = InspireAtomFeed.ID_SEQ_NAME, initialValue = 100, allocationSize = 1)
 public class InspireAtomFeed extends GeonetEntity implements Serializable {
     static final String ID_SEQ_NAME = "inspire_atom_feed_id_seq";
@@ -65,7 +67,7 @@ public class InspireAtomFeed extends GeonetEntity implements Serializable {
 
 
     public InspireAtomFeed() {
-        _entryList = new ArrayList<InspireAtomFeedEntry>();
+        _entryList = new ArrayList<>();
     }
 
     public static InspireAtomFeed build(Element atomDoc) {
@@ -263,49 +265,30 @@ public class InspireAtomFeed extends GeonetEntity implements Serializable {
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof InspireAtomFeed)) return false;
+        if (o == null || getClass() != o.getClass()) return false;
 
         InspireAtomFeed that = (InspireAtomFeed) o;
 
         if (_id != that._id) return false;
         if (_metadataId != that._metadataId) return false;
-        if (_atom != null ? !_atom.equals(that._atom) : that._atom != null) return false;
-        if (_atomDatasetid != null ? !_atomDatasetid.equals(that._atomDatasetid) : that._atomDatasetid != null)
+        if (!Objects.equals(_title, that._title)) return false;
+        if (!Objects.equals(_atom, that._atom)) return false;
+        if (!Objects.equals(_atomUrl, that._atomUrl)) return false;
+        if (!Objects.equals(_atomDatasetid, that._atomDatasetid))
             return false;
-        if (_atomDatasetns != null ? !_atomDatasetns.equals(that._atomDatasetns) : that._atomDatasetns != null)
+        if (!Objects.equals(_atomDatasetns, that._atomDatasetns))
             return false;
-        if (_atomUrl != null ? !_atomUrl.equals(that._atomUrl) : that._atomUrl != null)
-            return false;
-        if (_authorEmail != null ? !_authorEmail.equals(that._authorEmail) : that._authorEmail != null)
-            return false;
-        if (_authorName != null ? !_authorName.equals(that._authorName) : that._authorName != null)
-            return false;
-        if (_lang != null ? !_lang.equals(that._lang) : that._lang != null) return false;
-        if (_rights != null ? !_rights.equals(that._rights) : that._rights != null) return false;
-        if (_subtitle != null ? !_subtitle.equals(that._subtitle) : that._subtitle != null)
-            return false;
-        if (_title != null ? !_title.equals(that._title) : that._title != null) return false;
-        if (_entryList != null ? !_entryList.equals(that._entryList) : that._entryList != null)
-            return false;
-
-        return true;
+        if (!Objects.equals(_subtitle, that._subtitle)) return false;
+        if (!Objects.equals(_rights, that._rights)) return false;
+        if (!Objects.equals(_lang, that._lang)) return false;
+        if (!Objects.equals(_authorName, that._authorName)) return false;
+        if (!Objects.equals(_authorEmail, that._authorEmail)) return false;
+        return Objects.equals(_entryList, that._entryList);
     }
 
     @Override
     public int hashCode() {
-        int result = _id;
-        result = 31 * result + _metadataId;
-        result = 31 * result + (_title != null ? _title.hashCode() : 0);
-        result = 31 * result + (_atom != null ? _atom.hashCode() : 0);
-        result = 31 * result + (_atomUrl != null ? _atomUrl.hashCode() : 0);
-        result = 31 * result + (_atomDatasetid != null ? _atomDatasetid.hashCode() : 0);
-        result = 31 * result + (_atomDatasetns != null ? _atomDatasetns.hashCode() : 0);
-        result = 31 * result + (_subtitle != null ? _subtitle.hashCode() : 0);
-        result = 31 * result + (_rights != null ? _rights.hashCode() : 0);
-        result = 31 * result + (_lang != null ? _lang.hashCode() : 0);
-        result = 31 * result + (_authorName != null ? _authorName.hashCode() : 0);
-        result = 31 * result + (_authorEmail != null ? _authorEmail.hashCode() : 0);
-        result = 31 * result + (_entryList != null ? _entryList.hashCode() : 0);
-        return result;
+        return Objects.hash(_id, _metadataId, _title, _atom, _atomUrl, _atomDatasetid, _atomDatasetns, _subtitle,
+            _rights, _lang, _authorName, _authorEmail, _entryList);
     }
 }

--- a/domain/src/main/java/org/fao/geonet/repository/InspireAtomFeedRepository.java
+++ b/domain/src/main/java/org/fao/geonet/repository/InspireAtomFeedRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2023 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -26,6 +26,8 @@ package org.fao.geonet.repository;
 import org.fao.geonet.domain.InspireAtomFeed;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
+import java.util.List;
+
 
 /**
  * Repository class for InspireAtomFeed. Repository class for InspireAtomFeed.
@@ -41,4 +43,12 @@ public interface InspireAtomFeedRepository extends GeonetRepository<InspireAtomF
      * @return the metadata related to the inspire atom feed
      */
     InspireAtomFeed findByMetadataId(final int metadataId);
+
+    /**
+     * Find the list of all {@link InspireAtomFeed} with the provided {@code atomDatasetid}.
+     *
+     * @param atomDatasetid the atomDatasetid.
+     * @return a list of all the inspire atom feed elements with atomDatasetId.
+     */
+    List<InspireAtomFeed> findAllByAtomDatasetid(final String atomDatasetid);
 }

--- a/inspire-atom/src/main/java/org/fao/geonet/services/inspireatom/AtomServiceDescription.java
+++ b/inspire-atom/src/main/java/org/fao/geonet/services/inspireatom/AtomServiceDescription.java
@@ -1,79 +1,66 @@
-//=============================================================================
-//===	Copyright (C) 2001-2017 Food and Agriculture Organization of the
-//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
-//===	and United Nations Environment Programme (UNEP)
-//===
-//===	This program is free software; you can redistribute it and/or modify
-//===	it under the terms of the GNU General Public License as published by
-//===	the Free Software Foundation; either version 2 of the License, or (at
-//===	your option) any later version.
-//===
-//===	This program is distributed in the hope that it will be useful, but
-//===	WITHOUT ANY WARRANTY; without even the implied warranty of
-//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-//===	General Public License for more details.
-//===
-//===	You should have received a copy of the GNU General Public License
-//===	along with this program; if not, write to the Free Software
-//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
-//===
-//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
-//===	Rome - Italy. email: geonetwork@osgeo.org
-//==============================================================================
+/*
+ * Copyright (C) 2001-2023 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
 package org.fao.geonet.services.inspireatom;
 
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import jeeves.interfaces.Service;
-import jeeves.server.ServiceConfig;
 import jeeves.server.context.ServiceContext;
-
 import nonapi.io.github.classgraph.utils.Join;
-import org.apache.commons.lang.NotImplementedException;
-import org.fao.geonet.Util;
+import org.apache.commons.lang.StringUtils;
+import org.fao.geonet.GeonetContext;
 import org.fao.geonet.api.API;
 import org.fao.geonet.api.ApiParams;
 import org.fao.geonet.api.ApiUtils;
 import org.fao.geonet.api.exception.NotAllowedException;
 import org.fao.geonet.api.exception.ResourceNotFoundException;
+import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.AbstractMetadata;
-import org.fao.geonet.domain.ReservedOperation;
+import org.fao.geonet.domain.InspireAtomFeed;
+import org.fao.geonet.domain.InspireAtomFeedEntry;
+import org.fao.geonet.exceptions.ResourceNotFoundEx;
 import org.fao.geonet.guiapi.search.XsltResponseWriter;
 import org.fao.geonet.inspireatom.InspireAtomService;
+import org.fao.geonet.inspireatom.harvester.InspireAtomHarvester;
 import org.fao.geonet.inspireatom.model.DatasetFeedInfo;
+import org.fao.geonet.inspireatom.util.InspireAtomUtil;
+import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.kernel.setting.Settings;
 import org.fao.geonet.repository.InspireAtomFeedRepository;
 import org.fao.geonet.utils.Log;
-import org.apache.commons.lang.StringUtils;
-import org.fao.geonet.GeonetContext;
-import org.fao.geonet.constants.Geonet;
-import org.fao.geonet.exceptions.MetadataNotFoundEx;
-import org.fao.geonet.inspireatom.util.InspireAtomUtil;
-import org.fao.geonet.inspireatom.harvester.InspireAtomHarvester;
-import org.fao.geonet.domain.InspireAtomFeed;
-import org.fao.geonet.domain.InspireAtomFeedEntry;
-import org.fao.geonet.kernel.DataManager;
-import org.fao.geonet.lib.Lib;
 import org.jdom.Element;
-
-import java.nio.file.Path;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import org.fao.geonet.exceptions.ResourceNotFoundEx;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
-import static org.fao.geonet.api.ApiParams.API_PARAM_RECORD_UUID;
 import static org.fao.geonet.inspireatom.util.InspireAtomUtil.retrieveKeywordsFromFileIdentifier;
-import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.OK;
 
 @RequestMapping(value = {
@@ -127,9 +114,9 @@ public class AtomServiceDescription {
             throw new Exception("Inspire is disabled");
         }
 
-        AbstractMetadata record;
+        AbstractMetadata metadataRecord;
         try {
-            record = ApiUtils.canViewRecord(metadataUuid, request);
+            metadataRecord = ApiUtils.canViewRecord(metadataUuid, request);
         } catch (ResourceNotFoundException e) {
             Log.debug(API.LOG_MODULE_NAME, e.getMessage(), e);
             throw e;
@@ -138,9 +125,9 @@ public class AtomServiceDescription {
             throw new NotAllowedException(ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_VIEW);
         }
 
-        Element md = record.getXmlData(false);
-        String schema = record.getDataInfo().getSchemaId();
-        String id = record.getId() + "";
+        Element md = metadataRecord.getXmlData(false);
+        String schema = metadataRecord.getDataInfo().getSchemaId();
+        String id = String.valueOf(metadataRecord.getId());
 
         String atomProtocol = sm.getValue(Settings.SYSTEM_INSPIRE_ATOM_PROTOCOL);
 
@@ -187,7 +174,7 @@ public class AtomServiceDescription {
         // Dataset feeds referenced by service feed.
         List<DatasetFeedInfo> datasetsInformation = InspireAtomUtil.extractRelatedDatasetsInfoFromServiceFeed(inspireAtomFeed.getAtom(), dm);
 
-        // Get information from the the service atom feed.
+        // Get information from the service atom feed.
         String feedAuthorName = inspireAtomFeed.getAuthorName();
         String feedTitle = inspireAtomFeed.getTitle();
         String feedSubtitle = inspireAtomFeed.getSubtitle();
@@ -196,7 +183,7 @@ public class AtomServiceDescription {
         List<String> keywords = retrieveKeywordsFromFileIdentifier(context, metadataUuid);
 
         // Process datasets information
-        Element datasetsEl = processDatasetsInfo(datasetsInformation, metadataUuid, context);
+        Element datasetsEl = processDatasetsInfo(datasetsInformation, metadataUuid);
 
         Element response = new Element("response")
             .addContent(new Element("fileId").setText(metadataUuid))
@@ -220,28 +207,28 @@ public class AtomServiceDescription {
      *
      * @param datasetsInformation List of dataset identifiers to process.
      * @param serviceIdentifier  Service identifier.
-     * @param context            Service context.
      * @return JDOM Element with the datasets information.
      * @throws Exception Exception.
      */
-    private Element processDatasetsInfo(final List<DatasetFeedInfo> datasetsInformation, final String serviceIdentifier,
-                                        final ServiceContext context)
+    private Element processDatasetsInfo(final List<DatasetFeedInfo> datasetsInformation, final String serviceIdentifier)
         throws Exception {
         Element datasetsEl = new Element("datasets");
 
         for (DatasetFeedInfo datasetFeedInfo : datasetsInformation) {
-            // Get the metadata uuid for the dataset
-            String datasetUuid = inspireAtomFeedRepository.retrieveDatasetUuidFromIdentifier(datasetFeedInfo.identifier);
-
-            // If dataset metadata not found, ignore
-            if (StringUtils.isEmpty(datasetUuid)) {
-                Log.warning(Geonet.ATOM, "AtomServiceDescription for service metadata (" + serviceIdentifier +
-                    "): metadata for dataset identifier " + datasetFeedInfo.identifier + " is not found, ignoring it.");
+            // Get the metadata id for the dataset
+            InspireAtomFeed inspireAtomFeed;
+            List<InspireAtomFeed> inspireAtomFeedList = inspireAtomFeedRepository.findAllByAtomDatasetid(datasetFeedInfo.identifier);
+            if (!inspireAtomFeedList.isEmpty()) {
+                inspireAtomFeed = inspireAtomFeedList.get(0);
+            } else {
+                // If dataset metadata not found, ignore
+                Log.warning(Geonet.ATOM, String.format("AtomServiceDescription for service metadata (%s): metadata "
+                    + "for dataset identifier %s was not found, ignoring it.",
+                    serviceIdentifier, datasetFeedInfo.identifier));
                 continue;
             }
 
-            String id = dm.getMetadataId(datasetUuid);
-            InspireAtomFeed inspireAtomFeed = inspireAtomFeedRepository.findByMetadataId(Integer.parseInt(id));
+            String datasetUuid = dm.getMetadataUuid(String.valueOf(inspireAtomFeed.getMetadataId()));
 
             String idNs = inspireAtomFeed.getAtomDatasetid();
             String namespace = inspireAtomFeed.getAtomDatasetns();
@@ -266,10 +253,10 @@ public class AtomServiceDescription {
 
             // Get dataset download info
             // From INSPIRE spec: if a CRS has multiple downloads should be returned a link to feed document with the CRS downloads.
-            Map<String, Integer> downloadsCountByCrs = new HashMap<String, Integer>();
+            Map<String, Integer> downloadsCountByCrs = new HashMap<>();
             for (InspireAtomFeedEntry entry : inspireAtomFeed.getEntryList()) {
                 Integer count = downloadsCountByCrs.get(entry.getCrs());
-                if (count == null) count = Integer.valueOf(0);
+                if (count == null) count = 0;
                 downloadsCountByCrs.put(entry.getCrs(), count + 1);
             }
 

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
@@ -64,8 +64,11 @@
               data-ng-if="key === 'function' &&
                              !params.linkType.fields.function.hidden"
             >
-              <label id="gn-addonlinesrc-function-label" class="col-sm-2 control-label"
-                     data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.function.tooltip}}">
+              <label
+                id="gn-addonlinesrc-function-label"
+                class="col-sm-2 control-label"
+                data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.function.tooltip}}"
+              >
                 <span data-translate="">onlineFunction</span>
               </label>
               <div class="col-sm-9">
@@ -93,8 +96,11 @@
               data-ng-if="key === 'protocol' &&
                              !params.linkType.fields.protocol.hidden"
             >
-              <label id="gn-addonlinesrc-protocol-label" class="col-sm-2 control-label"
-                     data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.protocol.tooltip}}">
+              <label
+                id="gn-addonlinesrc-protocol-label"
+                class="col-sm-2 control-label"
+                data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.protocol.tooltip}}"
+              >
                 <span data-translate="">protocol</span>
               </label>
               <div class="col-sm-9">
@@ -120,8 +126,11 @@
               data-ng-if="key === 'mimeType' &&
                              !params.linkType.fields.mimeType.hidden"
             >
-              <label id="gn-addonlinesrc-mimeType-label" class="col-sm-2 control-label"
-                     data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.mimeType.tooltip}}">
+              <label
+                id="gn-addonlinesrc-mimeType-label"
+                class="col-sm-2 control-label"
+                data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.mimeType.tooltip}}"
+              >
                 <span data-translate="">mimeType</span>
               </label>
               <div class="col-sm-9">
@@ -331,7 +340,6 @@
               </div>
 
               <div class="col-sm-1 gn-control"></div>
-
             </div>
 
             <!-- Description Text area -->
@@ -415,7 +423,8 @@
                 for="gn-addonlinesrc-profile-input"
                 class="col-sm-2 control-label"
                 data-translate=""
-                data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.applicationProfile.tooltip}}">applicationProfile</label
+                data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.applicationProfile.tooltip}}"
+                >applicationProfile</label
               >
               <div class="col-sm-9">
                 <input


### PR DESCRIPTION
Code optimisations to retrieve the atom feeds. Tested in `3.12.x` and somehow `retrieveDatasetUuidFromIdentifier` causes that the call to `findByMetadataId` takes long time. In `main` doesn't seem so, maybe due to the JPA/Hibernate version.

The change does some cleanup of the code and avoids to retrieve the same information several times.