### PR TITLE
Fix load of static pages html content

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
@@ -64,8 +64,11 @@
               data-ng-if="key === 'function' &&
                              !params.linkType.fields.function.hidden"
             >
-              <label id="gn-addonlinesrc-function-label" class="col-sm-2 control-label"
-                     data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.function.tooltip}}">
+              <label
+                id="gn-addonlinesrc-function-label"
+                class="col-sm-2 control-label"
+                data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.function.tooltip}}"
+              >
                 <span data-translate="">onlineFunction</span>
               </label>
               <div class="col-sm-9">
@@ -93,8 +96,11 @@
               data-ng-if="key === 'protocol' &&
                              !params.linkType.fields.protocol.hidden"
             >
-              <label id="gn-addonlinesrc-protocol-label" class="col-sm-2 control-label"
-                     data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.protocol.tooltip}}">
+              <label
+                id="gn-addonlinesrc-protocol-label"
+                class="col-sm-2 control-label"
+                data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.protocol.tooltip}}"
+              >
                 <span data-translate="">protocol</span>
               </label>
               <div class="col-sm-9">
@@ -120,8 +126,11 @@
               data-ng-if="key === 'mimeType' &&
                              !params.linkType.fields.mimeType.hidden"
             >
-              <label id="gn-addonlinesrc-mimeType-label" class="col-sm-2 control-label"
-                     data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.mimeType.tooltip}}">
+              <label
+                id="gn-addonlinesrc-mimeType-label"
+                class="col-sm-2 control-label"
+                data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.mimeType.tooltip}}"
+              >
                 <span data-translate="">mimeType</span>
               </label>
               <div class="col-sm-9">
@@ -331,7 +340,6 @@
               </div>
 
               <div class="col-sm-1 gn-control"></div>
-
             </div>
 
             <!-- Description Text area -->
@@ -415,7 +423,8 @@
                 for="gn-addonlinesrc-profile-input"
                 class="col-sm-2 control-label"
                 data-translate=""
-                data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.applicationProfile.tooltip}}">applicationProfile</label
+                data-gn-field-tooltip="{{schema}}|{{params.linkType.fields.applicationProfile.tooltip}}"
+                >applicationProfile</label
               >
               <div class="col-sm-9">
                 <input

--- a/web-ui/src/main/resources/catalog/components/pages/GnStaticPagesDirective.js
+++ b/web-ui/src/main/resources/catalog/components/pages/GnStaticPagesDirective.js
@@ -44,7 +44,8 @@
 
             $http({
               method: "GET",
-              url: "../api/pages/" + $scope.language + "/" + page + "/content"
+              url: "../api/pages/" + $scope.language + "/" + page + "/content",
+              transformResponse: angular.identity
             }).then(
               function (response) {
                 $sce.trustAsJs(response.data);


### PR DESCRIPTION
Test case:

1) Create a static page with HTML content.
2) Refresh the page and click the link --> A message `Page not available` instead of the page content is displayed.

Note that in localhost doesn't happen, probably due to ignoring the CORS interceptor.

Thanks @fxprunayre about the code suggestion.