### PR TITLE
Exclude ATOM opensearch URLs from the portal filter checker. 

### DIFF
--- a/web/src/main/webResources/WEB-INF/web.xml
+++ b/web/src/main/webResources/WEB-INF/web.xml
@@ -116,6 +116,7 @@
         /xml/**,
         /xsl/**,
         /read/**,
+        /opensearch/**,
         /.*.jsp,
         /*.html,
         /*.css


### PR DESCRIPTION
Related to #6970

Using the INSPIRE Atom feeds endpoint: 

http://localhost:8080/geonetwork/opensearch/dut/2b087d2c-6a1c-4746-95c6-3d40bc4294f9/OpenSearchDescription.xml

was returning a 403 error.

The portal filter checker should exclude the value `opensearch`, related to the following forward rule: https://github.com/geonetwork/core-geonetwork/blob/29e131bad89441cd377cf5d4d42098b1d9ba606b/web/src/main/webResources/WEB-INF/urlrewrite.xml#L144-L150, from the portal check.

