### PR TITLE
Thesaurus / Multilingual titles / Set title according to record language.

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/thesaurus-transformation.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/thesaurus-transformation.xsl
@@ -234,7 +234,10 @@
         </mri:keyword>
       </xsl:if>
 
-      <xsl:copy-of select="geonet:add-iso19115-3.2018-thesaurus-info($currentThesaurus, $withThesaurusAnchor, /root/gui/thesaurus/thesauri, not(/root/request/keywordOnly))" />
+      <xsl:copy-of select="geonet:add-iso19115-3.2018-thesaurus-info(
+                                    $currentThesaurus, $listOfLanguage[1],
+                                    $withThesaurusAnchor,
+                                    /root/gui/thesaurus/thesauri, not(/root/request/keywordOnly))" />
 
     </mri:MD_Keywords>
   </xsl:template>
@@ -243,6 +246,7 @@
 
   <xsl:function name="geonet:add-iso19115-3.2018-thesaurus-info">
     <xsl:param name="currentThesaurus" as="xs:string"/>
+    <xsl:param name="mainLanguage" as="xs:string?"/>
     <xsl:param name="withThesaurusAnchor" as="xs:boolean"/>
     <xsl:param name="thesauri" as="node()"/>
     <xsl:param name="thesaurusInfo" as="xs:boolean"/>
@@ -253,18 +257,26 @@
                               codeListValue="{$thesauri/thesaurus[key = $currentThesaurus]/dname}" />
     </mri:type>
     <xsl:if test="$thesaurusInfo">
+      <xsl:variable name="thesaurusInMainLanguage"
+                    select="$thesauri/thesaurus[key = $currentThesaurus]
+                              /multilingualTitles/multilingualTitle[
+                                lang = util:twoCharLangCode($mainLanguage, '')]/title"/>
+      <xsl:variable name="thesaurusTitle"
+                    select="if ($thesaurusInMainLanguage != '')
+                            then $thesaurusInMainLanguage
+                            else $thesauri/thesaurus[key = $currentThesaurus]/title"/>
       <mri:thesaurusName>
         <cit:CI_Citation>
           <cit:title>
             <xsl:choose>
               <xsl:when test="$withThesaurusAnchor = true()">
                 <gcx:Anchor xlink:href="{$thesauri/thesaurus[key = $currentThesaurus]/defaultNamespace}">
-                  <xsl:value-of select="$thesauri/thesaurus[key = $currentThesaurus]/title"/>
+                  <xsl:value-of select="$thesaurusTitle"/>
                 </gcx:Anchor>
               </xsl:when>
               <xsl:otherwise>
                 <gco:CharacterString>
-                  <xsl:value-of select="$thesauri/thesaurus[key = $currentThesaurus]/title"/>
+                  <xsl:value-of select="$thesaurusTitle"/>
                 </gco:CharacterString>
               </xsl:otherwise>
             </xsl:choose>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/layout-custom-fields-keywords.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/layout-custom-fields-keywords.xsl
@@ -145,6 +145,8 @@
                   as="element()?"
                   select="if ($thesaurusList/thesaurus[@key=substring-after($thesaurusIdentifier, 'geonetwork.thesaurus.')])
                           then $thesaurusList/thesaurus[@key=substring-after($thesaurusIdentifier, 'geonetwork.thesaurus.')]
+                          else if ($listOfThesaurus/thesaurus[multilingualTitles/multilingualTitle/title=$thesaurusTitle])
+                          then $listOfThesaurus/thesaurus[multilingualTitles/multilingualTitle/title=$thesaurusTitle]
                           else $listOfThesaurus/thesaurus[title=$thesaurusTitle]"/>
 
     <xsl:choose>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/layout-custom-fields-keywords.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/layout-custom-fields-keywords.xsl
@@ -90,11 +90,12 @@
     <xsl:variable name="thesaurusIdentifier"
                   select="normalize-space(*/mri:thesaurusName/*/cit:identifier/*/mcc:code/*/text())"/>
 
+    <!-- Editor configuration can define to display thesaurus with or without fieldset -->
     <xsl:variable name="thesaurusConfig"
                   as="element()?"
-                  select="if ($thesaurusList/thesaurus[@key=substring-after($thesaurusIdentifier, 'geonetwork.thesaurus.')])
-                          then $thesaurusList/thesaurus[@key=substring-after($thesaurusIdentifier, 'geonetwork.thesaurus.')]
-                          else $listOfThesaurus/thesaurus[title=$thesaurusTitle]"/>
+                  select="if ($thesaurusList/thesaurus[@key = substring-after($thesaurusIdentifier, 'geonetwork.thesaurus.')])
+                          then $thesaurusList/thesaurus[@key = substring-after($thesaurusIdentifier, 'geonetwork.thesaurus.')]
+                          else $listOfThesaurus/thesaurus[title = $thesaurusTitle]"/>
 
 
     <xsl:choose>
@@ -140,15 +141,18 @@
                           then $overrideLabel
                           else (mri:thesaurusName/*/cit:title/(gco:CharacterString|lan:PT_FreeText/lan:textGroup/lan:LocalisedCharacterString|gcx:Anchor))[1]"/>
 
-
+    <!-- Check if thesaurus is defined in editor config or is available in the catalogue -->
+    <xsl:variable name="thesaurusKey"
+                  select="substring-after($thesaurusIdentifier, 'geonetwork.thesaurus.')"/>
     <xsl:variable name="thesaurusConfig"
                   as="element()?"
-                  select="if ($thesaurusList/thesaurus[@key=substring-after($thesaurusIdentifier, 'geonetwork.thesaurus.')])
-                          then $thesaurusList/thesaurus[@key=substring-after($thesaurusIdentifier, 'geonetwork.thesaurus.')]
-                          else if ($listOfThesaurus/thesaurus[multilingualTitles/multilingualTitle/title=$thesaurusTitle])
-                          then $listOfThesaurus/thesaurus[multilingualTitles/multilingualTitle/title=$thesaurusTitle]
-                          else $listOfThesaurus/thesaurus[title=$thesaurusTitle]"/>
-
+                  select="if ($thesaurusList/thesaurus[@key = $thesaurusKey])
+                          then $thesaurusList/thesaurus[@key = $thesaurusKey]
+                          else if ($listOfThesaurus/thesaurus[key = $thesaurusKey])
+                          then $listOfThesaurus/thesaurus[key = $thesaurusKey]
+                          else if ($listOfThesaurus/thesaurus[multilingualTitles/multilingualTitle/title = $thesaurusTitle])
+                          then $listOfThesaurus/thesaurus[multilingualTitles/multilingualTitle/title = $thesaurusTitle]
+                          else $listOfThesaurus/thesaurus[title = $thesaurusTitle]"/>
     <xsl:choose>
       <xsl:when test="$thesaurusConfig">
 

--- a/schemas/iso19139/src/main/plugin/iso19139/convert/thesaurus-transformation.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/convert/thesaurus-transformation.xsl
@@ -293,12 +293,15 @@
       </xsl:if>
 
       <xsl:copy-of
-        select="geonet:add-thesaurus-info($currentThesaurus, $withAnchor, $withThesaurusAnchor, /root/gui/thesaurus/thesauri, not(/root/request/keywordOnly))"/>
+        select="geonet:add-thesaurus-info($currentThesaurus, $listOfLanguage[1],
+                              $withAnchor, $withThesaurusAnchor,
+                              /root/gui/thesaurus/thesauri, not(/root/request/keywordOnly))"/>
     </gmd:MD_Keywords>
   </xsl:template>
 
   <xsl:function name="geonet:add-thesaurus-info">
     <xsl:param name="currentThesaurus" as="xs:string"/>
+    <xsl:param name="mainLanguage" as="xs:string?"/>
     <xsl:param name="withTitleAnchor" as="xs:boolean"/>
     <xsl:param name="withThesaurusAnchor" as="xs:boolean"/>
     <xsl:param name="thesauri" as="node()"/>
@@ -311,18 +314,28 @@
         codeListValue="{$thesauri/thesaurus[key = $currentThesaurus]/dname}"/>
     </gmd:type>
     <xsl:if test="$thesaurusInfo">
+
+      <xsl:variable name="thesaurusInMainLanguage"
+                    select="$thesauri/thesaurus[key = $currentThesaurus]
+                              /multilingualTitles/multilingualTitle[
+                                lang = util:twoCharLangCode($mainLanguage, '')]/title"/>
+      <xsl:variable name="thesaurusTitle"
+                    select="if ($thesaurusInMainLanguage != '')
+                            then $thesaurusInMainLanguage
+                            else $thesauri/thesaurus[key = $currentThesaurus]/title"/>
+
       <gmd:thesaurusName>
         <gmd:CI_Citation>
           <gmd:title>
             <xsl:choose>
               <xsl:when test="$withTitleAnchor = true()">
                 <gmx:Anchor xlink:href="{$thesauri/thesaurus[key = $currentThesaurus]/defaultNamespace}">
-                  <xsl:value-of select="$thesauri/thesaurus[key = $currentThesaurus]/title"/>
+                  <xsl:value-of select="$thesaurusTitle"/>
                 </gmx:Anchor>
               </xsl:when>
               <xsl:otherwise>
                 <gco:CharacterString>
-                  <xsl:value-of select="$thesauri/thesaurus[key = $currentThesaurus]/title"/>
+                  <xsl:value-of select="$thesaurusTitle"/>
                 </gco:CharacterString>
               </xsl:otherwise>
             </xsl:choose>

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields-keywords.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields-keywords.xsl
@@ -118,13 +118,12 @@
     <xsl:variable name="thesaurusIdentifier"
                   select="normalize-space(*/gmd:thesaurusName/gmd:CI_Citation/gmd:identifier/gmd:MD_Identifier/gmd:code/*/text())"/>
 
+    <!-- Editor configuration can define to display thesaurus with or without fieldset -->
     <xsl:variable name="thesaurusConfig"
                   as="element()?"
-                  select="if ($thesaurusList/thesaurus[@key=substring-after($thesaurusIdentifier, 'geonetwork.thesaurus.')])
-                          then $thesaurusList/thesaurus[@key=substring-after($thesaurusIdentifier, 'geonetwork.thesaurus.')]
-                          else if ($listOfThesaurus/thesaurus[multilingualTitles/multilingualTitle/title=$thesaurusTitle])
-                          then $listOfThesaurus/thesaurus[multilingualTitles/multilingualTitle/title=$thesaurusTitle]
-                          else $listOfThesaurus/thesaurus[title=$thesaurusTitle]"/>
+                  select="if ($thesaurusList/thesaurus[@key = substring-after($thesaurusIdentifier, 'geonetwork.thesaurus.')])
+                          then $thesaurusList/thesaurus[@key = substring-after($thesaurusIdentifier, 'geonetwork.thesaurus.')]
+                          else $listOfThesaurus/thesaurus[title = $thesaurusTitle]"/>
 
     <xsl:choose>
       <xsl:when test="($isFlatMode and not($thesaurusConfig/@fieldset)) or $thesaurusConfig/@fieldset = 'false'">
@@ -172,12 +171,18 @@
       </xsl:for-each>
     </xsl:variable>
 
-
+    <!-- Check if thesaurus is defined in editor config or is available in the catalogue -->
+    <xsl:variable name="thesaurusKey"
+                  select="substring-after($thesaurusIdentifier, 'geonetwork.thesaurus.')"/>
     <xsl:variable name="thesaurusConfig"
                   as="element()?"
-                  select="if ($thesaurusList/thesaurus[@key=substring-after($thesaurusIdentifier, 'geonetwork.thesaurus.')])
-                          then $thesaurusList/thesaurus[@key=substring-after($thesaurusIdentifier, 'geonetwork.thesaurus.')]
-                          else $listOfThesaurus/thesaurus[title=$thesaurusTitle]"/>
+                  select="if ($thesaurusList/thesaurus[@key = $thesaurusKey])
+                          then $thesaurusList/thesaurus[@key = $thesaurusKey]
+                          else if ($listOfThesaurus/thesaurus[key = $thesaurusKey])
+                          then $listOfThesaurus/thesaurus[key = $thesaurusKey]
+                          else if ($listOfThesaurus/thesaurus[multilingualTitles/multilingualTitle/title = $thesaurusTitle])
+                          then $listOfThesaurus/thesaurus[multilingualTitles/multilingualTitle/title = $thesaurusTitle]
+                          else $listOfThesaurus/thesaurus[title = $thesaurusTitle]"/>
 
     <xsl:choose>
       <xsl:when test="$thesaurusConfig">

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields-keywords.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields-keywords.xsl
@@ -122,6 +122,8 @@
                   as="element()?"
                   select="if ($thesaurusList/thesaurus[@key=substring-after($thesaurusIdentifier, 'geonetwork.thesaurus.')])
                           then $thesaurusList/thesaurus[@key=substring-after($thesaurusIdentifier, 'geonetwork.thesaurus.')]
+                          else if ($listOfThesaurus/thesaurus[multilingualTitles/multilingualTitle/title=$thesaurusTitle])
+                          then $listOfThesaurus/thesaurus[multilingualTitles/multilingualTitle/title=$thesaurusTitle]
                           else $listOfThesaurus/thesaurus[title=$thesaurusTitle]"/>
 
     <xsl:choose>

--- a/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info-keywords.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/update-fixed-info-keywords.xsl
@@ -250,6 +250,7 @@
 
               <xsl:copy-of select="geonet:add-thesaurus-info(
                                               $thesaurusKey,
+                                              $mainLanguage,
                                               false(),
                                               true(),
                                               $root/root/env/thesauri,


### PR DESCRIPTION
Follow up of https://github.com/geonetwork/core-geonetwork/pull/6770

When requesting keywords in ISO formats, populate the thesaurus title using the proper multilingual title based on record language.

Test:
* create a local thesaurus with a title in UI language
* add keywords
* create a metadata record and add those keywords = title is wrong.

Sample API call: http://localhost:8080/srv/api/registries/vocabularies/keyword?thesaurus=local.theme.demo&id=https:%2F%2Fregistry.geonetwork-opensource.org%2Ftheme%2Fdemo%2387aa1156-b91e-405c-92c3-5c7063a5ce68&transformation=to-iso19115-3.2018-keyword&langMap=%7B%22fre%22:%22%23FR%22%7D&lang=fre&textgroupOnly=false