### PR TITLE
Additional code refactor related to pull request 7124 to avoid code duplication

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
@@ -49,7 +49,6 @@ import org.fao.geonet.kernel.schema.MetadataSchema;
 import org.fao.geonet.kernel.schema.SchemaPlugin;
 import org.fao.geonet.kernel.search.EsSearchManager;
 import org.fao.geonet.kernel.search.IndexingMode;
-import org.fao.geonet.kernel.search.MetaSearcher;
 import org.fao.geonet.kernel.search.index.BatchOpsMetadataReindexer;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.kernel.setting.Settings;
@@ -915,11 +914,8 @@ public class BaseMetadataManager implements IMetadataManager {
         }
 
         // add baseUrl of this site (from settings)
-        String protocol = settingManager.getValue(Settings.SYSTEM_SERVER_PROTOCOL);
-        String host = settingManager.getValue(Settings.SYSTEM_SERVER_HOST);
         SettingInfo si = new SettingInfo();
-        String port = Integer.toString(si.getSitePort());
-        addElement(info, Edit.Info.Elem.BASEURL, protocol + "://" + host + port + context.getBaseUrl());
+        addElement(info, Edit.Info.Elem.BASEURL, si.getSiteUrl() + context.getBaseUrl());
         addElement(info, Edit.Info.Elem.LOCSERV, "/srv/en");
         return info;
     }

--- a/core/src/main/java/org/fao/geonet/kernel/setting/SettingInfo.java
+++ b/core/src/main/java/org/fao/geonet/kernel/setting/SettingInfo.java
@@ -1,5 +1,5 @@
 //=============================================================================
-//===	Copyright (C) 2001-2021 Food and Agriculture Organization of the
+//===	Copyright (C) 2001-2023 Food and Agriculture Organization of the
 //===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
 //===	and United Nations Environment Programme (UNEP)
 //===
@@ -24,10 +24,6 @@
 package org.fao.geonet.kernel.setting;
 
 import org.fao.geonet.ApplicationContextHolder;
-import org.fao.geonet.constants.Geonet;
-import org.apache.commons.lang3.StringUtils;
-
-import static org.fao.geonet.kernel.setting.SettingManager.isPortRequired;
 
 public class SettingInfo {
 
@@ -40,61 +36,28 @@ public class SettingInfo {
     //---------------------------------------------------------------------------
 
     /**
-     * Return a string like 'http://HOST[:PORT]'
+     * Despite the method name, returns the server URL. That's why it calls settingManager.getServerURL() instead
+     * of settingManager.getSiteURL().
+     *
+     * @return a string like 'http://HOST[:PORT]'
      */
     public String getSiteUrl() {
         SettingManager settingManager = ApplicationContextHolder.get().getBean(SettingManager.class);
-
-        String protocol = settingManager.getValue(Settings.SYSTEM_SERVER_PROTOCOL);
-        Integer port;
-        String host = settingManager.getValue(Settings.SYSTEM_SERVER_HOST);
-        Integer configuredPort = toIntOrNull(Settings.SYSTEM_SERVER_PORT);
-        if (configuredPort != null) {
-            port = configuredPort;
-        } else if (protocol.equalsIgnoreCase(Geonet.HttpProtocol.HTTPS)) {
-            port = Geonet.DefaultHttpPort.HTTPS;
-        } else {
-            port = Geonet.DefaultHttpPort.HTTP;
-        }
-
-        StringBuffer sb = new StringBuffer(protocol + "://");
-
-        sb.append(host);
-
-		if (isPortRequired(protocol, port + "")) {
-			sb.append(":");
-			sb.append(port);
-		}
-
-        return sb.toString();
+        return settingManager.getServerURL();
     }
 
-    /**
-   * Handle the case where the port in Settings is empty
-  */
 
+    /**
+     * Retrieves the server port.
+     *
+     * @return the server port.
+     */
     public Integer getSitePort() {
         SettingManager settingManager = ApplicationContextHolder.get().getBean(SettingManager.class);
-
-        // some conditional logic to handle the case where there's no port in the settings
-        int sitePort = Geonet.DefaultHttpPort.HTTP;
-        if (StringUtils.isNumeric(settingManager.getValue(Settings.SYSTEM_SERVER_PORT))) {
-            sitePort = settingManager.getValueAsInt(Settings.SYSTEM_SERVER_PORT);
-        }
-
-        return sitePort;
+        return settingManager.getServerPort();
     }
 
     //---------------------------------------------------------------------------
-
-    private Integer toIntOrNull(String key) {
-        try {
-            SettingManager settingManager = ApplicationContextHolder.get().getBean(SettingManager.class);
-            return Integer.parseInt(settingManager.getValue(key));
-        } catch (NumberFormatException e) {
-            return null;
-        }
-    }
 
     public String getSelectionMaxRecords() {
         SettingManager settingManager = ApplicationContextHolder.get().getBean(SettingManager.class);
@@ -119,6 +82,6 @@ public class SettingInfo {
 
     public String getFeedbackEmail() {
         SettingManager settingManager = ApplicationContextHolder.get().getBean(SettingManager.class);
-        return settingManager.getValue("system/feedback/email");
+        return settingManager.getValue(Settings.SYSTEM_FEEDBACK_EMAIL);
     }
 }

--- a/core/src/main/java/org/fao/geonet/kernel/setting/SettingManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/setting/SettingManager.java
@@ -477,10 +477,10 @@ public class SettingManager {
         // some conditional logic to handle the case where there's no port in the settings
         Integer sitePort;
 
-        Integer configuredPort = toIntOrNull(Settings.SYSTEM_SERVER_PORT);
-        if (configuredPort != null) {
+        Integer configuredPort = getValueAsInt(Settings.SYSTEM_SERVER_PORT, -1);
+        if (configuredPort != -1) {
             sitePort = configuredPort;
-        } else if (protocol.equalsIgnoreCase(Geonet.HttpProtocol.HTTPS)) {
+        } else if (protocol != null && protocol.equalsIgnoreCase(Geonet.HttpProtocol.HTTPS)) {
             sitePort = Geonet.DefaultHttpPort.HTTPS;
         } else {
             sitePort = Geonet.DefaultHttpPort.HTTP;


### PR DESCRIPTION
@archaeogeek apologies for the late review of #7124.

This pull requests contains a fix of `BaseMetadataManager`, that was not caused by your previous pull request, but when the port was empty returned the value ending with a colon `http://SERVERNAME:`, reported by @fxprunayre 

Also contains refactor of similar methods in `SettingInformation` and `SettingManager`. At some moment maybe we can remove `SettingInformation`.