### PR TITLE
Static pages / Fix links to load html pages content

### DIFF
--- a/web-ui/src/main/resources/catalog/components/pages/partials/menu-page.html
+++ b/web-ui/src/main/resources/catalog/components/pages/partials/menu-page.html
@@ -36,7 +36,7 @@
     </li>
   </ul>
   <a
-    data-ng-if="!isSubmenu"
+    data-ng-if="!isSubmenu && page"
     data-ng-show="isExternalLink"
     title="{{page.label}}"
     href="{{page.link}}"
@@ -45,9 +45,9 @@
     <span>{{page.label}}</span>
   </a>
   <a
-    data-ng-if="!isSubmenu"
+    data-ng-if="!isSubmenu && page"
     data-ng-show="!isExternalLink"
-    data-gn-active-tb-item="{{gnCfg.mods.page.appUrl + '/' + pageId}}?page={{pageId}}"
+    data-gn-active-tb-item="{{gnCfg.mods.page.appUrl + '/' + page.pageId}}?page={{page.pageId}}"
     title="{{page.pageId}}"
     data-ng-click="changePage($event)"
   >

--- a/web-ui/src/main/resources/catalog/components/pages/partials/menu-page.html
+++ b/web-ui/src/main/resources/catalog/components/pages/partials/menu-page.html
@@ -47,7 +47,7 @@
   <a
     data-ng-if="!isSubmenu"
     data-ng-show="!isExternalLink"
-    data-gn-active-tb-item="{{gnCfg.mods.page.appUrl + '/' + page.pageId}}?page={{page.pageId}}"
+    data-gn-active-tb-item="{{gnCfg.mods.page.appUrl + '/' + pageId}}?page={{pageId}}"
     title="{{page.pageId}}"
     data-ng-click="changePage($event)"
   >

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1447,7 +1447,7 @@
     "staticPageRemoved": "Static page removed",
     "chooseStaticPageFile": "Choose or drop static page file here",
     "ui-topCustomMenu": "Header custom menu items",
-    "ui-topCustomMenu-help": "List of static page IDs associated with the header section to display: <ul><li>When a list is provided, the links are displayed in the order provided and only for the pages listed.</li><li>When a list is not provided, all static pages configured for the header section are displayed, with no guaranteed order.</li>",
+    "ui-topCustomMenu-help": "List of static page IDs associated with the header section to display: <ul><li>When a list is provided, the links are displayed in the order provided and only for the pages listed.</li><li>When a list is not provided, all static pages configured for the header section are displayed, with no guaranteed order.</li>.\nPages can be inserted in between catalogue default menu which are: <pre>[\"gn-site-name-menu\",\n    \"gn-portal-switcher\",\n    \"gn-search-menu\",\n    \"gn-map-menu\",\n    \"gn-contribute-menu\",\n    \"gn-admin-menu\"]</pre>. Insert a page as a simple menu using its id eg. <pre>\"documentation\"</pre> or as a submenu using an object: <pre>{\"Quick search\": [\n  \"searchForAfrica\", \n  \"forReview\"\n]}</pre>",
     "ui-footerCustomMenu": "Footer custom menu items",
     "ui-footerCustomMenu-help": "List of static page IDs associated with the footer section to display: <ul><li>When a list is provided, the links are displayed in the order provided and only for the pages listed.</li><li>When a list is not provided, all static pages configured for the footer section are displayed, with no guaranteed order.</li>",
     "es.url": "ElasticSearch server",


### PR DESCRIPTION
Initialise `gnActiveTbItem` directive with `pageId`, `page.pageId` is not yet available when the directive is initialised.

Related to #7138