### PR TITLE
Sort custom translations by translation key to display them in the UI grouped by translation

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/tools/i18n/TranslationApi.java
+++ b/services/src/main/java/org/fao/geonet/api/tools/i18n/TranslationApi.java
@@ -39,6 +39,7 @@ import org.fao.geonet.repository.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -107,7 +108,9 @@ public class TranslationApi {
         @RequestParam(required = false) final List<String> type,
         ServletRequest request
     ) throws Exception {
-        return translationsRepository.findAll();
+        final Sort sort = SortUtils.createSort(Translations_.fieldName);
+
+        return translationsRepository.findAll(sort);
     }
 
     @io.swagger.v3.oas.annotations.Operation(


### PR DESCRIPTION
Currently the keys seem retrieved order by id or last update. This causes in the UI to display key values not grouped:

![translation-keys-not-grouped](https://github.com/geonetwork/core-geonetwork/assets/1695003/34d5f2e0-c12e-4fe6-9e34-b453aadfbe09)


This change sorts the custom translations by key.