### PR TITLE
Metadata workflow / Don't increase popularity when viewing a metadata working copy

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/mdview/mdviewService.js
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/mdviewService.js
@@ -195,7 +195,8 @@
         // TODO: do not add duplicates
         gnMdViewObj.previousRecords.push(md);
 
-        if (!gnMdViewObj.usingFormatter) {
+        // Don't increase popularity for working copies
+        if (!gnMdViewObj.usingFormatter && md.draft !== "y") {
           $http.post("../api/records/" + md.uuid + "/popularity");
         }
         this.setLocationUuid(md.uuid, formatter);


### PR DESCRIPTION
When a metadata has a working copy, accessing the metadata detail page was throwing an exception due to use the working copy identifier to update the approved metadata version popularity.

```
2023-07-07T11:33:05,709 ERROR [geonetwork] - No entity found with id: 117; nested exception is javax.persistence.EntityNotFoundException: No entity found with id: 117
org.springframework.orm.jpa.JpaObjectRetrievalFailureException: No entity found with id: 117; nested exception is javax.persistence.EntityNotFoundException: No entity found with id: 117
	at org.springframework.orm.jpa.EntityManagerFactoryUtils.convertJpaAccessExceptionIfPossible(EntityManagerFactoryUtils.java:379) ~[spring-orm-5.3.27.jar:5.3.27]
	at org.springframework.orm.jpa.vendor.HibernateJpaDialect.translateExceptionIfPossible(HibernateJpaDialect.java:235) ~[spring-orm-5.3.27.jar:5.3.27]
	at org.springframework.orm.jpa.AbstractEntityManagerFactoryBean.translateExceptionIfPossible(AbstractEntityManagerFactoryBean.java:551) ~[spring-orm-5.3.27.jar:5.3.27]
	at org.springframework.dao.support.ChainedPersistenceExceptionTranslator.translateExceptionIfPossible(ChainedPersistenceExceptionTranslator.java:61) ~[spring-tx-5.3.27.jar:5.3.27]
	at org.springframework.dao.support.DataAccessUtils.translateIfNecessary(DataAccessUtils.java:242) ~[spring-tx-5.3.27.jar:5.3.27]
	at org.springframework.dao.support.PersistenceExceptionTranslationInterceptor.invoke(PersistenceExceptionTranslationInterceptor.java:152) ~[spring-tx-5.3.27.jar:5.3.27]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.data.repository.core.support.SurroundingTransactionDetectorMethodInterceptor.invoke(SurroundingTransactionDetectorMethodInterceptor.java:61) ~[spring-data-commons-2.2.13.RELEASE.jar:2.2.13.RELEASE]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.data.jpa.repository.support.CrudMethodMetadataPostProcessor$CrudMethodMetadataPopulatingMethodInterceptor.invoke(CrudMethodMetadataPostProcessor.java:178) ~[spring-data-jpa-2.2.13.RELEASE.jar:2.2.13.RELEASE]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.interceptor.ExposeInvocationInterceptor.invoke(ExposeInvocationInterceptor.java:97) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.framework.ReflectiveMethodInvocation.proceed(ReflectiveMethodInvocation.java:186) ~[spring-aop-5.3.27.jar:5.3.27]
	at org.springframework.aop.framework.JdkDynamicAopProxy.invoke(JdkDynamicAopProxy.java:220) ~[spring-aop-5.3.27.jar:5.3.27]
	at com.sun.proxy.$Proxy227.update(Unknown Source) ~[?:?]
	at org.fao.geonet.kernel.datamanager.base.BaseMetadataUtils.increasePopularity(BaseMetadataUtils.java:582) ~[gn-core-4.2.6-SNAPSHOT.jar:?]
	at org.fao.geonet.kernel.DataManager.increasePopularity(DataManager.java:338) ~[gn-core-4.2.6-SNAPSHOT.jar:?]
	at org.fao.geonet.api.records.MetadataApi.increaseRecordPopularity(MetadataApi.java:575) ~[gn-services-4.2.6-SNAPSHOT.jar:?]
```

This code change only increases the popularity of the metadata with a working copy, when viewing the approved version as doesn't make sense to increase the popularity of the working copy and fixes the previous issue.