### PR TITLE
ISO19139 - Improve metadata full view for contacts when fields information is missing

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
@@ -622,16 +622,16 @@
     <!-- Display name is <org name> - <individual name> (<position name>) -->
     <!-- with separator/parentheses as required -->
     <xsl:variable name="displayName">
-      <xsl:if test="*/gmd:organisationName">
+      <xsl:if test="*/gmd:organisationName[normalize-space(.) != '']">
         <xsl:apply-templates mode="render-value-no-breaklines" select="*/gmd:organisationName"/>
       </xsl:if>
-      <xsl:if test="*/gmd:organisationName and */gmd:individualName|*/gmd:positionName"> - </xsl:if>
-      <xsl:if test="*/gmd:individualName">
+      <xsl:if test="*/gmd:organisationName[normalize-space(.) != ''] and */gmd:individualName[normalize-space(.) != '']|*/gmd:positionName[normalize-space(.) != '']"> - </xsl:if>
+      <xsl:if test="*/gmd:individualName[normalize-space(.) != '']">
         <xsl:apply-templates mode="render-value-no-breaklines" select="*/gmd:individualName"/>
       </xsl:if>
-      <xsl:if test="*/gmd:positionName">
+      <xsl:if test="*/gmd:positionName[normalize-space(.) != '']">
         <xsl:choose>
-          <xsl:when test="*/gmd:individualName">
+          <xsl:when test="*/gmd:individualName[normalize-space(.) != '']">
             (<xsl:apply-templates mode="render-value-no-breaklines" select="*/gmd:positionName"/>)
           </xsl:when>
           <xsl:otherwise>
@@ -666,7 +666,12 @@
               </xsl:choose>
             <br/>
             <xsl:for-each select="*/gmd:contactInfo/*">
-              <xsl:for-each select="gmd:address/*">
+              <xsl:for-each select="gmd:address/*[
+                  gmd:deliveryPoint[normalize-space(.) != ''] or
+                  gmd:city[normalize-space(.) != ''] or
+                  gmd:administrativeArea[normalize-space(.) != ''] or
+                  gmd:postalCode[normalize-space(.) != ''] or
+                  gmd:country[normalize-space(.) != '']]">
                 <div>
                 <i class="fa fa-fw fa-map-marker"><xsl:comment select="'address'"/></i>
                   <xsl:for-each select="gmd:deliveryPoint[normalize-space(.) != '']">


### PR DESCRIPTION
Before:

![contacts-before](https://github.com/geonetwork/core-geonetwork/assets/1695003/824be542-5d9a-47d1-a3e6-07d2c6c6c032)

After: 

![contacts-after](https://github.com/geonetwork/core-geonetwork/assets/1695003/3a03537f-cbf7-4970-b41c-ec8f8c195c2f)
