### PR TITLE
Harvester / Add property to turn off scheduling

### DIFF
--- a/common/src/main/java/org/fao/geonet/utils/Env.java
+++ b/common/src/main/java/org/fao/geonet/utils/Env.java
@@ -1,3 +1,26 @@
+//=============================================================================
+//===	Copyright (C) 2001-2023 Food and Agriculture Organization of the
+//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
+//===	and United Nations Environment Programme (UNEP)
+//===
+//===	This program is free software; you can redistribute it and/or modify
+//===	it under the terms of the GNU General Public License as published by
+//===	the Free Software Foundation; either version 2 of the License, or (at
+//===	your option) any later version.
+//===
+//===	This program is distributed in the hope that it will be useful, but
+//===	WITHOUT ANY WARRANTY; without even the implied warranty of
+//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//===	General Public License for more details.
+//===
+//===	You should have received a copy of the GNU General Public License
+//===	along with this program; if not, write to the Free Software
+//===	Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA 02111-1307 USA
+//===
+//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+//===	Rome - Italy. email: geonetwork@osgeo.org
+//==============================================================================
+
 package org.fao.geonet.utils;
 
 import org.apache.commons.lang.StringUtils;

--- a/common/src/main/java/org/fao/geonet/utils/Env.java
+++ b/common/src/main/java/org/fao/geonet/utils/Env.java
@@ -1,0 +1,33 @@
+package org.fao.geonet.utils;
+
+import org.apache.commons.lang.StringUtils;
+
+public final class Env {
+
+    /**
+     * Retrieves an environment variable with this priority:
+     * - Java environment variable.
+     * - System environment variable.
+     * - Default value provided as parameter.
+     *
+     * @param propertyName
+     * @param defaultValue
+     * @return
+     */
+    public static String getPropertyFromEnv(String propertyName, String defaultValue) {
+        // Check if provided in Java environment variable
+        String propertyValue = System.getProperty(propertyName);
+
+        if (StringUtils.isEmpty(propertyValue)) {
+            // System environment variable
+            propertyValue = System.getenv(propertyName.toUpperCase().replace('.', '_'));
+        }
+
+        if (StringUtils.isEmpty(propertyValue)) {
+            propertyValue = defaultValue;
+        }
+
+        return propertyValue;
+    }
+
+}

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/HarvestManagerImpl.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/HarvestManagerImpl.java
@@ -156,6 +156,10 @@ public class HarvestManagerImpl implements HarvestInfoProvider, HarvestManager {
                     } catch (OperationAbortedEx oae) {
                         Log.error(Geonet.HARVEST_MAN, "Cannot create harvester " + id + " of type \""
                             + type + "\"", oae);
+                    } catch (SchedulerException e) {
+                        // Badly configured schedules prevent Geonetwork from starting successfully, this prevents that.
+                        Log.error(Geonet.HARVEST_MAN, "Could not schedule harvester " + id + " of type "
+                            + type, e);
                     }
                 }
             }

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/AbstractParams.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/AbstractParams.java
@@ -24,6 +24,7 @@
 package org.fao.geonet.kernel.harvest.harvester;
 
 import com.google.common.collect.Maps;
+import org.fao.geonet.utils.Env;
 import org.locationtech.jts.util.Assert;
 import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.ApplicationContextHolder;
@@ -365,10 +366,19 @@ public abstract class AbstractParams implements Cloneable {
             } catch (DateTimeException e) {
                 log.error(e);
             }
-
         }
 
-        return QuartzSchedulerUtils.getTrigger(getUuid(), AbstractHarvester.HARVESTER_GROUP_NAME, getEvery(), MAX_EVERY, tz);
+        boolean enableScheduledHarvesters = Env.getPropertyFromEnv("harvester.scheduler.enabled", "true").equalsIgnoreCase("true");
+        final String schedule;
+        if (enableScheduledHarvesters) {
+            // the configured value for the harvester
+            schedule = getEvery();
+        } else {
+            // override with 'never'
+            schedule = "0 0 0 * * ? 2099";
+        }
+
+        return QuartzSchedulerUtils.getTrigger(getUuid(), AbstractHarvester.HARVESTER_GROUP_NAME, schedule, MAX_EVERY, tz);
     }
 
     /**

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/AbstractParams.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/AbstractParams.java
@@ -368,7 +368,9 @@ public abstract class AbstractParams implements Cloneable {
             }
         }
 
-        boolean enableScheduledHarvesters = Env.getPropertyFromEnv("harvester.scheduler.enabled", "true").equalsIgnoreCase("true");
+        boolean enableScheduledHarvesters = Env
+            .getPropertyFromEnv("harvester.scheduler.enabled", "true")
+            .equalsIgnoreCase("true");
         final String schedule;
         if (enableScheduledHarvesters) {
             // the configured value for the harvester

--- a/services/src/main/java/org/fao/geonet/api/site/SiteInformation.java
+++ b/services/src/main/java/org/fao/geonet/api/site/SiteInformation.java
@@ -27,9 +27,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import jeeves.server.ServiceConfig;
 import jeeves.server.context.ServiceContext;
 import org.apache.commons.dbcp2.BasicDataSource;
+import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.GeonetContext;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.kernel.search.EsSearchManager;
+import org.fao.geonet.utils.Env;
 import org.fao.geonet.utils.Log;
 import org.fao.geonet.utils.TransformerFactoryFactory;
 
@@ -52,6 +54,8 @@ public class SiteInformation {
     private Map<String, String> catProperties = new HashMap<>();
     private Map<String, String> indexProperties = new HashMap<>();
     private Map<String, String> systemProperties = new HashMap<>();
+
+    private Map<String, String> envProperties = new HashMap<>();
     private Map<String, String> databaseProperties = new HashMap<>();
     private Map<String, String> versionProperties = new HashMap<>();
 
@@ -68,6 +72,7 @@ public class SiteInformation {
             } catch (IOException e) {
                 Log.error(Geonet.GEONETWORK, e.getMessage(), e);
             }
+            loadEnvInfo();
             loadVersionInfo();
             loadSystemInfo();
         }
@@ -98,6 +103,15 @@ public class SiteInformation {
 
     public void setSystemProperties(Map<String, String> systemProperties) {
         this.systemProperties = systemProperties;
+    }
+
+    @JsonProperty(value = "env")
+    public Map<String, String> getEnvProperties() {
+        return envProperties;
+    }
+
+    public void setEnvProperties(Map<String, String> envProperties) {
+        this.envProperties = envProperties;
     }
 
     @JsonProperty(value = "database")
@@ -167,6 +181,19 @@ public class SiteInformation {
         indexProperties.put("es.url", esSearchManager.getClient().getServerUrl());
         indexProperties.put("es.version", esSearchManager.getClient().getServerVersion());
         indexProperties.put("es.index", esSearchManager.getDefaultIndex());
+    }
+
+    private void loadEnvInfo(){
+        String[] variables = {
+            "harvester.scheduler.enabled",
+            "db.migration_onstartup"
+        };
+        for (String variable : variables) {
+            String value = Env.getPropertyFromEnv(variable, "");
+            if (StringUtils.isNotEmpty(value)) {
+                envProperties.put(variable, value);
+            }
+        }
     }
 
     /**

--- a/web-ui/src/main/resources/catalog/js/admin/DashboardController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/DashboardController.js
@@ -147,6 +147,25 @@
         }
       });
 
+      $scope.infoSection = [{
+        key: 'catalogue',
+        label: 'catalogInformation',
+        help: 'installing-datadirectory'
+      },{
+        key: 'database',
+        label: 'dbInformation',
+        help: 'installing-db'
+      },{
+        key: 'index',
+        help: 'installing-index'
+      },{
+        key: 'version'
+      },{
+        key: 'main',
+        label: 'systemInformation'
+      },{
+        key: 'env'
+      }]
       $http.get("../api/site/info").then(function (response) {
         $scope.info = response.data;
       });

--- a/web-ui/src/main/resources/catalog/js/admin/HarvestSettingsController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/HarvestSettingsController.js
@@ -409,7 +409,7 @@
             function (response) {
               deferred.reject(response.data);
               $rootScope.$broadcast("StatusUpdated", {
-                msg: $translate.instant("harvesterUpdated"),
+                msg: $translate.instant("harvesterUpdateError"),
                 error: response.data,
                 timeout: 2,
                 type: "danger"

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -84,6 +84,7 @@
     "cantDeleteGroupHavingRecords": "This group contains records. Move all records to another group to be able to remove it.",
     "cantDeleteUserHavingRecords": "A user with records can't be deleted. Transfer records to another user.",
     "catalogInformation": "Catalog information",
+    "envInformation": "Environment variables",
     "categories": "Categories",
     "categoryDescriptionHelp": "Default category for metadata created in this group",
     "categoryName": "Identifier",

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -348,6 +348,7 @@
     "harvesterUnchangedRecords": "Unchanged",
     "harvesterType": "Node type",
     "harvesterUpdated": "Harvester updated",
+    "harvesterUpdateError": "Error on updating harvester",
     "harvesterValidate": "Validate records before import",
     "harvesterValidateHelp": "Invalid records will be rejected. Validation is based on the standard validation (ie. XSD, Schematrons).",
     "index.lucene.config": "Lucene configuration",

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -216,6 +216,7 @@
     "emptyPortal": "Portal <strong>{{portal}}</strong> is empty. You can check its <a href='#/settings/sources'>configuration</a> or <a href='catalog.edit'>create or import records</a>.",
     "emptyCatalogShouldBeFilled": "The catalog is empty, you probably want to import new records or configure a harvester. You could also insert <a href='#/metadata/metadata-and-template/load-templates/all'>all templates</a>, <a href='#/metadata/metadata-and-template/load-samples/all'>all samples</a> or <a href='#/metadata/metadata-and-template/load-samples-and-templates/all'>both</a>.",
     "enable": "Enable",
+    "disable": "Disable",
     "enableAllowedCategories": "Enable Allowed Categories",
     "exportLogAsZIP": "Export (ZIP)",
     "facetIndicatorHelp": "Statistics by records are defined based on facets configuration and may represent only the most frequent values.",

--- a/web-ui/src/main/resources/catalog/locales/fr-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/fr-admin.json
@@ -216,6 +216,7 @@
     "emptyPortal": "Le portail <strong>{{portal}}</strong> est vide. Vous pouvez <a href='#/settings/sources'>vérifier sa configuration</a> ou <a href='catalog.edit'>créer ou importer des fiches</a>.",
     "emptyCatalogShouldBeFilled": "Le catalogue est vide, vous devriez probablement importer des nouvelles fiches ou moissonner un catalogue distant. Vous pouvez également insérer <a href='#/metadata/metadata-and-template/load-templates/all'>les modèles</a>, <a href='#/metadata/metadata-and-template/load-samples/all'>les exemples</a> ou <a href='#/metadata/metadata-and-template/load-samples-and-templates/all'>les deux</a>.",
     "enable": "Activer",
+    "disable": "Désactiver",
     "enableAllowedCategories": "Activer le filtrage des catégories",
     "exportLogAsZIP": "Export (ZIP)",
     "facetIndicatorHelp": "Les statistiques sur les fiches reposent sur la configuration des facettes et peuvent ne représenter qu'un sous-ensemble du catalogue.",

--- a/web-ui/src/main/resources/catalog/locales/nl-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/nl-admin.json
@@ -216,6 +216,7 @@
     "emptyPortal": "Portaal <strong>{{portal}}</strong> is leeg. U kunt de <a href='#/settings/sources'>configuration</a> controleren of <a href='catalog.edit'>records importeren of aanmaken</a>.",
     "emptyCatalogShouldBeFilled": "De catalogus is leeg, u wilt waarschijnlijk nieuwe metadata bestanden importeren of een harvester configureren. U kunt ook <a href='#/metadata/metadata-and-template/load-templates/all'>alle templates</a> laden, <a href = '#/metadata/metadata-and-template/load-samples/all'> alle voorbeeld-data </a> of <a href='#/metadata/metadata-and-template/load-samples-and-templates/all'> beide </a> .",
     "enable": "Aanzetten",
+    "disable": "Uitzetten",
     "enableAllowedCategories": "Activeer toegestane categorien",
     "exportLogAsZIP": "Exporteer (ZIP)",
     "facetIndicatorHelp": "Statistieken van metadata bestanden worden gedefinieerd op basis van de facetten configuratie en kunnen daardoor alleen de meest voorkomende waarden vertegenwoordigen.",

--- a/web-ui/src/main/resources/catalog/style/gn_admin.less
+++ b/web-ui/src/main/resources/catalog/style/gn_admin.less
@@ -259,3 +259,9 @@ ul > li.list-group-item > input {
   margin-right: 40px;
   margin-left: 30px;
 }
+
+.gn-env {
+  table tr td:first-child {
+    width: 33%;
+  }
+}

--- a/web-ui/src/main/resources/catalog/templates/admin/dashboard/information.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/dashboard/information.html
@@ -1,13 +1,15 @@
-<div class="row">
-  <div class="col-lg-12">
+<div class="row gn-env">
+  <div class="col-lg-12"
+       data-ng-repeat="section in infoSection"
+       data-ng-show="(info[section.key] | json) != '{}'">
     <div class="panel panel-default">
-      <div class="panel-heading" data-gn-slide-toggle="" data-translate="">
-        catalogInformation
+      <div class="panel-heading" data-gn-slide-toggle="">
+        {{(section.label || (section.key + 'Information')) | translate}}
       </div>
       <div class="panel-body">
         <span>
           <table class="table">
-            <tr data-ng-repeat="(key, value) in info.catalogue">
+            <tr data-ng-repeat="(key, value) in info[section.key]">
               <td>{{key | translate}}</td>
               <td>
                 <strong>{{value}}</strong>
@@ -16,89 +18,8 @@
           </table>
         </span>
 
-        <div data-gn-need-help="maintainer-guide-home"></div>
-      </div>
-    </div>
-  </div>
-
-  <div class="col-lg-12">
-    <div class="panel panel-default">
-      <div class="panel-heading" data-gn-slide-toggle="" data-translate="">
-        dbInformation
-      </div>
-      <div class="panel-body">
-        <span>
-          <table class="table">
-            <tr data-ng-repeat="(key, value) in info.database">
-              <td>{{key | translate}}</td>
-              <td>
-                <strong>{{value}}</strong>
-              </td>
-            </tr>
-          </table>
-        </span>
-      </div>
-    </div>
-  </div>
-
-  <div class="col-lg-12">
-    <div class="panel panel-default">
-      <div class="panel-heading" data-gn-slide-toggle="" data-translate="">
-        systemInformation
-      </div>
-      <div class="panel-body">
-        <span>
-          <table class="table">
-            <tr data-ng-repeat="(key, value) in info.main">
-              <td>{{key | translate}}</td>
-              <td>
-                <strong>{{value}}</strong>
-              </td>
-            </tr>
-          </table>
-        </span>
-      </div>
-    </div>
-  </div>
-
-  <div class="col-lg-12">
-    <div class="panel panel-default">
-      <div class="panel-heading" data-gn-slide-toggle="" data-translate="">
-        versionInformation
-      </div>
-      <div class="panel-body">
-        <span>
-          <table class="table">
-            <tr data-ng-repeat="(key, value) in info.version">
-              <td>{{key | translate}}</td>
-              <td>
-                <strong>{{value}}</strong>
-              </td>
-            </tr>
-          </table>
-        </span>
-      </div>
-    </div>
-  </div>
-
-  <div class="col-lg-12">
-    <div class="panel panel-default">
-      <div class="panel-heading" data-gn-slide-toggle="" data-translate="">
-        indexInformation
-      </div>
-      <div class="panel-body">
-        <span>
-          <table class="table">
-            <tr data-ng-repeat="(key, value) in info.index">
-              <td>{{key | translate}}</td>
-              <td>
-                <span data-ng-switch="" data-on="key">
-                  <strong data-ng-switch-default="">{{value}}</strong>
-                </span>
-              </td>
-            </tr>
-          </table>
-        </span>
+        <div data-ng-if="section.help"
+             data-gn-need-help="{{section.help}}"></div>
       </div>
     </div>
   </div>

--- a/web/src/main/java/org/fao/geonet/EncryptorInitializer.java
+++ b/web/src/main/java/org/fao/geonet/EncryptorInitializer.java
@@ -29,6 +29,7 @@ import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.kernel.GeonetworkDataDirectory;
 import org.fao.geonet.utils.Log;
+import org.fao.geonet.utils.Env;
 import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
 import org.jasypt.exceptions.EncryptionInitializationException;
 import org.jasypt.hibernate5.encryptor.HibernatePBEEncryptorRegistry;
@@ -95,12 +96,12 @@ public class EncryptorInitializer {
         boolean updateConfiguration;
 
         if (StringUtils.isEmpty(encryptorAlgorithmPropFile)) {
-            encryptorAlgorithmPropFile = getPropertyFromEnv(ALGORITHM_KEY, DEFAULT_ALGORITHM);
+            encryptorAlgorithmPropFile = Env.getPropertyFromEnv(ALGORITHM_KEY, DEFAULT_ALGORITHM);
             encryptorAlgorithm = encryptorAlgorithmPropFile;
             // No algorithm configured yet
             updateConfiguration = true;
         } else {
-            String encryptorAlgorithmFromEnv = getPropertyFromEnv(ALGORITHM_KEY, "");
+            String encryptorAlgorithmFromEnv = Env.getPropertyFromEnv(ALGORITHM_KEY, "");
             if (StringUtils.isNotEmpty(encryptorAlgorithmFromEnv)) {
                 encryptorAlgorithm = encryptorAlgorithmFromEnv;
             } else {
@@ -113,7 +114,7 @@ public class EncryptorInitializer {
 
 
         if (StringUtils.isEmpty(encryptorPasswordPropFile)) {
-            encryptorPasswordPropFile = getPropertyFromEnv(PASSWORD_KEY, "");
+            encryptorPasswordPropFile = Env.getPropertyFromEnv(PASSWORD_KEY, "");
             // Creates a random encryptor password if the password is empty
             if (StringUtils.isEmpty(encryptorPasswordPropFile)) {
                 if (!firstInitialSetupFlag) {
@@ -131,7 +132,7 @@ public class EncryptorInitializer {
             // No password configured yet
             updateConfiguration = true;
         } else {
-            String encryptorPasswordFromEnv = getPropertyFromEnv(PASSWORD_KEY, "");
+            String encryptorPasswordFromEnv = Env.getPropertyFromEnv(PASSWORD_KEY, "");
             if (StringUtils.isNotEmpty(encryptorPasswordFromEnv)) {
                 encryptorPassword = encryptorPasswordFromEnv;
             } else {
@@ -335,31 +336,5 @@ public class EncryptorInitializer {
         }
 
         return new PropertiesConfiguration(securityPropsPath.toFile());
-    }
-
-    /**
-     * Retrieves an environment variable with this priority:
-     * - Java environment variable.
-     * - System environment variable.
-     * - Default value provided as parameter.
-     *
-     * @param propertyName
-     * @param defaultValue
-     * @return
-     */
-    private String getPropertyFromEnv(String propertyName, String defaultValue) {
-        // Check if provided in Java environment variable
-        String propertyValue = System.getProperty(propertyName);
-
-        if (StringUtils.isEmpty(propertyValue)) {
-            // System environment variable
-            propertyValue = System.getenv(propertyName.toUpperCase().replace('.', '_'));
-        }
-
-        if (StringUtils.isEmpty(propertyValue)) {
-            propertyValue = defaultValue;
-        }
-
-        return propertyValue;
     }
 }

--- a/web/src/main/webResources/WEB-INF/config.properties
+++ b/web/src/main/webResources/WEB-INF/config.properties
@@ -39,6 +39,11 @@ es.index.checker.interval=0/5 * * * * ?
 
 jms.url=${jms.url}
 
+# Turn off harvester scheduler only if running
+# on a scaled environment and that only one node
+# is responsible for scheduled harvesting tasks.
+harvester.scheduler.enabled=true
+
 bot.regexpFilter=@bot.regexpFilter@
 
 api.params.maxPageSize=20000
@@ -55,3 +60,5 @@ map.bbox.background.service=https://ows.terrestris.de/osm/service?SERVICE=WMS&am
 metadata.extentApi.disableFullUrlBackgroundMapServices=true
 
 db.migration_onstartup=true
+
+

--- a/web/src/main/webapp/WEB-INF/data/data/resources/config/manual.json
+++ b/web/src/main/webapp/WEB-INF/data/data/resources/config/manual.json
@@ -31,5 +31,8 @@
   "managing-directories": "administrator-guide/managing-classification-systems/managing-directories.html",
   "installing-index": "install-guide/installing-index.html",
   "maintainer-guide-home": "maintainer-guide/index.html",
+  "installing-datadirectory": "install-guide/customizing-data-directory.html",
+  "installing-db": "install-guide/configuring-database.html",
+  "installing-index": "install-guide/installing-index.html",
   "standards-home": "annexes/standards/index.html"
 }


### PR DESCRIPTION
Related to https://github.com/geonetwork/core-geonetwork/pull/6990

When running in a scaled environment, user may want to only have one instance taking care of scheduled harvesting tasks. Adding a config property to turn it off/on using `-Dharvester.scheduler.enabled=false`. All instances can run a manually triggered harvesting task. 

If set, the config property is also available in the admin > info panel 

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/3f162ea5-a467-4104-aa8b-9da43039f508)

Also improve:
* do not fail to startup if invalid scheduled config in database
* improve error message while failing to update an harvester config



