### PR TITLE
Increase the limit to retrieve the related metadata in the search results

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/es/EsHTTPProxy.java
+++ b/services/src/main/java/org/fao/geonet/api/es/EsHTTPProxy.java
@@ -166,7 +166,7 @@ public class EsHTTPProxy {
                 context,
                 context.getBean(IMetadataUtils.class)
                     .findOneByUuid(doc.get("_id").asText()),
-                relatedTypes, 0, 100);
+                relatedTypes, 0, 1000);
         } catch (Exception e) {
             LOGGER.warn("Failed to load related types for {}. Error is: {}",
                 getSourceString(doc, Geonet.IndexFieldNames.UUID),


### PR DESCRIPTION
The directive `gnRelatedDropdown` lists the associated resources, but if a metadata has more than the original value 100, the first 100 are rendered fine when have external links, but the metadata exists locally, while the rest are displayed with an empty title:

![related-dropdown](https://github.com/geonetwork/core-geonetwork/assets/1695003/431297e9-9885-4440-a31e-865aeb8dbfa1)

This code change updates the limit as service metadata can easily link to more than 100 datasets.
