### PR TITLE
Record view / Contact / Move website to popup

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/mdview/partials/contact.html
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/partials/contact.html
@@ -16,16 +16,16 @@
 
         <div class="col-md-8">
           <div class="gn-contact-card-role">{{c.role | translate}}</div>
-          <div class="gn-contact-card-org">
-            <span data-ng-if="::c.website">
-              <a data-ng-href="{{::c.website}}">{{c.organisation}}</a>
-            </span>
-            <span data-ng-if="::!c.website"> {{c.organisation}} </span>
-          </div>
+          <div class="gn-contact-card-org">{{c.organisation}}</div>
         </div>
       </div>
 
       <div gn-popover-content>
+        <a data-ng-href="{{::c.website}}" data-ng-if="::c.website">
+          <i class="fa fa-fw fa-link"></i>
+          {{c.organisation}}
+        </a>
+
         <div data-gn-metadata-individual="c" />
 
         <address data-ng-if="c.address != '' || c.phone != ''">
@@ -64,12 +64,7 @@
                 data-org-key="c.email | getMailDomain"
               />
               <div class="col-md-8">
-                <div class="gn-contact-card-org-group">
-                  <span data-ng-if="::c.website">
-                    <a data-ng-href="{{::c.website}}">{{c.organisation}}</a>
-                  </span>
-                  <span data-ng-if="::!c.website"> {{c.organisation}} </span>
-                </div>
+                <div class="gn-contact-card-org-group">{{c.organisation}}</div>
               </div>
             </div>
           </div>
@@ -80,6 +75,11 @@
         <!--     Removing for now, because if you close open popup
    the title disappear. <h3 class="popover-title">{{cnts[0].role | translate}}</h3>-->
         <div data-ng-repeat="c in cnts | orderBy:'organisation'">
+          <a data-ng-href="{{::c.website}}" data-ng-if="::c.website">
+            <i class="fa fa-fw fa-link"></i>
+            {{c.organisation}}
+          </a>
+
           <div data-gn-metadata-individual="c" />
 
           <address data-ng-if="c.address != '' || c.phone != ''">
@@ -118,12 +118,7 @@
         />
 
         <div class="col-md-8" ng-repeat="c in contactByOrgRole">
-          <div class="gn-contact-card-org-group">
-            <span data-ng-if="::c.website">
-              <a data-ng-href="{{::c.website}}">{{c.organisation}}</a>
-            </span>
-            <span data-ng-if="::!c.website"> {{c.organisation}} </span>
-          </div>
+          <div class="gn-contact-card-org-group">{{c.organisation}}</div>
 
           <div class="gn-contact-card-group-role" data-ng-repeat="r in ::c.roles">
             {{r | translate}} <span data-ng-if="!$last"><br /></span>
@@ -133,6 +128,11 @@
 
       <div gn-popover-content>
         <div data-ng-repeat="c in contactByOrgRole">
+          <a data-ng-href="{{::c.website}}" data-ng-if="::c.website">
+            <i class="fa fa-fw fa-link"></i>
+            {{c.organisation}}
+          </a>
+
           <div data-gn-metadata-individual="c" />
 
           <address data-ng-if="c.address != '' || c.phone != ''">

--- a/web-ui/src/main/resources/catalog/components/search/mdview/partials/contact.html
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/partials/contact.html
@@ -29,7 +29,10 @@
         <div data-gn-metadata-individual="c" />
 
         <address data-ng-if="c.address != '' || c.phone != ''">
-          <div data-ng-if="c.address != ''">{{c.address}}</div>
+          <div data-ng-if="c.address != ''">
+            <i class="fa fa-fw fa-map-marker"></i>
+            {{c.address}}
+          </div>
           <a href="tel:{{c.phone}}" data-ng-if="c.phone != ''">
             <span data-translate="">call</span> {{c.phone}}
           </a>
@@ -83,7 +86,10 @@
           <div data-gn-metadata-individual="c" />
 
           <address data-ng-if="c.address != '' || c.phone != ''">
-            <div data-ng-if="c.address != ''">{{c.address}}</div>
+            <div data-ng-if="c.address != ''">
+              <i class="fa fa-fw fa-map-marker"></i>
+              {{c.address}}
+            </div>
             <a href="tel:{{c.phone}}" data-ng-if="c.phone != ''">
               <span data-translate="">call</span> {{c.phone}}
             </a>
@@ -136,7 +142,10 @@
           <div data-gn-metadata-individual="c" />
 
           <address data-ng-if="c.address != '' || c.phone != ''">
-            <div data-ng-if="c.address != ''">{{c.address}}</div>
+            <div data-ng-if="c.address != ''">
+              <i class="fa fa-fw fa-map-marker"></i>
+              {{c.address}}
+            </div>
             <a href="tel:{{c.phone}}" data-ng-if="c.phone != ''">
               <span data-translate="">call</span> {{c.phone}}
             </a>


### PR DESCRIPTION
Having the organisation name with an hyperlink can be misleading for user as when we click on the contact, the popup with contact details is also displayed. So moving the website info in the popup to not have 2 click actions on same element.

Also use same icons as in full view for address.

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/b6e3fc55-c111-4232-8b2e-2fbac5e09888)