### PR TITLE
Record view / Display geographic identifier and description if any.

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/search/EsSearchManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/EsSearchManager.java
@@ -522,6 +522,7 @@ public class EsSearchManager implements ISearchManager {
             .add("cat")
             .add("keyword")
             .add("extentDescriptionObject")
+            .add("extentIdentifierObject")
             .add("resourceAltTitleObject")
             .add("resourceCredit")
             .add("resourceCreditObject")

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
@@ -721,6 +721,16 @@
         </xsl:for-each>
 
         <xsl:for-each select="*/gex:EX_Extent">
+
+          <xsl:for-each select="gex:geographicElement/*/gex:geographicIdentifier/
+                                  */mcc:code[*/normalize-space(.) != '']">
+            <xsl:copy-of select="gn-fn-index:add-multilingual-field('extentIdentifier', ., $allLanguages)"/>
+          </xsl:for-each>
+
+          <xsl:for-each select="gex:description[*/normalize-space(.) != '']">
+            <xsl:copy-of select="gn-fn-index:add-multilingual-field('extentDescription', ., $allLanguages)"/>
+          </xsl:for-each>
+
           <!-- TODO: index bounding polygon -->
           <xsl:for-each select=".//gex:EX_GeographicBoundingBox[
                                 ./gex:westBoundLongitude/gco:Decimal castable as xs:decimal and

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
@@ -668,6 +668,10 @@
         <xsl:for-each select="*/gmd:EX_Extent">
           <xsl:copy-of select="gn-fn-index:add-multilingual-field('extentDescription', gmd:description, $allLanguages)"/>
 
+          <xsl:for-each select=".//gmd:geographicIdentifier">
+            <xsl:copy-of select="gn-fn-index:add-multilingual-field('extentIdentifier', */gmd:code, $allLanguages)"/>
+          </xsl:for-each>
+
           <!-- TODO: index bounding polygon -->
           <xsl:variable name="bboxes"
                         select=".//gmd:EX_GeographicBoundingBox[

--- a/web-ui/src/main/resources/catalog/locales/en-v4.json
+++ b/web-ui/src/main/resources/catalog/locales/en-v4.json
@@ -336,6 +336,8 @@
   "siblingsReverseLinks": "Other resources (other record links)",
   "focusOnFrom": "Focus on resources from ",
   "focusOn": "Focus on ",
+  "extentDescription": "Extent description",
+  "extentIdentifier": "Extent identifier",
   "memberOf": "Member of:",
   "keywordAnchorLink": "More information about ",
   "facet-linkUrl": "Url",

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/type-dataset.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/type-dataset.html
@@ -32,6 +32,22 @@
       <div data-gn-data-preview="mdView.current.record" />
       <br />
     </div>
+
+    <div
+      data-ng-repeat="t in ['extentDescription', 'extentIdentifier']"
+      data-ng-if="mdView.current.record[t + 'Object']"
+    >
+      <ul
+        class="gn-label-list pull-left"
+        data-ng-repeat="c in mdView.current.record[t + 'Object']"
+      >
+        <li title="{{t | translate}}">
+          <i class="fa fa-fw fa-location-pin"></i>
+          {{c.default}}
+        </li>
+      </ul>
+    </div>
+
     <div
       data-gn-keyword-badges="mdView.current.record"
       data-thesaurus="viewConfig.locationThesaurus"


### PR DESCRIPTION
Geographic extent is sometime described using geographic identifier or description. If any, display them next to the map.

Make indexing more consistent in all ISO schemas.

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/1c17f74c-abde-43b0-b573-4d832ffc9cf2)
