### PR TITLE
Fix wmsQueue clear method logic

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/wmsQueue.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/wmsQueue.js
@@ -133,8 +133,11 @@
       this.clear = function (map) {
         var type = (map && map.get && map.get("type")) || "viewer";
         if (queue[type]) {
-          queue[type].queue.length = 0;
-          queue[type].errors.length = 0;
+          queue[type] = [];
+        }
+
+        if (errors[type]) {
+          errors[type] = [];
         }
       };
     }


### PR DESCRIPTION
Related to #7228.

The changes in that pull request worked with the default background layers as `queue[type]` is `undefined`, but with custom background layers `queue[type]` is not `undefined`, failing.
