### PR TITLE
UI config for batch editing access level

### DIFF
--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
@@ -1387,6 +1387,39 @@
                   </div>
                 </div>
 
+                <div data-ng-switch-when="batchEditingAccessLevel">
+                  <label class="control-label">{{('ui-' + key) | translate}}</label>
+
+                  <div class="checkbox">
+                    <label>
+                      <input type="radio" data-ng-model="mCfg[key]"
+                             value="editor"/>
+                      <i class="fa fa-fw fa-align-left"></i>&nbsp;
+                      <span data-translate="">Editor</span>
+                    </label>
+                  </div>
+                  <div class="checkbox">
+                    <label>
+                      <input type="radio" data-ng-model="mCfg[key]"
+                             value="reviewer"/>
+                      <i class="fa fa-fw fa-align-center"></i>&nbsp;
+                      <span data-translate="">Reviewer</span>
+                    </label>
+                  </div>
+                  <div class="checkbox">
+                    <label>
+                      <input type="radio" data-ng-model="mCfg[key]"
+                             value="administrator"/>
+                      <i class="fa fa-fw fa-align-right"></i>&nbsp;
+                      <span data-translate="">Administrator</span>
+                    </label>
+                  </div>
+
+                  <p class="help-block"
+                     data-ng-show="(('ui-' + key + '-help') | translate) != ('ui-' + key + '-help')">
+                    {{('ui-' + key + '-help') | translate}} </p>
+                </div>
+
                 <div class="row" data-ng-switch-default>
                   <div class="col-lg-5 gn-nopadding-left">
                     <label class="control-label">{{('ui-' + key) | translate}}</label>

--- a/web-ui/src/main/resources/catalog/components/toolbar/partials/menu-contribute.html
+++ b/web-ui/src/main/resources/catalog/components/toolbar/partials/menu-contribute.html
@@ -39,7 +39,7 @@
         <span class="fa fa-fw fa-bookmark"></span><span translate>directoryManager</span>
       </a>
     </li>
-    <li class="gn-menuitem-xs" role="menuitem">
+    <li class="gn-menuitem-xs" role="menuitem" data-ng-if="!gnCfg.mods.limitedBatchEditing.enabled || (gnCfg.mods.limitedBatchEditing.batchEditingAccessLevel=='editor' && user.isEditorOrMore()) || (gnCfg.mods.limitedBatchEditing.batchEditingAccessLevel=='reviewer' && user.isReviewerOrMore()) || (gnCfg.mods.limitedBatchEditing.batchEditingAccessLevel=='administrator' && user.isAdministrator())">
       <a data-gn-active-tb-item="{{gnCfg.mods.editor.appUrl}}#/batchedit">
         <span class="fa fa-fw fa-pencil"></span><span translate>batchEditing</span>
       </a>

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -1213,6 +1213,10 @@
           workflowHelper: {
             enabled: false,
             workflowAssistApps: [{ appUrl: "", appLabelKey: "" }]
+          },
+          limitedBatchEditing: {
+            enabled: true,
+            batchEditingAccessLevel: "administrator"
           }
         }
       };

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1138,6 +1138,8 @@
     "ui-mod-editor": "Editor application",
     "ui-mod-authentication": "Authentication",
     "ui-mod-workflowHelper": "Workflow assist",
+    "ui-mod-limitedBatchEditing": "Limited Batch Editing",
+    "ui-batchEditingAccessLevel": "Batch Editing Access Level:",
     "ui-signinUrl": "Sign in application URL",
     "ui-signoutUrl": "Sign out application URL",
     "ui-signinUrl-help": "URL of the home page. Can contain the following variables between 2 opening and closing '{': <ul><li><strong>node</strong> for the current portal</li><li><strong>lang</strong> for 3 letters language code</li><li> <strong>isoLang</strong> for 2 letters language code.</li></ul>",

--- a/web-ui/src/main/resources/catalog/locales/fr-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/fr-admin.json
@@ -1138,6 +1138,8 @@
     "ui-mod-editor": "Éditeur",
     "ui-mod-authentication": "Authentification",
     "ui-mod-workflowHelper": "Assistance au cycle de vie",
+    "ui-mod-limitedBatchEditing": "Edition par lots limitée",
+    "ui-batchEditingAccessLevel": "Niveau d'accès à l'édition par lots :",
     "ui-signinUrl": "URL pour la connexion",
     "ui-signoutUrl": "URL pour la déconnexion",
     "ui-signinUrl-help": "URL de la page d'accueil. L'URL peut contenir les variables suivantes entre 2 2 '{' ouvrantes et fermantes: <ul><li><strong>node</strong> pour le portail</li><li><strong>lang</strong> pour le code de la langue à 3 caractères</li><li> <strong>isoLang</strong> pour celui à 2 caractères.</li></ul>",


### PR DESCRIPTION
This feature was discuss in PR https://github.com/geonetwork/core-geonetwork/pull/7235 to have some certain level of user access the batch editing as the "batch editing" is not stable

This feature gives the UI config to set access level to prevent some certain level of user use the batch editing feature.

![image](https://github.com/geonetwork/core-geonetwork/assets/74916635/46d5658d-40dc-4429-8101-ed2c8477d38a)


![image](https://github.com/geonetwork/core-geonetwork/assets/74916635/f23df560-970e-40a1-a620-a6185490800b)


The change is limited in 4.0 but if it's not backportable to 3.12, we will make a separated version for it.