### PR TITLE
Escape {{ to avoid error parsing argument.

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/metadata/DefaultStatusActions.java
+++ b/core/src/main/java/org/fao/geonet/kernel/metadata/DefaultStatusActions.java
@@ -267,7 +267,7 @@ public class DefaultStatusActions implements StatusActions {
         // Replace link in message
         ApplicationContext applicationContext = ApplicationContextHolder.get();
         SettingManager sm = applicationContext.getBean(SettingManager.class);
-        textTemplate = textTemplate.replace("{{link}}", sm.getNodeURL()+ "api/records/{{index:uuid}}");
+        textTemplate = textTemplate.replace("{{link}}", sm.getNodeURL()+ "api/records/'{{'index:uuid'}}'");
 
         UserRepository userRepository = context.getBean(UserRepository.class);
         User owner = userRepository.findById(status.getOwner()).orElse(null);


### PR DESCRIPTION
Regression from #7130
Fixes the following error.
    Error is: can't parse argument number: {index:_uuid}