### PR TITLE
Update GeonetHttpRequestFactory to use system proxy defined in JAVA_OPTS

### DIFF
--- a/common/src/main/java/org/fao/geonet/utils/AbstractHttpRequest.java
+++ b/common/src/main/java/org/fao/geonet/utils/AbstractHttpRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2023 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -83,7 +83,7 @@ public class AbstractHttpRequest {
     private boolean useProxy;
     private String proxyHost;
     private int proxyPort;
-    private ArrayList<NameValuePair> alSimpleParams = new ArrayList<NameValuePair>();
+    private ArrayList<NameValuePair> alSimpleParams = new ArrayList<>();
     private String postData;
     private boolean preemptiveBasicAuth;
     private HttpClientContext httpClientContext;
@@ -272,6 +272,8 @@ public class AbstractHttpRequest {
                     input.setDefaultCredentialsProvider(credentialsProvider);
                 }
 
+                input.useSystemProperties();
+
                 if (useProxy) {
                     final HttpHost proxy = new HttpHost(proxyHost, proxyPort);
                     input.setProxy(proxy);
@@ -303,9 +305,9 @@ public class AbstractHttpRequest {
         }
 
         if (host == null || protocol == null) {
-            throw new IllegalStateException(String.format(getClass().getSimpleName() + " is not ready to be executed: \n\tprotocol: '%s' " +
+            throw new IllegalStateException(String.format("%s is not ready to be executed: \n\tprotocol: '%s' " +
                 "\n\tuserinfo: '%s'\n\thost: '%s' \n\tport: '%s' \n\taddress: '%s'\n\tquery '%s'" +
-                "\n\tfragment: '%s'", protocol, userInfo, host, port, address, query, fragment));
+                "\n\tfragment: '%s'", getClass().getSimpleName(), protocol, userInfo, host, port, address, query, fragment));
         }
 
         HttpRequestBase httpMethod;
@@ -352,25 +354,25 @@ public class AbstractHttpRequest {
 
     protected String getSentData(HttpRequestBase httpMethod) {
         URI uri = httpMethod.getURI();
-        StringBuilder sentData = new StringBuilder(httpMethod.getMethod()).append(" ").append(uri.getPath());
+        StringBuilder sentDataValue = new StringBuilder(httpMethod.getMethod()).append(" ").append(uri.getPath());
 
         if (uri.getQuery() != null) {
-            sentData.append("?" + uri.getQuery());
+            sentDataValue.append("?" + uri.getQuery());
         }
 
-        sentData.append("\r\n");
+        sentDataValue.append("\r\n");
 
         for (Header h : httpMethod.getAllHeaders()) {
-            sentData.append(h);
+            sentDataValue.append(h);
         }
 
-        sentData.append("\r\n");
+        sentDataValue.append("\r\n");
 
         if (httpMethod instanceof HttpPost) {
-            sentData.append(postData);
+            sentDataValue.append(postData);
         }
 
-        return sentData.toString();
+        return sentDataValue.toString();
     }
 
     private Element soapEmbed(Element elem) {
@@ -393,7 +395,7 @@ public class AbstractHttpRequest {
 
         List<Element> list = body.getChildren();
 
-        if (list.size() == 0)
+        if (list.isEmpty())
             throw new BadSoapResponseEx(envelope);
 
         return list.get(0);

--- a/common/src/main/java/org/fao/geonet/utils/AbstractHttpRequest.java
+++ b/common/src/main/java/org/fao/geonet/utils/AbstractHttpRequest.java
@@ -272,8 +272,6 @@ public class AbstractHttpRequest {
                     input.setDefaultCredentialsProvider(credentialsProvider);
                 }
 
-                input.useSystemProperties();
-
                 if (useProxy) {
                     final HttpHost proxy = new HttpHost(proxyHost, proxyPort);
                     input.setProxy(proxy);

--- a/common/src/main/java/org/fao/geonet/utils/GeonetHttpRequestFactory.java
+++ b/common/src/main/java/org/fao/geonet/utils/GeonetHttpRequestFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2023 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -200,6 +200,7 @@ public class GeonetHttpRequestFactory {
         final HttpClientBuilder builder = HttpClientBuilder.create();
         builder.setRedirectStrategy(new LaxRedirectStrategy());
         builder.disableContentCompression();
+        builder.useSystemProperties();
 
         synchronized (this) {
             if (connectionManager == null) {
@@ -249,40 +250,40 @@ public class GeonetHttpRequestFactory {
 
     private static class AdaptingResponse extends AbstractClientHttpResponse {
 
-        private final CloseableHttpResponse _response;
-        private final CloseableHttpClient _client;
+        private final CloseableHttpResponse response;
+        private final CloseableHttpClient client;
 
         public AdaptingResponse(CloseableHttpClient client, CloseableHttpResponse response) {
-            this._response = response;
-            this._client = client;
+            this.response = response;
+            this.client = client;
         }
 
         @Override
         public int getRawStatusCode() throws IOException {
-            return _response.getStatusLine().getStatusCode();
+            return response.getStatusLine().getStatusCode();
         }
 
         @Override
         public String getStatusText() throws IOException {
-            return _response.getStatusLine().getReasonPhrase();
+            return response.getStatusLine().getReasonPhrase();
         }
 
         @Override
         public void close() {
-            IOUtils.closeQuietly(_response);
-            IOUtils.closeQuietly(_client);
+            IOUtils.closeQuietly(response);
+            IOUtils.closeQuietly(client);
         }
 
         @Override
         public InputStream getBody() throws IOException {
-            return _response.getEntity().getContent();
+            return response.getEntity().getContent();
         }
 
         @Override
         public HttpHeaders getHeaders() {
             final HttpHeaders httpHeaders = new HttpHeaders();
 
-            final Header[] headers = _response.getAllHeaders();
+            final Header[] headers = response.getAllHeaders();
 
             for (Header header : headers) {
                 final HeaderElement[] elements = header.getElements();


### PR DESCRIPTION
Defining the proxy in the system properties was not used in certain requests, for example the ones done by CSW harvester.

Test case:

1) Execute GeoNetwork configuring in the system properties the proxy configuration, for example if running in localhost port 9090:

```
mvn jetty:run -Dhttp.proxyHost=localhost -Dhttp.proxyPort=9090 -Dhttps.proxyHost=localhost -Dhttps.proxyPort=9090
```

2) Stop the proxy server

3) Create a CSW harvester and run it --> 

  - Without the fix --> NO OK:  the harvester is executed fine, not using the proxy configuration.
  - With the fix --> OK: the harvester fails, as the proxy server is stopped, the proxy configuration is used.

---

The pull request includes also Sonarlint updates.