### PR TITLE
Set html emails as utf-8

### DIFF
--- a/core/src/main/java/org/fao/geonet/util/MailUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/MailUtil.java
@@ -68,6 +68,7 @@ public class MailUtil {
 
         email.setSubject(subject);
         try {
+            email.setCharset(EmailConstants.UTF_8);
             email.setHtmlMsg(htmlMessage);
         } catch (EmailException e1) {
             Log.error("Error setting email HTML content. Subject:" + subject, e1);


### PR DESCRIPTION
We are having an issue with emails not being encoded correctly. We have narrowed it down to html emails only.  Non html emails seem to work correctly.

Here is an example of an email that we received before this change:

![image](https://github.com/geonetwork/core-geonetwork/assets/1868233/bcf5495b-76f2-4ebd-842a-93fcd55b76de)

When I do view source in MS Outlook it starts with the following:

`<meta http-equiv="Content-Type" content="text/html; charset=utf-8">Les fiches suivantes ont �t� trait�es:
`
**With the change**

The email now looks like this.

![image](https://github.com/geonetwork/core-geonetwork/assets/1868233/b3311713-46c8-4f6a-be27-3547315524fe)

And when I user MS outlook view source - the first line looks like this:

`<meta http-equiv="Content-Type" content="text/html; charset=iso-8859-1">Les fiches suivantes ont été traitées:`


**Issues**

- I think the real problem is that geonetwork is sending HTML emails that are not really HTML emails.  They are only text with  HTML elements in them.  They definitely don't conform to any HTML standard.  
- I'm not sure if all HTML emails are in this format. If they are then it may be better to wrap all emails in `<html>` with a `<meta http-equiv` and the proper charset.

**Other**
- I did try SMTP4dev and the email displayed email correctly. And it started with the following.
```
Content-Type: text/html; charset=Cp1252
Content-Transfer-Encoding: quoted-printable

Les fiches suivantes ont =E9t=E9 trait=E9es:
```
So it looks like the default encoding is Cp1252? 

- It seems like MS outlook does not understand charset=Cp1252 and it is defaulting to utf-8.  But oddly as shown above, when we specify that it is UTF-8 it shows the source as iso-8859-1.  Almost seems like this is a bug in Outlook.

**Software**
I'm using the following version of outlook.
![image](https://github.com/geonetwork/core-geonetwork/assets/1868233/5defb79e-1540-4cbe-a749-fc990cbec3c5)

Looking for feeback on this issue.
