### PR TITLE
Fix record history parameter name. Related to #7074

### DIFF
--- a/web-ui/src/main/resources/catalog/components/history/GnHistoryService.js
+++ b/web-ui/src/main/resources/catalog/components/history/GnHistoryService.js
@@ -89,7 +89,7 @@
           filters.push("owner=" + filter.ownerFilter.id);
         }
         if (filter.recordFilter) {
-          filters.push("record=" + filter.recordFilter);
+          filters.push("recordIdentifier=" + filter.recordFilter);
         }
         if (filter.uuid) {
           filters.push("uuid=" + filter.uuid);


### PR DESCRIPTION
In #7074 was changed a parameter name of the the metadata workflow API, due to a Sonarlint suggestion. But the client code was not updated.