### PR TITLE
Metadata tooltips - improve the check method to try to find a match a standard default with no context defined, if there is no entry with the element context

### DIFF
--- a/core/src/main/java/org/fao/geonet/api/standards/StandardsUtils.java
+++ b/core/src/main/java/org/fao/geonet/api/standards/StandardsUtils.java
@@ -114,8 +114,25 @@ public class StandardsUtils {
         return result;
     }
 
+    /**
+     * Loop in the schema entries to find a match.
+     *
+     * If requireContextMatch = false, try to find a match a standard default with no context defined.
+     *
+     * @param scm
+     * @param schema
+     * @param entries
+     * @param context
+     * @param name
+     * @param isoType
+     * @param displayIf
+     * @param requireContextMatch
+     * @return
+     * @throws OperationAbortedEx
+     */
     private static Element checkEntries(SchemaManager scm, String schema, Element entries, String context,
                                         String name, String isoType, String displayIf, boolean requireContextMatch) throws OperationAbortedEx {
+        Element tentativeElement = null;
 
         for (Object o : entries.getChildren()) {
             Element currElem = (Element) o;
@@ -168,13 +185,18 @@ public class StandardsUtils {
                 return (Element) currElem.clone();
             }
             if (!requireContextMatch && displayIfAttribute == null) {
-                // Return an element not matching any context attribute
-                // or displayIf condition. Usually the default value of the standard.
-                return (Element) currElem.clone();
+                if (currContext != null) {
+                    // Keep tentative, in case there is a standard default with no context defined.
+                    tentativeElement = (Element) currElem.clone();
+                } else {
+                    // Return an element not matching any context attribute
+                    // or displayIf condition. Usually the default value of the standard.
+                    return (Element) currElem.clone();
+                }
             }
         }
 
-        return null; // no match found
+        return tentativeElement;
 
     }
 


### PR DESCRIPTION
Test case:

1) Create an iso19139 metadata and enable the tooltips

2) Click in the contact role.

  - Without the fix, the tooltip displayed is not correct:

    ```
    Reference to the ends (roles) of a concrete association
    ```
  
  - With the fix, the tooltip displayed is correct:

    ```
    Function performed by the responsible party
    ```

---

In iso19139 `labels.xml`:

```
  <element name="gmd:role" id="566.0" context="gmd:MD_Association">
    <label>Role</label>
    <description>Reference to the ends (roles) of a concrete association</description>
  </element>

  <element name="gmd:role" id="379.0">
    <label>Role</label>
    <description>Function performed by the responsible party</description>
    <condition>mandatory</condition>
  </element>
```

The following request: 

http://localhost:8080/geonetwork/srv/api/standards/iso19139/descriptors/gmd:role/details?parent=gmd:CI_ResponsibleParty&xpath=/col/gmd:role&isoType=&displayIf=undefined

in the original code as no exact match with context `gmd:CI_ResponsibleParty`, the code tries to match ignoring the context, but as the element with `context="gmd:MD_Association"` appears first in the file, that element was returned.

With the change, tries to find if any other element matching only the name, without context defined to return it.