### PR TITLE
ODS: Use explore API for OnlineResource linkages

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/fromJsonOpenDataSoft.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/fromJsonOpenDataSoft.xsl
@@ -482,7 +482,7 @@
 
                 <!-- Data download links are inferred from the record metadata -->
                 <xsl:variable name="count"
-                              select="dataset/metas/default/records_count"/>
+                              select="metas/records_count|dataset/metas/default/records_count"/>
                 <xsl:if test="$count > 0">
                   <xsl:call-template name="dataLink">
                     <xsl:with-param name="format">csv</xsl:with-param>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/fromJsonOpenDataSoft.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/fromJsonOpenDataSoft.xsl
@@ -496,7 +496,7 @@
                     </xsl:call-template>
                     <xsl:if test="$count &lt; 5000">
                       <xsl:call-template name="dataLink">
-                        <xsl:with-param name="format">shapefile</xsl:with-param>
+                        <xsl:with-param name="format">shp</xsl:with-param>
                       </xsl:call-template>
                     </xsl:if>
                   </xsl:if>
@@ -562,10 +562,9 @@
           <cit:linkage>
             <gco:CharacterString>
               <xsl:value-of select="concat(nodeUrl,
-                                   '/explore/dataset/',
+                                   '/api/explore/v2.1/catalog/datasets/',
                                    (datasetid|dataset/dataset_id)[1],
-                                   '/download?format=', $format,
-                                   '&amp;timezone=Europe/Berlin&amp;use_labels_for_header=false')" />
+                                   '/exports/', $format, '?use_labels=true')" />
             </gco:CharacterString>
           </cit:linkage>
           <cit:protocol>


### PR DESCRIPTION
This PR 
- adds a small fix for ods v1 concerning OnlineResource linkages
- inserts ODS explore API urls (which respond with `Access-Control-Allow-Origin:*` CORS headers) for OnlineResource linkages. This should facilitate the usage of the data links in other web apps.

Note: `v2.1` is hard coded in the API URL as ODS v1 does not seem to provide this API. However, ODS v1 endpoints generally also seem to propose a v2 endpoint.

Simple URL config PR was tested with:
- URL: https://opendata.lillemetropole.fr/api/datasets/1.0/search?refine.publisher=M%C3%A9tropole+Europ%C3%A9enne+de+Lille&refine.datasetid=accroche_velos
- Element to loop on: `/datasets`
- Element for the UUID of each record: `/datasetid` (remove `/` here when testing on 4.2.2 or smaller)
- XSL transformation to apply: `schema:iso19115-3.2018:convert/fromJsonOpenDataSoft`
