### PR TITLE
fix multi entry combiner ui formatting issue when adding online resource

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
@@ -395,12 +395,12 @@
                   />
                 </div>
               </div>
-              <div
+              <div class="col-sm-9 col-xs-9 "
                 data-ng-if="params.linkType.fields.desc.directive === 'gn-multientry-combiner-online-resources-description'"
               >
                 <div
                   data-gn-multientry-combiner-online-resources-description="{{params.linkType.fields.desc.directiveConfig}}"
-                  class="col-sm-9 col-xs-9 gn-value nopadding-in-table"
+                  class="gn-value nopadding-in-table"
                   data-label="description"
                   data-ng-required="params.linkType.fields.desc.required"
                 ></div>


### PR DESCRIPTION
This PR is to fix issue https://github.com/geonetwork/core-geonetwork/issues/7255

After the fix the screen look like 

![image](https://github.com/geonetwork/core-geonetwork/assets/74916635/b6c20ca7-4663-4f06-a7a3-34490ede8a60)


And fields layout are stable when shifting to different screen resolutions