### PR TITLE
Fix deletion sequence in editor: wait for DOM update before saving

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadatamanager/EditorService.js
+++ b/web-ui/src/main/resources/catalog/components/metadatamanager/EditorService.js
@@ -614,12 +614,12 @@
                 checkAddControls(target.get(0), true);
                 checkMoveControls(target.get(0));
 
-                target.slideUp(duration, function () {
+                target.slideUp(duration);
+                target.promise().done(function () {
                   $(this).remove();
+                  // TODO: Take care of moving the + sign
+                  defer.resolve(response.data);
                 });
-
-                // TODO: Take care of moving the + sign
-                defer.resolve(response.data);
               },
               function (response) {
                 defer.reject(response.data);


### PR DESCRIPTION
When deleting an element in the editor, the current sequence is as follows:
- Click the red cross
- Start slideUp animation
- Save
- End slideUp animation
- Update the DOM

In some configuration cases, such as when deleting a section block containing `thesaurus-list-picker` directive, the DOM is read during the save, causing the element to be only partially deleted:
![brave_QpBsw5FI5y](https://github.com/geonetwork/core-geonetwork/assets/32705577/50d1d277-8e40-4c34-9881-79f77cdb37a9)

dcat2 config-editor.xml
```xml
<?xml version="1.0" encoding="UTF-8"?>
<editor ...>
  <!-- Define form field types per metadata element. -->
  <fields>
    <!-- ... -->
    <for name="dct:type" xpath="dct:LicenseDocument" use="thesaurus-list-picker">
      <directiveAttributes
        thesaurus="external.theme.licence-type"
        xpath="/dct:license/dct:LicenseDocument/dct:type"
        max="1"
        labelKey="dcat.addType"/>
    </for>
    <!-- ... -->
  </fields>
  <!-- ... -->
  <views>
    <view ...>
      <!-- ... -->
      <tab id="tabDistribution" mode="flat" displayIfRecord="count(//dcat:dataset) > 0" hideIfNotDisplayed="true">
        <section>
          <section name="distribution"
                   forEach="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dcat:distribution"
                   del=".">
            <field xpath="dcat:Distribution/dct:title" or="title" in="dcat:Distribution"/>
            <field xpath="dcat:Distribution/dct:description" or="description" in="dcat:Distribution"/>
            <field xpath="dcat:Distribution/dcat:accessURL" or="accessURL" in="dcat:Distribution"/>
            <field xpath="dcat:Distribution/dct:format" or="format" in="dcat:Distribution"/>
            <field xpath="dcat:Distribution/dcat:mediaType" or="mediaType" in="dcat:Distribution"/>
            <field xpath="dcat:Distribution/dct:language" or="language" in="dcat:Distribution"/>
            <section xpath="dcat:Distribution/dct:license"/>
            <action type="add" or="license" in="dcat:Distribution">
              <template>
                <snippets name="licenses"/>
              </template>
            </action>
            <section xpath="dcat:Distribution/dct:rights"/>
            <action type="add" or="rights" in="dcat:Distribution">
              <template>
                <snippet>
                  <dct:rights>
                    <dct:RightsStatement>
                      <dct:title xml:lang="nl"/>
                      <dct:description xml:lang="nl"/>
                    </dct:RightsStatement>
                  </dct:rights>
                </snippet>
              </template>
            </action>
            <section xpath="dcat:Distribution/dct:conformsTo"/>
            <action type="add" or="conformsTo" in="dcat:Distribution">
              <template>
                <snippets name="protocols"/>
              </template>
            </action>
          </section>
          <action type="add" or="distribution" in="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset">
            <template>
              <snippet>
                <dcat:distribution>
                  <dcat:Distribution>
                    <dct:title xml:lang="nl"/>
                    <dct:description xml:lang="nl"/>
                    <dcat:accessURL rdf:resource=""/>
                  </dcat:Distribution>
                </dcat:distribution>
              </snippet>
            </template>
          </action>
        </section>
      </tab>
      <!-- ... -->
    </view>
    <!-- ... -->
  </views>
  <!-- ... -->
</editor>
```

This fix improve the deletion sequence by waiting for the animation to finish and the DOM to be updated before triggering the save.

CC: @fxprunayre 