### PR TITLE
Allow mulitple conditional default tabs in a single editor view

### DIFF
--- a/schemas/config-editor.xsd
+++ b/schemas/config-editor.xsd
@@ -479,6 +479,7 @@ relevant to have parent defined to have more control over the list.
     <xs:complexType>
       <xs:sequence>
         <xs:element ref="directiveAttributes" minOccurs="0" maxOccurs="1"/>
+        <xs:element ref="template" minOccurs="0" maxOccurs="1"/>
       </xs:sequence>
       <xs:attribute name="name" type="xs:string" use="required">
         <xs:annotation>

--- a/web/src/main/webapp/xslt/ui-metadata/menu-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/menu-builder.xsl
@@ -93,7 +93,9 @@
                     </xsl:if>
                     <!-- When a view contains multiple tab, the one with
                   the default attribute is the one to open -->
-                    <a data-ng-click="switchToTab('{tab[@default]/@id}', '{tab[@default]/@mode}')"
+                    <xsl:variable name="defaultTab"
+                                  select="tab[@default and gn-fn-metadata:check-elementandsession-visibility($schema, $metadata, $serviceInfo, @displayIfRecord, @displayIfServiceInfo)]"/>
+                    <a data-ng-click="switchToTab('{$defaultTab/@id}', '{$defaultTab/@mode}')"
                        href="">
                       <xsl:variable name="viewName" select="@name"/>
                       <xsl:value-of select="($strings/*[name() = $viewName]|$viewName)[1]"/>


### PR DESCRIPTION
This change enables the possibility to have multiple default tabs with `displayIfRecord` conditions in a single editor view.  
This is for example useful when having different default tabs for dataset and services metadata. 

```xml
<editor ...>
  <views>
    <view ...>
      <tab id="tabDataset" default="true" mode="flat" displayIfRecord="count(//dcat:dataset) > 0" hideIfNotDisplayed="true">...</tab>
      <tab id="tabService" default="true" mode="flat" displayIfRecord="count(//dcat:service) > 0" hideIfNotDisplayed="true">...</tab>
    </view>
  </views>
</editor>
```

CC @fxprunayre 