### PR TITLE
Make editor snippets referenceable and reusable

### DIFF
--- a/schemas/config-editor.xsd
+++ b/schemas/config-editor.xsd
@@ -73,6 +73,7 @@ a set of views with at least one defined view.
         <xs:element minOccurs="0" maxOccurs="1" ref="multilingualFields"/>
         <xs:element minOccurs="0" maxOccurs="1" ref="tableFields"/>
         <xs:element minOccurs="1" maxOccurs="1" ref="views"/>
+        <xs:element minOccurs="0" maxOccurs="1" ref="snippets"/>
         <xs:element minOccurs="0" maxOccurs="1" ref="batchEditing"/>
       </xs:sequence>
     </xs:complexType>
@@ -341,6 +342,60 @@ Element to match for creating the table.
     </xs:complexType>
   </xs:element>
 
+
+  <xs:element name="snippets">
+    <xs:annotation>
+      <xs:documentation>
+        <![CDATA[
+
+Defining reusable list of snippets which can be referenced in templates.
+----------------------------------------------------------------------------------
+
+Defining reusable list of snippets which can be referenced in templates.
+
+.. code-block:: xml
+
+    <editor>
+        <snippets>
+            <list name="reports">
+                <snippet label="inspire-address">
+                    <gmd:report>...</gmd:report>
+                </snippet>
+                <snippet label="inspire-administrative-units">
+                    <gmd:report>...</gmd:report>
+                </snippet>
+            </list>
+        </snippets>
+
+        <!-- ... -->
+        <action type="add" ...>
+            <template>
+                <snippets name="reports"/>
+            <template>
+        </action>
+        ]]></xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:sequence>
+        <xs:element name="list">
+          <xs:complexType>
+            <xs:attribute name="name" use="required">
+              <xs:annotation>
+                <xs:documentation>
+                  <![CDATA[
+Snippet list name to be used as a reference.
+                  ]]>
+                </xs:documentation>
+              </xs:annotation>
+            </xs:attribute>
+            <xs:sequence>
+              <xs:element minOccurs="1" maxOccurs="unbounded" ref="snippet"/>
+            </xs:sequence>
+          </xs:complexType>
+        </xs:element>
+      </xs:sequence>
+    </xs:complexType>
+  </xs:element>
 
   <xs:element name="header">
     <xs:annotation>
@@ -1374,7 +1429,14 @@ Warning: Template based field does not support multilingual editing for ISO stan
             <xs:documentation>The list of values to match from the template.</xs:documentation>
           </xs:annotation>
         </xs:element>
-        <xs:element minOccurs="1" maxOccurs="unbounded" ref="snippet"/>
+        <xs:choice>
+          <xs:element minOccurs="1" maxOccurs="unbounded" ref="snippet"/>
+          <xs:element minOccurs="1" maxOccurs="1" name="snippets">
+            <xs:complexType>
+              <xs:attribute name="name" use="required" type="xs:string"/>
+            </xs:complexType>
+          </xs:element>
+        </xs:choice>
       </xs:sequence>
     </xs:complexType>
   </xs:element>

--- a/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
@@ -542,8 +542,9 @@
               </xsl:when>
               <xsl:otherwise>
 
-                <xsl:variable name="hasMultipleChoice"
-                              select="count($template/snippet) gt 1"/>
+                <xsl:variable name="snippets" select="$template/snippet|$editorConfig/editor/snippets/list[@name = $template/snippets/@name]/snippet"/>
+
+                <xsl:variable name="hasMultipleChoice" select="count($snippets) gt 1"/>
 
                 <div class="btn-group" data-gn-template-field-add-button="{$id}">
                   <xsl:if test="$hasMultipleChoice">
@@ -570,7 +571,7 @@
                   <xsl:if test="$hasMultipleChoice">
                     <!-- A combo with the list of snippet available -->
                     <ul class="dropdown-menu">
-                      <xsl:for-each select="$template/snippet">
+                      <xsl:for-each select="$snippets">
                         <xsl:variable name="label" select="@label"/>
                         <li><a id="{concat($id, $label)}">
                           <xsl:value-of select="if ($strings/*[name() = $label] != '') then $strings/*[name() = $label] else $label"/>
@@ -792,14 +793,14 @@
                 <input class="gn-debug" type="text" name="{$xpathFieldId}" value="{@xpath}"/>
               </xsl:if>
 
-              <xsl:variable name="hasMultipleChoice"
-                            select="count($template/snippet) gt 1"/>
+              <xsl:variable name="snippets" select="$template/snippet|$editorConfig/editor/snippets/list[@name = $template/snippets/@name]/snippet"/>
+
+              <xsl:variable name="hasMultipleChoice" select="count($snippets) gt 1"/>
 
               <xsl:if test="$hasMultipleChoice">
-                <xsl:for-each select="$template/snippet">
+                <xsl:for-each select="$snippets">
                   <textarea id="{concat($id, @label, '-value')}">
-                    <xsl:value-of select="saxon:serialize(*,
-                                        'default-serialize-mode')"/>
+                    <xsl:value-of select="saxon:serialize(*, 'default-serialize-mode')"/>
                   </textarea>
                 </xsl:for-each>
               </xsl:if>
@@ -813,8 +814,7 @@
                 <xsl:if test="$isMissingLabel != ''">
                   <xsl:attribute name="data-not-set-check" select="$tagId"/>
                 </xsl:if>
-                <xsl:value-of select="saxon:serialize($template/snippet[1]/*,
-                                      'default-serialize-mode')"/>
+                <xsl:value-of select="saxon:serialize($snippets[1]/*, 'default-serialize-mode')"/>
               </textarea>
             </div>
           </xsl:if>

--- a/web/src/main/webapp/xslt/ui-metadata/form-configurator.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-configurator.xsl
@@ -509,7 +509,7 @@
               <template>
                 <xsl:copy-of select="$template/values"/>
                 <snippet>
-                  <xsl:apply-templates mode="gn-merge" select="$template/snippet/*">
+                  <xsl:apply-templates mode="gn-merge" select="$template/snippet/*|$editorConfig/editor/snippets/list[@name = $template/snippets/@name]/snippet/*">
                     <xsl:with-param name="node-to-merge" select="$currentNode"/>
                   </xsl:apply-templates>
                 </snippet>
@@ -564,7 +564,7 @@
 
             <xsl:variable name="currentNode">
               <xsl:apply-templates mode="gn-element-cleaner"
-                                   select="$template/snippet/*"/>
+                                   select="$template/snippet/*|$editorConfig/editor/snippets/list[@name = $template/snippets/@name]/snippet/*"/>
             </xsl:variable>
 
             <xsl:variable name="keyValues">


### PR DESCRIPTION
When configuring a list of snippets for a field in the editor, if we want to define the same list in another view, it is currently required to repeat the same snippet list.  
This becomes an issue when the list of snippets gets long as it makes the config file harder to read and maintain. 

This change implements a way to configure lists of reusable snippets in the config-editor.xml:

```xml
<editor ...>
  <snippets>
    <list name="licenses">
      <snippet label="license-modellicentie-gratis">
        <dct:license>
          <dct:LicenseDocument rdf:about="https://data.vlaanderen.be/id/licentie/modellicentie-gratis-hergebruik/v1.0">
            <dct:type>
              <skos:Concept rdf:about="http://purl.org/adms/licencetype/Attribution">
                <skos:prefLabel xml:lang="nl">Verplichte bronvermelding</skos:prefLabel>
                <skos:prefLabel xml:lang="en">Attribution</skos:prefLabel>
                <skos:prefLabel xml:lang="fr">Attribution</skos:prefLabel>
                <skos:prefLabel xml:lang="de">Attribution</skos:prefLabel>
                <skos:inScheme rdf:resource="http://purl.org/adms/licencetype/1.0"/>
              </skos:Concept>
            </dct:type>
            <dct:title xml:lang="nl">Modellicentie voor gratis hergebruik</dct:title>
            <dct:description xml:lang="nl">Onder deze licentie doet de instantie geen afstand van haar intellectuele rechten, maar mag de data voor eender welk doel hergebruikt worden, gratis en onder minimale restricties.</dct:description>
            <dct:identifier>https://data.vlaanderen.be/id/licentie/modellicentie-gratis-hergebruik/v1.0</dct:identifier>
          </dct:LicenseDocument>
        </dct:license>
      </snippet>
      <snippet label="license-cc0">
        <dct:license>
          <dct:LicenseDocument rdf:about="https://data.vlaanderen.be/id/licentie/creative-commons-zero-verklaring/v1.0">
            <dct:type>
              <skos:Concept rdf:about="http://purl.org/adms/licencetype/PublicDomain">
                <skos:prefLabel xml:lang="nl">Werk in het publiek domein</skos:prefLabel>
                <skos:prefLabel xml:lang="en">Public domain</skos:prefLabel>
                <skos:prefLabel xml:lang="fr">Public domain</skos:prefLabel>
                <skos:prefLabel xml:lang="de">Public domain</skos:prefLabel>
                <skos:inScheme rdf:resource="http://purl.org/adms/licencetype/1.0"/>
              </skos:Concept>
            </dct:type>
            <dct:title xml:lang="nl">Creative Commons Zero verklaring</dct:title>
            <dct:description xml:lang="nl">De instantie doet afstand van haar intellectuele eigendomsrechten voor zover dit wettelijk mogelijk is. Hierdoor kan de gebruiker de data hergebruiken voor eender welk doel, zonder een verplichting op naamsvermelding. Deze is de welbekende CC0 licentie.</dct:description>
            <dct:identifier>https://data.vlaanderen.be/id/licentie/creative-commons-zero-verklaring/v1.0</dct:identifier>
          </dct:LicenseDocument>
        </dct:license>
      </snippet>
    </list>
  </snippets>

  <views>
    <view ...>
      <tab ...>
        <section>
          <action type="add" or="license" in="dcat:Distribution">
            <template>
              <snippets name="licenses"/>
            </template>
          </action>
        </section>
      </tab>
    </view>
  </views>
</editor>
```

CC: @fxprunayre 