### PR TITLE
Add icons for related types (association and initiative)

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/linktosibling.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/linktosibling.html
@@ -91,8 +91,16 @@
             <tbody>
               <tr data-ng-repeat="obj in selection">
                 <td>{{obj.md.resourceTitle}}</td>
-                <td>{{obj.associationType | translate}}</td>
-                <td>{{obj.initiativeType | translate}}</td>
+                <td>
+                  <i
+                    class="fa fa-fw gn-icon-association-{{obj.associationType}} gn-margin-right-sm"
+                  />{{obj.associationType | translate}}
+                </td>
+                <td>
+                  <i
+                    class="fa fa-fw gn-icon-initiative-{{obj.initiativeType}} gn-margin-right-sm"
+                  />{{obj.initiativeType | translate}}
+                </td>
                 <td class="text-center">
                   <a
                     title="{{'removeFromSelection' | translate}}"

--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/related.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/related.html
@@ -232,23 +232,29 @@
             'gn-card-dataset': type !== 'parent' && type !== 'services' && type !== 'application' && type !== 'nonGeographicDataset'
             }"
         >
-          <i
-            class="fa fa-fw {{icon}} gn-icon-association-{{md.properties.associationType}} gn-icon-initiative-{{md.properties.initiativeType}}"
-          />
-          <span class="gn-truncate">
-            <span data-ng-hide="md.properties && !md.properties.associationType">
+          <span>
+            <span data-ng-if="!md.properties || (md.properties && md.properties.associationType == '')">
               {{(config.getLabel(mainType, type)) | translate}}</span
             >
             <span
-              class="gn-card-badge-sublabel"
+              data-ng-if="md.properties && md.properties.associationType"
               data-ng-show="md.properties && md.properties.associationType"
               title="{{(config.getLabel(mainType, type)) | translate}}"
-            >
-              <b translate>associationType</b><br />
-              {{md.properties.associationType | translate}}
+            > {{'associatedTo' | translate}}
+              <b title="{{'associationType' | translate}}">
+                <i
+                  class="fa fa-fw {{icon}} gn-icon-association-{{md.properties.associationType}}"
+                />
+                {{md.properties.associationType | translate}}
+              </b>
               <span data-ng-if="md.properties && md.properties.initiativeType">
-                <br /><b translate>initiativeType</b><br />
-                {{md.properties.initiativeType | translate}}
+                >
+                <b title="{{'initiativeType' | translate}}">
+                  <i
+                    class="fa fa-fw {{icon}} gn-icon-initiative-{{md.properties.initiativeType}}"
+                  />
+                  {{md.properties.initiativeType | translate}}
+                </b>
               </span>
             </span>
           </span>

--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/related.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/related.html
@@ -224,7 +224,7 @@
         formatter-url="formatter.defaultUrl"
       >
         <span
-          class="label label-default gn-card-badge"
+          class="gn-card-badge"
           data-ng-class="{
             'gn-card-series': type === 'parent',
             'gn-card-nonGeographicDataset': type === 'nonGeographicDataset',
@@ -232,22 +232,29 @@
             'gn-card-dataset': type !== 'parent' && type !== 'services' && type !== 'application' && type !== 'nonGeographicDataset'
             }"
         >
-          <i class="fa {{icon}}" />
-          <span data-ng-hide="md.properties && !md.properties.associationType">
-            {{(config.getLabel(mainType, type)) | translate}}</span
-          >
-          <span
-            data-ng-show="md.properties && md.properties.associationType"
-            title="{{(config.getLabel(mainType, type)) | translate}}"
-          >
-            {{md.properties.associationType | translate}}
-            <span data-ng-if="md.properties && md.properties.initiativeType">
-              ({{md.properties.initiativeType | translate}})
+          <i
+            class="fa fa-fw {{icon}} gn-icon-association-{{md.properties.associationType}} gn-icon-initiative-{{md.properties.initiativeType}}"
+          />
+          <span class="gn-truncate">
+            <span data-ng-hide="md.properties && !md.properties.associationType">
+              {{(config.getLabel(mainType, type)) | translate}}</span
+            >
+            <span
+              class="gn-card-badge-sublabel"
+              data-ng-show="md.properties && md.properties.associationType"
+              title="{{(config.getLabel(mainType, type)) | translate}}"
+            >
+              <b translate>associationType</b><br />
+              {{md.properties.associationType | translate}}
+              <span data-ng-if="md.properties && md.properties.initiativeType">
+                <br /><b translate>initiativeType</b><br />
+                {{md.properties.initiativeType | translate}}
+              </span>
             </span>
           </span>
           <i
             data-ng-if="md.origin === 'remote'"
-            class="fa fa-external-link"
+            class="fa fa-fw fa-external-link"
             title="{{'remoteRecord' | translate}}"
           ></i>
         </span>

--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/relatedEditorList.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/relatedEditorList.html
@@ -14,7 +14,9 @@
           gn-metadata-open="record"
           data-app-url="catalog.search"
         >
-          <i class="fa {{icon}}" />
+          <i
+            class="fa fa-fw {{icon}} gn-icon-association-{{record.properties.associationType}} gn-icon-initiative-{{record.properties.initiativeType}}"
+          />
           {{record.resourceTitle}}
         </a>
         <a

--- a/web-ui/src/main/resources/catalog/locales/en-v4.json
+++ b/web-ui/src/main/resources/catalog/locales/en-v4.json
@@ -402,6 +402,7 @@
   "text/xml; subtype=gml/3.1.1": "GML 3.1.1",
   "text/xml; subtype=gml/3.2": "GML 3.2",
   "lastCreatedRecords": "Last created records",
-  "associationType": "Association type:",
-  "initiativeType": "Initiative type:"
+  "associationType": "Association type",
+  "initiativeType": "Initiative type",
+  "associatedTo": "Associated "
 }

--- a/web-ui/src/main/resources/catalog/locales/en-v4.json
+++ b/web-ui/src/main/resources/catalog/locales/en-v4.json
@@ -401,5 +401,7 @@
   "text/xml; subtype=gml/2.1.2": "GML 2.1.2",
   "text/xml; subtype=gml/3.1.1": "GML 3.1.1",
   "text/xml; subtype=gml/3.2": "GML 3.2",
-  "lastCreatedRecords": "Last created records"
+  "lastCreatedRecords": "Last created records",
+  "associationType": "Association type:",
+  "initiativeType": "Initiative type:"
 }

--- a/web-ui/src/main/resources/catalog/style/gn_icons.less
+++ b/web-ui/src/main/resources/catalog/style/gn_icons.less
@@ -337,3 +337,79 @@
 .gn-status-draft-to-submitted-reviewer:before {
   content: @fa-var-check-circle;
 }
+
+// association types
+.gn-icon-association-crossReference:before {
+  content: @fa-var-shuffle;
+}
+.gn-icon-association-largerWorkCitation:before {
+  content: @fa-var-message;
+}
+.gn-icon-association-partOfSeamlessDatabase:before {
+  content: @fa-var-database;
+}
+.gn-icon-association-stereoMate:before {
+  content: @fa-var-headphones;
+}
+.gn-icon-association-isComposedOf:before {
+  content: @fa-var-sitemap;
+}
+.gn-icon-association-collectiveTitle:before {
+  content: @fa-var-heading;
+}
+.gn-icon-association-series:before {
+  content: @fa-var-copy;
+}
+.gn-icon-association-dependency:before {
+  content: @fa-var-diagram-next;
+}
+.gn-icon-association-revisionOf:before {
+  content: @fa-var-clock-rotate-left;
+}
+
+// initiative types
+.gn-icon-initiative-campaign:before {
+  content: @fa-var-bullhorn;
+}
+.gn-icon-initiative-collection:before {
+  content: @fa-var-share-nodes;
+}
+.gn-icon-initiative-exercise:before {
+  content: @fa-var-book-atlas;
+}
+.gn-icon-initiative-experiment:before {
+  content: @fa-var-flask;
+}
+.gn-icon-initiative-investigation:before {
+  content: @fa-var-magnifying-glass;
+}
+.gn-icon-initiative-mission:before {
+  content: @fa-var-crosshairs;
+}
+.gn-icon-initiative-sensor:before {
+  content: @fa-var-microchip;
+}
+.gn-icon-initiative-operation:before {
+  content: @fa-var-person-chalkboard;
+}
+.gn-icon-initiative-platform:before {
+  content: @fa-var-sitemap;
+}
+.gn-icon-initiative-process:before {
+  content: @fa-var-gears;
+}
+.gn-icon-initiative-program:before {
+  content: @fa-var-laptop-code;
+}
+.gn-icon-initiative-project:before {
+  content: @fa-var-paste;
+}
+.gn-icon-initiative-study:before {
+  content: @fa-var-graduation-cap;
+}
+.gn-icon-initiative-task:before {
+  content: @fa-var-list-check;
+}
+.gn-icon-initiative-trial:before {
+  content: @fa-var-gavel;
+}

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_result_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_result_default.less
@@ -106,11 +106,60 @@
   }
   .gn-card-badge {
     padding: 15px;
+    font-size: 100%;
     margin-top: 30px !important;
     color: #0e0e0e;
     position: absolute;
-    left: -5px;
-    bottom: 10px;
+    left: 0;
+    bottom: 0;
+    width: 100%;
+    text-align: left;
+    border-radius: 0;
+    &:before {
+      content: "\f077";
+      font-family: FontAwesome;
+      font-style: normal;
+      font-weight: normal;
+      text-decoration: inherit;
+      color: @gray-light;
+      font-size: 14px;
+      padding-top: 4px;
+      text-align: center;
+      background-color: @gray-lighter;
+      width: 30px;
+      height: 30px;
+      border-radius: 15px;
+      position: absolute;
+      display: block;
+      top: -15px;
+      left: calc(~"50% - 15px");
+    }
+    &:hover::before {
+      rotate: 180deg;
+      transition: rotate 0.35s;
+    }
+    .gn-truncate {
+      cursor: pointer;
+      width: calc(~"100% - 10px - 1.25em - 1.25em");
+      text-overflow: ellipsis;
+      overflow: hidden;
+      white-space: nowrap;
+      display: inline-block;
+      vertical-align: middle;
+      .gn-card-badge-sublabel {
+        display: none;
+      }
+    }
+    &:hover {
+      .gn-truncate {
+        white-space: normal;
+        line-height: 1.4em;
+        text-overflow: unset;
+        .gn-card-badge-sublabel {
+          display: inline-block;
+        }
+      }
+    }
   }
   .btn-block + .btn-block {
     margin-top: 0;

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_result_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_result_default.less
@@ -115,51 +115,6 @@
     width: 100%;
     text-align: left;
     border-radius: 0;
-    &:before {
-      content: "\f077";
-      font-family: FontAwesome;
-      font-style: normal;
-      font-weight: normal;
-      text-decoration: inherit;
-      color: @gray-light;
-      font-size: 14px;
-      padding-top: 4px;
-      text-align: center;
-      background-color: @gray-lighter;
-      width: 30px;
-      height: 30px;
-      border-radius: 15px;
-      position: absolute;
-      display: block;
-      top: -15px;
-      left: calc(~"50% - 15px");
-    }
-    &:hover::before {
-      rotate: 180deg;
-      transition: rotate 0.35s;
-    }
-    .gn-truncate {
-      cursor: pointer;
-      width: calc(~"100% - 10px - 1.25em - 1.25em");
-      text-overflow: ellipsis;
-      overflow: hidden;
-      white-space: nowrap;
-      display: inline-block;
-      vertical-align: middle;
-      .gn-card-badge-sublabel {
-        display: none;
-      }
-    }
-    &:hover {
-      .gn-truncate {
-        white-space: normal;
-        line-height: 1.4em;
-        text-overflow: unset;
-        .gn-card-badge-sublabel {
-          display: inline-block;
-        }
-      }
-    }
   }
   .btn-block + .btn-block {
     margin-top: 0;


### PR DESCRIPTION
Add icons for related types (association and initiative) in the editor and the footer of a card view. Where ever possible this PR adds icons in front of a link or label.

**The icons used**

<img width="628" alt="gn-related-icons" src="https://github.com/geonetwork/core-geonetwork/assets/19608667/a92ddbf9-3c57-4174-8da3-3a8d971cedfb">


In stead of a tooltip, the footer is expanded when you hover over it and the related types are displayed.

**Screenshot with the expanded footer**
<img width="1089" alt="gn-card-footer" src="https://github.com/geonetwork/core-geonetwork/assets/19608667/651f1501-32c6-4e3b-b439-5c19d116371e">
