### PR TITLE
Metadata editor / display metadata uuid for remote resources if the metadata title is not available

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/relatedEditorList.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/relatedEditorList.html
@@ -22,10 +22,10 @@
           data-ng-href="{{record.remoteUrl}}"
           rel="noopener noreferrer"
           target="_blank"
-          title="{{record.resourceTitle}}"
+          title="{{record.resourceTitle || record.uuid}}"
         >
           <i class="fa {{icon}}" />
-          {{record.resourceTitle}}
+          {{record.resourceTitle || record.uuid}}
           <i
             data-ng-if="record.origin === 'remote'"
             class="fa fa-external-link"


### PR DESCRIPTION
When a metadata references a remote resource, if the remote metadata title can not be processed, the entry was displaying an empty text in the metadata editor:

![empty-text](https://github.com/geonetwork/core-geonetwork/assets/1695003/65a5f631-23ae-4d5d-8a1f-386f4d5d8837)

With this change, it displays in these cases the metadata uuid:

![uuid-text](https://github.com/geonetwork/core-geonetwork/assets/1695003/2751f2be-1d78-46fc-82d6-d1448f74ade2)
