### PR TITLE
Metadata index set of records - index the approved and working copies when the workflow is enabled

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/search/index/OverviewIndexFieldUpdater.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/index/OverviewIndexFieldUpdater.java
@@ -1,3 +1,26 @@
+//=============================================================================
+//===	Copyright (C) 2001-2023 Food and Agriculture Organization of the
+//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
+//===	and United Nations Environment Programme (UNEP)
+//===
+//===	This program is free software; you can redistribute it and/or modify
+//===	it under the terms of the GNU General Public License as published by
+//===	the Free Software Foundation; either version 2 of the License, or (at
+//===	your option) any later version.
+//===
+//===	This program is distributed in the hope that it will be useful, but
+//===	WITHOUT ANY WARRANTY; without even the implied warranty of
+//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//===	General Public License for more details.
+//===
+//===	You should have received a copy of the GNU General Public License
+//===	along with this program; if not, write to the Free Software
+//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+//===
+//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+//===	Rome - Italy. email: geonetwork@osgeo.org
+//==============================================================================
+
 package org.fao.geonet.kernel.search.index;
 
 import org.apache.commons.lang.StringUtils;
@@ -20,13 +43,26 @@ public class OverviewIndexFieldUpdater {
     EsSearchManager searchManager;
 
     public void process(String uuid) {
+        processOverview(uuid);
+        processOverview(uuid + "-draft");
+    }
+
+    private ArrayList<HashMap<String, String>> getHitOverviews(Map<String, Object> fields) {
+        Object overviews = fields.get("overview");
+        if (overviews != null) {
+            return ((ArrayList) overviews);
+        }
+        return new ArrayList<>();
+    }
+
+    private void processOverview(String id) {
         Set<String> source = new HashSet<>();
         source.add("overview");
         SearchResponse response = null;
         try {
             response = searchManager.query(String.format(
-                "+uuid:\"%s\" _exists_:overview.url -_exists_:overview.data",
-                uuid), null, source, 0, 1);
+                "+id:\"%s\" _exists_:overview.url -_exists_:overview.data",
+                id), null, source, 0, 1);
             response.getHits().forEach(hit -> {
                 AtomicBoolean updates = new AtomicBoolean(false);
                 Map<String, Object> fields = hit.getSourceAsMap();
@@ -42,7 +78,7 @@ public class OverviewIndexFieldUpdater {
                     });
                 if (updates.get()) {
                     try {
-                        searchManager.updateFields(uuid, fields, source);
+                        searchManager.updateFields(id, fields, source);
                     } catch (Exception e) {
                         e.printStackTrace();
                     }
@@ -51,13 +87,5 @@ public class OverviewIndexFieldUpdater {
         } catch (Exception e) {
             e.printStackTrace();
         }
-    }
-
-    private ArrayList<HashMap<String, String>> getHitOverviews(Map<String, Object> fields) {
-        Object overviews = fields.get("overview");
-        if (overviews != null) {
-            return ((ArrayList) overviews);
-        }
-        return new ArrayList<>();
     }
 }

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataTagApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataTagApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2023 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -38,7 +38,9 @@ import org.fao.geonet.api.processing.report.MetadataProcessingReport;
 import org.fao.geonet.api.processing.report.SimpleMetadataProcessingReport;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.AbstractMetadata;
+import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.MetadataCategory;
+import org.fao.geonet.domain.MetadataDraft;
 import org.fao.geonet.domain.utils.ObjectJSONUtils;
 import org.fao.geonet.events.history.RecordCategoryChangeEvent;
 import org.fao.geonet.kernel.AccessManager;
@@ -192,8 +194,16 @@ public class MetadataTagApi {
             }
             fields.put(Geonet.IndexFieldNames.CAT, categories);
         }
-        searchManager.updateFields(metadata.getUuid(), fields,
-            Sets.newHashSet(new String[] {Geonet.IndexFieldNames.CAT}));
+
+        if (metadata instanceof MetadataDraft) {
+            searchManager.updateFields(metadata.getUuid() + "-draft", fields,
+                Sets.newHashSet(new String[] {Geonet.IndexFieldNames.CAT}));
+        } else {
+            searchManager.updateFields(metadata.getUuid(), fields,
+                Sets.newHashSet(new String[] {Geonet.IndexFieldNames.CAT}));
+        }
+
+
     }
 
     @io.swagger.v3.oas.annotations.Operation(


### PR DESCRIPTION
When the metadata workflow is enabled and a metadata has an approved and working copy, process both. 

The index code selects the metadata by uuid. In the original code, if the user was allowed to edit it, the working copy was indexed, otherwise the approved version. 

With this change both records are processed.