### PR TITLE
Sharing API error handling optional

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/MetadataSharingApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataSharingApi.java
@@ -558,7 +558,8 @@ public class MetadataSharingApi {
                 java.util.Optional<GroupOperations> allGroupOpsAfter =
                     privileges.stream().filter(p -> p.getGroup() == ReservedGroup.all.getId()).findFirst();
 
-                boolean publishedAfter = allGroupOpsAfter.get().getOperations().get(ReservedOperation.view.name());
+                // If we cannot find it then default to before value so that it will fail the next condition.
+                boolean publishedAfter = allGroupOpsAfter.isPresent()?allGroupOpsAfter.get().getOperations().getOrDefault(ReservedOperation.view.name(), publishedBefore):publishedBefore;
 
                 if (publishedBefore != publishedAfter) {
                     MetadataPublicationNotificationInfo metadataNotificationInfo = new MetadataPublicationNotificationInfo();


### PR DESCRIPTION
Handle empty allGroupOpsAfter instead of throwing error.

```
java.util.NoSuchElementException: No value present
	at java.util.Optional.get(Optional.java:135) ~[?:1.8.0_282]
	at org.fao.geonet.api.records.MetadataSharingApi.setOperations(MetadataSharingApi.java:561) ~[gn-services-4.4.0-SNAPSHOT.jar:?]
	at org.fao.geonet.api.records.MetadataSharingApi.share(MetadataSharingApi.java:335) ~[gn-services-4.4.0-SNAPSHOT.jar:?]
```

If we cannot find publishedAfter then default to publishedBefore so that no emails are sent.

**Reproduce**
To reproduce attempt to call sharing api with something like the following.

![image](https://github.com/geonetwork/core-geonetwork/assets/1868233/8f8135f7-ccf1-4766-b4d9-0970c75eb05b)


```
{
  "privileges": [
    {
      "operations": {
        "editing": true
      },
      "group": 100
    }
  ],
  "clear": false
}
```