### PR TITLE
Fix error that would occur when there were duplicate languages.

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/metadata.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/metadata.html
@@ -33,7 +33,7 @@
   <div>
     <h3 data-translate="">metadataLanguage</h3>
     <ul class="gn-comma-list">
-      <li data-ng-repeat="l in mdLanguages">{{l | translate}}</li>
+      <li data-ng-repeat="l in mdLanguages | unique">{{l | translate}}</li>
     </ul>
   </div>
 </div>


### PR DESCRIPTION
Fix issue that would occur on metadata that had duplication languages.

![image](https://github.com/geonetwork/core-geonetwork/assets/1868233/2e54c369-a10b-439b-bf22-0d8026cdc7f1)

Also the following would end up empty.
![image](https://github.com/geonetwork/core-geonetwork/assets/1868233/0cb4aa1f-4ccb-48b7-8fc1-a5ff3137fd9b)

 