### PR TITLE
Make samples loading fail if uuid already exists

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/MetadataSampleApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataSampleApi.java
@@ -125,7 +125,7 @@ public class MetadataSampleApi {
 
         Element params = new Element("params");
         params.addContent(new Element(Params.FILE_TYPE).setText("mef"));
-        params.addContent(new Element(Params.UUID_ACTION).setText(MEFLib.UuidAction.GENERATEUUID.toString()));
+        params.addContent(new Element(Params.UUID_ACTION).setText(MEFLib.UuidAction.NOTHING.toString()));
         for (String schemaName : schema) {
             Log.info(Geonet.DATA_MANAGER, "Loading sample data for schema "
                 + schemaName);

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataSampleApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataSampleApi.java
@@ -39,6 +39,7 @@ import org.fao.geonet.api.ApiUtils;
 import org.fao.geonet.api.processing.report.SimpleMetadataProcessingReport;
 import org.fao.geonet.api.tools.i18n.LanguageUtils;
 import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.constants.Params;
 import org.fao.geonet.domain.AbstractMetadata;
 import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.MetadataType;
@@ -123,8 +124,8 @@ public class MetadataSampleApi {
         UserSession userSession = ApiUtils.getUserSession(request.getSession());
 
         Element params = new Element("params");
-        params.addContent(new Element("file_type").setText("mef"));
-        params.addContent(new Element("uuidAction").setText("overwrite"));
+        params.addContent(new Element(Params.FILE_TYPE).setText("mef"));
+        params.addContent(new Element(Params.UUID_ACTION).setText(MEFLib.UuidAction.GENERATEUUID.toString()));
         for (String schemaName : schema) {
             Log.info(Geonet.DATA_MANAGER, "Loading sample data for schema "
                 + schemaName);


### PR DESCRIPTION
~~Make samples generate new uuid so that they don't overwrite any existing data.~~
Make samples loading fail if uuid already exists so that they don't overwrite any existing data.

Fix for #7274