### PR TITLE
Fix directive to display the most popular records, to display the most popular first

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/module.js
+++ b/web-ui/src/main/resources/catalog/views/default/module.js
@@ -78,6 +78,7 @@
         params: {
           isTemplate: "n",
           sortBy: "popularity",
+          sortOrder: "desc",
           from: 1,
           to: 12
         }


### PR DESCRIPTION
The home page displays the most popular metadata, but it displays them starting from the less popular.

Test case:

1) Load iso19139 samples
2) Access the metadata detail page for one of the metadata samples
3) In the search results, sort by popularity --> The previous metadata appears first
4) Go to the Home page -> Most popular 

  - Without the fix --> NO OK, the previous metadata appears the last one
  - With the fix --> the previous metadata appears the first one
