### PR TITLE
Add option to disable the time dimension in WMS services that support the time dimension, to retrieve the default image

### DIFF
--- a/web-ui/src/main/resources/catalog/components/viewer/layermanager/LayerManagerDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/layermanager/LayerManagerDirective.js
@@ -292,6 +292,8 @@
           scope.dimensions = {};
           scope.parameters = { time: "fa-clock-o", elevation: "fa-signal fa-rotate-90" };
 
+          scope.unsetTimeDimension = false;
+
           function initDimension(dimension) {
             var dimensionConfig = scope.layer.get(dimension);
             if (dimensionConfig) {
@@ -319,6 +321,19 @@
                 })
               };
               angular.extend(scope.dimensions[dimension], dimensionConfig);
+
+              scope.$watch("unsetTimeDimension", function (value) {
+                if (value) {
+                  scope.stop(dimension);
+
+                  delete scope.params[dimension.toUpperCase()];
+                  scope.layer.getSource().updateParams(scope.params);
+                } else {
+                  scope.params[dimension.toUpperCase()] =
+                    scope.dimensions[dimension].current;
+                  scope.layer.getSource().updateParams(scope.params);
+                }
+              });
 
               scope.$watch("dimensions." + dimension + ".current", function (instant) {
                 if (!instant) {

--- a/web-ui/src/main/resources/catalog/components/viewer/layermanager/partials/layerdimensions.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/layermanager/partials/layerdimensions.html
@@ -1,4 +1,4 @@
-<div data-ng-repeat="(dimension, icon) in parameters">
+<div data-ng-repeat="(dimension, icon) in parameters" data-ng-hide="unsetTimeDimension">
   <div
     data-ng-if="dimensions[dimension]"
     data-ng-init="config = dimensions[dimension]"
@@ -151,4 +151,8 @@
       ></option>
     </datalist>
   </div>
+</div>
+
+<div class="form-group">
+  <label><input type="checkbox" data-ng-model="unsetTimeDimension" /><span data-translate="">unsetTimeDimension</span></label>
 </div>

--- a/web-ui/src/main/resources/catalog/locales/en-search.json
+++ b/web-ui/src/main/resources/catalog/locales/en-search.json
@@ -549,5 +549,6 @@
   "fieldEmailNotValid": "A valid email address is required",
   "addLayerPrefix": "Add layer",
   "addLayerPostfix": "to the map",
-  "submit": "Submit"
+  "submit": "Submit",
+  "unsetTimeDimension": "Unset time dimension"
 }


### PR DESCRIPTION
Some WMS services with orthophotos composed of images taken at different times, use the time dimension. 

GeoNetwork 4 displays a slider to see the different images, but it's not possible to see the full orthophoto.

![wms-time-dimension](https://github.com/geonetwork/core-geonetwork/assets/1695003/b70ab4e0-6d9a-4f94-a963-d4fd91d06460)

This change adds an option to disable this feature, so the default value is returned, usually with all the images.

![wms-no-time-dimension](https://github.com/geonetwork/core-geonetwork/assets/1695003/85bb28fe-9ddb-4e4f-be8f-dd4ffda221b7)

--- 

Some issues pending:

- [ ] UI styling for the new option.
- [ ] When going to other application page, like the search and returning to the map, the option is not preserved.