### PR TITLE
DOI / ISO19115-3 / Support DOI set in resource identifier or distribution

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/datacite/view.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/datacite/view.xsl
@@ -159,8 +159,27 @@
       <xsl:choose>
         <xsl:when test="$doiId = ''">
           <xsl:variable name="doiFromMetadataLinkage"
-                        select="normalize-space(ancestor::mdb:MD_Metadata/mdb:metadataLinkage/*/cit:linkage/gco:CharacterString[starts-with(., $defaultDoiPrefix) or ../../cit:function/*/@codeListValue = 'doi'])"/>
-          <xsl:value-of select="$doiFromMetadataLinkage"/>
+                        select="normalize-space(ancestor::mdb:MD_Metadata/mdb:metadataLinkage/*/cit:linkage/gco:CharacterString[
+                                        starts-with(., $defaultDoiPrefix)])"/>
+          <xsl:if test="$doiFromMetadataLinkage != ''">
+            <xsl:value-of select="$doiFromMetadataLinkage"/>
+          </xsl:if>
+
+          <xsl:variable name="doiFromIdentifier"
+                        select="normalize-space(ancestor::mdb:MD_Metadata/mdb:identificationInfo/*/mri:citation/*/
+                                        cit:identifier/*/mcc:code[
+                                          starts-with(*/text(), $defaultDoiPrefix)
+                                          or starts-with(*/@xlink:href, $defaultDoiPrefix)])"/>
+          <xsl:if test="$doiFromMetadataLinkage = '' and $doiFromIdentifier != ''">
+            <xsl:value-of select="$doiFromIdentifier[1]"/>
+          </xsl:if>
+
+          <xsl:variable name="doiFromOnlineSrc"
+                        select="normalize-space(ancestor::mdb:MD_Metadata/mdb:distributionInfo//mrd:onLine/*[
+                                        matches(cit:protocol/gco:CharacterString, $doiProtocolRegex)]/cit:linkage/gco:CharacterString)"/>
+          <xsl:if test="$doiFromMetadataLinkage = '' and $doiFromIdentifier = '' and $doiFromOnlineSrc != ''">
+            <xsl:value-of select="$doiFromOnlineSrc"/>
+          </xsl:if>
         </xsl:when>
         <xsl:otherwise>
           <!-- Build a new one -->

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/datacite/view.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/datacite/view.xsl
@@ -158,6 +158,12 @@
       <!-- Return existing one -->
       <xsl:choose>
         <xsl:when test="$doiId = ''">
+          <!-- DOI can be located in different places depending on user practice.
+          At least we know three:
+          * metadata linkage (only in ISO19115-3)
+          * citation identifier
+          * onlineSrc
+          -->
           <xsl:variable name="doiFromMetadataLinkage"
                         select="normalize-space(ancestor::mdb:MD_Metadata/mdb:metadataLinkage/*/cit:linkage/gco:CharacterString[
                                         starts-with(., $defaultDoiPrefix)])"/>


### PR DESCRIPTION
DOI can be stored in different places depending on user convention:
* metadata linkage (only in ISO19115-3)
* resource identifier
* online link

Make DOI discovery more similar to ISO19139 (in case record are migrated from ISO19139) https://github.com/geonetwork/core-geonetwork/blob/main/schemas/iso19139/src/main/plugin/iso19139/formatter/datacite/view.xsl#L142

Datacite output is available at http://localhost:8080/geonetwork/srv/api/records/8a14572c-10c4-484e-9963-4dac4bec459b/formatters/datacite?output=xml