### PR TITLE
Do not break link in the middle of a word.

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -216,7 +216,6 @@ div[gn-transfer-ownership] * .list-group {
 
 a {
   word-wrap: break-word;
-  word-break: break-all;
 }
 .gn-break {
   word-wrap: break-word;
@@ -946,6 +945,11 @@ i.fa-times.delete:hover {
     }
     .gn-status-lg {
       font-size: inherit !important;
+    }
+    .gn-md-title {
+      a {
+        word-break: break-all;
+      }
     }
   }
 }


### PR DESCRIPTION
Do not break link in the middle of a word.

The breaking of links in a word is turned around, it's not for all links anymore but the break now has to be added to the exception in order to avoid side effects on the majority of links.