### PR TITLE
Standard / ISO / Mimefiletype encoding.

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/process/onlinesrc-add.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/process/onlinesrc-add.xsl
@@ -268,7 +268,7 @@
 
   <xsl:template name="setProtocol">
     <xsl:choose>
-      <xsl:when test="$mimeTypeStrategy = 'mimeType'">
+      <xsl:when test="$mimeTypeStrategy = 'mimeType' and $mimeType != ''">
         <gcx:MimeFileType type="{$mimeType}">
           <xsl:value-of select="$protocol"/>
         </gcx:MimeFileType>

--- a/schemas/iso19139/src/main/plugin/iso19139/process/onlinesrc-add.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/process/onlinesrc-add.xsl
@@ -518,7 +518,7 @@ Insert is made in first transferOptions found.
 
   <xsl:template name="setProtocol">
     <xsl:choose>
-      <xsl:when test="$mimeTypeStrategy = 'mimeType'">
+      <xsl:when test="$mimeTypeStrategy = 'mimeType' and $mimeType != ''">
         <gmx:MimeFileType type="{$mimeType}">
           <xsl:value-of select="$protocol"/>
         </gmx:MimeFileType>


### PR DESCRIPTION
Do not switch encoding of protocol if mimetype is empty. Preserve CharacterString if no mimetype.

Not all users are using the format for online source link. So avoid to create empty mime file type:
```xml
               <mrd:onLine>
                  <cit:CI_OnlineResource>
                     <cit:linkage>
                        <gco:CharacterString>https://service.pdok.nl/kadaster/wkpb/atom/v1_0/index.xml</gco:CharacterString>
                     </cit:linkage>
                     <cit:protocol>
                        <gcx:MimeFileType type="">INSPIRE Atom</gcx:MimeFileType>
                     </cit:protocol>
                     <cit:name>
                        <gco:CharacterString>dadadada</gco:CharacterString>
                     </cit:name>
                  </cit:CI_OnlineResource>
               </mrd:onLine>
```

To test, edit an online resource and do not set the format.

https://github.com/geonetwork/core-geonetwork/pull/6411