### PR TITLE
WMS tile images - if HEAD request fails, default to OL image src set

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -926,7 +926,8 @@
                       imageTile.getImage().src = imageUrl;
                     });
                   } else {
-                    console.warn("Error loading image for: " + src, r);
+                    // Other HEAD errors, default to OL image src set
+                    imageTile.getImage().src = src;
                   }
                 }
               );


### PR DESCRIPTION
It's unclear why was used `HEAD` instead of `GET` to retrieve the WMS tile images when loading WMS background layers in the map in the Add Thumbnail option in the metadata editor. 

Some services at least doesn't like that, returning an error 400.

![map-wms-error](https://github.com/geonetwork/core-geonetwork/assets/1695003/9387ad5f-7993-447a-b336-0f8e361fac8c)


