### PR TITLE
Indexing / Do not create empty object if no text

### DIFF
--- a/web/src/main/webapp/xslt/common/index-utils.xsl
+++ b/web/src/main/webapp/xslt/common/index-utils.xsl
@@ -294,35 +294,25 @@
         </xsl:for-each>
       </xsl:variable>
 
-      <xsl:choose>
-        <xsl:when test="count($textObject[. != '']) > 0">
-          <xsl:choose>
-            <xsl:when test="$asJson">
-              <xsl:if test="$isArray and position() = 1">[</xsl:if>
-              {<xsl:value-of select="string-join($textObject/text(), ', ')"/>}
-              <xsl:if test="$isArray and position() != last()">,</xsl:if>
-              <xsl:if test="$isArray and position() = last()">]</xsl:if>
-            </xsl:when>
-            <xsl:when test="$asXml">
-              <xsl:copy-of select="$textObject"/>
-            </xsl:when>
-            <xsl:otherwise>
-              <xsl:element name="{$fieldName}Object">
-                <xsl:attribute name="type" select="'object'"/>
-                {<xsl:value-of select="string-join($textObject/text(), ', ')"/>}
-              </xsl:element>
-            </xsl:otherwise>
-          </xsl:choose>
-        </xsl:when>
-        <xsl:otherwise>
-          <xsl:if test="not($asJson) and not($asXml)">
+      <xsl:if test="count($textObject[. != '']) > 0">
+        <xsl:choose>
+          <xsl:when test="$asJson">
+            <xsl:if test="$isArray and position() = 1">[</xsl:if>
+            {<xsl:value-of select="string-join($textObject/text(), ', ')"/>}
+            <xsl:if test="$isArray and position() != last()">,</xsl:if>
+            <xsl:if test="$isArray and position() = last()">]</xsl:if>
+          </xsl:when>
+          <xsl:when test="$asXml">
+            <xsl:copy-of select="$textObject"/>
+          </xsl:when>
+          <xsl:otherwise>
             <xsl:element name="{$fieldName}Object">
               <xsl:attribute name="type" select="'object'"/>
-              {}
+              {<xsl:value-of select="string-join($textObject/text(), ', ')"/>}
             </xsl:element>
-          </xsl:if>
-        </xsl:otherwise>
-      </xsl:choose>
+          </xsl:otherwise>
+        </xsl:choose>
+      </xsl:if>
     </xsl:for-each>
   </xsl:function>
 


### PR DESCRIPTION
When a CharacterString or an Anchor is empty, an empty object is created in the index. This is not necessary.

eg.
```xml
   <gmd:identificationInfo>
      <gmd:MD_DataIdentification>
         <gmd:citation>
            <gmd:CI_Citation>
               <gmd:title>
                  <gco:CharacterString>Biologische Waarderingskaart en Natura 2000 Habitat</gco:CharacterString>
               </gmd:title>
               <gmd:alternateTitle gco:nilReason="missing">
                  <gco:CharacterString/>
               </gmd:alternateTitle>
```

Index change:
![Pasted image](https://github.com/geonetwork/core-geonetwork/assets/1701393/577db7c5-9eb0-493b-97d2-44e35351f8e2)

This would avoid field label to be displayed with no value eg.
![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/dab432a6-89e7-4cd5-82a0-48819629266f)
