### PR TITLE
Create metadata category - check doesn't exist a category with the same name

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/categories/TagsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/categories/TagsApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2023 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -116,21 +116,30 @@ public class TagsApi {
             throw new IllegalArgumentException(String.format(
                 "A tag with id '%d' already exist", category.getId()
             ));
-        } else {
-            // Populate languages if not already set
-            java.util.List<Language> allLanguages = langRepository.findAll();
-            Map<String, String> labelTranslations = category.getLabelTranslations();
-            for (Language l : allLanguages) {
-                String label = labelTranslations.get(l.getId());
-                category.getLabelTranslations().put(l.getId(),
-                    label == null ? category.getName() : label);
-            }
-            categoryRepository.save(category);
-
-            translationPackBuilder.clearCache();
-
-            return new ResponseEntity(HttpStatus.NO_CONTENT);
         }
+
+        final MetadataCategory existingName = categoryRepository
+            .findOneByName(category.getName());
+        if (existingName != null) {
+            throw new IllegalArgumentException(String.format(
+                "A category with name '%s' already exist.",
+                category.getName()
+            ));
+        }
+
+        // Populate languages if not already set
+        java.util.List<Language> allLanguages = langRepository.findAll();
+        Map<String, String> labelTranslations = category.getLabelTranslations();
+        for (Language l : allLanguages) {
+            String label = labelTranslations.get(l.getId());
+            category.getLabelTranslations().put(l.getId(),
+                label == null ? category.getName() : label);
+        }
+        categoryRepository.save(category);
+
+        translationPackBuilder.clearCache();
+
+        return new ResponseEntity(HttpStatus.NO_CONTENT);
     }
 
     @io.swagger.v3.oas.annotations.Operation(


### PR DESCRIPTION
Currently is possible to create several metadata categories with the same name, that is used as a key value.

This change checks that the name is not used in another categories.

@fxprunayre some questions:

- Currently (also for Groups) is checked the same exact name, I think should be better to check with case insensitiveness?
- Not sure why not defined in as unique column in the model class? Although if we want to use case insensitiveness, probably not supported in all databases.
