### PR TITLE
Fix metadata editor tooltips close button when using the icon mode

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/FieldsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/FieldsDirective.js
@@ -368,7 +368,7 @@
                         tooltipsMode === "onhover" ? "hover" : isField ? "focus" : "click"
                     });
 
-                    if (tooltipsMode === "" || tooltipsMode === "onfocus") {
+                    if (tooltipsMode !== "onhover") {
                       // Remove first the event, to avoid ending with multiple events
                       // every time a new popup is displayed.
                       $(document)


### PR DESCRIPTION
Related to this change https://github.com/geonetwork/core-geonetwork/pull/6987 which caused the close button in the tooltip when using `icon` mode to not work.

![tooltip-close-button](https://github.com/geonetwork/core-geonetwork/assets/1695003/78c44a0e-d748-400f-b268-07fa1851c69e)
