### PR TITLE
INSPIRE ATOM - retrieve the metadata ATOM feed using only the resource identifier

### DIFF
--- a/inspire-atom/src/main/java/org/fao/geonet/inspireatom/harvester/InspireAtomHarvester.java
+++ b/inspire-atom/src/main/java/org/fao/geonet/inspireatom/harvester/InspireAtomHarvester.java
@@ -298,7 +298,7 @@ public class InspireAtomHarvester {
 
             try {
                 // Find the metadata UUID using the resource identifier gmd:MD_Identifier/gmd:code
-                metadataUuid = InspireAtomUtil.retrieveDatasetUuidFromIdentifier(ServiceContext.get(),
+                metadataUuid = InspireAtomUtil.retrieveDatasetUuidFromIdentifier(
                     gc.getBean(EsSearchManager.class), datasetFeedInfo.identifier);
 
                 String atomUrl = datasetFeedInfo.feedUrl;
@@ -376,7 +376,7 @@ public class InspireAtomHarvester {
             String metadataUuid = "";
 
             try {
-                metadataUuid = InspireAtomUtil.retrieveDatasetUuidFromIdentifier(context,
+                metadataUuid = InspireAtomUtil.retrieveDatasetUuidFromIdentifier(
                     gc.getBean(EsSearchManager.class), atomDatasetId);
 
                 String atomDatasetNs = datasetFeedInfo.namespace;

--- a/inspire-atom/src/main/java/org/fao/geonet/inspireatom/util/InspireAtomUtil.java
+++ b/inspire-atom/src/main/java/org/fao/geonet/inspireatom/util/InspireAtomUtil.java
@@ -1,5 +1,5 @@
 //=============================================================================
-//===	Copyright (C) 2001-2017 Food and Agriculture Organization of the
+//===	Copyright (C) 2001-2023 Food and Agriculture Organization of the
 //===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
 //===	and United Nations Environment Programme (UNEP)
 //===
@@ -24,7 +24,6 @@ package org.fao.geonet.inspireatom.util;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import jeeves.server.ServiceConfig;
 import jeeves.server.context.ServiceContext;
 import org.apache.commons.lang.StringUtils;
 import org.apache.lucene.search.TotalHits;
@@ -72,11 +71,6 @@ public class InspireAtomUtil {
     private static final String EXTRACT_DATASETS = "extract-datasets.xsl";
 
     /**
-     * Xslt process to get if a metadata is a service or a dataset.
-     **/
-    private static final String EXTRACT_MD_TYPE = "extract-type.xsl";
-
-    /**
      * Xslt process to get the atom feed link from the metadata.
      **/
     private static final String EXTRACT_ATOM_FEED = "extract-atom-feed.xsl";
@@ -115,6 +109,10 @@ public class InspireAtomUtil {
      * The download url suffix for download of dataset atom feeds.
      **/
     public static final String LOCAL_DOWNLOAD_DATASET_URL_SUFFIX = "atom/download/dataset";
+
+    private InspireAtomUtil() {
+
+    }
 
     /**
      * Issue an http request to retrieve the remote Atom feed document.
@@ -162,7 +160,7 @@ public class InspireAtomUtil {
                                               final String crs)
         throws Exception {
 
-        List<Element> elementsToRemove = new ArrayList<Element>();
+        List<Element> elementsToRemove = new ArrayList<>();
 
         Iterator it = feed.getChildren().iterator();
 
@@ -190,7 +188,7 @@ public class InspireAtomUtil {
     public static boolean isServiceMetadata(DataManager dm, String schema, Element md) throws Exception {
         java.nio.file.Path styleSheet = dm.getSchemaDir(schema).resolve("extract-type.xsl");
 
-        Map<String, Object> paramsM = new HashMap<String, Object>();
+        Map<String, Object> paramsM = new HashMap<>();
         String mdType = Xml.transform(md, styleSheet, paramsM).getText().trim();
 
         return "service".equalsIgnoreCase(mdType);
@@ -235,7 +233,7 @@ public class InspireAtomUtil {
 
         java.nio.file.Path defaultStyleSheet = dataManager.getSchemaDir("iso19139").resolve(EXTRACT_DATASETS_FROM_SERVICE_XSLT);
 
-        Map<String, Object> params = new HashMap<String, Object>();
+        Map<String, Object> params = new HashMap<>();
         Element atomIndexFields = Xml.transform(serviceFeed, defaultStyleSheet, params);
 
         List<DatasetFeedInfo> datasetsInformation = new ArrayList<>();
@@ -287,7 +285,7 @@ public class InspireAtomUtil {
                                                                 List<AbstractMetadata> iso19139Metadata, String type,
                                                                 String atomProtocol) throws Exception {
 
-        Map<String, String> metadataAtomFeeds = new HashMap<String, String>();
+        Map<String, String> metadataAtomFeeds = new HashMap<>();
 
         for (AbstractMetadata md : iso19139Metadata) {
             int id = md.getId();
@@ -386,8 +384,7 @@ public class InspireAtomUtil {
     }
 
 
-    public static String retrieveDatasetUuidFromIdentifier(ServiceContext context,
-                                                           EsSearchManager searchMan,
+    public static String retrieveDatasetUuidFromIdentifier(EsSearchManager searchMan,
                                                            String datasetIdCode) {
         String jsonQuery = "{" +
             "    \"bool\": {" +
@@ -515,34 +512,20 @@ public class InspireAtomUtil {
             .resolve(TRANSFORM_MD_TO_ATOM_FEED);
     }
 
-    public static Element getDatasetFeed(final ServiceContext context, final String spIdentifier,
-                                         final String spNamespace, final Map<String, Object> params, String requestedLanguage) throws Exception {
+    public static Element getMetadataFeedByResourceIdentifier(final ServiceContext context, final String spIdentifier,
+                                                              final String spNamespace, final Map<String, Object> params, String requestedLanguage) throws Exception {
 
-        ServiceConfig config = new ServiceConfig();
         EsSearchManager searchMan = context.getBean(EsSearchManager.class);
 
         // Search for the dataset identified by spIdentifier
         AbstractMetadata datasetMd = null;
 
         String jsonQuery = "{" +
-            "    \"bool\": {" +
-            "      \"must\": [" +
-            "        {" +
-            "          \"term\": {" +
-            "            \"resourceType\": {" +
-            "              \"value\": \"%s\"" +
-            "            }" +
-            "          }" +
-            "        }, " +
-            "        {" +
-            "          \"term\": {" +
-            "            \"resourceIdentifier.code\": {" +
-            "              \"value\": \"%s\"" +
-            "            }" +
-            "          }" +
-            "        }" +
-            "      ]" +
-            "    }" +
+            "     \"term\": {" +
+            "       \"resourceIdentifier.code\": {" +
+            "         \"value\": \"%s\"" +
+            "       }" +
+            "     }" +
             "}";
         ObjectMapper objectMapper = new ObjectMapper();
         IMetadataUtils repo = context.getBean(IMetadataUtils.class);
@@ -563,7 +546,7 @@ public class InspireAtomUtil {
 //                        searchResult = searcher.present(context, dsLuceneSearchParams.getRootElement(), config);
 //                    }
 //                }
-            JsonNode esJsonQuery = objectMapper.readTree(String.format(jsonQuery, "dataset", spIdentifier));
+            JsonNode esJsonQuery = objectMapper.readTree(String.format(jsonQuery, spIdentifier));
 
             final SearchResponse result = searchMan.query(
                 esJsonQuery,
@@ -646,9 +629,9 @@ public class InspireAtomUtil {
     }
 
     public static Element prepareOpenSearchDescriptionEltBeforeTransform(final ServiceContext context,
-                                                                         final Map<String, Object> params, final String fileIdentifier, final String schema,
-                                                                         final Element serviceAtomFeed, final String defaultLanguage,
-                                                                         final DataManager dataManager) throws Exception {
+                                                                         final Map<String, Object> params, final String fileIdentifier,
+                                                                         final Element serviceAtomFeed, final String defaultLanguage
+    ) throws Exception {
 
         List<String> keywords = retrieveKeywordsFromFileIdentifier(context, fileIdentifier);
         Namespace ns = serviceAtomFeed.getNamespace();
@@ -658,7 +641,7 @@ public class InspireAtomUtil {
         response.addContent(new Element("fileId").setText(fileIdentifier));
         response.addContent(new Element("title").setText(serviceAtomFeed.getChildText("title", ns)));
         response.addContent(new Element("subtitle").setText(serviceAtomFeed.getChildText("subtitle", ns)));
-        List<String> languages = new ArrayList<String>();
+        List<String> languages = new ArrayList<>();
         languages.add(XslUtil.twoCharLangCode(defaultLanguage));
         Iterator<Element> linksChildren = (serviceAtomFeed.getChildren("link", ns)).iterator();
         while (linksChildren.hasNext()) {
@@ -685,7 +668,7 @@ public class InspireAtomUtil {
         response.addContent(datasetsEl);
         Namespace inspiredlsns = serviceAtomFeed.getNamespace("inspire_dls");
         Iterator<Element> datasets = (serviceAtomFeed.getChildren("entry", ns)).iterator();
-        List<String> fileTypes = new ArrayList<String>();
+        List<String> fileTypes = new ArrayList<>();
         while (datasets.hasNext()) {
             Element dataset = datasets.next();
             String datasetIdCode = dataset.getChildText("spatial_dataset_identifier_code", inspiredlsns);
@@ -693,7 +676,7 @@ public class InspireAtomUtil {
 
             Element datasetAtomFeed = null;
             try {
-                datasetAtomFeed = InspireAtomUtil.getDatasetFeed(context, datasetIdCode, datasetIdNs, params, XslUtil.twoCharLangCode(defaultLanguage));
+                datasetAtomFeed = InspireAtomUtil.getMetadataFeedByResourceIdentifier(context, datasetIdCode, datasetIdNs, params, XslUtil.twoCharLangCode(defaultLanguage));
             } catch (Exception e) {
                 Log.error(Geonet.ATOM, "No dataset metadata found with uuid:"
                     + fileIdentifier);
@@ -708,7 +691,7 @@ public class InspireAtomUtil {
                     datasetEl.addContent(new Element("authorName").setText(authorName));
                 }
             }
-            Map<String, Integer> downloadsCountByCrs = new HashMap<String, Integer>();
+            Map<String, Integer> downloadsCountByCrs = new HashMap<>();
             Iterator<Element> entries = (datasetAtomFeed.getChildren("entry", ns)).iterator();
             while (entries.hasNext()) {
                 Element entry = entries.next();
@@ -717,7 +700,7 @@ public class InspireAtomUtil {
                     String term = category.getAttributeValue("term");
                     Integer count = downloadsCountByCrs.get(term);
                     if (count == null) {
-                        count = new Integer(0);
+                        count = 0;
                     }
                     downloadsCountByCrs.put(term, count + 1);
                 }
@@ -820,15 +803,13 @@ public class InspireAtomUtil {
 
     public static List<String> retrieveKeywordsFromFileIdentifier(ServiceContext context, String uuid) {
         EsSearchManager searchManager = context.getBean(EsSearchManager.class);
-        List<String> keywordsList = new ArrayList<String>();
+        List<String> keywordsList = new ArrayList<>();
         try {
             Map<String, Object> document = searchManager.getDocument(uuid);
             Object tags = document.get("tag");
             if (tags instanceof List) {
                 ArrayList<HashMap<String, String>> list = (ArrayList) tags;
-                list.forEach(tag -> {
-                    keywordsList.add(tag.get("default"));
-                });
+                list.forEach(tag -> keywordsList.add(tag.get("default")));
             }
         } catch (Exception ex) {
             Log.error(Geonet.ATOM, ex.getMessage(), ex);

--- a/inspire-atom/src/main/java/org/fao/geonet/services/inspireatom/AtomPredefinedFeed.java
+++ b/inspire-atom/src/main/java/org/fao/geonet/services/inspireatom/AtomPredefinedFeed.java
@@ -139,7 +139,7 @@ public class AtomPredefinedFeed {
         if (StringUtils.isNotBlank(searchTerms)) {
             params.put("searchTerms", searchTerms.toLowerCase());
         }
-        Element feed = InspireAtomUtil.getDatasetFeed(context, spIdentifier, spNamespace, params, language);
+        Element feed = InspireAtomUtil.getMetadataFeedByResourceIdentifier(context, spIdentifier, spNamespace, params, language);
         return writeOutResponse(Xml.getString(feed), "application", "atom+xml");
     }
 
@@ -247,7 +247,7 @@ public class AtomPredefinedFeed {
         if (StringUtils.isNotBlank(searchTerms)) {
             params.put("searchTerms", searchTerms.toLowerCase());
         }
-        Element feed = InspireAtomUtil.getDatasetFeed(context, spIdentifier, spNamespace, params, language);
+        Element feed = InspireAtomUtil.getMetadataFeedByResourceIdentifier(context, spIdentifier, spNamespace, params, language);
         Map<Integer, Element> crsCounts = new HashMap<Integer, Element>();;
         Namespace ns = Namespace.getNamespace("http://www.w3.org/2005/Atom");
         if (crs!=null) {
@@ -368,7 +368,9 @@ public class AtomPredefinedFeed {
         String defaultLanguage = dm.extractDefaultLanguage(schema, md);
         Map<String, Object> params = getDefaultXSLParams(sm, context, XslUtil.twoCharLangCode(defaultLanguage));
 
-        Element inputDoc = InspireAtomUtil.prepareOpenSearchDescriptionEltBeforeTransform(context, params, uuid, schema, InspireAtomUtil.convertDatasetMdToAtom("iso19139", InspireAtomUtil.prepareServiceFeedEltBeforeTransform(schema, md, dm), dm, params), defaultLanguage, dm);
+        Element inputDoc = InspireAtomUtil.prepareOpenSearchDescriptionEltBeforeTransform(context, params, uuid,
+            InspireAtomUtil.convertDatasetMdToAtom("iso19139",
+                InspireAtomUtil.prepareServiceFeedEltBeforeTransform(schema, md, dm), dm, params), defaultLanguage);
 
         return InspireAtomUtil.convertServiceMdToOpenSearchDescription(context, inputDoc, params);
     }


### PR DESCRIPTION
Support series metadata linked in INSPIRE ATOM services in the ATOM dataset describe service, otherwise a 404 error is returned in requests like this for series metadata.

https://localhostgeonetwork/srv/atom/describe/dataset?spatial_dataset_identifier_code=https://doi.org/10.11/3028ccf4-ff64-42ed-98f5-fea1b32da62a&language=de