### PR TITLE
Fix the check to display the Transfer ownership option in the metadata detail page

### DIFF
--- a/web-ui/src/main/resources/catalog/components/catalog/CatalogService.js
+++ b/web-ui/src/main/resources/catalog/components/catalog/CatalogService.js
@@ -786,7 +786,7 @@
           return this.valid > -1;
         },
         isOwned: function () {
-          return this.owner === "true";
+          return this.owner === true;
         },
         getOwnerId: function () {
           return this.ownerId;


### PR DESCRIPTION
The option to transfer the metadata ownership in Manage record menu of the metadata detail page was not displayed due to wrong check. 

In 3.12.x the value returned was a string and the check worked, but in 4.x the value is a boolean.

