### PR TITLE
Display metadata user and group owner in the transfer ownership dialog

### DIFF
--- a/web-ui/src/main/resources/catalog/components/catalog/CatalogService.js
+++ b/web-ui/src/main/resources/catalog/components/catalog/CatalogService.js
@@ -792,7 +792,7 @@
           return this.ownerId;
         },
         getGroupOwner: function () {
-          return this.owner;
+          return this.groupOwner;
         },
         getSchema: function () {
           return this.schema;

--- a/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionsDirective.js
@@ -728,6 +728,21 @@
           scope.userGroupDefined = false;
           scope.userGroups = null;
 
+          scope.ownerUserName = "";
+          scope.ownerGroupName = "";
+
+          if (ownerId) {
+            $http.get("../api/users/" + ownerId).then(function (response) {
+              scope.ownerUserName = response.data.username;
+            });
+          }
+
+          if (groupOwner) {
+            $http.get("../api/groups/" + groupOwner).then(function (response) {
+              scope.ownerGroupName = response.data.name;
+            });
+          }
+
           scope.selectGroup = function (group) {
             scope.selectedGroup = group;
           };

--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/transferownership.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/transferownership.html
@@ -1,5 +1,14 @@
 <div class="row">
   <div class="col-md-12" data-ng-show="userGroupDefined">
+    <p data-ng-if="ownerUserName">
+      <span data-translate="">recordOwner</span>: <span>{{ ownerUserName }}</span>
+    </p>
+    <p data-ng-if="ownerGroupName">
+      <span data-translate="">groupRecordOwner</span>: <span>{{ ownerGroupName }}</span>
+    </p>
+
+    <hr data-ng-if="ownerUserName || ownerGroupName" />
+
     <select
       class="form-control"
       data-ng-model="selectedUserGroup"

--- a/web-ui/src/main/resources/catalog/locales/en-core.json
+++ b/web-ui/src/main/resources/catalog/locales/en-core.json
@@ -157,6 +157,7 @@
     "keywordFilter": "Filter keyword",
     "keywords": "Keywords",
     "recordOwner": "Record owner",
+    "groupRecordOwner": "Group record owner",
     "map": "Map",
     "makeYourMap": "Map",
     "metadataPOCs": "Contact for the metadata",


### PR DESCRIPTION
Also fixes a wrong property name in `CatalogService.js`, `getGroupOwner` method.

![transferownership](https://github.com/geonetwork/core-geonetwork/assets/1695003/bf7bc87a-0427-4e79-b3fd-54b2b7e10020)
