### PR TITLE
WFS layer improvements

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/ows/OWSService.js
+++ b/web-ui/src/main/resources/catalog/components/common/ows/OWSService.js
@@ -589,12 +589,14 @@
                 name == layers[i].name.prefix + ":" + layers[i].name.localPart ||
                 name == layers[i].Name
               ) {
-                return layers[i];
+                needles.push(layers[i]);
+                continue;
               }
 
               //check title
               if (name == layers[i].title || name == layers[i].Title) {
-                return layers[i];
+                needles.push(layers[i]);
+                continue;
               }
 
               //check dataset identifer match
@@ -626,6 +628,9 @@
 
             //FIXME: allow multiple, remove duplicates
             if (needles.length > 0) {
+              if (capObj.version) {
+                needles[0].version = capObj.version;
+              }
               return needles[0];
             } else {
               return;

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -1309,7 +1309,9 @@
                           function (l) {
                             if (angular.isDefined(l.name)) {
                               scope.layers.push({
-                                Name: l.name.prefix + ":" + l.name.localPart,
+                                Name:
+                                  (l.name.prefix ? l.name.prefix + ":" : "") +
+                                  l.name.localPart,
                                 abstract: angular.isArray(l._abstract)
                                   ? l._abstract[0].value
                                   : l._abstract,


### PR DESCRIPTION
QGIS Server may not advertised namespace for feature type eg. https://geodata.valenceromansagglo.fr/api/ogc?SERVICE=WFS&REQUEST=GetCapabilities or https://sextant.ifremer.fr/services/wfs/ilico?service=WFS&request=GetCapabilities

Add the missing version parameter to the layer to properly add the layer.

We also have a `useProxy` property which does not look to be set for WFS layer - not sure if it is needed?