### PR TITLE
Hide thumbnail image in metadata page when the image can't be loaded due to an error.

### DIFF
--- a/schemas/dublin-core/src/main/plugin/dublin-core/formatter/xsl-view/view.xsl
+++ b/schemas/dublin-core/src/main/plugin/dublin-core/formatter/xsl-view/view.xsl
@@ -88,12 +88,18 @@
                     select="(dct:references|dc:relation)[
                               normalize-space(.) != ''
                               and matches(., '.*(.gif|.png|.jpeg|.jpg)$', 'i')]"/>
+
+      <xsl:variable name="imgOnError" as="xs:string?"
+                    select="if (count($overviews) > 1)
+                            then 'this.onerror=null; this.style.display=''none'';'
+                            else 'this.onerror=null; $(''.gn-md-side-overview'').hide();'"/>
+
       <xsl:for-each select="$overviews">
         <img data-gn-img-modal="md"
              class="gn-img-thumbnail"
              alt="{$schemaStrings/overview}"
              src="{.}"
-             onerror="this.onerror=null; $('.gn-md-side-overview').hide()"/>
+             onerror="{$imgOnError}"/>
       </xsl:for-each>
     </section>
   </xsl:template>

--- a/schemas/dublin-core/src/main/plugin/dublin-core/formatter/xsl-view/view.xsl
+++ b/schemas/dublin-core/src/main/plugin/dublin-core/formatter/xsl-view/view.xsl
@@ -92,7 +92,8 @@
         <img data-gn-img-modal="md"
              class="gn-img-thumbnail"
              alt="{$schemaStrings/overview}"
-             src="{.}"/>
+             src="{.}"
+             onerror="this.onerror=null; $('.gn-md-side-overview').hide()"/>
       </xsl:for-each>
     </section>
   </xsl:template>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/xsl-view/view.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/xsl-view/view.xsl
@@ -253,7 +253,8 @@
           <img data-gn-img-modal="md"
                class="gn-img-thumbnail center-block"
                alt="{$schemaStrings/overview}"
-               src="{mcc:fileName/*}"/>
+               src="{mcc:fileName/*}"
+               onerror="this.onerror=null; $('.gn-md-side-overview').hide()"/>
 
           <xsl:for-each select="mcc:fileDescription">
             <div class="gn-img-thumbnail-caption">

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/xsl-view/view.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/xsl-view/view.xsl
@@ -249,20 +249,27 @@
           </span>
         </h2>
 
-        <xsl:for-each select="mdb:identificationInfo/*/mri:graphicOverview/*">
-          <img data-gn-img-modal="md"
-               class="gn-img-thumbnail center-block"
-               alt="{$schemaStrings/overview}"
-               src="{mcc:fileName/*}"
-               onerror="this.onerror=null; $('.gn-md-side-overview').hide()"/>
+        <xsl:variable name="imgOnError" as="xs:string?"
+                      select="if (count(mdb:identificationInfo/*/mri:graphicOverview/*) > 1)
+                            then 'this.onerror=null; this.parentElement.style.display=''none'';'
+                            else 'this.onerror=null; $(''.gn-md-side-overview'').hide();'"/>
 
-          <xsl:for-each select="mcc:fileDescription">
-            <div class="gn-img-thumbnail-caption">
-              <xsl:call-template name="get-iso19115-3.2018-localised">
-                <xsl:with-param name="langId" select="$langId"/>
-              </xsl:call-template>
-            </div>
-          </xsl:for-each>
+        <xsl:for-each select="mdb:identificationInfo/*/mri:graphicOverview/*">
+          <div>
+            <img data-gn-img-modal="md"
+                 class="gn-img-thumbnail center-block"
+                 alt="{$schemaStrings/overview}"
+                 src="{mcc:fileName/*}"
+                 onerror="{$imgOnError}"/>
+
+            <xsl:for-each select="mcc:fileDescription">
+              <div class="gn-img-thumbnail-caption">
+                <xsl:call-template name="get-iso19115-3.2018-localised">
+                  <xsl:with-param name="langId" select="$langId"/>
+                </xsl:call-template>
+              </div>
+            </xsl:for-each>
+          </div>
         </xsl:for-each>
       </section>
     </xsl:if>

--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
@@ -223,21 +223,27 @@
         </span>
       </h2>
 
+      <xsl:variable name="imgOnError" as="xs:string?"
+                    select="if (count(gmd:identificationInfo/*/gmd:graphicOverview/*) > 1)
+                            then 'this.onerror=null; this.parentElement.style.display=''none'';'
+                            else 'this.onerror=null; $(''.gn-md-side-overview'').hide();'"/>
+
       <xsl:for-each select="gmd:identificationInfo/*/gmd:graphicOverview/*">
-        <img data-gn-img-modal="md"
-             class="gn-img-thumbnail"
-             alt="{$schemaStrings/overview}"
-             src="{gmd:fileName/*}"
-             onerror="this.onerror=null; $('.gn-md-side-overview').hide()"/>
+        <div>
+          <img data-gn-img-modal="md"
+               class="gn-img-thumbnail"
+               alt="{$schemaStrings/overview}"
+               src="{gmd:fileName/*}"
+               onerror="{$imgOnError}" />
 
-        <xsl:for-each select="gmd:fileDescription">
-          <div class="gn-img-thumbnail-caption">
-            <xsl:call-template name="localised">
-              <xsl:with-param name="langId" select="$langId"/>
-            </xsl:call-template>
-          </div>
-        </xsl:for-each>
-
+          <xsl:for-each select="gmd:fileDescription">
+            <div class="gn-img-thumbnail-caption">
+              <xsl:call-template name="localised">
+                <xsl:with-param name="langId" select="$langId"/>
+              </xsl:call-template>
+            </div>
+          </xsl:for-each>
+        </div>
       </xsl:for-each>
     </section>
   </xsl:template>

--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
@@ -227,7 +227,8 @@
         <img data-gn-img-modal="md"
              class="gn-img-thumbnail"
              alt="{$schemaStrings/overview}"
-             src="{gmd:fileName/*}"/>
+             src="{gmd:fileName/*}"
+             onerror="this.onerror=null; $('.gn-md-side-overview').hide()"/>
 
         <xsl:for-each select="gmd:fileDescription">
           <div class="gn-img-thumbnail-caption">

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/thumbnails.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/thumbnails.html
@@ -6,6 +6,7 @@
       alt="{{'overview' | translate}}"
       title="{{img.name}}"
       data-ng-src="{{img.url}}"
+      onerror="this.onerror=null; this.style.display='none';"
     />
     <p class="text-center" data-ng-if="img.name != ''">{{img.name}}</p>
   </li>

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/thumbnails.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/thumbnails.html
@@ -6,7 +6,7 @@
       alt="{{'overview' | translate}}"
       title="{{img.name}}"
       data-ng-src="{{img.url}}"
-      onerror="this.onerror=null; this.style.display='none';"
+      onerror="this.onerror=null; this.parentElement.style.display='none';"
     />
     <p class="text-center" data-ng-if="img.name != ''">{{img.name}}</p>
   </li>


### PR DESCRIPTION
Test case:

1) Create an iso19139 metadata and upload a thumbnail file.

2) Set the visibility to private.

3) Assign the privileges of the metadata to the group `ALL` without the `Download` privilege.

4) Access the metadata detail page with an anonymous user

Previously:

![missing-image](https://github.com/geonetwork/core-geonetwork/assets/1695003/9fecd18c-a77f-42f2-af58-c53c0aa16184)

With the change:

![hidden-image](https://github.com/geonetwork/core-geonetwork/assets/1695003/784d739a-4090-4899-922f-a21b2fe6d978)

5) Check also the full view formatter
