### PR TITLE
API / Sitemap / Improve speed when using URL template

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataUtils.java
@@ -360,17 +360,20 @@ public class BaseMetadataUtils implements IMetadataUtils {
 
     private String buildUrl(String uuid, String language, String url) {
         if (StringUtils.isNotEmpty(url)) {
+            String upperCaseUrl = url.toUpperCase();
             Map<String, String> substitutions = new HashMap<>();
             substitutions.put("{{UUID}}", uuid);
             substitutions.put("{{LANG}}", StringUtils.isEmpty(language) ? "" : language);
-            try {
-                String resourceId = getResourceIdentifier(uuid);
-                substitutions.put("{{RESOURCEID}}", StringUtils.isEmpty(resourceId) ? "" : resourceId);
-            } catch (Exception e) {
-                // No resource identifier xpath defined in schema
+            if (upperCaseUrl.contains("{{RESOURCEID}}")) {
+                try {
+                    String resourceId = getResourceIdentifier(uuid);
+                    substitutions.put("{{RESOURCEID}}", StringUtils.isEmpty(resourceId) ? "" : resourceId);
+                } catch (Exception e) {
+                    // No resource identifier xpath defined in schema
+                }
             }
             for (Map.Entry<String, String> s : substitutions.entrySet()) {
-                if (url.toUpperCase().contains(s.getKey())) {
+                if (upperCaseUrl.contains(s.getKey())) {
                     url = url.replaceAll("(?i)" + Pattern.quote(s.getKey()), s.getValue());
                 }
             }


### PR DESCRIPTION
Follow up of https://github.com/geonetwork/core-geonetwork/pull/6792. 

When sitemap is using a custom URL template, only collect resource identifier if the template contain the resource identifier key.  This avoid doing XPath query on all records in the page (2500) which is quite time consuming. A default sitemap is generated in ~200ms, when adding DOI or Resource identifier, it takes usually more than 30s.

API call http://localhost:8080/geonetwork/srv/api/sitemap?format=html&doc=1