### PR TITLE
Prevent invalid date written into xml

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/datepicker/DatePickerDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/datepicker/DatePickerDirective.js
@@ -257,7 +257,12 @@
               tag = scope.tagName !== undefined ? scope.tagName : "gco:DateTime";
               var time = $filter("date")(scope.time, "HH:mm:ss");
               // TODO: Set seconds, Timezone ?
-              scope.dateTime = $filter("date")(scope.date, "yyyy-MM-dd");
+              if (scope.date =='Invalid Date') {
+                scope.dateTime = '';
+              } else {
+                scope.dateTime = $filter("date")(scope.date, "yyyy-MM-dd");
+              }
+
               scope.dateTime += "T" + time + scope.timezone;
             } else {
               scope.dateTime = $filter("date")(scope.date, "yyyy-MM-dd");


### PR DESCRIPTION
This issue happens in both GN4 and lower versions (3.12).

If the user select datetime for the field, pick a time but not a date.
![image](https://github.com/geonetwork/core-geonetwork/assets/74916635/12aec355-e0c4-4db4-91ab-1d316b2ab8ba)


switch between xml view and UI view at least two times (or validate the records couple of times).
The "Invalid Date" string was put to the xml.

![image](https://github.com/geonetwork/core-geonetwork/assets/74916635/2c32c066-4070-4246-9cff-fe17c9ee4fa3)


