### PR TITLE
Metadata editor / link to remote dataset improvements

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -270,14 +270,12 @@
                 // No UUID can be easily extracted.
                 try {
                   scope.remoteRecord.title = doc.replace(
-                    /(.|[\r\n])*<title>(.*)<\/title>(.|[\r\n])*/,
-                    "$2"
+                    /(.|[\r\n])*<title(.*)>(.*)<\/title>(.|[\r\n])*/,
+                    "$3"
                   );
+
                   scope.remoteRecord.uuid = scope.remoteRecord.remoteUrl;
 
-                  if (scope.remoteRecord.title === "") {
-                    return false;
-                  }
                   // Looking for schema.org tags or json+ld format could also be an option.
                 } catch (e) {
                   console.warn(e);
@@ -1937,6 +1935,24 @@
 
                 scope.updateParams = function () {
                   scope.searchObj.params.any = scope.searchObj.any;
+                };
+
+                /**
+                 * Checks if there are selected records and the selected records have a title.
+                 *
+                 * @param selectRecords
+                 * @returns {boolean}
+                 */
+                scope.canEnableLinkButton = function (selectRecords) {
+                  if (selectRecords.length < 1) return false;
+
+                  // Check if the metadata titles are defined
+                  for (var i = 0; i < selectRecords.length; i++) {
+                    if (!selectRecords[i].title && !selectRecords[i].resourceTitle)
+                      return false;
+                  }
+
+                  return true;
                 };
 
                 /**

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
@@ -395,7 +395,8 @@
                   />
                 </div>
               </div>
-              <div class="col-sm-9 col-xs-9 "
+              <div
+                class="col-sm-9 col-xs-9"
                 data-ng-if="params.linkType.fields.desc.directive === 'gn-multientry-combiner-online-resources-description'"
               >
                 <div

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/linkToMd.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/linkToMd.html
@@ -35,7 +35,7 @@
         type="button"
         class="btn navbar-btn btn-success"
         data-gn-click-and-spin="gnOnlinesrc.linkToMd(mode, selectRecords[0], popupid)"
-        ng-disabled="(selectRecords.length < 1)"
+        ng-disabled="!canEnableLinkButton(selectRecords)"
       >
         <i class="fa gn-icon-{{mode}}" />
         <i class="icon-external-link"></i>&nbsp; {{btn.label}}

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/remote-record-selector.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/remote-record-selector.html
@@ -28,7 +28,7 @@
     </div>
   </form>
 
-  <div class="list-group" data-ng-if="remoteRecord.uuid">
+  <div class="col-md-offset-2 list-group" data-ng-if="remoteRecord.uuid">
     <li
       class="list-group-item"
       data-ng-click="updateSelection();triggerSearch();"

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/remote-record-selector.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/remote-record-selector.html
@@ -1,4 +1,4 @@
-<div data-ng-if="allowRemoteRecordLink">
+<div data-ng-if="allowRemoteRecordLink" xmlns="http://www.w3.org/1999/html">
   <form class="form-horizontal">
     <div class="form-group">
       <label for="gnRemoteRecordUrl" class="control-label col-sm-2" data-translate=""
@@ -28,13 +28,18 @@
     </div>
   </form>
 
-  <div class="list-group" data-ng-if="remoteRecord.title">
+  <div class="list-group" data-ng-if="remoteRecord.uuid">
     <li
       class="list-group-item"
       data-ng-click="updateSelection();triggerSearch();"
       data-ng-class="{'active' : selectionList[0].uuid === remoteRecord.uuid}"
     >
-      {{remoteRecord.title}} ({{remoteRecord.uuid}})
+      <input
+        type="text"
+        class="form-control"
+        data-ng-model="remoteRecord.title"
+        placeholder="{{'remoteAssociatedMetadataTitlePlaceholder' | translate}}"
+      />
     </li>
   </div>
 

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/remote-record-selector.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/remote-record-selector.html
@@ -39,7 +39,7 @@
         class="form-control"
         data-ng-model="remoteRecord.title"
         placeholder="{{'remoteAssociatedMetadataTitlePlaceholder' | translate}}"
-      />
+      /> ({{remoteRecord.uuid}})
     </li>
   </div>
 

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/remote-record-selector.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/remote-record-selector.html
@@ -1,4 +1,4 @@
-<div data-ng-if="allowRemoteRecordLink" xmlns="http://www.w3.org/1999/html">
+<div data-ng-if="allowRemoteRecordLink">
   <form class="form-horizontal">
     <div class="form-group">
       <label for="gnRemoteRecordUrl" class="control-label col-sm-2" data-translate=""

--- a/web-ui/src/main/resources/catalog/locales/en-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/en-editor.json
@@ -428,5 +428,6 @@
     "confirmCancelEdit": "Do you want to cancel all changes and close the editor?",
     "allowEditGroupMembers": "Allow group editors to edit",
     "wmsSelectedLayers": "Selected layers",
-    "wmsSelectedLayersNone": "No layers selected"
+    "wmsSelectedLayersNone": "No layers selected",
+    "remoteAssociatedMetadataTitlePlaceholder": "Remote associated metadata title"
 }


### PR DESCRIPTION
- Improve the title extraction For HTML links, to support title elements with attributes.
- Allow to define a custom title for the remote dataset link.

Currently if linking to a web page without title information, the title for the link was assigned to the full html.

With this change, the user can define a custom title for the remote dataset in this case:
![remote-dataset-title-1](https://github.com/geonetwork/core-geonetwork/assets/1695003/01ceaaeb-ac0f-4bb4-92e0-bcc245db31a9)

or override the title extracted with a custom one:


![remote-dataset-title-2](https://github.com/geonetwork/core-geonetwork/assets/1695003/18071792-2a7a-4f6e-af9f-d2baaa95bc33)





