### PR TITLE
Don't override proxy configuration when saving the settings, if the http proxy is configured in Java system properties

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/url/UrlChecker.java
+++ b/core/src/main/java/org/fao/geonet/kernel/url/UrlChecker.java
@@ -1,5 +1,5 @@
 //=============================================================================
-//===	Copyright (C) 2001-2019 Food and Agriculture Organization of the
+//===	Copyright (C) 2001-2023 Food and Agriculture Organization of the
 //===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
 //===	and United Nations Environment Programme (UNEP)
 //===
@@ -31,6 +31,7 @@ import org.apache.http.impl.client.HttpClientBuilder;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.LinkStatus;
 import org.fao.geonet.kernel.setting.SettingManager;
+import org.fao.geonet.lib.Lib;
 import org.fao.geonet.lib.NetLib;
 import org.fao.geonet.utils.GeonetHttpRequestFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -149,8 +150,7 @@ public class UrlChecker {
                     Log.info(Geonet.GEONETWORK,"UrlChecker: cannot determine hostname from url: "+url);
                  }
                 //now we have hostname, we can configure proxy
-                NetLib netLib = new NetLib();
-                netLib.setupProxy(settingManager, originalConfig, hostname);
+                Lib.net.setupProxy(settingManager, originalConfig, hostname);
                 return null;
             }
         };

--- a/core/src/main/java/org/fao/geonet/lib/ProxyConfiguration.java
+++ b/core/src/main/java/org/fao/geonet/lib/ProxyConfiguration.java
@@ -108,7 +108,7 @@ public class ProxyConfiguration {
 
         if (this.enabled) {
             if (this.isProxyConfiguredInSystemProperties) {
-                if (StringUtils.isNotBlank(ProxyConfiguration.HTTPS_PROXY_HOST)) {
+                if (StringUtils.isNotBlank(System.getProperty(ProxyConfiguration.HTTPS_PROXY_HOST))) {
                     this.host = System.getProperty(ProxyConfiguration.HTTPS_PROXY_HOST);
                     this.port = System.getProperty(ProxyConfiguration.HTTPS_PROXY_PORT);
                     this.username = System.getProperty(ProxyConfiguration.HTTPS_PROXY_USERNAME, "");

--- a/core/src/main/java/org/fao/geonet/lib/ProxyConfiguration.java
+++ b/core/src/main/java/org/fao/geonet/lib/ProxyConfiguration.java
@@ -1,0 +1,138 @@
+//=============================================================================
+//===	Copyright (C) 2001-2023 Food and Agriculture Organization of the
+//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
+//===	and United Nations Environment Programme (UNEP)
+//===
+//===	This program is free software; you can redistribute it and/or modify
+//===	it under the terms of the GNU General Public License as published by
+//===	the Free Software Foundation; either version 2 of the License, or (at
+//===	your option) any later version.
+//===
+//===	This program is distributed in the hope that it will be useful, but
+//===	WITHOUT ANY WARRANTY; without even the implied warranty of
+//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//===	General Public License for more details.
+//===
+//===	You should have received a copy of the GNU General Public License
+//===	along with this program; if not, write to the Free Software
+//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+//===
+//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+//===	Rome - Italy. email: geonetwork@osgeo.org
+//==============================================================================
+
+package org.fao.geonet.lib;
+
+import org.apache.commons.lang.StringUtils;
+import org.fao.geonet.kernel.setting.SettingManager;
+import org.fao.geonet.kernel.setting.Settings;
+
+/**
+ * Class to abstract the http proxy configuration from Java system properties or GeoNetwork configuration.
+ */
+public class ProxyConfiguration {
+    // HTTP Proxy host
+    public static final String HTTP_PROXY_HOST = "http.proxyHost";
+
+    // HTTP Proxy port
+    public static final String HTTP_PROXY_PORT = "http.proxyPort";
+
+    // HTTP Proxy username
+    public static final String HTTP_PROXY_USERNAME = "http.proxyUser";
+
+    // HTTP Proxy password
+    public static final String HTTP_PROXY_PASSWORD = "http.proxyPassword";
+
+    // HTTPS Proxy host
+    public static final String HTTPS_PROXY_HOST = "https.proxyHost";
+
+    // HTTPS Proxy port
+    public static final String HTTPS_PROXY_PORT = "https.proxyPort";
+
+    // HTTPS Proxy username
+    public static final String HTTPS_PROXY_USERNAME = "https.proxyUser";
+
+    // HTTPS Proxy password
+    public static final String HTTPS_PROXY_PASSWORD = "https.proxyPassword";
+
+    // HTTP Non-Proxy Hosts
+    public static final String HTTP_NON_PROXY_HOSTS = "http.nonProxyHosts";
+
+    private boolean enabled = false;
+
+    private boolean isProxyConfiguredInSystemProperties = false;
+    private String host;
+    private String port;
+    private String username;
+    private String password;
+    private String ignoreHostList;
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public boolean isProxyConfiguredInSystemProperties() {
+        return isProxyConfiguredInSystemProperties;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public String getPort() {
+        return port;
+    }
+
+    public String getUsername() {
+        return username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public String getIgnoreHostList() {
+        return ignoreHostList;
+    }
+
+    public ProxyConfiguration(boolean isProxyConfiguredInSystemProperties) {
+        this.isProxyConfiguredInSystemProperties = isProxyConfiguredInSystemProperties;
+        if (this.isProxyConfiguredInSystemProperties) {
+            this.enabled = true;
+        }
+    }
+
+    public void refresh(SettingManager settingManager) {
+        this.enabled = this.isProxyConfiguredInSystemProperties ||
+            settingManager.getValueAsBool(Settings.SYSTEM_PROXY_USE, false);
+
+        if (this.enabled) {
+            if (this.isProxyConfiguredInSystemProperties) {
+                if (StringUtils.isNotBlank(ProxyConfiguration.HTTPS_PROXY_HOST)) {
+                    this.host = System.getProperty(ProxyConfiguration.HTTPS_PROXY_HOST);
+                    this.port = System.getProperty(ProxyConfiguration.HTTPS_PROXY_PORT);
+                    this.username = System.getProperty(ProxyConfiguration.HTTPS_PROXY_USERNAME, "");
+                    this.password = System.getProperty(ProxyConfiguration.HTTPS_PROXY_PASSWORD, "");
+                } else {
+                    this.host = System.getProperty(ProxyConfiguration.HTTP_PROXY_HOST);
+                    this.port = System.getProperty(ProxyConfiguration.HTTP_PROXY_PORT);
+                    this.username = System.getProperty(ProxyConfiguration.HTTP_PROXY_USERNAME, "");
+                    this.password = System.getProperty(ProxyConfiguration.HTTP_PROXY_PASSWORD, "");
+                }
+
+                // Escape characters for regular expression matching
+                this.ignoreHostList = System.getProperty(ProxyConfiguration.HTTP_NON_PROXY_HOSTS, "")
+                    .replace("\\.", "\\\\.")
+                    .replace("\\*", "\\.\\*");
+
+            } else {
+                this.host = settingManager.getValue(Settings.SYSTEM_PROXY_HOST);
+                this.port = settingManager.getValue(Settings.SYSTEM_PROXY_PORT);
+                this.username = settingManager.getValue(Settings.SYSTEM_PROXY_USERNAME);
+                this.password = settingManager.getValue(Settings.SYSTEM_PROXY_PASSWORD);
+                this.ignoreHostList = settingManager.getValue(Settings.SYSTEM_PROXY_IGNOREHOSTLIST);
+
+            }
+        }
+    }
+}

--- a/services/src/main/java/org/fao/geonet/api/site/SiteApi.java
+++ b/services/src/main/java/org/fao/geonet/api/site/SiteApi.java
@@ -64,6 +64,7 @@ import org.fao.geonet.kernel.setting.SettingInfo;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.kernel.setting.Settings;
 import org.fao.geonet.lib.Lib;
+import org.fao.geonet.lib.ProxyConfiguration;
 import org.fao.geonet.repository.*;
 import org.fao.geonet.repository.specification.MetadataSpecs;
 import org.fao.geonet.resources.Resources;
@@ -161,12 +162,12 @@ public class SiteApi {
         try {
             // Load proxy information into Jeeves
             ProxyInfo pi = JeevesProxyInfo.getInstance();
-            boolean useProxy = settingMan.getValueAsBool(Settings.SYSTEM_PROXY_USE, false);
+            boolean useProxy = Lib.net.getProxyConfiguration().isEnabled();
             if (useProxy) {
-                String proxyHost = settingMan.getValue(Settings.SYSTEM_PROXY_HOST);
-                String proxyPort = settingMan.getValue(Settings.SYSTEM_PROXY_PORT);
-                String username = settingMan.getValue(Settings.SYSTEM_PROXY_USERNAME);
-                String password = settingMan.getValue(Settings.SYSTEM_PROXY_PASSWORD);
+                String proxyHost = Lib.net.getProxyConfiguration().getHost();
+                String proxyPort = Lib.net.getProxyConfiguration().getPort();
+                String username = Lib.net.getProxyConfiguration().getUsername();
+                String password = Lib.net.getProxyConfiguration().getPassword();
                 pi.setProxyInfo(proxyHost, Integer.valueOf(proxyPort), username, password);
             } else {
                 pi.setProxyInfo(null, -1, null, null);
@@ -733,6 +734,24 @@ public class SiteApi {
     @ResponseBody
     public StatusValueNotificationLevel[] getNotificationLevel() {
         return StatusValueNotificationLevel.values();
+    }
+
+    @io.swagger.v3.oas.annotations.Operation(
+        summary = "Get proxy configuration details",
+        description = "Get the proxy configuration.")
+    @RequestMapping(
+        path = "/info/proxy",
+        produces = MediaType.APPLICATION_JSON_VALUE,
+        method = RequestMethod.GET)
+    @ResponseStatus(HttpStatus.OK)
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Proxy configuration.")
+    })
+    @PreAuthorize("hasAuthority('Administrator')")
+    @ResponseBody
+    public ProxyConfiguration getProxyConfiguration(
+    ) {
+        return Lib.net.getProxyConfiguration();
     }
 
     @io.swagger.v3.oas.annotations.Operation(

--- a/web-ui/src/main/resources/catalog/js/admin/SystemSettingsController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/SystemSettingsController.js
@@ -192,6 +192,11 @@
        * element name in XML Jeeves request element).
        */
       function loadSettings() {
+        $http.get("../api/site/info/proxy").then(function (response) {
+          $scope.isProxyConfiguredInSystemProperties =
+            response.data.proxyConfiguredInSystemProperties;
+        });
+
         $http.get("../api/site/info/build").then(function (response) {
           $scope.systemInfo = response.data;
         });
@@ -269,10 +274,23 @@
                 var level2name = level1name + "/" + tokens[1];
                 if (sectionsLevel2.indexOf(level2name) === -1) {
                   sectionsLevel2.push(level2name);
+
+                  var sectionChildren;
+
+                  // Remove the system proxy information if using Java system properties
+                  if (
+                    level2name === "system/proxy" &&
+                    $scope.isProxyConfiguredInSystemProperties
+                  ) {
+                    sectionChildren = [];
+                  } else {
+                    sectionChildren = filterBySection($scope.settings, level2name);
+                  }
+
                   $scope.sectionsLevel1[level1name].children.push({
                     name: level2name,
                     position: $scope.settings[i].position,
-                    children: filterBySection($scope.settings, level2name)
+                    children: sectionChildren
                   });
                 }
               }

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1452,6 +1452,7 @@
     "ui-footerCustomMenu-help": "List of static page IDs associated with the footer section to display: <ul><li>When a list is provided, the links are displayed in the order provided and only for the pages listed.</li><li>When a list is not provided, all static pages configured for the footer section are displayed, with no guaranteed order.</li>",
     "es.url": "ElasticSearch server",
     "es.version": "ElasticSearch version",
-    "es.index": "Index name"
+    "es.index": "Index name",
+    "systemPropertiesProxyConfiguration": "Using http proxy settings in system properties."
 }
 

--- a/web-ui/src/main/resources/catalog/templates/admin/settings/system.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/settings/system.html
@@ -709,6 +709,12 @@
                     </div>
                   </div>
                 </div>
+
+                <div
+                  data-ng-if="section2.name == 'system/proxy' && isProxyConfiguredInSystemProperties"
+                >
+                  <h5 data-translate="">systemPropertiesProxyConfiguration</h5>
+                </div>
               </fieldset>
               <button
                 type="submit"

--- a/web/src/main/java/org/fao/geonet/Geonetwork.java
+++ b/web/src/main/java/org/fao/geonet/Geonetwork.java
@@ -1,5 +1,5 @@
 //=============================================================================
-//===	Copyright (C) 2001-2021 Food and Agriculture Organization of the
+//===	Copyright (C) 2001-2023 Food and Agriculture Organization of the
 //===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
 //===	and United Nations Environment Programme (UNEP)
 //===
@@ -54,6 +54,7 @@ import org.fao.geonet.kernel.setting.Settings;
 import org.fao.geonet.kernel.thumbnail.ThumbnailMaker;
 import org.fao.geonet.languages.IsoLanguagesMapper;
 import org.fao.geonet.lib.DbLib;
+import org.fao.geonet.lib.Lib;
 import org.fao.geonet.repository.MetadataRepository;
 import org.fao.geonet.repository.SettingRepository;
 import org.fao.geonet.repository.SourceRepository;
@@ -297,15 +298,18 @@ public class Geonetwork implements ApplicationHandler {
         // images/logos folder is not copied from old application
         createSiteLogo(settingMan.getSiteId(), context, context.getAppPath());
 
+        //-- Initialize the proxy configuration if required
+        Lib.net.setupProxy(settingMan);
+
         //--- load proxy information from settings into Jeeves for observers such
         //--- as jeeves.utils.XmlResolver to use
         ProxyInfo pi = JeevesProxyInfo.getInstance();
-        boolean useProxy = settingMan.getValueAsBool(Settings.SYSTEM_PROXY_USE, false);
+        boolean useProxy = Lib.net.getProxyConfiguration().isEnabled();
         if (useProxy) {
-            String proxyHost = settingMan.getValue(Settings.SYSTEM_PROXY_HOST);
-            String proxyPort = settingMan.getValue(Settings.SYSTEM_PROXY_PORT);
-            String username = settingMan.getValue(Settings.SYSTEM_PROXY_USERNAME);
-            String password = settingMan.getValue(Settings.SYSTEM_PROXY_PASSWORD);
+            String proxyHost = Lib.net.getProxyConfiguration().getHost();
+            String proxyPort = Lib.net.getProxyConfiguration().getPort();
+            String username = Lib.net.getProxyConfiguration().getUsername();
+            String password = Lib.net.getProxyConfiguration().getPassword();
             pi.setProxyInfo(proxyHost, Integer.valueOf(proxyPort), username, password);
         }
 


### PR DESCRIPTION
This change avoids overriding the http proxy configuration when saving the application settings, when the http proxy configuration is setup in system properties. For example, when starting up the application like:

```
mvn jetty:run -Dhttp.proxyHost=192.168.1.21 -Dhttp.proxyPort=9090 \ 
              -Dhttps.proxyHost=192.168.1.21 -Dhttps.proxyPort=9090
```

In this case, the settings page doesn't allow to configure the proxy settings:

![http-proxy-settings-page](https://github.com/geonetwork/core-geonetwork/assets/1695003/1382fc36-7267-4191-93ae-59a3b8ae9a27)

The change includes a code refactor of the proxy configuration. It can facilitate in the future to rely only on the http proxy configuration from system properties and remove the GeoNetwork related settings.

