### PR TITLE
Configuration to restrict the hosts and ports accessible by the http proxy servlet

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1480,8 +1480,8 @@
     -->
     <proxy.securityMode>DB_LINK_CHECK</proxy.securityMode>
     <!-- Hosts to exclude from http proxy access: typically localhost, intranet resources -->
-    <proxy.excludeHosts></proxy.excludeHosts>
-    <!--<proxy.excludeHosts>^(localhost|127\..*|0\..*|255\.255\.255\.255|.*\.local|.*\.localhost|0:0:0:0:0:0:1|::1)$</proxy.excludeHosts>-->
+<proxy.excludeHosts>^(localhost|127\..*|0\..*|255\.255\.255\.255|.*\.local|.*\.localhost|0:0:0:0:0:0:1|::1)$</proxy.excludeHosts>
+
     <!-- Additional ports (separated by | char) allowed to be access through the http proxy. 80 and 443 are always allowed -->
     <proxy.allowPorts></proxy.allowPorts>
     <!--<proxy.allowPorts>8443|8080</proxy.allowPorts>-->

--- a/pom.xml
+++ b/pom.xml
@@ -1480,7 +1480,7 @@
     -->
     <proxy.securityMode>DB_LINK_CHECK</proxy.securityMode>
     <!-- Hosts to exclude from http proxy access: typically localhost, intranet resources -->
-<proxy.excludeHosts>^(localhost|127\..*|0\..*|255\.255\.255\.255|.*\.local|.*\.localhost|0:0:0:0:0:0:1|::1)$</proxy.excludeHosts>
+    <proxy.excludeHosts>^(localhost|127\..*|0\..*|255\.255\.255\.255|.*\.local|.*\.localhost|0:0:0:0:0:0:1|::1)$</proxy.excludeHosts>
 
     <!-- Additional ports (separated by | char) allowed to be access through the http proxy. 80 and 443 are always allowed -->
     <proxy.allowPorts></proxy.allowPorts>

--- a/pom.xml
+++ b/pom.xml
@@ -1479,6 +1479,12 @@
        * allow only host registered in metadata link table
     -->
     <proxy.securityMode>DB_LINK_CHECK</proxy.securityMode>
+    <!-- Hosts to exclude from http proxy access: typically localhost, intranet resources -->
+    <proxy.excludeHosts></proxy.excludeHosts>
+    <!--<proxy.excludeHosts>^(localhost|127\..*|0\..*|255\.255\.255\.255|.*\.local|.*\.localhost|0:0:0:0:0:0:1|::1)$</proxy.excludeHosts>-->
+    <!-- Additional ports (separated by | char) allowed to be access through the http proxy. 80 and 443 are always allowed -->
+    <proxy.allowPorts></proxy.allowPorts>
+    <!--<proxy.allowPorts>8443|8080</proxy.allowPorts>-->
 
     <!-- Jetty plugin port configuration -->
     <jetty.port>8080</jetty.port>

--- a/web/src/main/java/org/fao/geonet/proxy/URITemplateProxyServlet.java
+++ b/web/src/main/java/org/fao/geonet/proxy/URITemplateProxyServlet.java
@@ -61,6 +61,10 @@ import java.io.InputStream;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.*;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import java.util.regex.PatternSyntaxException;
+import java.util.stream.Collectors;
 
 /**
  * This is a class extending the real proxy to make sure we can tweak specifics like removing the CSRF token on requests
@@ -76,6 +80,10 @@ public class URITemplateProxyServlet extends org.mitre.dsmiley.httpproxy.URITemp
     private static final String P_IS_SECURED = "isSecured";
 
     private static final String TARGET_URI_NAME = "targetUri";
+
+    private static final String P_EXCLUDE_HOSTS = "excludeHosts";
+
+    private static final String P_ALLOW_PORTS = "allowPorts";
 
     /*
      * These are the "hop-by-hop" headers that should not be copied.
@@ -103,6 +111,12 @@ public class URITemplateProxyServlet extends org.mitre.dsmiley.httpproxy.URITemp
     MetadataLinkRepository metadataLinkRepository;
     private String username;
     private String password;
+
+    // Regular expression pattern with the hosts to prevent access through the proxy
+    private Pattern excludeHostsPattern;
+
+    // Allowed ports allowed to access through the proxy
+    private Set<Integer> allowPorts = new HashSet<>(Arrays.asList(80, 443));
 
     /**
      * Init some properties from the servlet's init parameters. They try to be resolved the same way other GeoNetwork
@@ -166,6 +180,29 @@ public class URITemplateProxyServlet extends org.mitre.dsmiley.httpproxy.URITemp
             isSecured = Boolean.parseBoolean(doIsSecured);
         }
 
+        String excludeHosts = getConfigValue(P_EXCLUDE_HOSTS);
+        if (StringUtils.isBlank(excludeHosts)) {
+            excludeHosts = getConfigParam(P_EXCLUDE_HOSTS);
+        }
+
+        if (StringUtils.isNotBlank(excludeHosts)) {
+            try {
+                this.excludeHostsPattern = Pattern.compile(excludeHosts);
+            } catch (PatternSyntaxException ex) {
+                throw new ServletException(P_EXCLUDE_HOSTS + " doesn't contain a valid regular expression");
+            }
+        }
+
+        String additionalAllowPorts = getConfigValue(P_ALLOW_PORTS);
+        if (StringUtils.isBlank(additionalAllowPorts)) {
+            additionalAllowPorts = getConfigParam(P_EXCLUDE_HOSTS);
+        }
+
+        if (StringUtils.isNotBlank(additionalAllowPorts)) {
+            Set<Integer> validPorts = Arrays.stream(additionalAllowPorts.split("\\|"))
+                .filter(StringUtils::isNumeric).map(Integer::valueOf).collect(Collectors.toSet());
+            this.allowPorts.addAll(validPorts);
+        }
     }
 
     private String getConfigValue(String suffix) {
@@ -346,6 +383,16 @@ public class URITemplateProxyServlet extends org.mitre.dsmiley.httpproxy.URITemp
     protected void service(HttpServletRequest servletRequest, HttpServletResponse servletResponse)
         throws ServletException, IOException {
 
+        // Check that the url host or port is not forbidden to access by the proxy
+        if (!isUrlAllowed(servletRequest)) {
+            String message = String.format(
+                "The proxy does not allow to access '%s' .",
+                servletRequest.getParameter("url")
+            );
+            servletResponse.sendError(HttpServletResponse.SC_FORBIDDEN, message);
+            return;
+        }
+
         switch (securityMode) {
             case NONE:
                 super.service(servletRequest, servletResponse);
@@ -405,6 +452,37 @@ public class URITemplateProxyServlet extends org.mitre.dsmiley.httpproxy.URITemp
                 break;
         }
     }
+
+    private boolean isUrlAllowed(HttpServletRequest servletRequest) {
+        String url = servletRequest.getParameter("url");
+        if (StringUtils.isBlank(url)) {
+            return true;
+        }
+
+        try {
+            URI uri = new URI(url);
+
+            if (this.excludeHostsPattern != null) {
+                Matcher matcher = this.excludeHostsPattern.matcher(uri.getHost());
+
+                if (matcher.matches()) {
+                    return false;
+                }
+            }
+
+            int port = uri.getPort();
+
+            // Default port for the protocol has value -1
+            return (port == -1) || this.allowPorts.contains(port);
+        } catch (URISyntaxException e) {
+            throw new IllegalArgumentException(String.format(
+                "'%s' is invalid. Error is: '%s'",
+                url,
+                e.getMessage()
+            ));
+        }
+    }
+
 
     private enum SECURITY_MODE {
         NONE,

--- a/web/src/main/webResources/WEB-INF/web.xml
+++ b/web/src/main/webResources/WEB-INF/web.xml
@@ -411,6 +411,14 @@
       <param-name>securityMode</param-name>
       <param-value>${proxy.securityMode}</param-value>
     </init-param>
+    <init-param>
+      <param-name>excludeHosts</param-name>
+      <param-value>${proxy.excludeHosts}</param-value>
+    </init-param>
+    <init-param>
+      <param-name>allowPorts</param-name>
+      <param-value>${proxy.allowPorts}</param-value>
+    </init-param>
   </servlet>
   <servlet-mapping>
     <servlet-name>HttpProxy</servlet-name>


### PR DESCRIPTION
This change request adds configuration to restrict the hosts and ports accessible by the http proxy servlet, independently of the security mode configured.

- `proxy.excludeHosts`: Regular expression to match a set of host names  / IP's that should not be allowed to access by the http proxy, for example, the ones related to localhost.

- By default, has been changed to only allow the proxy to access ports 80 and 443, additional ports can be configured in `proxy.allowPorts`

These  properties can be configured using multiple methods, not only as init parameter
in `web.xml` servlet's config, but also as environment variable, system property or `config.properties`
entry.