### PR TITLE
Introducing scheduled refresh of harvesterjobs.

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/HarvestManager.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/HarvestManager.java
@@ -30,7 +30,6 @@ import org.fao.geonet.exceptions.JeevesException;
 import org.fao.geonet.kernel.harvest.harvester.AbstractHarvester;
 import org.jdom.Element;
 import org.quartz.SchedulerException;
-import org.springframework.context.ApplicationContext;
 import org.springframework.context.ConfigurableApplicationContext;
 
 import java.sql.SQLException;
@@ -51,6 +50,18 @@ public interface HarvestManager {
      * @param isReadOnly indicator if system is readonly
      */
     void init(@Nonnull ServiceContext context, boolean isReadOnly) throws Exception;
+
+    /**
+     * Refresh the harvesters.
+     * - Stops the existing scheduled jobs.
+     * - Reloads the harvester definitions from the database.
+     * - Start the jobs again.
+     * <p>
+     * Useful when running multiple instances as one instance is not aware of new harvesters added on the other one.
+     * <p>
+     * TODO when a durable solution for running highly available is implemented this scheduled task could be deleted, e.g., when created harvesters are notified through a shared message queue.
+     */
+    void refreshHarvesters();
 
     /**
      * Shutdown all harvesters and thread pools and jobs.

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/HarvestManagerImpl.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/HarvestManagerImpl.java
@@ -34,8 +34,6 @@ import org.fao.geonet.domain.HarvestHistory;
 import org.fao.geonet.domain.ISODate;
 import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.Profile;
-import org.fao.geonet.domain.Source;
-import org.fao.geonet.domain.SourceType;
 import org.fao.geonet.exceptions.BadInputEx;
 import org.fao.geonet.exceptions.JeevesException;
 import org.fao.geonet.exceptions.MissingParameterEx;
@@ -48,15 +46,12 @@ import org.fao.geonet.kernel.harvest.harvester.AbstractHarvester;
 import org.fao.geonet.kernel.harvest.harvester.AbstractParams;
 import org.fao.geonet.kernel.harvest.harvester.HarversterJobListener;
 import org.fao.geonet.kernel.setting.HarvesterSettingsManager;
-import org.fao.geonet.kernel.setting.SettingManager;
-import org.fao.geonet.kernel.setting.Settings;
 import org.fao.geonet.repository.HarvestHistoryRepository;
-import org.fao.geonet.repository.SourceRepository;
 import org.fao.geonet.repository.specification.MetadataSpecs;
 import org.fao.geonet.utils.Log;
 import org.fao.geonet.utils.Xml;
 import org.jdom.Element;
-import org.quartz.SchedulerException;
+import org.quartz.*;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.data.jpa.domain.Specification;
 
@@ -65,17 +60,17 @@ import java.sql.SQLException;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.TimeZone;
+import java.util.*;
+
+import static org.quartz.CronScheduleBuilder.cronSchedule;
+import static org.quartz.SimpleScheduleBuilder.simpleSchedule;
 
 /**
  * TODO Javadoc.
  */
 public class HarvestManagerImpl implements HarvestInfoProvider, HarvestManager {
+
+    private int harvesterRefreshIntervalMinutes = 1;
 
     private final List<String> summaryHarvesterSettings =
         Arrays.asList("harvesting", "node", "site", "name", "uuid",
@@ -129,6 +124,19 @@ public class HarvestManagerImpl implements HarvestInfoProvider, HarvestManager {
         AbstractHarvester.getScheduler().getListenerManager().addJobListener(
             HarversterJobListener.getInstance(this));
 
+        // intialise the harvesters...
+        initialiseHarvesters(context);
+        // ... and schedule a periodic refresh
+        long now = System.currentTimeMillis();
+        long nextSecond = (now/1000)*1000+1000;
+        long toSleep = nextSecond-now+500;
+
+        Log.debug(Geonet.HARVEST_MAN, String.format("Artificially sleeping to not refresh 'on' the minute for %s.", toSleep));
+        Thread.sleep(toSleep);
+        startHarvesterRefreshJob();
+    }
+
+    public synchronized void initialiseHarvesters(ServiceContext context) {
         final Element harvesting = settingMan.getList(null);
         if (harvesting != null) {
             Element entries = harvesting.getChild("children");
@@ -164,6 +172,51 @@ public class HarvestManagerImpl implements HarvestInfoProvider, HarvestManager {
                 }
             }
         }
+    }
+
+    private synchronized void stopHarvesters() {
+        for (AbstractHarvester ah : hmHarvesters.values()) {
+            try {
+                ah.shutdown();
+            } catch (SchedulerException e) {
+                Log.error(Geonet.HARVEST_MAN, "Error shutting down" + ah.getID(), e);
+            }
+        }
+        hmHarvesters.clear();
+    }
+
+    private void startHarvesterRefreshJob() throws SchedulerException {
+        Scheduler scheduler = AbstractHarvester.getScheduler();
+        scheduler.getContext().put("harvest-manager", this);
+        String group = "harvester-refresh";
+        JobDetail jobDetail = JobBuilder.newJob()
+            .ofType(RefreshHarvesterJob.class)
+            .withIdentity("refresh-job", group)
+            .build();
+        Trigger trigger = TriggerBuilder.newTrigger()
+            .withIdentity("refresh-timer", group)
+            .withSchedule(simpleSchedule().withIntervalInMinutes(harvesterRefreshIntervalMinutes).repeatForever())
+            .startNow()
+            .build();
+        scheduler.scheduleJob(jobDetail, trigger);
+    }
+
+    @Override
+    public synchronized void refreshHarvesters() {
+        // remove all harvesters
+        stopHarvesters();
+        // restart them
+        initialiseHarvesters(context);
+        // log the new state
+        Log.debug(Geonet.HARVEST_MAN, String.format("thread(%s) Refreshed harvesters (%s)",
+            Thread.currentThread().getName(),
+            hmHarvesters.size()));
+        hmHarvesters.forEach((s, abstractHarvester) ->
+            Log.debug(Geonet.HARVEST_MAN, String.format("thread(%s) > harvester (%s) id (%s) every(%s)",
+                Thread.currentThread().getName(),
+                s,
+                abstractHarvester.getID(),
+                abstractHarvester.getParams().getEvery())));
     }
 
     /**
@@ -692,4 +745,13 @@ public class HarvestManagerImpl implements HarvestInfoProvider, HarvestManager {
         }
 
     }
+
+    public int getHarvesterRefreshIntervalMinutes() {
+        return harvesterRefreshIntervalMinutes;
+    }
+
+    public void setHarvesterRefreshIntervalMinutes(int harvesterRefreshIntervalMinutes) {
+        this.harvesterRefreshIntervalMinutes = harvesterRefreshIntervalMinutes;
+    }
+
 }

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/RefreshHarvesterJob.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/RefreshHarvesterJob.java
@@ -1,0 +1,26 @@
+package org.fao.geonet.kernel.harvest;
+
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.utils.Log;
+import org.quartz.Job;
+import org.quartz.JobExecutionContext;
+import org.quartz.JobExecutionException;
+import org.quartz.SchedulerContext;
+import org.quartz.SchedulerException;
+
+public class RefreshHarvesterJob implements Job {
+
+    @Override
+    public void execute(JobExecutionContext context) throws JobExecutionException {
+        try {
+            SchedulerContext schedulerContext = context.getScheduler().getContext();
+            HarvestManagerImpl harvestManager = (HarvestManagerImpl) schedulerContext.get("harvest-manager");
+            if (harvestManager != null) {
+                harvestManager.refreshHarvesters();
+            }
+        } catch (SchedulerException e) {
+            Log.error(Geonet.HARVEST_MAN, e.getMessage());
+            e.printStackTrace();
+        }
+    }
+}

--- a/harvesters/src/main/resources/config-spring-geonetwork.xml
+++ b/harvesters/src/main/resources/config-spring-geonetwork.xml
@@ -30,7 +30,9 @@
 	">
 
   <bean id="Harvest" class="org.fao.geonet.component.harvester.csw.Harvest"/>
-  <bean id="HarvestManager" class="org.fao.geonet.kernel.harvest.HarvestManagerImpl"/>
+  <bean id="HarvestManager" class="org.fao.geonet.kernel.harvest.HarvestManagerImpl">
+    <property name="harvesterRefreshIntervalMinutes" value="2" />
+  </bean>
 
   <!-- The id of the beans is the same as the type in the harvester settings table and thus should not be changed -->
   <bean id="geonetwork" class="org.fao.geonet.kernel.harvest.harvester.geonet.GeonetHarvester"

--- a/web/src/main/webapp/WEB-INF/classes/log4j2.xml
+++ b/web/src/main/webapp/WEB-INF/classes/log4j2.xml
@@ -57,7 +57,7 @@
     <Logger name="geonetwork.geoserver.rest" level="error"/>
     <Logger name="geonetwork.harvest.wfs.features" level="debug"/>
     <Logger name="geonetwork.harvester" level="info"/>
-    <Logger name="geonetwork.harvester" level="info"/>
+    <Logger name="geonetwork.harvest-man" level="error"/>
     <Logger name="geonetwork.index" level="error"/>
     <Logger name="geonetwork.ldap" level="error"/>
     <Logger name="geonetwork.lucene" level="error"/>


### PR DESCRIPTION
@fxprunayre these are the relevant changes, condensed in a single commit, to refresh the harvesterjobs on a schedule. As we discussed, this is a stopgap solution until we manage the harvesterjobs through, e.g., a message queue.