### PR TITLE
Map / Localisation / Empty results if no query

### DIFF
--- a/web-ui/src/main/resources/catalog/components/viewer/gazetter/GazetteerDefaultFactory.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/gazetter/GazetteerDefaultFactory.js
@@ -46,7 +46,10 @@
             search: function (scope, loc, query) {
               var lang = gnGlobalSettings.lang;
 
-              if (query.length < 1) return;
+              if (query.length < 1) {
+                scope.results = [];
+                return;
+              }
               var coord = gnGetCoordinate(
                 scope.map.getView().getProjection().getWorldExtent(),
                 query


### PR DESCRIPTION
Type a search, delete characters, previous search results are still displayed.

This avoids
![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/cc2f22c8-c877-4460-bd78-db3816f5c43e)
