### PR TITLE
Map / WMS dimension saved in map

### DIFF
--- a/web-ui/src/main/resources/catalog/components/viewer/layermanager/LayerManagerDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/layermanager/LayerManagerDirective.js
@@ -295,13 +295,30 @@
           function initDimension(dimension) {
             var dimensionConfig = scope.layer.get(dimension);
             if (dimensionConfig) {
-              var idx = dimensionConfig.values.length - 1;
+              var currentLayerValue = scope.layer.getSource().getParams()[
+                dimension.toUpperCase()
+              ];
+              var idx = undefined;
+              var defaultValueIdx = dimensionConfig.values.length - 1;
               for (var i = 0; i < dimensionConfig.values.length; i++) {
-                if (dimensionConfig.values[i] === dimensionConfig.default) {
+                if (dimensionConfig.values[i] === currentLayerValue) {
                   idx = i;
                   break;
                 }
+                if (dimensionConfig.values[i] === dimensionConfig.default) {
+                  defaultValueIdx = i;
+                }
               }
+              if (currentLayerValue && !idx) {
+                console.warn(
+                  "Dimension value " +
+                    currentLayerValue +
+                    " not found in dimension list of values. Using default or latest value: " +
+                    dimensionConfig.values[defaultValueIdx]
+                );
+              }
+              idx = idx || defaultValueIdx;
+
               scope.dimensions[dimension] = {
                 current: dimensionConfig.values[idx],
                 idx: idx,

--- a/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
@@ -407,6 +407,9 @@
                 if (extension.uuid) {
                   layer.metadataUuid = extension.uuid;
                 }
+                if (extension.enabled) {
+                  layer.enabled = extension.enabled;
+                }
 
                 dimensions.forEach(function (dimension) {
                   if (extension[dimension.toLowerCase() + "DimensionValue"]) {
@@ -705,7 +708,9 @@
           if (processInputs) {
             extension.processInputs = processInputs;
           }
-
+          if (layer.showInfo) {
+            extension.enabled = true; // Enabled in layer manager
+          }
           dimensions.forEach(function (dimension) {
             if (source.getParams()[dimension]) {
               extension[dimension.toLowerCase() + "DimensionValue"] =
@@ -804,6 +809,9 @@
             olL.set("bgIdx", bgIdx);
           } else if (index) {
             olL.set("tree_index", index);
+          }
+          if (layer.enabled) {
+            olL.showInfo = layer.enabled; // Enabled in layer manager
           }
           var params = olL.getSource().getParams() || {};
           dimensions.forEach(function (dimension) {


### PR DESCRIPTION
 * Save current map dimension value in the map context to be able to open a map on specific date. Follow up of https://github.com/geonetwork/core-geonetwork/pull/6820 
 * Save if layer is enabled in layer manager

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/4fe0e512-da36-4385-bf16-c10e4f758782)

To test:
* add a layer from WMS-Time, enable layer and select a date 
* save the map
* open the map

Information saved in layer extension:
```xml
    <ows-context:Layer name="22KGA_CHL" hidden="false" opacity="1">
      <ows-context:Server service="urn:ogc:serviceType:WMS" version="1.3.0">
        <ows-context:OnlineResource xlink:href="https://www.aquacoope.org/geoserver/c_br/ows?SERVICE=WMS&amp;"/>
      </ows-context:Server>
      <ows-context:Extension>{"timeDimensionValue":"2021-10-06T00:00:00.000Z", "enabled": true}</ows-context:Extension>
    </ows-context:Layer>
```