### PR TITLE
Portal / RSS feeds point to current portal

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/templates/footer.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/footer.html
@@ -95,11 +95,4 @@
       <span class="fa fa-fw fa-rss" />
     </a>
   </li>
-  <!--<li>
-    <a href="rss.search?sortBy=changeDate&georss=simplepoint"
-       title="{{'rssFeed' | translate}}"
-       aria-label="{{'rssFeed' | translate}}">
-      <span class="fa fa-rss"/>
-    </a>
-  </li>-->
 </ul>

--- a/web-ui/src/main/resources/catalog/views/default/templates/footer.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/footer.html
@@ -87,11 +87,12 @@
     data-ng-repeat="rssFeed in rssFeeds"
   >
     <a
-      href="../../api/collections/main/items?{{rssFeed.url}}"
+      href="../../api/collections/{{nodeId === 'srv' ? 'main' : nodeId}}/items?{{rssFeed.url}}"
       title="{{rssFeed.label | translate}}"
       aria-label="{{rssFeed.label | translate}}"
     >
-      <span class="fa fa-rss" />
+      <span data-ng-if="rssFeeds.length > 1"> {{rssFeed.label | translate}} </span>
+      <span class="fa fa-fw fa-rss" />
     </a>
   </li>
   <!--<li>


### PR DESCRIPTION
RSS feeds now focus on the current portal in use (as OGC API Records provides endpoints per portal).

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/d7f8448e-60e5-4159-bdd2-d63c10dcaae3)

 If more than one feed declared, add the label to clearly identify the purpose of the link.

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/65d62d33-faea-4cf4-a647-3c2ea9188289)
