### PR TITLE
Map / WPS / Add support for custom parameter CRS

### DIFF
--- a/web-ui/src/main/resources/catalog/components/viewer/wps/WpsService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wps/WpsService.js
@@ -240,6 +240,19 @@
           // when bbox is cleared value is still set to ',,,'
           if (input.boundingBoxData && data && data != ",,,") {
             var bbox = data.split(",");
+            
+            var geomCrs = "EPSG:4326";
+            if (input.boundingBoxData._default &&
+              input.boundingBoxData._default.crs &&
+              input.boundingBoxData._default.crs !== geomCrs) {
+              geomCrs = input.boundingBoxData._default.crs;
+              try {
+                bbox = ol.proj.transformExtent(bbox, "EPSG:4326", geomCrs);
+              } catch (e) {
+                console.warn("WPS | Failed to convert boundingBoxData to requested CRS " + geomCrs);
+              }
+            }
+            
             request.value.dataInputs.input.push({
               identifier: {
                 value: input.identifier.value
@@ -247,7 +260,7 @@
               data: {
                 boundingBoxData: {
                   dimensions: 2,
-                  crs: "EPSG:4326",
+                  crs: geomCrs,
                   lowerCorner: [bbox[1], bbox[0]],
                   upperCorner: [bbox[3], bbox[2]]
                 }


### PR DESCRIPTION
A WPS may require a `BoundingBoxData` in a particular CRS. Add reprojection step if needed:

```
      <Input minOccurs="0" maxOccurs="1">
        <ows:Identifier>EXTENT</ows:Identifier>
        <ows:Title>A spatial extent</ows:Title>
        <ows:Metadata xlink:title="processing:type" xlink:href="extent" xlink:type="simple"/>
        <BoundingBoxData>
          <Default>
            <CRS>EPSG:2154</CRS>
          </Default>
          <Supported>
            <CRS>EPSG:2154</CRS>
          </Supported>
        </BoundingBoxData>
      </Input>
```