### PR TITLE
User feedback API fixes

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/userfeedback/UserFeedbackAPI.java
+++ b/services/src/main/java/org/fao/geonet/api/userfeedback/UserFeedbackAPI.java
@@ -514,14 +514,18 @@ public class UserFeedbackAPI {
                     String title = XslUtil.getIndexField(null, userFeedbackDto.getMetadataUUID(), "resourceTitleObject", "");
 
                     if (toAddress.size() > 0) {
-                        MailUtil.sendMail(toAddress,
-                            String.format(
-                                messages.getString("new_user_rating"),
-                                catalogueName, title),
-                            String.format(
-                                messages.getString("new_user_rating_text"),
-                                metadataUtils.getDefaultUrl(userFeedbackDto.getMetadataUUID(), locale.getISO3Language())),
-                            settingManager);
+                        try {
+                            MailUtil.sendMail(toAddress,
+                                String.format(
+                                    messages.getString("new_user_rating"),
+                                    catalogueName, title),
+                                String.format(
+                                    messages.getString("new_user_rating_text"),
+                                    metadataUtils.getDefaultUrl(userFeedbackDto.getMetadataUUID(), locale.getISO3Language())),
+                                settingManager);
+                        } catch (IllegalArgumentException ex) {
+                            Log.warning(API.LOG_MODULE_NAME, ex.getMessage(), ex);
+                        }
                     }
                 }
             }

--- a/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages.properties
+++ b/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages.properties
@@ -78,7 +78,7 @@ register_email_message=Dear User,\n\
   Yours sincerely,\n\
   The %s team.
 new_user_rating=%s / New user rating on %s
-new_user_rating_text=See record %sapi/records/%s
+new_user_rating_text=See record %s
 user_feedback_title=%s / User feedback on %s / %s
 user_feedback_text=User %s (%s - %s)\n\
   - Email: %s\n\

--- a/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages_fre.properties
+++ b/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages_fre.properties
@@ -66,7 +66,7 @@ register_email_message=Cher utilisateur,\n\
   Salutations,\n\
   L'\u00E9quipe %s.
 new_user_rating=%s / Nouvelle \u00E9valuation faite pour %s
-new_user_rating_text=Consulter la fiche %sapi/records/%s
+new_user_rating_text=Consulter la fiche %s
 user_feedback_title=%s / Nouveau commentaire sur %s / %s
 user_feedback_text=Utilisateur %s (%s - %s)\n\
   - Email: %s\n\


### PR DESCRIPTION
- Update mail message, related to #6792, causing the following error when creating a metadata user feedback:

```
{
    "message": "MissingFormatArgumentException",
    "code": "unsatisfied_request_parameter",
    "description": "Format specifier '%s'"
}
```

- Don't fail the metadata user feedback creation if the mail server is not configured