### PR TITLE
Record view / Social network link points to permalink.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/mdview/mdviewDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/mdviewDirective.js
@@ -562,6 +562,27 @@
     }
   ]);
 
+  module.directive("gnMetadataSocialLink", [
+    "gnUtilityService",
+    "$http",
+    function (gnUtilityService, $http) {
+      return {
+        templateUrl: "../../catalog/components/search/mdview/partials/social.html",
+        scope: {
+          md: "=gnMetadataSocialLink"
+        },
+        link: function (scope, element, attrs) {
+          scope.mdService = gnUtilityService;
+          $http
+            .get("../api/records/" + scope.md.getUuid() + "/permalink")
+            .then(function (r) {
+              scope.socialMediaLink = r.data;
+            });
+        }
+      };
+    }
+  ]);
+
   module.directive("gnQualityMeasuresTable", [
     "gnGlobalSettings",
     function (gnGlobalSettings) {

--- a/web-ui/src/main/resources/catalog/components/search/mdview/partials/social.html
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/partials/social.html
@@ -1,4 +1,4 @@
-<section class="gn-md-side-social" data-ng-show="isSocialbarEnabled">
+<section class="gn-md-side-social">
   <h2 data-translate="">shareOn</h2>
   <div class="btn-group">
     <a
@@ -16,14 +16,14 @@
       ><i class="fa fa-fw fa-facebook"></i
     ></a>
     <a
-      data-ng-href="http://www.linkedin.com/shareArticle?mini=true&amp;summary={{mdView.current.record.resourceTitle}}&amp;url={{socialMediaLink | encodeURIComponent}}"
+      data-ng-href="http://www.linkedin.com/sharing/share-offsite/?url={{socialMediaLink | encodeURIComponent}}"
       title="{{'shareOnLinkedIn' | translate}}"
       target="_blank"
       class="btn btn-default"
       ><i class="fa fa-fw fa-linkedin"></i
     ></a>
     <a
-      data-ng-href="mailto:?subject={{mdView.current.record.resourceTitle}}&amp;body={{socialMediaLink | encodeURIComponent}}"
+      data-ng-href="mailto:?subject={{md.resourceTitle}}&amp;body={{socialMediaLink | encodeURIComponent}}"
       title="{{'shareByEmail' | translate}}"
       target="_blank"
       class="btn btn-default"

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/share.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/share.html
@@ -1,4 +1,4 @@
-<div ng-include="'../../catalog/views/default/templates/recordView/social.html'" />
+<div gn-metadata-social-link="mdView.current.record" data-ng-show="isSocialbarEnabled" />
 
 <div data-ng-show="isRatingEnabled" class="gn-md-side-rating gn-margin-bottom">
   <h2>


### PR DESCRIPTION
Follow up of https://github.com/geonetwork/core-geonetwork/pull/6792

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/161818d9-0825-4b08-8e6a-173f2dd7138e)

if not using the permalink linked in and others will not be able to extract the page name from the JS app and not really point to the record. Update to last version of Linked in API https://learn.microsoft.com/en-us/linkedin/consumer/integrations/self-serve/plugins/share-plugin

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/a771860a-1ec2-47b1-9fbc-d7e37ccb8bd0)

