### PR TITLE
Record view / Add configuration to support statistics on more than 100 related records

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1507,6 +1507,7 @@
     Increase the value for large catalogue.
     TODO: Probably better to switch to scroll API for full indexing. -->
     <es.index.max_result_window.limit>15000</es.index.max_result_window.limit>
+    <es.index.max_inner_result_window.limit>200</es.index.max_inner_result_window.limit>
 
     <es.index.mapping.total_fields.limit>4000</es.index.mapping.total_fields.limit>
     <es.index.ignore_above>2000</es.index.ignore_above>

--- a/web-ui/src/main/resources/catalog/components/search/mdview/mdviewService.js
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/mdviewService.js
@@ -114,12 +114,13 @@
             // Configuration to retrieve the results for the aggregations
             var relatedFacetConfig =
               gnGlobalSettings.gnCfg.mods.recordview.relatedFacetConfig;
+            var nbOfRecords = Object.keys(recordsMap).length;
             Object.keys(relatedFacetConfig).map(function (k) {
               relatedFacetConfig[k].aggs = {
                 docs: {
                   top_hits: {
                     // associated stats with UUIDs
-                    size: 100,
+                    size: nbOfRecords,
                     _source: {
                       includes: ["uuid"]
                     }
@@ -158,7 +159,9 @@
                   JSON.stringify(relatedFacetConfig) +
                   "," +
                   '  "from": 0,' +
-                  '  "size": 100,' +
+                  '  "size": ' +
+                  nbOfRecords +
+                  "," +
                   '  "_source": ["uuid"]' +
                   "}";
               }

--- a/web/src/main/webResources/WEB-INF/data/config/index/records.json
+++ b/web/src/main/webResources/WEB-INF/data/config/index/records.json
@@ -2,6 +2,7 @@
   "settings": {
     "index": {
       "max_result_window": ${es.index.max_result_window.limit},
+      "max_inner_result_window": ${es.index.max_inner_result_window.limit},
       "query.default_field": "any.default",
       "mapping.total_fields.limit": ${es.index.mapping.total_fields.limit},
       "analysis": {


### PR DESCRIPTION


If a record has more than 100 related records, statistics are only provided on the first 100.
eg. https://sdi.eea.europa.eu/catalogue/srv/eng/catalog.search?#/metadata/3c362237-daa4-45e2-8c16-aaadfb1a003b


![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/b6802df6-6e14-4080-b156-00777ff1af99)


If extending the stats to more than 100 records, Elasticsearch returns:
```
Top hits result window is too large, the top hits aggregator [docs]'s
 from + size must be less than or equal to: [100] but was [105].
This limit can be set by changing the [index.max_inner_result_window] index level setting."
```

Adding the possibility to configure the index to compute stats on a larger window of results. By default 200.

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/8a5b9c18-9ef3-493a-bb83-3796a52b40d9)
