### PR TITLE
HA exercise update - Adding schemapublication_dir to admin info panel.

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/site/SiteInformation.java
+++ b/services/src/main/java/org/fao/geonet/api/site/SiteInformation.java
@@ -141,6 +141,7 @@ public class SiteInformation {
             Geonet.Config.CODELIST_DIR,
             Geonet.Config.RESOURCES_DIR,
             Geonet.Config.SCHEMAPLUGINS_DIR,
+            Geonet.Config.SCHEMAPUBLICATION_DIR,
             Geonet.Config.CONFIG_DIR,
             Geonet.Config.INDEX_CONFIG_DIR,
             Geonet.Config.FORMATTER_PATH,

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -187,6 +187,7 @@
     "data.resources": "Resources folder: ",
     "data.backupDir": "Backup folder: ",
     "data.schemaPluginsDir": "Standard folder: ",
+    "data.schemaPublicationDir": "Schema publication folder: ",
     "data.subversionPath": "Subversion repository: ",
     "data.geonetworkDataDir": "Base directory: ",
     "databaseStatus": "Database status",


### PR DESCRIPTION
@fxprunayre not sure the strings should be added to all `-admin.json` files, or just the `en-admin.json` with automatic fallbacks to the English variant? What happens when transifex create the corresponding `nl-admin.json` file, for example? Does it populate the missing labels?