### PR TITLE
Editor / Preserve scroll position on Firefox

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn_editor.less
+++ b/web-ui/src/main/resources/catalog/style/gn_editor.less
@@ -34,6 +34,7 @@ select {
 
 .gn-editor-container {
   padding: 20px 5px;
+  overflow-anchor: none;
 }
 
 @media only screen and (max-width: @screen-xs-max) {


### PR DESCRIPTION
On Firefox, when adding/removing elements which trigger form reload eg. adding thesaurus block, removing a fieldset, the browser usually scroll down the position before saving.

It seems related to https://developer.mozilla.org/en-US/docs/Web/CSS/overflow-anchor/Guide_to_scroll_anchoring