### PR TITLE
Fix write after response commit on proxy response

### DIFF
--- a/web/src/main/java/org/fao/geonet/proxy/URITemplateProxyServlet.java
+++ b/web/src/main/java/org/fao/geonet/proxy/URITemplateProxyServlet.java
@@ -362,6 +362,7 @@ public class URITemplateProxyServlet extends org.mitre.dsmiley.httpproxy.URITemp
                 } catch (SecurityException securityException) {
                     servletResponse.sendError(HttpServletResponse.SC_FORBIDDEN,
                         securityException.getMessage());
+                    return;
                 }
 
                 // Check if the link requested is in database link list
@@ -375,19 +376,16 @@ public class URITemplateProxyServlet extends org.mitre.dsmiley.httpproxy.URITemp
                             LinkSpecs.filter(host, null, null,
                                 null, null, null));
                         if (linksFound == 0) {
-                            String message = String.format(
-                                "The proxy does not allow to access '%s' " +
-                                    "because the URL host was not registered in any metadata records.",
-                                uri
-                            );
+                            String message = "The proxy does not allow to access the requested URI " +
+                                "because the URL host was not registered in any metadata records.";
                             if (linkRepository.count() == 0) {
-                                servletResponse.sendError(HttpServletResponse.SC_FORBIDDEN,
-                                    "The proxy is configured with DB_LINK_CHECK mode " +
-                                        "but the MetadataLink table is empty. " +
-                                        "Administrator may need to analyze record links from the admin console " +
-                                        "in order to register URL allowed by the proxy. " + message);
+                                message = "The proxy is configured with DB_LINK_CHECK mode " +
+                                    "but the MetadataLink table is empty. " +
+                                    "Administrator may need to analyze record links from the admin console " +
+                                    "in order to register URL allowed by the proxy.";
                             }
                             servletResponse.sendError(HttpServletResponse.SC_FORBIDDEN, message);
+                            return;
                         }
                         proxyCallAllowed = linksFound > 0;
                     } catch (URISyntaxException e) {


### PR DESCRIPTION
When the Links table is empty an 500 error happens when using the proxy: 
```
java.lang.IllegalStateException: Cannot call `sendError()` after the response has been committed
```

This is caused because the `response.sendError(...)` method is being called twice when the `Links` table has no entries. This commits fix this error calling the method only once.
In addition, it removes unnecessary info returned to the client.