### PR TITLE
fix for untranslated userRecord and userRecords labels in user admin page

### DIFF
--- a/web-ui/src/main/resources/catalog/templates/admin/usergroup/users.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/usergroup/users.html
@@ -493,9 +493,9 @@
             <i class="fa fa-search" />&nbsp;
             <ng-pluralize
               count="searchResults.count"
-              when="{'0': ('noRecordFound' | translate),
-                    'one': '1 ' +  ('userRecord' | translate) + ' {{userSelected.name}} {{userSelected.surname}}',
-                    'other': '{} ' +  ('userRecords' | translate) + ' {{userSelected.name}} {{userSelected.surname}}'}"
+              when="{'0': {{'noRecordFound' | translate}},
+                    'one': '1 ' +  {{'userRecord' | translate}} + ' {{userSelected.name}} {{userSelected.surname}}',
+                    'other': '{} ' +  {{'userRecords' | translate}} + ' {{userSelected.name}} {{userSelected.surname}}'}"
             ></ng-pluralize>
           </div>
           <div class="panel-body">

--- a/web-ui/src/main/resources/catalog/templates/admin/usergroup/users.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/usergroup/users.html
@@ -493,9 +493,9 @@
             <i class="fa fa-search" />&nbsp;
             <ng-pluralize
               count="searchResults.count"
-              when="{'0': {{'noRecordFound' | translate}},
-                    'one': '1 ' +  {{'userRecord' | translate}} + ' {{userSelected.name}} {{userSelected.surname}}',
-                    'other': '{} ' +  {{'userRecords' | translate}} + ' {{userSelected.name}} {{userSelected.surname}}'}"
+              when="{'0': '{{&quot;noRecordFound&quot; | translate}}',
+                    'one': '1 ' +  '{{&quot;userRecord&quot; | translate}}' + ' {{userSelected.name}} {{userSelected.surname}}',
+                    'other': '{} ' +  '{{&quot;userRecords&quot; | translate}}' + ' {{userSelected.name}} {{userSelected.surname}}'}"
             ></ng-pluralize>
           </div>
           <div class="panel-body">


### PR DESCRIPTION
This PR fixes the untranslated userRecord and userRecords labels in the record count section of admin console -> users and groups -> users -> user page