### PR TITLE
Record view / Series / Technical information

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/type-series.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/type-series.html
@@ -14,6 +14,13 @@
     <div gn-record-is-replaced-by="mdView.current.record.uuid"></div>
 
     <div
+      data-ng-if="!(mdView.current.record.related.uuids
+                    && mdView.current.record.related.uuids.length > 0)"
+      class="gn-margin-top"
+      ng-include="'../../catalog/views/default/templates/recordView/thumbnails.html'"
+    ></div>
+
+    <div
       class="gn-margin-top"
       ng-include="'../../catalog/views/default/templates/recordView/summary.html'"
     />
@@ -74,6 +81,25 @@
     ></div>
   </div>
 </div>
+
+
+<div class="row gn-section gn-section-{{mdView.current.record.resourceType[0]}}">
+  <div class="col-md-12 gn-record">
+    <h2 data-translate="">technicalInformation</h2>
+  </div>
+  <div
+    class="gn-md-side gn-nopadding-top col-md-8"
+  >
+    <div
+      class="col-3 gn-padding-bottom-lg"
+      ng-include="'../../catalog/views/default/templates/recordView/technical.html'"
+    />
+  </div>
+  <div class="col-md-4 gn-md-side gn-nopadding-top">
+    <div ng-include="'../../catalog/views/default/templates/recordView/spatial.html'" />
+  </div>
+</div>
+
 
 <div
   class="row gn-section gn-section-{{mdView.current.record.resourceType[0]}}"


### PR DESCRIPTION
Most of the time series are used as container and only provide general information. It may not be always the case, so the following changes are done in the record view for series : 
* display technical information after list of related records. 
![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/09a07932-ae39-460d-82ba-6d9366b49f61)

* display the series thumbnails when there is no child.

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/0fcae21f-be0d-4171-ab46-c8f070aae7d0)


eg. series with no child https://geocatalogue.apur.org/catalogue/srv/eng/catalog.search#/metadata/537e711a-eb13-41c9-9fc5-f351226f6e3a
series with children https://sdi.eea.europa.eu/catalogue/srv/eng/catalog.search#/metadata/34bd02bf-be87-4122-b9a2-1e846c27a786
