### PR TITLE
Display the login menu for authenticated users when the setting 'gnCfg.mods.authentication.enabled' is disabled

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/related.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/related.html
@@ -233,14 +233,17 @@
             }"
         >
           <span>
-            <span data-ng-if="!md.properties || (md.properties && md.properties.associationType == '')">
+            <span
+              data-ng-if="!md.properties || (md.properties && md.properties.associationType == '')"
+            >
               {{(config.getLabel(mainType, type)) | translate}}</span
             >
             <span
               data-ng-if="md.properties && md.properties.associationType"
               data-ng-show="md.properties && md.properties.associationType"
               title="{{(config.getLabel(mainType, type)) | translate}}"
-            > {{'associatedTo' | translate}}
+            >
+              {{'associatedTo' | translate}}
               <b title="{{'associationType' | translate}}">
                 <i
                   class="fa fa-fw {{icon}} gn-icon-association-{{md.properties.associationType}}"

--- a/web-ui/src/main/resources/catalog/components/toolbar/partials/menu-signin.html
+++ b/web-ui/src/main/resources/catalog/components/toolbar/partials/menu-signin.html
@@ -1,5 +1,5 @@
 <ul
-  data-ng-if="gnCfg.mods.authentication.enabled"
+  data-ng-if="gnCfg.mods.authentication.enabled || authenticated"
   class="nav navbar-nav username-dropdown accessible-dropdown"
 >
   <!-- logged in -->


### PR DESCRIPTION
When the setting `gnCfg.mods.authentication.enabled` is disabled, the login menu is not displayed in the top bar, users have to go directly to the login page to be able to login.

<img width="1396" alt="loginmenu-1" src="https://github.com/geonetwork/core-geonetwork/assets/1695003/0a3c985a-ed7f-4628-ab80-c98cfed65f16">

This can be useful to hide the login option.

The problem is that once the user is logged in, the menu is not displayed, so the logged user has no easy way to go to the user profile page or logout.

With this change, the login menu is displayed when the option `gnCfg.mods.authentication.enabled` is disabled, but the user is logged in.

<img width="332" alt="loginmenu-2" src="https://github.com/geonetwork/core-geonetwork/assets/1695003/8ac4a0dc-9fcb-4809-9454-386e3e9b323e">

