### PR TITLE
Fix CORSInterceptor, usage of a variable before is defined. 

### DIFF
--- a/web-ui/src/main/resources/catalog/components/utility/CORSInterceptor.js
+++ b/web-ui/src/main/resources/catalog/components/utility/CORSInterceptor.js
@@ -81,7 +81,7 @@
                 if (mapservice !== null) {
                   if (mapservice.useProxy) {
                     // If we need to use the proxy then add it to requireProxy list.
-                    if ($.inArray(url, gnGlobalSettings.requireProxy) === -1) {
+                    if ($.inArray(config.url, gnGlobalSettings.requireProxy) === -1) {
                       var url = config.url.split("/");
                       url = url[0] + "/" + url[1] + "/" + url[2] + "/";
                       gnGlobalSettings.requireProxy.push(url);

--- a/web-ui/src/main/resources/catalog/components/viewer/wps/WpsService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wps/WpsService.js
@@ -240,19 +240,23 @@
           // when bbox is cleared value is still set to ',,,'
           if (input.boundingBoxData && data && data != ",,,") {
             var bbox = data.split(",");
-            
+
             var geomCrs = "EPSG:4326";
-            if (input.boundingBoxData._default &&
+            if (
+              input.boundingBoxData._default &&
               input.boundingBoxData._default.crs &&
-              input.boundingBoxData._default.crs !== geomCrs) {
+              input.boundingBoxData._default.crs !== geomCrs
+            ) {
               geomCrs = input.boundingBoxData._default.crs;
               try {
                 bbox = ol.proj.transformExtent(bbox, "EPSG:4326", geomCrs);
               } catch (e) {
-                console.warn("WPS | Failed to convert boundingBoxData to requested CRS " + geomCrs);
+                console.warn(
+                  "WPS | Failed to convert boundingBoxData to requested CRS " + geomCrs
+                );
               }
             }
-            
+
             request.value.dataInputs.input.push({
               identifier: {
                 value: input.identifier.value


### PR DESCRIPTION
Related to #5941

The variable `url` is used before is declared. It seems that the correct variable to use is `config.url`.

----

Included in the PR prettier formatting for https://github.com/geonetwork/core-geonetwork/compare/main...GeoCat:core-geonetwork:fix-corsinterceptor?expand=1#diff-17af7f0ce89836e5f0d51b830431ce4ee01d98843e81399cd432359e80ae6591