### PR TITLE
Improved handling of empty titles

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/editor.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/editor.html
@@ -28,7 +28,10 @@
                 data-ng-href="catalog.search#/{{(md.draft == 'y')?'metadraf':'metadata'}}/{{md.uuid}}"
                 title="{{md.resourceAbstract}}"
                 class="gn-break"
-                >{{md.resourceTitle}}</a
+                >
+                <i data-ng-show="mdResourceTitle.trim()=='' || md.resourceTitle===undefined">{{'missingTitle' | translate}}</i>
+                {{md.resourceTitle}}
+              </a
               >
               <span data-ng-show="md.isTemplate == 's'">{{md.resourceTitle}}</span>
               <div class="gn-record-details text-muted">

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/editor.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/editor.html
@@ -28,11 +28,13 @@
                 data-ng-href="catalog.search#/{{(md.draft == 'y')?'metadraf':'metadata'}}/{{md.uuid}}"
                 title="{{md.resourceAbstract}}"
                 class="gn-break"
-                >
-                <i data-ng-show="mdResourceTitle.trim()=='' || md.resourceTitle===undefined">{{'missingTitle' | translate}}</i>
-                {{md.resourceTitle}}
-              </a
               >
+                <i
+                  data-ng-show="md.resourceTitle.trim()=='' || md.resourceTitle===undefined"
+                  >{{'missingTitle' | translate}}</i
+                >
+                {{md.resourceTitle}}
+              </a>
               <span data-ng-show="md.isTemplate == 's'">{{md.resourceTitle}}</span>
               <div class="gn-record-details text-muted">
                 <small><span data-translate="">owner</span>:</small>

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid.html
@@ -33,6 +33,7 @@
             title="{{md.resourceTitle}}"
             class="gn-break"
           >
+            <i data-ng-show="mdResourceTitle.trim()=='' || md.resourceTitle===undefined">{{'missingTitle' | translate}}</i>
             {{(md.resourceTitle) | characters:80}}
           </a>
         </h1>

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid.html
@@ -33,7 +33,9 @@
             title="{{md.resourceTitle}}"
             class="gn-break"
           >
-            <i data-ng-show="mdResourceTitle.trim()=='' || md.resourceTitle===undefined">{{'missingTitle' | translate}}</i>
+            <i data-ng-show="md.resourceTitle.trim()=='' || md.resourceTitle===undefined"
+              >{{'missingTitle' | translate}}</i
+            >
             {{(md.resourceTitle) | characters:80}}
           </a>
         </h1>

--- a/web-ui/src/main/resources/catalog/locales/ca-core.json
+++ b/web-ui/src/main/resources/catalog/locales/ca-core.json
@@ -573,5 +573,6 @@
     "batchSubmitInfo": "This option submits the selected metadata owned by the user.",
     "reviewerNotAllowedPublish": "Reviewer not allowed to publish the metadata",
     "reviewerNotAllowedUnpublish": "Reviewer not allowed to un-publish the metadata",
-    "reviewerNotAllowedPublishUnpublish": "Reviewer not allowed to publish / un-publish the metadata"
+    "reviewerNotAllowedPublishUnpublish": "Reviewer not allowed to publish / un-publish the metadata",
+    "missingTitle": "Missing title"
 }

--- a/web-ui/src/main/resources/catalog/locales/cs-core.json
+++ b/web-ui/src/main/resources/catalog/locales/cs-core.json
@@ -573,5 +573,6 @@
     "batchSubmitInfo": "Tato možnost odešle vybraná metadata vlastněná uživatelem.",
     "reviewerNotAllowedPublish": "Prohlížející nemá oprávnění publikovat metadata",
     "reviewerNotAllowedUnpublish": "Prohlížející nemůže zrušit publikování metadat",
-    "reviewerNotAllowedPublishUnpublish": "Prohlížející nemá oprávnění publikovat/zrušit publikování metadat"
+    "reviewerNotAllowedPublishUnpublish": "Prohlížející nemá oprávnění publikovat/zrušit publikování metadat",
+    "missingTitle": "Missing title"
 }

--- a/web-ui/src/main/resources/catalog/locales/da-core.json
+++ b/web-ui/src/main/resources/catalog/locales/da-core.json
@@ -573,5 +573,6 @@
     "batchSubmitInfo": "Denne indstilling indsender de valgte metadata, der ejes af brugeren.",
     "reviewerNotAllowedPublish": "Reviewer not allowed to publish the metadata",
     "reviewerNotAllowedUnpublish": "Reviewer not allowed to un-publish the metadata",
-    "reviewerNotAllowedPublishUnpublish": "Reviewer not allowed to publish / un-publish the metadata"
+    "reviewerNotAllowedPublishUnpublish": "Reviewer not allowed to publish / un-publish the metadata",
+    "missingTitle": "Missing title"
 }

--- a/web-ui/src/main/resources/catalog/locales/de-core.json
+++ b/web-ui/src/main/resources/catalog/locales/de-core.json
@@ -573,5 +573,6 @@
     "batchSubmitInfo": "This option submits the selected metadata owned by the user.",
     "reviewerNotAllowedPublish": "Reviewer not allowed to publish the metadata",
     "reviewerNotAllowedUnpublish": "Reviewer not allowed to un-publish the metadata",
-    "reviewerNotAllowedPublishUnpublish": "Reviewer not allowed to publish / un-publish the metadata"
+    "reviewerNotAllowedPublishUnpublish": "Reviewer not allowed to publish / un-publish the metadata",
+    "missingTitle": "Missing title"
 }

--- a/web-ui/src/main/resources/catalog/locales/en-core.json
+++ b/web-ui/src/main/resources/catalog/locales/en-core.json
@@ -575,5 +575,6 @@
     "batchSubmitInfo": "This option submits the selected metadata owned by the user.",
     "reviewerNotAllowedPublish": "Reviewer not allowed to publish the metadata",
     "reviewerNotAllowedUnpublish": "Reviewer not allowed to un-publish the metadata",
-    "reviewerNotAllowedPublishUnpublish": "Reviewer not allowed to publish / un-publish the metadata"
+    "reviewerNotAllowedPublishUnpublish": "Reviewer not allowed to publish / un-publish the metadata",
+    "missingTitle": "Missing title"
 }

--- a/web-ui/src/main/resources/catalog/locales/es-core.json
+++ b/web-ui/src/main/resources/catalog/locales/es-core.json
@@ -573,5 +573,6 @@
     "batchSubmitInfo": "This option submits the selected metadata owned by the user.",
     "reviewerNotAllowedPublish": "Reviewer not allowed to publish the metadata",
     "reviewerNotAllowedUnpublish": "Reviewer not allowed to un-publish the metadata",
-    "reviewerNotAllowedPublishUnpublish": "Reviewer not allowed to publish / un-publish the metadata"
+    "reviewerNotAllowedPublishUnpublish": "Reviewer not allowed to publish / un-publish the metadata",
+    "missingTitle": "Missing title"
 }

--- a/web-ui/src/main/resources/catalog/locales/fi-core.json
+++ b/web-ui/src/main/resources/catalog/locales/fi-core.json
@@ -573,5 +573,6 @@
     "batchSubmitInfo": "This option submits the selected metadata owned by the user.",
     "reviewerNotAllowedPublish": "Reviewer not allowed to publish the metadata",
     "reviewerNotAllowedUnpublish": "Reviewer not allowed to un-publish the metadata",
-    "reviewerNotAllowedPublishUnpublish": "Reviewer not allowed to publish / un-publish the metadata"
+    "reviewerNotAllowedPublishUnpublish": "Reviewer not allowed to publish / un-publish the metadata",
+    "missingTitle": "Missing title"
 }

--- a/web-ui/src/main/resources/catalog/locales/fr-core.json
+++ b/web-ui/src/main/resources/catalog/locales/fr-core.json
@@ -573,5 +573,6 @@
     "batchSubmitInfo": "Cette option propose les fiches sélectionnées appartenant à l'utilisateur.",
     "reviewerNotAllowedPublish": "Les relecteurs ne sont pas autorisés à publier des fiches.",
     "reviewerNotAllowedUnpublish": "Les relecteurs ne sont pas autorisés à dépublier des fiches",
-    "reviewerNotAllowedPublishUnpublish": "Les relecteurs ne sont pas autorisés à publier/dépublier des fiches"
+    "reviewerNotAllowedPublishUnpublish": "Les relecteurs ne sont pas autorisés à publier/dépublier des fiches",
+    "missingTitle": "Missing title"
 }

--- a/web-ui/src/main/resources/catalog/locales/is-core.json
+++ b/web-ui/src/main/resources/catalog/locales/is-core.json
@@ -573,5 +573,6 @@
     "batchSubmitInfo": "This option submits the selected metadata owned by the user.",
     "reviewerNotAllowedPublish": "Reviewer not allowed to publish the metadata",
     "reviewerNotAllowedUnpublish": "Reviewer not allowed to un-publish the metadata",
-    "reviewerNotAllowedPublishUnpublish": "Reviewer not allowed to publish / un-publish the metadata"
+    "reviewerNotAllowedPublishUnpublish": "Reviewer not allowed to publish / un-publish the metadata",
+    "missingTitle": "Missing title"
 }

--- a/web-ui/src/main/resources/catalog/locales/it-core.json
+++ b/web-ui/src/main/resources/catalog/locales/it-core.json
@@ -573,5 +573,6 @@
     "batchSubmitInfo": "This option submits the selected metadata owned by the user.",
     "reviewerNotAllowedPublish": "Reviewer not allowed to publish the metadata",
     "reviewerNotAllowedUnpublish": "Reviewer not allowed to un-publish the metadata",
-    "reviewerNotAllowedPublishUnpublish": "Reviewer not allowed to publish / un-publish the metadata"
+    "reviewerNotAllowedPublishUnpublish": "Reviewer not allowed to publish / un-publish the metadata",
+    "missingTitle": "Missing title"
 }

--- a/web-ui/src/main/resources/catalog/locales/ko-core.json
+++ b/web-ui/src/main/resources/catalog/locales/ko-core.json
@@ -573,5 +573,6 @@
     "batchSubmitInfo": "This option submits the selected metadata owned by the user.",
     "reviewerNotAllowedPublish": "Reviewer not allowed to publish the metadata",
     "reviewerNotAllowedUnpublish": "Reviewer not allowed to un-publish the metadata",
-    "reviewerNotAllowedPublishUnpublish": "Reviewer not allowed to publish / un-publish the metadata"
+    "reviewerNotAllowedPublishUnpublish": "Reviewer not allowed to publish / un-publish the metadata",
+    "missingTitle": "Missing title"
 }

--- a/web-ui/src/main/resources/catalog/locales/nl-core.json
+++ b/web-ui/src/main/resources/catalog/locales/nl-core.json
@@ -574,5 +574,6 @@
     "batchSubmitInfo": "This option submits the selected metadata owned by the user.",
     "reviewerNotAllowedPublish": "Reviewer not allowed to publish the metadata",
     "reviewerNotAllowedUnpublish": "Reviewer not allowed to un-publish the metadata",
-    "reviewerNotAllowedPublishUnpublish": "Reviewer not allowed to publish / un-publish the metadata"
+    "reviewerNotAllowedPublishUnpublish": "Reviewer not allowed to publish / un-publish the metadata",
+    "missingTitle": "Missing title"
 }

--- a/web-ui/src/main/resources/catalog/locales/pt-core.json
+++ b/web-ui/src/main/resources/catalog/locales/pt-core.json
@@ -573,5 +573,6 @@
     "batchSubmitInfo": "This option submits the selected metadata owned by the user.",
     "reviewerNotAllowedPublish": "Reviewer not allowed to publish the metadata",
     "reviewerNotAllowedUnpublish": "Reviewer not allowed to un-publish the metadata",
-    "reviewerNotAllowedPublishUnpublish": "Reviewer not allowed to publish / un-publish the metadata"
+    "reviewerNotAllowedPublishUnpublish": "Reviewer not allowed to publish / un-publish the metadata",
+    "missingTitle": "Missing title"
 }

--- a/web-ui/src/main/resources/catalog/locales/ru-core.json
+++ b/web-ui/src/main/resources/catalog/locales/ru-core.json
@@ -573,5 +573,6 @@
     "batchSubmitInfo": "This option submits the selected metadata owned by the user.",
     "reviewerNotAllowedPublish": "Reviewer not allowed to publish the metadata",
     "reviewerNotAllowedUnpublish": "Reviewer not allowed to un-publish the metadata",
-    "reviewerNotAllowedPublishUnpublish": "Reviewer not allowed to publish / un-publish the metadata"
+    "reviewerNotAllowedPublishUnpublish": "Reviewer not allowed to publish / un-publish the metadata",
+    "missingTitle": "Missing title"
 }

--- a/web-ui/src/main/resources/catalog/locales/sk-core.json
+++ b/web-ui/src/main/resources/catalog/locales/sk-core.json
@@ -573,5 +573,6 @@
     "batchSubmitInfo": "This option submits the selected metadata owned by the user.",
     "reviewerNotAllowedPublish": "Reviewer not allowed to publish the metadata",
     "reviewerNotAllowedUnpublish": "Reviewer not allowed to un-publish the metadata",
-    "reviewerNotAllowedPublishUnpublish": "Reviewer not allowed to publish / un-publish the metadata"
+    "reviewerNotAllowedPublishUnpublish": "Reviewer not allowed to publish / un-publish the metadata",
+    "missingTitle": "Missing title"
 }

--- a/web-ui/src/main/resources/catalog/locales/sv-core.json
+++ b/web-ui/src/main/resources/catalog/locales/sv-core.json
@@ -573,5 +573,6 @@
     "batchSubmitInfo": "This option submits the selected metadata owned by the user.",
     "reviewerNotAllowedPublish": "Reviewer not allowed to publish the metadata",
     "reviewerNotAllowedUnpublish": "Reviewer not allowed to un-publish the metadata",
-    "reviewerNotAllowedPublishUnpublish": "Reviewer not allowed to publish / un-publish the metadata"
+    "reviewerNotAllowedPublishUnpublish": "Reviewer not allowed to publish / un-publish the metadata",
+    "missingTitle": "Missing title"
 }

--- a/web-ui/src/main/resources/catalog/locales/zh-core.json
+++ b/web-ui/src/main/resources/catalog/locales/zh-core.json
@@ -573,5 +573,6 @@
     "batchSubmitInfo": "This option submits the selected metadata owned by the user.",
     "reviewerNotAllowedPublish": "Reviewer not allowed to publish the metadata",
     "reviewerNotAllowedUnpublish": "Reviewer not allowed to un-publish the metadata",
-    "reviewerNotAllowedPublishUnpublish": "Reviewer not allowed to publish / un-publish the metadata"
+    "reviewerNotAllowedPublishUnpublish": "Reviewer not allowed to publish / un-publish the metadata",
+    "missingTitle": "Missing title"
 }

--- a/web-ui/src/main/resources/catalog/views/default/directives/partials/infolist.html
+++ b/web-ui/src/main/resources/catalog/views/default/directives/partials/infolist.html
@@ -18,7 +18,10 @@
           gn-formatter="formatter.defaultUrl"
         >
           <h1>
-            <span class="clamp-2">{{md.resourceTitle}}</span>
+            <span class="clamp-2">
+              <i data-ng-show="mdResourceTitle.trim()=='' || md.resourceTitle===undefined">{{'missingTitle' | translate}}</i>
+              {{md.resourceTitle}}
+            </span>
           </h1>
         </a>
       </div>

--- a/web-ui/src/main/resources/catalog/views/default/directives/partials/infolist.html
+++ b/web-ui/src/main/resources/catalog/views/default/directives/partials/infolist.html
@@ -19,7 +19,10 @@
         >
           <h1>
             <span class="clamp-2">
-              <i data-ng-show="mdResourceTitle.trim()=='' || md.resourceTitle===undefined">{{'missingTitle' | translate}}</i>
+              <i
+                data-ng-show="md.resourceTitle.trim()=='' || md.resourceTitle===undefined"
+                >{{'missingTitle' | translate}}</i
+              >
               {{md.resourceTitle}}
             </span>
           </h1>


### PR DESCRIPTION
Handle empty titles when they obstruct the use of the UI (such as when they make a record unclickable).

![image](https://github.com/geonetwork/core-geonetwork/assets/11455912/6beb70e9-4ae0-4217-9b8b-222e97d5ceff)
![image](https://github.com/geonetwork/core-geonetwork/assets/11455912/98654172-0845-439a-b40c-22d4d2b708c6)
![image](https://github.com/geonetwork/core-geonetwork/assets/11455912/451cda4a-28a8-4e43-839f-b9552f2287df)
