### PR TITLE
Indexing / Bounding Polygon / Coordinate order

### DIFF
--- a/core/src/main/java/org/fao/geonet/util/XslUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/XslUtil.java
@@ -194,14 +194,14 @@ public final class XslUtil {
                     geom = JTS.transform(
                         geom,
                         CRS.findMathTransform((DefaultProjectedCRS) userData,
-                            DefaultGeographicCRS.WGS84, true)
+                            CRS.decode("EPSG:4326", true), true)
                     );
                 }
                 else if (userData instanceof DefaultGeographicCRS) {
                     geom = JTS.transform(
                         geom,
                         CRS.findMathTransform((DefaultGeographicCRS) userData,
-                            DefaultGeographicCRS.WGS84, true)
+                            CRS.decode("EPSG:4326", true), true)
                     );
                 }
 


### PR DESCRIPTION
Follow up of https://github.com/geonetwork/core-geonetwork/pull/7340

Clarify coordinate order for geo_shape field: 
"In GeoJSON and WKT, and therefore Elasticsearch, the correct coordinate order is longitude, latitude (X, Y) within coordinate arrays. This differs from many Geospatial APIs (e.g., Google Maps) that generally use the colloquial latitude, longitude (Y, X)."

Same config as https://github.com/geonetwork/core-geonetwork/blob/main/core/src/main/java/org/fao/geonet/kernel/region/Region.java#L57

Test :
* https://www.geocat.ch/geonetwork/srv/api/records/78a41177-6125-4f11-ac8b-4ec6166dad70/formatters/iso19139?output=xml
* check coordinate order in default view (advanced view is fine because base on the XML)

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/1234e370-fb52-47fb-bfed-960a90cf7b83)



![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/e01bff6b-0c9f-4a7d-b1c4-265fe159ce1d)
