### PR TITLE
Record view / Support multiple status.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -1267,18 +1267,22 @@
   ]);
 
   module.directive("gnStatusBadge", [
-    function () {
+    "$translate",
+    function ($translate) {
       return {
         restrict: "A",
         replace: true,
-        transclude: true,
-        template:
-          '<div data-ng-if="::md.cl_status.length > 0"' +
-          ' title="{{::md.cl_status[0].key | translate}}"' +
-          ' class="gn-status gn-status-{{::md.cl_status[0].key}}">{{::md.cl_status[0].key | translate}}' +
-          "</div>",
+        templateUrl: "../../catalog/components/utility/partials/statusbadge.html",
         scope: {
           md: "=gnStatusBadge"
+        },
+        link: function (scope, element, attrs) {
+          scope.statusTitle = "";
+          if (scope.md && scope.md.cl_status && scope.md.cl_status.length > 0) {
+            angular.forEach(scope.md.cl_status, function (status) {
+              scope.statusTitle += $translate.instant(status.key) + "\n";
+            });
+          }
         }
       };
     }

--- a/web-ui/src/main/resources/catalog/components/utility/partials/statusbadge.html
+++ b/web-ui/src/main/resources/catalog/components/utility/partials/statusbadge.html
@@ -1,0 +1,7 @@
+<div
+  data-ng-show="md.cl_status && md.cl_status.length > 0"
+  title="{{statusTitle}}"
+  class="gn-status gn-status-{{::md.cl_status[0].key}}"
+>
+  {{::md.cl_status[0].key | translate}}
+</div>

--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -741,10 +741,24 @@ i.fa-times.delete:hover {
 
 .gn-search-page {
   .gn-status {
-    position: absolute;
     bottom: 9px;
     margin-left: -8px;
     z-index: 98;
+  }
+  [data-search-results] .gn-status {
+    position: absolute;
+  }
+  [data-search-results] table .gn-status {
+    position: unset;
+  }
+  .gn-status-container {
+    text-align: right;
+    margin-right: -10px;
+
+    .gn-status {
+      border-radius: 3px;
+      margin-left: 2px;
+    }
   }
   .gn-status,
   .gn-workflow-status {

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/status.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/status.html
@@ -1,12 +1,9 @@
 <!-- Display the first metadata status (apply to ISO19139 record) -->
-<div
-  data-ng-if="mdView.current.record.cl_status.length > 0"
-  data-ng-repeat="c in mdView.current.record.cl_status track by $index"
-  class="col-md-12 gn-nopadding-left"
->
+<div data-ng-if="mdView.current.record.cl_status.length > 0" class="gn-status-container">
   <div
     data-ng-if="showStatusWatermarkFor.indexOf(c.key) === -1 && showStatusTopBarFor.indexOf(c.key) === -1"
-    class="gn-status gn-status-{{c.key}} gn-status-topright gn-status-md"
+    data-ng-repeat="c in mdView.current.record.cl_status track by $index"
+    class="gn-status gn-status-{{c.key}} gn-status-md"
   >
     {{c.key | translate}}
   </div>

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/type-dataset.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/type-dataset.html
@@ -2,12 +2,12 @@
 <div
   class="row gn-card gn-card-{{mdView.current.record.resourceType[0]}} gn-margin-top gn-margin-bottom gn-padding-top gn-padding-bottom"
 >
-  <div ng-include="'../../catalog/views/default/templates/recordView/status.html'" />
-
   <div class="col-md-8 gn-record">
     <div ng-include="'../../catalog/views/default/templates/recordView/title.html'" />
   </div>
   <div class="col-md-4 gn-md-side">
+    <div ng-include="'../../catalog/views/default/templates/recordView/status.html'" />
+
     <div gn-record-is-replaced-by="mdView.current.record.uuid"></div>
 
     <div

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/type-series.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/type-series.html
@@ -1,7 +1,6 @@
 <div
   class="row gn-card gn-card-{{mdView.current.record.resourceType[0]}} gn-margin-bottom gn-margin-top"
 >
-  <div ng-include="'../../catalog/views/default/templates/recordView/status.html'" />
   <div class="col-md-8 gn-record gn-{{mdView.current.record.resourceType[0]}}">
     <div class="">
       <div
@@ -11,6 +10,8 @@
     </div>
   </div>
   <div class="col-md-4 gn-md-side">
+    <div ng-include="'../../catalog/views/default/templates/recordView/status.html'" />
+
     <div gn-record-is-replaced-by="mdView.current.record.uuid"></div>
 
     <div


### PR DESCRIPTION
In ISO, a record may have more than one status even if not common. 

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/8c0bfa0c-5d8b-4282-a618-2815dbf50efb)


Fix the overlapping status badge by a dedicated container displaying all status. 

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/9070df0e-9795-45e7-9ad3-1f7184d2b222)


In the search results, only the first status is displayed (and others are listed in the tooltip for information).

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/3e2bd4d7-902f-4ba0-be01-46cb59e3589f)
