### PR TITLE
Groups maintenance / fix the display of the metadata owned by a group

### DIFF
--- a/web-ui/src/main/resources/catalog/js/admin/UserGroupController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/UserGroupController.js
@@ -797,7 +797,7 @@
         // Retrieve records in that group
         $scope.$broadcast("resetSearch", {
           isTemplate: ["y", "n", "s", "t"],
-          group: g.id,
+          groupOwner: g.id,
           sortBy: "resourceTitleObject.default.sort"
         });
 

--- a/web-ui/src/main/resources/catalog/templates/admin/usergroup/groups.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/usergroup/groups.html
@@ -295,9 +295,9 @@
           <h3>
             <ng-pluralize
               count="searchResults.count"
-              when="{'0': ('noRecordFound' | translate),
-                'one': '1' +  ('groupRecord' | translate) + ' {{groupSelected.label[lang]}}',
-                'other': '{}' +  ('groupRecords' | translate) + ' {{groupSelected.label[lang]}}'}"
+              when="{'0': '{{&quot;noRecordFound&quot; | translate}}',
+                'one': '1' + '{{&quot;groupRecord&quot; | translate}}' + ' {{groupSelected.label[lang]}}',
+                'other': '{}' + '{{&quot;groupRecords&quot; | translate}}' + ' {{groupSelected.label[lang]}}'}"
             ></ng-pluralize>
           </h3>
           <div


### PR DESCRIPTION
Fix the filter to display of the metadata owned by a group in the groups maintenance and untranslated texts (analog to #7354)