### PR TITLE
Fix bug with empty check on mdOtherLanguages in editor service

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadatamanager/EditorService.js
+++ b/web-ui/src/main/resources/catalog/components/metadatamanager/EditorService.js
@@ -400,7 +400,7 @@
              });
 
              gnCurrentEdit.allLanguages = {code2iso: {}, iso2code: {}, iso: []};
-             if (gnCurrentEdit.mdOtherLanguages != '') {
+             if (gnCurrentEdit.mdOtherLanguages && gnCurrentEdit.mdOtherLanguages != '') {
                angular.forEach(JSON.parse(gnCurrentEdit.mdOtherLanguages), function(code, iso) {
                  gnCurrentEdit.allLanguages.code2iso[code] = iso;
                  gnCurrentEdit.allLanguages.iso2code[iso] = code;


### PR DESCRIPTION
When editing a metadata record the following would appear in console

![image](https://github.com/geonetwork/core-geonetwork/assets/1868233/5dbccaef-21a3-44ed-bdb3-6fb2aa0f0946)

Fix is already applied on main branch.
https://github.com/geonetwork/core-geonetwork/blob/6b0baeef0e68070e9b9c1428e2de9d9721137ee4/web-ui/src/main/resources/catalog/components/metadatamanager/EditorService.js#L422