### PR TITLE
Fix issue with canViewRecord when calling related api

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/ApiUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/ApiUtils.java
@@ -113,7 +113,11 @@ public class ApiUtils {
         throws Exception {
 
         IMetadataUtils metadataUtils = ApplicationContextHolder.get().getBean(IMetadataUtils.class);
-        String id = String.valueOf(metadataUtils.findOneByUuid(uuidOrInternalId).getId());
+        AbstractMetadata metadata = metadataUtils.findOneByUuid(uuidOrInternalId);
+        String id = null;
+        if (metadata != null) {
+            id = String.valueOf(metadata.getId());
+        }
 
         if (StringUtils.isEmpty(id)) {
             //It wasn't a UUID

--- a/services/src/main/java/org/fao/geonet/api/ApiUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/ApiUtils.java
@@ -23,8 +23,6 @@
 
 package org.fao.geonet.api;
 
-import static org.fao.geonet.api.records.attachments.AbstractStore.getAndCheckMetadataId;
-
 import com.google.common.collect.Sets;
 import jeeves.constants.Jeeves;
 import jeeves.server.UserSession;
@@ -295,7 +293,7 @@ public class ApiUtils {
         String metadataId;
         if (!approved) {
             // If the record is not approved then we need to get the id of the record.
-            metadataId = String.valueOf(getAndCheckMetadataId(metadataUuid, approved));
+            metadataId = getInternalId(metadataUuid, approved);
         } else {
             // Otherwise use the uuid or id that was supplied.
             metadataId = metadataUuid;

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataApi.java
@@ -73,7 +73,7 @@ import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import static org.fao.geonet.api.ApiParams.*;
-import static org.fao.geonet.api.records.attachments.AbstractStore.getAndCheckMetadataId;
+
 import static org.fao.geonet.kernel.mef.MEFLib.Version.Constants.MEF_V1_ACCEPT_TYPE;
 import static org.fao.geonet.kernel.mef.MEFLib.Version.Constants.MEF_V2_ACCEPT_TYPE;
 

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataAssociatedApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataAssociatedApi.java
@@ -52,11 +52,8 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
 import java.util.*;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.fao.geonet.api.ApiParams.*;
-import static org.fao.geonet.api.records.attachments.AbstractStore.getAndCheckMetadataId;
 
 @RequestMapping(value = {
     "/{portal}/api/records"

--- a/services/src/main/java/org/fao/geonet/api/related/Related.java
+++ b/services/src/main/java/org/fao/geonet/api/related/Related.java
@@ -58,8 +58,6 @@ import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
 
-import static org.fao.geonet.api.records.attachments.AbstractStore.getAndCheckMetadataId;
-
 @RequestMapping(value = {
     "/{portal}/api/related"
 })


### PR DESCRIPTION
If attempting to call the related function for non approved record it would failing

This is a sample call that would fail
http://localhost:8080/geonetwork/srv/api/records/116/related?type=onlines&approved=false&rows=100

Switch `getAndCheckMetadataId` to `getInternalId` because `getAndCheckMetadataId` did not support id as parameter.

Also fixed bug in `getInternalId`. `metadataUtils.findOneByUuid(uuidOrInternalId).getId()` would throw an npe when findOneByUuid did not find the record.

