### PR TITLE
Workflow / Related records of the draft

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/es/EsHTTPProxy.java
+++ b/services/src/main/java/org/fao/geonet/api/es/EsHTTPProxy.java
@@ -171,7 +171,7 @@ public class EsHTTPProxy {
             related = MetadataUtils.getAssociated(
                 context,
                 context.getBean(IMetadataUtils.class)
-                    .findOneByUuid(doc.get("_id").asText()),
+                    .findOne(doc.get("_source").get("id").asText()),
                 relatedTypes, 0, 1000);
         } catch (Exception e) {
             LOGGER.warn("Failed to load related types for {}. Error is: {}",


### PR DESCRIPTION
Related records are available from the search API. For draft, no records are returned because the search was made by UUID instead of ID.

The call retrieving the draft and the approved version was containing relation only for the approved version (http://localhost:8080/geonetwork/srv/api/search/records/_search?relatedType=parent&relatedType=children&related...)

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/4b81c21b-1f51-4707-8ef9-690b12acd9e1)

Test:
* create a draft
* add relations to other record (parent/source/siblings/...)
* check the draft record view = relations are missing 


Identified while testing https://github.com/geonetwork/core-geonetwork/pull/7373