### PR TITLE
Documentation: Fix indents, admonitions, dates and missing images

### DIFF
--- a/docs/manual/docs/developer/development/index.md
+++ b/docs/manual/docs/developer/development/index.md
@@ -304,11 +304,11 @@ During the build process FindBugs and Checkstyle are ran. If a violation is foun
 
 Since the FindBugs and Checkstyle processes can be quite time consuming adding -DskipTests to the maven commandline will skip those processes as well as tests. For example:
 
-> mvn install -DskipTests
+    mvn install -DskipTests
 
 Or if you want to run the tests but skip static analysis:
 
-> mvn install -P-run-static-analysis
+    mvn install -P-run-static-analysis
 
 That disables the profile that executes the static analysis tasks.
 

--- a/docs/manual/docs/developer/mef/index.md
+++ b/docs/manual/docs/developer/mef/index.md
@@ -103,7 +103,7 @@ Any other element or attribute should be ignored by readers that don't understan
 
 ### Date format
 
-Unless differently specified, all dates in this file must be in the ISO/8601 format. The pattern must be YYYY-MM-DDTHH:mm:SS and the timezone should be the local one.
+Unless differently specified, all dates in this file must be in the ISO/8601 format. The pattern must be `YYYY-MM-DDTHH:mm:SS` and the timezone should be the local one.
 
 #### Date format example {#info_xml}
 

--- a/docs/manual/docs/developer/schemaPlugins/index.md
+++ b/docs/manual/docs/developer/schemaPlugins/index.md
@@ -591,9 +591,7 @@ There are certain XSLT templates that the presentation XSLT must have:
 
 -   the **main** template, which must be called: metadata-<schema-name>. For the MCP profile of iso19139 the main template would look like the following (taken from metadata-iso19139.mcp.xsl):
 
-```{=html}
-<!-- -->
-```
+    ``` xml
     <xsl:template name="metadata-iso19139.mcp">
       <xsl:param name="schema"/>
       <xsl:param name="edit" select="false()"/>
@@ -605,6 +603,7 @@ There are certain XSLT templates that the presentation XSLT must have:
         <xsl:with-param name="embedded" select="$embedded" />
       </xsl:apply-templates>
     </xsl:template>
+    ```
 
 Analyzing this template:
 
@@ -613,9 +612,7 @@ Analyzing this template:
 
 -   a **completeTab** template, which must be called: <schema-name>CompleteTab. This template will display all tabs, apart from the 'default' (or simple mode) and the 'XML View' tabs, in the left hand frame of the editor/viewer screen. Here is an example for the MCP:
 
-```{=html}
-<!-- -->
-```
+    ``` xml
     <xsl:template name="iso19139.mcpCompleteTab">
       <xsl:param name="tabLink"/>
 
@@ -650,7 +647,8 @@ Analyzing this template:
      GEONETWORK_DATA_DIR/schema_plugins/iso19139/present/
      metadata-iso19139.xsl) ......
 
-    </xsl:template>  
+    </xsl:template>
+    ````
 
 This template is called by the template named "tab" (which also adds the "default" and "XML View" tabs) in `INSTALL_DIR/web/geonetwork/xsl/metadata-tab-utils.xsl` using the schema name. That XSLT also has the code for the "displayTab" template.
 
@@ -658,9 +656,7 @@ This template is called by the template named "tab" (which also adds the "defaul
 
 -   a **root element** processing tab. This tab should match on the root element of the metadata record. For example, for the iso19139 schema:
 
-```{=html}
-<!-- -->
-```
+    ``` xml
     <xsl:template mode="iso19139" match="gmd:MD_Metadata">
       <xsl:param name="schema"/>
       <xsl:param name="edit"/>
@@ -687,14 +683,13 @@ This template is called by the template named "tab" (which also adds the "defaul
       .........
 
     </xsl:template>
+    ```
 
 This template is basically a very long "choose" statement with "when" clauses that test the value of the currently defined tab (in global variable currTab). Each "when" clause will display the set of metadata elements that correspond to the tab definition using "elementEP" directly (as in the "when" clause for the 'identification' tab above) or via a named template (as in the 'metadata' tab above). For the MCP our template is similar to the one above for iso19139, except that the match would be on "mcp:MD_Metadata" (and the processing mode may differ - see the section 'An alternative XSLT design for profiles' below for more details).
 
 -   a **brief** template, which must be called: <schema-name>Brief. This template processes the metadata record and extracts from it a format neutral summary of the metadata for purposes such as displaying the search results. Here is an example for the eml-gbif schema (because it is fairly short!):
 
-```{=html}
-<!-- -->
-```
+    ``` xml
     <xsl:template match="eml-gbifBrief">
      <xsl:for-each select="/metadata/*[1]">
       <metadata>
@@ -715,6 +710,7 @@ This template is basically a very long "choose" statement with "when" clauses th
       </metadata>
      </xsl:for-each>
     </xsl:template>
+    ```
 
 Analyzing this template:
 
@@ -741,9 +737,7 @@ This template splits the processing between the base iso19139 schema and a brief
 
 -   templates that match on elements specific to the schema. Here is an example from the eml-gbif schema:
 
-```{=html}
-<!-- -->
-```
+    ``` xml
     <!-- keywords are processed to add thesaurus name in brackets afterwards 
          in view mode -->
 
@@ -778,6 +772,7 @@ This template splits the processing between the base iso19139 schema and a brief
         </xsl:otherwise>
       </xsl:choose>
     </xsl:template>
+    ```
 
 Analyzing this template:
 
@@ -838,9 +833,7 @@ Here is an example for the MCP (iso19139.mcp) with base schema iso19139:
 
 -   the **main** template, which must be called: metadata-iso19139.mcp.xsl:
 
-```{=html}
-<!-- -->
-```
+    ``` xml
     <!-- main template - the way into processing iso19139.mcp -->
     <xsl:template name="metadata-iso19139.mcp">
       <xsl:param name="schema"/>
@@ -873,6 +866,7 @@ Here is an example for the MCP (iso19139.mcp) with base schema iso19139:
           </xsl:otherwise>
         </xsl:choose>
     </xsl:template>
+    ```
 
 Analyzing this template:
 
@@ -881,36 +875,33 @@ Analyzing this template:
 
 -   templates that match on elements specific to the profile have mode iso19139.mcp:
 
-```{=html}
-<!-- -->
-```
+    ``` xml
     <xsl:template mode="iso19139.mcp" match="mcp:taxonomicElement">
       <xsl:param name="schema"/>
       <xsl:param name="edit"/>
 
       .....
     </xsl:template> 
+    ```
 
 -   templates that override elements in the base schema are processed in the profile mode iso19139.mcp
 
-```{=html}
-<!-- -->
-```
+    ``` xml
     <xsl:template mode="iso19139.mcp" match="gmd:keyword">
       <xsl:param name="schema"/>
       <xsl:param name="edit"/>
 
       .....
     </xsl:template> 
+    ```
 
 Notice that the template header of the profile has a simpler design than that used for the original design? Neither the priority attribute or the schema XPath condition is required because we are using a different mode to the base schema.
 
 -   To support processing in two modes we need to add a null template to the profile mode iso19139.mcp as follows:
 
-```{=html}
-<!-- -->
-```
+    ``` xml
     <xsl:template mode="iso19139.mcp" match="*|@*"/> 
+    ```
 
 This template will match all elements that we don't have a specific template for in the profile mode iso19139.mcp. These elements will be processed in the base schema mode iso19139 instead because the null template returns nothing (see the main template discussion above).
 
@@ -1074,9 +1065,7 @@ The three XSLTs that support this interface are:
 
 -   **extract-thumbnails.xsl** - this XSLT extracts the thumbnails/browse graphics from the metadata record, turning it into generic XML that is the same for all metadata schemas. The elements need to have content that GeoNetwork understands. The following is an example of what the thumbnail interface for iso19139 expects (we'll duplicate this requirement for MCP):
 
-```{=html}
-<!-- -->
-```
+    ``` xml
     <gmd:graphicOverview>
       <gmd:MD_BrowseGraphic>
         <gmd:fileName>
@@ -1103,6 +1092,7 @@ The three XSLTs that support this interface are:
         </gmd:fileType>
       </gmd:MD_BrowseGraphic>
     </gmd:graphicOverview> 
+    ```
 
 When `extract-thumbnails.xsl` is run, it creates a small XML hierarchy from this information which looks something like the following:
 
@@ -1125,12 +1115,11 @@ Because the MCP is a profile of ISO19115/19139, the easiest path to creating the
 -   **update-child-from-parent-info.xsl** - this XSLT is run when a child record needs to have content copied into it from a parent record. It is an XSLT that changes the content of a few elements and leaves the remaining elements untouched. The behaviour of this XSLT would depend on which elements of the parent record will be used to update elements of the child record.
 -   **update-fixed-info.xsl** - this XSLT is run after editing to fix certain elements and content in the metadata record. For the MCP there are a number of actions we would like to take to 'hard-wire' certain elements and content. To do this the XSLT the following processing logic:
 
-```{=html}
-<!-- -->
-```
+    ``` xml
     if the element is one that we want to process then 
       add a template with a match condition for that element and process it
     else copy the element to output
+    ```
 
 Because the MCP is a profile of ISO19115/19139, the easiest path to creating this XSLT is to copy update-fixed-info.xsl from the iso19139 schema and modify it for the changes in namespace required by the MCP and then to include the processing we want.
 
@@ -1172,14 +1161,13 @@ This is a simple directory. Put XML metadata files to be used as templates in th
 
 -   **schema-suggestions.xml** - The default behaviour of the GeoNetwork advanced editor when building the editor forms is to show elements that are not in the metadata record as unexpanded elements. To add these elements to the record, the user will have to click on the '+' icon next to the element name. This can be tedious especially as some metadata standards have elements nested in others (ie. complex elements). The schema-suggestions.xml file allows you to specify elements that should be automatically expanded by the editor. An example of this is the online resource information in the ISO19115/19139 standard. If the following XML was added to the `schema-suggestions.xml` file:
 
-```{=html}
-<!-- -->
-```
+    ``` xml
     <field name="gmd:CI_OnlineResource">
       <suggest name="gmd:protocol"/>
       <suggest name="gmd:name"/>
       <suggest name="gmd:description"/>
     </field>
+    ```
 
 The effect of this would be that when an online resource element was expanded, then input fields for the protocol (a drop down/select list), name and description would automatically appear in the editor.
 
@@ -1187,9 +1175,7 @@ Once again, a good place to start when building a `schema-suggestions.xml` file 
 
 -   **schema-substitutes.xml** - Recall from the earlier [Creating the schema directory and schema.xsd file](index.md#schema_and_schema_xsd) section, that the method we used to extend the base ISO19115/19139 schemas is to extend the base type, define a new element with the extended base type and allow the new element to substitute for the base element. So for example, in the MCP, we want to add a new resource constraint element that holds Creative Commons and other commons type licensing information. This requires that the MD_Constraints type be extended and a new mcp:MD_Commons element be defined which can substitute for gmd:MD_Constraints. This is shown in the following snippet of XSD:
 
-```{=html}
-<!-- -->
-```
+    ``` xml
     <xs:complexType name="MD_CommonsConstraints_Type">
       <xs:annotation>
         <xs:documentation>
@@ -1216,6 +1202,7 @@ Once again, a good place to start when building a `schema-suggestions.xml` file 
     </xs:complexType>
 
     <xs:element name="MD_Commons" substitutionGroup="gmd:MD_Constraints" type="mcp:MD_CommonsConstraints_Type"/>
+    ```
 
 For MCP records, the GeoNetwork editor will show a choice of elements from the substitution group for gmd:MD_Constraints when adding 'Resource Constraints' to the metadata document. This will now include mcp:MD_Commons.
 

--- a/docs/manual/docs/developer/settings/index.md
+++ b/docs/manual/docs/developer/settings/index.md
@@ -196,9 +196,9 @@ Harvester settings in XML are used by the harvester services - see [Harvesting s
      </info> 
     </node>
 
-#### Notes
+!!! Notes
 
-    -    this harvester does not use the content/importXslt setting - instead a more sophisticated approach using the metadata processing services can be applied through the **importXslt** setting - for more details and an example see [Metadata Processing services](../xml_services/metadata_xml_processing.md) for more details.
+    -   this harvester does not use the content/importXslt setting - instead a more sophisticated approach using the metadata processing services can be applied through the **importXslt** setting - for more details and an example see [Metadata Processing services](../xml_services/metadata_xml_processing.md) for more details.
 
 ### Harvesting node webdav {#webdav_harvesting}
 
@@ -257,7 +257,7 @@ Harvester settings in XML are used by the harvester services - see [Harvesting s
      </info>
     </node> 
 
-#### Notes
+!!! Notes
 
     -    this harvester does not use the content/importXslt setting
 
@@ -326,7 +326,7 @@ Harvester settings in XML are used by the harvester services - see [Harvesting s
      </info>
     </node> 
 
-#### Notes
+!!! Notes
 
     -    this harvester does not use the content/importXslt setting
 
@@ -455,7 +455,7 @@ Harvester settings in XML are used by the harvester services - see [Harvesting s
      </info>
     </node>  
 
-#### Notes
+!!! Notes
 
     -    this harvester does not use the content/importXslt setting
     -    this harvester does not use the content/validate setting - this will change
@@ -557,7 +557,7 @@ Harvester settings in XML are used by the harvester services - see [Harvesting s
      </info>
     </node> 
 
-#### Notes
+!!! Notes
 
     -    this harvester does not use the content/importXslt setting
     -    this harvester does not use the content/validate setting
@@ -636,7 +636,7 @@ Harvester settings in XML are used by the harvester services - see [Harvesting s
      </info>
     </node>
 
-#### Notes
+!!! Notes
 
     -    this harvester does not use the content/importXslt setting
     -    this harvester does not use the content/validate setting
@@ -750,7 +750,7 @@ Harvester settings in XML are used by the harvester services - see [Harvesting s
      </info>
     </node>
 
-#### Notes
+!!! Notes
 
     -    this harvester does not use the content/importXslt setting
     -    ArcSDE java API libraries need to be installed by the user in GeoNetwork (folder `INSTALL_DIR/web/geonetwork/WEB-INF/lib`), as these are proprietary libraries not distributed with GeoNetwork. The following jars are required:
@@ -898,11 +898,11 @@ Harvester settings in XML are used by the harvester services - see [Harvesting s
      </info>
     </node>
 
-#### Notes
+!!! Notes
 
--   this harvester uses two REST services from the GeoPortal API:
+    -   this harvester uses two REST services from the GeoPortal API:
 
-    -    `rest/find/document` with searchText parameter to return an RSS listing of metadata records that meet the search criteria
-    -    `rest/document` with id parameter from each result returned in the RSS listing
+        -    `rest/find/document` with searchText parameter to return an RSS listing of metadata records that meet the search criteria
+        -    `rest/document` with id parameter from each result returned in the RSS listing
 
--   this harvester has been tested with GeoPortal 9.3.x. It should be used for that version of GeoPortal in preference to the CSW harvester.
+    -   this harvester has been tested with GeoPortal 9.3.x. It should be used for that version of GeoPortal in preference to the CSW harvester.

--- a/docs/manual/docs/index.md
+++ b/docs/manual/docs/index.md
@@ -5,6 +5,10 @@ hide:
 
 # GeoNetwork {#toc}
 
+!!! Warning
+
+    GeoNetwork `2.10.x` is deprecated and not maintained anymore.
+
 Welcome to GeoNetwork. this documentation is organized into specific guides targeting different audience.
 
 <div class="grid cards" markdown>

--- a/docs/manual/docs/stylesheets/extra.css
+++ b/docs/manual/docs/stylesheets/extra.css
@@ -1,4 +1,6 @@
-
+dt {
+  font-weight: bold;
+}
 img + em, .browser-border + em, .browser-mockup + em {
   display: block;
   text-align: left;

--- a/docs/manual/docs/users/admin/advanced-configuration/index.md
+++ b/docs/manual/docs/users/admin/advanced-configuration/index.md
@@ -327,13 +327,17 @@ Example:
 
 -   Add the following java properties to start-geonetwork.sh script:
 
-    > java -Xms48m -Xmx512m -Xss2M -XX:MaxPermSize=128m -Dgeonetwork.dir=/app/geonetwork_data_dir -Dgeonetwork.lucene.dir=/ssd/geonetwork_lucene_dir
-
+    ``` shell
+    java -Xms48m -Xmx512m -Xss2M -XX:MaxPermSize=128m -Dgeonetwork.dir=/app/geonetwork_data_dir -Dgeonetwork.lucene.dir=/ssd/geonetwork_lucene_dir
+    ```
+    
 -   Add the following system properties to start-geonetwork.sh script:
     
-    > # Set custom data directory location using system property
-    > export geonetwork_dir=/app/geonetwork_data_dir
-    > export geonetwork_lucene_dir=/ssd/geonetwork_lucene_dir
+    ``` shell
+    # Set custom data directory location using system property
+    export geonetwork_dir=/app/geonetwork_data_dir
+    export geonetwork_lucene_dir=/ssd/geonetwork_lucene_dir
+    ```
 
 ### System information
 
@@ -379,84 +383,86 @@ The property should be a path or a URL. The method used to find a overrides file
 
 An example of a overrides file is as follows:
 
-    <overrides>
-        <!-- import values.  The imported values are put at top of sections -->
-        <import file="./imported-config-overrides.xml" />
-         <!-- properties allow some properties to be defined that will be substituted -->
-         <!-- into text or attributes where ${property} is the substitution pattern -->
-         <!-- The properties can reference other properties -->
-         <properties>
-             <enabled>true</enabled>
-             <dir>xml</dir>
-             <aparam>overridden</aparam>
-         </properties>
-         <!-- A regular expression for matching the file affected. -->
-         <file name=".*WEB-INF/config\.xml">
-             <!-- This example will update the file attribute of the xml element with the name attribute 'countries' -->
-             <replaceAtt xpath="default/gui/xml[@name = 'countries']" attName="file" value="${dir}/europeanCountries.xml"/>
-             <!-- if there is no value then the attribute is removed -->
-             <replaceAtt xpath="default/gui" attName="removeAtt"/>
-             <!-- If the attribute does not exist it is added -->
-             <replaceAtt xpath="default/gui" attName="newAtt" value="newValue"/>
+``` xml
+<overrides>
+    <!-- import values.  The imported values are put at top of sections -->
+    <import file="./imported-config-overrides.xml" />
+     <!-- properties allow some properties to be defined that will be substituted -->
+     <!-- into text or attributes where ${property} is the substitution pattern -->
+     <!-- The properties can reference other properties -->
+     <properties>
+         <enabled>true</enabled>
+         <dir>xml</dir>
+         <aparam>overridden</aparam>
+     </properties>
+     <!-- A regular expression for matching the file affected. -->
+     <file name=".*WEB-INF/config\.xml">
+         <!-- This example will update the file attribute of the xml element with the name attribute 'countries' -->
+         <replaceAtt xpath="default/gui/xml[@name = 'countries']" attName="file" value="${dir}/europeanCountries.xml"/>
+         <!-- if there is no value then the attribute is removed -->
+         <replaceAtt xpath="default/gui" attName="removeAtt"/>
+         <!-- If the attribute does not exist it is added -->
+         <replaceAtt xpath="default/gui" attName="newAtt" value="newValue"/>
 
-             <!-- This example will replace all the xml in resources with the contained xml -->
-             <replaceXML xpath="resources">
-               <resource enabled="${enabled}">
-                 <name>main-db</name>
-                 <provider>jeeves.resources.dbms.DbmsPool</provider>
-                  <config>
-                      <user>admin</user>
-                      <password>admin</password>
-                      <driver>oracle.jdbc.driver.OracleDriver</driver>
-                      <!-- ${host} will be updated to be local host -->
-                      <url>jdbc:oracle:thin:@${host}:1521:fs</url>
-                      <poolSize>10</poolSize>
-                  </config>
-               </resource>
-             </replaceXML>
-             <!-- This example simple replaces the text of an element -->
-             <replaceText xpath="default/language">${lang}</replaceText>
-             <!-- This examples shows how only the text is replaced not the nodes -->
-             <replaceText xpath="default/gui">ExtraText</replaceText>
-             <!-- append xml as a child to a section (If xpath == "" then that indicates the root of the document),
-                  this case adds nodes to the root document -->
-             <addXML xpath=""><newNode/></addXML>
-             <!-- append xml as a child to a section, this case adds nodes to the root document -->
-             <addXML xpath="default/gui"><newNode2/></addXML>
-             <!-- remove a single node -->
-             <removeXML xpath="default/gui/xml[@name = countries2]"/>
-             <!-- The logging files can also be overridden, although not as easily as other files.  
-                  The files are assumed to be property files and all the properties are loaded in order.  
-                  The later properties overriding the previously defined parameters. Since the normal
-                  log file is not automatically located, the base must be also defined.  It can be the once
-                  shipped with geonetwork or another. -->
-             <logging>
-                 <logFile>/WEB-INF/log4j.cfg</logFile>
-                 <logFile>/WEB-INF/log4j-jeichar.cfg</logFile>
-             </logging>
-         </file>
-         <file name=".*WEB-INF/config2\.xml">
-             <replaceText xpath="default/language">de</replaceText>
-         </file>
-         <!-- a normal file tag is for updating XML configuration files -->
-         <!-- textFile tags are for updating normal text files like sql files -->
-         <textFile name="test-sql.sql">
-             <!-- each line in the text file is matched against the linePattern attribute and the new value is used for substitution -->
-             <update linePattern="(.*) Relations">$1 NewRelations</update>
-             <update linePattern="(.*)relatedId(.*)">$1${aparam}$2</update>
-         </textFile>
-        <!-- configure the spring aspects of geonetwork -->
-        <spring>
-          <!-- import a complete spring xml file -->
-          <import file="./config-spring-overrides.xml"/>
-          <!-- declare a file as a spring properties override file: See http://static.springsource.org/spring/docs/3.0.x/api/org/springframework/beans/factory/config/PropertyOverrideConfigurer.html -->
-          <propertyOverrides file="./config-property-overrides.properties" />
-          <!-- set a property on one bean to reference another bean -->
-          <set>beanName.propertyName=beanName</set>
-          <!-- add a references to a bean to a property on another bean.  This assumes the property is a collection -->
-          <add>beanName.propertyName=beanName</add>
-        </spring>
-     </overrides>
+         <!-- This example will replace all the xml in resources with the contained xml -->
+         <replaceXML xpath="resources">
+           <resource enabled="${enabled}">
+             <name>main-db</name>
+             <provider>jeeves.resources.dbms.DbmsPool</provider>
+              <config>
+                  <user>admin</user>
+                  <password>admin</password>
+                  <driver>oracle.jdbc.driver.OracleDriver</driver>
+                  <!-- ${host} will be updated to be local host -->
+                  <url>jdbc:oracle:thin:@${host}:1521:fs</url>
+                  <poolSize>10</poolSize>
+              </config>
+           </resource>
+         </replaceXML>
+         <!-- This example simple replaces the text of an element -->
+         <replaceText xpath="default/language">${lang}</replaceText>
+         <!-- This examples shows how only the text is replaced not the nodes -->
+         <replaceText xpath="default/gui">ExtraText</replaceText>
+         <!-- append xml as a child to a section (If xpath == "" then that indicates the root of the document),
+              this case adds nodes to the root document -->
+         <addXML xpath=""><newNode/></addXML>
+         <!-- append xml as a child to a section, this case adds nodes to the root document -->
+         <addXML xpath="default/gui"><newNode2/></addXML>
+         <!-- remove a single node -->
+         <removeXML xpath="default/gui/xml[@name = countries2]"/>
+         <!-- The logging files can also be overridden, although not as easily as other files.  
+              The files are assumed to be property files and all the properties are loaded in order.  
+              The later properties overriding the previously defined parameters. Since the normal
+              log file is not automatically located, the base must be also defined.  It can be the once
+              shipped with geonetwork or another. -->
+         <logging>
+             <logFile>/WEB-INF/log4j.cfg</logFile>
+             <logFile>/WEB-INF/log4j-jeichar.cfg</logFile>
+         </logging>
+     </file>
+     <file name=".*WEB-INF/config2\.xml">
+         <replaceText xpath="default/language">de</replaceText>
+     </file>
+     <!-- a normal file tag is for updating XML configuration files -->
+     <!-- textFile tags are for updating normal text files like sql files -->
+     <textFile name="test-sql.sql">
+         <!-- each line in the text file is matched against the linePattern attribute and the new value is used for substitution -->
+         <update linePattern="(.*) Relations">$1 NewRelations</update>
+         <update linePattern="(.*)relatedId(.*)">$1${aparam}$2</update>
+     </textFile>
+    <!-- configure the spring aspects of geonetwork -->
+    <spring>
+      <!-- import a complete spring xml file -->
+      <import file="./config-spring-overrides.xml"/>
+      <!-- declare a file as a spring properties override file: See http://static.springsource.org/spring/docs/3.0.x/api/org/springframework/beans/factory/config/PropertyOverrideConfigurer.html -->
+      <propertyOverrides file="./config-property-overrides.properties" />
+      <!-- set a property on one bean to reference another bean -->
+      <set>beanName.propertyName=beanName</set>
+      <!-- add a references to a bean to a property on another bean.  This assumes the property is a collection -->
+      <add>beanName.propertyName=beanName</add>
+    </spring>
+ </overrides>
+```
 
 ## Lucene configuration {#adv_configuration_lucene}
 

--- a/docs/manual/docs/users/appendix/glossary_of_metadata/index.md
+++ b/docs/manual/docs/users/appendix/glossary_of_metadata/index.md
@@ -16,7 +16,7 @@ Administrative area
 
 Temporal extent - Begin date
 
-:   Formatted as 2007-09-12T15:00:00 (YYYY-MM-DDTHH:mm:ss)
+:   Formatted as 2007-09-12T15:00:00 (`YYYY-MM-DDTHH:mm:ss`)
 
 Character set
 
@@ -44,11 +44,11 @@ Data quality info
 
 Date
 
-:   Reference date and event used to describe it (YYYY-MM-DD)
+:   Reference date and event used to describe it (`YYYY-MM-DD`)
 
 Date stamp
 
-:   Date that the metadata was created (YYYY-MM-DDThh:mm:ss)
+:   Date that the metadata was created (`YYYY-MM-DDThh:mm:ss`)
 
 Date type
 
@@ -104,7 +104,7 @@ Electronic mail address
 
 Temporal extent - End date
 
-:   Formatted as 2007-09-12T15:00:00 (YYYY-MM-DDTHH:mm:ss)
+:   Formatted as 2007-09-12T15:00:00 (`YYYY-MM-DDTHH:mm:ss`)
 
 Equivalent scale
 

--- a/docs/manual/docs/users/managing_metadata/harvesting/index.md
+++ b/docs/manual/docs/users/managing_metadata/harvesting/index.md
@@ -6,18 +6,18 @@ Harvesting is the process of collecting metadata from a remote source and storin
 
 GeoNetwork is able to harvest from the following sources (for more details see below):
 
-> 1.  Another GeoNetwork node (version 2.1 or above). See [GeoNetwork Harvesting](gn/index.md)
-> 2.  An old GeoNetwork 2.0 node (deprecated). See [GeoNetwork 2.0 Harvester](gn2.0/index.md)
-> 3.  A WebDAV server. See [WEBDAV Harvesting](webdav/index.md)
-> 4.  A CSW 2.0.1 or 2.0.2 catalogue server. See [CSW Harvesting](csw/index.md)
-> 5.  A GeoPortal 9.3.x or 10.x server. See [GeoPortal REST Harvesting](geoPREST/index.md)
-> 6.  A File system acessible by GeoNetwork. See [Local File System Harvesting](localfilesystem/index.md)
-> 7.  An OAI-PMH server. See [OAIPMH Harvesting](oaipmh/index.md)
-> 8.  An OGC service using its GetCapabilities document. These include WMS, WFS, WPS and WCS services. See [Harvesting OGC Services](ogcwxs/index.md)
-> 9.  An ArcSDE server. See [Harvesting an ARCSDE Node](sde/index.md)
-> 10. A THREDDS catalog. See [THREDDS Harvesting](thredds/index.md)
-> 11. An OGC WFS using a GetFeature query. See [WFS GetFeature Harvesting](wfs-getfeatures/index.md)
-> 12. One or more Z3950 servers. See [Z3950 Harvesting](z3950/index.md)
+1.  Another GeoNetwork node (version 2.1 or above). See [GeoNetwork Harvesting](gn/index.md)
+2.  An old GeoNetwork 2.0 node (deprecated). See [GeoNetwork 2.0 Harvester](gn2.0/index.md)
+3.  A WebDAV server. See [WEBDAV Harvesting](webdav/index.md)
+4.  A CSW 2.0.1 or 2.0.2 catalogue server. See [CSW Harvesting](csw/index.md)
+5.  A GeoPortal 9.3.x or 10.x server. See [GeoPortal REST Harvesting](geoPREST/index.md)
+6.  A File system acessible by GeoNetwork. See [Local File System Harvesting](localfilesystem/index.md)
+7.  An OAI-PMH server. See [OAIPMH Harvesting](oaipmh/index.md)
+8.  An OGC service using its GetCapabilities document. These include WMS, WFS, WPS and WCS services. See [Harvesting OGC Services](ogcwxs/index.md)
+9.  An ArcSDE server. See [Harvesting an ARCSDE Node](sde/index.md)
+10. A THREDDS catalog. See [THREDDS Harvesting](thredds/index.md)
+11. An OGC WFS using a GetFeature query. See [WFS GetFeature Harvesting](wfs-getfeatures/index.md)
+12. One or more Z3950 servers. See [Z3950 Harvesting](z3950/index.md)
 
 ## Mechanism overview
 

--- a/docs/manual/docs/users/managing_metadata/massive_replace/index.md
+++ b/docs/manual/docs/users/managing_metadata/massive_replace/index.md
@@ -12,7 +12,7 @@ To use this feature the user you must be **registered** as **Reviewer**, **User 
 
 3.  Select **Actions on selection** > **Massive metadata update**.
 
-    > ![](massive_update.png)
+    ![](massive_update.png)
 
 This form allows to configure the replacements to apply to the metadata selection.
 
@@ -39,7 +39,7 @@ To define the replacements to apply to the selected metadata:
 
 Once all the replacements are defined, you can test it before applying it. Click **Test** button to produce a report with the metadata that will be updated:
 
-> ![](massive_update_test.png)
+![](massive_update_test.png)
 
 !!! note
 
@@ -48,7 +48,7 @@ Once all the replacements are defined, you can test it before applying it. Click
 
 To apply the replacements and save the changes, click **Update metadata** button. A confirmation message is displayed before executing the process.
 
-> ![](massive_update_confirmation.png)
+![](massive_update_confirmation.png)
 
 The process will replace any occurrence of the text indicated in (3) with the text indicated in (4) for the metadata element indicated in (2) and can take several time, depending on the size of the selection.
 
@@ -58,7 +58,7 @@ At the end of the process a summary is displayed.
 
 2.  Number of records updated: total records that have been updated.
 
-    > ![](massive_update_result.png)
+    ![](massive_update_result.png)
 
 ## Replacements available
 

--- a/docs/manual/docs/users/managing_metadata/status/index.md
+++ b/docs/manual/docs/users/managing_metadata/status/index.md
@@ -43,38 +43,36 @@ A default pair of metadata status change actions defined in Java is provided wit
 **statusChange**: This action is called when status is changed by a user. What happens depends on the status change taking place:
 
 -   when an 'Editor' changes the state on a metadata record(s) from 'Draft' or 'Unknown' to 'Submitted', the Content Reviewers from the groupOwner of the record are informed of the status change via email which looks like the following. They can log in and click on the link supplied in the email to access the submitted records. Here is an example email sent by this action:
->
-> ```{=html}
-> <!-- -->
-> ```
->     Date: Tue, 13 Dec 2011 12:58:58 +1100 (EST)
->     From: Metadata Workflow <feedback@localgeonetwork.org.au>
->     Subject: Metadata records SUBMITTED by userone@localgeonetwork.org.au (User One) on 2011-12-13T12:58:58
->     To: "reviewer@localgeonetwork.org.au" <Reviewer@localgeonetwork.org.au>
->     Reply-to: User One <userone@localgeonetwork.org.au.au>
->     Message-id: <1968852534.01323741538713.JavaMail.geonetwork@localgeonetwork.org.au>
->
->     These records are complete. Please review.
->
->     Records are available from the following URL:
->     http://localgeonetwork.org.au/geonetwork/srv/en/main.search?_status=4&_statusChangeDate=2011-12-13T12:58:58
->
+
+    ``` html
+    Date: Tue, 13 Dec 2011 12:58:58 +1100 (EST)
+    From: Metadata Workflow <feedback@localgeonetwork.org.au>
+    Subject: Metadata records SUBMITTED by userone@localgeonetwork.org.au (User One) on 2011-12-13T12:58:58
+    To: "reviewer@localgeonetwork.org.au" <Reviewer@localgeonetwork.org.au>
+    Reply-to: User One <userone@localgeonetwork.org.au.au>
+    Message-id: <1968852534.01323741538713.JavaMail.geonetwork@localgeonetwork.org.au>
+    
+    These records are complete. Please review.
+    
+    Records are available from the following URL:
+    http://localgeonetwork.org.au/geonetwork/srv/en/main.search?_status=4&_statusChangeDate=2011-12-13T12:58:58
+    ```
+
 -   when a 'Content Reviewer' changes the state on a metadata record(s) from 'Submitted' to 'Accepted' or 'Rejected', the owner of the metadata record is informed of the status change via email. The email received by the metadata record owner looks like the following. Again, the user can log in and use the link supplied in the email to access the approved/rejected records. Here is an example email sent by this action:
->
-> ```{=html}
-> <!-- -->
-> ```
->     Date: Wed, 14 Dec 2011 12:28:01 +1100 (EST)
->     From: Metadata Workflow <feedback@localgeonetwork.org.au>
->     Subject: Metadata records APPROVED by reviewer@localgeonetwork.org.au (Reviewer) on 2011-12-14T12:28:00
->     To: "User One" <userone@localgeonetwork.org.au>
->     Message-ID: <1064170697.31323826081004.JavaMail.geonetwork@localgeonetwork.org.au>
->     Reply-To: Reviewer <reviewer@localgeonetwork.org.au>
->
->     Records approved - please resubmit for approval when online resources attached
->
->     Records are available from the following URL:
->     http://localgeonetwork.org.au/geonetwork/srv/en/main.search?_status=2&_statusChangeDate=2011-12-14T12:28:00
+
+    ``` html
+    Date: Wed, 14 Dec 2011 12:28:01 +1100 (EST)
+    From: Metadata Workflow <feedback@localgeonetwork.org.au>
+    Subject: Metadata records APPROVED by reviewer@localgeonetwork.org.au (Reviewer) on 2011-12-14T12:28:00
+    To: "User One" <userone@localgeonetwork.org.au>
+    Message-ID: <1064170697.31323826081004.JavaMail.geonetwork@localgeonetwork.org.au>
+    Reply-To: Reviewer <reviewer@localgeonetwork.org.au>
+    
+    Records approved - please resubmit for approval when online resources attached
+    
+    Records are available from the following URL:
+    http://localgeonetwork.org.au/geonetwork/srv/en/main.search?_status=2&_statusChangeDate=2011-12-14T12:28:00
+    ```
 
 **onEdit**: This action is called when a record is edited and saved by a user. If the user did not indicate that the edit changes were a 'Minor edit' and the current status of the record is 'Approved', then the default action is to set the status to 'Draft' and remove the privileges for the GeoNetwork group 'All'.
 

--- a/docs/manual/docs/users/quickstartguide/getting_started/index.md
+++ b/docs/manual/docs/users/quickstartguide/getting_started/index.md
@@ -133,10 +133,10 @@ At last, you can customise the number of output results per page in the *Hits Pe
 
 If INSPIRE Search panel is enable in Administration > System configuration page, an additional section is displayed to allow searching INSPIRE metadata in the catalog.
 
-> <figure>
-> <img src="advanced_search_inspire.png" alt="advanced_search_inspire.png" />
-> <figcaption><em>"Inspire" section in the Advanced search</em></figcaption>
-> </figure>
+<figure>
+<img src="advanced_search_inspire.png" alt="advanced_search_inspire.png" />
+<figcaption><em>"Inspire" section in the Advanced search</em></figcaption>
+</figure>
 
 -   *Annex*: Allows to search for metadata related to a specific Inspire annex. The Inspire annexes for a metadata are based on the Inspire theme keywords assigned to it.
 -   *Source type*: Allows to search for dataset or service metadata.
@@ -157,29 +157,29 @@ The output of a search provides you a list of the metadata records that should f
 
 2.  **Download**: Depending on the privileges that have been set for each record, when this button is present, the dataset is available and downloadable. The process for retrieving data is simple and quick by just clicking the download button or by using the proper link in the specific metadata section for distribution info in the full metadata view.
 
-    > <figure>
-    > <img src="search_output1.png" alt="search_output1.png" />
-    > <figcaption><em>A single search result</em></figcaption>
-    > </figure>
-    >
-    > <figure>
-    > <img src="download.png" alt="download.png" />
-    > <figcaption><em>Available services related to the resource</em></figcaption>
-    > </figure>
+    <figure>
+    <img src="search_output1.png" alt="search_output1.png" />
+    <figcaption><em>A single search result</em></figcaption>
+    </figure>
+    
+    <figure>
+    <img src="download.png" alt="download.png" />
+    <figcaption><em>Available services related to the resource</em></figcaption>
+    </figure>
 
 3.  **Interactive Map**: The map service is also optional. When this button is shown, an interactive map for this layer is available and, by default, it will be displayed on the map screen of the simple search. To better visualise the map through the map viewer, **click** on **Show Map** on the top of search results panel.
 
-    > <figure>
-    > <img src="interactive_map.png" alt="interactive_map.png" />
-    > <figcaption><em>The interactive map viewer</em></figcaption>
-    > </figure>
+    <figure>
+    <img src="interactive_map.png" alt="interactive_map.png" />
+    <figcaption><em>The interactive map viewer</em></figcaption>
+    </figure>
 
 4.  **Graphic Overviews**: There are small and large overviews of the map used to properly evaluate usefulness of the data, especially if the interactive map is not available. Simply click on the small image to enlarge it.
 
-    > <figure>
-    > <img src="thumbnail.png" alt="thumbnail.png" />
-    > <figcaption><em>Large preview image</em></figcaption>
-    > </figure>
+    <figure>
+    <img src="thumbnail.png" alt="thumbnail.png" />
+    <figcaption><em>Large preview image</em></figcaption>
+    </figure>
 
 ## Privileges, roles and user groups
 

--- a/docs/manual/docs/users/quickstartguide/new_metadata/index.md
+++ b/docs/manual/docs/users/quickstartguide/new_metadata/index.md
@@ -33,31 +33,31 @@ In addition to the main mandatory fields, we recommend you to fill out these opt
 
 1.  Enter your username and password and click on the login button. The system will identify you and assign the correct privileges to work with.
 
-    > <figure>
-    > <img src="login.png" alt="login.png" />
-    > <figcaption><em>Login</em></figcaption>
-    > </figure>
+    <figure>
+    <img src="login.png" alt="login.png" />
+    <figcaption><em>Login</em></figcaption>
+    </figure>
 
 2.  Open the Administration page by clicking the Administration button in the banner and then click on the New metadata link.
 
-    > <figure>
-    > <img src="Admin.png" alt="Admin.png" />
-    > <figcaption><em>Administration panel</em></figcaption>
-    > </figure>
+    <figure>
+    <img src="Admin.png" alt="Admin.png" />
+    <figcaption><em>Administration panel</em></figcaption>
+    </figure>
 
 3.  From the metadata creation page, select the metadata standard to use from the dropdown list (Figure 4.3, "Template selection")
 
-    > <figure>
-    > <img src="metadataCreation.png" alt="metadataCreation.png" />
-    > <figcaption><em>Template selection</em></figcaption>
-    > </figure>
+    <figure>
+    <img src="metadataCreation.png" alt="metadataCreation.png" />
+    <figcaption><em>Template selection</em></figcaption>
+    </figure>
 
 4.  After selecting the correct template, you should identify which group of users the metadata will belong to and finally click on **Create**.
 
-    > <figure>
-    > <img src="selectGroup.png" alt="selectGroup.png" />
-    > <figcaption><em>Group selection</em></figcaption>
-    > </figure>
+    <figure>
+    <img src="selectGroup.png" alt="selectGroup.png" />
+    <figcaption><em>Group selection</em></figcaption>
+    </figure>
 
 5.  A new metadata form based on the selected template will be displayed for you to fill out.
 

--- a/docs/manual/docs/users/quickstartguide/new_metadata/linking.md
+++ b/docs/manual/docs/users/quickstartguide/new_metadata/linking.md
@@ -95,27 +95,21 @@ Metadata records in ISO19139 could be related to resources defined in WMS servic
 1.  *URL*: Url of WMS service
 2.  Name of the resource: empty.
 
-<figure>
-<img src="onlineResourceWebMapService2.png" alt="onlineResourceWebMapService2.png" />
-<figcaption><em>WMS online resource</em></figcaption>
-</figure>
+![onlineResourceWebMapService2.png](onlineResourceWebMapService2.png)
+WMS online resource
 
 The *Interactive Map* button opens a window to select the layer/s defined in WMS capabilities document to load in map viewer.
 
-<figure>
-<img src="onlineResourceWebMapService2SelectLayer.png" alt="onlineResourceWebMapService2SelectLayer.png" />
-<figcaption><em>Window to select WMS layer/s referenced in online resource to load in map viewer</em></figcaption>
-</figure>
+![onlineResourceWebMapService2SelectLayer.png](onlineResourceWebMapService2SelectLayer.png)
+Window to select WMS layer/s referenced in online resource to load in map viewer
 
 -   Selecting protocols **OGC-WMS Web Map Service**, **OGC Web Map Service 1.1.1** or **OGC Web Map Service 1.3.0**:
 
 1.  *URL*: Url of WMS service
 2.  *Name of the resource*: WMS layer name (optional)
 
-<figure>
-<img src="onlineResourceWebMapService1.png" alt="onlineResourceWebMapService1.png" />
-<figcaption><em>WMS online resource</em></figcaption>
-</figure>
+![onlineResourceWebMapService1.png](onlineResourceWebMapService1.png)
+WMS online resource
 
 The behaviour the *Interactive Map* button depends if user indicated the layer name in the field *Name of the resource* or not, to show the window to select the layer/s to load in map viewer or load the layer directly.
 
@@ -135,10 +129,8 @@ To Upload a Dataset, follow these steps:
 4.  Click the Browse button and navigate to the folder where the file to be released is stored. Consider if you want to upload multiple files as one unique zip file or as multiple separate downloads. It is a good idea to add additional documentation with the datasets that provide the user with information related to the data described. Reminder: by default, the size of a single file upload cannot exceed 100 Mbytes unless your system administrator has configured a larger limit in the GeoNetwork config.xml file;
 5.  Click Upload and then Save the metadata record.
 
-<figure>
-<img src="uploadData.png" alt="uploadData.png" />
-<figcaption><em>An online resource</em></figcaption>
-</figure>
+![uploadData.png](uploadData.png)
+An online resource
 
 ### Linking WMS for data visualization
 


### PR DESCRIPTION
Small fixes in the MD documentation files for indents, admonitions, dates and missing images