### PR TITLE
Jetty bundle / Add JAVA_OPTS configuration for the /monitor/metrics endpoint to work correctly

### DIFF
--- a/release/bin/startup.bat
+++ b/release/bin/startup.bat
@@ -7,7 +7,7 @@ del logs\*request.log*
 del logs\output.log
 move logs\geonetwork.log.* logs\archive
 
-java -Xms512m -Xmx1g -Djetty.httpConfig.requestHeaderSize=32768 -Dorg.eclipse.jetty.server.Request.maxFormContentSize=500000 -Dorg.eclipse.jetty.server.Request.maxFormKeys=4000 -Dmime-mappings=..\web\geonetwork\WEB-INF\mime-types.properties -DSTOP.PORT=8079 -Djava.awt.headless=true -DSTOP.KEY=geonetwork -jar start.jar
+java -Xms512m -Xmx1g --add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED -Djetty.httpConfig.requestHeaderSize=32768 -Dorg.eclipse.jetty.server.Request.maxFormContentSize=500000 -Dorg.eclipse.jetty.server.Request.maxFormKeys=4000 -Dmime-mappings=..\web\geonetwork\WEB-INF\mime-types.properties -DSTOP.PORT=8079 -Djava.awt.headless=true -DSTOP.KEY=geonetwork -jar start.jar
 
 rem Try changing the Xmx parameter if having memory errors
 rem If you want to hide the dos window when GeoNetwork is started, comment the previous line and comment out the last line

--- a/release/bin/startup.sh
+++ b/release/bin/startup.sh
@@ -32,7 +32,7 @@ find logs -maxdepth 1 -name 'geonetwork.log.*' -type f -exec mv -t logs/archive/
 
 export JAVA_MEM_OPTS="-Xms512m -Xmx1g"
 
-export JAVA_OPTS="$JAVA_MEM_OPTS -Djetty.httpConfig.requestHeaderSize=32768 -Dorg.eclipse.jetty.server.Request.maxFormContentSize=500000 -Dorg.eclipse.jetty.server.Request.maxFormKeys=4000 -Xss2M -Djeeves.filecharsetdetectandconvert=enabled -Dmime-mappings=../web/geonetwork/WEB-INF/mime-types.properties -DSTOP.PORT=8079 -Djava.awt.headless=true -DSTOP.KEY=geonetwork"
+export JAVA_OPTS="$JAVA_MEM_OPTS --add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED -Djetty.httpConfig.requestHeaderSize=32768 -Dorg.eclipse.jetty.server.Request.maxFormContentSize=500000 -Dorg.eclipse.jetty.server.Request.maxFormKeys=4000 -Xss2M -Djeeves.filecharsetdetectandconvert=enabled -Dmime-mappings=../web/geonetwork/WEB-INF/mime-types.properties -DSTOP.PORT=8079 -Djava.awt.headless=true -DSTOP.KEY=geonetwork"
 
 # Set custom data directory location using Java property
 # export JAVA_OPTS="$JAVA_OPTS -Dgeonetwork.dir=/app/geonetwork_data_dir"


### PR DESCRIPTION
To test:

1) Generate the zip bundle in the `release` module

2) Unzip / start Jetty

3) Login to GeoNetwork and access http://localhost:8080/geonetwork/monitor/metrics, a JSON document should be returned, no error