### PR TITLE
Add missing roleHierarchy bean to service test context file

### DIFF
--- a/services/src/test/resources/services-web-test-context.xml
+++ b/services/src/test/resources/services-web-test-context.xml
@@ -24,6 +24,19 @@
     </property>
   </bean>
 
+  <bean id="roleHierarchy"
+        class="org.springframework.security.access.hierarchicalroles.RoleHierarchyImpl">
+    <property name="hierarchy">
+      <value>
+        Administrator > UserAdmin
+        UserAdmin > Reviewer
+        Reviewer > Editor
+        Editor > RegisteredUser
+        RegisteredUser > Guest
+      </value>
+    </property>
+  </bean>
+
   <bean name="statusActionFactory"
         class="org.fao.geonet.kernel.metadata.StatusActionsFactory">
     <constructor-arg name="className" value="org.fao.geonet.kernel.metadata.DefaultStatusActions"/>


### PR DESCRIPTION
Thanks @wangf1122 for reporting the issue.

In `main` branch was added as part of https://github.com/geonetwork/core-geonetwork/pull/6989.