### PR TITLE
[backport-4.2.x] Fix version / language navigation with canonical_version: stable and use of --no-redirect

### DIFF
--- a/docs/manual/README.md
+++ b/docs/manual/README.md
@@ -103,13 +103,13 @@ We use ``mike`` for publishing to https://geonetwork.github.io using `<major>.<m
 1. To deploy SNAPSHOT development docs from the `main` branch to website `gh-pages` branch:
 
    ```bash
-   mike deploy --push --update-aliases 4.4 devel
+   mike deploy --push --no-redirect --update-aliases 4.4 devel
    ```
     
 2. To deploy documentation for a new release:
    
    ```bash
-   mike deploy --push --update-aliases 4.2 stable
+   mike deploy --push --no-redirect--update-aliases 4.2 stable
    ```
    
    When starting a new branch you can make it the default:
@@ -121,7 +121,7 @@ We use ``mike`` for publishing to https://geonetwork.github.io using `<major>.<m
 3. To publish documentation for a maintenance release:
 
    ```bash
-   mike deploy --push --update-aliases 3.12 maintenance
+   mike deploy --push --no-redirect --update-aliases 3.12 maintenance
    ```
 
 4. To show published versions:

--- a/docs/manual/mkdocs.yml
+++ b/docs/manual/mkdocs.yml
@@ -78,8 +78,6 @@ plugins:
   - exclude:
       glob:
         - annexes/gallery/bin/README.md
-  - mike:
-      canonical_version: stable
 
 # Customizations
 extra:

--- a/docs/manual/mkdocs.yml
+++ b/docs/manual/mkdocs.yml
@@ -2,7 +2,7 @@
 site_name: GeoNetwork opensource
 site_description: GeoNetwork catalogue for listing, searching and reviewing records.
 site_dir: target/html
-site_url: https://docs.geonetwork-opensource.org/
+site_url: https://jodygarnett.github.io/core-geonetwork
 
 # Repository
 repo_name: core-geonetwork

--- a/docs/manual/mkdocs.yml
+++ b/docs/manual/mkdocs.yml
@@ -79,7 +79,7 @@ plugins:
       glob:
         - annexes/gallery/bin/README.md
   - mike:
-      canonical_version: latest
+      canonical_version: stable
 
 # Customizations
 extra:

--- a/docs/manual/mkdocs.yml
+++ b/docs/manual/mkdocs.yml
@@ -2,7 +2,7 @@
 site_name: GeoNetwork opensource
 site_description: GeoNetwork catalogue for listing, searching and reviewing records.
 site_dir: target/html
-site_url: https://jodygarnett.github.io/core-geonetwork
+site_url: https://docs.geonetwork-opensource.org/
 
 # Repository
 repo_name: core-geonetwork


### PR DESCRIPTION
Also documents use of `--no-redirect` so we can have consistent devel, stable, and latest URLs.