### PR TITLE
Fix version / language navigation with canonical_version: stable and use of --no-redirect 

### DIFF
--- a/docs/manual/README.md
+++ b/docs/manual/README.md
@@ -100,38 +100,40 @@ If you are not familiar with python the mkdocs-material website has instructions
 
 We use ``mike`` for publishing to https://geonetwork.github.io using `<major>.<minor>` version:
 
-1. To deploy SNAPSHOT development docs from the `main` branch to website `gh-pages` branch:
+1. To deploy docs from the `main` branch to website `gh-pages` branch:
 
    ```bash
-   mike deploy --push --no-redirect --update-aliases 4.4 devel
+   mike deploy --push --no-redirect --update-aliases 4.4 latest
    ```
     
 2. To deploy documentation for a new release:
    
    ```bash
-   mike deploy --push --no-redirect--update-aliases 4.2 stable
+   mike deploy --push --no-redirect --update-aliases 4.2 stable
    ```
    
-   When starting a new branch you can make it the default:
+3. When starting a new branch you can make it the default:
    
    ```bash
    mike set-default --push 4.2
    ```
+   
+   Hint: When starting a new branch update `overview/changelog/` navigation tree also.
 
-3. To publish documentation for a maintenance release:
+4. To publish documentation for a maintenance release:
 
    ```bash
    mike deploy --push --no-redirect --update-aliases 3.12 maintenance
    ```
 
-4. To show published versions:
+5. To show published versions:
 
    ```bash
    
    mike list
    ```
 
-5. To preview things locally (uses your local ``gh-pages`` branch):
+6. To preview things locally (uses your local ``gh-pages`` branch):
    
    ```bash
    mike serve

--- a/docs/manual/README.md
+++ b/docs/manual/README.md
@@ -103,13 +103,13 @@ We use ``mike`` for publishing to https://geonetwork.github.io using `<major>.<m
 1. To deploy SNAPSHOT development docs from the `main` branch to website `gh-pages` branch:
 
    ```bash
-   mike deploy --push --update-aliases 4.4 devel
+   mike deploy --push --no-redirect --update-aliases 4.4 devel
    ```
     
 2. To deploy documentation for a new release:
    
    ```bash
-   mike deploy --push --update-aliases 4.2 stable
+   mike deploy --push --no-redirect--update-aliases 4.2 stable
    ```
    
    When starting a new branch you can make it the default:
@@ -121,7 +121,7 @@ We use ``mike`` for publishing to https://geonetwork.github.io using `<major>.<m
 3. To publish documentation for a maintenance release:
 
    ```bash
-   mike deploy --push --update-aliases 3.12 maintenance
+   mike deploy --push --no-redirect --update-aliases 3.12 maintenance
    ```
 
 4. To show published versions:

--- a/docs/manual/docs/overview/change-log/latest.md
+++ b/docs/manual/docs/overview/change-log/latest.md
@@ -1,0 +1,10 @@
+# Latest
+
+GeoNetwork 4.4.x is recommended for those enjoying the newest features from the GeoNetwork community. 
+
+This series is under active development by our community, with new features, improvements, documentation updates, bug reports, fixes, and releases.
+
+## Latest
+
+-   [Version 4.4.0](version-4.4.0.md)
+

--- a/docs/manual/docs/overview/change-log/stable.md
+++ b/docs/manual/docs/overview/change-log/stable.md
@@ -5,7 +5,6 @@ This series is under active use by our community, with regular improvements, doc
 
 ## Latest
 
--   [Version 4.4.0](version-4.4.0.md)
 -   [Version 4.2.6](version-4.2.6.md)
 
 

--- a/docs/manual/mkdocs.yml
+++ b/docs/manual/mkdocs.yml
@@ -78,8 +78,6 @@ plugins:
   - exclude:
       glob:
         - annexes/gallery/bin/README.md
-  - mike:
-      canonical_version: stable
 
 # Customizations
 extra:

--- a/docs/manual/mkdocs.yml
+++ b/docs/manual/mkdocs.yml
@@ -2,7 +2,7 @@
 site_name: GeoNetwork opensource
 site_description: GeoNetwork catalogue for listing, searching and reviewing records.
 site_dir: target/html
-site_url: https://docs.geonetwork-opensource.org/
+site_url: https://jodygarnett.github.io/core-geonetwork
 
 # Repository
 repo_name: core-geonetwork

--- a/docs/manual/mkdocs.yml
+++ b/docs/manual/mkdocs.yml
@@ -79,7 +79,7 @@ plugins:
       glob:
         - annexes/gallery/bin/README.md
   - mike:
-      canonical_version: latest
+      canonical_version: stable
 
 # Customizations
 extra:

--- a/docs/manual/mkdocs.yml
+++ b/docs/manual/mkdocs.yml
@@ -2,7 +2,7 @@
 site_name: GeoNetwork opensource
 site_description: GeoNetwork catalogue for listing, searching and reviewing records.
 site_dir: target/html
-site_url: https://jodygarnett.github.io/core-geonetwork
+site_url: https://docs.geonetwork-opensource.org/
 
 # Repository
 repo_name: core-geonetwork

--- a/docs/manual/mkdocs.yml
+++ b/docs/manual/mkdocs.yml
@@ -136,9 +136,11 @@ nav:
     - overview/authors.md
     - 'Changelog':
       - overview/change-log/index.md
+      - 'Latest':
+        - overview/change-log/latest.md
+        - overview/change-log/version-4.4.0.md
       - 'Stable':
         - overview/change-log/stable.md
-        - overview/change-log/version-4.4.0.md
         - overview/change-log/version-4.2.6.md
         - overview/change-log/version-4.2.5.md
         - overview/change-log/version-4.2.4.md


### PR DESCRIPTION
Also documents use of `--no-redirect` so we can have consistent devel, stable, and latest URLs.

I noticed that I was following the instructions on mike [README.md](https://github.com/jimporter/mike), which are actually out of date (the instructions for https://pypi.org/project/mike/1.1.2/ are more accurate.

The option `--alias-type=copy` has been replaced with `--no-redirect`  (sadly this means it is not a configuration option we can add to mkdocs.yml)