### PR TITLE
Follow up of #7279 to unify the button links in the metadata detail page as done for the analog change in main branch

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/RelatedDirective.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/RelatedDirective.js
@@ -178,6 +178,33 @@
                            scope.relations[idx] = value;
                          }
 
+                         // For draft version append "approved=false" to url
+                         if (scope.md.draft === "y" && idx === "onlines") {
+                           for (var i = 0; i < scope.relations[idx].length; i++) {
+                             if (scope.relations[idx][i].url) {
+                               if (typeof scope.relations[idx][i].url === 'string') {
+                                 if (
+                                   scope.relations[idx][i].url.match(
+                                     ".*/api/records/" + scope.md['geonet:info'].uuid + "/attachments/.*"
+                                   ) != null
+                                 ) {
+                                   scope.relations[idx][i].url += "?approved=false";
+                                 }
+                               } else if (typeof scope.relations[idx][i].url === 'object') {
+                                 for (u in scope.relations[idx][i].url) {
+                                   if (
+                                     scope.relations[idx][i].url[u].match(
+                                       ".*/api/records/" + scope.md['geonet:info'].uuid + "/attachments/.*"
+                                     ) != null
+                                   ) {
+                                     scope.relations[idx][i].url[u] += "?approved=false";
+                                   }
+                                 }
+                               }
+                             }
+                           }
+                         }
+
                          if (scope.relations.siblings && scope.relations.associated) {
                            for (var i = 0; i < scope.relations.associated.length; i++) {
                              if (scope.relations.siblings.filter(function (e) {

--- a/web-ui/src/main/resources/catalog/components/metadataactions/RelatedResourcesService.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/RelatedResourcesService.js
@@ -55,12 +55,11 @@
         'gnAlertService',
         'gnConfigService',
         'gnConfig',
-        'gnUrlUtils',
         '$filter',
         'gnExternalViewer',
         function(gnMap, gnOwsCapabilities, gnSearchSettings, gnViewerSettings,
             olDecorateLayer, gnSearchLocation, gnOwsContextService, gnWfsService,
-            gnAlertService, gnConfigService, gnConfig, gnUrlUtils, $filter, gnExternalViewer) {
+            gnAlertService, gnConfigService, gnConfig, $filter, gnExternalViewer) {
 
           this.configure = function(options) {
             angular.extend(this.map, options);
@@ -189,28 +188,18 @@
             }
           };
 
-          var openLink = function(link, record) {
-            var url = $filter('gnLocalized')(link.url) || link.url;
+          var openLink = function(record, link) {
+            var url = $filter('gnLocalized')(record.url) || record.url;
             if (url &&
-              angular.isString(url) &&
-              url.match("^(http|ftp|sftp|\\\\|//)")) {
-
-              if (record && record.draft === "y") {
-                if (
-                  url.match(".*/api/records/" + record.uuid + "/attachments/.*") != null
-                ) {
-                  url = gnUrlUtils.remove(url, ["approved"], true);
-                }
-                url += (url.indexOf("?") > 0 ? "&" : "?") + "approved=false";
-              }
-
+                angular.isString(url) &&
+                url.match("^(http|ftp|sftp|\\\\|//)")) {
               return window.open(url, '_blank');
             } else if (url && url.indexOf('www.') == 0) {
               return window.open('http://' + url, '_blank');
-            } else if (link.title &&
-              angular.isString(link.title) &&
-              link.title.match("^(http|ftp|sftp|\\\\|//)")) {
-              return window.location.assign(link.title);
+            } else if (record.title &&
+                       angular.isString(record.title) &&
+                       record.title.match("^(http|ftp|sftp|\\\\|//)")) {
+              return window.location.assign(record.title);
             } else {
               gnAlertService.addAlert({
                 msg: 'Unable to open link',


### PR DESCRIPTION
The BP to 3.12.x applied a different solution to the button links in the metadata detail page to open the online resources for the approved / working copy.

This PR adds analog code to https://github.com/geonetwork/core-geonetwork/pull/7248/files#diff-56dcf6dc1a8abde25966a791bff4c603791e3a402d723b17a042c8e444daecffR412-R424 and reverts the alternative solution applied in #7279 