### PR TITLE
Release / Create SQL migration script for new version

### DIFF
--- a/docs/manual/docs/contributing/doing-a-release.md
+++ b/docs/manual/docs/contributing/doing-a-release.md
@@ -4,6 +4,10 @@ This section documents the steps followed by the development team to do a new re
 
 Once the release branch has been thoroughly tested and is stable a release can be made.
 
+The following script can be used on Linux and Mac. For this a running build environment is needed
+with the following utilities: sed, xmlstarlet and sftp.
+
+
 1.  Prepare the release
 
     ``` shell
@@ -90,25 +94,6 @@ Once the release branch has been thoroughly tested and is stable a release can b
     # Set version number to SNAPSHOT
     ./update-version.sh $newversion $nextversion
 
-    # Add SQL migration step for the next version
-    mkdir web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v424
-    cat <<EOF > web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v424/migrate-default.sql
-    UPDATE Settings SET value='4.2.4' WHERE name='system/platform/version';
-    UPDATE Settings SET value='SNAPSHOT' WHERE name='system/platform/subVersion';
-    EOF
-    vi web/src/main/webResources/WEB-INF/config-db/database_migration.xml
-    ```
-
-    In `WEB-INF/config-db/database_migration.xml` add an entry for the new version in the 2 steps:
-
-    ``` xml
-    <entry key="3.12.2">
-      <list>
-        <value>WEB-INF/classes/setup/sql/migrate/v3122/migrate-</value>
-      </list>
-    </entry>
-    ```
-
     ``` shell
     git add .
     git commit -m "Update version to $nextversion"
@@ -178,25 +163,6 @@ Once the release branch has been thoroughly tested and is stable a release can b
     # Create it if it does not exist yet
     git checkout master
     ./update-version.sh $currentversion $nextMajorVersion
-    ```
-
-    In the following folder `web/src/main/webapp/WEB-INF/classes/setup/sql/migrate` create `v370` folder.
-
-    In this folder create a `migrate-default.sql` with the following content:
-
-    ``` sql
-    UPDATE Settings SET value='3.7.0' WHERE name='system/platform/version';
-    UPDATE Settings SET value='SNAPSHOT' WHERE name='system/platform/subVersion';
-    ```
-
-    In `web/src/main/webResources/WEB-INF/config-db/database_migration.xml` add the following for the migration to call the migration script:
-
-    ``` xml
-    <entry key="3.7.0">
-      <list>
-        <value>WEB-INF/classes/setup/sql/migrate/v370/migrate-</value>
-      </list>
-    </entry>
     ```
 
     Commit the new version

--- a/update-version.sh
+++ b/update-version.sh
@@ -103,11 +103,30 @@ echo
 
 # Update SQL - needs improvements
 echo 'SQL script'
-sed $sedopt "s/'system\/platform\/version', '.*', 0/'system\/platform\/version', '${new_version_main}', 0/g" web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
-sed $sedopt "s/'system\/platform\/subVersion', '.*', 0/'system\/platform\/subVersion', '${sub_version}', 0/g" web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
+echo '  * Set version in initial data'
+sqlscriptfolder=web/src/main/webapp/WEB-INF/classes/setup/sql
+sed $sedopt "s/'system\/platform\/version', '.*', 0/'system\/platform\/version', '${new_version_main}', 0/g" $sqlscriptfolder/data/data-db-default.sql
+sed $sedopt "s/'system\/platform\/subVersion', '.*', 0/'system\/platform\/subVersion', '${sub_version}', 0/g" $sqlscriptfolder/data/data-db-default.sql
 
-find . -wholename *v${new_version_main_nopoint//[.]/}/migrate-default.sql -exec sed $sedopt "s/value='${version}' WHERE name='system\/platform\/version'/value='${new_version_main}' WHERE name='system\/platform\/version'/g" {} \;
-find . -wholename *v${new_version_main_nopoint//[.]/}/migrate-default.sql -exec sed $sedopt "s/value='.*' WHERE name='system\/platform\/subVersion'/value='${sub_version}' WHERE name='system\/platform\/subVersion'/g" {} \;
+
+
+echo "  * Set version in migration script v${new_version_main_nopoint//[.]/}/migrate-default.sql"
+
+sqlmigrationfile=$sqlscriptfolder/migrate/v${new_version_main_nopoint//[.]/}/migrate-default.sql
+
+if [ -f "$sqlmigrationfile" ]; then
+  echo "    * Updating version in existing migration script $sqlmigrationfile."
+  sed $sedopt "s/value='${version}' WHERE name='system\/platform\/version'/value='${new_version_main}' WHERE name='system\/platform\/version'/g" $sqlmigrationfile
+  sed $sedopt "s/value='.*' WHERE name='system\/platform\/subVersion'/value='${sub_version}' WHERE name='system\/platform\/subVersion'/g" $sqlmigrationfile
+else
+  echo "    * Creating migration script $sqlmigrationfile."
+  mkdir $sqlscriptfolder/migrate/v${new_version_main_nopoint//[.]/}
+  cat <<EOF > $sqlmigrationfile
+UPDATE Settings SET value='${new_version_main}' WHERE name='system/platform/version';
+UPDATE Settings SET value='${sub_version}' WHERE name='system/platform/subVersion';
+EOF
+fi
+
 
 # Update version pom files
 mvn versions:set-property -Dproperty=gn.project.version -DnewVersion=${new_version}

--- a/update-version.sh
+++ b/update-version.sh
@@ -128,6 +128,18 @@ EOF
 fi
 
 
+sqlmigrationconfig=web/src/main/webResources/WEB-INF/config-db/database_migration.xml
+if hash xmlstarlet 2>/dev/null; then
+  xmlstarlet ed -L \
+      -s "//*[@id='dataMigrationMap' and not(*[local-name() = 'entry' and @key ='${new_version_main}'])]" -t elem -n "newentry" \
+      -i //newentry -t attr -n "key" -v "${new_version_main}" \
+      -s //newentry -t elem -n "list" \
+      -s //newentry/list -t elem -n "value" -v "WEB-INF/classes/setup/sql/migrate/v${new_version_main_nopoint}/migrate-" \
+      -r //newentry -v entry \
+      $sqlmigrationconfig
+else
+    echo "  * WARNING: Can't update automatically $sqlmigrationconfig. Install xmlstarlet utility or update file manually."
+fi
 
 # Update version pom files
 mvn versions:set-property -Dproperty=gn.project.version -DnewVersion=${new_version}

--- a/update-version.sh
+++ b/update-version.sh
@@ -110,9 +110,9 @@ sed $sedopt "s/'system\/platform\/subVersion', '.*', 0/'system\/platform\/subVer
 
 
 
-echo "  * Set version in migration script v${new_version_main_nopoint//[.]/}/migrate-default.sql"
+echo "  * Set version in migration script v${new_version_main_nopoint}/migrate-default.sql"
 
-sqlmigrationfile=$sqlscriptfolder/migrate/v${new_version_main_nopoint//[.]/}/migrate-default.sql
+sqlmigrationfile=$sqlscriptfolder/migrate/v${new_version_main_nopoint}/migrate-default.sql
 
 if [ -f "$sqlmigrationfile" ]; then
   echo "    * Updating version in existing migration script $sqlmigrationfile."
@@ -120,12 +120,13 @@ if [ -f "$sqlmigrationfile" ]; then
   sed $sedopt "s/value='.*' WHERE name='system\/platform\/subVersion'/value='${sub_version}' WHERE name='system\/platform\/subVersion'/g" $sqlmigrationfile
 else
   echo "    * Creating migration script $sqlmigrationfile."
-  mkdir $sqlscriptfolder/migrate/v${new_version_main_nopoint//[.]/}
+  mkdir $sqlscriptfolder/migrate/v${new_version_main_nopoint}
   cat <<EOF > $sqlmigrationfile
 UPDATE Settings SET value='${new_version_main}' WHERE name='system/platform/version';
 UPDATE Settings SET value='${sub_version}' WHERE name='system/platform/subVersion';
 EOF
 fi
+
 
 
 # Update version pom files


### PR DESCRIPTION
If the target version SQL migration do not exist, create it.

This will avoid the manual step https://github.com/geonetwork/core-geonetwork/blob/main/docs/manual/docs/contributing/doing-a-release.md?plain=1#L93-L98