### PR TITLE
Record view / fix double approved parameter in the metadata working copy page, for the buttons in the online resources panel.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/RelatedDirective.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/RelatedDirective.js
@@ -320,13 +320,15 @@
     "gnRelatedResources",
     "gnExternalViewer",
     "gnConfigService",
+    "gnUrlUtils",
     function (
       gnRelatedService,
       gnGlobalSettings,
       gnSearchSettings,
       gnRelatedResources,
       gnExternalViewer,
-      gnConfigService
+      gnConfigService,
+      gnUrlUtils
     ) {
       return {
         restrict: "A",
@@ -417,7 +419,15 @@
                       ".*/api/records/" + scope.md.uuid + "/attachments/.*"
                     ) != null
                   ) {
-                    scope.relations[idx][i].url += "?approved=false";
+                    scope.relations[idx][i].url = gnUrlUtils.remove(
+                      scope.relations[idx][i].url,
+                      ["approved"],
+                      true
+                    );
+                    scope.relations[idx][i].url = gnUrlUtils.append(
+                      scope.relations[idx][i].url,
+                      "approved=false"
+                    );
                   }
                 }
               }


### PR DESCRIPTION
Related to #7248

The code to load the relations of a metadata is executed in a `watchCollection` and can enter several times. The way to add the parameter was not handling this case producing wrong urls like:

http://localhost:8080/geonetwork/srv/api/records/5b74c2db-9c0c-4fbe-b0d4-3070fc71466b/attachments/report.pdf?approved=false?approved=false