### PR TITLE
Rename ElasticSearch to Elasticsearch

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/search/EsSearchManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/EsSearchManager.java
@@ -153,7 +153,7 @@ public class EsSearchManager implements ISearchManager {
             .build();
 
         FIELDLIST_RELATED_SCRIPTED = ImmutableMap.<String, String>builder()
-            // ElasticSearch scripted field to get the first overview url. Scripted fields must return single values.
+            // Elasticsearch scripted field to get the first overview url. Scripted fields must return single values.
             .put("overview", "return params['_source'].overview == null ? [] : params['_source'].overview.stream().map(f -> f.url).findFirst().orElse('');")
             .build();
     }

--- a/core/src/test/java/org/fao/geonet/kernel/ElasticsearchIndexingTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/ElasticsearchIndexingTest.java
@@ -17,7 +17,7 @@ import java.net.URL;
 import java.util.Objects;
 import static org.junit.Assert.*;
 
-public class ElasticSearchIndexingTest extends AbstractIntegrationTestWithMockedSingletons {
+public class ElasticsearchIndexingTest extends AbstractIntegrationTestWithMockedSingletons {
 
     @Autowired
     private EsSearchManager searchManager;

--- a/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/es/CswFilter2Es.java
+++ b/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/es/CswFilter2Es.java
@@ -99,7 +99,7 @@ public class CswFilter2Es extends AbstractFilterVisitor {
 
     private boolean useFilter = true;
 
-    // Stack to build the ElasticSearch Query
+    // Stack to build the Elasticsearch Query
     Deque<String> stack = new ArrayDeque<String>();
 
     private final String templateNot = " {\"bool\": {\n" +

--- a/csw-server/src/test/java/org/fao/geonet/kernel/csw/services/getrecords/es/CswFilter2EsTest.java
+++ b/csw-server/src/test/java/org/fao/geonet/kernel/csw/services/getrecords/es/CswFilter2EsTest.java
@@ -45,7 +45,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
- * CswFilter2Es converts (XML-based) CSW queries into ElasticSearch queries.
+ * CswFilter2Es converts (XML-based) CSW queries into Elasticsearch queries.
  * These ES-queries are in JSON-notation. We do not want to test the resulting
  * JSON-String char-by-char as this is error-prone.<br>
  * <p>
@@ -292,10 +292,10 @@ class CswFilter2EsTest {
 
     /**
      * Converts xml-string into OGC Filter expression using a specific filter
-     * version. This Filter is then finally converted to an ElasticSearch expression
+     * version. This Filter is then finally converted to an Elasticsearch expression
      * and checked against the expected output.
      *
-     * @param expected          JsonNode representing the expected ElasticSearch
+     * @param expected          JsonNode representing the expected Elasticsearch
      *                          query.
      * @param actual            XML text of the OGC Filter.
      * @param filterSpecVersion see {@link FilterCapabilities}

--- a/csw-server/src/test/java/org/fao/geonet/kernel/csw/services/getrecords/es/CswSortBy2EsTest.java
+++ b/csw-server/src/test/java/org/fao/geonet/kernel/csw/services/getrecords/es/CswSortBy2EsTest.java
@@ -43,7 +43,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 import java.util.List;
 
 /**
- * CswFilter2Es converts (XML-based) CSW queries into ElasticSearch queries.
+ * CswFilter2Es converts (XML-based) CSW queries into Elasticsearch queries.
  * These ES-queries are in JSON-notation. We do not want to test the resulting
  * JSON-String char-by-char as this is error-prone.<br>
  * <p>

--- a/csw-server/src/test/java/org/fao/geonet/kernel/csw/services/getrecords/es/EsJsonHelper.java
+++ b/csw-server/src/test/java/org/fao/geonet/kernel/csw/services/getrecords/es/EsJsonHelper.java
@@ -31,7 +31,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.List;
 
 /**
- * Tools to build up ElasticSearch JSON structures via Jackson.
+ * Tools to build up Elasticsearch JSON structures via Jackson.
  *
  * @author bhoefling
  *

--- a/docs/manual/docs/install-guide/installing-from-war-file.md
+++ b/docs/manual/docs/install-guide/installing-from-war-file.md
@@ -7,7 +7,7 @@ At the end of the installation process you will end up with the web applications
 Host ports requirements:
 
 -   Java web server [Apache Tomcat](http://tomcat.apache.org/) or [Jetty](https://www.eclipse.org/jetty/): 8080
--   [ElasticSearch](https://www.elastic.co/elasticsearch/): 9200
+-   [Elasticsearch](https://www.elastic.co/elasticsearch/): 9200
 -   [Kibana](https://www.elastic.co/kibana/): 5601
 -   Database eg. 5432 for a default [PostgreSQL](https://www.postgresql.org/) installation
 

--- a/docs/manual/docs/maintainer-guide/statistics/index.md
+++ b/docs/manual/docs/maintainer-guide/statistics/index.md
@@ -1,16 +1,16 @@
 # Setting up search/content statistics {#statistics}
 
-Since GeoNetwork 3.4 search and content statistics are stored in [ElasticSearch](https://www.elastic.co/products/elasticsearch/) using [Kibana](https://www.elastic.co/products/kibana) dashboards to visualize them in the GeoNetwork administration application.
+Since GeoNetwork 3.4 search and content statistics are stored in [Elasticsearch](https://www.elastic.co/products/elasticsearch/) using [Kibana](https://www.elastic.co/products/kibana) dashboards to visualize them in the GeoNetwork administration application.
 
-This guide describes the configuration required to integrate ElasticSearch/Kibana in GeoNetwork to store and visualize the search and content statistics.
+This guide describes the configuration required to integrate Elasticsearch/Kibana in GeoNetwork to store and visualize the search and content statistics.
 
-GeoNetwork 3.8.x supports ElasticSearch/Kibana 7.2, other versions may not work properly.
+GeoNetwork 3.8.x supports Elasticsearch/Kibana 7.2, other versions may not work properly.
 
 !!! note
 
-    This guide doesn't provide a production level setup for ElasticSearch/Kibana. Please refer to the ElasticSearch/Kibana documentation to do a proper setup/configuration for a production environment.
+    This guide doesn't provide a production level setup for Elasticsearch/Kibana. Please refer to the Elasticsearch/Kibana documentation to do a proper setup/configuration for a production environment.
 
 
--   [Setup ElasticSearch](setup-elasticsearch.md)
+-   [Setup Elasticsearch](setup-elasticsearch.md)
 -   [Setup Kibana](setup-kibana.md)
 -   [Setup GeoNetwork](setup-geonetwork.md)

--- a/docs/manual/docs/maintainer-guide/statistics/setup-elasticsearch.md
+++ b/docs/manual/docs/maintainer-guide/statistics/setup-elasticsearch.md
@@ -1,19 +1,19 @@
-# Setup ElasticSearch {#statistics_es}
+# Setup Elasticsearch {#statistics_es}
 
-This section describes how to setup ElasticSearch to be used in GeoNetwork to store the search/content statistics. Note that Geonetwork must have been built with the `es` profile for ElasticSearch to be used. See <https://github.com/geonetwork/core-geonetwork/tree/master/software_development> for details.
+This section describes how to setup Elasticsearch to be used in GeoNetwork to store the search/content statistics. Note that Geonetwork must have been built with the `es` profile for Elasticsearch to be used. See <https://github.com/geonetwork/core-geonetwork/tree/master/software_development> for details.
 
 ## Installation
 
-ElasticSearch can be installed manually, or for some operating systems packages are available.
+Elasticsearch can be installed manually, or for some operating systems packages are available.
 
 !!! note
 
-    If installed manually, ElasticSearch must be configured as a service to ensure it starts automatically when the server is started. This is beyond the scope of this guide.
+    If installed manually, Elasticsearch must be configured as a service to ensure it starts automatically when the server is started. This is beyond the scope of this guide.
 
 
 To install manually:
 
--   Download ElasticSearch from <http://www.elastic.co/downloads/past-releases/>. For Geonetwork 3.8.x version 7.2.x is recommended.
+-   Download Elasticsearch from <http://www.elastic.co/downloads/past-releases/>. For Geonetwork 3.8.x version 7.2.x is recommended.
 
 -   Unzip the file and copy it, for example, to ``/opt/elasticsearch``
 
@@ -24,7 +24,7 @@ To install manually:
     $ ./elasticsearch &
     ```
 
--   Verify in a browser that ElasticSearch is running: <http://localhost:9200/>
+-   Verify in a browser that Elasticsearch is running: <http://localhost:9200/>
 
 ## Load indexes
 

--- a/docs/manual/docs/maintainer-guide/statistics/setup-geonetwork.md
+++ b/docs/manual/docs/maintainer-guide/statistics/setup-geonetwork.md
@@ -2,7 +2,7 @@
 
 !!! note
 
-    GeoNetwork package should be build using the Maven `es` profile in order to be able to configure the search/content statistics to use ElasticSearch/Kibana:
+    GeoNetwork package should be build using the Maven `es` profile in order to be able to configure the search/content statistics to use Elasticsearch/Kibana:
     
     ``` shell
     $ cd GN_SOURCES/
@@ -47,9 +47,9 @@ To setup the search/content statistics in GeoNetwork, do the following steps:
 
 ## Content statistics/validation
 
-Content and validation status statistics are available also from to `us` in <http://localhost:8080/geonetwork/srv/eng/admin.console#/dashboard>, but require to index manually the content in ElasticSearch. This will be improved in future versions.
+Content and validation status statistics are available also from to `us` in <http://localhost:8080/geonetwork/srv/eng/admin.console#/dashboard>, but require to index manually the content in Elasticsearch. This will be improved in future versions.
 
--   To index the content and validation status in ElasticSearch, go to <http://localhost:8080/geonetwork/srv/eng/admin.console#/tools> and select the following option:
+-   To index the content and validation status in Elasticsearch, go to <http://localhost:8080/geonetwork/srv/eng/admin.console#/tools> and select the following option:
 
     ![](img/content-indexing.png)
 

--- a/services/src/main/java/org/fao/geonet/api/es/EsHTTPProxy.java
+++ b/services/src/main/java/org/fao/geonet/api/es/EsHTTPProxy.java
@@ -91,7 +91,7 @@ import java.util.zip.GZIPOutputStream;
     "/{portal}/api"
 })
 @Tag(name = "search",
-    description = "Proxy for ElasticSearch catalog search operations")
+    description = "Proxy for Elasticsearch catalog search operations")
 @Controller
 public class EsHTTPProxy {
     public static final String[] _validContentTypes = {
@@ -794,7 +794,7 @@ public class EsHTTPProxy {
 
 
     /**
-     * Process the metadata schema filters to filter out from the ElasticSearch response
+     * Process the metadata schema filters to filter out from the Elasticsearch response
      * the elements defined in the metadata schema filters.
      *
      * It uses a jsonpath to filter the elements, typically is configured with the following jsonpath, to
@@ -803,7 +803,7 @@ public class EsHTTPProxy {
      *  $.*[?(@.nilReason == 'withheld')]
      *
      * The metadata index process, has to define this attribute. Any element that requires to be filtered, should be
-     * defined as an object in ElasticSearch.
+     * defined as an object in Elasticsearch.
      *
      * Example for contacts:
      *

--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -2578,7 +2578,7 @@
         replace: true,
         scope: {
           uuid: "=gnMetadataSelector", // Model property with the metadata uuid selected
-          searchObj: "=", // ElasticSearch search object
+          searchObj: "=", // Elasticsearch search object
           md: "=", // Metadata object selected
           elementName: "@" // Input element name for the uuid control
         },

--- a/web-ui/src/main/resources/catalog/components/viewer/heatmap/HeatmapDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/heatmap/HeatmapDirective.js
@@ -31,7 +31,7 @@
    * @name gn_heatmap.directive:gnHeatmap
    *
    * @description
-   * Given a feature type, this directive will query the ElasticSearch backend
+   * Given a feature type, this directive will query the Elasticsearch backend
    * to render a heatmap of features on the map.
    * The heatmap is actually several box features which gives info when
    * hovered (feature count, etc.). These features are redrawn on every map

--- a/web-ui/src/main/resources/catalog/components/viewer/wfsfilter/WfsFilterService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wfsfilter/WfsFilterService.js
@@ -668,7 +668,7 @@
       };
 
       /**
-       * takes an ElasticSearch request object as input and ouputs a simplified
+       * takes an Elasticsearch request object as input and ouputs a simplified
        * object with properties describing names and values of the defined
        * filters.
        * Values are always an array holding the different values if any.
@@ -723,7 +723,7 @@
       };
 
       /**
-       * takes an ElasticSearch request object as input and ouputs an object
+       * takes an Elasticsearch request object as input and ouputs an object
        * with human readable properties.
        * note: full text search & bbox extent are ignored
        *

--- a/web-ui/src/main/resources/catalog/components/viewer/wps/WpsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wps/WpsDirective.js
@@ -231,7 +231,7 @@
                   scope.wfsLink.name
                 );
 
-                // use filter values in ElasticSearch object state
+                // use filter values in Elasticsearch object state
                 // to overload input
                 if (esObject) {
                   // this will hold wfs filter values

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1460,8 +1460,8 @@
     "ui-topCustomMenu-help": "List of static page IDs associated with the header section to display: <ul><li>When a list is provided, the links are displayed in the order provided and only for the pages listed.</li><li>When a list is not provided, all static pages configured for the header section are displayed, with no guaranteed order.</li>.\nPages can be inserted in between catalogue default menu which are: <pre>[\"gn-site-name-menu\",\n    \"gn-portal-switcher\",\n    \"gn-search-menu\",\n    \"gn-map-menu\",\n    \"gn-contribute-menu\",\n    \"gn-admin-menu\"]</pre>. Insert a page as a simple menu using its id eg. <pre>\"documentation\"</pre> or as a submenu using an object: <pre>{\"Quick search\": [\n  \"searchForAfrica\", \n  \"forReview\"\n]}</pre>",
     "ui-footerCustomMenu": "Footer custom menu items",
     "ui-footerCustomMenu-help": "List of static page IDs associated with the footer section to display: <ul><li>When a list is provided, the links are displayed in the order provided and only for the pages listed.</li><li>When a list is not provided, all static pages configured for the footer section are displayed, with no guaranteed order.</li>",
-    "es.url": "ElasticSearch server",
-    "es.version": "ElasticSearch version",
+    "es.url": "Elasticsearch server",
+    "es.version": "Elasticsearch version",
     "es.index": "Index name",
     "systemPropertiesProxyConfiguration": "Using http proxy settings in system properties."
 }

--- a/web/src/main/webapp/xml/validation/schemaPlugins/schema-ident.xsd
+++ b/web/src/main/webapp/xml/validation/schemaPlugins/schema-ident.xsd
@@ -251,7 +251,7 @@
     <xs:attribute name="jsonpath">
       <xs:annotation>
         <xs:documentation>
-          An JSON path to select elements to filter in the ElasticSearch index.
+          An JSON path to select elements to filter in the Elasticsearch index.
         </xs:documentation>
       </xs:annotation>
     </xs:attribute>


### PR DESCRIPTION
Renamed ElasticSearch to Elasticsearch as it seems to be the official name of the product.

Based on the following site
https://www.elastic.co/elasticsearch/

Nowhere can I find Elastic**S**earch.  It always seems to be spelled with lowercase **s**