### PR TITLE
GeoNetwork 4.2.x minor versions library updates

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataIndexer.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataIndexer.java
@@ -29,12 +29,10 @@ import com.yammer.metrics.core.TimerContext;
 import jeeves.monitor.MonitorManager;
 import jeeves.monitor.timer.IndexingRecordMeter;
 import jeeves.monitor.timer.IndexingRecordTimer;
-import jeeves.monitor.timer.ServiceManagerXslOutputTransformTimer;
 import jeeves.server.UserSession;
 import jeeves.server.context.ServiceContext;
 import jeeves.xlink.Processor;
 import org.apache.commons.lang.StringUtils;
-import org.eclipse.jetty.util.ConcurrentHashSet;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.api.records.attachments.Store;
 import org.fao.geonet.constants.Geonet;
@@ -74,6 +72,7 @@ import org.springframework.transaction.interceptor.TransactionAspectSupport;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -144,9 +143,9 @@ public class BaseMetadataIndexer implements IMetadataIndexer, ApplicationEventPu
         this.metadataManager = metadataManager;
     }
 
-    Set<String> waitForIndexing = new HashSet<String>();
-    Set<String> indexing = new HashSet<String>();
-    Set<IndexMetadataTask> batchIndex = new ConcurrentHashSet<IndexMetadataTask>();
+    Set<String> waitForIndexing = new HashSet<>();
+    Set<String> indexing = new HashSet<>();
+    Set<IndexMetadataTask> batchIndex = ConcurrentHashMap.newKeySet();
 
     @Override
     public void forceIndexChanges() throws IOException {

--- a/pom.xml
+++ b/pom.xml
@@ -1549,7 +1549,7 @@
      request the list of hosts (but JPA cache db queries). -->
     <cors.allowedHosts>*</cors.allowedHosts>
 
-    <jetty.version>9.4.48.v20220622</jetty.version>
+    <jetty.version>9.4.52.v20230823</jetty.version>
     <jetty.file>jetty-distribution-${jetty.version}</jetty.file>
     <jetty.download>https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/${jetty.version}/${jetty.file}.tar.gz</jetty.download>
 
@@ -1559,8 +1559,8 @@
     <jts.version>1.18.2</jts.version>
     <pg.version>42.3.3</pg.version>
 
-    <spring.version>5.3.27</spring.version>
-    <spring.security.version>5.7.8</spring.security.version>
+    <spring.version>5.3.30</spring.version>
+    <spring.security.version>5.7.11</spring.security.version>
     <spring.jpa.version>2.2.13.RELEASE</spring.jpa.version>
     <springboot.version>2.7.0</springboot.version>
     <springdoc.version>1.5.9</springdoc.version>
@@ -1575,7 +1575,7 @@
     <node.version>v8.11.1</node.version>
     <npm.version>5.8.0</npm.version>
     <xmlunit.version>2.1.1</xmlunit.version>
-    <jackson.version>2.10.4</jackson.version>
+    <jackson.version>2.10.5</jackson.version>
     <flying-saucer>9.1.22</flying-saucer>
     <camel.version>2.25.1</camel.version>
     <log4j2.version>2.17.2</log4j2.version>


### PR DESCRIPTION
Update minor versions for these dependencies:

- Jetty -> `9.4.52.v20230823`
- Spring Framework -> `5.3.30`
- Spring Security -> `5.7.11`
- Jackson -> `2.10.5`