### PR TITLE
GeoNetwork 4.4.x minor versions library updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1589,9 +1589,9 @@
     <jts.version>1.18.2</jts.version>
     <pg.version>42.3.3</pg.version>
 
-    <spring.version>5.3.27</spring.version>
-    <spring.security.version>5.8.3</spring.security.version>
-    <spring.jpa.version>2.7.12</spring.jpa.version>
+    <spring.version>5.3.30</spring.version>
+    <spring.security.version>5.8.7</spring.security.version>
+    <spring.jpa.version>2.7.16</spring.jpa.version>
     <springboot.version>2.7.0</springboot.version>
     <springdoc.version>1.5.13</springdoc.version>
     <hibernate.version>5.6.15.Final</hibernate.version>


### PR DESCRIPTION
Update minor versions for these dependencies:

- Spring Framework -> `5.3.30`
- Spring Security -> `5.8.7`
- Spring JPA ->  `2.7.16`