### PR TITLE
Add documentation to GitHub workflows

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,30 @@
+name: Documentation
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+     - "docs/manual/**"
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout GeoNetwork
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.x
+      - name: mkdocs install
+        run: pip install --upgrade pip && pip install -r docs/manual/requirements.txt
+      - name: git configuration
+        run: git config user.name 'github-actions[bot]' && git config user.email 'github-actions[bot]@users.noreply.github.com'
+      - name: deploy latest docs to gh-pages branch
+        working-directory: docs/manual
+        run: |
+          mike deploy --push --title "4.4 Latest" --no-redirect --update-aliases 4.4 latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,11 +5,16 @@ on:
     branches:
       - main
     paths:
-     - "docs/manual/**"
+      - "docs/manual/**"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "docs/manual/**"
   workflow_dispatch:
 
 jobs:
-  deploy:
+  deploy-docs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout GeoNetwork
@@ -24,7 +29,13 @@ jobs:
         run: pip install --upgrade pip && pip install -r docs/manual/requirements.txt
       - name: git configuration
         run: git config user.name 'github-actions[bot]' && git config user.email 'github-actions[bot]@users.noreply.github.com'
+      - name: build docs without publishing them
+        if: ${{ github.event_name == 'pull_request' }}
+        working-directory: docs/manual
+        run: |
+          mike deploy --title "4.4 Latest" --no-redirect --update-aliases 4.4 latest
       - name: deploy latest docs to gh-pages branch
+        if: ${{ github.event_name != 'pull_request' }}
         working-directory: docs/manual
         run: |
           mike deploy --push --title "4.4 Latest" --no-redirect --update-aliases 4.4 latest

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -3,7 +3,7 @@ name: Linux GitHub CI
 on: [pull_request,push,workflow_dispatch]
 
 env:
-  MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3 -Xmx512m -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss,SSS
+  MAVEN_OPTS: -Dmaven.wagon.httpconnectionManager.ttlSeconds=25 -Dmaven.wagon.http.retryHandler.count=3 -Xmx512m -Dorg.slf4j.simpleLogger.showDateTime=true -Dorg.slf4j.simpleLogger.dateTimeFormat=HH:mm:ss,SSS -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=warn
   TAKARI_SMART_BUILDER_VERSION: 0.6.1
 
 jobs:
@@ -27,12 +27,20 @@ jobs:
         distribution: 'temurin'
         java-version: ${{ matrix.jdk }}
         cache: 'maven'
+    - name: Setup Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.x
+    - name: mkdocs install
+      working-directory: docs/manual
+      run: pip install --upgrade pip && pip install -r requirements.txt
     - name: Set up Maven
       uses: stCarolas/setup-maven@v4
       with:
         maven-version: 3.6.3
     - name: Build with Maven
-      run: mvn -B -V install -DskipTests=true -Dmaven.javadoc.skip=true
+      run: |
+        mvn -B -ntp -V install -DskipTests=true -Dmaven.javadoc.skip=true -Pwith-doc
     - name: Remove SNAPSHOT jars from repository
       run: |
         find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}
@@ -62,7 +70,7 @@ jobs:
     - name: Test with maven
       run: |
         mvn -B resources:resources@copy-index-schema-to-source -f web
-        mvn -B -V -fae verify -Pit
+        mvn -B -ntp -V -fae verify -Pit
     - name: Remove SNAPSHOT jars from repository
       run: |
         find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ git*.properties
 */*/target/
 */target/
 .*/
+!.github
 #GeoNetwork*
 /geonetwork*
 camel-harvesters/wfsfeature-harvester/logs

--- a/docs/manual/docs/index.fr.md
+++ b/docs/manual/docs/index.fr.md
@@ -3,7 +3,7 @@ hide:
   - navigation
 ---
 
-# GeoNetwork {#toc}
+# GeoNetwork 4.4 {#toc}
 
 Bienvenue à GeoNetwork. Cette documentation est organisée en guides spécifiques destinés à différents publics.
 

--- a/docs/manual/docs/index.md
+++ b/docs/manual/docs/index.md
@@ -3,7 +3,7 @@ hide:
   - navigation
 ---
 
-# GeoNetwork {#toc}
+# GeoNetwork 4.4 {#toc}
 
 Welcome to GeoNetwork. This documentation is organized into specific guides targeting different audience. 
 

--- a/docs/manual/mkdocs.yml
+++ b/docs/manual/mkdocs.yml
@@ -126,7 +126,7 @@ markdown_extensions:
 
 # Page tree
 nav:
-  - index.md
+  - 'GeoNetwork': index.md
   - 'Overview':
     - overview/index.md
     - overview/about.md


### PR DESCRIPTION
GitHub workflow actions for docs, with this changes docs are checked as part of the build, and when the `docs/manual` folder is modified new documentation is published. 

* main: this pull-request
* 4.2.x: https://github.com/geonetwork/core-geonetwork/pull/7415
* 3.12.x: https://github.com/geonetwork/core-geonetwork/pull/7414

The result looks something like this in the version selector (addressing feedback it was hard to tell what is "latest").

<img width="490" alt="image" src="https://github.com/geonetwork/core-geonetwork/assets/629681/a4348cf0-2eb6-496a-b55e-f41356d145ed">

Reference: https://squidfunk.github.io/mkdocs-material/publishing-your-site/

## docs.yml

* mike deploy on change to branch (we will need to backport this workflow to active branches)
* there is no need to deploy on release tag, as docs are now "live" from main

Change to `main` branch are deployed immediately to `latest`, latest title is "4.4 Latest" in version selector.

Demo:  https://jodygarnett.github.io/core-geonetwork/latest/ builds from jodygarnett/core-geonetwork`main` branch

## linux.yml

* set up doc build environment
* included profile to build docs

Demo: For test sandbox see https://github.com/jodygarnett/core-geonetwork/pull/5 showing this QA run on a small documentation change.

```
[INFO] -----------------< org.geonetwork-opensource:gn-guide >-----------------
Building GeoNetwork Guide 4.4.1-SNAPSHOT                         [35/39]
...
[INFO] --- maven-antrun-plugin:3.0.0:run (docs) @ gn-guide ---
[INFO] Executing tasks
[INFO]      [exec] INFO    -  mkdocs_static_i18n: Building 'en' documentation to directory: /home/runner/work/core-geonetwork/core-geonetwork/docs/manual/target/html
```
