### PR TITLE
Site information / manage Elasticsearch exceptions when trying to retrieve the index information

### DIFF
--- a/index/src/main/java/org/fao/geonet/index/es/EsRestClient.java
+++ b/index/src/main/java/org/fao/geonet/index/es/EsRestClient.java
@@ -38,6 +38,7 @@ import org.apache.http.nio.conn.SchemeIOSessionStrategy;
 import org.apache.http.nio.conn.ssl.SSLIOSessionStrategy;
 import org.apache.http.ssl.SSLContextBuilder;
 import org.apache.lucene.search.TotalHits;
+import org.elasticsearch.ElasticsearchException;
 import org.elasticsearch.ElasticsearchStatusException;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthRequest;
 import org.elasticsearch.action.admin.cluster.health.ClusterHealthResponse;
@@ -504,7 +505,7 @@ public class EsRestClient implements InitializingBean {
 //        return getClient().ping(RequestOptions.DEFAULT);
     }
 
-    public String getServerVersion() throws IOException {
+    public String getServerVersion() throws IOException, ElasticsearchException {
         MainResponse.Version version = client.info(RequestOptions.DEFAULT).getVersion();
 
         return version.getNumber();

--- a/services/src/main/java/org/fao/geonet/api/site/SiteInformation.java
+++ b/services/src/main/java/org/fao/geonet/api/site/SiteInformation.java
@@ -28,6 +28,7 @@ import jeeves.server.ServiceConfig;
 import jeeves.server.context.ServiceContext;
 import org.apache.commons.dbcp2.BasicDataSource;
 import org.apache.commons.lang.StringUtils;
+import org.elasticsearch.ElasticsearchException;
 import org.fao.geonet.GeonetContext;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.kernel.search.EsSearchManager;
@@ -65,7 +66,7 @@ public class SiteInformation {
             }
             try {
                 loadIndexInfo(context);
-            } catch (IOException e) {
+            } catch (IOException | ElasticsearchException e) {
                 Log.error(Geonet.GEONETWORK, e.getMessage(), e);
             }
             loadEnvInfo();


### PR DESCRIPTION
Follow up #7179

Test case:

1) Configure a non existing host name for Elasticsearch in https://github.com/geonetwork/core-geonetwork/blob/6deb3043724996966cd207cc0ad1c5643009ff66/pom.xml#L1529

2) Start up GeoNetwork

3) Access the Site information page: http://localhost:8080/geonetwork/srv/eng/admin.console#/dashboard/information

  - Without the fix: all the sections are displayed empty
  - With the fix: the page is displayed fine. Elasticsearch information only displays the URL as the other fields can't be retrieved. 