### PR TITLE
Reset user password dialog - don't display the field to request the old password for administrators

### DIFF
--- a/web-ui/src/main/resources/catalog/templates/admin/usergroup/users.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/usergroup/users.html
@@ -545,6 +545,7 @@
           <form id="gn-password-reset" class="form-horizontal" name="gnPasswordReset">
             <input type="hidden" name="_csrf" value="{{csrf}}" />
             <div
+              data-ng-if="!user.isAdministratorOrMore()"
               class="form-group"
               data-ng-class="gnPasswordReset.passwordOld.$error.required ? 'has-error' : ''"
             >


### PR DESCRIPTION
Enabling the option for administrator user to be able to reset other users passwords

 https://github.com/geonetwork/core-geonetwork/blob/609389b5b4b86a05f9283343055f3e0b8602f4d5/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql#L736-L740

, should not request to the Administrator user to fill the users old password to reset. 

Using an administrator user, the field can be left empty, but it's confusing to display it, as it's not required.

**Without the change**

![reset-password-administrator-1](https://github.com/geonetwork/core-geonetwork/assets/1695003/5d498fed-bc44-43a7-8ad3-c2adb8033a4d)

**With the change**

![reset-password-administrator-2](https://github.com/geonetwork/core-geonetwork/assets/1695003/1e342063-9667-42ea-9d98-2796437b1ab6)
