### PR TITLE
Change the url the icon in the homepage is linking to

### DIFF
--- a/docs/manual/mkdocs.yml
+++ b/docs/manual/mkdocs.yml
@@ -12,7 +12,6 @@ edit_uri: edit/main/docs/manual/docs
 # Copyright
 copyright: Copyright &copy; 2001 - 2023 FAO-UN and others
 
-
 extra_css:
   - stylesheets/extra.css
 
@@ -84,6 +83,7 @@ extra:
   version:
     provider: mike
     default: stable
+  homepage: https://geonetwork-opensource.org/
   social:
     - icon: fontawesome/brands/github
       link: https://github.com/geonetwork


### PR DESCRIPTION
This PR changes the link the logo is pointing, it used to be the root of the documentation, now it is the GeoNetwork site

<img width="511" alt="gn-mkdocs" src="https://github.com/geonetwork/core-geonetwork/assets/19608667/41d6f3e3-d38d-4556-94ca-436491e62f61">
