### PR TITLE
Sort the portals by label, not by name (identifier)

### DIFF
--- a/web-ui/src/main/resources/catalog/components/usersearches/UserSearchesDirective.js
+++ b/web-ui/src/main/resources/catalog/components/usersearches/UserSearchesDirective.js
@@ -49,6 +49,10 @@
           if (scope.showPortalSwitcher) {
             getPortals();
           }
+
+          scope.sortByLabel = function (portal) {
+            return portal.label[scope.lang];
+          };
         }
       };
     }

--- a/web-ui/src/main/resources/catalog/components/usersearches/partials/portalswitcher.html
+++ b/web-ui/src/main/resources/catalog/components/usersearches/partials/portalswitcher.html
@@ -39,7 +39,7 @@
     <li
       class="gn-menuitem-xs"
       role="menuitem"
-      data-ng-repeat="p in portals | filter: {listableInHeaderSelector: true} |orderBy:'label'"
+      data-ng-repeat="p in portals | filter: {listableInHeaderSelector: true} |orderBy:sortByLabel"
     >
       <a href="../../{{p.uuid}}/{{lang}}/catalog.search">
         <img

--- a/web-ui/src/main/resources/catalog/components/usersearches/partials/portalswitcher.html
+++ b/web-ui/src/main/resources/catalog/components/usersearches/partials/portalswitcher.html
@@ -39,7 +39,7 @@
     <li
       class="gn-menuitem-xs"
       role="menuitem"
-      data-ng-repeat="p in portals | filter: {listableInHeaderSelector: true} |orderBy:'name'"
+      data-ng-repeat="p in portals | filter: {listableInHeaderSelector: true} |orderBy:'label'"
     >
       <a href="../../{{p.uuid}}/{{lang}}/catalog.search">
         <img

--- a/web-ui/src/main/resources/catalog/templates/admin/usergroup/users.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/usergroup/users.html
@@ -545,6 +545,7 @@
           <form id="gn-password-reset" class="form-horizontal" name="gnPasswordReset">
             <input type="hidden" name="_csrf" value="{{csrf}}" />
             <div
+              data-ng-if="!user.isAdministratorOrMore()"
               class="form-group"
               data-ng-class="gnPasswordReset.passwordOld.$error.required ? 'has-error' : ''"
             >

--- a/web-ui/src/main/resources/catalog/templates/admin/usergroup/users.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/usergroup/users.html
@@ -545,7 +545,6 @@
           <form id="gn-password-reset" class="form-horizontal" name="gnPasswordReset">
             <input type="hidden" name="_csrf" value="{{csrf}}" />
             <div
-              data-ng-if="!user.isAdministratorOrMore()"
               class="form-group"
               data-ng-class="gnPasswordReset.passwordOld.$error.required ? 'has-error' : ''"
             >


### PR DESCRIPTION
Sort the portals by label, not by name. So the portals are sorted on their translated names, not their identifier.
  
# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
