### PR TITLE
linux.yml workflow update to address warning: change profile with_doc to docs

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -40,7 +40,7 @@ jobs:
         maven-version: 3.6.3
     - name: Build with Maven
       run: |
-        mvn -B -ntp -V install -DskipTests=true -Dmaven.javadoc.skip=true -Pwith-doc
+        mvn -B -ntp -V install -DskipTests=true -Dmaven.javadoc.skip=true -Pdocs
     - name: Remove SNAPSHOT jars from repository
       run: |
         find ~/.m2/repository -name "*SNAPSHOT*" -type d | xargs rm -rf {}


### PR DESCRIPTION
Fox the linux.yml workflow with is producing a warning (we did not rebase the https://github.com/geonetwork/core-geonetwork/pull/7411 and did not catch that the profile changed names in another PR).

> [WARNING] The requested profile "with_doc" could not be activated because it does not exist.

This pull request is friends with https://github.com/geonetwork/core-geonetwork/pull/7412 (which fixes the release procedure and build order so the user guide is built before the war).

<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md
- [x] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
