### PR TITLE
Metadata editor / ISO19115-3.2008 / Filter out metadata templates inthe online resources dialog

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/config/associated-panel/default.json
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/config/associated-panel/default.json
@@ -30,7 +30,8 @@
           "metadataStore": {
             "label": "searchAnApplication",
             "params": {
-              "resourceType": "application"
+              "resourceType": "application",
+              "isTemplate": "n"
             }
           }
         },
@@ -63,7 +64,8 @@
           "metadataStore": {
             "label": "searchAservice",
             "params": {
-              "serviceType": ["OGC:WMS", "WMS", "view"]
+              "serviceType": ["OGC:WMS", "WMS", "view"],
+              "isTemplate": "n"
             }
           }
         },
@@ -95,7 +97,8 @@
           "metadataStore": {
             "label": "searchAservice",
             "params": {
-              "serviceType": "view"
+              "serviceType": "view",
+              "isTemplate": "n"
             }
           }
         },
@@ -132,7 +135,8 @@
           "metadataStore": {
             "label": "searchAservice",
             "params": {
-              "serviceType": ["OGC:WMTS", "WMTS"]
+              "serviceType": ["OGC:WMTS", "WMTS"],
+              "isTemplate": "n"
             }
           }
         },
@@ -164,7 +168,8 @@
           "metadataStore": {
             "label": "searchAservice",
             "params": {
-              "serviceType": "ESRI:REST"
+              "serviceType": "ESRI:REST",
+              "isTemplate": "n"
             }
           }
         },
@@ -196,7 +201,8 @@
           "metadataStore": {
             "label": "searchAservice",
             "params": {
-              "serviceType": "ESRI:REST"
+              "serviceType": "ESRI:REST",
+              "isTemplate": "n"
             }
           }
         },
@@ -310,7 +316,8 @@
           "metadataStore": {
             "label": "searchAservice",
             "params": {
-              "serviceType": ["OGC:WFS", "WFS", "download"]
+              "serviceType": ["OGC:WFS", "WFS", "download"],
+              "isTemplate": "n"
             }
           }
         },
@@ -342,7 +349,8 @@
           "metadataStore": {
             "label": "searchAservice",
             "params": {
-              "serviceType": ["OGC:WCS", "WCS"]
+              "serviceType": ["OGC:WCS", "WCS"],
+              "isTemplate": "n"
             }
           }
         },
@@ -374,7 +382,8 @@
           "metadataStore": {
             "label": "searchAservice",
             "params": {
-              "serviceType": "download"
+              "serviceType": "download",
+              "isTemplate": "n"
             }
           }
         },
@@ -411,7 +420,8 @@
           "metadataStore": {
             "label": "searchAservice",
             "params": {
-              "serviceType": "download"
+              "serviceType": "download",
+              "isTemplate": "n"
             }
           }
         },


### PR DESCRIPTION
The online resources dialog for ISO19115-3.2008 allows to select metadata records to add the resources referenced by the selected metadata.

Currently the list displays also the metadata templates. 

![select-view-service](https://github.com/geonetwork/core-geonetwork/assets/1695003/2826b980-14cd-4633-93e9-b55286cf2f91)

This change filters out the templates:

![select-view-service-2](https://github.com/geonetwork/core-geonetwork/assets/1695003/be7d1a78-eb17-4174-b689-0870c1b63693)

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

