### PR TITLE
Indexing / Add related record title to the full text search

### DIFF
--- a/web/src/main/webResources/WEB-INF/data/config/index/records.json
+++ b/web/src/main/webResources/WEB-INF/data/config/index/records.json
@@ -1778,7 +1778,8 @@
             "type": "keyword"
           },
           "title": {
-            "type": "keyword"
+            "type": "keyword",
+            "copy_to": "any.common"
           },
           "origin": {
             "type": "keyword"


### PR DESCRIPTION
Some catalogues link records to others which can be in the same catalogue or in remote sites.

Links are encoded using 
```xml
<gmd:source uuidref="https://ec.europa.eu/eurostat/cache/metadata/en/env_nwat_esms.htm"
 xlink:title="Water statistics on national level (env_nwat)" 
xlink:href="https://ec.europa.eu/eurostat/cache/metadata/en/env_nwat_esms.htm"/>
```
and the `xlink:title` may contain the remote record title (or the customized title cf. https://github.com/geonetwork/core-geonetwork/pull/7324)

This adds the related records title to the full text search.

Sample record
https://sdi.eea.europa.eu/catalogue/srv/eng/catalog.search#/metadata/04b55edf-9a98-4123-87ab-7845af61d07d With that change searching for `env_nwat` will return the record due to the source dataset.

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/1d79995b-d430-4a95-b548-563d31e7e76c)




# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
