### PR TITLE
Search results / Fix button size

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/savedselections/partials/action.html
+++ b/web-ui/src/main/resources/catalog/components/common/savedselections/partials/action.html
@@ -5,7 +5,7 @@
 >
   <button
     type="button"
-    class="btn btn-default dropdown-toggle"
+    class="btn btn-default btn-sm dropdown-toggle"
     data-toggle="dropdown"
     aria-haspopup="true"
     aria-expanded="false"


### PR DESCRIPTION
When saved selection is enabled the button is not of the same size as other.

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/65d3c3e0-222a-4620-84c9-6383e5eee634)


# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
