### PR TITLE
Standard / Feature catalogues / Do not index empty codelist value

### DIFF
--- a/schemas/iso19110/src/main/plugin/iso19110/index-fields/index.xsl
+++ b/schemas/iso19110/src/main/plugin/iso19110/index-fields/index.xsl
@@ -120,9 +120,11 @@
               <xsl:if test="*/gfc:cardinality">
                 ,"cardinality": "<xsl:value-of select="concat(*/gfc:cardinality//gco:lower/*/text(), '..', */gfc:cardinality//gco:upper/*/text())"/>"
               </xsl:if>
-              <xsl:if test="*/gfc:listedValue">
+              <xsl:variable name="codeList"
+                            select="*/gfc:listedValue[normalize-space(*) != '']"/>
+              <xsl:if test="$codeList">
                 ,"values": [
-                <xsl:for-each select="*/gfc:listedValue">{
+                <xsl:for-each select="$codeList">{
                   "label": "<xsl:value-of select="gn-fn-index:json-escape(*/gfc:label/*/text())"/>",
                   "code": "<xsl:value-of select="gn-fn-index:json-escape(*/gfc:code/*/text())"/>",
                   "definition": "<xsl:value-of select="gn-fn-index:json-escape(*/gfc:definition/*/text())"/>"}

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
@@ -1026,9 +1026,11 @@
               <xsl:if test="*/gfc:cardinality">
                 ,"cardinality": "<xsl:value-of select="gn-fn-index:json-escape(*/gfc:cardinality/*/text())"/>"
               </xsl:if>
-              <xsl:if test="*/gfc:listedValue">
+              <xsl:variable name="codeList"
+                            select="*/gfc:listedValue[normalize-space(*) != '']"/>
+              <xsl:if test="$codeList">
                 ,"values": [
-                <xsl:for-each select="*/gfc:listedValue">{
+                <xsl:for-each select="$codeList">{
                   "label": "<xsl:value-of select="gn-fn-index:json-escape(*/gfc:label/gco:CharacterString/text())"/>",
                   "code": "<xsl:value-of select="gn-fn-index:json-escape(*/gfc:code/*/text())"/>",
                   "definition": "<xsl:value-of select="gn-fn-index:json-escape(*/gfc:definition/gco:CharacterString/text())"/>"}


### PR DESCRIPTION
Ignore empty codelist value (but it is better to not leave empty codelist value in encoded records).

To avoid:

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/0f307b74-713c-4ce2-886c-da356596caaa)


Sample record for testing https://metadata.vlaanderen.be/srv/dut/catalog.search#/metadata/f1e77b4f-a174-4e2d-9af7-fe7f548b5a5c


# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
