### PR TITLE
Remove the `Download metadata` button on the Metadata page

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/metadata.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/metadata.html
@@ -1,16 +1,3 @@
-<div class="gn-margin-bottom hidden-print">
-  <span class="badge badge-rounded" title="{{'updatedOn' | translate}}">
-    <i class="fa fa-fw fa-file-code-o"></i>
-  </span>
-  <a
-    class="btn btn-default btn-sm"
-    data-ng-href="../api/records/{{mdView.current.record.uuid}}/formatters/xml"
-    target="_blank"
-  >
-    <span data-translate="">metadataInXML</span>
-  </a>
-</div>
-
 <div class="gn-md-side-calendar gn-margin-bottom">
   <span class="badge badge-rounded" title="{{'updatedOn' | translate}}">
     <i class="fa fa-fw fa-calendar"></i>


### PR DESCRIPTION
Remove the `Download metadata` button in the metadata block on the Metadata page.

This button is a duplicate function for one of the download options in the dropdown in the top of the page

<img width="316" alt="gn-download-button" src="https://github.com/geonetwork/core-geonetwork/assets/19608667/22012ced-fc3a-48ee-aaeb-d57f559b22af">


# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
