### PR TITLE
List styling for related records

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/related.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/related.html
@@ -176,8 +176,8 @@
       {{type.replace('siblings', '') | translate}}
     </h3>
 
-    <ul class="gn-related-list">
-      <li data-ng-repeat="md in items | orderBy:getOrderBy">
+    <ul class="gn-related-list list-group">
+      <li class="list-group-item" data-ng-repeat="md in items | orderBy:getOrderBy">
         <a
           data-ng-hide="md.remoteUrl"
           href=""

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_result_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_result_default.less
@@ -176,6 +176,19 @@
       background-color: lighten(@gray-base, 85%);
     }
   }
+  .gn-card-series, .gn-card-dataset, .gn-card-nonGeographicDataset, .gn-card-service, .gn-card-application {
+    .gn-related-list {
+      &.list-group {
+        padding: 0;
+        margin-bottom: 10px;
+        .list-group-item {
+          background: none;
+          border: 0;
+          padding: 0;
+        }
+      }
+    }
+  }
   .gn-series {
     .nav-pills {
       li {


### PR DESCRIPTION
Add a list styling to related records when the `data-layout="title"`

**Before**:

<img width="817" alt="gn-related-before" src="https://github.com/geonetwork/core-geonetwork/assets/19608667/b8f6771d-7922-4f7f-a040-10d7de122994">

**After**:

<img width="815" alt="gn-related-after" src="https://github.com/geonetwork/core-geonetwork/assets/19608667/c4a3cad1-a011-4acc-b184-6de32dba8346">

Related to: https://github.com/osgeonl/geonetwork-dutch-skin/pull/76

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
