### PR TITLE
OpenId / Use the user profile configured locally if the configuration option OPENIDCONNECT_USERPROFILEUPDATEENABLED is disabled

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/OidcUser2GeonetworkUser.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/OidcUser2GeonetworkUser.java
@@ -90,8 +90,9 @@ public class OidcUser2GeonetworkUser {
         simpleUser.updateUser(user); // copy attributes from the IDToken to the GN user
 
         Map<Profile, List<String>> profileGroups = oidcRoleProcessor.getProfileGroups(attributes);
-        user.setProfile(oidcRoleProcessor.getProfile(attributes));
-
+        if (newUserFlag || oidcConfiguration.isUpdateProfile()) {
+            user.setProfile(oidcRoleProcessor.getProfile(attributes));
+        }
 
         //Apply changes to database is required.
         if (withDbUpdate) {
@@ -138,7 +139,9 @@ public class OidcUser2GeonetworkUser {
         simpleUser.updateUser(user); // copy attributes from the IDToken to the GN user
 
         Map<Profile, List<String>> profileGroups = oidcRoleProcessor.getProfileGroups(idToken);
-        user.setProfile(oidcRoleProcessor.getProfile(idToken));
+        if (newUserFlag || oidcConfiguration.isUpdateProfile()) {
+            user.setProfile(oidcRoleProcessor.getProfile(idToken));
+        }
 
 
         //Apply changes to database is required.

--- a/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/OidcUser2GeonetworkUser.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/OidcUser2GeonetworkUser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Food and Agriculture Organization of the
+ * Copyright (C) 2023 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -76,6 +76,12 @@ public class OidcUser2GeonetworkUser {
         if (!StringUtils.hasText(simpleUser.getUsername()))
             return null;
 
+        if (!oidcConfiguration.isUpdateProfile()) {
+            // SimpleOidcUser.updateUser assigns the user profile to the OpenId user profile, unless
+            // SimpleOidcUser.profile is empty. Force the empty value, to avoid the assignment.
+            simpleUser.setProfile("");
+        }
+
         User user;
         boolean newUserFlag = false;
         try {
@@ -124,6 +130,12 @@ public class OidcUser2GeonetworkUser {
         SimpleOidcUser simpleUser = simpleOidcUserFactory.create(idToken, attributes);
         if (!StringUtils.hasText(simpleUser.getUsername()))
             return null;
+
+        if (!oidcConfiguration.isUpdateProfile()) {
+            // SimpleOidcUser.updateUser assigns the user profile to the OpenId user profile, unless
+            // SimpleOidcUser.profile is empty. Force the empty value, to avoid the assignment.
+            simpleUser.setProfile("");
+        }
 
         User user;
         boolean newUserFlag = false;


### PR DESCRIPTION
Analog to #6871

Funded by Ifremer

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
