### PR TITLE
Fix path for serverTime / sessionExpiry when GeoNetwork runs in / It creates these cookies per each path.

### DIFF
--- a/core/src/main/java/org/geonetwork/http/SessionTimeoutCookieFilter.java
+++ b/core/src/main/java/org/geonetwork/http/SessionTimeoutCookieFilter.java
@@ -24,8 +24,6 @@
 package org.geonetwork.http;
 
 import java.io.IOException;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 import javax.servlet.FilterChain;
 import javax.servlet.FilterConfig;
@@ -40,7 +38,6 @@ import javax.servlet.http.HttpSession;
 import org.apache.commons.lang.StringUtils;
 
 import jeeves.server.UserSession;
-import jeeves.server.dispatchers.ServiceManager;
 import jeeves.server.sources.http.JeevesServlet;
 
 /**
@@ -64,18 +61,20 @@ public class SessionTimeoutCookieFilter implements javax.servlet.Filter {
         if (session != null) {
             long currTime = System.currentTimeMillis();
 
+            String cookiePath = StringUtils.isBlank(httpReq.getContextPath()) ? "/" : httpReq.getContextPath();
+
             Cookie cookie = new Cookie("serverTime", "" + currTime);
-            cookie.setPath(httpReq.getContextPath());
+            cookie.setPath(cookiePath);
             cookie.setSecure(req.getServletContext().getSessionCookieConfig().isSecure());
             httpResp.addCookie(cookie);
 
             UserSession userSession = null;
-            if (session != null) {
-                Object tmp = session.getAttribute(JeevesServlet.USER_SESSION_ATTRIBUTE_KEY);
-                if (tmp instanceof UserSession) {
-                    userSession = (UserSession) tmp;
-                }
+
+            Object tmp = session.getAttribute(JeevesServlet.USER_SESSION_ATTRIBUTE_KEY);
+            if (tmp instanceof UserSession) {
+                userSession = (UserSession) tmp;
             }
+
             // If user is authenticated, then set expiration time
             if (userSession != null && StringUtils.isNotEmpty(userSession.getName())) {
                 long expiryTime = currTime + session.getMaxInactiveInterval() * 1000;
@@ -83,7 +82,7 @@ public class SessionTimeoutCookieFilter implements javax.servlet.Filter {
             } else {
                 cookie = new Cookie("sessionExpiry", "" + currTime);
             }
-            cookie.setPath(httpReq.getContextPath());
+            cookie.setPath(cookiePath);
             cookie.setSecure(req.getServletContext().getSessionCookieConfig().isSecure());
             httpResp.addCookie(cookie);
         }


### PR DESCRIPTION
`request.getContextPath()` for servlets in the root context, returns an empty string instead of /. The browser doesn't receive the path, uses the request path for the cookie.

![1VGVQC0aQbn6](https://github.com/geonetwork/core-geonetwork/assets/1695003/8ac3e121-795f-4549-b315-ebb0a3d5038d)


Thanks @juanluisrp for reporting the issue.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
