### PR TITLE
Optimise query used to retrieve metadata links results

### DIFF
--- a/domain/src/main/java/org/fao/geonet/repository/specification/LinkSpecs.java
+++ b/domain/src/main/java/org/fao/geonet/repository/specification/LinkSpecs.java
@@ -33,7 +33,6 @@ import org.fao.geonet.domain.Metadata_;
 import org.fao.geonet.domain.OperationAllowed;
 import org.fao.geonet.domain.OperationAllowedId_;
 import org.fao.geonet.domain.OperationAllowed_;
-import org.fao.geonet.domain.ReservedGroup;
 import org.fao.geonet.domain.ReservedOperation;
 import org.springframework.data.jpa.domain.Specification;
 
@@ -82,12 +81,18 @@ public class LinkSpecs {
                     predicates.add(metadataJoin.get("metadataUuid").in(associatedRecords));
                 }
 
-                if (editingGroupIds != null && editingGroupIds.length > 0) {
-                    Join<Link, MetadataLink> metadataJoin = root.join(Link_.records, JoinType.INNER);
+                Join<Link, MetadataLink> metadataJoin = root.join(Link_.records, JoinType.INNER);
+                Subquery<Integer> subquery = query.subquery(Integer.class);
+                final Root<OperationAllowed> opAllowRoot = subquery.from(OperationAllowed.class);
+                final Root<Metadata> metadataRoot = subquery.from(Metadata.class);
 
-                    Subquery<Integer> subquery = query.subquery(Integer.class);
-                    final Root<OperationAllowed> opAllowRoot = subquery.from(OperationAllowed.class);
-                    final Root<Metadata> metadataRoot = subquery.from(Metadata.class);
+                boolean editinGroupQuery = editingGroupIds != null && editingGroupIds.length > 0;
+                boolean groupPublishedQuery = groupPublishedIds != null && groupPublishedIds.length > 0;
+                boolean groupOwnerQuery = groupOwnerIds != null && groupOwnerIds.length > 0;
+
+                List<Predicate> subQueryPredicates = new ArrayList<>();
+
+                if (editinGroupQuery) {
                     final Predicate groupOwnerPredicate =
                         metadataRoot.get(Metadata_.sourceInfo).get(MetadataSourceInfo_.groupOwner).in(editingGroupIds);
                     final Predicate metadataOperations = cb.equal(metadataRoot.get(Metadata_.id), opAllowRoot.get(OperationAllowed_.id).get(OperationAllowedId_.metadataId));
@@ -96,52 +101,41 @@ public class LinkSpecs {
                         cb.equal(
                             opAllowRoot.get(OperationAllowed_.id).get(OperationAllowedId_.operationId),
                             cb.literal(ReservedOperation.editing.getId()));
-                    subquery.where(
-                            cb.or(
-                                cb.and(metadataOperations, groupOwnerPredicate),
-                                cb.and(editableGroups, operationTypeEdit)));
 
-                    Path<Integer> opAllowedMetadataId = opAllowRoot.get(OperationAllowed_.id).get(OperationAllowedId_.metadataId);
-                    subquery.select(opAllowedMetadataId);
-
-                    predicates.add(metadataJoin.get(MetadataLink_.metadataId).in(subquery));
-                    query.distinct(true);
+                    subQueryPredicates.add(cb.or(
+                        cb.and(metadataOperations, groupOwnerPredicate),
+                        cb.and(editableGroups, operationTypeEdit)));
                 }
 
-                if (groupPublishedIds != null && groupPublishedIds.length > 0) {
-                    Join<Link, MetadataLink> metadataJoin = root.join(Link_.records, JoinType.INNER);
-
-                    Subquery<Integer> subquery = query.subquery(Integer.class);
-                    Root<OperationAllowed> opAllowRoot = subquery.from(OperationAllowed.class);
+                if (groupPublishedQuery) {
                     Predicate publishedToIndicatedGroup =
                         opAllowRoot.get(OperationAllowed_.id).get(OperationAllowedId_.groupId).in(groupPublishedIds);
                     Predicate operationTypeView = cb.equal(
                         opAllowRoot.get(OperationAllowed_.id).get(OperationAllowedId_.operationId),
                         cb.literal(ReservedOperation.view.getId()));
-                    subquery.where(
-                        cb.and(publishedToIndicatedGroup, operationTypeView));
+
+                    subQueryPredicates.add(cb.and(publishedToIndicatedGroup, operationTypeView));
+                }
+
+                if (groupOwnerQuery) {
+                    final Predicate groupOwnerPredicate =
+                        metadataRoot.get(Metadata_.sourceInfo).get(MetadataSourceInfo_.groupOwner).in(groupOwnerIds);
+
+                    subQueryPredicates.add(groupOwnerPredicate);
+                }
+
+
+                if (subQueryPredicates.size() > 0) {
+                    subquery.where(subQueryPredicates.toArray(new Predicate[]{}));
 
                     Path<Integer> opAllowedMetadataId = opAllowRoot.get(OperationAllowed_.id).get(OperationAllowedId_.metadataId);
                     subquery.select(opAllowedMetadataId);
 
                     predicates.add(metadataJoin.get(MetadataLink_.metadataId).in(subquery));
-                    query.distinct(true);
                 }
 
-                if (groupOwnerIds != null && groupOwnerIds.length > 0) {
-                    Join<Link, MetadataLink> metadataJoin = root.join(Link_.records, JoinType.INNER);
-                    Subquery<Integer> subquery = query.subquery(Integer.class);
-                    final Root<Metadata> metadataRoot = subquery.from(Metadata.class);
-                    final Predicate groupOwnerPredicate =
-                        metadataRoot.get(Metadata_.sourceInfo).get(MetadataSourceInfo_.groupOwner).in(groupOwnerIds);
-                    subquery.where(groupOwnerPredicate);
+                query.distinct(true);
 
-                    Path<Integer> metadataId = metadataRoot.get(Metadata_.id);
-                    subquery.select(metadataId);
-
-                    predicates.add(metadataJoin.get(MetadataLink_.metadataId).in(subquery));
-                    query.distinct(true);
-                }
                 return cb.and(predicates.toArray(new Predicate[]{}));
             }
         };


### PR DESCRIPTION
The query to retrieve the metadata links status information when using filters, specially with users that are User Administrators and have the Editor profile, can take very long time (more than 45 minutes).

Updated the code to simplify the query with a new one, that semantically should be equivalent. The new one is not superfast, but it finishes in seconds.

**Original query**

```
select
    distinct count(distinct link0_.id) as col_0_0_
from
    Links link0_
    inner join MetadataLink records1_ on link0_.id = records1_.linkId
    inner join MetadataLink records2_ on link0_.id = records2_.linkId
    inner join MetadataLink records3_ on link0_.id = records3_.linkId
where
    (
        records1_.metadataId in (
            select
                operationa4_.metadataId
            from
                OperationAllowed operationa4_
                cross join Metadata metadata5_
            where
                metadata5_.id = operationa4_.metadataId
                and (metadata5_.groupOwner in (9))
                or (operationa4_.groupId in (9))
                and operationa4_.operationId = 2
        )
    )
    and (
        records2_.metadataId in (
            select
                operationa6_.metadataId
            from
                OperationAllowed operationa6_
            where
                (operationa6_.groupId in (9))
                and operationa6_.operationId = 0
        )
    )
    and (
        records3_.metadataId in (
            select
                metadata7_.id
            from
                Metadata metadata7_
            where
                metadata7_.groupOwner in (9)
        )
    )
```

**Updated query**

```
select distinct count(distinct link0_.id) as col_0_0_ 
from 
    Links link0_ inner join MetadataLink records1_ on link0_.id=records1_.linkId 
where 
    records1_.metadataId in (
        select 
            operationa2_.metadataId 
        from 
            OperationAllowed operationa2_ 
            cross join Metadata metadata3_
         where 
            (metadata3_.id=operationa2_.metadataId 
            
            and 
                (metadata3_.groupOwner in (9)) or (operationa2_.groupId in (9)) 
                        and operationa2_.operationId=2) 
		 		
            and 
                (operationa2_.groupId in (9)) and operationa2_.operationId=0 
		 	
            and 
                (metadata3_.groupOwner in (9)))
```

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
