### PR TITLE
Add node identifier parameter for xlst processing. Required in skin.xsl

### DIFF
--- a/services/src/main/java/org/fao/geonet/guiapi/search/XsltResponseWriter.java
+++ b/services/src/main/java/org/fao/geonet/guiapi/search/XsltResponseWriter.java
@@ -69,6 +69,7 @@ public class XsltResponseWriter {
         gui.addContent(new Element("nodeUrl").setText(settingManager.getNodeURL()));
         gui.addContent(new Element("baseUrl").setText(settingManager.getBaseURL()));
         gui.addContent(new Element("serverUrl").setText(settingManager.getServerURL()));
+        gui.addContent(new Element("nodeId").setText(settingManager.getNodeId()));
         // TODO: set language based on header
         gui.addContent(new Element("language").setText("eng"));
 


### PR DESCRIPTION
Follow up of #7015, identified in GeoNetwork 3.12.x

In certain setups, accessing the no JS search page: http://localhost:8080/geonetwork/srv/search returns an error 400:

```
Error on line 71 of skin.xsl:
  XTTE0790: An empty sequence is not allowed as the second argument of geonet:updateUrlPlaceholder()
2023-10-24 09:48:06,491 ERROR [geonetwork] - An empty sequence is not allowed as the second argument of geonet:updateUrlPlaceholder()
; SystemID: file:///opt/geonetwork/xslt/ui-search/../common/../skin/default/skin.xsl; Line#: 71; Column#: -1
net.sf.saxon.trans.XPathException: An empty sequence is not allowed as the second argument of geonet:updateUrlPlaceholder()
```

The class that applies the xslt transformation doesn't add the `nodeId` field. It's unclear as local testing doesn't produce the previous error (same missing value).

This change, adds the missing field to be processed.

In GeoNetwork 4.x, the search no JS page is not implemented (https://github.com/geonetwork/core-geonetwork/blob/61df1e5d1570813fea68c14f6420b48471cd2f71/services/src/main/java/org/fao/geonet/guiapi/search/SearchApi.java#L123-L129), but the change will be required if at some moment is implemented.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
