### PR TITLE
Added missing translation for 'Revision'

### DIFF
--- a/web-ui/src/main/resources/catalog/locales/en-search.json
+++ b/web-ui/src/main/resources/catalog/locales/en-search.json
@@ -212,6 +212,7 @@
   "publicationDate": "Publication date",
   "creationDate": "Creation date",
   "revisionDate": "Revision date",
+  "Revision": "Revision",
   "tempExtentBegin": "Period",
   "updateFrequency": "Update frequency",
   "quality": "Quality",


### PR DESCRIPTION
A translation was missing for "Revision" in the technical partial. For 'Version' on the right, it was already there.

![image](https://github.com/geonetwork/core-geonetwork/assets/11455912/d9f851c3-f1b5-4686-a81e-d1bf4028d7b4)
