### PR TITLE
Harvesting / WFS feature / Add WFS2 support for MapServer

### DIFF
--- a/workers/wfsfeature-harvester/src/main/java/org/fao/geonet/harvester/wfsfeatures/model/WFSHarvesterParameter.java
+++ b/workers/wfsfeature-harvester/src/main/java/org/fao/geonet/harvester/wfsfeatures/model/WFSHarvesterParameter.java
@@ -33,6 +33,7 @@ import java.util.Map;
  */
 @XmlRootElement(name = "wfs")
 public class WFSHarvesterParameter implements Serializable {
+    public static final String DEFAULT_VERSION = "1.1.0";
     private String metadataUuid;
 
     private String url;
@@ -41,7 +42,7 @@ public class WFSHarvesterParameter implements Serializable {
 
     private String typeName;
 
-    private String version = "1.1.0";
+    private String version = DEFAULT_VERSION;
 
     private int timeOut = 300000;
 

--- a/workers/wfsfeature-harvester/src/main/java/org/fao/geonet/harvester/wfsfeatures/worker/WFSDataStoreWithStrategyInvestigator.java
+++ b/workers/wfsfeature-harvester/src/main/java/org/fao/geonet/harvester/wfsfeatures/worker/WFSDataStoreWithStrategyInvestigator.java
@@ -45,11 +45,10 @@ import java.util.Map;
  */
 public class WFSDataStoreWithStrategyInvestigator extends WFSDataStoreFactory {
 
-    private static Logger LOGGER =  LoggerFactory.getLogger(WFSHarvesterRouteBuilder.LOGGER_NAME);
     private String describeFeatureTypeUrl;
 
-    public void init (String url, String typeName) throws Exception {
-        this.describeFeatureTypeUrl = new OwsUtils().getDescribeFeatureTypeUrl(url, typeName, "1.1.0");
+    public void init (String url, String typeName, String version) throws Exception {
+        this.describeFeatureTypeUrl = new OwsUtils().getDescribeFeatureTypeUrl(url, typeName, version);
     }
 
     @Override
@@ -66,7 +65,7 @@ public class WFSDataStoreWithStrategyInvestigator extends WFSDataStoreFactory {
             }
         }
 
-        final URL capabilitiesURL = (URL) URL.lookUp(params);
+        final URL capabilitiesURL = URL.lookUp(params);
 
         final HTTPClient http = getHttpClient(params);
         http.setTryGzip(config.isTryGZIP());

--- a/workers/wfsfeature-harvester/src/main/java/org/fao/geonet/harvester/wfsfeatures/worker/WFSHarvesterExchangeState.java
+++ b/workers/wfsfeature-harvester/src/main/java/org/fao/geonet/harvester/wfsfeatures/worker/WFSHarvesterExchangeState.java
@@ -116,7 +116,7 @@ public class WFSHarvesterExchangeState implements Serializable {
         if (INVESTIGATOR_STRATEGY.equals(parameters.getStrategy())) {
             factory = new WFSDataStoreWithStrategyInvestigator();
             ((WFSDataStoreWithStrategyInvestigator) factory).init(
-                parameters.getUrl(), parameters.getTypeName());
+                parameters.getUrl(), parameters.getTypeName(), parameters.getVersion());
         } else {
             factory = new WFSDataStoreFactory();
         }
@@ -145,15 +145,9 @@ public class WFSHarvesterExchangeState implements Serializable {
             }
 
             wfsDatastore = factory.createDataStore(m);
-            // Default to GeoTools auto mode for MapServer.
             if(factory instanceof WFSDataStoreWithStrategyInvestigator) {
                 WFSClientWithStrategyInvestigator wfsClientWithStrategyInvestigator = (WFSClientWithStrategyInvestigator) wfsDatastore.getWfsClient();
                 this.strategyId = wfsClientWithStrategyInvestigator.getStrategyId();
-                if (MAPSERVER_STRATEGY.equals(wfsClientWithStrategyInvestigator.getStrategyId())) {
-                    Map<String, Object> connectionParameters = new HashMap<>();
-                    connectionParameters.put("WFSDataStoreFactory:GET_CAPABILITIES_URL", parameters.getUrl());
-                    wfsDatastore = (WFSDataStore) DataStoreFinder.getDataStore(connectionParameters);
-                }
             }
         } catch (IOException e) {
             String errorMsg = String.format(


### PR DESCRIPTION
Mapserver may return by default GetCapabilities in version 2.0.0. Depending on the URL set in metadata records, WFS harvesting may fails with:

```
2023-10-27T10:54:42,350 ERROR [geonetwork.harvest.wfs.features] -
Failed to connect to server 'http://geoservices.brgm.fr/geologie?language=fre&'.
Error is class net.opengis.wfs20.impl.WFSCapabilitiesTypeImpl
cannot be cast to class net.opengis.wfs.WFSCapabilitiesType
(net.opengis.wfs20.impl.WFSCapabilitiesTypeImpl and net.opengis.wfs.WFSCapabilitiesType
are in unnamed module of loader org.eclipse.jetty.webapp.WebAppClassLoader @cda6100)
```
because of the `MapServerWFSStrategy` extending WFS1 strategy.

Use `StrictWFS_2_0_Strategy` if harvesting is done using 2.0.0 on MapServer.

Can be tested with
```
curl 'http://localhost:8080/geonetwork/srv/api/workers/data/wfs/actions/start' \
  -X 'PUT' \
  -H 'Accept: application/json, text/plain, */*' \
  -H 'Accept-Language: eng' \
  -H 'Content-Type: application/json;charset=UTF-8' \
  -H 'Cookie: JSESSIONID=node0hjdye0js612o1qex2n36lekt81.node0; serverTime=1698396822574; sessionExpiry=1698398922574; XSRF-TOKEN=c353b2ca-a77c-4552-839c-37405771c4e2;' \
  -H 'X-XSRF-TOKEN: c353b2ca-a77c-4552-839c-37405771c4e2' \
  --data-raw '{"url":"http://geoservices.brgm.fr/geologie?language=fre&","strategy":"investigator","typeName":"GITES_EMP","version":"2.0.0"}' \
  --compressed
```

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/e94adc38-1581-4982-89ee-45f6d4307452)


Tested with GeoServer, QGISServer, MapServer

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md
- [x] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
