### PR TITLE
change label to "Access to the catalogue"

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/loc/eng/strings.xml
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/loc/eng/strings.xml
@@ -59,7 +59,7 @@
   <providedBy>Provided by</providedBy>
   <shareOnSocialSite>Share on social sites</shareOnSocialSite>
   <viewMode>Views</viewMode>
-  <linkToPortal>Access to the portal</linkToPortal>
+  <linkToPortal>Access to the catalogue</linkToPortal>
   <linkToPortal-help>Read here the full details and access to the data.</linkToPortal-help>
   <citationProposal>Citation proposal</citationProposal>
   <citationProposal-help>This proposal was automatically generated, check if the metadata authors did not specified custom citation requirements.</citationProposal-help>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/chi/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/chi/strings.xml
@@ -63,7 +63,7 @@
   <providedBy>Provided by</providedBy>
   <shareOnSocialSite>Share on social sites</shareOnSocialSite>
   <viewMode>Views</viewMode>
-  <linkToPortal>Access to the portal</linkToPortal>
+  <linkToPortal>Access to the catalogue</linkToPortal>
   <linkToPortal-help>Read here the full details and access to the data.</linkToPortal-help>
   <citationProposal>Citation proposal</citationProposal>
   <citationProposal-help>This proposal was automatically generated, check if the metadata authors did not specified custom citation requirements.</citationProposal-help>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/eng/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/eng/strings.xml
@@ -63,7 +63,7 @@
   <providedBy>Provided by</providedBy>
   <shareOnSocialSite>Share on social sites</shareOnSocialSite>
   <viewMode>Views</viewMode>
-  <linkToPortal>Access to the portal</linkToPortal>
+  <linkToPortal>Access to the catalogue</linkToPortal>
   <linkToPortal-help>Read here the full details and access to the data.</linkToPortal-help>
   <citationProposal>Citation proposal</citationProposal>
   <citationProposal-help>This proposal was automatically generated, check if the metadata authors did not specified custom citation requirements.</citationProposal-help>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/fre/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/fre/strings.xml
@@ -36,7 +36,7 @@
   <providedBy>Fourni par</providedBy>
   <shareOnSocialSite>Partager</shareOnSocialSite>
   <viewMode>Mode d'affichage</viewMode>
-  <linkToPortal>Lien vers le portail</linkToPortal>
+  <linkToPortal>Lien vers le catalogue</linkToPortal>
   <linkToPortal-help>Consultez l'intégralité des métadonnées et accédez à la donnée.</linkToPortal-help>
 
 

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/swe/strings.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/swe/strings.xml
@@ -65,7 +65,7 @@
   <providedBy>Provided by</providedBy>
   <shareOnSocialSite>Share on social sites</shareOnSocialSite>
   <viewMode>Views</viewMode>
-  <linkToPortal>Access to the portal</linkToPortal>
+  <linkToPortal>Access to the catalogue</linkToPortal>
   <linkToPortal-help>Read here the full details and access to the data.</linkToPortal-help>
   <citationProposal>Citation proposal</citationProposal>
   <citationProposal-help>This proposal was automatically generated, check if the metadata authors did not specified custom citation requirements.</citationProposal-help>


### PR DESCRIPTION
We had discussion with Geonetwork regular meeting. The label "portal" is not so précised to describe. We will just use "catalogue" 

![image](https://github.com/geonetwork/core-geonetwork/assets/74916635/12336556-7083-46e0-8851-421218cb1b2e)
