### PR TITLE
Record view / Improve language list.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/catalog/CatalogService.js
+++ b/web-ui/src/main/resources/catalog/components/catalog/CatalogService.js
@@ -762,6 +762,12 @@
         getUuid: function () {
           return this.uuid;
         },
+        getMetadataLanguages: function () {
+          if (!this.mainLanguage) {
+            return [];
+          }
+          return [this.mainLanguage].concat(this.otherLanguage).unique();
+        },
         isPublished: function (pubOption) {
           if (pubOption) {
             return this.isPublishedToGroup(pubOption.publicationGroup);

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_result_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_result_default.less
@@ -262,7 +262,7 @@
         line-break: normal;
       }
       &:after {
-        content: ",";
+        content: ", ";
       }
       &:last-child:after {
         content: "";

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/metadata.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/metadata.html
@@ -10,8 +10,8 @@
 </div>
 
 <div
-  data-ng-init="mdLanguages = [mdView.current.record.mainLanguage].concat(mdView.current.record.otherLanguage || [])"
-  data-aang-if="mdLanguages.length > 0"
+  data-ng-init="mdLanguages = mdView.current.record.getMetadataLanguages()"
+  data-ng-show="mdLanguages.length > 0"
   class="gn-margin-bottom flex-row"
 >
   <span class="badge badge-rounded" title="{{'language' | translate}}">
@@ -20,7 +20,7 @@
   <div>
     <h3 data-translate="">metadataLanguage</h3>
     <ul class="gn-comma-list">
-      <li data-ng-repeat="l in mdLanguages | unique">{{l | translate}}</li>
+      <li data-ng-repeat="l in mdLanguages">{{l | translate}}</li>
     </ul>
   </div>
 </div>

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/technical.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/technical.html
@@ -105,8 +105,9 @@
     <div>
       <h3 data-translate="">language</h3>
       <ul class="gn-comma-list">
-        <li data-ng-repeat="l in mdView.current.record.resourceLanguage">
-          {{l | translate}}
+        <li data-ng-repeat="l in mdView.current.record.resourceLanguage"
+            data-translate="">
+          {{l}}
         </li>
       </ul>
     </div>


### PR DESCRIPTION
* Improve space between values (before and after in resource language, after in metadata language)

Before

![](https://github.com/geonetwork/core-geonetwork/assets/1701393/f7796da1-9c5a-4e32-91f6-e8f43fc30180)

After
![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/c9dc4ec3-5dc4-47c2-8439-d7c2631de4fa)


* Unique languages in list (as multilingual record may advertise the main language in other languages) (similar to https://github.com/geonetwork/core-geonetwork/pull/6884/files) - record for testing https://www.geocat.ch/geonetwork/srv/api/records/8698bf0b-fceb-4f0f-989b-111e7c4af0a4/formatters/iso19139

* Hide language if no language defined (eg. ISO19110) - record for testing https://metadata.vlaanderen.be/srv/api/records/35CFB30F-23C1-4EFA-B846-093E2645CF8D/formatters/xml

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/2b4aba1a-3c37-407f-a749-f61f0f867809)


# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md
- [x] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
