### PR TITLE
WRO4J / Fix unresolvable source map file on Windows

### DIFF
--- a/web-ui/src/main/resources/catalog/lib/angular.ext/date.js
+++ b/web-ui/src/main/resources/catalog/lib/angular.ext/date.js
@@ -291,4 +291,3 @@
     /******/ ])
 });
 ;
-//# sourceMappingURL=date.js.map


### PR DESCRIPTION
Since the update of WRO4J to version 1.10.1, the project could not be started on Windows machines.  
The reason was that WRO4J was trying to access a nonexistent sourcemap file.

By removing the link to the missing sourcemap, the issue is resolved.

CC: @fxprunayre 