### PR TITLE
Restructure the 'composed of' block on the detail page

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/RelatedDirective.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/RelatedDirective.js
@@ -568,7 +568,8 @@
 
   module.directive("gnRecordsFilters", [
     "$rootScope",
-    function ($rootScope) {
+    "gnGlobalSettings",
+    function ($rootScope, gnGlobalSettings) {
       return {
         restrict: "A",
         templateUrl: function (elem, attrs) {
@@ -588,6 +589,8 @@
           scope.showTypes = !angular.isDefined(scope.type);
           scope.type = scope.type || "blocks";
           scope.criteria = { p: {} };
+          scope.relatedFacetConfig =
+            gnGlobalSettings.gnCfg.mods.recordview.relatedFacetConfig;
 
           function removeEmptyFilters(filters, agg) {
             var cleanFilterPos = [];
@@ -612,7 +615,7 @@
           }
 
           // Remove the filters without values
-          scope.filtersToProcess = scope.filters || Object.keys(scope.agg);
+          scope.filtersToProcess = scope.filters || Object.keys(scope.relatedFacetConfig);
           scope.agg && removeEmptyFilters(scope.filtersToProcess, scope.agg);
 
           reset();

--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/recordsFilters.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/recordsFilters.html
@@ -1,28 +1,19 @@
 <div data-ng-if="agg">
-  <div class="row">
-    <div class="col-md-2">
-      <h2>{{title}}</h2>
-    </div>
-    <div class="col-md-10">
-      <div data-ng-repeat="filter in filtersToProcess" class="row">
-        <div class="col-md-3">
-          <div class="pull-right">{{('facet-' + filter) | facetKeyTranslator}}</div>
-        </div>
-        <div class="col-md-9">
-          <div class="btn-group btn-group-sm" role="group" aria-label="filter">
-            <button
-              data-ng-repeat="(key, b) in agg[filter].buckets"
-              data-ng-click="filterRecordsBy(filter, b.key)"
-              data-ng-disabled="b.doc_count === children.length"
-              type="button"
-              class="btn btn-default"
-              data-ng-class="{'btn-primary': current === (filter + '-' + b.key)}"
-            >
-              {{(b.key | translate) || '&nbsp;'}} ({{b.doc_count}})
-            </button>
-          </div>
-        </div>
-      </div>
+  <h2>{{title}}</h2>
+  <p class="text-muted" translate="">filterHelp</p>
+  <div data-ng-repeat="filter in filtersToProcess">
+    <label>{{('facet-' + filter) | facetKeyTranslator}}</label>
+    <div>
+      <button
+        data-ng-repeat="(key, b) in agg[filter].buckets"
+        data-ng-click="filterRecordsBy(filter, b.key)"
+        data-ng-disabled="b.doc_count === children.length"
+        type="button"
+        class="btn btn-default btn-sm gn-margin-bottom-sm gn-margin-right-sm"
+        data-ng-class="{'btn-primary': current === (filter + '-' + b.key)}"
+      >
+        {{(b.key | translate) || '&nbsp;'}} ({{b.doc_count}})
+      </button>
     </div>
   </div>
 </div>

--- a/web-ui/src/main/resources/catalog/locales/en-v4.json
+++ b/web-ui/src/main/resources/catalog/locales/en-v4.json
@@ -414,5 +414,6 @@
   "lastCreatedRecords": "Last created records",
   "associationType": "Association type",
   "initiativeType": "Initiative type",
-  "associatedTo": "Associated "
+  "associatedTo": "Associated ",
+  "filterHelp": "Please click on one of the buttons below to activate the filter"
 }

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_card_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_card_default.less
@@ -453,7 +453,10 @@ table.gn-resultview {
     .gn-card {
       min-width: 150px;
       width: calc(~"(100% / 4) - 20px");
-      @media (max-width: @screen-sm-min) {
+      @media (max-width: 1440px) {
+        width: calc(~"(100% / 3) - 20px");
+      }
+      @media (max-width: @screen-lg-min) {
         width: calc(~"(100% / 2) - 20px");
       }
       @media (max-width: @screen-xs) {

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/type-series.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/type-series.html
@@ -82,7 +82,7 @@
       data-ng-if="mdView.current.record.related.uuids"
       data-gn-related="mdView.current.record"
       data-user="user"
-      data-layout="title"
+      data-layout="card"
       data-types="services"
       data-title="{{'<span class=\'badge badge-rounded\'><i class=\'fa fa-fw fa-cloud\'></i></span><strong>' + ('openRecordservices' | translate) + '</strong>'}}"
     ></div>

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/type-series.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/type-series.html
@@ -30,40 +30,47 @@
   </div>
 </div>
 
-<!-- Records filters -->
-<div class="col-md-12 gn-section gn-margin-bottom gn-padding-bottom-lg"
-  data-ng-if="mdView.current.record.related.uuids"
-  data-gn-records-filters
-  data-agg="mdView.current.record.related.children.length > 0
-      ? mdView.current.record.related.aggregations_children
-      :mdView.current.record.related.aggregations_siblings"
-  data-title="{{'seriesComposedOf' | translate}}"
-></div>
+<div class="row">
+  <!-- Records filters -->
+  <div
+    class="col-md-4 col-sm-12 gn-margin-bottom gn-padding-bottom-lg"
+    data-ng-if="mdView.current.record.related.uuids"
+    data-gn-records-filters
+    data-agg="mdView.current.record.related.children.length > 0
+        ? mdView.current.record.related.aggregations_children
+        :mdView.current.record.related.aggregations_siblings"
+    data-title="{{'seriesComposedOf' | translate}}"
+  ></div>
 
-<div class="col-md-12 gn-margin-bottom"
-  data-ng-if="mdView.current.record.related.uuids"
-  data-gn-related-with-stats="mdView.current.record.related.children.length > 0
-                                        ? mdView.current.record.related.children
-                                        : mdView.current.record.related.siblings"
-  data-agg="mdView.current.record.related.children.length > 0
-      ? mdView.current.record.related.aggregations_children
-      :mdView.current.record.related.aggregations_siblings"
-  data-type="'blocks'"
-  data-sort-by="resourceTitle"
-  data-title="{{'seriesComposedOf' | translate}}"
-></div>
+  <div class="col-md-8 col-sm-12">
 
-<!-- Related records table -->
-<div class="col-md-12"
-  data-gn-records-table="mdView.current.record.related.children.length > 0
-                            ? mdView.current.record.related.children
-                            : mdView.current.record.related.siblings"
-  data-agg="mdView.current.record.related.children.length > 0
-      ? mdView.current.record.related.aggregations_children
-      :mdView.current.record.related.aggregations_siblings"
-  labels="{{::viewConfig.collectionTableConfig.labels}}"
-  columns="{{::viewConfig.collectionTableConfig.columns}}"
->
+
+    <div
+      class="gn-margin-bottom"
+      data-ng-if="mdView.current.record.related.uuids"
+      data-gn-related-with-stats="mdView.current.record.related.children.length > 0
+                                            ? mdView.current.record.related.children
+                                            : mdView.current.record.related.siblings"
+      data-agg="mdView.current.record.related.children.length > 0
+          ? mdView.current.record.related.aggregations_children
+          :mdView.current.record.related.aggregations_siblings"
+      data-type="'blocks'"
+      data-sort-by="resourceTitle"
+      data-title="{{'seriesComposedOf' | translate}}"
+    ></div>
+
+    <!-- Related records table -->
+    <div
+      data-gn-records-table="mdView.current.record.related.children.length > 0
+                                ? mdView.current.record.related.children
+                                : mdView.current.record.related.siblings"
+      data-agg="mdView.current.record.related.children.length > 0
+          ? mdView.current.record.related.aggregations_children
+          :mdView.current.record.related.aggregations_siblings"
+      labels="{{::viewConfig.collectionTableConfig.labels}}"
+      columns="{{::viewConfig.collectionTableConfig.columns}}"
+    ></div>
+  </div>
 </div>
 
 <div class="row gn-section gn-section-{{mdView.current.record.resourceType[0]}}">

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/type-series.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/type-series.html
@@ -29,42 +29,41 @@
     <div data-gn-data-preview="mdView.current.record"></div>
   </div>
 </div>
-<div class="col-md-12 gn-record">
-  <!-- Records filters -->
-  <div
-    data-ng-if="mdView.current.record.related.uuids"
-    data-gn-records-filters
-    data-agg="mdView.current.record.related.children.length > 0
-        ? mdView.current.record.related.aggregations_children
-        :mdView.current.record.related.aggregations_siblings"
-    data-title="{{'seriesComposedOf' | translate}}"
-  ></div>
 
-  <!-- Related records -->
-  <div
-    data-ng-if="mdView.current.record.related.uuids"
-    data-gn-related-with-stats="mdView.current.record.related.children.length > 0
-                                          ? mdView.current.record.related.children
-                                          : mdView.current.record.related.siblings"
-    data-agg="mdView.current.record.related.children.length > 0
-        ? mdView.current.record.related.aggregations_children
-        :mdView.current.record.related.aggregations_siblings"
-    data-type="'blocks'"
-    data-sort-by="resourceTitle"
-    data-title="{{'seriesComposedOf' | translate}}"
-  ></div>
+<!-- Records filters -->
+<div class="col-md-12 gn-section gn-margin-bottom gn-padding-bottom-lg"
+  data-ng-if="mdView.current.record.related.uuids"
+  data-gn-records-filters
+  data-agg="mdView.current.record.related.children.length > 0
+      ? mdView.current.record.related.aggregations_children
+      :mdView.current.record.related.aggregations_siblings"
+  data-title="{{'seriesComposedOf' | translate}}"
+></div>
 
-  <!-- Related records table -->
-  <div
-    data-gn-records-table="mdView.current.record.related.children.length > 0
-                              ? mdView.current.record.related.children
-                              : mdView.current.record.related.siblings"
-    data-agg="mdView.current.record.related.children.length > 0
-        ? mdView.current.record.related.aggregations_children
-        :mdView.current.record.related.aggregations_siblings"
-    labels="{{::viewConfig.collectionTableConfig.labels}}"
-    columns="{{::viewConfig.collectionTableConfig.columns}}"
-  />
+<div class="col-md-12 gn-margin-bottom"
+  data-ng-if="mdView.current.record.related.uuids"
+  data-gn-related-with-stats="mdView.current.record.related.children.length > 0
+                                        ? mdView.current.record.related.children
+                                        : mdView.current.record.related.siblings"
+  data-agg="mdView.current.record.related.children.length > 0
+      ? mdView.current.record.related.aggregations_children
+      :mdView.current.record.related.aggregations_siblings"
+  data-type="'blocks'"
+  data-sort-by="resourceTitle"
+  data-title="{{'seriesComposedOf' | translate}}"
+></div>
+
+<!-- Related records table -->
+<div class="col-md-12"
+  data-gn-records-table="mdView.current.record.related.children.length > 0
+                            ? mdView.current.record.related.children
+                            : mdView.current.record.related.siblings"
+  data-agg="mdView.current.record.related.children.length > 0
+      ? mdView.current.record.related.aggregations_children
+      :mdView.current.record.related.aggregations_siblings"
+  labels="{{::viewConfig.collectionTableConfig.labels}}"
+  columns="{{::viewConfig.collectionTableConfig.columns}}"
+>
 </div>
 
 <div class="row gn-section gn-section-{{mdView.current.record.resourceType[0]}}">
@@ -76,7 +75,7 @@
       data-ng-if="mdView.current.record.related.uuids"
       data-gn-related="mdView.current.record"
       data-user="user"
-      data-layout="card"
+      data-layout="title"
       data-types="services"
       data-title="{{'<span class=\'badge badge-rounded\'><i class=\'fa fa-fw fa-cloud\'></i></span><strong>' + ('openRecordservices' | translate) + '</strong>'}}"
     ></div>


### PR DESCRIPTION
This PR restyles and restructures the `composed of` block on the Metadata page. Columns and whitespace are added and the buttonbar is now split into separate buttons with a clear `active` state.

**Screenshot** of the new layout

<img width="1121" alt="gn-composedof" src="https://github.com/geonetwork/core-geonetwork/assets/19608667/f45e05b3-27ad-479c-a6aa-c0bacc2eb574">

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
