### PR TITLE
Fix indexing of iso19110 metadata with cardinalities composed of multiple ranges

### DIFF
--- a/schemas/iso19110/src/main/plugin/iso19110/index-fields/index.xsl
+++ b/schemas/iso19110/src/main/plugin/iso19110/index-fields/index.xsl
@@ -118,7 +118,12 @@
               "link": "<xsl:value-of select="*/gfc:code/*/@xlink:href"/>",
               "type": "<xsl:value-of select="*/gfc:valueType/gco:TypeName/gco:aName/*/text()"/>"
               <xsl:if test="*/gfc:cardinality">
-                ,"cardinality": "<xsl:value-of select="concat(*/gfc:cardinality//gco:lower/*/text(), '..', */gfc:cardinality//gco:upper/*/text())"/>"
+                <xsl:variable name="cardinalityValue">
+                  <xsl:for-each select="*/gfc:cardinality/*/gco:range">
+                    <xsl:value-of select="concat(*/gco:lower/*/text(), '..', */gco:upper/*/text())"/><xsl:if test="position() != last()">,</xsl:if>
+                  </xsl:for-each>
+                </xsl:variable>
+                ,"cardinality": "<xsl:value-of select="$cardinalityValue"/>"
               </xsl:if>
               <xsl:variable name="codeList"
                             select="*/gfc:listedValue[normalize-space(*) != '']"/>


### PR DESCRIPTION
The indexing fails for iso19110 metadata with the following error when the cardinality is composed of multiple ranges:

```
Error at xsl:value-of on line 147 of index.xsl:
  XPTY0004: A sequence of more than one item is not allowed as the first argument of concat()
```

Test metadata: 

https://www.nationaalgeoregister.nl/geonetwork/srv/api/records/8c6a569e-51b3-4328-8725-cfc5e4b21a8d/formatters/xml?approved=true


# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
