### PR TITLE
Use request language for API services that use XSLT for responses

### DIFF
--- a/inspire-atom/src/main/java/org/fao/geonet/services/inspireatom/AtomDescribe.java
+++ b/inspire-atom/src/main/java/org/fao/geonet/services/inspireatom/AtomDescribe.java
@@ -1,5 +1,5 @@
 //=============================================================================
-//===	Copyright (C) 2001-2010 Food and Agriculture Organization of the
+//===	Copyright (C) 2001-2023 Food and Agriculture Organization of the
 //===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
 //===	and United Nations Environment Programme (UNEP)
 //===
@@ -143,7 +143,7 @@ public class AtomDescribe {
                 ? processDatasetFeed(spatial_dataset_identifier_code, spatial_dataset_identifier_namespace, context)
                 : processServiceFeed(fileIdentifier, context);
 
-        return new XsltResponseWriter(null, "atom-describe")
+        return new XsltResponseWriter(null, "atom-describe", context.getLanguage())
             .withXml(response)
             .withXsl("xslt/services/inspire-atom/describe.xsl")
             .asElement();

--- a/inspire-atom/src/main/java/org/fao/geonet/services/inspireatom/AtomSearch.java
+++ b/inspire-atom/src/main/java/org/fao/geonet/services/inspireatom/AtomSearch.java
@@ -1,5 +1,5 @@
 //=============================================================================
-//===	Copyright (C) 2001-2007 Food and Agriculture Organization of the
+//===	Copyright (C) 2001-2023 Food and Agriculture Organization of the
 //===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
 //===	and United Nations Environment Programme (UNEP)
 //===
@@ -215,11 +215,11 @@ public class AtomSearch {
 
         Locale locale = languageUtils.parseAcceptLanguage(request.getLocales());
         String language = isoLanguagesMapper.iso639_2T_to_iso639_2B(locale.getISO3Language());
-        language = XslUtil.twoCharLangCode(language, "eng").toLowerCase();
+        String language2Code = XslUtil.twoCharLangCode(language, "eng").toLowerCase();
 
-        return new XsltResponseWriter(null, "atom-feeds")
+        return new XsltResponseWriter(null, "atom-feeds", language)
             .withXml(feeds)
-            .withJson(String.format("catalog/locales/%s-v4.json", language))
+            .withJson(String.format("catalog/locales/%s-v4.json", language2Code))
             .withXsl("xslt/services/inspire-atom/search-results.xsl")
             .asHtml();
     }

--- a/inspire-atom/src/main/java/org/fao/geonet/services/inspireatom/AtomServiceDescription.java
+++ b/inspire-atom/src/main/java/org/fao/geonet/services/inspireatom/AtomServiceDescription.java
@@ -82,7 +82,6 @@ public class AtomServiceDescription {
     @Autowired
     InspireAtomFeedRepository inspireAtomFeedRepository;
 
-
     @io.swagger.v3.oas.annotations.Operation(
         summary = "Describe service",
         description = "")
@@ -194,7 +193,7 @@ public class AtomServiceDescription {
             .addContent(new Element("url").setText(feedUrl))
             .addContent(datasetsEl);
 
-        return new XsltResponseWriter(null, "opensearch")
+        return new XsltResponseWriter(null, "opensearch", context.getLanguage())
             .withXml(response)
             .withXsl("xslt/services/inspire-atom/opensearch.xsl")
             .asElement();

--- a/services/src/main/java/org/fao/geonet/api/records/CatalogApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/CatalogApi.java
@@ -463,12 +463,12 @@ public class CatalogApi {
 
         Locale locale = languageUtils.parseAcceptLanguage(httpRequest.getLocales());
         String language = IsoLanguagesMapper.iso639_2T_to_iso639_2B(locale.getISO3Language());
-        language = XslUtil.twoCharLangCode(language, "eng").toLowerCase();
+        String language2code = XslUtil.twoCharLangCode(language, "eng").toLowerCase();
 
-        new XsltResponseWriter("env", "search")
-            .withJson(String.format("catalog/locales/%s-v4.json", language))
-            .withJson(String.format("catalog/locales/%s-core.json", language))
-            .withJson(String.format("catalog/locales/%s-search.json", language))
+        new XsltResponseWriter("env", "search", language)
+            .withJson(String.format("catalog/locales/%s-v4.json", language2code))
+            .withJson(String.format("catalog/locales/%s-core.json", language2code))
+            .withJson(String.format("catalog/locales/%s-search.json", language2code))
             .withXml(response)
             .withParams(params)
             .withXsl("xslt/services/pdf/portal-present-fop.xsl")
@@ -574,7 +574,7 @@ public class CatalogApi {
                 }
             });
 
-            Element r = new XsltResponseWriter(null, "search")
+            Element r = new XsltResponseWriter(null, "search", context.getLanguage())
                 .withParams(allRequestParams.entrySet().stream()
                     .collect(Collectors.toMap(
                         Entry::getKey,

--- a/services/src/main/java/org/fao/geonet/guiapi/search/SearchApi.java
+++ b/services/src/main/java/org/fao/geonet/guiapi/search/SearchApi.java
@@ -113,8 +113,8 @@ public class SearchApi {
 
             response.getWriter().write(
                 new XsltResponseWriter(null, "search", language)
-                    .withJson("catalog/locales/en-core.json")
-                    .withJson("catalog/locales/en-search.json")
+                    .withJson(String.format("catalog/locales/%s-core.json", language2code))
+                    .withJson(String.format("catalog/locales/%s-search.json", language2code))
                     .withXml(results)
                     .withXsl(
                         isRdf ?

--- a/services/src/main/java/org/fao/geonet/guiapi/search/SearchApi.java
+++ b/services/src/main/java/org/fao/geonet/guiapi/search/SearchApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2023 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -30,9 +30,12 @@ import jeeves.server.context.ServiceContext;
 import org.apache.commons.lang.NotImplementedException;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.api.ApiUtils;
+import org.fao.geonet.api.tools.i18n.LanguageUtils;
 import org.fao.geonet.kernel.search.EsSearchManager;
+import org.fao.geonet.languages.IsoLanguagesMapper;
 import org.fao.geonet.utils.Xml;
 import org.jdom.Element;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
@@ -41,6 +44,7 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.util.Locale;
 import java.util.Map;
 
 @RequestMapping(value = {
@@ -51,6 +55,9 @@ import java.util.Map;
 @Controller("search")
 public class SearchApi {
     public static final String APPLICATION_RDF_XML = "application/rdf+xml";
+
+    @Autowired
+    LanguageUtils languageUtils;
 
     @Operation(
         summary = "Get statistics about a field",
@@ -101,8 +108,11 @@ public class SearchApi {
         } else if (isJson) {
             response.getWriter().write(Xml.getJSON(results));
         } else {
+            Locale locale = languageUtils.parseAcceptLanguage(request.getLocales());
+            String language = IsoLanguagesMapper.iso639_2T_to_iso639_2B(locale.getISO3Language());
+
             response.getWriter().write(
-                new XsltResponseWriter(null, "search")
+                new XsltResponseWriter(null, "search", language)
                     .withJson("catalog/locales/en-core.json")
                     .withJson("catalog/locales/en-search.json")
                     .withXml(results)

--- a/services/src/main/java/org/fao/geonet/guiapi/search/SearchApi.java
+++ b/services/src/main/java/org/fao/geonet/guiapi/search/SearchApi.java
@@ -110,6 +110,7 @@ public class SearchApi {
         } else {
             Locale locale = languageUtils.parseAcceptLanguage(request.getLocales());
             String language = IsoLanguagesMapper.iso639_2T_to_iso639_2B(locale.getISO3Language());
+            String language2code = XslUtil.twoCharLangCode(language, "eng").toLowerCase();
 
             response.getWriter().write(
                 new XsltResponseWriter(null, "search", language)

--- a/services/src/main/java/org/fao/geonet/guiapi/search/XsltResponseWriter.java
+++ b/services/src/main/java/org/fao/geonet/guiapi/search/XsltResponseWriter.java
@@ -59,7 +59,7 @@ public class XsltResponseWriter {
     Path xsl;
     Map<String, Object> xslParams = new HashMap<>();
 
-    public XsltResponseWriter(String envTagName, String serviceName) {
+    public XsltResponseWriter(String envTagName, String serviceName, String language) {
         SettingManager settingManager = ApplicationContextHolder.get().getBean(SettingManager.class);
         String url = settingManager.getBaseURL();
         Element gui = new Element("gui");
@@ -70,8 +70,7 @@ public class XsltResponseWriter {
         gui.addContent(new Element("baseUrl").setText(settingManager.getBaseURL()));
         gui.addContent(new Element("serverUrl").setText(settingManager.getServerURL()));
         gui.addContent(new Element("nodeId").setText(settingManager.getNodeId()));
-        // TODO: set language based on header
-        gui.addContent(new Element("language").setText("eng"));
+        gui.addContent(new Element("language").setText(language));
 
 
         Element settings = settingManager.getAllAsXML(true);


### PR DESCRIPTION
This change uses the http request language for XSLT processes used in some API requests to return the response. Previously the language was hardcoded to English.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation