### PR TITLE
Ensure only non-service records are display when linking a dataset from a service

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -1697,7 +1697,7 @@
                   } else {
                     // Any records which are not services
                     // ie. dataset, series, ...
-                    searchParams["-type"] = "service";
+                    searchParams["-resourceType"] = "service";
                   }
                   scope.$broadcast("resetSearch", searchParams);
                   scope.layers = [];


### PR DESCRIPTION
In the `gnLinkServiceToDataset` directive, a filter is applied to only display non-service resource type in the modal. 
However, this filter is applied on the incorrect index field `type` instead of `resourceType`.  
![image](https://github.com/geonetwork/core-geonetwork/assets/32705577/46d92c05-645a-4c02-98a8-3b4c6b36cf6c)

By modifying this filter, only the dataset/fc records are shown.

Before:  
![image](https://github.com/geonetwork/core-geonetwork/assets/32705577/64902685-54c2-41a5-901c-164e294279f0)


After:  
![image](https://github.com/geonetwork/core-geonetwork/assets/32705577/09afcf0b-fbfa-426a-893a-bb9bc3ea0bbb)

CC: @fxprunayre 