### PR TITLE
Validation of INSPIRE ATOM services to return API exceptions instead of error 400

### DIFF
--- a/inspire-atom/src/main/java/org/fao/geonet/services/inspireatom/AtomDescribe.java
+++ b/inspire-atom/src/main/java/org/fao/geonet/services/inspireatom/AtomDescribe.java
@@ -50,6 +50,7 @@ import org.fao.geonet.lib.Lib;
 import org.jdom.Element;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.MediaType;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
@@ -136,6 +137,16 @@ public class AtomDescribe {
         if (!inspireEnable) {
             Log.info(Geonet.ATOM, "Inspire is disabled");
             throw new Exception("Inspire is disabled");
+        }
+
+        if (StringUtils.isEmpty(fileIdentifier)) {
+            if (StringUtils.isEmpty(spatial_dataset_identifier_code)) {
+                throw new MissingServletRequestParameterException("spatial_dataset_identifier_code", "String");
+            }
+
+            if (StringUtils.isEmpty(spatial_dataset_identifier_namespace)) {
+                throw new MissingServletRequestParameterException("spatial_dataset_identifier_namespace", "String");
+            }
         }
 
         Element response =

--- a/inspire-atom/src/main/java/org/fao/geonet/services/inspireatom/AtomGetData.java
+++ b/inspire-atom/src/main/java/org/fao/geonet/services/inspireatom/AtomGetData.java
@@ -91,18 +91,18 @@ public class AtomGetData {
     public Element downloadResource(
         @Parameter(
             description = "spatial_dataset_identifier_code",
-            required = false)
-        @RequestParam(defaultValue = "")
+            required = true)
+        @RequestParam
             String spatial_dataset_identifier_code,
         @Parameter(
             description = "spatial_dataset_identifier_namespace",
-            required = false)
-        @RequestParam(defaultValue = "")
+            required = true)
+        @RequestParam
             String spatial_dataset_identifier_namespace,
         @Parameter(
             description = "crs",
-            required = false)
-        @RequestParam(defaultValue = "")
+            required = true)
+        @RequestParam
             String crs,
         @Parameter(hidden = true)
             HttpServletRequest request,


### PR DESCRIPTION
Follow up of #6395

INSPIRE ATOM Describe and Download services return http error 400 without further details if mandatory parameters are not provided. 

```
This page isn’t working 
If the problem continues, contact the site owner.
HTTP ERROR 400
```

Updated the code to return API exception messages, similar to what was returned in GeoNetwork 3.12.x:

```
<apiError>
  <code>required_parameter_missing</code>
  <message>Required request parameter 'spatial_dataset_identifier_namespace' for method parameter type String is not present</message>
</apiError>
```

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

