### PR TITLE
Remote INSPIRE Atom Feeds harvester - Remove duplicates by dataset identifier

### DIFF
--- a/inspire-atom/src/main/java/org/fao/geonet/inspireatom/harvester/InspireAtomHarvester.java
+++ b/inspire-atom/src/main/java/org/fao/geonet/inspireatom/harvester/InspireAtomHarvester.java
@@ -1,5 +1,5 @@
 //=============================================================================
-//===	Copyright (C) 2001-2010 Food and Agriculture Organization of the
+//===	Copyright (C) 2001-2023 Food and Agriculture Organization of the
 //===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
 //===	and United Nations Environment Programme (UNEP)
 //===
@@ -49,6 +49,10 @@ import org.jdom.Element;
 import org.springframework.data.jpa.domain.Specification;
 
 import java.util.*;
+
+import static java.util.Comparator.comparing;
+import static java.util.stream.Collectors.collectingAndThen;
+import static java.util.stream.Collectors.toCollection;
 
 
 /**
@@ -261,7 +265,12 @@ public class InspireAtomHarvester {
             }
         }
 
-        return datasetsInformation;
+        // Remove duplicates by dataset identifier, that could be obtained from datasets referenced by different service feeds
+        List<DatasetFeedInfo> uniqueDatasetsInformation = datasetsInformation.stream()
+            .collect(collectingAndThen(toCollection(() -> new TreeSet<>(comparing(DatasetFeedInfo::getIdentifier))),
+                ArrayList::new));
+
+        return uniqueDatasetsInformation;
     }
 
 

--- a/inspire-atom/src/main/java/org/fao/geonet/inspireatom/harvester/InspireAtomHarvester.java
+++ b/inspire-atom/src/main/java/org/fao/geonet/inspireatom/harvester/InspireAtomHarvester.java
@@ -71,14 +71,14 @@ public class InspireAtomHarvester {
     /**
      * Constructor.
      *
-     * @param geonetGontext GeoNetwork context.
+     * @param geonetContext GeoNetwork context.
      */
-    public InspireAtomHarvester(final GeonetContext geonetGontext) {
-        this.gc = geonetGontext;
+    public InspireAtomHarvester(final GeonetContext geonetContext) {
+        this.gc = geonetContext;
     }
 
     /**
-     * Process the metadata to check if have an atom document referenced. In this case, the atom
+     * Process the metadata to check if it has an atom document referenced. In this case, the atom
      * document is retrieved and stored in the metadata table.
      */
     public final Element harvest() {
@@ -93,7 +93,7 @@ public class InspireAtomHarvester {
         String atomProtocol = sm.getValue(Settings.SYSTEM_INSPIRE_ATOM_PROTOCOL);
 
         // Using index information, as type is only available in index and not in database.
-        // If retrieved from database retrieves all iso19139 metadata and should apply for each result an xslt process
+        // If retrieved from database retrieves all iso19139 metadata and should apply for each result a xslt process
         // to identify if a service or dataset (slow process)
 
         List<AbstractMetadata> iso19139Metadata = InspireAtomUtil.searchMetadataByTypeAndProtocol(ServiceContext.get(),
@@ -146,7 +146,7 @@ public class InspireAtomHarvester {
      * @param metadataId Metadata identifier
      */
     public final void harvestServiceMetadata(final ServiceContext context, final String metadataId) {
-        Logger logger = Log.createLogger(Geonet.ATOM);
+        Logger localLogger = Log.createLogger(Geonet.ATOM);
 
         final InspireAtomFeedRepository repository = context.getBean(InspireAtomFeedRepository.class);
         DataManager dataMan = context.getBean(DataManager.class);
@@ -154,27 +154,27 @@ public class InspireAtomHarvester {
 
         final IMetadataUtils metadataUtils = gc.getBean(IMetadataUtils.class);
         AbstractMetadata iso19139Metadata = metadataUtils.findOne(
-        		Specification.where((Specification<Metadata>) MetadataSpecs.isType(MetadataType.METADATA))
-        			.and((Specification<Metadata>) MetadataSpecs.isIso19139Schema())
-                    .and((Specification<Metadata>) MetadataSpecs.hasMetadataId(Integer.parseInt(metadataId))));
+            Specification.where((Specification<Metadata>) MetadataSpecs.isType(MetadataType.METADATA))
+                .and((Specification<Metadata>) MetadataSpecs.isIso19139Schema())
+                .and((Specification<Metadata>) MetadataSpecs.hasMetadataId(Integer.parseInt(metadataId))));
 
         Element result = new Element("response");
 
         try {
-            logger.info("ATOM feed harvest started for metadata: " + metadataId);
+            localLogger.info("ATOM feed harvest started for metadata: " + metadataId);
 
             // Value used in metadata editor for online resources to identify an INSPIRE atom resource
             String atomProtocol = sm.getValue(Settings.SYSTEM_INSPIRE_ATOM_PROTOCOL);
 
             // Removes all atom information from existing metadata. Harvester will reload with updated information
-            logger.info("ATOM feed harvest: remove existing metadata feed");
+            localLogger.info("ATOM feed harvest: remove existing metadata feed");
             repository.deleteAll(InspireAtomFeedSpecs.hasMetadataId(Integer.parseInt(metadataId)));
-            dataMan.indexMetadata(Arrays.asList(new String[]{metadataId}));
+            dataMan.indexMetadata(Arrays.asList(metadataId));
 
             // Process service metadata feeds
             //    datasetsInformation stores the dataset information for identifier and namespace for the services feed.
             //    This information is not available in the datasets feeds
-            logger.info("ATOM feed harvest: processing service metadata feeds");
+            localLogger.info("ATOM feed harvest: processing service metadata feeds");
 
             // Retrieve the service metadata referencing atom feed document
             Map<String, String> serviceMetadataWithAtomFeed =
@@ -184,13 +184,13 @@ public class InspireAtomHarvester {
                 processServiceMetadataFeeds(dataMan, serviceMetadataWithAtomFeed, result);
 
             // Process dataset metadata feeds related to the service metadata
-            logger.info("ATOM feed harvest for metadata: " + metadataId + ",  processing dataset metadata feeds");
-            processDatasetsMetadataFeeds(context, dataMan, datasetsInformation, result);
+            localLogger.info("ATOM feed harvest for metadata: " + metadataId + ",  processing dataset metadata feeds");
+            processDatasetsMetadataFeeds(dataMan, datasetsInformation, result);
 
-            logger.info("ATOM feed harvest finished for metadata: " + metadataId);
+            localLogger.info("ATOM feed harvest finished for metadata: " + metadataId);
         } catch (Exception x) {
-            logger.error("ATOM feed harvest error: " + x.getMessage());
-            logger.error(x);
+            localLogger.error("ATOM feed harvest error: " + x.getMessage());
+            localLogger.error(x);
         }
     }
 
@@ -198,13 +198,13 @@ public class InspireAtomHarvester {
     /**
      * Process service metadata feeds.
      *
-     * @return a Map with the datasets referenced in the service feeds (dataset-id,
+     * @return a List with the datasets referenced in the service feeds (dataset-id,
      * dataset-namespace). The namespace is only available in the service feeds. Dataset feeds seem
      * not containing this information.
      */
     private List<DatasetFeedInfo> processServiceMetadataFeeds(final DataManager dataMan,
-                                                            final Map<String, String> serviceMetadataWithAtomFeeds,
-                                                            Element result)
+                                                              final Map<String, String> serviceMetadataWithAtomFeeds,
+                                                              Element result)
         throws Exception {
 
         List<DatasetFeedInfo> datasetsInformation = new ArrayList<>();
@@ -221,7 +221,7 @@ public class InspireAtomHarvester {
 
             try {
                 String atomUrl = entry.getValue();
-                logger.info("Processing feed (" + i++ + "/"+ total + ") for service metadata with uuid:" + metadataUuid);
+                logger.info("Processing feed (" + i++ + "/" + total + ") for service metadata with uuid:" + metadataUuid);
                 logger.info("Atom feed Url for service metadata (" + metadataUuid + "): " + atomUrl);
 
                 String atomFeedDocument = InspireAtomUtil.retrieveRemoteAtomFeedDocument(gc, atomUrl);
@@ -244,12 +244,12 @@ public class InspireAtomHarvester {
                 repository.save(inspireAtomFeed);
 
                 // Index the metadata to store the atom feed information in the index
-                dataMan.indexMetadata(Arrays.asList(new String[]{metadataId}));
+                dataMan.indexMetadata(Arrays.asList(metadataId));
 
 
                 // Extract datasets information (identifier, namespace) from the service feed:
                 //      The namespace is only available in service feed and no in dataset feeds.
-                //      Also NGR metadata uses MD_Identifier instead of RS_Identifier so lacks of this information
+                //      Also, NGR metadata uses MD_Identifier instead of RS_Identifier so lacks of this information
                 logger.debug("Extract datasets information (identifier, namespace) from service atom feed  (" + atomUrl + ")");
 
                 datasetsInformation.addAll(InspireAtomUtil.extractRelatedDatasetsInfoFromServiceFeed(atomFeedDocument, dataMan));
@@ -266,35 +266,20 @@ public class InspireAtomHarvester {
         }
 
         // Remove duplicates by dataset identifier, that could be obtained from datasets referenced by different service feeds
-        List<DatasetFeedInfo> uniqueDatasetsInformation = datasetsInformation.stream()
+        return datasetsInformation.stream()
             .collect(collectingAndThen(toCollection(() -> new TreeSet<>(comparing(DatasetFeedInfo::getIdentifier))),
                 ArrayList::new));
-
-        return uniqueDatasetsInformation;
     }
 
-
-    /**
-     * Process dataset metadata feeds.
-     */
-    private void processDatasetsMetadataFeeds(final DataManager dataMan,
-                                              final List<DatasetFeedInfo> datasetsFeedInformation,
-                                              Element result)
-        throws Exception {
-
-        processDatasetsMetadataFeeds(ServiceContext.get(), dataMan, datasetsFeedInformation, result);
-    }
 
     /**
      * Process the feeds for a set datasets related to a service metadata.
      *
      * @param datasetsFeedInformation Datasets map (datasetid, namespace)
      */
-    private void processDatasetsMetadataFeeds(final ServiceContext context,
-                                              final DataManager dataMan,
+    private void processDatasetsMetadataFeeds(final DataManager dataMan,
                                               final List<DatasetFeedInfo> datasetsFeedInformation,
-                                              final Element result)
-        throws Exception {
+                                              final Element result) {
 
         final InspireAtomFeedRepository repository = gc.getBean(InspireAtomFeedRepository.class);
 
@@ -302,7 +287,7 @@ public class InspireAtomHarvester {
         long i = 1;
 
         // Process the metadata retrieving the atom feed content and store it in the catalog.
-        for(DatasetFeedInfo datasetFeedInfo: datasetsFeedInformation) {
+        for (DatasetFeedInfo datasetFeedInfo : datasetsFeedInformation) {
             String metadataUuid = "";
 
             try {
@@ -312,15 +297,18 @@ public class InspireAtomHarvester {
 
                 String atomUrl = datasetFeedInfo.feedUrl;
 
-                logger.info("Processing feed (" + i++ + "/"+ total + ") for dataset metadata with uuid:" + metadataUuid + ", feed url: " + atomUrl);
+                logger.info("Processing feed (" + i++ + "/" + total + ") for dataset metadata with uuid:"
+                    + metadataUuid + ", feed url: " + atomUrl);
 
                 if (StringUtils.isEmpty(metadataUuid)) {
-                    logger.warning("Metadata with dataset identifier (" + datasetFeedInfo.identifier + ") is not available. Skip dataset feed processing");
+                    logger.warning("Metadata with dataset identifier (" + datasetFeedInfo.identifier
+                        + ") is not available. Skip dataset feed processing");
                     continue;
                 }
 
                 if (!atomUrl.toLowerCase().endsWith(".xml")) {
-                    logger.warning("Atom feed Document (" + atomUrl + ") for dataset metadata (" + metadataUuid + ") is not a valid feed");
+                    logger.warning("Atom feed Document (" + atomUrl + ") for dataset metadata (" + metadataUuid
+                        + ") is not a valid feed");
                     continue;
                 }
 
@@ -349,7 +337,7 @@ public class InspireAtomHarvester {
                 repository.save(inspireAtomFeed);
 
                 // Index the metadata to store the atom feed information in the index
-                dataMan.indexMetadata(Arrays.asList(new String[]{metadataId}));
+                dataMan.indexMetadata(Arrays.asList(metadataId));
                 result.addContent(new Element("feed").setAttribute("uuid", metadataUuid)
                     .setAttribute("feed", atomUrl).setAttribute("status", "ok"));
             } catch (Exception ex) {
@@ -357,83 +345,6 @@ public class InspireAtomHarvester {
                 logger.error("Failed to process atom feed for dataset metadata: " + metadataUuid + " " + ex.getMessage());
                 logger.error(ex);
                 result.addContent(new Element("feed").setAttribute("uuid", metadataUuid).setAttribute("error", ex.getMessage()).setAttribute("status", "error"));
-            }
-        }
-    }
-
-
-    /**
-     * Process the feeds for a set datasets related to a service metadata.
-     *
-     */
-    private void processDatasetsMetadataFeedsForService(final ServiceContext context,
-                                                        final DataManager dataMan,
-                                                        final List<DatasetFeedInfo> datasetsFeedInformation,
-                                                        final Element result)
-        throws Exception {
-
-        // Retrieve the metadata referencing atom feed documents.
-
-        // Value used in metadata editor for online resources to identify an INSPIRE atom resource
-        String atomProtocol = gc.getBean(SettingManager.class).getValue("system/inspire/atomProtocol");
-
-        final InspireAtomFeedRepository repository = gc.getBean(InspireAtomFeedRepository.class);
-
-        // Process the metadata retrieving the atom feed content and store it in the catalog.
-        for(DatasetFeedInfo datasetFeedInfo: datasetsFeedInformation) {
-            String atomDatasetId = datasetFeedInfo.identifier;
-            String metadataUuid = "";
-
-            try {
-                metadataUuid = InspireAtomUtil.retrieveDatasetUuidFromIdentifier(
-                    gc.getBean(EsSearchManager.class), atomDatasetId);
-
-                String atomDatasetNs = datasetFeedInfo.namespace;
-                logger.debug("Dataset, id=" + atomDatasetId + ", namespace=" + atomDatasetNs);
-
-                if (StringUtils.isEmpty(metadataUuid)) {
-                    logger.warning("Can't find dataset metadata with datasetIdCode:" + atomDatasetId);
-                    continue;
-                }
-
-                logger.info("Processing feed for dataset metadata with uuid:" + metadataUuid);
-
-                String metadataId = dataMan.getMetadataId(metadataUuid);
-
-                // Get the atom feed url for the dataset
-                String atomUrl = datasetFeedInfo.feedUrl;
-                logger.debug("Dataset, feedurl=" + atomUrl);
-
-                // Retrieve the atom document and store it.
-                String atomFeedDocument = InspireAtomUtil.retrieveRemoteAtomFeedDocument(gc, atomUrl);
-                logger.debug("Dataset feed: " + atomFeedDocument);
-
-                Element atomDoc = Xml.loadString(atomFeedDocument, false);
-
-                // Skip document if not a feed
-                if (!atomDoc.getNamespace().equals(Geonet.Namespaces.ATOM)) {
-                    logger.warning("Atom feed Document (" + atomUrl + ") for dataset metadata (" + metadataUuid + ") is not a valid feed");
-                    continue;
-                }
-
-                InspireAtomFeed inspireAtomFeed = InspireAtomFeed.build(atomDoc);
-                inspireAtomFeed.setMetadataId(Integer.parseInt(metadataId));
-                inspireAtomFeed.setAtomDatasetid(atomDatasetId);
-                inspireAtomFeed.setAtomDatasetns(atomDatasetNs);
-                inspireAtomFeed.setAtomUrl(atomUrl);
-                inspireAtomFeed.setAtom(atomFeedDocument);
-
-                repository.save(inspireAtomFeed);
-
-                // Index the metadata to store the atom feed information in the index
-                dataMan.indexMetadata(Arrays.asList(new String[]{metadataId}));
-
-                result.addContent(new Element("feed").setAttribute("uuid", metadataUuid).setAttribute("feed", atomUrl).setAttribute("status", "ok"));
-            } catch (Exception ex) {
-                // Log exception and continue processing the other metadata
-                logger.error("Failed to process atom feed for dataset metadata: " + metadataUuid + " " + ex.getMessage());
-                result.addContent(new Element("feed").setAttribute("uuid", metadataUuid).setAttribute("error", ex.getMessage()).setAttribute("status", "error"));
-
             }
         }
     }


### PR DESCRIPTION
In the remote INSPIRE Atom Feeds harvester, could happen that several service feeds reference the same dataset. This produces duplicated entries in the InspireAtomFeed, causing errors other parts of the application, for example when trying to use the INSPIRE ATOM search endpoint:

http://localhost:8080/geonetwork/opensearch/eng/f95c6429-2cdf-47b8-bc2a-e614440050b8/search

```
2023-11-15T19:31:27,693 ERROR [geonetwork] - query did not return a unique result: 2; nested exception is javax.persistence.NonUniqueResultException: query did not return a unique result: 2
org.springframework.dao.IncorrectResultSizeDataAccessException: query did not return a unique result: 2; nested exception is javax.persistence.NonUniqueResultException: query did not return a unique result: 2
	at org.springframework.orm.jpa.EntityManagerFactoryUtils.convertJpaAccessExceptionIfPossible(EntityManagerFactoryUtils.java:385) ~[spring-orm-5.3.27.jar:5.3.27]
..
	at com.sun.proxy.$Proxy231.findByMetadataId(Unknown Source) ~[?:?]
	at org.fao.geonet.inspireatom.InspireAtomService.findByMetadataId(InspireAtomService.java:73) ~[gn-inspire-atom-4.2.7-SNAPSHOT.jar:?]
```

This change processes the list of datasets obtained from the service feeds to remove duplicates by dataset identifier.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
