### PR TITLE
Add web/src/main/webapp/WEB-INF/data/data/resources/schemapublication folder to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,4 @@ web/src/main/webapp/WEB-INF/prebuilt
 web/src/main/webapp/data/
 web/src/main/webapp/doc/en
 web/src/main/webapp/doc/fr
+web/src/main/webapp/WEB-INF/data/data/resources/schemapublication


### PR DESCRIPTION
This changes adds the folder `web/src/main/webapp/WEB-INF/data/data/resources/schemapublication` to `.gitignore`, as should not be committed in the code repository.

Related to https://github.com/geonetwork/core-geonetwork/pull/7337

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation