### PR TITLE
CSW Harvester / Don't set a default search filter field

### DIFF
--- a/web-ui/src/main/resources/catalog/components/admin/harvester/HarvesterDirective.js
+++ b/web-ui/src/main/resources/catalog/components/admin/harvester/HarvesterDirective.js
@@ -430,7 +430,7 @@
             }
 
             scope.harvester.filters.push({
-              field: scope.cswCriteriaTranslated[0],
+              field: "",
               operator: "LIKE",
               value: "",
               condition: condition


### PR DESCRIPTION
Currently the CSW harvester, when adding a search filter, sets the field value to the first queryable field. This causes confusion to some users, as to get the list of fields, should be removed the value first.

![csw-harvester-searchfield-1](https://github.com/geonetwork/core-geonetwork/assets/1695003/f33e4d21-df18-41b9-88ab-8ea069c96739)

This change displays the field with an empty value and when the user enters in it, the list of available fields:

![csw-harvester-searchfield-2](https://github.com/geonetwork/core-geonetwork/assets/1695003/1abf97f9-b564-47c9-be1c-bdf7c61b311b)


# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation