### PR TITLE
Fix language for region picker directives

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/partials/drawbbox.html
+++ b/web-ui/src/main/resources/catalog/components/common/map/partials/drawbbox.html
@@ -3,7 +3,7 @@
     <!--Region picker-->
     <label class="col-sm-3 control-label" data-translate="">chooseRegion</label>
     <div class="col-md-8">
-      <div data-gn-region-picker=""></div>
+      <div data-gn-region-picker="" data-lang="{{lang}}"></div>
     </div>
   </div>
 

--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -482,6 +482,8 @@
           var addGeonames = !attrs["disableGeonames"];
           scope.regionTypes = [];
 
+          scope.lang = attrs["lang"];
+
           function setDefault() {
             var defaultThesaurus = attrs["default"];
             for (var t in scope.regionTypes) {
@@ -736,6 +738,8 @@
               }
             });
           }
+          scope.lang = attrs["lang"];
+
           scope.$watch("regionType", function (val) {
             if (scope.regionType) {
               if (scope.regionType.id == "geonames") {

--- a/web-ui/src/main/resources/catalog/components/utility/partials/regionpicker.html
+++ b/web-ui/src/main/resources/catalog/components/utility/partials/regionpicker.html
@@ -18,6 +18,7 @@
     class="form-control"
     autocomplete="off"
     data-gn-region-picker-input=""
+    data-lang="{{lang}}"
     placeholder="{{'chooseRegion' | translate}}"
   />
   <span class="fa fa-spinner fa-spin" data-ng-show="regionLoading"></span>

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/csw.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/csw.html
@@ -94,6 +94,7 @@
                  data-ng-model="harvesterSelected.searches[0][c].value"/>
         </div>
       </div>-->
+
       <div data-ng-show="cswBboxFilter">
         <label class="control-label" data-translate="">csw-harvesterBboxFilter</label>
         <div
@@ -104,7 +105,7 @@
           data-hbottom=""
           data-htop=""
           data-show-clear-button="true"
-          data-lang="$parent.$parent.lang"
+          data-lang="$parent.lang"
         ></div>
       </div>
     </fieldset>


### PR DESCRIPTION
Region picker used in the CSW harvester doesn't work correctly with a regions thesaurus that has items in non English language.

The list of regions was displayed with empty labels:

![csw-harvester-regions-1](https://github.com/geonetwork/core-geonetwork/assets/1695003/f2393e0f-9ab0-4ba8-af59-08b8192ba7d9)

With the fix the list is displayed correctly:

![csw-harvester-regions-2](https://github.com/geonetwork/core-geonetwork/assets/1695003/73f95df1-26e1-48ef-94c6-543e62d286b0)


Test case:

1) Replace the regions thesaurus with this [one](https://www.nationaalgeoregister.nl/geonetwork/srv/eng/thesaurus.download?ref=external.place.regions)

2) Switch to Dutch UI and create a CSW harvester filling the URL of the harvester

3) in the `BBOX filter`, select the value `Nederland`

4) Without the fix, a list with empty labels is displayed. With the fix the labels are displayed correctly.


# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
