### PR TITLE
Add option to show less facet values

### DIFF
--- a/web-ui/src/main/resources/catalog/components/elasticsearch/EsFacet.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/EsFacet.js
@@ -83,6 +83,9 @@
           }
         }
       };
+      this.getDefaultSize = function () {
+        return DEFAULT_SIZE;
+      };
       this.buildDefaultQuery = function (query, size) {
         return {
           script_fields: defaultScriptedFields,
@@ -392,6 +395,9 @@
               facetModel.type = "terms";
               facetModel.size = reqAgg.terms.size;
               facetModel.more = respAgg.sum_other_doc_count > 0;
+              facetModel.less =
+                respAgg.buckets &&
+                respAgg.buckets.length > Math.min(reqAgg.terms.size, DEFAULT_SIZE);
               facetModel.includeFilter = reqAgg.terms.include !== undefined;
               facetModel.excludeFilter = reqAgg.terms.exclude !== undefined;
               var esFacet = this;

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/FacetDirective.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/FacetDirective.js
@@ -101,6 +101,12 @@
     });
   };
 
+  FacetsController.prototype.loadLessTerms = function (facet) {
+    this.searchCtrl.loadLessTerms(facet).then(function (terms) {
+      angular.copy(terms, facet);
+    });
+  };
+
   FacetsController.prototype.filterTerms = function (facet) {
     if (facet.meta && facet.meta.filterByTranslation) {
       var match = [];

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facets.html
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facets.html
@@ -142,6 +142,15 @@
         >
           <span translate>more</span>
         </a>
+        <span data-ng-if="facet.more && facet.less"> | </span>
+        <a
+          href
+          data-ng-class="facet.more ? '' : 'gn-facet-less'"
+          ng-if="facet.less"
+          ng-click="ctrl.loadLessTerms(facet)"
+        >
+          <span translate>less</span>
+        </a>
       </div>
     </div>
   </div>

--- a/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchFormDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/searchmanager/SearchFormDirective.js
@@ -544,6 +544,28 @@
       );
     };
 
+    this.loadLessTerms = function (facet, moreItemsNumber) {
+      var request = gnESService.generateEsRequest(
+        $scope.finalParams,
+        $scope.searchObj.state,
+        $scope.searchObj.configId,
+        $scope.searchObj.filters
+      );
+
+      var itemsToRequest = facet.items.length - (moreItemsNumber || 20);
+      if (itemsToRequest <= 0) {
+        itemsToRequest = gnESFacet.getDefaultSize();
+      }
+      return gnESClient.getTermsParamsWithNewSizeOrFilter(
+        request.query,
+        facet.key,
+        facet.config,
+        itemsToRequest,
+        facet.include || undefined,
+        facet.exclude || undefined
+      );
+    };
+
     this.filterTerms = function (facet) {
       var request = gnESService.generateEsRequest(
         $scope.finalParams,

--- a/web-ui/src/main/resources/catalog/style/gn_search.less
+++ b/web-ui/src/main/resources/catalog/style/gn_search.less
@@ -124,7 +124,8 @@
       color: @brand-primary;
     }
   }
-  .gn-facet-more {
+  .gn-facet-more,
+  .gn-facet-less {
     margin-left: 15px;
   }
   .gn-facet-input-group {


### PR DESCRIPTION
Currently the facet filters allow to display more values, but doesn't allow to reduce the number of values listed, unless refreshing the full page.

This change adds a `less` option to reduce the list to the previous number of elements.

**Previously:**

![facets-1](https://github.com/geonetwork/core-geonetwork/assets/1695003/f336398c-47f6-41b9-acb6-0b302a2fbed2)

**With the change:**

![facets-2](https://github.com/geonetwork/core-geonetwork/assets/1695003/eb06949c-13d2-432f-a62a-4f52e3d45338)

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
