### PR TITLE
Consistent styling of recordgroup label

### DIFF
--- a/web-ui/src/main/resources/catalog/components/utility/partials/recordOriginLogo.html
+++ b/web-ui/src/main/resources/catalog/components/utility/partials/recordOriginLogo.html
@@ -12,5 +12,5 @@
     aria-label="{{'sourceCatalog' | translate}}"
     class="gn-source-logo"
   />
-  <strong>{{recordGroup.label | gnLocalized}}</strong>
+  <span>{{recordGroup.label | gnLocalized}}</span>
 </span>

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/metadata.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/metadata.html
@@ -29,7 +29,7 @@
   <span class="badge badge-rounded" title="{{'sourceCatalog' | translate}}">
     <i class="fa fa-fw fa-cloud"></i>
   </span>
-  <span data-translate="">sourceCatalog</span>:
+  <h3 data-translate="">sourceCatalog</h3>:
   <span data-gn-record-origin-logo="mdView.current.record" />
 </div>
 


### PR DESCRIPTION
mini styling fix, I saw this and figured it would be a mistake

before
![image](https://github.com/geonetwork/core-geonetwork/assets/11455912/2d3b98b5-b5fe-4164-a5e1-03de7cc3e474)

after
![image](https://github.com/geonetwork/core-geonetwork/assets/11455912/f21e8afd-4f88-418a-98b9-6f5dba7d234c)



# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
