### PR TITLE
Metadata workflow / Record view / reload the page with the approved version when cancelling a working copy

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionService.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionService.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2023 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -291,6 +291,10 @@
           );
         }
         return deferred.promise;
+      };
+
+      this.cancelWorkingCopy = function (md) {
+        return gnMetadataManager.remove(md.id);
       };
 
       this.getMetadataIdToEdit = function (md) {

--- a/web-ui/src/main/resources/catalog/components/search/mdview/mdviewModule.js
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/mdviewModule.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2023 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -59,6 +59,7 @@
     "$rootScope",
     "$filter",
     "gnUtilityService",
+    "$window",
     function (
       $scope,
       $http,
@@ -77,7 +78,8 @@
       gnConfigService,
       $rootScope,
       $filter,
-      gnUtilityService
+      gnUtilityService,
+      $window
     ) {
       $scope.formatter = gnSearchSettings.formatter;
       $scope.gnMetadataActions = gnMetadataActions;
@@ -191,6 +193,35 @@
               type: "success"
             });
             $scope.closeRecord(md);
+          },
+          function (reason) {
+            // Data needs improvements
+            // See https://github.com/geonetwork/core-geonetwork/issues/723
+            gnAlertService.addAlert({
+              msg: reason.data.description,
+              type: "danger"
+            });
+          }
+        );
+      };
+
+      $scope.cancelWorkingCopy = function (md) {
+        return gnMetadataActions.cancelWorkingCopy(md).then(
+          function (data) {
+            gnAlertService.addAlert({
+              msg: $translate.instant("metadataRemoved", {
+                title: { title: md.resourceTitle }
+              }),
+              type: "success"
+            });
+
+            // Set a timeout to reload the page, to display the alert
+            $window.setTimeout(function () {
+              $window.location.href = $location
+                .absUrl()
+                .replace("/metadraf/", "/metadata/");
+              $window.location.reload();
+            }, 500);
           },
           function (reason) {
             // Data needs improvements

--- a/web-ui/src/main/resources/catalog/components/search/mdview/mdviewModule.js
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/mdviewModule.js
@@ -210,7 +210,7 @@
           function (data) {
             gnAlertService.addAlert({
               msg: $translate.instant("metadataRemoved", {
-                title: { title: md.resourceTitle }
+                title: md.resourceTitle
               }),
               type: "success"
             });

--- a/web-ui/src/main/resources/catalog/locales/ca-core.json
+++ b/web-ui/src/main/resources/catalog/locales/ca-core.json
@@ -546,7 +546,7 @@
     "categoriesUpdated": "Categories updated.",
     "warnPublishDraft": "When publishing records with workflow enabled, the status will change to 'Approve'. Are you sure you want to continue?",
     "cancelWorkingCopy": "Cancel working copy",
-    "deleteWorkingCopyRecordConfirm": "Do you really want to remove the working copy '{{title}}'?",
+    "deleteWorkingCopyRecordConfirm": "Do you really want to remove the working copy '{{resourceTitle}}'?",
     "workingCopy": "Working copy",
     "onTheWeb": "More online information",
     "pdfReportTocTitle": "Contents",

--- a/web-ui/src/main/resources/catalog/locales/cs-core.json
+++ b/web-ui/src/main/resources/catalog/locales/cs-core.json
@@ -546,7 +546,7 @@
     "categoriesUpdated": "Kategorie aktualizovány.",
     "warnPublishDraft": "Při publikování záznamů s povoleným pracovním postupem se stav změní na 'Schválit'. Jste si jistý, že chcete pokračovat?",
     "cancelWorkingCopy": "Zrušit pracovní kopii",
-    "deleteWorkingCopyRecordConfirm": "Opravdu chcete odstranit pracovní kopii '{{title}}'?",
+    "deleteWorkingCopyRecordConfirm": "Opravdu chcete odstranit pracovní kopii '{{resourceTitle}}'?",
     "workingCopy": "Pracovní kopie",
     "onTheWeb": "Více online informací",
     "pdfReportTocTitle": "Obsah",

--- a/web-ui/src/main/resources/catalog/locales/da-core.json
+++ b/web-ui/src/main/resources/catalog/locales/da-core.json
@@ -546,7 +546,7 @@
     "categoriesUpdated": "Kategorier opdateret.",
     "warnPublishDraft": "Når du udgiver poster med workflow aktiveret, ændres status til 'Godkend'. Er du sikker på, at du vil fortsætte?",
     "cancelWorkingCopy": "Annuller arbejdskopi",
-    "deleteWorkingCopyRecordConfirm": "Vil du virkelig fjerne arbejdskopien '{{title}}'?",
+    "deleteWorkingCopyRecordConfirm": "Vil du virkelig fjerne arbejdskopien '{{resourceTitle}}'?",
     "workingCopy": "Arbejdskopi",
     "onTheWeb": "Mere online information",
     "pdfReportTocTitle": "Indhold",

--- a/web-ui/src/main/resources/catalog/locales/de-core.json
+++ b/web-ui/src/main/resources/catalog/locales/de-core.json
@@ -546,7 +546,7 @@
     "categoriesUpdated": "Kategorien aktualisiert.",
     "warnPublishDraft": "Wenn Sie Datensätze mit aktiviertem Workflow veröffentlichen, ändert sich der Status in  'genehmigt'. Sind Sie sicher, dass Sie fortfahren möchten?",
     "cancelWorkingCopy": "Arbeitskopie abbrechen",
-    "deleteWorkingCopyRecordConfirm": "Möchten Sie die Arbeitskopie '{{title}}' wirklich entfernen?",
+    "deleteWorkingCopyRecordConfirm": "Möchten Sie die Arbeitskopie '{{resourceTitle}}' wirklich entfernen?",
     "workingCopy": "Arbeitskopie",
     "onTheWeb": "Weiterführende Online-Informationen",
     "pdfReportTocTitle": "Inhalte",

--- a/web-ui/src/main/resources/catalog/locales/en-core.json
+++ b/web-ui/src/main/resources/catalog/locales/en-core.json
@@ -546,7 +546,7 @@
     "categoriesUpdated": "Categories updated.",
     "warnPublishDraft": "When publishing records with workflow enabled, the status will change to 'Approve'. Are you sure you want to continue?",
     "cancelWorkingCopy": "Cancel working copy",
-    "deleteWorkingCopyRecordConfirm": "Do you really want to remove the working copy '{{title}}'?",
+    "deleteWorkingCopyRecordConfirm": "Do you really want to remove the working copy '{{resourceTitle}}'?",
     "workingCopy": "Working copy",
     "onTheWeb": "More online information",
     "pdfReportTocTitle": "Contents",

--- a/web-ui/src/main/resources/catalog/locales/es-core.json
+++ b/web-ui/src/main/resources/catalog/locales/es-core.json
@@ -546,7 +546,7 @@
     "categoriesUpdated": "Categorías actualizadas.",
     "warnPublishDraft": "Al publicar registros con el flujo de trabajo habilitado, el estado cambiará a  'Approve'. Estás seguro de que quieres continuar?",
     "cancelWorkingCopy": "Cancelar copia de trabajo",
-    "deleteWorkingCopyRecordConfirm": "¿Realmente desea eliminar la copia de trabajo '{{title}}'?",
+    "deleteWorkingCopyRecordConfirm": "¿Realmente desea eliminar la copia de trabajo '{{resourceTitle}}'?",
     "workingCopy": "Copia de trabajo",
     "onTheWeb": "Más información en línea",
     "pdfReportTocTitle": "Contenido",

--- a/web-ui/src/main/resources/catalog/locales/fi-core.json
+++ b/web-ui/src/main/resources/catalog/locales/fi-core.json
@@ -546,7 +546,7 @@
     "categoriesUpdated": "Categories updated.",
     "warnPublishDraft": "When publishing records with workflow enabled, the status will change to 'Approve'. Are you sure you want to continue?",
     "cancelWorkingCopy": "Cancel working copy",
-    "deleteWorkingCopyRecordConfirm": "Do you really want to remove the working copy '{{title}}'?",
+    "deleteWorkingCopyRecordConfirm": "Do you really want to remove the working copy '{{resourceTitle}}'?",
     "workingCopy": "Working copy",
     "onTheWeb": "More online information",
     "pdfReportTocTitle": "Contents",

--- a/web-ui/src/main/resources/catalog/locales/fr-core.json
+++ b/web-ui/src/main/resources/catalog/locales/fr-core.json
@@ -546,7 +546,7 @@
     "categoriesUpdated": "Catégorie mise à jour.",
     "warnPublishDraft": "Lors de la publication d'une fiche ayant un statut brouillon, le statut passera à approuvé. Voulez-vous continuer ?",
     "cancelWorkingCopy": "Annuler la copie de travail",
-    "deleteWorkingCopyRecordConfirm": "Voulez-vous vraiment supprimer la copie de travail ?",
+    "deleteWorkingCopyRecordConfirm": "Voulez-vous vraiment supprimer la copie de travail '{{ resourceTitle}}' ?",
     "workingCopy": "Brouillon",
     "onTheWeb": "Plus d'information en ligne",
     "pdfReportTocTitle": "Titre de la table des matières",

--- a/web-ui/src/main/resources/catalog/locales/is-core.json
+++ b/web-ui/src/main/resources/catalog/locales/is-core.json
@@ -546,7 +546,7 @@
     "categoriesUpdated": "Flokkar uppfærðir.",
     "warnPublishDraft": "Þegar færslur eru birtar með vinnuflæði virkt, mun staðan breytast yfir í  'Samþykkt. Ertu viss um að þú viljir halda áfram?",
     "cancelWorkingCopy": "Hætta við vinnuafrit",
-    "deleteWorkingCopyRecordConfirm": "Ertu viss um að þú viljir fjarlægja vinnuafritið '{{titill}}'?",
+    "deleteWorkingCopyRecordConfirm": "Ertu viss um að þú viljir fjarlægja vinnuafritið '{{resourceTitle}}'?",
     "workingCopy": "Vinnuafrit",
     "onTheWeb": "More online information",
     "pdfReportTocTitle": "Contents",

--- a/web-ui/src/main/resources/catalog/locales/it-core.json
+++ b/web-ui/src/main/resources/catalog/locales/it-core.json
@@ -546,7 +546,7 @@
     "categoriesUpdated": "Categories updated.",
     "warnPublishDraft": "When publishing records with workflow enabled, the status will change to 'Approve'. Are you sure you want to continue?",
     "cancelWorkingCopy": "Cancel working copy",
-    "deleteWorkingCopyRecordConfirm": "Do you really want to remove the working copy '{{title}}'?",
+    "deleteWorkingCopyRecordConfirm": "Do you really want to remove the working copy '{{resourceTitle}}'?",
     "workingCopy": "Working copy",
     "onTheWeb": "More online information",
     "pdfReportTocTitle": "Contents",

--- a/web-ui/src/main/resources/catalog/locales/ko-core.json
+++ b/web-ui/src/main/resources/catalog/locales/ko-core.json
@@ -546,7 +546,7 @@
     "categoriesUpdated": "카테고리를 갱신하였습니다.",
     "warnPublishDraft": "When publishing records with workflow enabled, the status will change to 'Approve'. Are you sure you want to continue?",
     "cancelWorkingCopy": "Cancel working copy",
-    "deleteWorkingCopyRecordConfirm": "Do you really want to remove the working copy '{{title}}'?",
+    "deleteWorkingCopyRecordConfirm": "Do you really want to remove the working copy '{{resourceTitle}}'?",
     "workingCopy": "Working copy",
     "onTheWeb": "More online information",
     "pdfReportTocTitle": "Contents",

--- a/web-ui/src/main/resources/catalog/locales/nl-core.json
+++ b/web-ui/src/main/resources/catalog/locales/nl-core.json
@@ -546,7 +546,7 @@
     "categoriesUpdated": "Categoriën geupdated.",
     "warnPublishDraft": "Wanneer de workflow is geactiveerd en de records worden gepubliceerd dan veranderd de status in 'Goedgekeurd'. Doorgaan?",
     "cancelWorkingCopy": "Annuleer concept versie",
-    "deleteWorkingCopyRecordConfirm": "Weet je zeker dat je de concept versie '{{title}}' wilt verwijderen?",
+    "deleteWorkingCopyRecordConfirm": "Weet je zeker dat je de concept versie '{{resourceTitle}}' wilt verwijderen?",
     "workingCopy": "Concept versie",
     "onTheWeb": "Meer informatie online",
     "pdfReportTocTitle": "Inhoudsopgave",

--- a/web-ui/src/main/resources/catalog/locales/pt-core.json
+++ b/web-ui/src/main/resources/catalog/locales/pt-core.json
@@ -546,7 +546,7 @@
     "categoriesUpdated": "Categorias atualizadas.",
     "warnPublishDraft": "Ao publicar um registro com o fluxo de trabalho habilitado, o status vai automaticamente ser alterado para Aprovado. Tem certeza que deseja continuar?",
     "cancelWorkingCopy": "Cancelar Cópia de Trabalho",
-    "deleteWorkingCopyRecordConfirm": "Você realmente deseja remover a Cópia de Trabalho '{{title}}'?",
+    "deleteWorkingCopyRecordConfirm": "Você realmente deseja remover a Cópia de Trabalho '{{resourceTitle}}'?",
     "workingCopy": "Cópia de Trabalho",
     "onTheWeb": "Mais informações online",
     "pdfReportTocTitle": "Contents",

--- a/web-ui/src/main/resources/catalog/locales/ru-core.json
+++ b/web-ui/src/main/resources/catalog/locales/ru-core.json
@@ -546,7 +546,7 @@
     "categoriesUpdated": "Categories updated.",
     "warnPublishDraft": "When publishing records with workflow enabled, the status will change to 'Approve'. Are you sure you want to continue?",
     "cancelWorkingCopy": "Cancel working copy",
-    "deleteWorkingCopyRecordConfirm": "Do you really want to remove the working copy '{{title}}'?",
+    "deleteWorkingCopyRecordConfirm": "Do you really want to remove the working copy '{{resourceTitle}}'?",
     "workingCopy": "Working copy",
     "onTheWeb": "More online information",
     "pdfReportTocTitle": "Содержание",

--- a/web-ui/src/main/resources/catalog/locales/sk-core.json
+++ b/web-ui/src/main/resources/catalog/locales/sk-core.json
@@ -546,7 +546,7 @@
     "categoriesUpdated": "Categories updated.",
     "warnPublishDraft": "When publishing records with workflow enabled, the status will change to 'Approve'. Are you sure you want to continue?",
     "cancelWorkingCopy": "Cancel working copy",
-    "deleteWorkingCopyRecordConfirm": "Do you really want to remove the working copy '{{title}}'?",
+    "deleteWorkingCopyRecordConfirm": "Do you really want to remove the working copy '{{resourceTitle}}'?",
     "workingCopy": "Working copy",
     "onTheWeb": "More online information",
     "pdfReportTocTitle": "Contents",

--- a/web-ui/src/main/resources/catalog/locales/sv-core.json
+++ b/web-ui/src/main/resources/catalog/locales/sv-core.json
@@ -546,7 +546,7 @@
     "categoriesUpdated": "Uppdatareade kategorier.",
     "warnPublishDraft": "När du publicerar poster med arbetsflöde aktiverat kommer status att ändras till 'Godkänn'. Är du säker på att du vill fortsätta?",
     "cancelWorkingCopy": "Avbryt arbetskopian",
-    "deleteWorkingCopyRecordConfirm": "Vill du verkligen ta bort arbetskopian '{{title}}'?",
+    "deleteWorkingCopyRecordConfirm": "Vill du verkligen ta bort arbetskopian '{{resourceTitle}}'?",
     "workingCopy": "Arbetskopia",
     "onTheWeb": "Mer information online",
     "pdfReportTocTitle": "Innehåll",

--- a/web-ui/src/main/resources/catalog/locales/zh-core.json
+++ b/web-ui/src/main/resources/catalog/locales/zh-core.json
@@ -546,7 +546,7 @@
     "categoriesUpdated": "分类已更新。",
     "warnPublishDraft": "When publishing records with workflow enabled, the status will change to 'Approve'. Are you sure you want to continue?",
     "cancelWorkingCopy": "Cancel working copy",
-    "deleteWorkingCopyRecordConfirm": "Do you really want to remove the working copy '{{title}}'?",
+    "deleteWorkingCopyRecordConfirm": "Do you really want to remove the working copy '{{resourceTitle}}'?",
     "workingCopy": "Working copy",
     "onTheWeb": "More online information",
     "pdfReportTocTitle": "Contents",

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/recordView.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/recordView.html
@@ -103,8 +103,7 @@
               data-ng-show="(!mdView.current.record.isPublished() || (mdView.current.record.isPublished() && user.canDeletePublishedMetadata()) ) && user.canEditRecord(mdView.current.record)
                             && (user.isReviewerOrMore() || mdView.current.record.mdStatus != 4 || !isMdWorkflowEnable)"
               data-gn-click-and-spin="deleteRecord(mdView.current.record)"
-              data-ng-init="translateValues = {resourceTitle: (mdView.current.record.resourceTitle | json)}"
-              data-gn-confirm-click="{{'deleteRecordConfirm' | translate:translateValues}}"
+              data-gn-confirm-click="{{'deleteRecordConfirm' | translate: {resourceTitle: (mdView.current.record.resourceTitle | json)} }}"
               title="{{'delete' | translate}}"
             >
               <span class="fa fa-fw fa-times"></span>
@@ -118,8 +117,7 @@
               data-ng-show="(!mdView.current.record.isPublished() || (mdView.current.record.isPublished() && user.canDeletePublishedMetadata()) ) && user.canEditRecord(mdView.current.record)
                             && (user.isReviewerOrMore() || mdView.current.record.mdStatus != 4 || !isMdWorkflowEnable)"
               data-gn-click-and-spin="cancelWorkingCopy(mdView.current.record)"
-              data-ng-init="translateValues = {resourceTitle: (mdView.current.record.resourceTitle | json)}"
-              data-gn-confirm-click="{{'deleteWorkingCopyRecordConfirm' | translate:translateValues}}"
+              data-gn-confirm-click="{{'deleteWorkingCopyRecordConfirm' | translate: {resourceTitle: (mdView.current.record.resourceTitle | json)} }}"
               title="{{'cancelWorkingCopy' | translate}}"
             >
               <span class="fa fa-fw fa-times"></span>

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/recordView.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/recordView.html
@@ -99,12 +99,28 @@
             <a
               class="btn btn-default"
               href
+              data-ng-if="mdView.current.record.draft != 'y'"
               data-ng-show="(!mdView.current.record.isPublished() || (mdView.current.record.isPublished() && user.canDeletePublishedMetadata()) ) && user.canEditRecord(mdView.current.record)
                             && (user.isReviewerOrMore() || mdView.current.record.mdStatus != 4 || !isMdWorkflowEnable)"
               data-gn-click-and-spin="deleteRecord(mdView.current.record)"
               data-ng-init="translateValues = {resourceTitle: (mdView.current.record.resourceTitle | json)}"
-              data-gn-confirm-click="{{(mdView.current.record.draft != 'y') ? 'deleteRecordConfirm' : 'deleteWorkingCopyRecordConfirm' | translate:translateValues}}"
-              title="{{(mdView.current.record.draft != 'y') ? 'delete' : 'cancelWorkingCopy' | translate}}"
+              data-gn-confirm-click="{{'deleteRecordConfirm' | translate:translateValues}}"
+              title="{{'delete' | translate}}"
+            >
+              <span class="fa fa-fw fa-times"></span>
+              <span data-translate="" class="hidden-sm hidden-xs">delete</span>
+            </a>
+
+            <a
+              class="btn btn-default"
+              href
+              data-ng-if="mdView.current.record.draft == 'y'"
+              data-ng-show="(!mdView.current.record.isPublished() || (mdView.current.record.isPublished() && user.canDeletePublishedMetadata()) ) && user.canEditRecord(mdView.current.record)
+                            && (user.isReviewerOrMore() || mdView.current.record.mdStatus != 4 || !isMdWorkflowEnable)"
+              data-gn-click-and-spin="cancelWorkingCopy(mdView.current.record)"
+              data-ng-init="translateValues = {resourceTitle: (mdView.current.record.resourceTitle | json)}"
+              data-gn-confirm-click="{{'deleteWorkingCopyRecordConfirm' | translate:translateValues}}"
+              title="{{'cancelWorkingCopy' | translate}}"
             >
               <span class="fa fa-fw fa-times"></span>
               <span
@@ -112,12 +128,6 @@
                 class="hidden-sm hidden-xs"
                 data-ng-if="mdView.current.record.draft == 'y'"
                 >cancelWorkingCopy</span
-              >
-              <span
-                data-translate=""
-                class="hidden-sm hidden-xs"
-                data-ng-if="mdView.current.record.draft != 'y'"
-                >delete</span
               >
             </a>
           </div>


### PR DESCRIPTION
Currently when cancelling a working copy , the user is redirected to the search results. With this change, the record view page is reloaded with the approved version.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
