### PR TITLE
Docs / Fix the mike version to 2.0.0 and change the parameter --no-redirect to --alias-type=copy (changed in mike 2.0.0)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,9 +33,9 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         working-directory: docs/manual
         run: |
-          mike deploy --title "4.4 Latest" --no-redirect --update-aliases 4.4 latest
+          mike deploy --title "4.4 Latest" --alias-type=copy --update-aliases 4.4 latest
       - name: deploy latest docs to gh-pages branch
         if: ${{ github.event_name != 'pull_request' }}
         working-directory: docs/manual
         run: |
-          mike deploy --push --title "4.4 Latest" --no-redirect --update-aliases 4.4 latest
+          mike deploy --push --title "4.4 Latest" ---alias-type=copy --update-aliases 4.4 latest

--- a/docs/manual/requirements.txt
+++ b/docs/manual/requirements.txt
@@ -2,4 +2,4 @@ mkdocs-material
 mkdocs-static-i18n>=1.0.5
 mkdocs-include-markdown-plugin
 mkdocs-exclude
-mike
+mike==2.0.0


### PR DESCRIPTION
# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
