### PR TITLE
Reset user password dialog - don't display the field to request the old password for administrators - unify UI check with backend check

### DIFF
--- a/web-ui/src/main/resources/catalog/templates/admin/usergroup/users.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/usergroup/users.html
@@ -545,7 +545,7 @@
           <form id="gn-password-reset" class="form-horizontal" name="gnPasswordReset">
             <input type="hidden" name="_csrf" value="{{csrf}}" />
             <div
-              data-ng-if="!user.isAdministratorOrMore()"
+              data-ng-show="!user.isAdministratorOrMore() || (user.isAdministratorOrMore() && !allowAdminReset)"
               class="form-group"
               data-ng-class="gnPasswordReset.passwordOld.$error.required ? 'has-error' : ''"
             >


### PR DESCRIPTION
Follow up of #7417

Test cases:

**CASE 1: With the admin user try to reset the admin user password.**

(Case fixed in the code change)

1) With the fix, the old password is requested and the password change works. (Without the fix, the old password is not requested and the password change fails).


**CASE 2: With a non-admin user, try to reset his password.**

(Additional case to test to verify is not broken by the code change)

1) Create a new user 
2) Login with the new user
3) The reset password for the user request the old and new password. The password change works as expected.

**CASE 3: Reset passwords with the setting to allow reset user passwords by admin users.**

(Additional case to test to verify is not broken by the code change)

1) Add the following setting to the database and restart GeoNetwork:

```
INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/security/password/allowAdminReset', 'true', 2, 12004, 'n');
```

2) Login as admin user and try to reset the password, the old password is not requested and the password change works.
3) Change the password of the new user, the old password is not requested and the password change works.


# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
