### PR TITLE
Fix issue with saving metadata status causes indexing of metadata which causes issues for db rollbacks

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataStatus.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataStatus.java
@@ -73,7 +73,7 @@ public interface IMetadataStatus {
      *
      * @return the saved status entity object
      */
-    MetadataStatus setStatusExt(MetadataStatus status) throws Exception;
+    MetadataStatus setStatusExt(MetadataStatus status, boolean updateIndex) throws Exception;
 
     /**
      * Set status of metadata id and reindex metadata id afterwards.

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataStatus.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataStatus.java
@@ -69,7 +69,10 @@ public interface IMetadataStatus {
     MetadataStatus setStatusExt(ServiceContext context, int id, int status, ISODate changeDate, String changeMessage) throws Exception;
 
     /**
-     * Set status of metadata id and do not reindex metadata id afterwards.
+     * Set status of metadata id and reindex metadata id afterwards based on updateIndex flag
+     *
+     * @param status metadata status to set
+     * @param updateIndex index update flag
      *
      * @return the saved status entity object
      */

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataStatus.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataStatus.java
@@ -160,9 +160,11 @@ public class BaseMetadataStatus implements IMetadataStatus {
     }
 
     @Override
-    public MetadataStatus setStatusExt(MetadataStatus metatatStatus) throws Exception {
+    public MetadataStatus setStatusExt(MetadataStatus metatatStatus, boolean updateIndex) throws Exception {
         metadataStatusRepository.save(metatatStatus);
-        metadataIndexer.indexMetadata(metatatStatus.getMetadataId() + "", true, IndexingMode.full);
+        if (updateIndex) {
+            metadataIndexer.indexMetadata(metatatStatus.getMetadataId() + "", true, IndexingMode.full);
+        }
         return metatatStatus;
     }
 

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/draft/DraftMetadataUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/draft/DraftMetadataUtils.java
@@ -589,7 +589,7 @@ public class DraftMetadataUtils extends BaseMetadataUtils {
 
                     List<MetadataStatus> listOfStatusChange = new ArrayList<>(1);
                     listOfStatusChange.add(metadataStatus);
-                    sa.onStatusChange(listOfStatusChange);
+                    sa.onStatusChange(listOfStatusChange, true);
                 }
             }
 

--- a/core/src/main/java/org/fao/geonet/kernel/metadata/DefaultStatusActions.java
+++ b/core/src/main/java/org/fao/geonet/kernel/metadata/DefaultStatusActions.java
@@ -220,8 +220,8 @@ public class DefaultStatusActions implements StatusActions {
      */
     private boolean applyStatusChange(int metadataId, MetadataStatus status, String toStatusId, boolean updateIndex) throws Exception {
         boolean deleted = false;
-        if (!deleted && updateIndex) {
-            metadataStatusManager.setStatusExt(status, true);
+        if (!deleted) {
+            metadataStatusManager.setStatusExt(status, updateIndex);
         }
         return deleted;
     }

--- a/core/src/main/java/org/fao/geonet/kernel/metadata/DefaultStatusActions.java
+++ b/core/src/main/java/org/fao/geonet/kernel/metadata/DefaultStatusActions.java
@@ -221,7 +221,7 @@ public class DefaultStatusActions implements StatusActions {
     private boolean applyStatusChange(int metadataId, MetadataStatus status, String toStatusId) throws Exception {
         boolean deleted = false;
         if (!deleted) {
-            metadataStatusManager.setStatusExt(status);
+            metadataStatusManager.setStatusExt(status, false);
         }
         return deleted;
     }

--- a/core/src/main/java/org/fao/geonet/kernel/metadata/DefaultStatusActions.java
+++ b/core/src/main/java/org/fao/geonet/kernel/metadata/DefaultStatusActions.java
@@ -136,7 +136,7 @@ public class DefaultStatusActions implements StatusActions {
      * @return
      * @throws Exception
      */
-    public Map<Integer, StatusChangeType> onStatusChange(List<MetadataStatus> listOfStatus) throws Exception {
+    public Map<Integer, StatusChangeType> onStatusChange(List<MetadataStatus> listOfStatus, boolean updateIndex) throws Exception {
 
         if (listOfStatus.stream().map(MetadataStatus::getMetadataId).distinct().count() != listOfStatus.size()) {
             throw new IllegalArgumentException("Multiple status update received on the same metadata");
@@ -179,7 +179,7 @@ public class DefaultStatusActions implements StatusActions {
                 context.debug("Change status of metadata with id " + status.getMetadataId() + " from " + currentStatusId + " to " + statusId);
 
             // we know we are allowed to do the change, apply any side effects
-            boolean deleted = applyStatusChange(status.getMetadataId(), status, statusId);
+            boolean deleted = applyStatusChange(status.getMetadataId(), status, statusId, updateIndex);
 
             // inform content reviewers if the status is submitted
             try {
@@ -218,10 +218,10 @@ public class DefaultStatusActions implements StatusActions {
      * eg. if APPROVED, publish a record,
      * if RETIRED, unpublish or delete the record.
      */
-    private boolean applyStatusChange(int metadataId, MetadataStatus status, String toStatusId) throws Exception {
+    private boolean applyStatusChange(int metadataId, MetadataStatus status, String toStatusId, boolean updateIndex) throws Exception {
         boolean deleted = false;
-        if (!deleted) {
-            metadataStatusManager.setStatusExt(status, false);
+        if (!deleted && updateIndex) {
+            metadataStatusManager.setStatusExt(status, true);
         }
         return deleted;
     }

--- a/core/src/main/java/org/fao/geonet/kernel/metadata/StatusActions.java
+++ b/core/src/main/java/org/fao/geonet/kernel/metadata/StatusActions.java
@@ -38,6 +38,6 @@ public interface StatusActions {
 
     public void onEdit(int id, boolean minorEdit) throws Exception;
 
-    public Map<Integer, StatusChangeType> onStatusChange(List<MetadataStatus> status) throws Exception;
+    public Map<Integer, StatusChangeType> onStatusChange(List<MetadataStatus> status, boolean updateIndex) throws Exception;
 
 }

--- a/listeners/src/main/java/org/fao/geonet/listener/metadata/draft/ApprovePublishedRecord.java
+++ b/listeners/src/main/java/org/fao/geonet/listener/metadata/draft/ApprovePublishedRecord.java
@@ -121,7 +121,7 @@ public class ApprovePublishedRecord implements ApplicationListener<MetadataPubli
         status.setChangeDate(new ISODate());
         status.setUserId(ServiceContext.get().getUserSession().getUserIdAsInt());
 
-        metadataStatus.setStatusExt(status, true);
+        metadataStatus.setStatusExt(status, false);
 
         Log.trace(Geonet.DATA_MANAGER, "Metadata with id " + md.getId() + " automatically approved due to publishing.");
     }

--- a/listeners/src/main/java/org/fao/geonet/listener/metadata/draft/ApprovePublishedRecord.java
+++ b/listeners/src/main/java/org/fao/geonet/listener/metadata/draft/ApprovePublishedRecord.java
@@ -121,7 +121,7 @@ public class ApprovePublishedRecord implements ApplicationListener<MetadataPubli
         status.setChangeDate(new ISODate());
         status.setUserId(ServiceContext.get().getUserSession().getUserIdAsInt());
 
-        metadataStatus.setStatusExt(status);
+        metadataStatus.setStatusExt(status, true);
 
         Log.trace(Geonet.DATA_MANAGER, "Metadata with id " + md.getId() + " automatically approved due to publishing.");
     }

--- a/listeners/src/main/java/org/fao/geonet/listener/metadata/draft/ApproveRecord.java
+++ b/listeners/src/main/java/org/fao/geonet/listener/metadata/draft/ApproveRecord.java
@@ -148,7 +148,7 @@ public class ApproveRecord implements ApplicationListener<MetadataStatusChanged>
             status.setChangeDate(new ISODate());
             status.setUserId(event.getUser());
 
-            metadataStatus.setStatusExt(status, true);
+            metadataStatus.setStatusExt(status, false);
 
         } else if (md instanceof Metadata) {
             draft = null; //metadataDraftRepository.findOneByUuid(md.getUuid());

--- a/listeners/src/main/java/org/fao/geonet/listener/metadata/draft/ApproveRecord.java
+++ b/listeners/src/main/java/org/fao/geonet/listener/metadata/draft/ApproveRecord.java
@@ -148,7 +148,7 @@ public class ApproveRecord implements ApplicationListener<MetadataStatusChanged>
             status.setChangeDate(new ISODate());
             status.setUserId(event.getUser());
 
-            metadataStatus.setStatusExt(status);
+            metadataStatus.setStatusExt(status, true);
 
         } else if (md instanceof Metadata) {
             draft = null; //metadataDraftRepository.findOneByUuid(md.getUuid());

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java
@@ -499,7 +499,7 @@ public class MetadataWorkflowApi {
 
         List<MetadataStatus> listOfStatusChange = new ArrayList<>(1);
         listOfStatusChange.add(metadataStatusValue);
-        Map<Integer, StatusChangeType> statusUpdate = sa.onStatusChange(listOfStatusChange);
+        Map<Integer, StatusChangeType> statusUpdate = sa.onStatusChange(listOfStatusChange, false);
 
         int metadataIdApproved = metadata.getId();
 
@@ -1308,6 +1308,6 @@ public class MetadataWorkflowApi {
         metadataStatusValue.setPreviousState(previousStatus);
         List<MetadataStatus> listOfStatusChange = new ArrayList<>(1);
         listOfStatusChange.add(metadataStatusValue);
-        sa.onStatusChange(listOfStatusChange);
+        sa.onStatusChange(listOfStatusChange, true);
     }
 }

--- a/services/src/main/java/org/fao/geonet/api/records/editing/MetadataEditingApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/editing/MetadataEditingApi.java
@@ -420,7 +420,7 @@ public class MetadataEditingApi {
 
                         List<MetadataStatus> listOfStatusChange = new ArrayList<>(1);
                         listOfStatusChange.add(metadataStatus);
-                        sa.onStatusChange(listOfStatusChange);
+                        sa.onStatusChange(listOfStatusChange, true);
                     } else {
                         throw new SecurityException(String.format("Only users with editor profile can submit."));
                     }
@@ -442,7 +442,7 @@ public class MetadataEditingApi {
 
                         List<MetadataStatus> listOfStatusChange = new ArrayList<>(1);
                         listOfStatusChange.add(metadataStatus);
-                        sa.onStatusChange(listOfStatusChange);
+                        sa.onStatusChange(listOfStatusChange, true);
                     } else {
                         throw new SecurityException(String.format("Only users with review profile can approve."));
                     }


### PR DESCRIPTION
The issue happens in this API where the index was update prematurely.

It's supposed to be done here
https://github.com/geonetwork/core-geonetwork/blob/e75ee33f308cb08ad291263c9cff3f71ed4c9457/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java#L508

But was updated within this code above the thread
https://github.com/geonetwork/core-geonetwork/blob/e75ee33f308cb08ad291263c9cff3f71ed4c9457/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java#L502

We should add such option to prevent the index updated. 

The issue is if something happens in the publish event into the customized event listener. There are exceptions can be thrown due to the business logic check

https://github.com/geonetwork/core-geonetwork/blob/e75ee33f308cb08ad291263c9cff3f71ed4c9457/core/src/main/java/org/fao/geonet/kernel/metadata/DefaultStatusActions.java#L203-L206

The database will roll back properly. But the search engine will have the updated status. If we refresh the web page, it will display the wrong status.

For example,

![image](https://github.com/geonetwork/core-geonetwork/assets/74916635/9e652b34-415c-4b33-ab70-8b1c6dbdbe6a)


Retired failed due to some business logic check in event listener.
![image](https://github.com/geonetwork/core-geonetwork/assets/74916635/1cd132a7-1738-4927-a2af-31e6ee75ff31)


![image](https://github.com/geonetwork/core-geonetwork/assets/74916635/edf6fb68-0621-48ed-a0df-0c3be8cfb196)


Here is the search engine's result
http://localhost:8080/catalogue/srv/eng/q?_content_type=json&_draft=y+or+n+or+e&_isTemplate=y+or+n&fast=index&uuid=476399f3-ec21-4792-9a7b-8b36800946dc
![image](https://github.com/geonetwork/core-geonetwork/assets/74916635/809c4dde-a8b4-4c65-b32d-70c58386a6ab)


