### PR TITLE
When getting locale message, default locale to LocaleContextHolder when locale is null

### DIFF
--- a/core/src/main/java/org/fao/geonet/languages/LocaleMessages.java
+++ b/core/src/main/java/org/fao/geonet/languages/LocaleMessages.java
@@ -33,6 +33,7 @@ import org.fao.geonet.repository.IsoLanguageRepository;
 import org.fao.geonet.utils.Log;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.BeanFactoryAnnotationUtils;
+import org.springframework.context.i18n.LocaleContextHolder;
 import org.springframework.context.support.ResourceBundleMessageSource;
 
 import com.google.common.collect.BiMap;
@@ -57,16 +58,16 @@ public class LocaleMessages {
      *
      * @param messageKey message key to use when retrieving the value from the properties file.
      * @param args Argument that may be supplied to the messagekey string
-     * @param locale locale to use when getting the message key
+     * @param locale locale to use when getting the message key. If null then it will default to locale context holder.
      * @param resourceBundleBeanQualifier resource bundle qualifier to use when getting ResourceBundleMessageSource bean
      * @return message
      */
 
     public static String getMessageForLocale(String messageKey, Object[] args, Locale locale, String resourceBundleBeanQualifier) {
-        if (!StringUtils.isEmpty(messageKey) && locale !=null) {
+        if (!StringUtils.isEmpty(messageKey)) {
             ResourceBundleMessageSource resourceBundleMessageSource = getResourceBundleMessageSource(resourceBundleBeanQualifier);
             if (resourceBundleMessageSource != null) {
-                return resourceBundleMessageSource.getMessage(messageKey, args, locale);
+                return resourceBundleMessageSource.getMessage(messageKey, args, locale == null ? LocaleContextHolder.getLocale() : locale);
             }
         }
         // If we could not find the ResourceBundleMessageSource or the messageKey was in an invalid format then lets return the original key as the message.


### PR DESCRIPTION
When getting locale message, default locale to LocaleContextHolder when locale is null

It was noticed that if we did something like the following when calling an api.

`throw new WebApplicationException().withMessageKey("message.key"));`

The API Error would contain the message based on the key as follow

"message.key"

The reason for this is because no locale was identified in the exception.  If we do the following 
 
`throw new WebApplicationException().withMessageKey("message.key").withLocale(LocaleContextHolder.getLocale());`

Then the API Error would contain the message on the key as follow

"Some Text for locale"

Since it is better to show text to the end users instead of showing the message key, this PR will default the message key to LocaleContextHolder.getLocale() automatically so that we don't need to supply it for each exception raised.

  
# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
