### PR TITLE
Fix some cases that were not considering both message and description when displaying errors.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/mdview/mdviewModule.js
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/mdviewModule.js
@@ -196,7 +196,7 @@
             // Data needs improvements
             // See https://github.com/geonetwork/core-geonetwork/issues/723
             gnAlertService.addAlert({
-              msg: reason.data.description,
+              msg: reason.data.message || reason.data.description,
               type: "danger"
             });
           }

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/SelectionDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/SelectionDirective.js
@@ -96,7 +96,7 @@
                   },
                   function (r) {
                     gnAlertService.addAlert({
-                      msg: r.data.description,
+                      msg: r.data.message || r.data.description,
                       delay: 20000,
                       type: "danger"
                     });

--- a/web-ui/src/main/resources/catalog/components/validationtools/GnmdInspireValidationDirective.js
+++ b/web-ui/src/main/resources/catalog/components/validationtools/GnmdInspireValidationDirective.js
@@ -143,7 +143,7 @@
                     });
                   } else {
                     gnAlertService.addAlert({
-                      msg: error.data.description,
+                      msg: error.data.message || error.data.description,
                       type: "danger"
                     });
                   }


### PR DESCRIPTION
It was noticed that if we attempted to handle a delete event on a records and we throw an error like this

`throw new WebApplicationException().withMessageKey("message.key"));`

The API Error would contain a message and null description because the description key was not supplied.

As the record delete error handling only seems to expect to use the description, the user would end up seeing a message like the following

![image](https://github.com/geonetwork/core-geonetwork/assets/1868233/d736fc9d-282e-4dcb-a899-4976c830a889)

 It can be fixed if we change the error to the following however I believe all errors should handle both message and description.
`throw new WebApplicationException().withDescriptionKey("message.key"));`

This PR is to update some cases where the error message was only using description instead of using one of the other.

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
