### PR TITLE
WMS Time Dimension bug in time interval generation

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -2576,14 +2576,14 @@
     var durationValue = moment.duration(duration);
     timeIntervalValues.push(startDate);
 
-    var nextValue = moment(startDate).add(durationValue).utc().format();
+    var nextValue = moment.utc(startDate).add(durationValue).toISOString();
 
     if (!endDate) {
       timeIntervalValues.push(nextValue);
     } else {
-      while (moment(nextValue).isBefore(moment(endDate))) {
+      while (moment.utc(nextValue).isBefore(moment.utc(endDate))) {
         timeIntervalValues.push(nextValue);
-        nextValue = moment(nextValue).add(durationValue).utc().format();
+        nextValue = moment.utc(nextValue).add(durationValue).toISOString();
       }
     }
 


### PR DESCRIPTION
Hi 

I was testing one of my monthly wms services I notice that the interval dates are not been generated correctly


![inconsistent_dates](https://github.com/geonetwork/core-geonetwork/assets/11145763/62066aaf-89f1-44ea-af8a-fdf659464a0e)

On further investigation I found the bug, 

When we initialize a `moment` object it converts the date to local time 
and when we format it back to UTC will be from the local time 

This is a problem when we cross time saving periods, depending the time of the year the local time differs +1 hour to UTC 

Example: 

> 2022-05-01T00:00:00+01:00` 
 will be converted to 
> 2022-04-30T23:00:00Z

which is not the timestamp in the WMS service defined for example by the following definition 
'2022-01-01/2022-12-01/P1M'
 

Always dealing with UTC datetimes (`moment.utc()`) solves the problem because no conversion needed( and we should only work with UTC datetimes )  

![consistent_dates](https://github.com/geonetwork/core-geonetwork/assets/11145763/61ef039e-00f3-4f56-8c41-3bf78ff848b0)

