### PR TITLE
GeoNetwork 4.4.x minor versions library updates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1579,7 +1579,7 @@
      request the list of hosts (but JPA cache db queries). -->
     <cors.allowedHosts>*</cors.allowedHosts>
 
-    <jetty.version>9.4.52.v20230823</jetty.version>
+    <jetty.version>9.4.53.v20231009</jetty.version>
     <jetty.file>jetty-distribution-${jetty.version}</jetty.file>
     <jetty.download>https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/${jetty.version}/${jetty.file}.tar.gz</jetty.download>
 
@@ -1589,9 +1589,9 @@
     <jts.version>1.19.0</jts.version>
     <pg.version>42.6.0</pg.version>
 
-    <spring.version>5.3.30</spring.version>
-    <spring.security.version>5.8.7</spring.security.version>
-    <spring.jpa.version>2.7.16</spring.jpa.version>
+    <spring.version>5.3.31</spring.version>
+    <spring.security.version>5.8.8</spring.security.version>
+    <spring.jpa.version>2.7.18</spring.jpa.version>
     <springboot.version>2.7.0</springboot.version>
     <springdoc.version>1.5.13</springdoc.version>
     <hibernate.version>5.6.15.Final</hibernate.version>
@@ -1604,7 +1604,7 @@
     <wro.debug>true</wro.debug>
     <fop.version>2.7</fop.version>
     <xmlunit.version>2.1.1</xmlunit.version>
-    <jackson.version>2.15.2</jackson.version>
+    <jackson.version>2.15.3</jackson.version>
     <flying-saucer>9.1.22</flying-saucer>
     <camel.version>2.25.1</camel.version>
     <log4j2.version>2.17.2</log4j2.version>


### PR DESCRIPTION
Update minor versions for these dependencies:

- Spring Framework: 5.3.31
- Spring Security: 5.8.8
- Spring JPA: 2.7.18
- Jackson: 2.15.3
- Jetty: 9.4.53.v20231009

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
