### PR TITLE
Metadata indexing / Escape website and logo information for contacts

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
@@ -1431,8 +1431,8 @@
       </xsl:if>
       "role":"<xsl:value-of select="$role"/>",
       "email":"<xsl:value-of select="gn-fn-index:json-escape($email)"/>",
-      "website":"<xsl:value-of select="$website"/>",
-      "logo":"<xsl:value-of select="$logo"/>",
+      "website":"<xsl:value-of select="gn-fn-index:json-escape($website)"/>",
+      "logo":"<xsl:value-of select="gn-fn-index:json-escape($logo)"/>",
       "individual":"<xsl:value-of select="gn-fn-index:json-escape($individualName)"/>",
       "position":"<xsl:value-of select="gn-fn-index:json-escape($positionName)"/>",
       "phone":"<xsl:value-of select="gn-fn-index:json-escape($phone)"/>",

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
@@ -1279,8 +1279,8 @@
       </xsl:if>
       "role":"<xsl:value-of select="$role"/>",
       "email":"<xsl:value-of select="gn-fn-index:json-escape($email[1])"/>",
-      "website":"<xsl:value-of select="$website"/>",
-      "logo":"<xsl:value-of select="$logo"/>",
+      "website":"<xsl:value-of select="gn-fn-index:json-escape($website)"/>",
+      "logo":"<xsl:value-of select="gn-fn-index:json-escape($logo)"/>",
       "individual":"<xsl:value-of select="gn-fn-index:json-escape($individualName)"/>",
       "position":"<xsl:value-of select="gn-fn-index:json-escape($positionName)"/>",
       "phone":"<xsl:value-of select="gn-fn-index:json-escape($phone[1])"/>",


### PR DESCRIPTION
Test case:

1) Create an iso19139 or iso19115-3.2008 metadata
2) Add a new contact and in the contact online resource information add a linkage URL with this content: `\\SERVER\home\test`

Without the fix, there is an indexing error:

```
ERROR [geonetwork.index] - Parsing invalid JSON node ...  
Error is: Unrecognized character escape 'h' (code 104) ...
```

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
