### PR TITLE
Use Apache Commons Text library to escape JSON content in xslt processing

### DIFF
--- a/core/src/main/java/org/fao/geonet/util/XslUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/XslUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2020 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2023 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -39,6 +39,7 @@ import org.apache.commons.beanutils.PropertyUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.NotImplementedException;
 import org.apache.commons.lang.StringUtils;
+import org.apache.commons.text.StringEscapeUtils;
 import org.apache.http.HttpResponse;
 import org.apache.http.client.HttpClient;
 import org.apache.http.client.methods.HttpGet;
@@ -469,7 +470,7 @@ public final class XslUtil {
         return ApplicationContextHolder.get().getBean(org.fao.geonet.NodeInfo.class).getId();
     }
 
-    
+
     public static String getNodeLogo(String key) {
         Optional<Source> source = getSource(key);
         return source.isPresent() ? source.get().getLogo() : "";
@@ -1705,5 +1706,9 @@ public final class XslUtil {
             }
         });
         return listOfLinks;
+    }
+
+    public static String escapeForJson(String value) {
+        return StringEscapeUtils.escapeJson(value);
     }
 }

--- a/schemas/dublin-core/src/main/plugin/dublin-core/index-fields/index.xsl
+++ b/schemas/dublin-core/src/main/plugin/dublin-core/index-fields/index.xsl
@@ -71,7 +71,7 @@
     <xsl:variable name="resourceTitleObject" as="xs:string"
                   select="concat('{',
                           $doubleQuote, 'default', $doubleQuote, ':',
-                          $doubleQuote, gn-fn-index:json-escape($mainTitle) ,$doubleQuote,
+                          $doubleQuote, util:escapeForJson($mainTitle) ,$doubleQuote,
                         '}')"/>
 
     <xsl:variable name="identifier" as="xs:string?"
@@ -150,30 +150,30 @@
       </xsl:for-each>
 
       <xsl:for-each select="dc:format">
-        <format><xsl:value-of select="gn-fn-index:json-escape(.)"/></format>
+        <format><xsl:value-of select="util:escapeForJson(.)"/></format>
       </xsl:for-each>
 
       <xsl:for-each select="dc:type[. != '']">
-        <resourceType><xsl:value-of select="gn-fn-index:json-escape(.)"/></resourceType>
+        <resourceType><xsl:value-of select="util:escapeForJson(.)"/></resourceType>
       </xsl:for-each>
 
       <xsl:for-each select="dc:source">
-        <lineage><xsl:value-of select="gn-fn-index:json-escape(.)"/></lineage>
+        <lineage><xsl:value-of select="util:escapeForJson(.)"/></lineage>
       </xsl:for-each>
 
       <!-- TODO Change mapping of dc:relation -->
       <xsl:for-each select="dc:relation">
-        <related><xsl:value-of select="gn-fn-index:json-escape(.)"/></related>
+        <related><xsl:value-of select="util:escapeForJson(.)"/></related>
       </xsl:for-each>
 
       <!-- TODO Change mapping of dct:accessRights -->
       <xsl:for-each select="dct:accessRights">
-        <useLimitation><xsl:value-of select="gn-fn-index:json-escape(.)"/></useLimitation>
+        <useLimitation><xsl:value-of select="util:escapeForJson(.)"/></useLimitation>
       </xsl:for-each>
 
       <!-- TODO Change mapping of dct:rights -->
       <xsl:for-each select="dct:rights">
-        <useLimitation><xsl:value-of select="gn-fn-index:json-escape(.)"/></useLimitation>
+        <useLimitation><xsl:value-of select="util:escapeForJson(.)"/></useLimitation>
       </xsl:for-each>
 
       <xsl:variable name="allKeywords">
@@ -187,7 +187,7 @@
                 <keyword>
                   <values>
                     <value>
-                      "default": <xsl:value-of select="concat($doubleQuote, gn-fn-index:json-escape(.), $doubleQuote)"/>
+                      "default": <xsl:value-of select="concat($doubleQuote, util:escapeForJson(.), $doubleQuote)"/>
                     </value>
                   </values>
                 </keyword>
@@ -206,7 +206,7 @@
                 <keyword>
                   <values>
                     <value>
-                      "default": <xsl:value-of select="concat($doubleQuote, gn-fn-index:json-escape(.), $doubleQuote)"/>
+                      "default": <xsl:value-of select="concat($doubleQuote, util:escapeForJson(.), $doubleQuote)"/>
                     </value>
                   </values>
                 </keyword>
@@ -227,8 +227,8 @@
         <!-- Index link where last token after the last / is the link name. -->
         <link type="object">{
           "protocol":"<xsl:value-of select="'WWW:LINK'"/>",
-          "urlObject":{"default": "<xsl:value-of select="gn-fn-index:json-escape(.)"/>"},
-          "nameObject":{"default": "<xsl:value-of select="gn-fn-index:json-escape($name)"/>"},
+          "urlObject":{"default": "<xsl:value-of select="util:escapeForJson(.)"/>"},
+          "nameObject":{"default": "<xsl:value-of select="util:escapeForJson($name)"/>"},
           "descriptionObject":{"default": ""},
           "function": ""
           }</link>

--- a/schemas/iso19110/src/main/plugin/iso19110/index-fields/index.xsl
+++ b/schemas/iso19110/src/main/plugin/iso19110/index-fields/index.xsl
@@ -50,7 +50,7 @@
         <xsl:variable name="resourceTitleObject" as="xs:string"
                       select="concat('{',
                           $doubleQuote, 'default', $doubleQuote, ':',
-                          $doubleQuote, gn-fn-index:json-escape(.) ,$doubleQuote,
+                          $doubleQuote, util:escapeForJson(.) ,$doubleQuote,
                         '}')"/>
 
         <xsl:copy-of select="gn-fn-index:add-object-field(
@@ -97,11 +97,11 @@
 
       <xsl:variable name="jsonFeatureTypes">[
         <xsl:for-each select=".//gfc:featureType">{
-          "typeName" : "<xsl:value-of select="gn-fn-index:json-escape(gfc:FC_FeatureType/gfc:typeName/*/text())"/>",
-          "definition" :"<xsl:value-of select="gn-fn-index:json-escape(gfc:FC_FeatureType/gfc:definition/*/text())"/>",
-          "code" :"<xsl:value-of select="gn-fn-index:json-escape(gfc:FC_FeatureType/gfc:code/*/text())"/>",
+          "typeName" : "<xsl:value-of select="util:escapeForJson(gfc:FC_FeatureType/gfc:typeName/*/text())"/>",
+          "definition" :"<xsl:value-of select="util:escapeForJson(gfc:FC_FeatureType/gfc:definition/*/text())"/>",
+          "code" :"<xsl:value-of select="util:escapeForJson(gfc:FC_FeatureType/gfc:code/*/text())"/>",
           "isAbstract" :"<xsl:value-of select="gfc:FC_FeatureType/gfc:isAbstract/*/text()"/>",
-          "aliases" : "<xsl:value-of select="gn-fn-index:json-escape(gfc:FC_FeatureType/gfc:aliases/*/text())"/>"
+          "aliases" : "<xsl:value-of select="util:escapeForJson(gfc:FC_FeatureType/gfc:aliases/*/text())"/>"
           <!--"inheritsFrom" : "<xsl:value-of select="gfc:FC_FeatureType/gfc:inheritsFrom/*/text()"/>",
           "inheritsTo" : "<xsl:value-of select="gfc:FC_FeatureType/gfc:inheritsTo/*/text()"/>",
           "constrainedBy" : "<xsl:value-of select="gfc:FC_FeatureType/gfc:constrainedBy/*/text()"/>",
@@ -112,9 +112,9 @@
           <xsl:if test="count($attributes) > 0">
             ,"attributeTable" : [
             <xsl:for-each select="$attributes">
-              {"name": "<xsl:value-of select="gn-fn-index:json-escape(*/gfc:memberName/*/text())"/>",
-              "definition": "<xsl:value-of select="gn-fn-index:json-escape(*/gfc:definition/*/text())"/>",
-              "code": "<xsl:value-of select="gn-fn-index:json-escape(*/gfc:code/*/text())"/>",
+              {"name": "<xsl:value-of select="util:escapeForJson(*/gfc:memberName/*/text())"/>",
+              "definition": "<xsl:value-of select="util:escapeForJson(*/gfc:definition/*/text())"/>",
+              "code": "<xsl:value-of select="util:escapeForJson(*/gfc:code/*/text())"/>",
               "link": "<xsl:value-of select="*/gfc:code/*/@xlink:href"/>",
               "type": "<xsl:value-of select="*/gfc:valueType/gco:TypeName/gco:aName/*/text()"/>"
               <xsl:if test="*/gfc:cardinality">
@@ -130,9 +130,9 @@
               <xsl:if test="$codeList">
                 ,"values": [
                 <xsl:for-each select="$codeList">{
-                  "label": "<xsl:value-of select="gn-fn-index:json-escape(*/gfc:label/*/text())"/>",
-                  "code": "<xsl:value-of select="gn-fn-index:json-escape(*/gfc:code/*/text())"/>",
-                  "definition": "<xsl:value-of select="gn-fn-index:json-escape(*/gfc:definition/*/text())"/>"}
+                  "label": "<xsl:value-of select="util:escapeForJson(*/gfc:label/*/text())"/>",
+                  "code": "<xsl:value-of select="util:escapeForJson(*/gfc:code/*/text())"/>",
+                  "definition": "<xsl:value-of select="util:escapeForJson(*/gfc:definition/*/text())"/>"}
                   <xsl:if test="position() != last()">,</xsl:if>
                 </xsl:for-each>
                 ]
@@ -204,13 +204,13 @@
                               'organisation', $organisationName, $languages, true())"/>,
       </xsl:if>
       "role":"<xsl:value-of select="$role"/>",
-      "email":"<xsl:value-of select="gn-fn-index:json-escape($email[1])"/>",
+      "email":"<xsl:value-of select="util:escapeForJson($email[1])"/>",
       "website":"<xsl:value-of select="$website"/>",
       "logo":"<xsl:value-of select="$logo"/>",
-      "individual":"<xsl:value-of select="gn-fn-index:json-escape($individualName)"/>",
-      "position":"<xsl:value-of select="gn-fn-index:json-escape($positionName)"/>",
-      "phone":"<xsl:value-of select="gn-fn-index:json-escape($phone[1])"/>",
-      "address":"<xsl:value-of select="gn-fn-index:json-escape($address)"/>"
+      "individual":"<xsl:value-of select="util:escapeForJson($individualName)"/>",
+      "position":"<xsl:value-of select="util:escapeForJson($positionName)"/>",
+      "phone":"<xsl:value-of select="util:escapeForJson($phone[1])"/>",
+      "address":"<xsl:value-of select="util:escapeForJson($address)"/>"
       }
     </xsl:element>
   </xsl:template>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/jsonld/iso19115-3.2018-to-jsonld.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/jsonld/iso19115-3.2018-to-jsonld.xsl
@@ -305,9 +305,9 @@
         <xsl:variable name="p" select="normalize-space(cit:protocol/*/text())"/>
         {
         "@type":"DataDownload",
-        "contentUrl": "<xsl:value-of select="gn-fn-index:json-escape((cit:linkage/*/text())[1])" />"
+        "contentUrl": "<xsl:value-of select="util:escapeForJson((cit:linkage/*/text())[1])" />"
         <xsl:if test="cit:protocol">,
-          "encodingFormat": "<xsl:value-of select="gn-fn-index:json-escape(if ($p != '') then $p else cit:protocol/*/@xlink:href)"/>"
+          "encodingFormat": "<xsl:value-of select="util:escapeForJson(if ($p != '') then $p else cit:protocol/*/@xlink:href)"/>"
         </xsl:if>
         <xsl:if test="cit:name">,
           "name": <xsl:apply-templates mode="toJsonLDLocalized" select="cit:name"/>
@@ -426,7 +426,7 @@
                         select="$metadata/gmd:locale/*[concat('#', @id) = $languageId]/gmd:languageCode/*/@codeListValue"/>
           {
           <xsl:value-of select="concat('&quot;@value&quot;: &quot;',
-                              gn-fn-index:json-escape(gmd:LocalisedCharacterString/text()),
+                              util:escapeForJson(gmd:LocalisedCharacterString/text()),
                               '&quot;')"/>,
           <xsl:value-of select="concat('&quot;@language&quot;: &quot;',
                               $languageCode,
@@ -441,14 +441,14 @@
         <xsl:variable name="requestedValue"
                       select="lan:PT_FreeText/*/lan:LocalisedCharacterString[@id = $requestedLanguageId]/text()"/>
         <xsl:value-of select="concat('&quot;',
-                              gn-fn-index:json-escape(
+                              util:escapeForJson(
                                 if ($requestedValue != '') then $requestedValue else (gco:CharacterString|gcx:Anchor)),
                               '&quot;')"/>
       </xsl:when>
       <xsl:otherwise>
         <!-- A simple property value -->
         <xsl:value-of select="concat('&quot;',
-                              gn-fn-index:json-escape(gco:CharacterString|gcx:Anchor),
+                              util:escapeForJson(gco:CharacterString|gcx:Anchor),
                               '&quot;')"/>
       </xsl:otherwise>
     </xsl:choose>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index-subtemplate.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index-subtemplate.xsl
@@ -113,13 +113,13 @@
                           then concat(' (', $contactInfo, ')') else ''"/>
 
     <resourceTitleObject type="object">{
-      "default": "<xsl:value-of select="gn-fn-index:json-escape(
+      "default": "<xsl:value-of select="util:escapeForJson(
                                           concat($org, $orgContactInfoSuffix))"/>"
       <xsl:for-each
         select="cit:party/cit:CI_Organisation/cit:name/lan:PT_FreeText/*/lan:LocalisedCharacterString[. != '']">
         ,"lang<xsl:value-of select="$allLanguages/lang[
                                       @id = current()/@locale/substring(., 2, 2)
-                                    ]/@value"/>": "<xsl:value-of select="gn-fn-index:json-escape(
+                                    ]/@value"/>": "<xsl:value-of select="util:escapeForJson(
                                                concat(., $orgContactInfoSuffix))"/>"
       </xsl:for-each>
       }
@@ -128,7 +128,7 @@
     <xsl:copy-of select="gn-fn-index:add-field('Org', $org)"/>
 
     <any type="object">{"common": "<xsl:value-of
-      select="gn-fn-index:json-escape(normalize-space(.))"/>"}
+      select="util:escapeForJson(normalize-space(.))"/>"}
     </any>
 
     <xsl:for-each
@@ -144,11 +144,11 @@
     <xsl:variable name="org" select="normalize-space(cit:name/gco:CharacterString)"/>
 
     <resourceTitleObject type="object">{
-      "default": "<xsl:value-of select="gn-fn-index:json-escape($org)"/>"
+      "default": "<xsl:value-of select="util:escapeForJson($org)"/>"
       <xsl:for-each select="cit:name/lan:PT_FreeText/*/lan:LocalisedCharacterString[. != '']">
         ,"lang<xsl:value-of select="$allLanguages/lang[
                                       @id = current()/@locale/substring(., 2, 2)
-                                    ]/@value"/>": "<xsl:value-of select="gn-fn-index:json-escape(.)"/>"
+                                    ]/@value"/>": "<xsl:value-of select="util:escapeForJson(.)"/>"
       </xsl:for-each>
       }
     </resourceTitleObject>
@@ -168,7 +168,7 @@
     <xsl:variable name="description"
                   select="mrs:referenceSystemIdentifier/*/mcc:description/*/text()"/>
     <resourceTitleObject type="object">{
-      "default": "<xsl:value-of select="gn-fn-index:json-escape(if ($description != '')
+      "default": "<xsl:value-of select="util:escapeForJson(if ($description != '')
                                           then concat($description, ' (', $code, ')')
                                           else $code)"/>"
       }
@@ -191,9 +191,9 @@
 
     <resourceTitleObject type="object">{
       "default": "<xsl:value-of select="if ($specifications != '' )
-                                        then gn-fn-index:json-escape($specifications)
+                                        then util:escapeForJson($specifications)
                                         else if ($measures != '' )
-                                        then gn-fn-index:json-escape($measures)
+                                        then util:escapeForJson($measures)
                                         else normalize-space(.)"/>"
       }
     </resourceTitleObject>
@@ -217,7 +217,7 @@
                   select="string-join(mco:useLimitations/*/text(), ', ')"/>
 
     <resourceTitleObject type="object">{
-      "default": "<xsl:value-of select="gn-fn-index:json-escape(
+      "default": "<xsl:value-of select="util:escapeForJson(
                     if ($references != '')
                     then $references else if ($others != '')
                     then $others
@@ -238,7 +238,7 @@
                   select="concat('S:', .//gex:southBoundLatitude/*/text(), ', W:', .//gex:westBoundLongitude/*/text(), ', N:', .//gex:northBoundLatitude/*/text(), ', E:',.//gex:eastBoundLongitude/*/text())"/>
 
     <resourceTitleObject type="object">{
-      "default": "<xsl:value-of select="gn-fn-index:json-escape(
+      "default": "<xsl:value-of select="util:escapeForJson(
                     if ($desc != '')
                     then $desc
                     else $name)"/>"
@@ -250,7 +250,7 @@
 
   <xsl:template name="subtemplate-common-fields">
     <any type="object">{"common": "<xsl:value-of
-      select="gn-fn-index:json-escape(normalize-space(.))"/>"}
+      select="util:escapeForJson(normalize-space(.))"/>"}
     </any>
   </xsl:template>
 

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
@@ -920,10 +920,10 @@
           </xsl:if>
 
           <crsDetails type="object">{
-            "code": "<xsl:value-of select="gn-fn-index:json-escape($crs)"/>",
-            "codeSpace": "<xsl:value-of select="gn-fn-index:json-escape(mcc:codeSpace/*/text())"/>",
-            "name": "<xsl:value-of select="gn-fn-index:json-escape($crsLabel)"/>",
-            "url": "<xsl:value-of select="gn-fn-index:json-escape(mcc:code/*/@xlink:href)"/>"
+            "code": "<xsl:value-of select="util:escapeForJson($crs)"/>",
+            "codeSpace": "<xsl:value-of select="util:escapeForJson(mcc:codeSpace/*/text())"/>",
+            "name": "<xsl:value-of select="util:escapeForJson($crsLabel)"/>",
+            "url": "<xsl:value-of select="util:escapeForJson(mcc:code/*/@xlink:href)"/>"
             }</crsDetails>
         </xsl:for-each>
       </xsl:for-each>
@@ -954,7 +954,7 @@
 
         <xsl:if test="string($title)">
           <specificationConformance type="object">{
-            "title": "<xsl:value-of select="gn-fn-index:json-escape($title)" />",
+            "title": "<xsl:value-of select="util:escapeForJson($title)" />",
             <xsl:if test="gn-fn-index:is-isoDate((*/mdq:specification/cit:CI_Citation/cit:date/cit:CI_Date/cit:date/gco:Date)[1])">
               "date": "<xsl:value-of select="(*/mdq:specification/cit:CI_Citation/cit:date/cit:CI_Date/cit:date/gco:Date)[1]" />",
             </xsl:if>
@@ -962,7 +962,7 @@
               "link": "<xsl:value-of select="*/mdq:specification/*/cit:title/*/@xlink:href"/>",
             </xsl:if>
             <xsl:if test="*/mdq:explanation/*/text() != ''">
-              "explanation": "<xsl:value-of select="gn-fn-index:json-escape((*/mdq:explanation/*/text())[1])" />",
+              "explanation": "<xsl:value-of select="util:escapeForJson((*/mdq:explanation/*/text())[1])" />",
             </xsl:if>
             "pass": "<xsl:value-of select="$pass" />"
             }
@@ -1002,11 +1002,11 @@
       <xsl:variable name="jsonFeatureTypes">[
         <xsl:for-each select="mdb:contentInfo//gfc:FC_FeatureCatalogue/gfc:featureType">{
 
-          "typeName" : "<xsl:value-of select="gn-fn-index:json-escape(gfc:FC_FeatureType/gfc:typeName/text())"/>",
-          "definition" :"<xsl:value-of select="gn-fn-index:json-escape(gfc:FC_FeatureType/gfc:definition/*/text())"/>",
-          "code" :"<xsl:value-of select="gn-fn-index:json-escape(gfc:FC_FeatureType/gfc:code/*/text())"/>",
+          "typeName" : "<xsl:value-of select="util:escapeForJson(gfc:FC_FeatureType/gfc:typeName/text())"/>",
+          "definition" :"<xsl:value-of select="util:escapeForJson(gfc:FC_FeatureType/gfc:definition/*/text())"/>",
+          "code" :"<xsl:value-of select="util:escapeForJson(gfc:FC_FeatureType/gfc:code/*/text())"/>",
           "isAbstract" :"<xsl:value-of select="gfc:FC_FeatureType/gfc:isAbstract/*/text()"/>",
-          "aliases" : "<xsl:value-of select="gn-fn-index:json-escape(gfc:FC_FeatureType/gfc:aliases/*/text())"/>"
+          "aliases" : "<xsl:value-of select="util:escapeForJson(gfc:FC_FeatureType/gfc:aliases/*/text())"/>"
           <!--"inheritsFrom" : "<xsl:value-of select="gfc:FC_FeatureType/gfc:inheritsFrom/*/text()"/>",
           "inheritsTo" : "<xsl:value-of select="gfc:FC_FeatureType/gfc:inheritsTo/*/text()"/>",
           "constrainedBy" : "<xsl:value-of select="gfc:FC_FeatureType/gfc:constrainedBy/*/text()"/>",
@@ -1018,22 +1018,22 @@
             ,"attributeTable" : [
             <xsl:for-each select="$attributes">
               <!-- TODO: Add multilingual support-->
-              {"name": "<xsl:value-of select="gn-fn-index:json-escape(*/gfc:memberName/text())"/>",
-              "definition": "<xsl:value-of select="gn-fn-index:json-escape(*/gfc:definition/gco:CharacterString/text())"/>",
-              "code": "<xsl:value-of select="gn-fn-index:json-escape(*/gfc:code/*/text())"/>",
+              {"name": "<xsl:value-of select="util:escapeForJson(*/gfc:memberName/text())"/>",
+              "definition": "<xsl:value-of select="util:escapeForJson(*/gfc:definition/gco:CharacterString/text())"/>",
+              "code": "<xsl:value-of select="util:escapeForJson(*/gfc:code/*/text())"/>",
               "link": "<xsl:value-of select="*/gfc:code/*/@xlink:href"/>",
               "type": "<xsl:value-of select="*/gfc:valueType/gco:TypeName/gco:aName/*/text()"/>"
               <xsl:if test="*/gfc:cardinality">
-                ,"cardinality": "<xsl:value-of select="gn-fn-index:json-escape(*/gfc:cardinality/*/text())"/>"
+                ,"cardinality": "<xsl:value-of select="util:escapeForJson(*/gfc:cardinality/*/text())"/>"
               </xsl:if>
               <xsl:variable name="codeList"
                             select="*/gfc:listedValue[normalize-space(*) != '']"/>
               <xsl:if test="$codeList">
                 ,"values": [
                 <xsl:for-each select="$codeList">{
-                  "label": "<xsl:value-of select="gn-fn-index:json-escape(*/gfc:label/gco:CharacterString/text())"/>",
-                  "code": "<xsl:value-of select="gn-fn-index:json-escape(*/gfc:code/*/text())"/>",
-                  "definition": "<xsl:value-of select="gn-fn-index:json-escape(*/gfc:definition/gco:CharacterString/text())"/>"}
+                  "label": "<xsl:value-of select="util:escapeForJson(*/gfc:label/gco:CharacterString/text())"/>",
+                  "code": "<xsl:value-of select="util:escapeForJson(*/gfc:code/*/text())"/>",
+                  "definition": "<xsl:value-of select="util:escapeForJson(*/gfc:definition/gco:CharacterString/text())"/>"}
                   <xsl:if test="position() != last()">,</xsl:if>
                 </xsl:for-each>
                 ]
@@ -1069,9 +1069,9 @@
 
       <xsl:for-each select="$additionalDocuments">
         <link type="object">{
-          "protocol": "<xsl:value-of select="gn-fn-index:json-escape(
+          "protocol": "<xsl:value-of select="util:escapeForJson(
                                         protocol/text())"/>",
-          "function": "<xsl:value-of select="gn-fn-index:json-escape(
+          "function": "<xsl:value-of select="util:escapeForJson(
                                         function/text())"/>",
           <xsl:if test="normalize-space(url) != ''">
             "urlObject": <xsl:value-of select="gn-fn-index:add-multilingual-field(
@@ -1088,7 +1088,7 @@
           <xsl:if test="nilReason">
             "nilReason": "<xsl:value-of select="nilReason"/>",
           </xsl:if>
-          "applicationProfile": "<xsl:value-of select="gn-fn-index:json-escape(
+          "applicationProfile": "<xsl:value-of select="util:escapeForJson(
                                         applicationProfile/text())"/>"
           }
         </link>
@@ -1147,7 +1147,7 @@
                                             'description', .//cit:CI_Organisation/cit:name,
                                              $allLanguages, true())"/>
                 <xsl:if test="$individualName != ''">
-                  ,"individual":"<xsl:value-of select="gn-fn-index:json-escape($individualName)"/>"
+                  ,"individual":"<xsl:value-of select="util:escapeForJson($individualName)"/>"
                 </xsl:if>
                 }
                 <xsl:if test="position() != last()">,</xsl:if>
@@ -1187,17 +1187,17 @@
                         select="mdq:dateTime/gco:DateTime"/>
 
           <measure type="object">{
-            "name": "<xsl:value-of select="gn-fn-index:json-escape($name)"/>",
+            "name": "<xsl:value-of select="util:escapeForJson($name)"/>",
             <xsl:if test="$description != ''">
-              "description": "<xsl:value-of select="gn-fn-index:json-escape($description)"/>",
+              "description": "<xsl:value-of select="util:escapeForJson($description)"/>",
             </xsl:if>
             <xsl:if test="$measureDate != ''">
-              "date": "<xsl:value-of select="gn-fn-index:json-escape($measureDate)"/>",
+              "date": "<xsl:value-of select="util:escapeForJson($measureDate)"/>",
             </xsl:if>
             <!-- First value only. -->
-            "value": "<xsl:value-of select="gn-fn-index:json-escape($value/gco:Record[1])"/>",
+            "value": "<xsl:value-of select="util:escapeForJson($value/gco:Record[1])"/>",
             <xsl:if test="$unit != ''">
-              "unit": "<xsl:value-of select="gn-fn-index:json-escape($unit)"/>",
+              "unit": "<xsl:value-of select="util:escapeForJson($unit)"/>",
             </xsl:if>
             "type": "<xsl:value-of select="local-name(.)"/>"
             }
@@ -1249,11 +1249,11 @@
             <xsl:value-of select="cit:linkage/*/text()"/>
           </xsl:element>
           <link type="object">{
-            "protocol":"<xsl:value-of select="gn-fn-index:json-escape(cit:protocol/*/text())"/>",
+            "protocol":"<xsl:value-of select="util:escapeForJson(cit:protocol/*/text())"/>",
             "mimeType":"<xsl:value-of select="if (*/gcx:MimeFileType)
-                                              then gn-fn-index:json-escape(*/gcx:MimeFileType/@type)
+                                              then util:escapeForJson(*/gcx:MimeFileType/@type)
                                               else if (starts-with(cit:protocol/gco:CharacterString, 'WWW:DOWNLOAD:'))
-                                              then gn-fn-index:json-escape(replace(cit:protocol/gco:CharacterString, 'WWW:DOWNLOAD:', ''))
+                                              then util:escapeForJson(replace(cit:protocol/gco:CharacterString, 'WWW:DOWNLOAD:', ''))
                                               else ''"/>",
             <xsl:if test="normalize-space(cit:linkage) != ''">
               "urlObject": <xsl:value-of select="gn-fn-index:add-multilingual-field(
@@ -1271,7 +1271,7 @@
               "nilReason": "<xsl:value-of select="../@gco:nilReason"/>",
             </xsl:if>
             "function":"<xsl:value-of select="cit:function/cit:CI_OnLineFunctionCode/@codeListValue"/>",
-            "applicationProfile":"<xsl:value-of select="gn-fn-index:json-escape(cit:applicationProfile/gco:CharacterString/text())"/>",
+            "applicationProfile":"<xsl:value-of select="util:escapeForJson(cit:applicationProfile/gco:CharacterString/text())"/>",
             "group": <xsl:value-of select="$transferGroup"/>
             }
           </link>
@@ -1304,7 +1304,7 @@
             <xsl:copy-of select="gn-fn-index:build-record-link(@uuidref, @xlink:href, @xlink:title, 'parent')"/>
             <!--
             TODOES - Need more work with routing
-            <recordJoin type="object">{"name": "children", "parent": "<xsl:value-of select="gn-fn-index:json-escape(.)"/>"}</recordLink>-->
+            <recordJoin type="object">{"name": "children", "parent": "<xsl:value-of select="util:escapeForJson(.)"/>"}</recordLink>-->
           </xsl:for-each>
         </xsl:when>
         <xsl:otherwise>
@@ -1430,13 +1430,13 @@
                                 'organisation', $organisationName, $languages, true())"/>,
       </xsl:if>
       "role":"<xsl:value-of select="$role"/>",
-      "email":"<xsl:value-of select="gn-fn-index:json-escape($email)"/>",
-      "website":"<xsl:value-of select="gn-fn-index:json-escape($website)"/>",
-      "logo":"<xsl:value-of select="gn-fn-index:json-escape($logo)"/>",
-      "individual":"<xsl:value-of select="gn-fn-index:json-escape($individualName)"/>",
-      "position":"<xsl:value-of select="gn-fn-index:json-escape($positionName)"/>",
-      "phone":"<xsl:value-of select="gn-fn-index:json-escape($phone)"/>",
-      "address":"<xsl:value-of select="gn-fn-index:json-escape($address)"/>"
+      "email":"<xsl:value-of select="util:escapeForJson($email)"/>",
+      "website":"<xsl:value-of select="util:escapeForJson($website)"/>",
+      "logo":"<xsl:value-of select="util:escapeForJson($logo)"/>",
+      "individual":"<xsl:value-of select="util:escapeForJson($individualName)"/>",
+      "position":"<xsl:value-of select="util:escapeForJson($positionName)"/>",
+      "phone":"<xsl:value-of select="util:escapeForJson($phone)"/>",
+      "address":"<xsl:value-of select="util:escapeForJson($address)"/>"
       <xsl:if test="@gco:nilReason">
         ,"nilReason": "<xsl:value-of select="@gco:nilReason"/>"
       </xsl:if>
@@ -1444,7 +1444,7 @@
         ,"identifiers":[
         <xsl:for-each select="$identifiers">
           {
-            "code": "<xsl:value-of select="gn-fn-index:json-escape(mcc:code/(gco:CharacterString|gcx:Anchor))"/>",
+            "code": "<xsl:value-of select="util:escapeForJson(mcc:code/(gco:CharacterString|gcx:Anchor))"/>",
             "codeSpace": "<xsl:value-of select="(mcc:codeSpace/(gco:CharacterString|gcx:Anchor))[1]/normalize-space()"/>",
             "link": "<xsl:value-of select="mcc:code/gcx:Anchor/@xlink:href"/>"
           }
@@ -1549,7 +1549,7 @@
           </xsl:choose>
           <!--
             TODOES - Need more work with routing -->
-          <!--          <recordLink type="object">{"name": "dataset", "parent": "<xsl:value-of select="gn-fn-index:json-escape(.)"/>"}</recordLink>-->
+          <!--          <recordLink type="object">{"name": "dataset", "parent": "<xsl:value-of select="util:escapeForJson(.)"/>"}</recordLink>-->
         </xsl:if>
       </xsl:for-each>
 

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/utility-tpl.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/utility-tpl.xsl
@@ -19,6 +19,7 @@
   xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0"
   xmlns:gfc="http://standards.iso.org/iso/19110/gfc/1.1"
   xmlns:gn-fn-index="http://geonetwork-opensource.org/xsl/functions/index"
+  xmlns:util="java:org.fao.geonet.util.XslUtil"
   xmlns:gn="http://www.fao.org/geonetwork"
   xmlns:xs="http://www.w3.org/2001/XMLSchema" exclude-result-prefixes="#all">
 
@@ -40,8 +41,8 @@
   <xsl:template mode="get-formats-as-json" match="mdb:MD_Metadata">
     [
     <xsl:for-each select="mdb:distributionInfo/*/mrd:distributionFormat/*/mrd:formatSpecificationCitation/*/cit:title/*/text()">{
-      "value": "WWW:DOWNLOAD:<xsl:value-of select="gn-fn-index:json-escape(.)"/>",
-      "label": "<xsl:value-of select="gn-fn-index:json-escape(.)"/>"}
+      "value": "WWW:DOWNLOAD:<xsl:value-of select="util:escapeForJson(.)"/>",
+      "label": "<xsl:value-of select="util:escapeForJson(.)"/>"}
       <xsl:if test="position() != last()">,</xsl:if>
     </xsl:for-each>
     ]

--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/jsonld/iso19139-to-jsonld.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/jsonld/iso19139-to-jsonld.xsl
@@ -248,9 +248,9 @@
         <xsl:variable name="p" select="normalize-space(gmd:protocol/*/text())"/>
         {
         "@type":"DataDownload",
-        "contentUrl":"<xsl:value-of select="gn-fn-index:json-escape(gmd:linkage/gmd:URL/text())"/>"
+        "contentUrl":"<xsl:value-of select="util:escapeForJson(gmd:linkage/gmd:URL/text())"/>"
         <xsl:if test="gmd:protocol">,
-        "encodingFormat":"<xsl:value-of select="gn-fn-index:json-escape(if ($p != '') then $p else gmd:protocol/*/@xlink:href)"/>"
+        "encodingFormat":"<xsl:value-of select="util:escapeForJson(if ($p != '') then $p else gmd:protocol/*/@xlink:href)"/>"
         </xsl:if>
         <xsl:if test="gmd:name">,
         "name": <xsl:apply-templates mode="toJsonLDLocalized"
@@ -403,7 +403,7 @@
                         select="$metadata/gmd:locale/*[concat('#', @id) = $languageId]/gmd:languageCode/*/@codeListValue"/>
           {
           <xsl:value-of select="concat('&quot;@value&quot;: &quot;',
-                              gn-fn-index:json-escape(gmd:LocalisedCharacterString/text()),
+                              util:escapeForJson(gmd:LocalisedCharacterString/text()),
                               '&quot;')"/>,
           <xsl:value-of select="concat('&quot;@language&quot;: &quot;',
                               $languageCode,
@@ -418,14 +418,14 @@
         <xsl:variable name="requestedValue"
                       select="gmd:PT_FreeText/*/gmd:LocalisedCharacterString[@id = $requestedLanguageId]/text()"/>
         <xsl:value-of select="concat('&quot;',
-                              gn-fn-index:json-escape(
+                              util:escapeForJson(
                                 if ($requestedValue != '') then $requestedValue else (gco:CharacterString|gmx:Anchor)),
                               '&quot;')"/>
       </xsl:when>
       <xsl:otherwise>
         <!-- A simple property value -->
         <xsl:value-of select="concat('&quot;',
-                              gn-fn-index:json-escape(gco:CharacterString|gmx:Anchor),
+                              util:escapeForJson(gco:CharacterString|gmx:Anchor),
                               '&quot;')"/>
       </xsl:otherwise>
     </xsl:choose>

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/index-subtemplate.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/index-subtemplate.xsl
@@ -90,12 +90,12 @@
                           then concat(' (', $contactInfo, ')') else ''"/>
 
     <resourceTitleObject type="object">{
-      "default": "<xsl:value-of select="gn-fn-index:json-escape(
+      "default": "<xsl:value-of select="util:escapeForJson(
                                           concat($org, $orgContactInfoSuffix))"/>"
       <xsl:for-each select="gmd:organisationName/gmd:PT_FreeText/*/gmd:LocalisedCharacterString[. != '']">
         ,"lang<xsl:value-of select="$allLanguages/lang[
                                       @id = current()/@locale/substring(., 2, 2)
-                                    ]/@value"/>": "<xsl:value-of select="gn-fn-index:json-escape(
+                                    ]/@value"/>": "<xsl:value-of select="util:escapeForJson(
                                        concat(., $orgContactInfoSuffix))"/>"
       </xsl:for-each>
       }</resourceTitleObject>
@@ -122,11 +122,11 @@
                           |gmd:description/gmd:PT_FreeText/*/gmd:LocalisedCharacterString[. != '']
                           )[1])"/>
         <resourceTitleObject type="object">{
-          "default": "<xsl:value-of select="gn-fn-index:json-escape($description)"/>"
+          "default": "<xsl:value-of select="util:escapeForJson($description)"/>"
           <xsl:for-each select="gmd:description/gmd:PT_FreeText/*/gmd:LocalisedCharacterString[. != '']">
             ,"lang<xsl:value-of select="$allLanguages/lang[
                                       @id = current()/@locale/substring(., 2, 2)
-                                    ]/@value"/>": "<xsl:value-of select="gn-fn-index:json-escape(.)"/>"
+                                    ]/@value"/>": "<xsl:value-of select="util:escapeForJson(.)"/>"
           </xsl:for-each>
           }</resourceTitleObject>
 
@@ -136,7 +136,7 @@
                       select="concat('S:', .//gmd:southBoundLatitude/*/text(), ', W:', .//gmd:westBoundLongitude/*/text(), ', N:', .//gmd:northBoundLatitude/*/text(), ', E:',.//gmd:eastBoundLongitude/*/text())"/>
 
         <resourceTitleObject type="object">{
-          "default": "<xsl:value-of select="gn-fn-index:json-escape($name)"/>"
+          "default": "<xsl:value-of select="util:escapeForJson($name)"/>"
           }
         </resourceTitleObject>
       </xsl:otherwise>
@@ -153,7 +153,7 @@
                         then gmd:name/gco:CharacterString
                         else concat(gmd:name/gco:CharacterString, ' ', gmd:version/gco:CharacterString)"/>
     <resourceTitleObject type="object">{
-      "default": "<xsl:value-of select="gn-fn-index:json-escape($title)"/>"
+      "default": "<xsl:value-of select="util:escapeForJson($title)"/>"
       }</resourceTitleObject>
 
     <xsl:call-template name="subtemplate-common-fields"/>
@@ -168,7 +168,7 @@
                         string-join(gmd:MD_LegalConstraints/gmd:otherConstraints/*/text(), ', '))"/>
 
     <resourceTitleObject type="object">{
-      "default": "<xsl:value-of select="gn-fn-index:json-escape($constraint)"/>"
+      "default": "<xsl:value-of select="util:escapeForJson($constraint)"/>"
       }
     </resourceTitleObject>
 
@@ -181,7 +181,7 @@
     <xsl:variable name="title"
                   select="gmd:result/gmd:DQ_ConformanceResult/gmd:specification/gmd:CI_Citation/gmd:title/(gco:CharacterString|gmx:Anchor)"/>
     <resourceTitleObject type="object">{
-      "default": "<xsl:value-of select="gn-fn-index:json-escape($title)"/>"
+      "default": "<xsl:value-of select="util:escapeForJson($title)"/>"
       }</resourceTitleObject>
 
     <xsl:call-template name="subtemplate-common-fields"/>

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
@@ -335,7 +335,7 @@
 
           <xsl:for-each select="gmd:identifier/*[string(gmd:code/*)]">
             <resourceIdentifier type="object">{
-              "code": "<xsl:value-of select="gn-fn-index:json-escape(gmd:code/(gco:CharacterString|gmx:Anchor))"/>",
+              "code": "<xsl:value-of select="util:escapeForJson(gmd:code/(gco:CharacterString|gmx:Anchor))"/>",
               "codeSpace": "<xsl:value-of select="gmd:codeSpace/(gco:CharacterString|gmx:Anchor)"/>",
               "link": "<xsl:value-of select="gmd:code/gmx:Anchor/@xlink:href"/>"
               }</resourceIdentifier>
@@ -866,10 +866,10 @@
           </xsl:if>
 
           <crsDetails type="object">{
-            "code": "<xsl:value-of select="gn-fn-index:json-escape((gmd:code/*/text())[1])"/>",
-            "codeSpace": "<xsl:value-of select="gn-fn-index:json-escape((gmd:codeSpace/*/text())[1])"/>",
-            "name": "<xsl:value-of select="gn-fn-index:json-escape($crsLabel)"/>",
-            "url": "<xsl:value-of select="gn-fn-index:json-escape(gmd:code/*/@xlink:href)"/>"
+            "code": "<xsl:value-of select="util:escapeForJson((gmd:code/*/text())[1])"/>",
+            "codeSpace": "<xsl:value-of select="util:escapeForJson((gmd:codeSpace/*/text())[1])"/>",
+            "name": "<xsl:value-of select="util:escapeForJson($crsLabel)"/>",
+            "url": "<xsl:value-of select="util:escapeForJson(gmd:code/*/@xlink:href)"/>"
             }</crsDetails>
         </xsl:for-each>
       </xsl:for-each>
@@ -899,7 +899,7 @@
 
         <xsl:if test="string($title)">
           <specificationConformance type="object">{
-            "title": "<xsl:value-of select="gn-fn-index:json-escape($title)" />",
+            "title": "<xsl:value-of select="util:escapeForJson($title)" />",
             <xsl:if test="gn-fn-index:is-isoDate((*/gmd:specification/gmd:CI_Citation/gmd:date/gmd:CI_Date/gmd:date/gco:Date)[1])">
               "date": "<xsl:value-of select="(*/gmd:specification/gmd:CI_Citation/gmd:date/gmd:CI_Date/gmd:date/gco:Date)[1]" />",
             </xsl:if>
@@ -907,7 +907,7 @@
               "link": "<xsl:value-of select="*/gmd:specification/*/gmd:title/*/@xlink:href"/>",
             </xsl:if>
             <xsl:if test="*/gmd:explanation/*/text() != ''">
-              "explanation": "<xsl:value-of select="gn-fn-index:json-escape((*/gmd:explanation/*/text())[1])" />",
+              "explanation": "<xsl:value-of select="util:escapeForJson((*/gmd:explanation/*/text())[1])" />",
             </xsl:if>
             "pass": "<xsl:value-of select="$pass" />"
             }
@@ -934,7 +934,7 @@
                           then 'remote'
                         else 'catalog'"/>",
           "to": "<xsl:value-of select="@uuidref"/>",
-          "title": "<xsl:value-of select="gn-fn-index:json-escape(@xlink:title)"/>",
+          "title": "<xsl:value-of select="util:escapeForJson(@xlink:title)"/>",
           "url": "<xsl:value-of select="$xlink"/>"
           }</recordLink>
         <hasfeaturecat><xsl:value-of select="@uuidref"/></hasfeaturecat>
@@ -957,7 +957,7 @@
                           then 'remote'
                         else 'catalog'"/>",
             "to": "<xsl:value-of select="@uuidref"/>",
-            "title": "<xsl:value-of select="gn-fn-index:json-escape(@xlink:title)"/>",
+            "title": "<xsl:value-of select="util:escapeForJson(@xlink:title)"/>",
             "url": "<xsl:value-of select="$xlink"/>"
             }</recordLink>
         </xsl:for-each>
@@ -979,17 +979,17 @@
           <xsl:variable name="measureDate"
                         select="../../gmd:dateTime/gco:DateTime"/>
           <measure type="object">{
-            "name": "<xsl:value-of select="gn-fn-index:json-escape($name)"/>",
+            "name": "<xsl:value-of select="util:escapeForJson($name)"/>",
             <xsl:if test="$description != ''">
-              "description": "<xsl:value-of select="gn-fn-index:json-escape($description)"/>",
+              "description": "<xsl:value-of select="util:escapeForJson($description)"/>",
             </xsl:if>
             <xsl:if test="$measureDate != ''">
-              "date": "<xsl:value-of select="gn-fn-index:json-escape($measureDate)"/>",
+              "date": "<xsl:value-of select="util:escapeForJson($measureDate)"/>",
             </xsl:if>
             <!-- First value only. -->
-            "value": "<xsl:value-of select="gn-fn-index:json-escape($value/gco:Record[1])"/>",
+            "value": "<xsl:value-of select="util:escapeForJson($value/gco:Record[1])"/>",
             <xsl:if test="$unit != ''">
-              "unit": "<xsl:value-of select="gn-fn-index:json-escape($unit)"/>",
+              "unit": "<xsl:value-of select="util:escapeForJson($unit)"/>",
             </xsl:if>
             "type": "<xsl:value-of select="local-name(.)"/>"
             }
@@ -1035,7 +1035,7 @@
                                           select="gn-fn-index:add-multilingual-field(
                                             'description', gmd:organisationName, $allLanguages, true())"/>
                   <xsl:if test="gmd:individualName/gco:CharacterString/text()">
-                    ,"individual":"<xsl:value-of select="gn-fn-index:json-escape(gmd:individualName/gco:CharacterString/text())"/>"
+                    ,"individual":"<xsl:value-of select="util:escapeForJson(gmd:individualName/gco:CharacterString/text())"/>"
                   </xsl:if>
                 }
                 <xsl:if test="position() != last()">,</xsl:if>
@@ -1088,7 +1088,7 @@
           <xsl:variable name="protocol"
                         select="gmd:protocol/*/text()"/>
           <xsl:variable name="linkName"
-                        select="gn-fn-index:json-escape((gmd:name/*/text())[1])"/>
+                        select="util:escapeForJson((gmd:name/*/text())[1])"/>
 
           <linkUrl>
             <xsl:value-of select="gmd:linkage/gmd:URL"/>
@@ -1105,13 +1105,13 @@
             <atomfeed><xsl:value-of select="gmd:linkage/gmd:URL"/></atomfeed>
           </xsl:if>
           <link type="object">{
-            "protocol":"<xsl:value-of select="gn-fn-index:json-escape((gmd:protocol/*/text())[1])"/>",
+            "protocol":"<xsl:value-of select="util:escapeForJson((gmd:protocol/*/text())[1])"/>",
             "mimeType":"<xsl:value-of select="if (*/gmx:MimeFileType)
-                                              then gn-fn-index:json-escape(*/gmx:MimeFileType/@type)
+                                              then util:escapeForJson(*/gmx:MimeFileType/@type)
                                               else if (starts-with(gmd:protocol/gco:CharacterString, 'WWW:DOWNLOAD:'))
-                                              then gn-fn-index:json-escape(replace(gmd:protocol/gco:CharacterString, 'WWW:DOWNLOAD:', ''))
+                                              then util:escapeForJson(replace(gmd:protocol/gco:CharacterString, 'WWW:DOWNLOAD:', ''))
                                               else ''"/>",
-            "urlObject":{"default": "<xsl:value-of select="gn-fn-index:json-escape(gmd:linkage/gmd:URL)"/>"},
+            "urlObject":{"default": "<xsl:value-of select="util:escapeForJson(gmd:linkage/gmd:URL)"/>"},
             <xsl:if test="normalize-space(gmd:name) != ''">
               "nameObject": <xsl:value-of select="gn-fn-index:add-multilingual-field(
                                 'name', gmd:name, $allLanguages, true())"/>,
@@ -1124,7 +1124,7 @@
               "nilReason": "<xsl:value-of select="../@gco:nilReason"/>",
             </xsl:if>
             "function":"<xsl:value-of select="gmd:function/gmd:CI_OnLineFunctionCode/@codeListValue"/>",
-            "applicationProfile":"<xsl:value-of select="gn-fn-index:json-escape(gmd:applicationProfile/gco:CharacterString/text())"/>",
+            "applicationProfile":"<xsl:value-of select="util:escapeForJson(gmd:applicationProfile/gco:CharacterString/text())"/>",
             "group": <xsl:value-of select="$transferGroup"/>
             }
             <!--Link object in Angular used to be
@@ -1164,7 +1164,7 @@
             <xsl:copy-of select="gn-fn-index:build-record-link(., @xlink:href, @xlink:title, 'parent')"/>
             <!--
             TODOES - Need more work with routing -->
-            <!--            <recordJoin type="object">{"name": "children", "parent": "<xsl:value-of select="gn-fn-index:json-escape(.)"/>"}</recordLink>-->
+            <!--            <recordJoin type="object">{"name": "children", "parent": "<xsl:value-of select="util:escapeForJson(.)"/>"}</recordLink>-->
           </xsl:for-each>
         </xsl:when>
         <xsl:otherwise>
@@ -1278,13 +1278,13 @@
                               'organisation', $organisationName, $languages, true())"/>,
       </xsl:if>
       "role":"<xsl:value-of select="$role"/>",
-      "email":"<xsl:value-of select="gn-fn-index:json-escape($email[1])"/>",
-      "website":"<xsl:value-of select="gn-fn-index:json-escape($website)"/>",
-      "logo":"<xsl:value-of select="gn-fn-index:json-escape($logo)"/>",
-      "individual":"<xsl:value-of select="gn-fn-index:json-escape($individualName)"/>",
-      "position":"<xsl:value-of select="gn-fn-index:json-escape($positionName)"/>",
-      "phone":"<xsl:value-of select="gn-fn-index:json-escape($phone[1])"/>",
-      "address":"<xsl:value-of select="gn-fn-index:json-escape($address)"/>"
+      "email":"<xsl:value-of select="util:escapeForJson($email[1])"/>",
+      "website":"<xsl:value-of select="util:escapeForJson($website)"/>",
+      "logo":"<xsl:value-of select="util:escapeForJson($logo)"/>",
+      "individual":"<xsl:value-of select="util:escapeForJson($individualName)"/>",
+      "position":"<xsl:value-of select="util:escapeForJson($positionName)"/>",
+      "phone":"<xsl:value-of select="util:escapeForJson($phone[1])"/>",
+      "address":"<xsl:value-of select="util:escapeForJson($address)"/>"
       <xsl:if test="@gco:nilReason">
         ,"nilReason": "<xsl:value-of select="@gco:nilReason"/>"
       </xsl:if>
@@ -1384,7 +1384,7 @@
 
           <!--
             TODOES - Need more work with routing -->
-          <!--          <recordLink type="object">{"name": "dataset", "parent": "<xsl:value-of select="gn-fn-index:json-escape(.)"/>"}</recordLink>-->
+          <!--          <recordLink type="object">{"name": "dataset", "parent": "<xsl:value-of select="util:escapeForJson(.)"/>"}</recordLink>-->
         </xsl:if>
       </xsl:for-each>
     </xsl:for-each>

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/utility-tpl.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/utility-tpl.xsl
@@ -29,6 +29,7 @@
                 xmlns:gmx="http://www.isotc211.org/2005/gmx"
                 xmlns:gn-fn-index="http://geonetwork-opensource.org/xsl/functions/index"
                 xmlns:gn="http://www.fao.org/geonetwork"
+                xmlns:util="java:org.fao.geonet.util.XslUtil"
                 version="2.0"
                 exclude-result-prefixes="#all">
 
@@ -47,8 +48,8 @@
   <xsl:template mode="get-formats-as-json" match="gmd:MD_Metadata">
     [
     <xsl:for-each select="gmd:distributionInfo/*/gmd:distributionFormat/*/gmd:name/*/text()">{
-      "value": "WWW:DOWNLOAD:<xsl:value-of select="gn-fn-index:json-escape(.)"/>",
-      "label": "<xsl:value-of select="gn-fn-index:json-escape(.)"/>"}
+      "value": "WWW:DOWNLOAD:<xsl:value-of select="util:escapeForJson(.)"/>",
+      "label": "<xsl:value-of select="util:escapeForJson(.)"/>"}
       <xsl:if test="position() != last()">,</xsl:if>
     </xsl:for-each>
     ]

--- a/services/src/main/java/org/fao/geonet/api/es/EsHTTPProxy.java
+++ b/services/src/main/java/org/fao/geonet/api/es/EsHTTPProxy.java
@@ -815,7 +815,7 @@ public class EsHTTPProxy {
      *      <xsl:element name="contact{$fieldSuffix}">
      *        <xsl:attribute name="type" select="'object'"/>{
      *        ...
-     *        "address":"<xsl:value-of select="gn-fn-index:json-escape($address)"/>"
+     *        "address":"<xsl:value-of select="util:escapeForJson($address)"/>"
      *        <xsl:if test="$hasWithheld">
      *         ,"nilReason": "withheld"
      *        </xsl:if>

--- a/web/src/main/webapp/xslt/common/index-utils.xsl
+++ b/web/src/main/webapp/xslt/common/index-utils.xsl
@@ -683,7 +683,11 @@
   </xsl:function>
 
   <xsl:function name="gn-fn-index:json-escape" as="xs:string?">
-    <!-- This functions is deprecated. Please update your code to use util:escapeForJson function -->
+    <!-- This function is deprecated. Please update your code to define the following namespace:
+            xmlns:util="java:org.fao.geonet.util.XslUtil"
+            
+            and use util:escapeForJson function 
+    -->
     
       <xsl:param name="v" as="xs:string?" />
       <xsl:choose>

--- a/web/src/main/webapp/xslt/common/index-utils.xsl
+++ b/web/src/main/webapp/xslt/common/index-utils.xsl
@@ -685,13 +685,13 @@
   <xsl:function name="gn-fn-index:json-escape" as="xs:string?">
     <!-- This functions is deprecated. Please update your code to use util:escapeForJson function -->
     
-      <xsl:param name="v" as="xs:string?"/>
+      <xsl:param name="v" as="xs:string?" />
       <xsl:choose>
-        <xsl:when test="normalize-space($v) = ''"></xsl:when>
-        <xsl:otherwise>
-          <xsl:value-of select="util:escapeForJson($v)"/>
-        </xsl:otherwise>
-      </xsl:choose>
-    </xsl:function>
+      <xsl:when test="normalize-space($v) = ''"></xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="util:escapeForJson($v)" />
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
 
 </xsl:stylesheet>

--- a/web/src/main/webapp/xslt/common/index-utils.xsl
+++ b/web/src/main/webapp/xslt/common/index-utils.xsl
@@ -687,10 +687,10 @@
     
       <xsl:param name="v" as="xs:string?" />
       <xsl:choose>
-      <xsl:when test="normalize-space($v) = ''"></xsl:when>
-      <xsl:otherwise>
-        <xsl:value-of select="util:escapeForJson($v)" />
-      </xsl:otherwise>
+        <xsl:when test="normalize-space($v) = ''"></xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="util:escapeForJson($v)" />
+        </xsl:otherwise>
     </xsl:choose>
   </xsl:function>
 

--- a/web/src/main/webapp/xslt/common/index-utils.xsl
+++ b/web/src/main/webapp/xslt/common/index-utils.xsl
@@ -682,4 +682,16 @@
                           else $fieldName"/>
   </xsl:function>
 
+  <xsl:function name="gn-fn-index:json-escape" as="xs:string?">
+    <!-- This functions is deprecated. Please update your code to use util:escapeForJson function -->
+    
+      <xsl:param name="v" as="xs:string?"/>
+      <xsl:choose>
+        <xsl:when test="normalize-space($v) = ''"></xsl:when>
+        <xsl:otherwise>
+          <xsl:value-of select="util:escapeForJson($v)"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:function>
+
 </xsl:stylesheet>

--- a/web/src/main/webapp/xslt/common/index-utils.xsl
+++ b/web/src/main/webapp/xslt/common/index-utils.xsl
@@ -150,7 +150,7 @@
       </xsl:for-each>
       "to": "<xsl:value-of select="normalize-space($uuid)"/>",
       "url": "<xsl:value-of select="normalize-space($url)"/>",
-      "title": "<xsl:value-of select="gn-fn-index:json-escape($recordTitle)"/>",
+      "title": "<xsl:value-of select="util:escapeForJson($recordTitle)"/>",
       "origin": "<xsl:value-of select="normalize-space($origin)"/>"
       }</recordLink>
   </xsl:function>
@@ -245,10 +245,10 @@
           <xsl:when test="$languages and count($element//(*:CharacterString|*:Anchor|*:LocalisedCharacterString)) = 0">
             <xsl:if test="position() = 1">
               <value><xsl:value-of select="concat($doubleQuote, 'default', $doubleQuote, ':',
-                                             $doubleQuote, gn-fn-index:json-escape(.), $doubleQuote)"/></value>
+                                             $doubleQuote, util:escapeForJson(.), $doubleQuote)"/></value>
               <xsl:for-each select="$elements">
                 <value><xsl:value-of select="concat($doubleQuote, 'lang', @xml:lang, $doubleQuote, ':',
-                                             $doubleQuote, gn-fn-index:json-escape(.), $doubleQuote)"/></value>
+                                             $doubleQuote, util:escapeForJson(.), $doubleQuote)"/></value>
               </xsl:for-each>
             </xsl:if>
           </xsl:when>
@@ -256,9 +256,9 @@
             <!-- The default language -->
             <xsl:for-each select="$element//(*:CharacterString|*:Anchor)[. != '']">
               <value><xsl:value-of select="concat($doubleQuote, 'default', $doubleQuote, ':',
-                                           $doubleQuote, gn-fn-index:json-escape(.), $doubleQuote)"/></value>
+                                           $doubleQuote, util:escapeForJson(.), $doubleQuote)"/></value>
               <value><xsl:value-of select="concat($doubleQuote, 'lang', $mainLanguage, $doubleQuote, ':',
-                                           $doubleQuote, gn-fn-index:json-escape(.), $doubleQuote)"/></value>
+                                           $doubleQuote, util:escapeForJson(.), $doubleQuote)"/></value>
             </xsl:for-each>
 
             <xsl:variable name="translations"
@@ -271,7 +271,7 @@
                             select="concat('#', $languages/lang[@id != 'default' and @value = $mainLanguage]/@id)"/>
 
               <value><xsl:value-of select="concat($doubleQuote, 'default', $doubleQuote, ':',
-                                           $doubleQuote, gn-fn-index:json-escape(
+                                           $doubleQuote, util:escapeForJson(
                                            if ($translations[@local = $mainLanguageId])
                                            then $translations[@local = $mainLanguageId]
                                            else $translations[1]), $doubleQuote)"/></value>
@@ -287,7 +287,7 @@
                               select="concat('lang', $elementLanguage3LetterCode)"/>
                 <value><xsl:value-of select="concat(
                                         $doubleQuote, $field, $doubleQuote, ':',
-                                        $doubleQuote, gn-fn-index:json-escape(.), $doubleQuote)"/></value>
+                                        $doubleQuote, util:escapeForJson(.), $doubleQuote)"/></value>
               </xsl:if>
             </xsl:for-each>
 
@@ -296,16 +296,16 @@
             <!-- Index each values in a field. -->
             <xsl:for-each select="distinct-values($element[. != ''])">
               <value><xsl:value-of select="concat($doubleQuote, 'default', $doubleQuote, ':',
-                                           $doubleQuote, gn-fn-index:json-escape(.), $doubleQuote)"/></value>
+                                           $doubleQuote, util:escapeForJson(.), $doubleQuote)"/></value>
               <value><xsl:value-of select="concat($doubleQuote, 'lang', $mainLanguage, $doubleQuote, ':',
-                                           $doubleQuote, gn-fn-index:json-escape(.), $doubleQuote)"/></value>
+                                           $doubleQuote, util:escapeForJson(.), $doubleQuote)"/></value>
             </xsl:for-each>
           </xsl:otherwise>
         </xsl:choose>
 
         <xsl:for-each select="$element//*:Anchor/@xlink:href">
           <value><xsl:value-of select="concat($doubleQuote, 'link', $doubleQuote, ':',
-                                           $doubleQuote, gn-fn-index:json-escape(.), $doubleQuote)"/></value>
+                                           $doubleQuote, util:escapeForJson(.), $doubleQuote)"/></value>
         </xsl:for-each>
       </xsl:variable>
 
@@ -434,12 +434,12 @@
       <xsl:for-each select="$allKeywords/thesaurus[info/@field]">
         "<xsl:value-of select="if (info/@field != '') then info/@field else 'otherKeywords'"/>": {
         <xsl:if test="info/@id != ''">
-          "id": "<xsl:value-of select="gn-fn-index:json-escape(info/@id)"/>",
+          "id": "<xsl:value-of select="util:escapeForJson(info/@id)"/>",
         </xsl:if>
-        "title": "<xsl:value-of select="gn-fn-index:json-escape(info/@title)"/>",
-        "theme": "<xsl:value-of select="gn-fn-index:json-escape(info/@type)"/>",
+        "title": "<xsl:value-of select="util:escapeForJson(info/@title)"/>",
+        "theme": "<xsl:value-of select="util:escapeForJson(info/@type)"/>",
         <xsl:if test="info/@uri != ''">
-          "link": "<xsl:value-of select="gn-fn-index:json-escape(info/@uri)"/>",
+          "link": "<xsl:value-of select="util:escapeForJson(info/@uri)"/>",
         </xsl:if>
         "keywords": [
         <xsl:for-each select="keywords/keyword">
@@ -467,14 +467,14 @@
         <xsl:if test="count($defaults) > 0">"default": [
           <xsl:for-each select="$defaults">
             <xsl:sort select="."/>
-            <xsl:value-of select="concat($doubleQuote, gn-fn-index:json-escape(.), $doubleQuote)"/><xsl:if test="position() != last()">,</xsl:if>
+            <xsl:value-of select="concat($doubleQuote, util:escapeForJson(.), $doubleQuote)"/><xsl:if test="position() != last()">,</xsl:if>
           </xsl:for-each>
           ]<xsl:if test="count($keys) > 0">,</xsl:if>
         </xsl:if>
         <xsl:if test="count($keys) > 0">"key": [
           <xsl:for-each select="$keys">
             <xsl:sort select="."/>
-            <xsl:value-of select="concat($doubleQuote, gn-fn-index:json-escape(.), $doubleQuote)"/><xsl:if test="position() != last()">,</xsl:if>
+            <xsl:value-of select="concat($doubleQuote, util:escapeForJson(.), $doubleQuote)"/><xsl:if test="position() != last()">,</xsl:if>
           </xsl:for-each>
           ]
         </xsl:if>
@@ -528,16 +528,16 @@
     <xsl:variable name="textObject">
       <!-- The codelist key -->
       <xsl:value-of select="concat($doubleQuote, 'key', $doubleQuote, ':',
-                                       $doubleQuote, gn-fn-index:json-escape($value/@codeListValue), $doubleQuote)"/>
+                                       $doubleQuote, util:escapeForJson($value/@codeListValue), $doubleQuote)"/>
 
       <xsl:variable name="translation"
                     select="util:getCodelistTranslation(
                           string($codelistType), string($value/@codeListValue), string($mainLanguage))"/>
 
       <xsl:value-of select="concat(',', $doubleQuote, 'default', $doubleQuote, ':',
-                                       $doubleQuote, gn-fn-index:json-escape($translation), $doubleQuote)"/>
+                                       $doubleQuote, util:escapeForJson($translation), $doubleQuote)"/>
       <xsl:value-of select="concat(',', $doubleQuote, 'lang', $mainLanguage, $doubleQuote, ':',
-                                     $doubleQuote, gn-fn-index:json-escape($translation), $doubleQuote)"/>
+                                     $doubleQuote, util:escapeForJson($translation), $doubleQuote)"/>
 
 
       <xsl:for-each select="$languages/lang[@id != 'default']/@value">
@@ -545,16 +545,16 @@
                       select="util:getCodelistTranslation(
                         string($codelistType), string($value/@codeListValue), string(.))"/>
         <xsl:value-of select="concat(',', $doubleQuote, 'lang', ., $doubleQuote, ':',
-                                   $doubleQuote, gn-fn-index:json-escape($translation), $doubleQuote)"/>
+                                   $doubleQuote, util:escapeForJson($translation), $doubleQuote)"/>
       </xsl:for-each>
 
       <xsl:for-each select="$value/@codeList">
         <xsl:value-of select="concat(',', $doubleQuote, 'link', $doubleQuote, ':',
-                                         $doubleQuote, gn-fn-index:json-escape(.), $doubleQuote)"/>
+                                         $doubleQuote, util:escapeForJson(.), $doubleQuote)"/>
       </xsl:for-each>
       <xsl:for-each select="$value/text()">
         <xsl:value-of select="concat(',', $doubleQuote, 'text', $doubleQuote, ':',
-                                         $doubleQuote, gn-fn-index:json-escape(.), $doubleQuote)"/>
+                                         $doubleQuote, util:escapeForJson(.), $doubleQuote)"/>
       </xsl:for-each>
     </xsl:variable>
     <xsl:if test="$textObject != ''">
@@ -612,7 +612,7 @@
         <value><xsl:value-of select="concat('&quot;date&quot;: &quot;', $start/text(), '&quot;')"/></value>
       </xsl:if>
       <xsl:for-each select="$start/@*[. != '']">
-        <value><xsl:value-of select="concat('&quot;', name(.), '&quot;: &quot;', gn-fn-index:json-escape(.), '&quot;')"/></value>
+        <value><xsl:value-of select="concat('&quot;', name(.), '&quot;: &quot;', util:escapeForJson(.), '&quot;')"/></value>
       </xsl:for-each>
     </xsl:variable>
     <xsl:variable name="rangeEndDetails">
@@ -623,7 +623,7 @@
         <value><xsl:value-of select="concat('&quot;date&quot;: &quot;', $end/text(), '&quot;')"/></value>
       </xsl:if>
       <xsl:for-each select="$end/@*[. != '']">
-        <value><xsl:value-of select="concat('&quot;', name(.), '&quot;: &quot;', gn-fn-index:json-escape(.), '&quot;')"/></value>
+        <value><xsl:value-of select="concat('&quot;', name(.), '&quot;: &quot;', util:escapeForJson(.), '&quot;')"/></value>
       </xsl:for-each>
     </xsl:variable>
 
@@ -682,19 +682,4 @@
                           else $fieldName"/>
   </xsl:function>
 
-
-  <xsl:function name="gn-fn-index:json-escape" as="xs:string?">
-    <xsl:param name="v" as="xs:string?"/>
-    <xsl:choose>
-      <xsl:when test="normalize-space($v) = ''"></xsl:when>
-      <xsl:otherwise>
-        <xsl:value-of select="replace(replace(replace(replace(replace($v,
-                  '\\','\\\\'),
-                  $doubleQuote, $escapedDoubleQuote),
-                  '&#09;', '\\t'),
-                  '&#10;', '\\n'),
-                  '&#13;', '\\r')"/>
-      </xsl:otherwise>
-    </xsl:choose>
-  </xsl:function>
 </xsl:stylesheet>


### PR DESCRIPTION
Replace xslt JSON texts escaping to use Apache Commons Text:

https://commons.apache.org/proper/commons-text/javadocs/api-release/org/apache/commons/text/StringEscapeUtils.html#escapeJson(java.lang.String)

This provides the benefit of not needing to maintain ad hoc code, whereas there are well-known libraries that implement these types of features, covered by unit tests, which are difficult to manage with XSLT.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

