### PR TITLE
Administration form validation improvements

### DIFF
--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -2725,4 +2725,43 @@
       }
     };
   });
+
+  module.directive("equalWith", function () {
+    return {
+      require: "ngModel",
+      scope: { equalWith: "&" },
+      link: function (scope, elem, attrs, ngModelCtrl) {
+        ngModelCtrl.$validators.equalWith = function (modelValue) {
+          return modelValue === scope.equalWith();
+        };
+
+        scope.$watch(scope.equalWith, function (value) {
+          ngModelCtrl.$validate();
+        });
+      }
+    };
+  });
+
+  module.directive("confirmOnExit", function () {
+    return {
+      link: function ($scope, elem, attrs) {
+        window.onbeforeunload = function () {
+          if ($scope[attrs["name"]].$dirty) {
+            return "The form has changes, if you exit the changes will be lost. Do you want to exit on the page?";
+          }
+        };
+        $scope.$on("$locationChangeStart", function (event, next, current) {
+          if ($scope[attrs["name"]].$dirty) {
+            if (
+              !confirm(
+                "The form has changes, if you exit the changes will be lost. Do you want to exit on the page?"
+              )
+            ) {
+              event.preventDefault();
+            }
+          }
+        });
+      }
+    };
+  });
 })();

--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -2745,18 +2745,15 @@
   module.directive("confirmOnExit", function () {
     return {
       link: function ($scope, elem, attrs) {
+        var message = attrs["confirmMessage"];
         window.onbeforeunload = function () {
           if ($scope[attrs["name"]].$dirty) {
-            return "The form has changes, if you exit the changes will be lost. Do you want to exit on the page?";
+            return message;
           }
         };
         $scope.$on("$locationChangeStart", function (event, next, current) {
           if ($scope[attrs["name"]].$dirty) {
-            if (
-              !confirm(
-                "The form has changes, if you exit the changes will be lost. Do you want to exit on the page?"
-              )
-            ) {
+            if (!confirm(message)) {
               event.preventDefault();
             }
           }

--- a/web-ui/src/main/resources/catalog/js/admin/UserGroupController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/UserGroupController.js
@@ -32,7 +32,8 @@
     "gn_dbtranslation",
     "gn_multiselect",
     "gn_mdtypewidget",
-    "blueimp.fileupload"
+    "blueimp.fileupload",
+    "ngMessages"
   ]);
 
   /**

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1470,6 +1470,10 @@
     "es.url": "Elasticsearch server",
     "es.version": "Elasticsearch version",
     "es.index": "Index name",
-    "systemPropertiesProxyConfiguration": "Using http proxy settings in system properties."
+    "systemPropertiesProxyConfiguration": "Using http proxy settings in system properties.",
+    "fieldRequired": "The value is required",
+    "fieldTooLong": "The value is too long",
+    "fieldTooShort": "The value is too short",
+    "fieldEmailNotValid": "A valid email address is required"
 }
 

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1474,6 +1474,7 @@
     "fieldRequired": "The value is required",
     "fieldTooLong": "The value is too long",
     "fieldTooShort": "The value is too short",
-    "fieldEmailNotValid": "A valid email address is required"
+    "fieldEmailNotValid": "A valid email address is required",
+    "formConfirmExit": "The form has changes, if you exit the changes will be lost. Do you want to exit on the page?"
 }
 

--- a/web-ui/src/main/resources/catalog/templates/admin/usergroup/users.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/usergroup/users.html
@@ -172,8 +172,8 @@
                   data-ng-messages="gnUserEdit.username.$error"
                   data-ng-if="gnUserEdit.username.$touched"
                 >
-                  <p data-ng-message="maxlength">Username is too long.</p>
-                  <p data-ng-message="required">Username is required.</p>
+                  <p data-ng-message="maxlength" data-translate="">fieldTooLong</p>
+                  <p data-ng-message="required" data-translate="">fieldRequired</p>
                 </div>
                 <p
                   class="help-block"

--- a/web-ui/src/main/resources/catalog/templates/admin/usergroup/users.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/usergroup/users.html
@@ -117,6 +117,7 @@
           data-ng-keypress="updatingUser()"
           class="form-horizontal"
           role="form"
+          data-confirm-message="{{ 'formConfirmExit' | translate}}"
           data-confirm-on-exit=""
           novalidate=""
         >

--- a/web-ui/src/main/resources/catalog/templates/admin/usergroup/users.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/usergroup/users.html
@@ -117,6 +117,8 @@
           data-ng-keypress="updatingUser()"
           class="form-horizontal"
           role="form"
+          data-confirm-on-exit=""
+          novalidate=""
         >
           <input type="hidden" name="_csrf" value="{{csrf}}" />
           <fieldset>
@@ -142,7 +144,8 @@
 
             <div
               data-ng-class="gnUserEdit.username.$error.required ||
-                                gnUserEdit.username.$error.gnDuplicateCheck ? 'has-error' : ''"
+                             (gnUserEdit.username.$touched && gnUserEdit.username.$invalid) ||
+                             gnUserEdit.username.$error.gnDuplicateCheck ? 'has-error' : ''"
               class="form-group"
             >
               <label class="control-label col-sm-3" data-translate="">username</label>
@@ -160,9 +163,18 @@
                   data-gn-duplicate-check-apply="userOperation == 'newuser'"
                   data-gn-duplicate-check-remote="../api/users/properties/userid?exist={value}"
                   data-ng-disabled="!user.isUserAdminOrMore() || !isUserProfileUpdateEnabled"
+                  data-ng-maxlength="255"
+                  placeholder="{{'usernameHelp' | translate}}"
                   autocomplete="off"
                 />
-                <p class="help-block" data-translate="">usernameHelp</p>
+                <div
+                  class="help-block"
+                  data-ng-messages="gnUserEdit.username.$error"
+                  data-ng-if="gnUserEdit.username.$touched"
+                >
+                  <p data-ng-message="maxlength">Username is too long.</p>
+                  <p data-ng-message="required">Username is required.</p>
+                </div>
                 <p
                   class="help-block"
                   ng-if="gnUserEdit.username.$error.gnDuplicateCheck"
@@ -175,8 +187,10 @@
             <!-- Password are disabled when updating user -->
             <div ng-if="userOperation == 'newuser'">
               <div
-                data-ng-class="gnUserEdit.password.$error.required || gnUserEdit.password.$error.minlength ||
-                               gnUserEdit.password.$error.maxlength ||  gnUserEdit.password.$error.pattern ? 'has-error' : ''"
+                data-ng-class="gnUserEdit.password.$error.required ||
+                               gnUserEdit.password.$error.minlength ||
+                               gnUserEdit.password.$error.maxlength ||
+                               gnUserEdit.password.$error.pattern ? 'has-error' : ''"
                 class="form-group"
               >
                 <label class="control-label col-sm-3" data-translate="">password</label>
@@ -227,7 +241,7 @@
               </div>
               <div
                 data-ng-class="gnUserEdit.password.$valid == false ||
-                  (passwordCheck !== userSelected.password) ? 'has-error' : ''"
+                               (passwordCheck !== userSelected.password) ? 'has-error' : ''"
                 class="form-group"
               >
                 <label class="control-label col-sm-3" data-translate=""
@@ -262,7 +276,7 @@
               </div>
             </div>
             <div
-              data-ng-class="gnUserEdit.name.$error.required ? 'has-error' : ''"
+              data-ng-class="gnUserEdit.name.$touched && gnUserEdit.name.$invalid ? 'has-error' : ''"
               class="form-group"
             >
               <label class="control-label col-sm-3" data-translate="">name</label>
@@ -272,13 +286,22 @@
                   name="name"
                   class="form-control"
                   data-ng-model="userSelected.name"
+                  data-ng-maxlength="255"
                   data-ng-required="true"
                   data-ng-disabled="!isUserProfileUpdateEnabled"
                 />
+                <div
+                  class="help-block"
+                  data-ng-messages="gnUserEdit.name.$error"
+                  data-ng-if="gnUserEdit.name.$touched"
+                >
+                  <p data-ng-message="maxlength" data-translate="">fieldTooLong</p>
+                  <p data-ng-message="required" data-translate="">fieldRequired</p>
+                </div>
               </div>
             </div>
             <div
-              data-ng-class="userSelected.surname == '' ? 'has-error' : ''"
+              data-ng-class="gnUserEdit.surname.$touched && gnUserEdit.surname.$invalid ? 'has-error' : ''"
               class="form-group"
             >
               <label class="control-label col-sm-3" data-translate="">surname</label>
@@ -289,12 +312,21 @@
                   class="form-control"
                   data-ng-model="userSelected.surname"
                   data-ng-required=""
+                  data-ng-maxlength="255"
                   data-ng-disabled="!isUserProfileUpdateEnabled"
                 />
+                <div
+                  class="help-block"
+                  data-ng-messages="gnUserEdit.surname.$error"
+                  data-ng-if="gnUserEdit.surname.$touched"
+                >
+                  <p data-ng-message="maxlength" data-translate="">fieldTooLong</p>
+                  <p data-ng-message="required" data-translate="">fieldRequired</p>
+                </div>
               </div>
             </div>
             <div
-              data-ng-class="gnUserEdit.email.$error.email || gnUserEdit.email.$error.required ? 'has-error' : ''"
+              data-ng-class="gnUserEdit.email.$touched && gnUserEdit.email.$invalid ? 'has-error' : ''"
               class="form-group"
             >
               <label class="control-label col-sm-3" data-translate="">email</label>
@@ -305,12 +337,25 @@
                   class="form-control"
                   data-ng-model="userSelected.emailAddresses[0]"
                   data-ng-required="true"
+                  data-ng-maxlength="128"
                   data-ng-disabled="!isUserProfileUpdateEnabled"
                 />
+                <div
+                  class="help-block"
+                  data-ng-messages="gnUserEdit.email.$error"
+                  data-ng-if="gnUserEdit.email.$touched"
+                >
+                  <p data-ng-message="maxlength" data-translate="">fieldTooLong</p>
+                  <p data-ng-message="required" data-translate="">fieldRequired</p>
+                  <p data-ng-message="email" data-translate="">fieldEmailNotValid</p>
+                </div>
                 <p class="help-block" data-translate="">configureYourAvatar</p>
               </div>
             </div>
-            <div class="form-group">
+            <div
+              class="form-group"
+              data-ng-class="{ 'has-error': gnUserEdit.org.$touched && gnUserEdit.org.$invalid}"
+            >
               <label class="control-label col-sm-3" data-translate="">organisation</label>
               <!-- TODO : Add org list -->
               <div class="col-sm-9">
@@ -318,78 +363,121 @@
                   type="text"
                   name="org"
                   class="form-control"
+                  data-ng-maxlength="255"
                   data-ng-model="userSelected.organisation"
                   data-ng-disabled="!isUserProfileUpdateEnabled"
                 />
+                <div
+                  class="help-block"
+                  data-ng-messages="gnUserEdit.org.$error"
+                  data-ng-if="gnUserEdit.org.$touched"
+                >
+                  <p data-ng-message="maxlength" data-translate="">fieldTooLong</p>
+                </div>
               </div>
             </div>
 
             <fieldset>
               <legend data-translate="">address</legend>
 
-              <div class="form-group">
+              <div
+                class="form-group"
+                data-ng-class="{ 'has-error': gnUserEdit.address.$touched && gnUserEdit.address.$invalid}"
+              >
                 <label class="control-label col-sm-3" data-translate="">address</label>
                 <div class="col-sm-9">
                   <input
                     type="text"
                     name="address"
                     class="form-control"
+                    data-ng-maxlength="255"
                     data-ng-model="userSelected.addresses[0].address"
                     data-ng-disabled="!isUserProfileUpdateEnabled"
                   />
+                  <div class="help-block" data-ng-messages="gnUserEdit.address.$error">
+                    <p data-ng-message="maxlength" data-translate="">fieldTooLong</p>
+                  </div>
                 </div>
               </div>
 
-              <div class="form-group">
+              <div
+                class="form-group"
+                data-ng-class="{ 'has-error': gnUserEdit.zip.$touched && gnUserEdit.zip.$invalid}"
+              >
                 <label class="control-label col-sm-3" data-translate="">zip</label>
                 <div class="col-sm-9">
                   <input
                     type="text"
                     name="zip"
                     class="form-control"
+                    data-ng-maxlength="16"
                     data-ng-model="userSelected.addresses[0].zip"
                     data-ng-disabled="!isUserProfileUpdateEnabled"
                   />
+                  <div class="help-block" data-ng-messages="gnUserEdit.zip.$error">
+                    <p data-ng-message="maxlength" data-translate="">fieldTooLong</p>
+                  </div>
                 </div>
               </div>
 
-              <div class="form-group">
+              <div
+                class="form-group"
+                data-ng-class="{ 'has-error': gnUserEdit.state.$touched && gnUserEdit.state.$invalid}"
+              >
                 <label class="control-label col-sm-3" data-translate="">state</label>
                 <div class="col-sm-9">
                   <input
                     type="text"
                     name="state"
                     class="form-control"
+                    data-ng-maxlength="255"
                     data-ng-model="userSelected.addresses[0].state"
                     data-ng-disabled="!isUserProfileUpdateEnabled"
                   />
+                  <div class="help-block" data-ng-messages="gnUserEdit.state.$error">
+                    <p data-ng-message="maxlength" data-translate="">fieldTooLong</p>
+                  </div>
                 </div>
               </div>
 
-              <div class="form-group">
+              <div
+                class="form-group"
+                data-ng-class="{ 'has-error': gnUserEdit.city.$touched && gnUserEdit.city.$invalid}"
+              >
                 <label class="control-label col-sm-3" data-translate="">city</label>
                 <div class="col-sm-9">
                   <input
                     type="text"
                     name="city"
                     class="form-control"
+                    data-ng-maxlength="255"
                     data-ng-model="userSelected.addresses[0].city"
                     data-ng-disabled="!isUserProfileUpdateEnabled"
                   />
+                  <div data-ng-messages="gnUserEdit.city.$error">
+                    <p data-ng-message="maxlength" data-translate="fieldTooLong"></p>
+                  </div>
                 </div>
               </div>
 
-              <div class="form-group">
+              <div
+                class="form-group"
+                data-ng-class="{ 'has-error': gnUserEdit.country.$touched && gnUserEdit.country.$invalid}"
+              >
                 <label class="control-label col-sm-3" data-translate="">country</label>
                 <div class="col-sm-9">
                   <input
                     type="text"
                     name="country"
                     class="form-control"
+                    data-ng-maxlength="255"
                     data-ng-model="userSelected.addresses[0].country"
                     data-gn-country-picker=""
                     data-ng-disabled="!isUserProfileUpdateEnabled"
                   />
+                  <div data-ng-messages="gnUserEdit.country.$error">
+                    <p data-ng-message="maxlength" data-translate="">fieldTooLong</p>
+                  </div>
                 </div>
               </div>
             </fieldset>


### PR DESCRIPTION
Replace https://github.com/geonetwork/core-geonetwork/pull/3543 for main (fix conflicts, add missing translation)
Follow up of https://github.com/geonetwork/core-geonetwork/pull/7449


- Usage of `ng-messages` for validation errors, adding missing validations like maxlength.
- Added directive to check password/confirm passwords are equal in users form.
- Added directive to confirm exiting a form with changes.

Initial changes done for the users form to review. If looks fine the plan is to update other administration forms to unify the validation across all forms.

![with-changes](https://user-images.githubusercontent.com/1695003/52332539-32f5a400-29fb-11e9-8f7e-a8fa2f972bf2.png)


# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md
- [x] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
