### PR TITLE
Fix check to verify if a group has enabled the workflow, checking if the workflow is also enabled

### DIFF
--- a/core/src/main/java/org/fao/geonet/util/WorkflowUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/WorkflowUtil.java
@@ -33,6 +33,9 @@ import java.util.regex.Pattern;
 
 public class WorkflowUtil {
 
+    /**
+     * Avoid creation of new instances of this utility class making its constructor private.
+     */
     private WorkflowUtil() {
 
     }
@@ -41,13 +44,16 @@ public class WorkflowUtil {
      * Checks if the workflow is enabled and a group has the workflow enabled.
      *
      * @param groupName Group name
-     * @return
+     * @return {@code true} if the workflow is enabled and it has been enabled for all groups or the group name matches
+     * the regular expression in {@link Settings#METADATA_WORKFLOW_DRAFT_WHEN_IN_GROUP}. False otherwise.
      */
     public static boolean isGroupWithEnabledWorkflow(String groupName) {
         SettingManager settingManager = ApplicationContextHolder.get().getBean(SettingManager.class);
 
         boolean isWorkflowEnabled = settingManager.getValueAsBool(Settings.METADATA_WORKFLOW_ENABLE);
-        if (!isWorkflowEnabled) return false;
+        if (!isWorkflowEnabled) {
+            return false;
+        }
 
         String groupMatchingRegex = settingManager.getValue(Settings.METADATA_WORKFLOW_DRAFT_WHEN_IN_GROUP);
 

--- a/core/src/main/java/org/fao/geonet/util/WorkflowUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/WorkflowUtil.java
@@ -1,29 +1,25 @@
-//=============================================================================
-//===
-//=== ThreadUtils
-//===
-//=============================================================================
-//===	Copyright (C) 2001-2007 Food and Agriculture Organization of the
-//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
-//===	and United Nations Environment Programme (UNEP)
-//===
-//===	This program is free software; you can redistribute it and/or modify
-//===	it under the terms of the GNU General Public License as published by
-//===	the Free Software Foundation; either version 2 of the License, or (at
-//===	your option) any later version.
-//===
-//===	This program is distributed in the hope that it will be useful, but
-//===	WITHOUT ANY WARRANTY; without even the implied warranty of
-//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
-//===	General Public License for more details.
-//===
-//===	You should have received a copy of the GNU General Public License
-//===	along with this program; if not, write to the Free Software
-//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
-//===
-//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
-//===	Rome - Italy. email: geonetwork@osgeo.org
-//=============================================================================
+/*
+ * Copyright (C) 2001-2023 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
 
 package org.fao.geonet.util;
 
@@ -37,14 +33,21 @@ import java.util.regex.Pattern;
 
 public class WorkflowUtil {
 
+    private WorkflowUtil() {
+
+    }
+
     /**
-     * Checks if a group has the workflow enabled.
+     * Checks if the workflow is enabled and a group has the workflow enabled.
      *
      * @param groupName Group name
      * @return
      */
     public static boolean isGroupWithEnabledWorkflow(String groupName) {
         SettingManager settingManager = ApplicationContextHolder.get().getBean(SettingManager.class);
+
+        boolean isWorkflowEnabled = settingManager.getValueAsBool(Settings.METADATA_WORKFLOW_ENABLE);
+        if (!isWorkflowEnabled) return false;
 
         String groupMatchingRegex = settingManager.getValue(Settings.METADATA_WORKFLOW_DRAFT_WHEN_IN_GROUP);
 
@@ -56,7 +59,4 @@ public class WorkflowUtil {
             return false;
         }
     }
-
-
-
 }

--- a/core/src/test/java/org/fao/geonet/util/WorkflowUtilTest.java
+++ b/core/src/test/java/org/fao/geonet/util/WorkflowUtilTest.java
@@ -29,7 +29,7 @@ import org.fao.geonet.kernel.setting.Settings;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.*;
 
 public class WorkflowUtilTest extends AbstractCoreIntegrationTest {
     @Autowired
@@ -38,30 +38,47 @@ public class WorkflowUtilTest extends AbstractCoreIntegrationTest {
     @Test
     public void testWorkflowDisabled() {
         settingManager.setValue(Settings.METADATA_WORKFLOW_ENABLE, false);
-        assertEquals(false, WorkflowUtil.isGroupWithEnabledWorkflow("sample"));
+        assertFalse(WorkflowUtil.isGroupWithEnabledWorkflow("sample"));
+    }
+
+    @Test
+    public void testWorkflowDisabledAndEnabledAllGroups() {
+        settingManager.setValue(Settings.METADATA_WORKFLOW_ENABLE, false);
+        settingManager.setValue(Settings.METADATA_WORKFLOW_DRAFT_WHEN_IN_GROUP, ".*");
+        assertFalse(WorkflowUtil.isGroupWithEnabledWorkflow("sample"));
+    }
+
+    @Test
+    public void testWorkflowDisabledAndEnabledInGroupList() {
+        settingManager.setValue(Settings.METADATA_WORKFLOW_ENABLE, false);
+        settingManager.setValue(Settings.METADATA_WORKFLOW_DRAFT_WHEN_IN_GROUP, "sample|test");
+        assertFalse(WorkflowUtil.isGroupWithEnabledWorkflow("sample"));
+
+        settingManager.setValue(Settings.METADATA_WORKFLOW_DRAFT_WHEN_IN_GROUP, "sam*|test");
+        assertFalse(WorkflowUtil.isGroupWithEnabledWorkflow("sample"));
     }
 
     @Test
     public void testWorkflowEnabledAllGroups() {
         settingManager.setValue(Settings.METADATA_WORKFLOW_ENABLE, true);
         settingManager.setValue(Settings.METADATA_WORKFLOW_DRAFT_WHEN_IN_GROUP, ".*");
-        assertEquals(true, WorkflowUtil.isGroupWithEnabledWorkflow("sample"));
+        assertTrue(WorkflowUtil.isGroupWithEnabledWorkflow("sample"));
     }
 
     @Test
     public void testWorkflowEnabledInGroupList() {
         settingManager.setValue(Settings.METADATA_WORKFLOW_ENABLE, true);
         settingManager.setValue(Settings.METADATA_WORKFLOW_DRAFT_WHEN_IN_GROUP, "sample|test");
-        assertEquals(true, WorkflowUtil.isGroupWithEnabledWorkflow("sample"));
+        assertTrue(WorkflowUtil.isGroupWithEnabledWorkflow("sample"));
 
         settingManager.setValue(Settings.METADATA_WORKFLOW_DRAFT_WHEN_IN_GROUP, "sam*|test");
-        assertEquals(true, WorkflowUtil.isGroupWithEnabledWorkflow("sample"));
+        assertTrue(WorkflowUtil.isGroupWithEnabledWorkflow("sample"));
     }
 
     @Test
     public void testWorkflowEnabledNotInGroupList() {
         settingManager.setValue(Settings.METADATA_WORKFLOW_ENABLE, true);
         settingManager.setValue(Settings.METADATA_WORKFLOW_DRAFT_WHEN_IN_GROUP, "test");
-        assertEquals(false, WorkflowUtil.isGroupWithEnabledWorkflow("sample"));
+        assertFalse(WorkflowUtil.isGroupWithEnabledWorkflow("sample"));
     }
 }

--- a/core/src/test/java/org/fao/geonet/util/WorkflowUtilTest.java
+++ b/core/src/test/java/org/fao/geonet/util/WorkflowUtilTest.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2001-2023 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+package org.fao.geonet.util;
+
+import org.fao.geonet.AbstractCoreIntegrationTest;
+import org.fao.geonet.kernel.setting.SettingManager;
+import org.fao.geonet.kernel.setting.Settings;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static org.junit.Assert.assertEquals;
+
+public class WorkflowUtilTest extends AbstractCoreIntegrationTest {
+    @Autowired
+    SettingManager settingManager;
+
+    @Test
+    public void testWorkflowDisabled() {
+        settingManager.setValue(Settings.METADATA_WORKFLOW_ENABLE, false);
+        assertEquals(false, WorkflowUtil.isGroupWithEnabledWorkflow("sample"));
+    }
+
+    @Test
+    public void testWorkflowEnabledAllGroups() {
+        settingManager.setValue(Settings.METADATA_WORKFLOW_ENABLE, true);
+        settingManager.setValue(Settings.METADATA_WORKFLOW_DRAFT_WHEN_IN_GROUP, ".*");
+        assertEquals(true, WorkflowUtil.isGroupWithEnabledWorkflow("sample"));
+    }
+
+    @Test
+    public void testWorkflowEnabledInGroupList() {
+        settingManager.setValue(Settings.METADATA_WORKFLOW_ENABLE, true);
+        settingManager.setValue(Settings.METADATA_WORKFLOW_DRAFT_WHEN_IN_GROUP, "sample|test");
+        assertEquals(true, WorkflowUtil.isGroupWithEnabledWorkflow("sample"));
+
+        settingManager.setValue(Settings.METADATA_WORKFLOW_DRAFT_WHEN_IN_GROUP, "sam*|test");
+        assertEquals(true, WorkflowUtil.isGroupWithEnabledWorkflow("sample"));
+    }
+
+    @Test
+    public void testWorkflowEnabledNotInGroupList() {
+        settingManager.setValue(Settings.METADATA_WORKFLOW_ENABLE, true);
+        settingManager.setValue(Settings.METADATA_WORKFLOW_DRAFT_WHEN_IN_GROUP, "test");
+        assertEquals(false, WorkflowUtil.isGroupWithEnabledWorkflow("sample"));
+    }
+}


### PR DESCRIPTION
Test case:

With the workflow disabled.

1. Enable the metadata history in the System Settings

![history-setting](https://github.com/geonetwork/core-geonetwork/assets/1695003/bb2049d1-674d-4712-9909-5bfe922efa2d)

2. Create a new metadata
3. Go to the history page, no workflow events listed --> OK

![history-events-1](https://github.com/geonetwork/core-geonetwork/assets/1695003/7e983134-a43b-4980-b6d8-fd68fad05b36)

4. Publish the metadata
5. Go to the history page, **without the change** workflow events listed --> NO OK

![history-events-2](https://github.com/geonetwork/core-geonetwork/assets/1695003/09a8a010-a2a6-4665-875c-d50a03c963a9)

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [X] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
