### PR TITLE
Add icon to static pages, configurable

### DIFF
--- a/domain/src/main/java/org/fao/geonet/domain/page/Page.java
+++ b/domain/src/main/java/org/fao/geonet/domain/page/Page.java
@@ -58,12 +58,13 @@ public class Page extends GeonetEntity implements Serializable {
     private PageStatus status;
 
     private String label;
+    private String icon;
 
     public Page() {
 
     }
 
-    public Page(PageIdentity pageIdentity, byte[] data, String link, PageFormat format, List<PageSection> sections, PageStatus status, String label) {
+    public Page(PageIdentity pageIdentity, byte[] data, String link, PageFormat format, List<PageSection> sections, PageStatus status, String label, String icon) {
         super();
         this.pageIdentity = pageIdentity;
         this.data = data;
@@ -72,6 +73,7 @@ public class Page extends GeonetEntity implements Serializable {
         this.sections = sections;
         this.status = status;
         this.label = label;
+        this.icon = icon;
     }
 
     public enum PageStatus {
@@ -139,6 +141,11 @@ public class Page extends GeonetEntity implements Serializable {
         return label;
     }
 
+    @Column
+    public String getIcon() {
+        return icon;
+    }
+
     public void setPageIdentity(PageIdentity pageIdentity) {
         this.pageIdentity = pageIdentity;
     }
@@ -165,6 +172,10 @@ public class Page extends GeonetEntity implements Serializable {
 
     public void setLabel(String label) {
         this.label = label;
+    }
+
+    public void setIcon(String icon) {
+        this.icon = icon;
     }
 
     @Override

--- a/services/src/main/java/org/fao/geonet/api/pages/PageProperties.java
+++ b/services/src/main/java/org/fao/geonet/api/pages/PageProperties.java
@@ -19,6 +19,7 @@ public class PageProperties implements Serializable {
     private String link;
     private String content;
     private String label;
+    private String icon;
     private Page.PageFormat format;
     private Page page;
 
@@ -34,6 +35,7 @@ public class PageProperties implements Serializable {
         sections = p.getSections();
         status = p.getStatus();
         label = p.getLabel();
+        icon = p.getIcon();
     }
 
     @Override
@@ -103,5 +105,13 @@ public class PageProperties implements Serializable {
 
     public void setLabel(String label) {
         this.label = label;
+    }
+
+    public String getIcon() {
+        return icon;
+    }
+
+    public void setIcon(String icon) {
+        this.icon = icon;
     }
 }

--- a/services/src/main/java/org/fao/geonet/api/pages/PagesAPI.java
+++ b/services/src/main/java/org/fao/geonet/api/pages/PagesAPI.java
@@ -172,8 +172,8 @@ public class PagesAPI {
 
         Optional<Page> page = pageRepository.findById(new PageIdentity(language, pageId));
 
-        if (!page.isPresent()) {
-            Page newPage = getEmptyHiddenDraftPage(pageProperties.getLanguage(), pageProperties.getPageId(), pageProperties.getLabel(), format);
+        if (page.isEmpty()) {
+            Page newPage = getEmptyHiddenDraftPage(pageProperties.getLanguage(), pageProperties.getPageId(), pageProperties.getLabel(), pageProperties.getIcon(), format);
             fillContent(data, link, content, newPage);
 
             if (section != null) {
@@ -201,6 +201,7 @@ public class PagesAPI {
         String newPageId = pageProperties.getPageId();
         Page.PageFormat format = pageProperties.getFormat();
         String newLabel = pageProperties.getLabel();
+        String newIcon = pageProperties.getIcon();
 
         checkValidLanguage(language);
 
@@ -214,7 +215,7 @@ public class PagesAPI {
 
         Optional<Page> page = pageRepository.findById(new PageIdentity(language, pageId));
 
-        if (!page.isPresent()) {
+        if (page.isEmpty()) {
             throw new ResourceNotFoundException("Can't update non existing page " + pageId + ".");
         }
         Page pageToUpdate = page.get();
@@ -238,7 +239,8 @@ public class PagesAPI {
                 format != null ? format : pageToUpdate.getFormat(),
                 pageProperties.getSections() != null ? pageProperties.getSections() : pageToUpdate.getSections(),
                 pageProperties.getStatus() != null ? pageProperties.getStatus() : pageToUpdate.getStatus(),
-                newLabel != null ? newLabel : pageToUpdate.getLabel());
+                newLabel != null ? newLabel : pageToUpdate.getLabel(),
+                newIcon != null ? newIcon : pageToUpdate.getIcon());
 
             pageRepository.save(pageCopy);
             pageRepository.delete(pageToUpdate);
@@ -248,6 +250,7 @@ public class PagesAPI {
             pageToUpdate.setSections(pageProperties.getSections() != null ? pageProperties.getSections() : pageToUpdate.getSections());
             pageToUpdate.setStatus(pageProperties.getStatus() != null ? pageProperties.getStatus() : pageToUpdate.getStatus());
             pageToUpdate.setLabel(newLabel);
+            pageToUpdate.setIcon(newIcon);
             pageRepository.save(pageToUpdate);
         }
 
@@ -339,7 +342,7 @@ public class PagesAPI {
 
         final Optional<Page> page = pageRepository.findById(new PageIdentity(language, pageId));
 
-        if (!page.isPresent()) {
+        if (page.isEmpty()) {
             return ResponseEntity.notFound().build();
         }
 
@@ -522,7 +525,7 @@ public class PagesAPI {
         throws ResourceNotFoundException {
         final Optional<Page> page = pageRepository.findById(new PageIdentity(language, pageId));
 
-        if (!page.isPresent()) {
+        if (page.isEmpty()) {
             throw new ResourceNotFoundException("Page " + pageId + " not found");
         }
         return page.get();
@@ -531,9 +534,9 @@ public class PagesAPI {
     /**
      * @return An empty hidden draft Page
      */
-    protected Page getEmptyHiddenDraftPage(final String language, final String pageId, final String label, final Page.PageFormat format) {
+    protected Page getEmptyHiddenDraftPage(final String language, final String pageId, final String label, final String icon, final Page.PageFormat format) {
         final List<Page.PageSection> sections = new ArrayList<>();
-        return new Page(new PageIdentity(language, pageId), null, null, format, sections, Page.PageStatus.HIDDEN, label);
+        return new Page(new PageIdentity(language, pageId), null, null, format, sections, Page.PageStatus.HIDDEN, label, icon);
     }
 
     /**

--- a/services/src/test/java/org/fao/geonet/api/pages/PagesApiTest.java
+++ b/services/src/test/java/org/fao/geonet/api/pages/PagesApiTest.java
@@ -109,6 +109,7 @@ public class PagesApiTest extends AbstractServiceIntegrationTest {
         newPage.setPageId(pageId);
         newPage.setLink(link + "updated");
         newPage.setLabel(pageId + "updated");
+        newPage.setIcon("dummy-icon");
         newPage.getSections().add(Page.PageSection.FOOTER);
         MockHttpServletRequestBuilder updatePageBuilder = put("/srv/api/pages/eng/license")
             .content(gson.toJson(newPage))
@@ -123,6 +124,7 @@ public class PagesApiTest extends AbstractServiceIntegrationTest {
         Assert.assertTrue(page.isPresent());
         Assert.assertEquals(link + "updated", page.get().getLink());
         Assert.assertEquals(pageId + "updated", page.get().getLabel());
+        Assert.assertEquals("dummy-icon", page.get().getIcon());
         Assert.assertTrue(page.get().getSections().contains(Page.PageSection.TOP));
         Assert.assertTrue(page.get().getSections().contains(Page.PageSection.FOOTER));
 

--- a/web-ui/src/main/resources/catalog/components/pages/partials/menu-page.html
+++ b/web-ui/src/main/resources/catalog/components/pages/partials/menu-page.html
@@ -7,6 +7,10 @@
     aria-haspopup="true"
     aria-expanded="true"
   >
+    <span
+      data-ng-show="page.icon && page.icon.length > 0"
+      class="fa fa-fw {{page.icon}}"
+    ></span>
     <span>{{page.label}}</span>
     <span class="caret hidden-xs"></span>
   </a>
@@ -23,6 +27,10 @@
         href="{{page.link}}"
         target="{{page.link.indexOf('http') === 0 ? '_blank' : '_self'}}"
       >
+        <span
+          data-ng-show="page.icon && page.icon.length > 0"
+          class="fa fa-fw {{page.icon}}"
+        ></span>
         <span>{{page.label}}</span>
       </a>
       <a
@@ -31,6 +39,10 @@
         title="{{page.pageId}}"
         data-ng-click="changePage($event)"
       >
+        <span
+          data-ng-show="page.icon && page.icon.length > 0"
+          class="fa fa-fw {{page.icon}}"
+        ></span>
         <span>{{page.label}}</span>
       </a>
     </li>
@@ -42,6 +54,10 @@
     href="{{page.link}}"
     target="_blank"
   >
+    <span
+      data-ng-show="page.icon && page.icon.length > 0"
+      class="fa fa-fw {{page.icon}}"
+    ></span>
     <span>{{page.label}}</span>
   </a>
   <a
@@ -51,6 +67,10 @@
     title="{{page.pageId}}"
     data-ng-click="changePage($event)"
   >
+    <span
+      data-ng-show="page.icon && page.icon.length > 0"
+      class="fa fa-fw {{page.icon}}"
+    ></span>
     <span>{{page.label}}</span>
   </a>
 </li>

--- a/web-ui/src/main/resources/catalog/locales/en-v4.json
+++ b/web-ui/src/main/resources/catalog/locales/en-v4.json
@@ -293,6 +293,8 @@
   "pageContent": "Page content",
   "pageContentFile": "Page content file",
   "pageLabel": "Page label",
+  "pageIcon": "Page icon",
+  "pageIcon-help": "Optionally, define a <a target='_blank' href='https://fontawesome.com/v4/icons/'>font-awesome icon</a>. Example: 'fa-wrench'.",
   "pageSection": "Page section",
   "pageApiLink": "Page API link",
   "uiRestorePrevious": "Restore last saved",

--- a/web-ui/src/main/resources/catalog/templates/admin/settings/static-pages.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/settings/static-pages.html
@@ -144,6 +144,23 @@
           </div>
 
           <div class="form-group">
+            <label class="control-label col-sm-3" data-translate="">pageIcon</label>
+
+            <div class="col-sm-9">
+              <input
+                type="text"
+                name="label"
+                class="form-control"
+                data-ng-model="staticPageSelected.icon"
+              />
+            </div>
+
+            <div class="col-sm-9 col-sm-offset-3">
+              <p class="help-block ng-scope" data-translate="">pageIcon-help</p>
+            </div>
+          </div>
+
+          <div class="form-group">
             <label class="control-label col-sm-3" data-translate="">format</label>
 
             <div class="col-sm-9">

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v442/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v442/migrate-default.sql
@@ -1,2 +1,4 @@
 UPDATE Settings SET value='4.4.2' WHERE name='system/platform/version';
 UPDATE Settings SET value='SNAPSHOT' WHERE name='system/platform/subVersion';
+
+ALTER TABLE public.spg_page ADD icon varchar NULL;


### PR DESCRIPTION
Added a configurable icon to the static pages. The icon is not shown when not supplied. Added help text indicating it needs to be a font-awesome icon.

![image](https://github.com/geonetwork/core-geonetwork/assets/11455912/044f27e0-1252-425d-ae98-a1c71f3642f3)
![image](https://github.com/geonetwork/core-geonetwork/assets/11455912/e9824d80-105c-446c-88f7-ecadf409df50)

@fxprunayre not sure what happens for submenus - the context leads me to believe only top / footer items are allowed for now, and that seems to work fine on my end.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
