### PR TITLE
Elasticsearch index creation - log the exception when a parsing error of the index configuration file occurs

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/search/EsSearchManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/EsSearchManager.java
@@ -35,6 +35,7 @@ import jeeves.server.UserSession;
 import jeeves.server.context.ServiceContext;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
+import org.elasticsearch.ElasticsearchParseException;
 import org.elasticsearch.action.ActionListener;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
 import org.elasticsearch.action.bulk.BulkRequest;
@@ -271,11 +272,11 @@ public class EsSearchManager implements ISearchManager {
                 DeleteIndexRequest request = new DeleteIndexRequest(indexName);
                 AcknowledgedResponse deleteIndexResponse = client.getClient().indices().delete(request, RequestOptions.DEFAULT);
                 if (deleteIndexResponse.isAcknowledged()) {
-                    LOGGER.debug("Index '{}' removed.", new Object[]{indexName});
+                    LOGGER.debug("Index '{}' removed.", indexName);
                 }
             } catch (Exception e) {
                 // index does not exist ?
-                LOGGER.debug("Error during index '{}' removal. Error is: {}", new Object[]{indexName, e.getMessage()});
+                LOGGER.debug("Error during index '{}' removal. Error is: {}", indexName, e.getMessage());
             }
         }
 
@@ -304,7 +305,7 @@ public class EsSearchManager implements ISearchManager {
                     CreateIndexResponse createIndexResponse = client.getClient().indices().create(createIndexRequest, RequestOptions.DEFAULT);
 
                     if (createIndexResponse.isAcknowledged()) {
-                        LOGGER.debug("Index '{}' created", new Object[]{indexName});
+                        LOGGER.debug("Index '{}' created", indexName);
                     } else {
                         final String message = String.format("Index '%s' was not created. Error is: %s", indexName, createIndexResponse.toString());
                         LOGGER.error(message);
@@ -317,10 +318,13 @@ public class EsSearchManager implements ISearchManager {
                         indexName));
                 }
             }
+        } catch (ElasticsearchParseException ex) {
+            LOGGER.error(ex.getMessage(), ex);
+            throw new IOException(ex.getMessage());
         } catch (Exception cnce) {
             final String message = String.format("Could not connect to index '%s'. Error is %s. Is the index server  up and running?",
                 defaultIndex, cnce.getMessage());
-            LOGGER.error(message);
+            LOGGER.error(message, cnce);
             throw new IOException(message);
         }
     }
@@ -444,7 +448,7 @@ public class EsSearchManager implements ISearchManager {
             } catch (Exception e) {
                 LOGGER.error(
                     "An error occurred while indexing {} documents in current indexing list. Error is {}.",
-                    new Object[]{listOfDocumentsToIndex.size(), e.getMessage()});
+                        listOfDocumentsToIndex.size(), e.getMessage());
             } finally {
                 // TODO: Trigger this async ?
                 documents.keySet().forEach(uuid -> overviewFieldUpdater.process(uuid));
@@ -489,14 +493,14 @@ public class EsSearchManager implements ISearchManager {
                     // TODO: Report the JSON which was causing the error ?
 
                     LOGGER.error("Document with error #{}: {}.",
-                        new Object[]{e.getId(), e.getFailureMessage()});
+                            e.getId(), e.getFailureMessage());
                     LOGGER.error(failureDoc);
 
                     try {
                         listErrorOfDocumentsToIndex.put(e.getId(), mapper.writeValueAsString(docWithErrorInfo));
                     } catch (JsonProcessingException e1) {
                         LOGGER.error("Generated document for the index is not properly formatted. Check document #{}: {}.",
-                            new Object[]{e.getId(), e1.getMessage()});
+                                e.getId(), e1.getMessage());
                     }
                 }
             });
@@ -505,7 +509,7 @@ public class EsSearchManager implements ISearchManager {
                 BulkResponse response = client.bulkRequest(defaultIndex, listErrorOfDocumentsToIndex);
                 if (response.status().getStatus() != 201) {
                     LOGGER.error("Failed to save error documents {}.",
-                        new Object[]{Arrays.toString(errorDocumentIds.toArray())});
+                            Arrays.toString(errorDocumentIds.toArray()));
                 }
             }
         }
@@ -638,7 +642,7 @@ public class EsSearchManager implements ISearchManager {
                                 mapper.readTree(node.getText()));
                         } catch (IOException e) {
                             LOGGER.error("Parsing invalid JSON node {} for property {}. Error is: {}",
-                                new Object[]{node.getTextNormalize(), propertyName, e.getMessage()});
+                                    node.getTextNormalize(), propertyName, e.getMessage());
                         }
                     } else {
                         arrayNode.add(
@@ -657,7 +661,7 @@ public class EsSearchManager implements ISearchManager {
                     doc.set("geom", mapper.readTree(nodeElements.get(0).getTextNormalize()));
                 } catch (IOException e) {
                     LOGGER.error("Parsing invalid geometry for JSON node {}. Error is: {}",
-                        new Object[]{nodeElements.get(0).getTextNormalize(), e.getMessage()});
+                            nodeElements.get(0).getTextNormalize(), e.getMessage());
                 }
                 continue;
             }
@@ -670,7 +674,7 @@ public class EsSearchManager implements ISearchManager {
                         ));
                 } catch (IOException e) {
                     LOGGER.error("Parsing invalid JSON node {} for property {}. Error is: {}",
-                        new Object[]{nodeElements.get(0).getTextNormalize(), propertyName, e.getMessage()});
+                            nodeElements.get(0).getTextNormalize(), propertyName, e.getMessage());
                 }
             } else {
                 doc.put(propertyName,


### PR DESCRIPTION
Currently when a parsing error of the Elasticsearch index configuration happens, the following entry is added in the log file:

```
2023-12-06T10:59:01,750 ERROR [geonetwork.index] - Could not connect to index 'gn-records'. Error is Failed to parse content to map. Is the index server  up and running?
```

Informs about a parsing error, but no further details.

This change logs the exception, that contains details about the location of the error in the configuration file, useful to fix the issue:

```
2023-12-06T10:59:01,750 ERROR [geonetwork.index] - Could not connect to index 'gn-records'. Error is Failed to parse content to map. Is the index server  up and running?
org.elasticsearch.ElasticsearchParseException: Failed to parse content to map
...
Caused by: com.fasterxml.jackson.core.JsonParseException: Unexpected character (',' (code 44)): expected a value
 at [Source: (ByteArrayInputStream); line: 1081, column: 45]
	at com.fasterxml.jackson.core.JsonParser._constructError(JsonParser.java:2477) ~[jackson-core-2.15.3.jar:2.15.3]
	at com.fasterxml.jackson.core.base.ParserMinimalBase._reportError(ParserMinimalBase.java:750) ~[jackson-core-2.15.3.jar:2.15.3]
	at com.fasterxml.jackson.core.base.ParserMinimalBase._reportUnexpectedChar(ParserMinimalBase.java:674) ~[jackson-core-2.15.3.jar:2.15.3]
```

Includes Sonarlint improvements.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
