### PR TITLE
Harvesters without owner > cryptic parse exception

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
@@ -529,7 +529,7 @@ public class Aligner extends BaseAligner<CswParams> {
             try {
                 Integer groupIdVal = null;
                 if (StringUtils.isNotEmpty(params.getOwnerIdGroup())) {
-                    groupIdVal = Integer.parseInt(params.getOwnerIdGroup());
+                    groupIdVal = getGroupOwner();
                 }
 
                 params.getValidate().validate(dataMan, context, response, groupIdVal);

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geoPREST/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geoPREST/Aligner.java
@@ -291,7 +291,7 @@ public class Aligner extends BaseAligner<GeoPRESTParams> {
             try {
                 Integer groupIdVal = null;
                 if (StringUtils.isNotEmpty(params.getOwnerIdGroup())) {
-                    groupIdVal = Integer.parseInt(params.getOwnerIdGroup());
+                    groupIdVal = getGroupOwner();
                 }
 
                 params.getValidate().validate(dataMan, context, response, groupIdVal);

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Aligner.java
@@ -465,7 +465,7 @@ public class Aligner extends BaseAligner<GeonetParams> {
         try {
             Integer groupIdVal = null;
             if (StringUtils.isNotEmpty(params.getOwnerIdGroup())) {
-                groupIdVal = Integer.parseInt(params.getOwnerIdGroup());
+                groupIdVal = getGroupOwner();
             }
 
             params.getValidate().validate(dataMan, context, md, groupIdVal);
@@ -746,7 +746,7 @@ public class Aligner extends BaseAligner<GeonetParams> {
         try {
             Integer groupIdVal = null;
             if (StringUtils.isNotEmpty(params.getOwnerIdGroup())) {
-                groupIdVal = Integer.parseInt(params.getOwnerIdGroup());
+                groupIdVal = getGroupOwner();
             }
 
             params.getValidate().validate(dataMan, context, md, groupIdVal);

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet20/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet20/Aligner.java
@@ -369,7 +369,7 @@ public class Aligner extends AbstractAligner<GeonetParams> {
             try {
                 Integer groupIdVal = null;
                 if (StringUtils.isNotEmpty(params.getOwnerIdGroup())) {
-                    groupIdVal = Integer.parseInt(params.getOwnerIdGroup());
+                    groupIdVal = getGroupOwner();
                 }
 
                 params.getValidate().validate(dataMan, context, md, groupIdVal);

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/oaipmh/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/oaipmh/Harvester.java
@@ -472,7 +472,7 @@ class Harvester extends BaseAligner<OaiPmhParams> implements IHarvester<HarvestR
                 try {
                     Integer groupIdVal = null;
                     if (StringUtils.isNotEmpty(params.getOwnerIdGroup())) {
-                        groupIdVal = Integer.parseInt(params.getOwnerIdGroup());
+                        groupIdVal = getGroupOwner();
                     }
 
                     params.getValidate().validate(dataMan, context, md, groupIdVal);

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/webdav/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/webdav/Harvester.java
@@ -351,7 +351,7 @@ class Harvester extends BaseAligner<WebDavParams> implements IHarvester<HarvestR
             try {
                 Integer groupIdVal = null;
                 if (StringUtils.isNotEmpty(params.getOwnerIdGroup())) {
-                    groupIdVal = Integer.parseInt(params.getOwnerIdGroup());
+                    groupIdVal = getGroupOwner();
                 }
 
                 params.getValidate().validate(dataMan, context, md, groupIdVal);


### PR DESCRIPTION
I was setting up harvesters and noticed that, when not setting the groupOwner and owner, I received a cryptic error after the harvester finished.
![image](https://github.com/geonetwork/core-geonetwork/assets/11455912/d1c7e87f-a5c0-4c26-bb24-dedbd79b6920)

Turns out, a nullpointer was created due to the groupOwner being passed as 'undefined', eventually resulting in a null list of UUID's.
![image](https://github.com/geonetwork/core-geonetwork/assets/11455912/41e28935-d44a-4bd6-bbff-66d12d3ab575)

Apart from a durable fix I modified the parameter parsing of the groupOwner (making use of a pre-existing method, present in the aligner), making it at least not fail anymore.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md
- [x] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
