### PR TITLE
Avoid race condition, resize map once target size ok

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/openlayers/olMapDirective.js
+++ b/web-ui/src/main/resources/catalog/components/common/openlayers/olMapDirective.js
@@ -66,6 +66,14 @@
           });
 
           map.setTarget(target);
+          var target = element[0];
+
+          var resizeObserver = new ResizeObserver(function() {
+            map.updateSize();
+            resizeObserver.unobserve(target);
+          });
+
+          map.setTarget(target);
           resizeObserver.observe(target);
         }
     };


### PR DESCRIPTION
<!--Include a few sentences describing the overall goals for this Pull Request-->

Used to optimize resize when entering is done.

  Solves wrong centering of bbox.
![image](https://github.com/geonetwork/core-geonetwork/assets/39771412/045b7da3-9437-4e29-9f95-7f258ffe28e6)


<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
