### PR TITLE
Add ownerId to geonet:info

### DIFF
--- a/core/src/main/java/org/fao/geonet/constants/Edit.java
+++ b/core/src/main/java/org/fao/geonet/constants/Edit.java
@@ -74,6 +74,7 @@ public final class Edit {
             public static final String TITLE = "title";
             public static final String IS_HARVESTED = "isHarvested";
             public static final String HARVEST_INFO = "harvestInfo";
+            public static final String OWNERID = "ownerId";
             public static final String OWNERNAME = "ownername";
             public static final String GROUPOWNERNAME = "groupOwnerName";
             public static final String POPULARITY = "popularity";

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
@@ -867,6 +867,7 @@ public class BaseMetadataManager implements IMetadataManager {
         // add owner name
         java.util.Optional<User> user = userRepository.findById(Integer.parseInt(owner));
         if (user.isPresent()) {
+            addElement(info, Edit.Info.Elem.OWNERID, user.get().getId());
             String ownerName = user.get().getName();
             addElement(info, Edit.Info.Elem.OWNERNAME, ownerName);
         }


### PR DESCRIPTION
Add ownerId to geonet:info
It is a more reliable way to identify the exact user since the owername is not a reliable way to connect the metadata record to the user.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
