### PR TITLE
Fix Danish lang missing metadata number counter on front-page

### DIFF
--- a/web-ui/src/main/resources/catalog/locales/da-search.json
+++ b/web-ui/src/main/resources/catalog/locales/da-search.json
@@ -163,7 +163,7 @@
     "exportPDF": "Eksport (PDF)",
     "exportMEF": "Eksport (ZIP)",
     "welcomeText": "Her finder du data, tjenester og kort og meget mere.",
-    "searchOver": "Søg i <strong>{{poster}}</strong>, data sæt, tjenester og kort, ... ",
+    "searchOver": "Søg i <strong>{{records}}</strong>, data sæt, tjenester og kort, ... ",
     "browseBy": "Gennemse efter",
     "browseTopics": "Gennemse emner",
     "browseTypes": "Gennemse ressourcer",


### PR DESCRIPTION
Selecting Danish language, the metadata number count is gone from the search-window on the front-page.
It should be {{records}} not {{poster}} 

# Checklist

- [ x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md
- [ x] *Pull request* provided for `main` branch, backports managed with label
- [ x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
