### PR TITLE
Typo in config preventing conversion of config property string to integer.

### DIFF
--- a/core/src/main/resources/config-spring-geonetwork.xml
+++ b/core/src/main/resources/config-spring-geonetwork.xml
@@ -55,7 +55,7 @@
         lazy-init="true"/>
 
   <bean id="ThesaurusManager" class="org.fao.geonet.kernel.ThesaurusManager" lazy-init="true">
-    <property name="thesaurusCacheMaxSize" value="\${thesaurus.cache.maxsize}"/>
+    <property name="thesaurusCacheMaxSize" value="${thesaurus.cache.maxsize}"/>
   </bean>
 
   <util:list id="allThesaurusExclude">


### PR DESCRIPTION

while trying to run some tests, the following error occured:
```
Caused by: org.springframework.beans.TypeMismatchException: Failed to convert property value of type 'java.lang.String' to required type 'int' for property 'thesaurusCacheMaxSize'; nested exception is java.lang.NumberFormatException: For input string: "\400000"
```

This point to the config-spring-geonetwork.xml configuration mapping which contains the following line:
```
 <property name="thesaurusCacheMaxSize" value="\${thesaurus.cache.maxsize}"/>
```
removing the '\\' character which was preventing the conversion to an integer value.
```
 <property name="thesaurusCacheMaxSize" value="${thesaurus.cache.maxsize}"/>
```
