### PR TITLE
Overview not shown in PDF export when the overview image is stored in GeoNetwork and requires authentication to access it.

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/formatters/ImageReplacedElementFactory.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/ImageReplacedElementFactory.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2023 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -28,11 +28,14 @@ import com.google.common.io.Files;
 import com.lowagie.text.Image;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
+import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.api.ApiUtils;
+import org.fao.geonet.api.records.attachments.Store;
 import org.fao.geonet.api.records.extent.MapRenderer;
 import org.fao.geonet.api.records.extent.MetadataExtentApi;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.constants.Params;
+import org.fao.geonet.domain.MetadataResourceVisibility;
 import org.fao.geonet.utils.Log;
 import org.xhtmlrenderer.extend.FSImage;
 import org.xhtmlrenderer.extend.ReplacedElement;
@@ -82,10 +85,11 @@ public class ImageReplacedElementFactory implements ReplacedElementFactory {
         if (imgFormatExts == null) {
             synchronized (ImageReplacedElementFactory.class) {
                 if (imgFormatExts == null) {
-                    imgFormatExts = Sets.newHashSet();
+                    Set<String> tmpImgFormatExts = Sets.newHashSet();
                     for (String ext : ImageIO.getReaderFileSuffixes()) {
-                        imgFormatExts.add(ext.toLowerCase());
+                        tmpImgFormatExts.add(ext.toLowerCase());
                     }
+                    imgFormatExts = tmpImgFormatExts;
                 }
             }
         }
@@ -93,9 +97,11 @@ public class ImageReplacedElementFactory implements ReplacedElementFactory {
         return imgFormatExts;
     }
 
-    static private Pattern ONE_EXTENT_API_REGEX = Pattern.compile(".*/(.*)/extents/([0-9]+)\\.png.*");
-    static private Pattern ALL_EXTENT_API_REGEX = Pattern.compile(".*/(.*)/extents\\.png.*");
-    static private final String EXTENT_XPATH = ".//*[local-name() ='extent']/*/*[local-name() = 'geographicElement']/*";
+    private static final Pattern ONE_EXTENT_API_REGEX = Pattern.compile(".*/(.*)/extents/(\\d+)\\.png.*");
+    private static final Pattern ALL_EXTENT_API_REGEX = Pattern.compile(".*/(.*)/extents\\.png.*");
+    private static final String EXTENT_XPATH = ".//*[local-name() ='extent']/*/*[local-name() = 'geographicElement']/*";
+
+    private static final String DEFAULT_SRS = "EPSG:4326";
 
     @Override
     public ReplacedElement createReplacedElement(LayoutContext layoutContext, BlockBox box,
@@ -109,15 +115,15 @@ public class ImageReplacedElementFactory implements ReplacedElementFactory {
         if (!"img".equals(nodeName)) {
             try {
                 return superFactory.createReplacedElement(layoutContext, box, userAgentCallback, cssWidth, cssHeight);
-            } catch (Throwable e) {
+            } catch (Exception e) {
                 return new EmptyReplacedElement(cssWidth, cssHeight);
             }
         }
 
-
         String src = element.getAttribute("src");
+        String baseUrlNoLang = baseURL.substring(0, baseURL.length() - 4);
 
-        boolean useExtentApi = src.startsWith(baseURL.substring(0, baseURL.length() - 4))
+        boolean useExtentApi = src.startsWith(baseUrlNoLang)
                 && mapRenderer != null
                 && (ALL_EXTENT_API_REGEX.matcher(src).matches()
                 || ONE_EXTENT_API_REGEX.matcher(src).matches());
@@ -135,7 +141,7 @@ public class ImageReplacedElementFactory implements ReplacedElementFactory {
                     regionId = String.format("metadata:@id%s:@xpath(%s)[%s]", ApiUtils.getInternalId(oneMatcher.group(1), true), EXTENT_XPATH, oneMatcher.group(2));
                 }
                 Map<String, String> parameters = getParams(src);
-                String srs = parameters.get(MetadataExtentApi.MAP_SRS_PARAM) != null ? parameters.get(MetadataExtentApi.MAP_SRS_PARAM) : "EPSG:4326";
+                String srs = parameters.get(MetadataExtentApi.MAP_SRS_PARAM) != null ? parameters.get(MetadataExtentApi.MAP_SRS_PARAM) : DEFAULT_SRS;
                 Integer width = parameters.get(MetadataExtentApi.WIDTH_PARAM) != null ? Integer.parseInt(parameters.get(MetadataExtentApi.WIDTH_PARAM)) : null;
                 Integer height = parameters.get(MetadataExtentApi.HEIGHT_PARAM) != null ? Integer.parseInt(parameters.get(MetadataExtentApi.HEIGHT_PARAM)) : null;
                 String background = parameters.get(MetadataExtentApi.BACKGROUND_PARAM);
@@ -145,20 +151,25 @@ public class ImageReplacedElementFactory implements ReplacedElementFactory {
             }
             float factor = layoutContext.getDotsPerPixel();
             return loadImage(layoutContext, box, userAgentCallback, cssWidth, cssHeight, new BufferedImageLoader(image), factor);
-        } else if (src.startsWith(baseURL + "region.getmap.png") | src.endsWith("/geom.png") && mapRenderer != null) {
+        } else if (src.startsWith(baseURL + "region.getmap.png") || src.endsWith("/geom.png") && mapRenderer != null) {
             BufferedImage image = null;
             try {
                 Map<String, String> parameters = getParams(src);
 
                 String id = parameters.get(Params.ID);
-                String srs = parameters.get(MetadataExtentApi.MAP_SRS_PARAM) != null ? parameters.get(MetadataExtentApi.MAP_SRS_PARAM) : "EPSG:4326";
+                String srs = parameters.get(MetadataExtentApi.MAP_SRS_PARAM) != null ? parameters.get(MetadataExtentApi.MAP_SRS_PARAM) : DEFAULT_SRS;
                 Integer width = parameters.get(MetadataExtentApi.WIDTH_PARAM) != null ? Integer.parseInt(parameters.get(MetadataExtentApi.WIDTH_PARAM)) : null;
                 Integer height = parameters.get(MetadataExtentApi.HEIGHT_PARAM) != null ? Integer.parseInt(parameters.get(MetadataExtentApi.HEIGHT_PARAM)) : null;
                 String background = parameters.get(MetadataExtentApi.BACKGROUND_PARAM);
                 String geomParam = parameters.get(MetadataExtentApi.GEOM_PARAM);
                 String geomType = parameters.get(MetadataExtentApi.GEOM_TYPE_PARAM) != null ? parameters.get(MetadataExtentApi.GEOM_TYPE_PARAM) : "WKT";
-                String geomSrs = parameters.get(MetadataExtentApi.GEOM_SRS_PARAM) != null ? parameters.get(MetadataExtentApi.GEOM_SRS_PARAM) : "EPSG:4326";
+                String geomSrs = parameters.get(MetadataExtentApi.GEOM_SRS_PARAM) != null ? parameters.get(MetadataExtentApi.GEOM_SRS_PARAM) : DEFAULT_SRS;
 
+                if ((width == null) && (height == null)) {
+                    // Width or height are required. If not set the default width with the same value
+                    // as defined in MetadataExtentApi.getOneRecordExtentAsImage
+                    width = 300;
+                }
                 image = mapRenderer.render(
                     id, srs, width, height, background, geomParam, geomType, geomSrs, null, null);
             } catch (Exception e) {
@@ -189,6 +200,21 @@ public class ImageReplacedElementFactory implements ReplacedElementFactory {
             }
             float factor = layoutContext.getDotsPerPixel();
             return loadImage(layoutContext, box, userAgentCallback, cssWidth, cssHeight, new UrlImageLoader(builder.toString()), factor);
+
+        } else if (src.startsWith(baseUrlNoLang) && src.contains("/attachments/")) {
+            // Process attachments urls to load the images from the data directory
+            Matcher m = Pattern.compile(baseUrlNoLang + "api/records/(.*)/attachments/(.*)$").matcher(src);
+            if (m.find()) {
+                String uuid =  m.group(1);
+                String file =  m.group(2);
+
+                float factor = layoutContext.getDotsPerPixel();
+                return loadImage(layoutContext, box, userAgentCallback, cssWidth, cssHeight, new DataDirectoryImageLoader(uuid, file), factor);
+            } else if (isSupportedImageFormat(src)) {
+                float factor = layoutContext.getDotsPerPixel();
+                return loadImage(layoutContext, box, userAgentCallback, cssWidth, cssHeight, new UrlImageLoader(src), factor);
+            }
+
         } else if (isSupportedImageFormat(src)) {
             float factor = layoutContext.getDotsPerPixel();
             return loadImage(layoutContext, box, userAgentCallback, cssWidth, cssHeight, new UrlImageLoader(src), factor);
@@ -196,7 +222,7 @@ public class ImageReplacedElementFactory implements ReplacedElementFactory {
 
         try {
             return superFactory.createReplacedElement(layoutContext, box, userAgentCallback, cssWidth, cssHeight);
-        } catch (Throwable e) {
+        } catch (Exception e) {
             return new EmptyReplacedElement(cssWidth, cssHeight);
         }
     }
@@ -247,7 +273,7 @@ public class ImageReplacedElementFactory implements ReplacedElementFactory {
 
             try {
                 return superFactory.createReplacedElement(layoutContext, box, userAgentCallback, cssWidth, cssHeight);
-            } catch (Throwable e2) {
+            } catch (Exception e2) {
                 return new EmptyReplacedElement(cssWidth, cssHeight);
             }
         }
@@ -295,6 +321,35 @@ public class ImageReplacedElementFactory implements ReplacedElementFactory {
             }
         }
     }
+
+
+    /**
+     * Class to load images from the metadata data directory.
+     */
+    private class DataDirectoryImageLoader implements ImageLoader {
+        private final String uuid;
+        private final String file;
+        public DataDirectoryImageLoader(String uuid, String file) {
+            this.uuid = uuid;
+            this.file = file;
+        }
+
+        @Override
+        public Image loadImage() throws Exception {
+            Store store = ApplicationContextHolder.get().getBean("filesystemStore", Store.class);
+            BufferedImage bufferedImage;
+            try (Store.ResourceHolder imageFile = store.getResourceInternal(
+                this.uuid,
+                MetadataResourceVisibility.PUBLIC,
+                this.file, true)) {
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                bufferedImage = ImageIO.read(imageFile.getPath().toFile());
+                ImageIO.write(bufferedImage, "png", baos);
+                return Image.getInstance(baos.toByteArray());
+            }
+        }
+    }
+
 
     /* Define an AWT BufferedImage image loader */
 


### PR DESCRIPTION
Fixes #7540

The pull request contains also several Sonarlint fixes.

Test case:

1) Create an iso19139 metadata and upload an overview image.
2) In the Record view, export the metadata to PDF.

  - Without the fix: the overview image is not displayed in the PDF.
  - With the fix: the overview image is displayed in the PDF.

---

Aside of the changes this class requires review and cleanup that will be reported in a separate issue for clarity.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
