### PR TITLE
Fix the grid on the homepage of the documentation

### DIFF
--- a/docs/manual/docs/index.fr.md
+++ b/docs/manual/docs/index.fr.md
@@ -7,7 +7,7 @@ hide:
 
 Bienvenue à GeoNetwork. Cette documentation est organisée en guides spécifiques destinés à différents publics.
 
-<div class="grid cards" markdown>
+<div class="gn-grid cards" markdown>
 
 :fontawesome-solid-signs-post: [Vue d'ensemble](overview/index.md)
 

--- a/docs/manual/docs/index.fr.md
+++ b/docs/manual/docs/index.fr.md
@@ -7,38 +7,54 @@ hide:
 
 Bienvenue à GeoNetwork. Cette documentation est organisée en guides spécifiques destinés à différents publics.
 
-<div class="gn-grid cards" markdown>
+<div class="grid cards" markdown>
 
-:fontawesome-solid-signs-post: [Vue d'ensemble](overview/index.md)
+-   :fontawesome-solid-signs-post: [Vue d'ensemble](overview/index.md)
+    
+    ---
+    
+    Historique de GeoNetwork, communauté, détails de la licence et derniers changements.
+    
+-   :fontawesome-solid-circle-info: [Aide en ligne](help/index.md)
+    
+    ---
+  
+    Aide en ligne pour les visiteurs du catalogue (aucune connexion n'est requise).
+    
+-   :fontawesome-solid-person-circle-question: [Guide de l'utilisateur](user-guide/index.md)
+    
+    ---
+    
+    Guide de l'utilisateur opérationnel décrivant l'édition, la révision et la gestion des enregistrements (nécessite une connexion).
+    
+-   :fontawesome-solid-screwdriver-wrench: [Guide du mainteneur](maintainer-guide/index.md)
+  
+    ---
+    
+    Instructions d'installation, de configuration et de mise à jour
+    
+-   :fontawesome-solid-user-graduate: [Tutoriels](tutorials/index.md)
+    
+    ---
+    
+    Explorer des sujets à l'aide de tutoriels étape par étape
 
-:   Historique de GeoNetwork, communauté, détails de la licence et derniers changements.
+-   :fontawesome-solid-plug: [Référence API](api/index.md)
+    
+    ---
+    
+    Référence API pour les développeurs accédant aux services du catalogue.
+    
+-   :fontawesome-regular-file-code: [Développement](devel/index.md)
+    
+    ---
 
-:fontawesome-solid-circle-info: [Aide en ligne](help/index.md)
+    Informations sur le développement, la personnalisation de GeoNetwork et la participation au projet GeoNetwork.
 
-:   Aide en ligne pour les visiteurs du catalogue (aucune connexion n'est requise).
+-   :fontawesome-regular-bookmark: [Annexes](annexes/index.md)
 
-:fontawesome-solid-person-circle-question: [Guide de l'utilisateur](user-guide/index.md)
+    ---
 
-:   Guide de l'utilisateur opérationnel décrivant l'édition, la révision et la gestion des enregistrements (nécessite une connexion).
-
-:fontawesome-solid-screwdriver-wrench: [Guide du mainteneur](maintainer-guide/index.md)
-
-:   Instructions d'installation, de configuration et de mise à jour
-
-:fontawesome-solid-user-graduate: [Tutoriels](tutorials/index.md)
-
-:   Explorer des sujets à l'aide de tutoriels étape par étape
-
-:fontawesome-solid-plug: [Référence API](api/index.md)
-
-:   Référence API pour les développeurs accédant aux services du catalogue.
-
-:fontawesome-regular-file-code: [Développement](devel/index.md)
-
-:   Informations sur le développement, la personnalisation de GeoNetwork et la participation au projet GeoNetwork.
-
-:fontawesome-regular-bookmark: [Annexes](annexes/index.md)
-
-:   Informations de référence
+    Informations de référence
 
 </div>

--- a/docs/manual/docs/index.md
+++ b/docs/manual/docs/index.md
@@ -9,36 +9,52 @@ Welcome to GeoNetwork. This documentation is organized into specific guides targ
 
 <div class="grid cards" markdown>
 
-:fontawesome-solid-signs-post:   [Overview](overview/index.md)
+-   :fontawesome-solid-signs-post:   [Overview](overview/index.md)
 
-: GeoNetwork background, community, license details, and the latest changes.
+    ---
 
-:fontawesome-solid-circle-info:   [Online Help](help/index.md)
+    GeoNetwork background, community, license details, and the latest changes.
+    
+-   :fontawesome-solid-circle-info:   [Online Help](help/index.md)
+    
+    ---
 
-: Online help for visitors to the catalogue (no login required).
+    Online help for visitors to the catalogue (no login required).
+    
+-   :fontawesome-solid-person-circle-question:   [User Guide](user-guide/index.md)
+    
+    ---
 
-:fontawesome-solid-person-circle-question:   [User Guide](user-guide/index.md)
+    Operational user-guide describing the editing, review and management of records (requires-login).
+    
+-   :fontawesome-solid-screwdriver-wrench:   [Maintainer Guide](maintainer-guide/index.md)
+    
+    ---
 
-: Operational user-guide describing the editing, review and management of records (requires-login).
+    Installation, setup and update instructions
+    
+ -  :fontawesome-solid-user-graduate:   [Tutorials](tutorials/index.md)
+    
+    ---
 
-:fontawesome-solid-screwdriver-wrench:   [Maintainer Guide](maintainer-guide/index.md)
+    Explore topics using step-by-step tutorials
+    
+-   :fontawesome-solid-plug:   [API Reference](api/index.md)
+    
+    ---
 
-: Installation, setup and update instructions
+    API Reference for developers accecssing catalogue services.
+    
+-   :fontawesome-regular-file-code:   [Development](devel/index.md)
+    
+    ---
 
-:fontawesome-solid-user-graduate:   [Tutorials](tutorials/index.md)
+    Development information on customizing GeoNetwork and taking part in the GeoNetwork project.
+    
+-   :fontawesome-regular-bookmark:   [Annexes](annexes/index.md)
+    
+    ---
 
-: Explore topics using step-by-step tutorials
-
-:fontawesome-solid-plug:   [API Reference](api/index.md)
-
-: API Reference for developers accecssing catalogue services.
-
-:fontawesome-regular-file-code:   [Development](devel/index.md)
-
-: Development information on customizing GeoNetwork and taking part in the GeoNetwork project.
-
-:fontawesome-regular-bookmark:   [Annexes](annexes/index.md)
-
-: Reference information
+    Reference information
 
 </div>

--- a/docs/manual/docs/index.md
+++ b/docs/manual/docs/index.md
@@ -7,7 +7,7 @@ hide:
 
 Welcome to GeoNetwork. This documentation is organized into specific guides targeting different audience. 
 
-<div class="grid cards" markdown>
+<div class="gn-grid cards" markdown>
 
 :fontawesome-solid-signs-post:   [Overview](overview/index.md)
 

--- a/docs/manual/docs/index.md
+++ b/docs/manual/docs/index.md
@@ -7,7 +7,7 @@ hide:
 
 Welcome to GeoNetwork. This documentation is organized into specific guides targeting different audience. 
 
-<div class="gn-grid cards" markdown>
+<div class="grid cards" markdown>
 
 :fontawesome-solid-signs-post:   [Overview](overview/index.md)
 

--- a/docs/manual/overrides/assets/stylesheets/extra.css
+++ b/docs/manual/overrides/assets/stylesheets/extra.css
@@ -9,50 +9,6 @@ img + em, .browser-border + em, .browser-mockup + em {
   font-size: 0.75rem;
 }
 
-/* grid */
-.md-typeset .grid {
-  column-count: 2;
-  column-gap: 2em;
-  margin-bottom: 20px;
-  display: block !important;
-}
-.md-typeset .grid ul, .md-typeset .grid dl {
-  display: grid;
-  grid-template-columns: repeat(auto-fit,minmax(16rem,1fr));
-  margin: 0;
-}
-.md-typeset .grid.cards dt, .md-typeset .grid.cards dd {
-  border: 0.05rem solid var(--md-default-fg-color--lightest);
-  border-radius: 0.1rem;
-  display: block;
-  margin: 0;
-  padding: 0.8rem;
-  transition: border .25s,box-shadow .25s;
-  break-inside: avoid;
-}
-.md-typeset .grid.cards dt {
-  font-weight: bold;
-  margin-top: 0.5rem;
-}
-.md-typeset .grid.cards dt .twemoji {
-  margin-right: 5px;
-}
-.md-typeset .grid.cards dd {
-  margin-top: -1px;
-}
-.md-typeset .grid.cards dd p {
-  margin: 0;
-}
-@media (max-width: 768px) {
-  .md-typeset .grid dl {
-    display: inline-block;
-    margin-bottom: 20px;
-  }
-  .md-typeset .grid.cards dt, .md-typeset .grid.cards dd {
-    width: calc(100vw - 1.2rem - 1.2rem);
-  }
-}
-
 /* definition list used to display general inputs */
 .md-typeset dl dd {
   margin: 10px 0;

--- a/docs/manual/overrides/assets/stylesheets/extra.css
+++ b/docs/manual/overrides/assets/stylesheets/extra.css
@@ -10,17 +10,18 @@ img + em, .browser-border + em, .browser-mockup + em {
 }
 
 /* grid */
-.md-typeset .gn-grid {
+.md-typeset .grid {
   column-count: 2;
   column-gap: 2em;
   margin-bottom: 20px;
+  display: block !important;
 }
-.md-typeset .gn-grid dl {
+.md-typeset .grid ul, .md-typeset .grid dl {
   display: grid;
   grid-template-columns: repeat(auto-fit,minmax(16rem,1fr));
   margin: 0;
 }
-.md-typeset .gn-grid.cards dt, .md-typeset .gn-grid.cards dd {
+.md-typeset .grid.cards dt, .md-typeset .grid.cards dd {
   border: 0.05rem solid var(--md-default-fg-color--lightest);
   border-radius: 0.1rem;
   display: block;
@@ -29,25 +30,25 @@ img + em, .browser-border + em, .browser-mockup + em {
   transition: border .25s,box-shadow .25s;
   break-inside: avoid;
 }
-.md-typeset .gn-grid.cards dt {
+.md-typeset .grid.cards dt {
   font-weight: bold;
   margin-top: 0.5rem;
 }
-.md-typeset .gn-grid.cards dt .twemoji {
+.md-typeset .grid.cards dt .twemoji {
   margin-right: 5px;
 }
-.md-typeset .gn-grid.cards dd {
+.md-typeset .grid.cards dd {
   margin-top: -1px;
 }
-.md-typeset .gn-grid.cards dd p {
+.md-typeset .grid.cards dd p {
   margin: 0;
 }
 @media (max-width: 768px) {
-  .md-typeset .gn-grid dl {
+  .md-typeset .grid dl {
     display: inline-block;
     margin-bottom: 20px;
   }
-  .md-typeset .gn-grid.cards dt, .md-typeset .gn-grid.cards dd {
+  .md-typeset .grid.cards dt, .md-typeset .grid.cards dd {
     width: calc(100vw - 1.2rem - 1.2rem);
   }
 }

--- a/docs/manual/overrides/assets/stylesheets/extra.css
+++ b/docs/manual/overrides/assets/stylesheets/extra.css
@@ -10,43 +10,44 @@ img + em, .browser-border + em, .browser-mockup + em {
 }
 
 /* grid */
-.md-typeset .grid {
+.md-typeset .gn-grid {
   column-count: 2;
   column-gap: 2em;
   margin-bottom: 20px;
 }
-.md-typeset .grid dl {
+.md-typeset .gn-grid dl {
   display: grid;
   grid-template-columns: repeat(auto-fit,minmax(16rem,1fr));
   margin: 0;
 }
-.md-typeset .grid.cards dt, .md-typeset .grid.cards dd {
+.md-typeset .gn-grid.cards dt, .md-typeset .gn-grid.cards dd {
   border: 0.05rem solid var(--md-default-fg-color--lightest);
   border-radius: 0.1rem;
   display: block;
   margin: 0;
   padding: 0.8rem;
   transition: border .25s,box-shadow .25s;
+  break-inside: avoid;
 }
-.md-typeset .grid.cards dt {
+.md-typeset .gn-grid.cards dt {
   font-weight: bold;
+  margin-top: 0.5rem;
 }
-.md-typeset .grid.cards dt .twemoji {
+.md-typeset .gn-grid.cards dt .twemoji {
   margin-right: 5px;
 }
-.md-typeset .grid.cards dd {
-  margin-bottom: 0.8rem;
+.md-typeset .gn-grid.cards dd {
   margin-top: -1px;
 }
-.md-typeset .grid.cards dd p {
+.md-typeset .gn-grid.cards dd p {
   margin: 0;
 }
 @media (max-width: 768px) {
-  .md-typeset .grid dl {
+  .md-typeset .gn-grid dl {
     display: inline-block;
     margin-bottom: 20px;
   }
-  .md-typeset .grid.cards dt, .md-typeset .grid.cards dd {
+  .md-typeset .gn-grid.cards dt, .md-typeset .gn-grid.cards dd {
     width: calc(100vw - 1.2rem - 1.2rem);
   }
 }

--- a/docs/manual/requirements.txt
+++ b/docs/manual/requirements.txt
@@ -1,4 +1,4 @@
-mkdocs-material
+mkdocs-material>=9.5.3
 mkdocs-static-i18n>=1.0.5
 mkdocs-include-markdown-plugin
 mkdocs-exclude


### PR DESCRIPTION
Fix the grid on the homepage of the documentation.

Rename `.grid` to `.gn-grid` to avoid conflicting classnames, and some additional styling so content doesn't break between columns.

When the documentation is released and deployed online styles were conflicting. The styles are renamed but the conflict didn't occur locally, so hopefully it's solved.

**Before**

![gn-doc-before](https://github.com/geonetwork/core-geonetwork/assets/19608667/38b90ec6-81eb-410c-be13-8be7715a985a)

**After**

![gn-doc-after](https://github.com/geonetwork/core-geonetwork/assets/19608667/e94d021e-00bc-487c-a3c4-ea0df5f3ae53)

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
