### PR TITLE
Metadata extents API / Make configurable to display the metadata bboxes using geodesic extents for local projections.

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/setting/Settings.java
+++ b/core/src/main/java/org/fao/geonet/kernel/setting/Settings.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2021 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2023 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -128,6 +128,7 @@ public class Settings {
     public static final String REGION_GETMAP_MAPPROJ = "region/getmap/mapproj";
     public static final String REGION_GETMAP_WIDTH = "region/getmap/width";
     public static final String REGION_GETMAP_SUMMARY_WIDTH = "region/getmap/summaryWidth";
+    public static final String REGION_GETMAP_GEODESIC_EXTENTS = "region/getmap/useGeodesicExtents";
     public static final String METADATA_WORKFLOW_ENABLE = "metadata/workflow/enable";
     public static final String METADATA_WORKFLOW_DRAFT_WHEN_IN_GROUP = "metadata/workflow/draftWhenInGroup";
     public static final String METADATA_WORKFLOW_ALLOW_SUBMIT_APPROVE_INVALID_MD = "metadata/workflow/allowSubmitApproveInvalidMd";

--- a/services/src/main/java/org/fao/geonet/api/records/extent/MapRenderer.java
+++ b/services/src/main/java/org/fao/geonet/api/records/extent/MapRenderer.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2022 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2023 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -24,7 +24,6 @@
 package org.fao.geonet.api.records.extent;
 
 import jeeves.server.context.ServiceContext;
-import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.api.regions.GeomFormat;
 import org.fao.geonet.exceptions.BadParameterEx;
@@ -33,15 +32,12 @@ import org.fao.geonet.kernel.region.RegionNotFoundEx;
 import org.fao.geonet.kernel.region.RegionsDAO;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.kernel.setting.Settings;
-import org.fao.geonet.lib.Lib;
 import org.geotools.geometry.jts.JTS;
-import org.geotools.geometry.jts.JTSFactoryFinder;
 import org.geotools.geometry.jts.ReferencedEnvelope;
 import org.geotools.referencing.CRS;
 import org.locationtech.jts.awt.ShapeWriter;
 import org.locationtech.jts.geom.Envelope;
 import org.locationtech.jts.geom.Geometry;
-import org.locationtech.jts.geom.GeometryFactory;
 import org.geotools.api.metadata.extent.Extent;
 import org.geotools.api.metadata.extent.GeographicBoundingBox;
 import org.geotools.api.metadata.extent.GeographicExtent;
@@ -49,15 +45,9 @@ import org.geotools.api.referencing.crs.CoordinateReferenceSystem;
 import org.geotools.api.referencing.operation.MathTransform;
 import org.springframework.context.ApplicationContext;
 
-import javax.imageio.ImageIO;
 import java.awt.*;
 import java.awt.geom.AffineTransform;
 import java.awt.image.BufferedImage;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
-import java.net.URLConnection;
 import java.util.Collection;
 import java.util.Map;
 import java.util.SortedSet;
@@ -89,30 +79,28 @@ public class MapRenderer {
      * intersection of the geometry with the coordinate system domain of validity.
      */
     public static Geometry computeGeomInDomainOfValidity(Geometry geom, CoordinateReferenceSystem mapCRS) {
-        final GeometryFactory geometryFactory = JTSFactoryFinder.getGeometryFactory(null);
         final Extent domainOfValidity = mapCRS.getDomainOfValidity();
         Geometry adjustedGeom = geom;
         if (domainOfValidity != null) {
             for (final GeographicExtent extent :
                 domainOfValidity.getGeographicElements()) {
-                if (Boolean.FALSE.equals(extent.getInclusion())) {
+                if ((extent == null) || (Boolean.FALSE.equals(extent.getInclusion()))) {
                     continue;
                 }
-                if (extent instanceof GeographicBoundingBox) {
-                    if (extent != null) {
-                        GeographicBoundingBox box = (GeographicBoundingBox) extent;
 
-                        Envelope env = new Envelope(
-                            box.getWestBoundLongitude(),
-                            box.getEastBoundLongitude(),
-                            box.getSouthBoundLatitude(),
-                            box.getNorthBoundLatitude());
-                        if (env.contains(geom.getEnvelopeInternal())) {
-                            return geom;
-                        } else {
-                            Geometry extentPolygon = JTS.toGeometry(env);
-                            adjustedGeom = geom.intersection(extentPolygon);
-                        }
+                if (extent instanceof GeographicBoundingBox) {
+                    GeographicBoundingBox box = (GeographicBoundingBox) extent;
+
+                    Envelope env = new Envelope(
+                        box.getWestBoundLongitude(),
+                        box.getEastBoundLongitude(),
+                        box.getSouthBoundLatitude(),
+                        box.getNorthBoundLatitude());
+                    if (env.contains(geom.getEnvelopeInternal())) {
+                        return geom;
+                    } else {
+                        Geometry extentPolygon = JTS.toGeometry(env);
+                        adjustedGeom = geom.intersection(extentPolygon);
                     }
                 }
             }
@@ -123,11 +111,14 @@ public class MapRenderer {
     }
 
     public BufferedImage render(String id, String srs, Integer width, Integer height,
-                                String background, String geomParam, String geomType, String geomSrs, String fillColor, String strokeColor) throws Exception {
+                                String background, String geomParam, String geomType,
+                                String geomSrs, String fillColor, String strokeColor) throws Exception {
         ApplicationContext appContext = context.getApplicationContext();
         Map<String, String> regionGetMapBackgroundLayers = appContext.getBean("regionGetMapBackgroundLayers", Map.class);
         SortedSet<ExpandFactor> regionGetMapExpandFactors = appContext.getBean("regionGetMapExpandFactors", SortedSet.class);
         SettingManager settingManager = appContext.getBean(SettingManager.class);
+        boolean isGlobalSrs = srs.equals("EPSG:4326") || srs.equals("EPSG:3857");
+        boolean useGeodesicExtents = settingManager.getValueAsBool(Settings.REGION_GETMAP_GEODESIC_EXTENTS, false);
 
         Geometry geom = null;
         if (id != null) {
@@ -192,7 +183,6 @@ public class MapRenderer {
                 ;
 
             BufferedImage baseMapImage = baseMapRenderer.render();
-           // ImageIO.write(baseMapImage, "png", new File("delme.png"));
 
             image = baseMapImage;
         } else {
@@ -209,8 +199,9 @@ public class MapRenderer {
             Color geomStrokeColor = getColor(strokeColor, new Color(0, 0, 0, 255));
             AffineTransform worldToScreenTransform = worldToScreenTransform(bboxOfImage, imageDimensions);
             for (int i = 0; i < geom.getNumGeometries(); i++) {
+                Geometry geomExtent = (!isGlobalSrs && !useGeodesicExtents ?  geom.getGeometryN(i).getEnvelope() : geom.getGeometryN(i));
                 // draw each included geometry separately to ensure they are filled correctly
-                Shape shape = worldToScreenTransform.createTransformedShape(shapeWriter.toShape(geom.getGeometryN(i)));
+                Shape shape = worldToScreenTransform.createTransformedShape(shapeWriter.toShape(geomExtent));
                 graphics.setColor(geomFillColor);
                 graphics.fill(shape);
 

--- a/services/src/main/java/org/fao/geonet/api/records/extent/MapRenderer.java
+++ b/services/src/main/java/org/fao/geonet/api/records/extent/MapRenderer.java
@@ -75,6 +75,21 @@ public class MapRenderer {
     }
 
     /**
+     * Returns a bounding box geometry.
+     *
+     * @param geom                  Bounding box geometry.
+     * @param srs                   Bounding box geometry srs.
+     * @param useGeodesicExtents    false: returns the bounding box geometry as a rectangle (using min / max bounds).
+     *                              true: returns the bounding box geometry.
+     * @return bounding box geometry.
+     */
+    public static Geometry getGeometryExtent(Geometry geom, String srs, boolean useGeodesicExtents) {
+        boolean isGlobalSrs = srs.equals("EPSG:4326") || srs.equals("EPSG:3857");
+
+        return (!isGlobalSrs && !useGeodesicExtents ?  geom.getEnvelope() : geom);
+    }
+
+    /**
      * Check if a geometry is in the domain of validity of a projection and if not return the
      * intersection of the geometry with the coordinate system domain of validity.
      */
@@ -117,7 +132,7 @@ public class MapRenderer {
         Map<String, String> regionGetMapBackgroundLayers = appContext.getBean("regionGetMapBackgroundLayers", Map.class);
         SortedSet<ExpandFactor> regionGetMapExpandFactors = appContext.getBean("regionGetMapExpandFactors", SortedSet.class);
         SettingManager settingManager = appContext.getBean(SettingManager.class);
-        boolean isGlobalSrs = srs.equals("EPSG:4326") || srs.equals("EPSG:3857");
+
         boolean useGeodesicExtents = settingManager.getValueAsBool(Settings.REGION_GETMAP_GEODESIC_EXTENTS, false);
 
         Geometry geom = null;
@@ -199,7 +214,7 @@ public class MapRenderer {
             Color geomStrokeColor = getColor(strokeColor, new Color(0, 0, 0, 255));
             AffineTransform worldToScreenTransform = worldToScreenTransform(bboxOfImage, imageDimensions);
             for (int i = 0; i < geom.getNumGeometries(); i++) {
-                Geometry geomExtent = (!isGlobalSrs && !useGeodesicExtents ?  geom.getGeometryN(i).getEnvelope() : geom.getGeometryN(i));
+                Geometry geomExtent = MapRenderer.getGeometryExtent(geom.getGeometryN(i), srs, useGeodesicExtents);
                 // draw each included geometry separately to ensure they are filled correctly
                 Shape shape = worldToScreenTransform.createTransformedShape(shapeWriter.toShape(geomExtent));
                 graphics.setColor(geomFillColor);

--- a/services/src/test/java/org/fao/geonet/api/records/extent/MapRendererTest.java
+++ b/services/src/test/java/org/fao/geonet/api/records/extent/MapRendererTest.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (C) 2001-2023 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
 package org.fao.geonet.api.records.extent;
 
 import org.fao.geonet.kernel.region.Region;
@@ -47,5 +70,56 @@ public class MapRendererTest {
         bbox.setSRID(4326);
         String result = wktWriter.write(MapRenderer.computeGeomInDomainOfValidity(bbox, Region.decodeCRS("EPSG:3857")));
         assertEquals("POLYGON ((159.70909090909092 -85.06, 135 -76, 161 -76, 153 -81, 161.12 -85.06, 159.70909090909092 -85.06))", result);
+    }
+
+    @Test
+    public void extentGeodesicLocalProjection() throws Exception {
+        String test = "POLYGON ((646.3563610491983 308975.2885578188, 10545.528150276805 637111.0281460616, 276050.8102636032 636456.3084312443, 284347.2430806639 308289.5622343737, 646.3563610491983 308975.2885578188))";
+        String localSrs = "EPSG:28992";
+        Geometry geometry = wktReader.read(test);
+        geometry.setSRID(28992);
+
+        Geometry geometryExtent = MapRenderer.getGeometryExtent(geometry, localSrs, true);
+        assertEquals(geometry, geometryExtent);
+    }
+
+    @Test
+    public void extentNonGeodesicLocalProjection() throws Exception {
+        String test = "POLYGON ((646.3563610491983 308975.2885578188, 10545.528150276805 637111.0281460616, 276050.8102636032 636456.3084312443, 284347.2430806639 308289.5622343737, 646.3563610491983 308975.2885578188))";
+        String localSrs = "EPSG:28992";
+        Geometry geometry = wktReader.read(test);
+        geometry.setSRID(28992);
+
+        Geometry geometryExtent = MapRenderer.getGeometryExtent(geometry, localSrs, false);
+        assertEquals(geometry.getEnvelope(), geometryExtent);
+    }
+
+    @Test
+    public void extentGlobal3857Projection() throws Exception {
+        String test = "POLYGON ((159.70909090909092 -85.06, 135 -76, 161 -76, 153 -81, 161.12 -85.06, 159.70909090909092 -85.06))";
+        String globalSrs = "EPSG:3857";
+        Geometry geometry = wktReader.read(test);
+        geometry.setSRID(3857);
+
+        // For global projections
+        Geometry geometryExtent = MapRenderer.getGeometryExtent(geometry, globalSrs, true);
+        assertEquals(geometry, geometryExtent);
+
+        geometryExtent = MapRenderer.getGeometryExtent(geometry, globalSrs, false);
+        assertEquals(geometry, geometryExtent);
+    }
+
+    @Test
+    public void extentGlobal4326Projection() throws Exception {
+        String test = "POLYGON ((165 -87, 135 -76, 161 -76, 153 -81, 165 -87))";
+        String globalSrs = "EPSG:4326";
+        Geometry geometry = wktReader.read(test);
+        geometry.setSRID(4326);
+
+        Geometry geometryExtent = MapRenderer.getGeometryExtent(geometry, globalSrs, true);
+        assertEquals(geometry, geometryExtent);
+
+        geometryExtent = MapRenderer.getGeometryExtent(geometry, globalSrs, false);
+        assertEquals(geometry, geometryExtent);
     }
 }

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1041,6 +1041,8 @@
     "region/getmap/background": "Background map, URL or Named Layer ID",
     "region/getmap/mapproj": "Map projection",
     "region/getmap/summaryWidth": "Summary width",
+    "region/getmap/useGeodesicExtents": "Display geodesic extents",
+    "region/getmap/useGeodesicExtents-help": "By default, the displayed metadata extents are planar (i.e. rectangular). If you enable this option, the metadata extents will become geodesic. If the map uses a projected coordinate system, this may lead to non-rectangular extents (e.g. trapezoid).",
     "region/getmap/width": "Width",
     "metadata/editor": "Metadata editor configuration",
     "metadata/editor/schemaConfig": "Standard configuration",

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
@@ -670,6 +670,7 @@ INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('region
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('region/getmap/width', '500', 0, 9590, 'n');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('region/getmap/summaryWidth', '500', 0, 9590, 'n');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('region/getmap/mapproj', 'EPSG:3857', 0, 9590, 'n');
+INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('region/getmap/useGeodesicExtents', 'false', 2, 9591, 'n');
 
 
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('metadata/url/sitemapLinkUrl', NULL, 0, 9165, 'y');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v442/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v442/migrate-default.sql
@@ -1,4 +1,6 @@
 UPDATE Settings SET value='4.4.2' WHERE name='system/platform/version';
 UPDATE Settings SET value='SNAPSHOT' WHERE name='system/platform/subVersion';
 
+INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('region/getmap/useGeodesicExtents', 'false', 2, 9591, 'n');
+
 ALTER TABLE public.spg_page ADD icon varchar NULL;


### PR DESCRIPTION
Similar to #6982, but for the metadata map extent API.

Adds a new setting to configure to use the geodesic extents when using a local projection (for global projections: EPSG:4326 and EPSG:3857, the setting is ignored).

By default, the setting is disabled, displaying the extents planars (being similar to #6982).

![setting-geodesic-extents](https://github.com/geonetwork/core-geonetwork/assets/1695003/e06633d4-10ae-46c9-adec-67de9134fdcb)

With the setting **disabled**, using a local projection:

![setting-disabled](https://github.com/geonetwork/core-geonetwork/assets/1695003/ddc28f57-b826-436c-8199-f3ff44496589)

With the setting **enabled**, using a local projection:

![setting-enabled](https://github.com/geonetwork/core-geonetwork/assets/1695003/89a380ed-05e5-4666-8b1d-5381afd504e6)

--- 

Includes Sonarlint improvements.


# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
