### PR TITLE
INSPIRE Atom feeds / Fix link to atom search endpoint

### DIFF
--- a/web/src/main/webResources/WEB-INF/urlrewrite.xml
+++ b/web/src/main/webResources/WEB-INF/urlrewrite.xml
@@ -183,14 +183,6 @@
 
   <rule>
     <note>
-      INSPIRE HTML search
-    </note>
-    <from>^/(.*)/(.*)/opensearch/htmlsearch\?.*q=(.*)</from>
-    <to type="permanent-redirect">%{context-path}/$1/$2/catalog.search#/search?any=$3</to>
-  </rule>
-
-  <rule>
-    <note>
       INSPIRE Atom Describe (service)
     </note>
     <from>^/opensearch/(.*)/(.*)/describe?(.*)$</from>

--- a/web/src/main/webapp/xslt/services/inspire-atom/opensearch.xsl
+++ b/web/src/main/webapp/xslt/services/inspire-atom/opensearch.xsl
@@ -56,7 +56,7 @@
 
           <os:Url type="text/html" rel="results">
             <xsl:attribute name="template"
-                           select="concat(/root/gui/url,'/srv/', /root/gui/language,'/opensearch/htmlsearch?q={searchTerms?}')"/>
+                           select="concat(/root/gui/url,'/opensearch/', /root/gui/language,'/search?q={searchTerms?}')"/>
           </os:Url>
         </xsl:when>
         <xsl:otherwise>

--- a/web/src/main/webapp/xslt/services/inspire-atom/opensearchdescription.xsl
+++ b/web/src/main/webapp/xslt/services/inspire-atom/opensearchdescription.xsl
@@ -20,6 +20,7 @@
   <xsl:param name="atomDescribeServiceUrlSuffix" />
   <xsl:param name="atomDescribeDatasetUrlSuffix" />
   <xsl:param name="atomDownloadDatasetUrlSuffix" />
+  <xsl:param name="baseUrl" />
   <xsl:param name="nodeName" />
   <xsl:output method="xml" indent="no" encoding="utf-8"/>
 
@@ -53,7 +54,7 @@
       <Url type="text/html" rel="results">
         <xsl:attribute name="template">
           <xsl:value-of
-            select="concat($nodeUrl, $requestedLanguage, '/', $opensearchUrlSuffix, '/htmlsearch?q={searchTerms?}')"/>
+            select="concat($baseUrl, $opensearchUrlSuffix, '/', $requestedLanguage, '/search?q={searchTerms?}')"/>
         </xsl:attribute>
       </Url>
 


### PR DESCRIPTION
Follow up of https://github.com/geonetwork/core-geonetwork/pull/6395

The URL in the ATOM Feeds `OpenSearchDescription.xml` document pointed to `/htmlsearch`. This service is not defined in GeoNetwork 4.x and also in GeoNetwork 3.12.x was redirecting to the application search results page. What looks not correct as the endpoint is to return ATOM Feeds.

Updated to use the correct endpoint.

Test case (with local feeds): 

1) Enable the INSPIRE setting
2) Create an iso19139 service metadata
3) Request the OpenSearchDescription.xml document: 

http://localhost:8080/geonetwork/srv/opensearch/OpenSearchDescription.xml?uuid=SERVICEUUID

Without the change:

```
http://localhost:8080/geonetwork/srv/en/opensearch/htmlsearch?q={searchTerms?}
```
Endpoint fails as doesn't exist

With the change:

```
http://localhost:8080/geonetwork/opensearch/en/search?q={searchTerms?}
```


# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
