### PR TITLE
Add German codelist translations for scope code

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/loc/ger/codelists.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/ger/codelists.xml
@@ -1578,26 +1578,25 @@
             <label>Publication</label>
             <description>Publication</description>
         </entry>-->
-    <!--TODO: NEEDS TRANSLATION -->
     <!-- Used for facet translation only and not displayed in editor -->
     <entry hideInEditMode="true">
       <code>map</code>
-      <label>Map</label>
+      <label>Karte</label>
       <description></description>
     </entry>
     <entry hideInEditMode="true">
       <code>staticMap</code>
-      <label>Static map</label>
+      <label>Statische Karte</label>
       <description></description>
     </entry>
     <entry hideInEditMode="true">
       <code>interactiveMap</code>
-      <label>Interactive map</label>
+      <label>Interaktive Karte</label>
       <description></description>
     </entry>
     <entry hideInEditMode="true">
       <code>featureCatalog</code>
-      <label>Feature catalog</label>
+      <label>Objektkatalog</label>
       <description></description>
     </entry>
   </codelist>


### PR DESCRIPTION
The codelist value `map` in German had an untranslated value:

https://github.com/geonetwork/core-geonetwork/blob/0c8c74edce3df0e789f022f6ebd0d07bd4c08fdd/schemas/iso19139/src/main/plugin/iso19139/loc/ger/codelists.xml#L1583-L1587

Interfering with the German `map` translation in:

https://github.com/geonetwork/core-geonetwork/blob/0c8c74edce3df0e789f022f6ebd0d07bd4c08fdd/web-ui/src/main/resources/catalog/locales/de-core.json#L161

And causing the search map displaying the English value in the German user interface:

![german-searchmap](https://github.com/geonetwork/core-geonetwork/assets/1695003/6912589d-0811-4162-a2d5-b98aaf1b6fab)
----

Test case:

1) Go to the search page in German: http://localhost:8080/geonetwork/srv/ger/catalog.search

   - Without the fix: the map search label displays the value `Map` (NO OK)
   - With the fix: the map search labels displays the value `Karte` (OK)
   
----

Maybe we should use some prefix for the keys in the json files, for example `ui-XXXX` or even the file name, so keys in the different files doesn't have this kind of overlap keys issues: `search-XXXX`, `core-XXXX`, etc.

To check how this change affects the existing translations in Transifex. What do you think @fxprunayre?

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
