### PR TITLE
fix duplicate check on uuid+initiative+association

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/schematron/schematron-rules-iso.sch
+++ b/schemas/iso19139/src/main/plugin/iso19139/schematron/schematron-rules-iso.sch
@@ -348,21 +348,19 @@ USA.
 			<sch:report test="gmd:aggregateDataSetName or gmd:aggregateDataSetIdentifier"
 				>$loc/strings/report.M23</sch:report>
 
-
-
-      <sch:let name="mdRefRef" value="gmd:aggregateDataSetIdentifier/*/gmd:code/*"/>
+      <sch:let name="mdRefRef" value="gmd:aggregateDataSetIdentifier/*/gmd:code/gco:CharacterString"/>
       <sch:let name="association" value="gmd:associationType/*/@codeListValue"/>
       <sch:let name="initiative" value="gmd:initiativeType/*/@codeListValue"/>
 
+
       <sch:let name="hasNoDuplicate"
                value="count(../../*/gmd:MD_AggregateInformation[
-                                      gmd:aggregateDataSetIdentifier/*/gmd:code/* = $mdRefRef
+                                      gmd:aggregateDataSetIdentifier/*/gmd:code/gco:CharacterString = $mdRefRef
                                       and concat(
                                         gmd:associationType/*/@codeListValue,
                                         gmd:initiativeType/*/@codeListValue) =
                                         concat($association, $initiative)]) = 1"/>
       <sch:assert test="$hasNoDuplicate">$loc/strings/report.M23-dup</sch:assert>
-
     </sch:rule>
   </sch:pattern>
 

--- a/schemas/iso19139/src/main/plugin/iso19139/schematron/schematron-rules-iso.sch
+++ b/schemas/iso19139/src/main/plugin/iso19139/schematron/schematron-rules-iso.sch
@@ -64,6 +64,7 @@ USA.
   <sch:ns prefix="gml" uri="http://www.opengis.net/gml/3.2"/>
   <sch:ns prefix="gml320" uri="http://www.opengis.net/gml"/>
 	<sch:ns prefix="gmd" uri="http://www.isotc211.org/2005/gmd"/>
+  <sch:ns prefix="gmx" uri="http://www.isotc211.org/2005/gmx"/>
 	<sch:ns prefix="srv" uri="http://www.isotc211.org/2005/srv"/>
 	<sch:ns prefix="gco" uri="http://www.isotc211.org/2005/gco"/>
 	<sch:ns prefix="geonet" uri="http://www.fao.org/geonetwork"/>
@@ -348,14 +349,14 @@ USA.
 			<sch:report test="gmd:aggregateDataSetName or gmd:aggregateDataSetIdentifier"
 				>$loc/strings/report.M23</sch:report>
 
-      <sch:let name="mdRefRef" value="gmd:aggregateDataSetIdentifier/*/gmd:code/gco:CharacterString"/>
+      <sch:let name="mdRefRef" value="gmd:aggregateDataSetIdentifier/*/gmd:code/(gco:CharacterString|gmx:Anchor)"/>
       <sch:let name="association" value="gmd:associationType/*/@codeListValue"/>
       <sch:let name="initiative" value="gmd:initiativeType/*/@codeListValue"/>
 
 
       <sch:let name="hasNoDuplicate"
                value="count(../../*/gmd:MD_AggregateInformation[
-                                      gmd:aggregateDataSetIdentifier/*/gmd:code/gco:CharacterString = $mdRefRef
+                                      gmd:aggregateDataSetIdentifier/*/gmd:code/(gco:CharacterString|gmx:Anchor) = $mdRefRef
                                       and concat(
                                         gmd:associationType/*/@codeListValue,
                                         gmd:initiativeType/*/@codeListValue) =

--- a/web/src/test/java/org/fao/geonet/kernel/schema/SchematronRulesIsoTest.java
+++ b/web/src/test/java/org/fao/geonet/kernel/schema/SchematronRulesIsoTest.java
@@ -33,9 +33,9 @@ import java.nio.file.Path;
 import java.util.Arrays;
 import java.util.Collections;
 
-import static org.fao.geonet.constants.Geonet.Namespaces.GCO;
-import static org.fao.geonet.constants.Geonet.Namespaces.GMD;
+import static org.fao.geonet.constants.Geonet.Namespaces.*;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 
 /**
  * Test some of the rules in the schematron-rules-iso.sch files in the iso19139 schema plugin.
@@ -147,6 +147,88 @@ public class SchematronRulesIsoTest extends AbstractSchematronTest {
         final Element dateTypeEl = Xml.selectElement(testMetadata, "gmd:identificationInfo/*/gmd:citation/*/gmd:date/*/gmd:dateType",
             Arrays.asList(GMD, GCO));
         testNoStringErrors(testMetadata, dateTypeEl);
+    }
+
+    @Test
+    public void testAggregationInfoCombinations() throws Exception {
+        final Element testMetadata = Xml.loadStream(SchematronRulesIsoTest.class.getResourceAsStream(INSPIRE_VALID_ISO19139_XML));
+        final Element mdDataIdentification = Xml.selectElement(testMetadata, "gmd:identificationInfo/gmd:MD_DataIdentification", Collections.singletonList(GMD));
+        assertNotNull(mdDataIdentification);
+
+        Element results = Xml.transform(testMetadata, getSchematronXsl(), params);
+        int errorsStart = countFailures(results);
+
+        // first we test cases that should not introduce failures
+        addDatasetIdentifier(mdDataIdentification, "uuid-1", null, "largerWorkCitation", null);
+        assertEquals(errorsStart, countFailures(Xml.transform(testMetadata, getSchematronXsl(), params)));
+        addDatasetIdentifier(mdDataIdentification, "uuid-2", null, "largerWorkCitation", null);
+        assertEquals(errorsStart, countFailures(Xml.transform(testMetadata, getSchematronXsl(), params)));
+        addDatasetIdentifier(mdDataIdentification, "uuid-2", null, "crossReference", null);
+        assertEquals(errorsStart, countFailures(Xml.transform(testMetadata, getSchematronXsl(), params)));
+        addDatasetIdentifier(mdDataIdentification, "uuid-3", null, "crossReference", "campaign");
+        assertEquals(errorsStart, countFailures(Xml.transform(testMetadata, getSchematronXsl(), params)));
+        addDatasetIdentifier(mdDataIdentification, "uuid-3", null, "crossReference", "collection");
+        assertEquals(errorsStart, countFailures(Xml.transform(testMetadata, getSchematronXsl(), params)));
+        addDatasetIdentifier(mdDataIdentification, "uuid-4", "href-4", "crossReference", "collection");
+        assertEquals(errorsStart, countFailures(Xml.transform(testMetadata, getSchematronXsl(), params)));
+
+        // adding duplicate uuid+initiativeType+associationType combinations should fail
+        Element bad = addDatasetIdentifier(mdDataIdentification, "uuid-1", null, "largerWorkCitation", null);
+        assertEquals(errorsStart+2, countFailures(Xml.transform(testMetadata, getSchematronXsl(), params)));
+        bad.detach();
+        bad = addDatasetIdentifier(mdDataIdentification, "uuid-3", null, "crossReference", "campaign");
+        assertEquals(errorsStart+2, countFailures(Xml.transform(testMetadata, getSchematronXsl(), params)));
+        bad.detach();
+        bad = addDatasetIdentifier(mdDataIdentification, "uuid-1", "href-1", "largerWorkCitation", null);
+        assertEquals(errorsStart+2, countFailures(Xml.transform(testMetadata, getSchematronXsl(), params)));
+        bad.detach();
+        bad = addDatasetIdentifier(mdDataIdentification, "uuid-4", "href-4", "crossReference", "collection");
+        assertEquals(errorsStart+2, countFailures(Xml.transform(testMetadata, getSchematronXsl(), params)));
+        bad.detach();
+    }
+
+    private static Element addDatasetIdentifier(Element parent, String uuid, String href, String associationType, String initiativeType) {
+        Element ai = new Element("aggregationInfo", GMD);
+        Element mdAi = new Element("MD_AggregateInformation", GMD);
+        Element adsi = new Element("aggregateDataSetIdentifier", GMD);
+        Element mdIdentifier = new Element("MD_Identifier", GMD);
+        Element code = new Element("code", GMD);
+
+        Element at = new Element("associationType", GMD);
+        Element dsAt = new Element("DS_AssociationTypeCode", GMD);
+        dsAt.setAttribute("codeListValue", associationType);
+        dsAt.setAttribute("codeList", "http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#DS_AssociationTypeCode");
+
+        at.addContent(dsAt);
+        ai.addContent(mdAi);
+        mdAi.addContent(adsi);
+        mdAi.addContent(at);
+        adsi.addContent(mdIdentifier);
+        mdIdentifier.addContent(code);
+
+        if(initiativeType!=null) {
+            Element it = new Element("initiativeType", GMD);
+            Element dsIt = new Element("DS_InitiativeTypeCode", GMD);
+            dsIt.setAttribute("codeListValue", initiativeType);
+            dsIt.setAttribute("codeList", "http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#DS_InitiativeTypeCode");
+            it.addContent(dsIt);
+            mdAi.addContent(it);
+        }
+
+        if(href!=null) {
+            Element anchor = new Element("Anchor", GMX);
+            anchor.setAttribute("href", href, XLINK);
+            anchor.setText(uuid);
+            code.addContent(anchor);
+        } else {
+            Element cs = new Element("CharacterString", GCO);
+            cs.setText(uuid);
+            code.addContent(cs);
+        }
+
+        parent.addContent(ai);
+
+        return ai;
     }
 
     private void testNoStringErrors(Element testMetadata, Element contact) throws Exception {


### PR DESCRIPTION
I believe to have identified a bug in a previous PR (https://github.com/geonetwork/core-geonetwork/pull/6930) @fxprunayre .

When adding multiple related datasets the duplicate check fails when they have the same association and initiative. More specifically: in my test I'm adding multiple dataset with **no** initiative and identical association values.

The schematron check compares the `$mdRefRef` variable but that contains multiple elements instead of the desired UUID (as I understood). In my tests, `$mdRefRef` contains two elements: `gco:CharacterString` and `geonet:element`. The comparison in `$hasNoDuplicate` then proceeds to fail.
  
# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [x] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
