### PR TITLE
Home page / sort topic categories and INSPIRE themes facets alphabetically

### DIFF
--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/FacetDirective.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/FacetDirective.js
@@ -184,6 +184,18 @@
           };
         }
       };
+
+      this.sortByQuantity = function (agg, bucket) {
+        return function (facet) {
+          return facet.count;
+        };
+      };
+
+      this.sortByQuantityDesc = function (agg, bucket) {
+        return function (facet) {
+          return -1 * facet.count;
+        };
+      };
     }
   ]);
 
@@ -472,7 +484,6 @@
         },
         link: function (scope, element, attrs) {
           scope.iso2lang = gnLangs.getIso2Lang(gnLangs.getCurrent());
-          scope.facetSorter = gnFacetSorter.sortByTranslation;
 
           function init() {
             scope.missingValue =
@@ -487,6 +498,14 @@
           }
 
           init();
+
+          scope.getFacetSorter = function (facet) {
+            if (facet.meta && facet.meta.orderByTranslation) {
+              return gnFacetSorter.sortByTranslation;
+            } else {
+              return gnFacetSorter.sortByQuantityDesc;
+            }
+          };
 
           scope.$watch("key", function (n, o) {
             if (n && n !== o) {

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/FacetDirective.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/FacetDirective.js
@@ -453,8 +453,9 @@
   ]);
 
   module.directive("esFacetCards", [
+    "gnFacetSorter",
     "gnLangs",
-    function (gnLangs) {
+    function (gnFacetSorter, gnLangs) {
       return {
         restrict: "A",
         scope: {
@@ -471,6 +472,7 @@
         },
         link: function (scope, element, attrs) {
           scope.iso2lang = gnLangs.getIso2Lang(gnLangs.getCurrent());
+          scope.facetSorter = gnFacetSorter.sortByTranslation;
 
           function init() {
             scope.missingValue =

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/FacetDirective.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/FacetDirective.js
@@ -184,18 +184,6 @@
           };
         }
       };
-
-      this.sortByQuantity = function (agg, bucket) {
-        return function (facet) {
-          return facet.count;
-        };
-      };
-
-      this.sortByQuantityDesc = function (agg, bucket) {
-        return function (facet) {
-          return -1 * facet.count;
-        };
-      };
     }
   ]);
 

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/FacetDirective.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/FacetDirective.js
@@ -499,14 +499,7 @@
 
           init();
 
-          scope.getFacetSorter = function (facet) {
-            if (facet.meta && facet.meta.orderByTranslation) {
-              return gnFacetSorter.sortByTranslation;
-            } else {
-              return gnFacetSorter.sortByQuantityDesc;
-            }
-          };
-
+          scope.facetSorter = gnFacetSorter.sortByTranslation;
           scope.$watch("key", function (n, o) {
             if (n && n !== o) {
               init();

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facet-cards.html
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facet-cards.html
@@ -1,5 +1,5 @@
 <div
-  data-ng-repeat="(k, facet) in aggregations[key].items | orderBy:facetSorter(aggregations[key], aggregations[key].key)"
+  data-ng-repeat="(k, facet) in aggregations[key].items | orderBy: getFacetSorter(aggregations[key])(aggregations[key], aggregations[key].key)"
   data-ng-init="facetValue = facet.value;"
   data-ng-show="facetValue"
   data-ng-class="isInspire ? ('bg-iti-' + (facet.key | facetCssClassCode: isInspire)) : ''"

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facet-cards.html
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facet-cards.html
@@ -1,5 +1,5 @@
 <div
-  data-ng-repeat="(k, facet) in aggregations[key].items | orderBy: getFacetSorter(aggregations[key])(aggregations[key], aggregations[key].key)"
+  data-ng-repeat="(k, facet) in aggregations[key].items | orderBy: facetSorter(aggregations[key], aggregations[key].key)"
   data-ng-init="facetValue = facet.value;"
   data-ng-show="facetValue"
   data-ng-class="isInspire ? ('bg-iti-' + (facet.key | facetCssClassCode: isInspire)) : ''"

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facet-cards.html
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facet-cards.html
@@ -1,5 +1,5 @@
 <div
-  data-ng-repeat="(k, facet) in aggregations[key].items"
+  data-ng-repeat="(k, facet) in aggregations[key].items | orderBy:facetSorter(aggregations[key], aggregations[key].key)"
   data-ng-init="facetValue = facet.value;"
   data-ng-show="facetValue"
   data-ng-class="isInspire ? ('bg-iti-' + (facet.key | facetCssClassCode: isInspire)) : ''"

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -142,7 +142,8 @@
                     type: "icon",
                     prefix: "fa fa-2x pull-left gn-icon iti-",
                     expression: "http://inspire.ec.europa.eu/theme/(.*)"
-                  }
+                  },
+                  orderByTranslation: true
                 }
               },
               "cl_topic.key": {
@@ -154,7 +155,8 @@
                   decorator: {
                     type: "icon",
                     prefix: "fa fa-2x pull-left gn-icon-"
-                  }
+                  },
+                  orderByTranslation: true
                 }
               },
               // 'OrgForResource': {


### PR DESCRIPTION
Currently the topic categories and INSPIRE themes filters in the home page seem sorted by the amount of metadata in each category. This change adds support to sort the values alphabetically.

Before:

![home-facets-before](https://github.com/geonetwork/core-geonetwork/assets/1695003/ec229b6d-c6ab-4411-b83e-c1999b9c04fb)


After:

![home-facets-after](https://github.com/geonetwork/core-geonetwork/assets/1695003/c1e48674-6a09-47a0-bb69-c733b22d5485)


# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
