### PR TITLE
Fix duplicate SpringDoc tags.

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/ApiParams.java
+++ b/services/src/main/java/org/fao/geonet/api/ApiParams.java
@@ -33,6 +33,10 @@ public class ApiParams {
     public static final String API_CLASS_CATALOG_TAG = "site";
     public static final String API_CLASS_REGISTRIES_OPS = "Registries related operations";
     public static final String API_CLASS_REGISTRIES_TAG = "registries";
+    public static final String API_CLASS_TOOLS_TAG = "tools";
+    public static final String API_CLASS_TOOLS_OPS = "Utility operations";
+    public static final String API_CLASS_FORMATTERS_TAG = "formatters";
+    public static final String API_CLASS_FORMATTERS_OPS = "Formatter operations";
 
 
     public static final String API_PARAM_RECORD_UUID = "Record UUID.";

--- a/services/src/main/java/org/fao/geonet/api/records/DoiApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/DoiApi.java
@@ -48,6 +48,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 import java.util.Map;
 
+import static org.fao.geonet.api.ApiParams.API_CLASS_RECORD_OPS;
 import static org.fao.geonet.api.ApiParams.API_CLASS_RECORD_TAG;
 import static org.fao.geonet.api.ApiParams.API_PARAM_RECORD_UUID;
 
@@ -57,7 +58,8 @@ import static org.fao.geonet.api.ApiParams.API_PARAM_RECORD_UUID;
 @RequestMapping(value = {
     "/{portal}/api/records"
 })
-@Tag(name = API_CLASS_RECORD_TAG)
+@Tag(name = API_CLASS_RECORD_TAG,
+    description = API_CLASS_RECORD_OPS)
 @Controller("doi")
 @PreAuthorize("hasAuthority('Editor')")
 @ReadWriteController

--- a/services/src/main/java/org/fao/geonet/api/records/InspireValidationApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/InspireValidationApi.java
@@ -82,6 +82,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 
+import static org.fao.geonet.api.ApiParams.API_CLASS_RECORD_OPS;
 import static org.fao.geonet.api.ApiParams.API_CLASS_RECORD_TAG;
 import static org.fao.geonet.api.ApiParams.API_PARAM_RECORD_UUID;
 
@@ -89,7 +90,8 @@ import static org.fao.geonet.api.ApiParams.API_PARAM_RECORD_UUID;
 @RequestMapping(value = {
     "/{portal}/api/records"
 })
-@Tag(name = API_CLASS_RECORD_TAG)
+@Tag(name = API_CLASS_RECORD_TAG,
+    description = API_CLASS_RECORD_OPS)
 @Controller("inspire")
 @PreAuthorize("hasAuthority('Editor')")
 @ReadWriteController

--- a/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsActionsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsActionsApi.java
@@ -50,13 +50,15 @@ import javax.annotation.PostConstruct;
 import javax.servlet.http.HttpServletRequest;
 import java.nio.file.Path;
 
+import static org.fao.geonet.api.ApiParams.API_CLASS_RECORD_OPS;
+import static org.fao.geonet.api.ApiParams.API_CLASS_RECORD_TAG;
 import static org.fao.geonet.api.ApiParams.API_PARAM_RECORD_UUID;
 
 @EnableWebMvc
 @Controller
 @Service
-@Tag(name = "records",
-    description = "Metadata record operations")
+@Tag(name = API_CLASS_RECORD_TAG,
+    description = API_CLASS_RECORD_OPS)
 public class AttachmentsActionsApi {
     private final ApplicationContext appContext = ApplicationContextHolder.get();
     @Autowired

--- a/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsApi.java
@@ -25,6 +25,9 @@
 
 package org.fao.geonet.api.records.attachments;
 
+import static org.fao.geonet.api.ApiParams.API_CLASS_RECORD_OPS;
+import static org.fao.geonet.api.ApiParams.API_CLASS_RECORD_TAG;
+
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
@@ -80,7 +83,8 @@ import java.util.List;
 @EnableWebMvc
 @Service
 @RequestMapping(value = {"/{portal}/api/records/{metadataUuid}/attachments"})
-@Tag(name = "records", description = "Metadata record operations")
+@Tag(name = API_CLASS_RECORD_TAG,
+    description = API_CLASS_RECORD_OPS)
 public class AttachmentsApi {
     public static final Integer MIN_IMAGE_SIZE = 1;
     public static final Integer MAX_IMAGE_SIZE = 2048;

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/CacheApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/CacheApi.java
@@ -23,6 +23,9 @@
 
 package org.fao.geonet.api.records.formatters;
 
+import static org.fao.geonet.api.ApiParams.API_CLASS_FORMATTERS_OPS;
+import static org.fao.geonet.api.ApiParams.API_CLASS_FORMATTERS_TAG;
+
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -40,8 +43,8 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 @RequestMapping(value = {
     "/{portal}/api/formatters"
 })
-@Tag(name = "formatters",
-    description = "Formatter operations")
+@Tag(name = API_CLASS_FORMATTERS_TAG,
+    description = API_CLASS_FORMATTERS_OPS)
 @Controller("formatters")
 @ReadWriteController
 public class CacheApi {

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterAdminApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterAdminApi.java
@@ -73,6 +73,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import static org.fao.geonet.api.ApiParams.API_CLASS_FORMATTERS_OPS;
+import static org.fao.geonet.api.ApiParams.API_CLASS_FORMATTERS_TAG;
 import static org.fao.geonet.api.records.formatters.FormatterConstants.SCHEMA_PLUGIN_FORMATTER_DIR;
 import static org.fao.geonet.api.records.formatters.FormatterConstants.VIEW_XSL_FILENAME;
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
@@ -82,8 +84,8 @@ import static org.springframework.web.bind.annotation.RequestMethod.GET;
  *
  * @author jeichar
  */
-@Tag(name = "formatters",
-    description = "Formatter admin operations")
+@Tag(name = API_CLASS_FORMATTERS_TAG,
+    description = API_CLASS_FORMATTERS_OPS)
 @Controller("formattersList")
 public class FormatterAdminApi extends AbstractFormatService {
 

--- a/services/src/main/java/org/fao/geonet/api/sld/SldApi.java
+++ b/services/src/main/java/org/fao/geonet/api/sld/SldApi.java
@@ -1,5 +1,8 @@
 package org.fao.geonet.api.sld;
 
+import static org.fao.geonet.api.ApiParams.API_CLASS_TOOLS_OPS;
+import static org.fao.geonet.api.ApiParams.API_CLASS_TOOLS_TAG;
+
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jeeves.transaction.TransactionManager;
@@ -47,8 +50,8 @@ import java.util.Optional;
 @RequestMapping(value = {
     "/{portal}/api/tools/ogc"
 })
-@Tag(name = "tools",
-    description = "Utility operations")
+@Tag(name = API_CLASS_TOOLS_TAG,
+    description = API_CLASS_TOOLS_OPS)
 public class SldApi {
 
     public static final String LOGGER = Geonet.GEONETWORK + ".api.sld";

--- a/services/src/main/java/org/fao/geonet/api/tools/i18n/TranslationApi.java
+++ b/services/src/main/java/org/fao/geonet/api/tools/i18n/TranslationApi.java
@@ -52,6 +52,8 @@ import java.util.*;
 import java.util.stream.Collectors;
 
 import static java.util.stream.Collectors.groupingBy;
+import static org.fao.geonet.api.ApiParams.API_CLASS_TOOLS_OPS;
+import static org.fao.geonet.api.ApiParams.API_CLASS_TOOLS_TAG;
 import static org.springframework.http.HttpStatus.CREATED;
 import static org.springframework.http.HttpStatus.OK;
 
@@ -61,7 +63,8 @@ import static org.springframework.http.HttpStatus.OK;
 @RequestMapping(value = {
     "/{portal}/api/i18n"
 })
-@Tag(name = "tools")
+@Tag(name = API_CLASS_TOOLS_TAG,
+    description = API_CLASS_TOOLS_OPS)
 @RestController
 public class TranslationApi {
 

--- a/services/src/main/java/org/fao/geonet/api/tools/mail/MailApi.java
+++ b/services/src/main/java/org/fao/geonet/api/tools/mail/MailApi.java
@@ -45,6 +45,9 @@ package org.fao.geonet.api.tools.mail;
 //===	Rome - Italy. email: geonetwork@osgeo.org
 //==============================================================================
 
+import static org.fao.geonet.api.ApiParams.API_CLASS_TOOLS_OPS;
+import static org.fao.geonet.api.ApiParams.API_CLASS_TOOLS_TAG;
+
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.fao.geonet.api.API;
 import org.fao.geonet.api.tools.i18n.LanguageUtils;
@@ -73,8 +76,8 @@ import java.util.ResourceBundle;
 @RequestMapping(value = {
     "/{portal}/api/tools/mail"
 })
-@Tag(name = "tools",
-    description = "Utility operations")
+@Tag(name = API_CLASS_TOOLS_TAG,
+    description = API_CLASS_TOOLS_OPS)
 @Controller("mail")
 public class MailApi {
 

--- a/services/src/main/java/org/fao/geonet/api/tools/migration/MigrationApi.java
+++ b/services/src/main/java/org/fao/geonet/api/tools/migration/MigrationApi.java
@@ -23,6 +23,9 @@
 
 package org.fao.geonet.api.tools.migration;
 
+import static org.fao.geonet.api.ApiParams.API_CLASS_TOOLS_OPS;
+import static org.fao.geonet.api.ApiParams.API_CLASS_TOOLS_TAG;
+
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.fao.geonet.ApplicationContextHolder;
@@ -43,7 +46,8 @@ import java.sql.Connection;
 @RequestMapping(value = {
     "/{portal}/api/tools/migration"
 })
-@Tag(name = "tools")
+@Tag(name = API_CLASS_TOOLS_TAG,
+    description = API_CLASS_TOOLS_OPS)
 @RestController
 public class MigrationApi {
 


### PR DESCRIPTION
Ensure that all tags have the same description.

If we post the open api spec to https://editor.swagger.io/ there are a bunch of errors.  
This PR is to fix the following errors. 
![image](https://github.com/geonetwork/core-geonetwork/assets/1868233/8fb155aa-340e-4c5b-ba1e-5a0eeabb599b)

![image](https://github.com/geonetwork/core-geonetwork/assets/1868233/e2031d1b-c56d-48c6-86f1-a95c7ff9c934)

The issue is caused by duplicate tags due to the descriptions being different.

This PR is to ensure that the tags causing errors are using the same tag name and description.


# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
