### PR TITLE
Update SpringDoc json/yaml generator to make the results more deterministic.

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/OpenApiController.java
+++ b/services/src/main/java/org/fao/geonet/api/OpenApiController.java
@@ -21,9 +21,7 @@
 package org.fao.geonet.api;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import io.swagger.v3.core.util.Json;
 import io.swagger.v3.core.util.PathUtils;
-import io.swagger.v3.core.util.Yaml;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.models.OpenAPI;
 import org.springdoc.api.AbstractOpenApiResource;
@@ -33,12 +31,9 @@ import org.springdoc.core.customizers.OperationCustomizer;
 import org.springdoc.webmvc.core.RouterFunctionProvider;
 import org.springframework.beans.factory.ObjectFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.core.annotation.AnnotationUtils;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
-import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.ModelAndView;
@@ -48,7 +43,6 @@ import org.springframework.web.servlet.mvc.method.RequestMappingInfoHandlerMappi
 
 import javax.servlet.http.HttpServletRequest;
 
-import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 import static org.springdoc.core.Constants.*;


### PR DESCRIPTION
Update SpringDoc json/yaml generator to make the results more deterministic.

This will make it easier to compare different versions between gn releases.

These are the properties that were enabled.

   springdoc.writer-with-order-by-keys=true
   springdoc.writer-with-default-pretty-printer=true


# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
