### PR TITLE
Fix initialization of SpringDoc so that it does not use null servername and null version

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/OpenApiConfig.java
+++ b/services/src/main/java/org/fao/geonet/api/OpenApiConfig.java
@@ -52,9 +52,6 @@ import static org.fao.geonet.kernel.setting.Settings.SYSTEM_PLATFORM_VERSION;
 @OpenAPIDefinition
 public class OpenApiConfig {
 
-    /**
-     * Using static value so that should the bean be called twice, it will reuse the same object.
-     */
     private static OpenAPI openAPI = null;
 
     private static SettingManager settingManager = null;
@@ -65,8 +62,25 @@ public class OpenApiConfig {
     }
 
     @Bean
-    public OpenAPI OpenApiConfig(SettingManager settingManager) {
-        this.settingManager = settingManager;
+    public OpenAPI openApi(final SettingManager settingManager) {
+        return OpenApiConfig.setupOpenApiConfig(settingManager);
+    }
+
+    /**
+     * Setup OpenAPI configuration.
+     *
+     * Using static function so that should the bean be called twice (which it does), it will reuse the same static objects.
+     * During first call, the settingManager may not be properly setup (i.e. initial install) and will return null values for version and host information.
+     * Subsequent calls will update the related OpenAPI information with the settingManager values.
+     *
+     * It is also static so that when we update the object on second call, it will also update the object returned from the first call as they will be
+     * pointing to the same object.
+     *
+     * @param settingManager containing host and version information required.
+     * @return OpenAPI object.
+     */
+    private static OpenAPI setupOpenApiConfig(final SettingManager settingManager) {
+        OpenApiConfig.settingManager = settingManager;
         if (openAPI == null) {
             openAPI = new OpenAPI().info(new Info()
                     .description("This is the description of the GeoNetwork OpenAPI. Use this API to manage your catalog.")
@@ -99,7 +113,7 @@ public class OpenApiConfig {
     /**
      * Update openAPI object with version related information.
      */
-    private void setVersionRelatedInfo() {
+    private static void setVersionRelatedInfo() {
 
         String version = settingManager.getValue(SYSTEM_PLATFORM_VERSION);
 
@@ -113,7 +127,7 @@ public class OpenApiConfig {
      * Update openAPI object with host related information.
      */
     public static void setHostRelatedInfo() {
-        if (settingManager==null || openAPI == null) {
+        if (settingManager == null || openAPI == null) {
             return;
         }
 

--- a/services/src/main/java/org/fao/geonet/api/OpenApiConfig.java
+++ b/services/src/main/java/org/fao/geonet/api/OpenApiConfig.java
@@ -1,6 +1,6 @@
 /*
  * =============================================================================
- * ===	Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * ===	Copyright (C) 2001-2023 Food and Agriculture Organization of the
  * ===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * ===	and United Nations Environment Programme (UNEP)
  * ===
@@ -36,7 +36,6 @@ import io.swagger.v3.oas.models.servers.ServerVariable;
 import io.swagger.v3.oas.models.servers.ServerVariables;
 import org.fao.geonet.NodeInfo;
 import org.fao.geonet.kernel.setting.SettingManager;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
@@ -51,7 +50,14 @@ import static org.fao.geonet.kernel.setting.Settings.SYSTEM_PLATFORM_VERSION;
 @Configuration
 @EnableCaching
 @OpenAPIDefinition
-public class OpenApiConfig  {
+public class OpenApiConfig {
+
+    /**
+     * Using static value so that should the bean be called twice, it will reuse the same object.
+     */
+    private static OpenAPI openAPI = null;
+
+    private static SettingManager settingManager = null;
 
     @Bean(name = "cacheManager")
     public CacheManager cacheManager() {
@@ -59,11 +65,60 @@ public class OpenApiConfig  {
     }
 
     @Bean
-    @Autowired
     public OpenAPI OpenApiConfig(SettingManager settingManager) {
-        List<Server> servers = new ArrayList<>();
+        this.settingManager = settingManager;
+        if (openAPI == null) {
+            openAPI = new OpenAPI().info(new Info()
+                    .description("This is the description of the GeoNetwork OpenAPI. Use this API to manage your catalog.")
+                    .contact(new Contact()
+                        .email("geonetwork-users@lists.sourceforge.net")
+                        .name("GeoNetwork user mailing list")
+                        .url("https://sourceforge.net/p/geonetwork/mailman/geonetwork-users/")
+                    )
+                    .license(new License()
+                        .name("GPL 2.0")
+                        .url("http://www.gnu.org/licenses/old-licenses/gpl-2.0.html")))
+                .externalDocs(new ExternalDocumentation()
+                    .description("Learn how to access the catalog using the GeoNetwork REST API."));
+
+            setVersionRelatedInfo();
+            setHostRelatedInfo();
+
+        } else if (openAPI.getInfo() != null && openAPI.getInfo().getVersion() == null) {
+            // During initial install, the version will not be set when using the JeevesApplicationContext
+            // But it will be set afterward when creating WebApplicationContext.  So if the version is null but our new version is not null
+            // then lets update data based on the version.
+            setVersionRelatedInfo();
+            // If the version was not set then the hostUrl was also not set correctly so update that as well.
+            setHostRelatedInfo();
+        }
+
+        return openAPI;
+    }
+
+    /**
+     * Update openAPI object with version related information.
+     */
+    private void setVersionRelatedInfo() {
 
         String version = settingManager.getValue(SYSTEM_PLATFORM_VERSION);
+
+        openAPI.getInfo().setVersion(version);
+        openAPI.getInfo().setTitle(String.format(
+            "GeoNetwork %s OpenAPI Documentation",
+            version));
+    }
+
+    /**
+     * Update openAPI object with host related information.
+     */
+    public static void setHostRelatedInfo() {
+        if (settingManager==null || openAPI == null) {
+            return;
+        }
+
+        List<Server> servers = new ArrayList<>();
+
         String hostUrl = settingManager.getBaseURL().replaceAll("/+$", "");
 
         ServerVariable catalogVariable = new ServerVariable()
@@ -85,24 +140,7 @@ public class OpenApiConfig  {
                 .addServerVariable("portal", portalVariable)
             )
         );
-
-        return new OpenAPI().info(new Info()
-                .title(String.format(
-                    "GeoNetwork %s OpenAPI Documentation",
-                    version))
-                .description("This is the description of the GeoNetwork OpenAPI. Use this API to manage your catalog.")
-                .contact(new Contact()
-                    .email("geonetwork-users@lists.sourceforge.net")
-                    .name("GeoNetwork user mailing list")
-                    .url("https://sourceforge.net/p/geonetwork/mailman/geonetwork-users/")
-                )
-                .version(version)
-                .license(new License()
-                    .name("GPL 2.0")
-                    .url("http://www.gnu.org/licenses/old-licenses/gpl-2.0.html")))
-            .externalDocs(new ExternalDocumentation()
-                .description("Learn how to access the catalog using the GeoNetwork REST API.")
-                .url(String.format("%s/doc/api", hostUrl)))
-            .servers(servers);
+        openAPI.setServers(servers);
+        openAPI.getExternalDocs().setUrl(String.format("%s/doc/api", hostUrl));
     }
 }

--- a/services/src/main/java/org/fao/geonet/api/site/SiteApi.java
+++ b/services/src/main/java/org/fao/geonet/api/site/SiteApi.java
@@ -42,6 +42,7 @@ import org.fao.geonet.NodeInfo;
 import org.fao.geonet.SystemInfo;
 import org.fao.geonet.api.ApiParams;
 import org.fao.geonet.api.ApiUtils;
+import org.fao.geonet.api.OpenApiConfig;
 import org.fao.geonet.api.exception.NotAllowedException;
 import org.fao.geonet.api.site.model.SettingSet;
 import org.fao.geonet.api.site.model.SettingsListResponse;
@@ -420,6 +421,7 @@ public class SiteApi {
         ApplicationContext applicationContext = ApplicationContextHolder.get();
         String currentUuid = settingManager.getSiteId();
         String oldSiteName = settingManager.getSiteName();
+        String oldBaseUrl = settingManager.getBaseURL();
 
         if (!settingManager.setValues(allRequestParams)) {
             throw new OperationAbortedEx("Cannot set all values");
@@ -438,6 +440,11 @@ public class SiteApi {
                 );
                 sourceRepository.save(siteSource);
             }
+        }
+        String newBaseUrl = settingManager.getBaseURL();
+        // Update SpringDoc host information if the base url is changed.
+        if (!oldBaseUrl.equals(newBaseUrl)) {
+            OpenApiConfig.setHostRelatedInfo();
         }
 
         // Update the system default timezone. If the setting is blank use the timezone user.timezone property from command line or


### PR DESCRIPTION
Fix initialization of SpringDoc so that it does not use null servername and null version

Before this fix. The initial deployment of geonetwork in a new database would cause Spring Doc api to look like the following

![image](https://github.com/geonetwork/core-geonetwork/assets/1868233/609496ac-8fb4-4bad-8785-743fa72b2a81)

Also if checking the yaml api on https://editor.swagger.io/, we would see the following error because the version was not set.
![image](https://github.com/geonetwork/core-geonetwork/assets/1868233/1f3e5847-91cc-4d67-a44e-db5235329fa2)

The issue was mostly caused by 2 contexts being used. 
JeevesApplicationContext was being loaded first and at that time, the database was not initialized with the data and ended up returning a null servername and null version from the settings manager.

Then it would later initialize WebApplicationContext and this would initialized the correct version.  But when going to /doc/api/ it was using the JeevesApplicationContext version which was incorrect.

This fix modified OpenApi object so that it is a static object that is shared with all context.  This helped fix initial api setting so that it was not set to null://null:80/geonetwork/srv/api 

After this fix, a new installation of geonetwork will show the following:

![image](https://github.com/geonetwork/core-geonetwork/assets/1868233/83873449-c649-4326-a9a2-4d287a02bbbb)


Also as part of this fix, SiteApi was updated so that if the server url is changed then it will update the static OpenApi object without requiring an application restart.


# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
