### PR TITLE
GeoNetwork harvester / Check if a resource exists to save it, instead of trying to retrieve the file details, to avoid confusing NoSuchFileException exception

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Aligner.java
@@ -30,6 +30,7 @@ import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.GeonetContext;
 import org.fao.geonet.Logger;
 import org.fao.geonet.MetadataResourceDatabaseMigration;
+import org.fao.geonet.api.exception.ResourceNotFoundException;
 import org.fao.geonet.api.records.attachments.Store;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.*;
@@ -77,9 +78,9 @@ public class Aligner extends BaseAligner<GeonetParams> {
     private UUIDMapper localUuids;
     private String processName;
     private String preferredSchema;
-    private Map<String, Object> processParams = new HashMap<String, Object>();
+    private Map<String, Object> processParams = new HashMap<>();
     private MetadataRepository metadataRepository;
-    private Map<String, Map<String, String>> hmRemoteGroups = new HashMap<String, Map<String, String>>();
+    private Map<String, Map<String, String>> hmRemoteGroups = new HashMap<>();
     private SettingManager settingManager;
 
     public Aligner(AtomicBoolean cancelMonitor, Logger log, ServiceContext context, XmlRequest req,
@@ -119,7 +120,7 @@ public class Aligner extends BaseAligner<GeonetParams> {
         for (Element entity : list) {
             String name = entity.getChildText("name");
 
-            Map<String, String> hm = new HashMap<String, String>();
+            Map<String, String> hm = new HashMap<>();
             hmEntity.put(name, hm);
 
             @SuppressWarnings("unchecked")
@@ -163,7 +164,7 @@ public class Aligner extends BaseAligner<GeonetParams> {
 
                     result.locallyRemoved++;
                 }
-            } catch (Throwable t) {
+            } catch (Exception t) {
                 log.error("Couldn't remove metadata with uuid " + uuid);
                 log.error(t);
                 result.unchangedMetadata++;
@@ -197,7 +198,6 @@ public class Aligner extends BaseAligner<GeonetParams> {
                     String id = dataMan.getMetadataId(ri.uuid);
 
                     // look up value of localrating/enable
-                    SettingManager settingManager = context.getBean(SettingManager.class);
                     String localRating = settingManager.getValue(Settings.SYSTEM_LOCALRATING_ENABLE);
 
                     if (id == null) {
@@ -230,6 +230,7 @@ public class Aligner extends BaseAligner<GeonetParams> {
                             case SKIP:
                                 log.debug("Skipping record with uuid " + ri.uuid);
                                 result.uuidSkipped++;
+                                break;
                             default:
                                 break;
                         }
@@ -248,7 +249,7 @@ public class Aligner extends BaseAligner<GeonetParams> {
                     }
 
                 }
-            } catch (Throwable t) {
+            } catch (Exception t) {
                 log.error("Couldn't insert or update metadata with uuid " + ri.uuid);
                 log.error(t);
                 result.unchangedMetadata++;
@@ -282,7 +283,7 @@ public class Aligner extends BaseAligner<GeonetParams> {
             Log.debug(Geonet.MEF, "Multiple metadata files");
 
         Map<String, Pair<String, Element>> mdFiles =
-            new HashMap<String, Pair<String, Element>>();
+            new HashMap<>();
         for (Path file : files) {
             if (Files.isRegularFile(file)) {
                 Element metadata = Xml.loadFile(file);
@@ -353,8 +354,8 @@ public class Aligner extends BaseAligner<GeonetParams> {
     }
 
     private void addMetadata(final RecordInfo ri, final boolean localRating, String uuid) throws Exception {
-        final String id[] = {null};
-        final Element md[] = {null};
+        final String[] id = {null};
+        final Element[] md = {null};
 
         //--- import metadata from MEF file
 
@@ -595,13 +596,13 @@ public class Aligner extends BaseAligner<GeonetParams> {
     }
 
     private Map<String, Set<String>> buildPrivileges(Element privil) {
-        Map<String, Set<String>> map = new HashMap<String, Set<String>>();
+        Map<String, Set<String>> map = new HashMap<>();
 
         for (Object o : privil.getChildren("group")) {
             Element group = (Element) o;
             String name = group.getAttributeValue("name");
 
-            Set<String> set = new HashSet<String>();
+            Set<String> set = new HashSet<>();
             map.put(name, set);
 
             for (Object op : group.getChildren("operation")) {
@@ -662,9 +663,9 @@ public class Aligner extends BaseAligner<GeonetParams> {
      */
     private void updateMetadata(final RecordInfo ri, final String id, final boolean localRating,
                                 final boolean useChangeDate, String localChangeDate, Boolean force) throws Exception {
-        final Element md[] = {null};
-        final Element publicFiles[] = {null};
-        final Element privateFiles[] = {null};
+        final Element[] md = {null};
+        final Element[] publicFiles = {null};
+        final Element[] privateFiles = {null};
 
         if (localUuids.getID(ri.uuid) == null && !force) {
             if (log.isDebugEnabled())
@@ -756,7 +757,6 @@ public class Aligner extends BaseAligner<GeonetParams> {
             return;
         }
 
-        final IMetadataManager metadataManager = context.getBean(IMetadataManager.class);
         Metadata metadata;
         if (!force && !ri.isMoreRecentThan(date)) {
             if (log.isDebugEnabled())
@@ -883,12 +883,23 @@ public class Aligner extends BaseAligner<GeonetParams> {
         ISODate remIsoDate = new ISODate(changeDate);
         boolean saveFile;
 
-        final MetadataResource description = store.getResourceDescription(context, metadataUuid, visibility, file, true);
-        if (description == null) {
+        Store.ResourceHolder resourceHolder;
+        try {
+            resourceHolder = store.getResource(context, metadataUuid, visibility, file, true);
+        } catch (ResourceNotFoundException ex) {
+            resourceHolder = null;
+        }
+
+        if (resourceHolder == null) {
             saveFile = true;
         } else {
-            ISODate locIsoDate = new ISODate(description.getLastModification().getTime(), false);
-            saveFile = (remIsoDate.timeDifferenceInSeconds(locIsoDate) > 0);
+            final MetadataResource description = resourceHolder.getMetadata();
+            if (description == null) {
+                saveFile = true;
+            } else {
+                ISODate locIsoDate = new ISODate(description.getLastModification().getTime(), false);
+                saveFile = (remIsoDate.timeDifferenceInSeconds(locIsoDate) > 0);
+            }
         }
 
         if (saveFile) {

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Aligner.java
@@ -890,16 +890,11 @@ public class Aligner extends BaseAligner<GeonetParams> {
             resourceHolder = null;
         }
 
-        if (resourceHolder == null) {
-            saveFile = true;
+        if ((resourceHolder != null) && (resourceHolder.getMetadata() != null)) {
+            ISODate locIsoDate = new ISODate(resourceHolder.getMetadata().getLastModification().getTime(), false);
+            saveFile = (remIsoDate.timeDifferenceInSeconds(locIsoDate) > 0);
         } else {
-            final MetadataResource description = resourceHolder.getMetadata();
-            if (description == null) {
-                saveFile = true;
-            } else {
-                ISODate locIsoDate = new ISODate(description.getLastModification().getTime(), false);
-                saveFile = (remIsoDate.timeDifferenceInSeconds(locIsoDate) > 0);
-            }
+            saveFile = true;
         }
 
         if (saveFile) {


### PR DESCRIPTION
The GeoNetwork harvester, when using MEF format and the remote metadata has files attached, logs this type of exceptions:

```
2023-12-21 11:00:09,194 ERROR [geonetwork.resources] - Error getting size of file <path>/geonetwork_data/data/metadata_data/118200-118299/118243/public/grafik.png: <path>/geonetwork_data/data/metadata_data/118200-118299/118243/public/grafik.png
java.nio.file.NoSuchFileException: <path>/geonetwork_data/data/metadata_data/118200-118299/118243/public/grafik.png
at sun.nio.fs.UnixException.translateToIOException(UnixException.java:86)
at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:102)
at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:107)
at sun.nio.fs.UnixFileAttributeViews$Basic.readAttributes(UnixFileAttributeViews.java:55)
at sun.nio.fs.UnixFileSystemProvider.readAttributes(UnixFileSystemProvider.java:144)
at sun.nio.fs.LinuxFileSystemProvider.readAttributes(LinuxFileSystemProvider.java:99)
at java.nio.file.Files.readAttributes(Files.java:1737)
at java.nio.file.Files.size(Files.java:2332)
at org.fao.geonet.api.records.attachments.FilesystemStore.getResourceDescription(FilesystemStore.java:145)
at org.fao.geonet.api.records.attachments.FilesystemStore.getResourceDescription(FilesystemStore.java:127)
at org.fao.geonet.api.records.attachments.ResourceLoggerStore.getResourceDescription(ResourceLoggerStore.java:151)
at org.fao.geonet.kernel.harvest.harvester.geonet.Aligner.saveFile(Aligner.java:914)
at org.fao.geonet.kernel.harvest.harvester.geonet.Aligner.handleFile(Aligner.java:878)
at org.fao.geonet.kernel.harvest.harvester.geonet.Aligner.access$700(Aligner.java:89)
at org.fao.geonet.kernel.harvest.harvester.geonet.Aligner$2.handlePublicFile(Aligner.java:735)
at org.fao.geonet.kernel.mef.MEF2Visitor.handleBin(MEF2Visitor.java:147)
at org.fao.geonet.kernel.mef.MEF2Visitor.handleXml(MEF2Visitor.java:108)
at org.fao.geonet.kernel.mef.MEF2Visitor.visit(MEF2Visitor.java:52)
at org.fao.geonet.kernel.mef.MEFLib.visit(MEFLib.java:157)
at org.fao.geonet.kernel.harvest.harvester.geonet.Aligner.updateMetadata(Aligner.java:710)
at org.fao.geonet.kernel.harvest.harvester.geonet.Aligner.align(Aligner.java:263)
at org.fao.geonet.kernel.harvest.harvester.geonet.Harvester.harvest(Harvester.java:231)
...
```

It's not really an error in the harvesting process, but the log is confusing.

1) When running for first time the harvester, when identifies a file to add to the data directory of a metadata, checks if the file exists retrieving some information of the file and that causes the exception log as initially the file doesn't exist. The exception is not failing the harvester, it's processed correctly to add the file, but the log is confusing.

2) When running for second time the harvester, when identifies a file to add to the data directory of a metadata, does the same check (that doesn't fail) and if exists removes the file to add the updated one, but this 2on time works as 1) and logs also the exception, but all is processed properly.

These exceptions are caused by the usage of this method that logs an exception when the resource doesn't exist:

https://github.com/geonetwork/core-geonetwork/blob/1f16287e654bc24b6b19b6f3bcd98ef593229676/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStore.java#L160-L178

Changed the code to use the following method that throws an Exception, but doesn't log it. The harvester code captures the exception to decide if the file should be saved or not.

https://github.com/geonetwork/core-geonetwork/blob/1f16287e654bc24b6b19b6f3bcd98ef593229676/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStore.java#L106-L122

---

The change request contains also Sonarlint improvements.

---

Test case:

1) Create a GeoNetwork harvester to a server that has the iso19139 samples

2) Execute the harvester.

  - Without the change: The exceptions described previously are logged.
  - With the change: There are not confusing exceptions in the log.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

