### PR TITLE
Fix SpringDoc duplicate OperationId

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/mapservers/MapServersApi.java
+++ b/services/src/main/java/org/fao/geonet/api/mapservers/MapServersApi.java
@@ -257,7 +257,7 @@ public class MapServersApi {
         @ApiResponse(responseCode = "403", description = ApiParams.API_RESPONSE_NOT_ALLOWED_ONLY_REVIEWER)
     })
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void updateMapserver(
+    public void updateMapserverAuth(
         @Parameter(
             description = API_PARAM_MAPSERVER_IDENTIFIER,
             required = true,

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataApi.java
@@ -106,7 +106,7 @@ public class MetadataApi {
 
     private ApplicationContext context;
 
-    public static RelatedResponse getAssociatedResources(
+    public static RelatedResponse getRelatedResources(
         String language, ServiceContext context,
         AbstractMetadata md, RelatedItemType[] type, int start, int rows) throws Exception {
         // TODO PERF: ByPass XSL processing and create response directly
@@ -471,7 +471,7 @@ public class MetadataApi {
                 if (withRelated) {
                     // Adding children in MEF file
 
-                    RelatedResponse related = getAssociatedResources(
+                    RelatedResponse related = getRelatedResources(
                         metadataUuid, null, approved, 0, 100, request);
                     uuidsToExport.addAll(getUuidsOfAssociatedRecords(related.getParent()));
                     uuidsToExport.addAll(getUuidsOfAssociatedRecords(related.getChildren()));
@@ -609,7 +609,7 @@ public class MetadataApi {
         @ApiResponse(responseCode = "403", description = ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_VIEW)
     })
     @ResponseBody
-    public RelatedResponse getAssociatedResources(
+    public RelatedResponse getRelatedResources(
         @Parameter(
             description = API_PARAM_RECORD_UUID,
             required = true)
@@ -644,7 +644,7 @@ public class MetadataApi {
         String language = languageUtils.getIso3langCode(request.getLocales());
         final ServiceContext serviceContext = ApiUtils.createServiceContext(request);
 
-        return getAssociatedResources(language, serviceContext, md, type, start, rows);
+        return getRelatedResources(language, serviceContext, md, type, start, rows);
     }
 
     @io.swagger.v3.oas.annotations.Operation(
@@ -680,7 +680,7 @@ public class MetadataApi {
         Map<String, String[]> decodeMap = new HashMap<>();
 
         try {
-            RelatedResponse related = getAssociatedResources(
+            RelatedResponse related = getRelatedResources(
                 metadataUuid, type, approved, 0, 100, request);
 
             if (isIncludedAttributeTable(related.getFcats())) {

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataSharingApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataSharingApi.java
@@ -429,7 +429,7 @@ public class MetadataSharingApi {
     @ResponseStatus(HttpStatus.CREATED)
     public
     @ResponseBody
-    MetadataProcessingReport shares(
+    MetadataProcessingReport shareMultipleRecords(
         @Parameter(description = ApiParams.API_PARAM_RECORD_UUIDS_OR_SELECTION,
             required = false)
         @RequestParam(required = false) String[] uuids,

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataSharingApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataSharingApi.java
@@ -357,7 +357,7 @@ public class MetadataSharingApi {
     @ResponseStatus(HttpStatus.CREATED)
     public
     @ResponseBody
-    MetadataProcessingReport publish(
+    MetadataProcessingReport publishMultipleRecords(
         @Parameter(description = ApiParams.API_PARAM_RECORD_UUIDS_OR_SELECTION,
             required = false)
         @RequestParam(required = false) String[] uuids,
@@ -393,7 +393,7 @@ public class MetadataSharingApi {
     @ResponseStatus(HttpStatus.CREATED)
     public
     @ResponseBody
-    MetadataProcessingReport unpublish(
+    MetadataProcessingReport unpublishMultipleRecords(
         @Parameter(description = ApiParams.API_PARAM_RECORD_UUIDS_OR_SELECTION,
             required = false)
         @RequestParam(required = false) String[] uuids,
@@ -429,7 +429,7 @@ public class MetadataSharingApi {
     @ResponseStatus(HttpStatus.CREATED)
     public
     @ResponseBody
-    MetadataProcessingReport share(
+    MetadataProcessingReport shares(
         @Parameter(description = ApiParams.API_PARAM_RECORD_UUIDS_OR_SELECTION,
             required = false)
         @RequestParam(required = false) String[] uuids,

--- a/services/src/main/java/org/fao/geonet/api/records/editing/MetadataEditingApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/editing/MetadataEditingApi.java
@@ -596,7 +596,7 @@ public class MetadataEditingApi {
     @ApiResponses(value = {@ApiResponse(responseCode = "201", description = "Element reordered."),
         @ApiResponse(responseCode = "403", description = ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_EDIT)})
     @ResponseBody
-    public void addElement(@Parameter(description = API_PARAM_RECORD_UUID, required = true) @PathVariable String metadataUuid,
+    public void reorderElement(@Parameter(description = API_PARAM_RECORD_UUID, required = true) @PathVariable String metadataUuid,
                            @Parameter(description = "Reference of the element to move.", required = true) @RequestParam String ref,
                            @Parameter(description = "Direction", required = true) @PathVariable Direction direction,
                            @Parameter(description = "Should attributes be shown on the editor snippet?", required = false) @RequestParam(defaultValue = "false") boolean displayAttributes,

--- a/services/src/main/java/org/fao/geonet/api/site/SiteApi.java
+++ b/services/src/main/java/org/fao/geonet/api/site/SiteApi.java
@@ -571,7 +571,7 @@ public class SiteApi {
         method = RequestMethod.PUT)
     @PreAuthorize("hasAuthority('Editor')")
     @ResponseBody
-    public HttpEntity index(
+    public HttpEntity indexSite(
         @Parameter(description = "Drop and recreate index",
             required = false)
         @RequestParam(required = false, defaultValue = "true")

--- a/services/src/main/java/org/fao/geonet/api/tools/i18n/TranslationApi.java
+++ b/services/src/main/java/org/fao/geonet/api/tools/i18n/TranslationApi.java
@@ -313,7 +313,7 @@ public class TranslationApi {
             MediaType.APPLICATION_JSON_VALUE
         })
     @ResponseBody
-    public Map<String, List<String>> getTranslationsPackage() {
+    public Map<String, List<String>> getTranslationsPackages() {
         return translationPackBuilder.getPackages();
     }
 


### PR DESCRIPTION
OperationId are generally created based on the function name.  In some cases multiple function names were the same and this was causing OperationId conflicts which was causing one to be called functionName and the other to be called functionName_1.  

The main issue is that each time the application is restarted and the open api spec document is initially created i the cache it can flip which function is called functionName and functionName_1.  So if this is not fixed then the open api spec can change each time the application is restarted.

By simply renaming the function names, it resolves the duplicate OperationId.

Note: there are still other cases of functionName_1 but they are due to other issues that is that will be resolved in another PR.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
