### PR TITLE
Fix duplicate API endpoint /feeds

### DIFF
--- a/inspire-atom/src/main/java/org/fao/geonet/services/inspireatom/AtomSearch.java
+++ b/inspire-atom/src/main/java/org/fao/geonet/services/inspireatom/AtomSearch.java
@@ -200,7 +200,7 @@ public class AtomSearch {
         summary = "Get ATOM feeds",
         description = "")
     @GetMapping(
-        value = "/feeds",
+        value = "/feedsAsHtml",
         produces = MediaType.TEXT_HTML_VALUE
     )
     @ApiResponses(value = {


### PR DESCRIPTION
Fix duplicate API endpoint /feeds

There were GET 2 apis with the end point /feeds.
~~One was renamed to /feedsAsHtml~~
Merged into one api and check accept header to determine the results to be returned.

I'm not sure where /feeds was used so I don't know which one was supposed to be called?  So I just renamed it based on the function name.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [x] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
