### PR TITLE
Fix SpringDoc duplicate Schema name

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/model/related/FCRelatedMetadataItem.java
+++ b/services/src/main/java/org/fao/geonet/api/records/model/related/FCRelatedMetadataItem.java
@@ -27,6 +27,8 @@ import javax.xml.bind.annotation.*;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 /**
  * <p>Java class for anonymous complex type.
  *
@@ -378,6 +380,8 @@ public class FCRelatedMetadataItem extends RelatedMetadataItem {
                 "type",
                 "values"
             })
+            // Use different schema name for source to resolve conflict with org.fao.geonet.kernel.schema.labels.Element
+            @Schema(name = "FCRelatedElement")
             public static class Element {
 
                 protected String name;

--- a/services/src/main/java/org/fao/geonet/api/records/model/related/RelatedResponse.java
+++ b/services/src/main/java/org/fao/geonet/api/records/model/related/RelatedResponse.java
@@ -8,6 +8,7 @@ import javax.xml.bind.annotation.XmlType;
 import java.util.ArrayList;
 import java.util.List;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 
 /**
  * <p>Java class for relatedResponse complex type.
@@ -1014,6 +1015,8 @@ public class RelatedResponse {
     @XmlType(name = "", propOrder = {
         "item"
     })
+    // Use different schema name for source to resolve conflict with org.fao.geonet.domain.Source
+    @Schema(name = "RelatedSource")
     public static class Source implements IListOnlyClassToArray {
 
         protected List<RelatedMetadataItem> item;

--- a/services/src/main/java/org/fao/geonet/api/records/model/validation/Report.java
+++ b/services/src/main/java/org/fao/geonet/api/records/model/validation/Report.java
@@ -7,6 +7,7 @@ import javax.xml.bind.annotation.adapters.CollapsedStringAdapter;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.math.BigInteger;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 
 /**
  * <p>Java class for anonymous complex type.
@@ -46,6 +47,8 @@ import java.math.BigInteger;
     "schematronVerificationError"
 })
 @XmlRootElement(name = "report")
+// Use different schema name for report to resolve conflict with org.fao.geonet.api.processing.report.Report
+@Schema(name = "ValidationReport")
 public class Report {
 
     @XmlElement(required = true)


### PR DESCRIPTION
Fix SpringDoc duplicate Schema name

Without this fix springdoc would randomly pick between 2 conflicting schemas and this could produce incorrect results in the open api spec.

Oddly, there seems to be a bug in spring docs with resolving the schema.  I would have expected schemaName and schemaName_1 but instead it simply pick one of the 2.  The means that 50% of the time the duplicate schema will pick the correct schema for one API and not the other and the other 50% of the time it will be the opposite.

Here is one example of incorrect data.

Looking at the following api
![image](https://github.com/geonetwork/core-geonetwork/assets/1868233/f8c7bcd2-880a-48cc-9410-4b01debfb91f)
If you restart the application several times, you may see the following.

![image](https://github.com/geonetwork/core-geonetwork/assets/1868233/770efa95-9948-45c9-8be6-afa1a03917e6)

Or the following

![image](https://github.com/geonetwork/core-geonetwork/assets/1868233/2a86d2e4-aeb7-4c24-81bd-d4e48b016b18)

By changing the name on one of the schema's it will ensure that there is no conflict.  For this example the validation "`report`"  was renamed to "`ValidationReport`"

This will end up referencing the correct schema as 
`$ref: '#/components/schemas/ValidationReport'`




<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
