### PR TITLE
Spring doc API for index should return a structured object instead of JSONObject

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/MetadataIndexApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataIndexApi.java
@@ -29,13 +29,10 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jeeves.server.UserSession;
-import jeeves.server.context.ServiceContext;
 import jeeves.services.ReadWriteController;
-import net.sf.json.JSONObject;
 import org.fao.geonet.api.ApiParams;
 import org.fao.geonet.api.ApiUtils;
 import org.fao.geonet.kernel.DataManager;
-import org.fao.geonet.kernel.SelectionManager;
 import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.kernel.search.index.BatchOpsMetadataReindexer;
 import org.fao.geonet.kernel.setting.SettingManager;
@@ -46,7 +43,6 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
-import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 import java.util.Set;
 
@@ -86,7 +82,7 @@ public class MetadataIndexApi {
     })
     public
     @ResponseBody
-    JSONObject index(
+    IndexResponse index(
         @Parameter(description = API_PARAM_RECORD_UUIDS_OR_SELECTION,
             required = false,
             example = "")
@@ -125,11 +121,30 @@ public class MetadataIndexApi {
         new BatchOpsMetadataReindexer(dataManager, ids)
             .process(settingManager.getSiteId(), false);
 
-        JSONObject res = new JSONObject();
-        res.put("success", true);
-        res.put("count", index);
-
-        return res;
+        IndexResponse indexResponse = new IndexResponse();
+        indexResponse.setSuccess(true);
+        indexResponse.setCount(index);
+        return indexResponse;
     }
 
+    private static class IndexResponse {
+        private boolean success;
+        private int count;
+
+        public boolean isSuccess() {
+            return success;
+        }
+
+        public void setSuccess(boolean success) {
+            this.success = success;
+        }
+
+        public int getCount() {
+            return count;
+        }
+
+        public void setCount(int count) {
+            this.count = count;
+        }
+    }
 }


### PR DESCRIPTION
API should return a structured object instead of JSONObject
Updated indexer to return an object IndexResponse instead of JSONObject

This was causing a couple issues.
1 - JSONObject is a weird object to be returned from an API when the results are really a String.
2 - There were a couple API's that were returning JSONObject but not the same one. One was net.sf.json.JSONObject and the other was org.json.JSONObject. This was causing a conflict in the SpringDoc API which was causing bugs in the open api specification.  The JSONObject schema could change on each application restart.
3 - It was causing issues when trying to use CodeGen as it has issue using JSONObject objects as it conflict with the normal JSONObject.

This fix updates the indexer so that it returns a new IndexResponse object.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [x] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
