### PR TITLE
Spring doc API for link api should accept a structured object instead of JSONObject

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/links/LinksApi.java
+++ b/services/src/main/java/org/fao/geonet/api/links/LinksApi.java
@@ -52,7 +52,6 @@ import org.fao.geonet.repository.MetadataRepository;
 import org.fao.geonet.repository.specification.LinkSpecs;
 import org.jdom.JDOMException;
 import org.json.JSONException;
-import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.data.domain.Page;
@@ -146,9 +145,9 @@ public class LinksApi {
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     @PreAuthorize("isAuthenticated()")
     public Page<Link> getRecordLinks(
-        @Parameter(description = "Filter, e.g. \"{url: 'png', lastState: 'ko', records: 'e421', groupId: 12}\", lastState being 'ok'/'ko'/'unknown'", required = false)
+        @Parameter(description = "Filter, e.g. \"{url: 'png', lastState: 'ko', records: 'e421'}\", lastState being 'ok'/'ko'/'unknown'", required = false)
         @RequestParam(required = false)
-            JSONObject filter,
+            LinkFilter filter,
         @Parameter(description = "Optional, filter links to records published in that group.", required = false)
         @RequestParam(required = false)
             Integer[] groupIdFilter,
@@ -187,9 +186,9 @@ public class LinksApi {
         produces = MediaType.APPLICATION_JSON_VALUE)
     @PreAuthorize("isAuthenticated()")
     public Page<Link> getRecordLinksPost(
-        @Parameter(description = "Filter, e.g. \"{url: 'png', lastState: 'ko', records: 'e421', groupId: 12}\", lastState being 'ok'/'ko'/'unknown'", required = false)
+        @Parameter(description = "Filter, e.g. \"{url: 'png', lastState: 'ko', records: 'e421'}\", lastState being 'ok'/'ko'/'unknown'", required = false)
         @RequestParam(required = false)
-        JSONObject filter,
+        LinkFilter filter,
         @Parameter(description = "Optional, filter links to records published in that group.", required = false)
         @RequestParam(required = false)
         Integer[] groupIdFilter,
@@ -207,7 +206,7 @@ public class LinksApi {
         return getLinks(filter, groupIdFilter, groupOwnerIdFilter, pageRequest, userSession);
     }
     private Page<Link> getLinks(
-        JSONObject filter,
+        LinkFilter filter,
         Integer[] groupIdFilter,
         Integer[] groupOwnerIdFilter,
         Pageable pageRequest,
@@ -228,22 +227,22 @@ public class LinksApi {
             Integer stateToMatch = null;
             String url = null;
             List<String> associatedRecords = null;
-            if (filter.has("lastState")) {
+            if (filter.getLastState() != null) {
                 stateToMatch = 0;
-                if (filter.getString("lastState").equalsIgnoreCase("ok")) {
+                if (filter.getLastState().equalsIgnoreCase("ok")) {
                     stateToMatch = 1;
-                } else if (filter.getString("lastState").equalsIgnoreCase("ko")) {
+                } else if (filter.getLastState().equalsIgnoreCase("ko")) {
                     stateToMatch = -1;
                 }
             }
 
-            if (filter.has("url")) {
-                url = filter.getString("url");
+            if (filter.getUrl() != null) {
+                url = filter.getUrl();
             }
 
-            if (filter.has("records")) {
+            if (filter.getRecords() != null) {
                 associatedRecords = Arrays.stream(
-                    filter.getString("records").split(" ")
+                    filter.getRecords().split(" ")
                 ).collect(Collectors.toList());
             }
 
@@ -277,9 +276,9 @@ public class LinksApi {
     @PreAuthorize("isAuthenticated()")
     @ResponseBody
     public void getRecordLinksAsCsv(
-        @Parameter(description = "Filter, e.g. \"{url: 'png', lastState: 'ko', records: 'e421', groupId: 12}\", lastState being 'ok'/'ko'/'unknown'", required = false)
+        @Parameter(description = "Filter, e.g. \"{url: 'png', lastState: 'ko', records: 'e421'}\", lastState being 'ok'/'ko'/'unknown'", required = false)
         @RequestParam(required = false)
-            JSONObject filter,
+        LinkFilter filter,
         @Parameter(description = "Optional, filter links to records published in that group.", required = false)
         @RequestParam(required = false)
             Integer[] groupIdFilter,
@@ -444,5 +443,35 @@ public class LinksApi {
         }
         mAnalyseProcesses.addFirst(mAnalyseProcess);
         return mAnalyseProcess;
+    }
+
+    private static class LinkFilter {
+        private String url;
+        private String lastState;
+        private String records;
+
+        public String getUrl() {
+            return url;
+        }
+
+        public void setUrl(String url) {
+            this.url = url;
+        }
+
+        public String getLastState() {
+            return lastState;
+        }
+
+        public void setLastState(String lastState) {
+            this.lastState = lastState;
+        }
+
+        public String getRecords() {
+            return records;
+        }
+
+        public void setRecords(String records) {
+            this.records = records;
+        }
     }
 }

--- a/services/src/main/java/org/fao/geonet/api/links/LinksApi.java
+++ b/services/src/main/java/org/fao/geonet/api/links/LinksApi.java
@@ -25,6 +25,8 @@ package org.fao.geonet.api.links;
 
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import com.google.gson.Gson;
+
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.Parameters;
@@ -63,6 +65,7 @@ import org.springframework.jmx.export.MBeanExporter;
 import org.springframework.jmx.export.naming.SelfNaming;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
+import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
@@ -71,6 +74,8 @@ import javax.management.MalformedObjectNameException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
+
+import java.beans.PropertyEditorSupport;
 import java.io.IOException;
 import java.sql.SQLException;
 import java.util.ArrayDeque;
@@ -443,6 +448,22 @@ public class LinksApi {
         }
         mAnalyseProcesses.addFirst(mAnalyseProcess);
         return mAnalyseProcess;
+    }
+
+    @InitBinder
+    public void initBinder(WebDataBinder dataBinder) {
+        dataBinder.registerCustomEditor(LinkFilter.class, new PropertyEditorSupport() {
+            Object value;
+            @Override
+            public Object getValue() {
+                return value;
+            }
+
+            @Override
+            public void setAsText(String text) throws IllegalArgumentException {
+                value = new Gson().fromJson(text, LinkFilter.class);
+            }
+        });
     }
 
     private static class LinkFilter {


### PR DESCRIPTION
API should accept a structured object instead of JSONObject
Updated link search to accept an object LinkFilter instead of JSONObject

This was causing a couple issues.
1 - JSONObject is a weird object to be accepted from an API when the results are really a String.
2 - There were a couple API's that were returning JSONObject but not the same one. One was net.sf.json.JSONObject and the other was org.json.JSONObject. This was causing a conflict in the SpringDoc API which was causing bugs in the open api specification. The JSONObject schema could change on each application restart. (i.e. see  #7584)
3 - It was causing issues when trying to use CodeGen as it has issue using JSONObject objects as it conflict with the normal JSONObject.

Note: Usage description had "`groupId: 12`" as a sample however I could not find any case where `groupId` was being used so I removed that from the comment. I'm guessing that it was replaced by "`groupIdFilter`" at some point and the documentation was not updated.

This fix updates the link api so that it accepts a new LinkFilter object.




# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [x] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
