### PR TITLE
Fix duplicate operation id caused by use of 2 methods  GET/POST method from getKeywordById api

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
@@ -327,7 +327,7 @@ public class KeywordsApi {
     )
     @RequestMapping(
         path = "/keyword",
-        method = RequestMethod.POST,
+        method = RequestMethod.GET,
         produces = {
             MediaType.APPLICATION_XML_VALUE,
             MediaType.APPLICATION_JSON_VALUE
@@ -337,7 +337,7 @@ public class KeywordsApi {
     })
     @ResponseBody
     @ResponseStatus(HttpStatus.OK)
-    public Object getKeywordByIds(
+    public Object getKeywordById(
         @Parameter(
             description = "Keyword identifier or list of keyword identifiers comma separated.",
             required = true)
@@ -396,17 +396,17 @@ public class KeywordsApi {
      * @throws Exception the exception
      */
     @io.swagger.v3.oas.annotations.Operation(
-        summary = "Get keyword by id",
+        summary = "Get keyword by ids",
         description = "Retrieve XML representation of keyword(s) from same thesaurus" +
             "using different transformations. " +
             "'to-iso19139-keyword' is the default and return an ISO19139 snippet." +
             "'to-iso19139-keyword-as-xlink' return an XLinked element. Custom transformation " +
             "can be create on a per schema basis." +
-        "Use POST method if you want to support larger parameters list"
+            "This can be used instead of the GET method for cases where you need to submit large parameters list"
     )
     @RequestMapping(
-        path = "/keywordById",
-        method = RequestMethod.GET,
+        path = "/keyword",
+        method = RequestMethod.POST,
         produces = {
             MediaType.APPLICATION_XML_VALUE,
             MediaType.APPLICATION_JSON_VALUE
@@ -416,40 +416,40 @@ public class KeywordsApi {
     })
     @ResponseBody
     @ResponseStatus(HttpStatus.OK)
-    public Object getKeywordById(
+    public Object getKeywordByIds(
         @Parameter(
             description = "Keyword identifier or list of keyword identifiers comma separated.",
             required = true)
         @RequestParam(name = "id")
-        String uri,
+            String uri,
         @Parameter(
             description = "Thesaurus to look info for the keyword(s).",
             required = true)
         @RequestParam(name = "thesaurus")
-        String sThesaurusName,
+            String sThesaurusName,
         @Parameter(
             description = "Languages.",
             required = false)
         @RequestParam(name = "lang", required = false)
-        String[] langs,
+            String[] langs,
         @Parameter(
             description = "Only print the keyword, no thesaurus information.",
             required = false)
         @RequestParam(required = false, defaultValue = "false")
-        boolean keywordOnly,
+            boolean keywordOnly,
         @Parameter(
             description = "XSL template to use (ISO19139 keyword by default, see convert.xsl).",
             required = false)
         @RequestParam(required = false)
-        String transformation,
+            String transformation,
         @Parameter(
             description = "langMap, that converts the values in the 'lang' parameter to how they will be actually represented in the record. {'fre':'fra'} or {'fre':'fr'}.  Missing/empty means to convert to iso 2 letter.",
             required = false)
         @RequestParam (name = "langMap", required = false)
-        String  langMapJson,
+            String  langMapJson,
         @Parameter(hidden = true)
         @RequestParam
-        Map<String, String> allRequestParams,
+            Map<String, String> allRequestParams,
         @RequestHeader(
             value = "Accept",
             defaultValue = MediaType.APPLICATION_XML_VALUE
@@ -457,7 +457,7 @@ public class KeywordsApi {
         String accept,
         @Parameter(hidden = true)
         HttpServletRequest request
-    ) throws Exception {
+        ) throws Exception {
         return getKeyword(uri,sThesaurusName,langs, keywordOnly, transformation,langMapJson,allRequestParams, accept, request);
     }
 

--- a/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
@@ -327,10 +327,7 @@ public class KeywordsApi {
     )
     @RequestMapping(
         path = "/keyword",
-        method = {
-            RequestMethod.GET,
-            RequestMethod.POST
-        },
+        method = RequestMethod.GET,
         produces = {
             MediaType.APPLICATION_XML_VALUE,
             MediaType.APPLICATION_JSON_VALUE

--- a/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
@@ -327,7 +327,7 @@ public class KeywordsApi {
     )
     @RequestMapping(
         path = "/keyword",
-        method = RequestMethod.GET,
+        method = RequestMethod.POST,
         produces = {
             MediaType.APPLICATION_XML_VALUE,
             MediaType.APPLICATION_JSON_VALUE
@@ -337,7 +337,7 @@ public class KeywordsApi {
     })
     @ResponseBody
     @ResponseStatus(HttpStatus.OK)
-    public Object getKeywordById(
+    public Object getKeywordByIds(
         @Parameter(
             description = "Keyword identifier or list of keyword identifiers comma separated.",
             required = true)
@@ -509,6 +509,84 @@ public class KeywordsApi {
         }
     }
 
+    /**
+     * Gets the keyword by id.
+     *
+     * @param uri              the uri
+     * @param sThesaurusName   the s thesaurus name
+     * @param langs            the langs
+     * @param keywordOnly      the keyword only
+     * @param transformation   the transformation
+     * @param allRequestParams the all request params
+     * @param request          the request
+     * @return the keyword by id
+     * @throws Exception the exception
+     */
+    @io.swagger.v3.oas.annotations.Operation(
+        summary = "Get keyword by id",
+        description = "Retrieve XML representation of keyword(s) from same thesaurus" +
+            "using different transformations. " +
+            "'to-iso19139-keyword' is the default and return an ISO19139 snippet." +
+            "'to-iso19139-keyword-as-xlink' return an XLinked element. Custom transformation " +
+            "can be create on a per schema basis." +
+        "Use POST method if you want to support larger parameters list"
+    )
+    @RequestMapping(
+        path = "/keywordById",
+        method = RequestMethod.GET,
+        produces = {
+            MediaType.APPLICATION_XML_VALUE,
+            MediaType.APPLICATION_JSON_VALUE
+        })
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "XML snippet with requested keywords."),
+    })
+    @ResponseBody
+    @ResponseStatus(HttpStatus.OK)
+    public Object getKeywordById(
+        @Parameter(
+            description = "Keyword identifier or list of keyword identifiers comma separated.",
+            required = true)
+        @RequestParam(name = "id")
+        String uri,
+        @Parameter(
+            description = "Thesaurus to look info for the keyword(s).",
+            required = true)
+        @RequestParam(name = "thesaurus")
+        String sThesaurusName,
+        @Parameter(
+            description = "Languages.",
+            required = false)
+        @RequestParam(name = "lang", required = false)
+        String[] langs,
+        @Parameter(
+            description = "Only print the keyword, no thesaurus information.",
+            required = false)
+        @RequestParam(required = false, defaultValue = "false")
+        boolean keywordOnly,
+        @Parameter(
+            description = "XSL template to use (ISO19139 keyword by default, see convert.xsl).",
+            required = false)
+        @RequestParam(required = false)
+        String transformation,
+        @Parameter(
+            description = "langMap, that converts the values in the 'lang' parameter to how they will be actually represented in the record. {'fre':'fra'} or {'fre':'fr'}.  Missing/empty means to convert to iso 2 letter.",
+            required = false)
+        @RequestParam (name = "langMap", required = false)
+        String  langMapJson,
+        @Parameter(hidden = true)
+        @RequestParam
+        Map<String, String> allRequestParams,
+        @RequestHeader(
+            value = "Accept",
+            defaultValue = MediaType.APPLICATION_XML_VALUE
+        )
+        String accept,
+        @Parameter(hidden = true)
+        HttpServletRequest request
+    ) throws Exception {
+        return getKeywordByIds(uri,sThesaurusName,langs, keywordOnly, transformation,langMapJson,allRequestParams, accept, request);
+    }
 
     /**
      * Gets the thesaurus.


### PR DESCRIPTION
An api should not do GET/POST in the same operation as it seems to cause issues in open api specification document.
It caused duplicates duplicate OperationID that would occur (getKeywordById and getKeywordById_1)

This PR will split 2 OperationID (getKeywordById and getKeywordByIds)

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [x] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
