### PR TITLE
Fix issue with @ResponseStatus and @ApiResponse being out of sync.

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/MetadataInsertDeleteApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataInsertDeleteApi.java
@@ -253,7 +253,7 @@ public class MetadataInsertDeleteApi {
             MediaType.APPLICATION_JSON_VALUE
         }
     )
-    @ApiResponses(value = {@ApiResponse(responseCode = "204", description = "Report about deleted records."),
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Report about deleted records."),
         @ApiResponse(responseCode = "403", description = ApiParams.API_RESPONSE_NOT_ALLOWED_ONLY_EDITOR)})
     @PreAuthorize("hasAuthority('Editor')")
     @ResponseStatus(HttpStatus.OK)

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataProcessApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataProcessApi.java
@@ -162,7 +162,7 @@ public class MetadataProcessApi {
         RequestMethod.POST,}, produces = MediaType.APPLICATION_XML_VALUE)
     @PreAuthorize("hasAuthority('Editor')")
     @ResponseStatus(HttpStatus.OK)
-    @ApiResponses(value = {@ApiResponse(responseCode = "204", description = "Record processed and saved."),
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Record processed and saved."),
         @ApiResponse(responseCode = "403", description = ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_EDIT)})
     public @ResponseBody
     ResponseEntity processRecord(

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataTagApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataTagApi.java
@@ -391,7 +391,7 @@ public class MetadataTagApi {
         })
     @ResponseStatus(value = HttpStatus.NO_CONTENT)
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "201", description = "Report about removed records."),
+        @ApiResponse(responseCode = "204", description = "Tag Deleted."),
         @ApiResponse(responseCode = "403", description = ApiParams.API_RESPONSE_NOT_ALLOWED_ONLY_EDITOR)
     })
     @PreAuthorize("hasAuthority('Editor')")

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataTagApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataTagApi.java
@@ -389,9 +389,9 @@ public class MetadataTagApi {
         produces = {
             MediaType.APPLICATION_JSON_VALUE
         })
-    @ResponseStatus(value = HttpStatus.NO_CONTENT)
+    @ResponseStatus(value = HttpStatus.OK)
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "204", description = "Tag Deleted."),
+        @ApiResponse(responseCode = "200", description = "Report about removed records."),
         @ApiResponse(responseCode = "403", description = ApiParams.API_RESPONSE_NOT_ALLOWED_ONLY_EDITOR)
     })
     @PreAuthorize("hasAuthority('Editor')")

--- a/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsApi.java
@@ -246,7 +246,7 @@ public class AttachmentsApi {
     // @PreAuthorize("permitAll")
     @RequestMapping(value = "/{resourceId:.+}", method = RequestMethod.GET)
     @ResponseStatus(value = HttpStatus.OK)
-    @ApiResponses(value = {@ApiResponse(responseCode = "201", description = "Record attachment."),
+    @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Record attachment."),
         @ApiResponse(responseCode = "403", description = "Operation not allowed. "
             + "User needs to be able to download the resource.")})
     public void getResource(

--- a/services/src/main/java/org/fao/geonet/api/sources/SourcesApi.java
+++ b/services/src/main/java/org/fao/geonet/api/sources/SourcesApi.java
@@ -272,7 +272,7 @@ public class SourcesApi {
     @PreAuthorize("hasAuthority('Administrator')")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "201", description = "Source deleted."),
+        @ApiResponse(responseCode = "204", description = "Source deleted."),
         @ApiResponse(responseCode = "403", description = ApiParams.API_RESPONSE_NOT_ALLOWED_ONLY_ADMIN)
     })
     @ResponseBody


### PR DESCRIPTION
Fix issue with @ResponseStatus and @ApiResponse being out of sync.
Update @ApiResponse so that they are in sync with @ResponseStatus

It would not create the proper Open API documentation when these return codes were not correct.

Note: It was noticed that some API's have NO_CONTENT (204) but it is not a void function?  But when I tested some they did not seem to return any content.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
