### PR TITLE
Fix case of wrong use for HttpStatus.CREATED and HttpStatus.OK

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/groups/GroupsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/groups/GroupsApi.java
@@ -296,7 +296,7 @@ public class GroupsApi {
         produces = MediaType.APPLICATION_JSON_VALUE,
         method = RequestMethod.PUT
     )
-    @ResponseStatus(value = HttpStatus.OK)
+    @ResponseStatus(value = HttpStatus.CREATED)
     @PreAuthorize("hasAuthority('UserAdmin')")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "201", description = "Group created."),

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataApi.java
@@ -521,7 +521,7 @@ public class MetadataApi {
         @ApiResponse(responseCode = "403", description = ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_VIEW),
         @ApiResponse(responseCode = "404", description = ApiParams.API_RESPONSE_RESOURCE_NOT_FOUND)
     })
-    @ResponseStatus(HttpStatus.CREATED)
+    @ResponseStatus(HttpStatus.OK)
     public ResponseEntity<String> getRecordPopularity(
         @Parameter(description = API_PARAM_RECORD_UUID,
             required = true)

--- a/services/src/main/java/org/fao/geonet/api/usersearches/UserSearchesApi.java
+++ b/services/src/main/java/org/fao/geonet/api/usersearches/UserSearchesApi.java
@@ -290,7 +290,7 @@ public class UserSearchesApi {
     @RequestMapping(
         produces = MediaType.APPLICATION_JSON_VALUE,
         method = RequestMethod.PUT)
-    @ResponseStatus(value = HttpStatus.OK)
+    @ResponseStatus(value = HttpStatus.CREATED)
     @PreAuthorize("isAuthenticated()")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "201", description = "User search created.")


### PR DESCRIPTION
Fix case of wrong use for HttpStatus.CREATED and HttpStatus.OK
In some cases HttpStatus.CREATED was used when it should have been HttpStatus.OK and other cases it is the opposite.

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
