### PR TITLE
Fix add element attribute in the metadata editor

### DIFF
--- a/web/src/main/webapp/xslt/ui-metadata/edit/edit-embedded.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/edit/edit-embedded.xsl
@@ -45,7 +45,7 @@
 
   <xsl:template match="/">
 
-    <xsl:variable name="snippet">
+    <xsl:variable name="tempSnippet">
       <!-- Process the added object using schema layout ... -->
       <xsl:for-each
         select="/root/*[name(.)!='gui' and name(.)!='request']//*[@gn:addedObj = 'true']">
@@ -55,6 +55,23 @@
           <xsl:with-param name="base" select="."/>
         </saxon:call-template>
       </xsl:for-each>
+    </xsl:variable>
+
+    <xsl:variable name="snippet">
+      <xsl:choose>
+        <xsl:when test="string($tempSnippet)"><xsl:copy-of select="$tempSnippet" /></xsl:when>
+        <xsl:otherwise>
+          <!-- If no template defined for the added object, process the parent of the added element using schema layout ... -->
+          <xsl:for-each
+            select="/root/*[name(.)!='gui' and name(.)!='request']//*[@gn:addedObj = 'true']">
+            <!-- Dispatch to profile mode -->
+            <xsl:variable name="profileTemplate" select="concat('dispatch-', $schema)"/>
+            <saxon:call-template name="{$profileTemplate}">
+              <xsl:with-param name="base" select=".."/>
+            </saxon:call-template>
+          </xsl:for-each>
+        </xsl:otherwise>
+      </xsl:choose>
     </xsl:variable>
 
     <!-- In case the form generated contains multiple children


### PR DESCRIPTION
Adding some element attributes causes the element section is removed from the user interface until the metadata is saved. See below the explanation.

Test case:

1) Create an iso19139 metadata

2) In the XML view add the following resource constraint:

```
         <gmd:resourceConstraints>
            <gmd:MD_LegalConstraints>
               <gmd:accessConstraints>
                  <gmd:MD_RestrictionCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode"
                                          codeListValue="otherRestrictions"/>
               </gmd:accessConstraints>
               <gmd:otherConstraints>
                  <gmx:Anchor xlink:href="http://inspire.ec.europa.eu/metadata-codelist/LimitationsOnPublicAccess/noLimitations">No limitations on public access</gmx:Anchor>
               </gmd:otherConstraints>
            </gmd:MD_LegalConstraints>
         </gmd:resourceConstraints>
```

3) In the default view, try to add the `Link` attribute. Without the fix, the section disappears from the editor. Clicking `Save metadata` the section is displayed with the attribute:

[error.webm](https://github.com/geonetwork/core-geonetwork/assets/1695003/8618b31e-2d58-4186-abd4-40892a693f81)

With the fix it works as expected:

[fix.webm](https://github.com/geonetwork/core-geonetwork/assets/1695003/968fb023-545c-42cc-bd72-b5090e6ec0a1)


With `NilReason` attribute it works fine.

----

`NilReason` attribute belongs to `gmd:otherConstraints` and there is a xslt editor template that handles it, so it works fine. But `Link` attribute belongs to `gmx:Anchor` and there is no xslt template handling that element.

The change tries the element added and if an empty rendering element is returned, it tries the parent element.



# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
