### PR TITLE
Harvesters / remove unused groupsCopyPolicy property

### DIFF
--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/arcsde.js
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/arcsde.js
@@ -42,7 +42,6 @@ var gnHarvesterarcsde = {
                 {"@name": "dynamic"}
               ]
             }],
-            "groupsCopyPolicy": [],
             "info":   {
               "lastRun": [],
               "running": false
@@ -53,7 +52,7 @@ var gnHarvesterarcsde = {
         var body = '<node id="' + h['@id'] + '" '
                 + '    type="' + h['@type'] + '">'
                 + '  <ownerGroup><id>' + h.ownerGroup[0] + '</id></ownerGroup>'
-                + '  <ownerUser><id>' + h.ownerUser[0] + '</id></ownerUser>' 
+                + '  <ownerUser><id>' + h.ownerUser[0] + '</id></ownerUser>'
                 + '  <site>'
                 + '    <name>' + h.site.name + '</name>'
                 + '    <server>' + h.site.server + '</server>'

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/geoPREST.js
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/geoPREST.js
@@ -39,7 +39,6 @@ var gnHarvestergeoPREST = {
                 {"@name": "dynamic"}
               ]
             }],
-            "groupsCopyPolicy": [],
             "info":   {
               "lastRun": [],
               "running": false

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/geonetwork20.js
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/geonetwork20.js
@@ -47,7 +47,6 @@ var gnHarvestergeonetwork20 = {
                 {"@name": "dynamic"}
               ]
             }],
-            "groupsCopyPolicy": [],
             "info":   {
               "lastRun": [],
               "running": false
@@ -58,7 +57,7 @@ var gnHarvestergeonetwork20 = {
         var body = '<node id="' + h['@id'] + '" '
                 + '    type="' + h['@type'] + '">'
                 + '  <ownerGroup><id>' + h.ownerGroup[0] + '</id></ownerGroup>'
-                + '  <ownerUser><id>' + h.ownerUser[0] + '</id></ownerUser>' 
+                + '  <ownerUser><id>' + h.ownerUser[0] + '</id></ownerUser>'
                 + '  <site>'
                 + '    <name>' + h.site.name + '</name>'
                 + '    <host>' + h.site.host.replace(/&/g, '&amp;') + '</host>'

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/oaipmh.js
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/oaipmh.js
@@ -42,7 +42,6 @@ var gnHarvesteroaipmh = {
                 {"@name": "dynamic"}
               ]
             }],
-            "groupsCopyPolicy": [],
             "info":   {
               "lastRun": [],
               "running": false


### PR DESCRIPTION
This property was used in GeoNetwork 2.x for the GeoNetwork harvester to define how to handle the permissions in the remote groups, see documentation in https://docs.geonetwork-opensource.org/2.10/users/managing_metadata/harvesting/gn/#adding-a-geonetwork-harvester

In GeoNetwork 3.x was replaced by a local groups privileges, but the code was not removed from the GeoNetwork harvester and also the property was added in the UI Javascript code of some other harvesters, but it is not used anywhere.

This change request removes the property from these other harvesters.

The code for the GeoNetwork harvester is still available, but not used as the user interface doesn't allow to configure these groups, @fxprunayre should we remove also the code related to this property from the GeoNetwork harvester?

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation