### PR TITLE
Service context null pointer

### DIFF
--- a/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
@@ -97,7 +97,7 @@ public abstract class AbstractStore implements Store {
     }
 
     protected static AccessManager getAccessManager(final ServiceContext context) {
-        return context.getBean(AccessManager.class);
+        return ApplicationContextHolder.get().getBean(AccessManager.class);
     }
 
     public static int getAndCheckMetadataId(String metadataUuid, Boolean approved) throws Exception {

--- a/datastorages/cmis/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
+++ b/datastorages/cmis/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
@@ -617,7 +617,7 @@ public class CMISStore extends AbstractStore {
     }
 
     private GeonetworkDataDirectory getDataDirectory(ServiceContext context) {
-        return context.getBean(GeonetworkDataDirectory.class);
+        return ApplicationContextHolder.get().getBean(GeonetworkDataDirectory.class);
     }
 
     /**
@@ -690,7 +690,7 @@ public class CMISStore extends AbstractStore {
 
             if (metadataResourceExternalManagementPropertiesUrl.contains("{lang}") || metadataResourceExternalManagementPropertiesUrl.contains("{ISO3lang}")) {
                 final IsoLanguagesMapper mapper = ApplicationContextHolder.get().getBean(IsoLanguagesMapper.class);
-                String contextLang = context.getLanguage() == null ? Geonet.DEFAULT_LANGUAGE : context.getLanguage();
+                String contextLang = context==null || context.getLanguage() == null ? Geonet.DEFAULT_LANGUAGE : context.getLanguage();
                 String lang;
                 String iso3Lang;
 

--- a/datastorages/jcloud/src/main/java/org/fao/geonet/api/records/attachments/JCloudStore.java
+++ b/datastorages/jcloud/src/main/java/org/fao/geonet/api/records/attachments/JCloudStore.java
@@ -381,7 +381,7 @@ public class JCloudStore extends AbstractStore {
     }
 
     private GeonetworkDataDirectory getDataDirectory(ServiceContext context) {
-        return context.getBean(GeonetworkDataDirectory.class);
+        return ApplicationContextHolder.get().getBean(GeonetworkDataDirectory.class);
     }
 
     /**


### PR DESCRIPTION
Based on this PR https://github.com/geonetwork/core-geonetwork/pull/7556 there seems to be some bug in cmisStore where the ServiceContext was passed as null object. 

The issue is not reproduceable in the 4.0 main branch due to the mechanism difference. But it's reproduceable in the 3.12 backport commit https://github.com/ianwallen/core-geonetwork/commit/91795de5fdc059c04334b10d45f7a00ef1daf38f

The null pointer avoidance is needed in order to make it work

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [] *API Changes* are identified in commit messages
- [] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [] *Build documentation* provided for development instructions in `README.md` files
- [] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
