### PR TITLE
Add missing @ApiResponse status for successful api search response.

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/es/EsHTTPProxy.java
+++ b/services/src/main/java/org/fao/geonet/api/es/EsHTTPProxy.java
@@ -301,12 +301,9 @@ public class EsHTTPProxy {
         HttpServletResponse response,
         @RequestBody
         @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "JSON request based on Elasticsearch API.",
-            content = @Content(
-                mediaType = MediaType.APPLICATION_JSON_VALUE,
-                schema = @Schema(
-                    type = "object",
-                    additionalProperties = Schema.AdditionalPropertiesValue.TRUE,
-                    example = "{\"query\":{\"match\":{\"_id\":\"catalogue_uuid\"}}}")))
+            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, examples = {
+                @ExampleObject(value = "{\"query\":{\"match\":{\"_id\":\"catalogue_uuid\"}}}")
+            }))
         Map<String, Object> body) throws Exception {
         ServiceContext context = ApiUtils.createServiceContext(request);
         call(context, httpSession, request, response, SEARCH_ENDPOINT, body, bucket, relatedTypes);
@@ -342,12 +339,9 @@ public class EsHTTPProxy {
         HttpServletResponse response,
         @RequestBody
         @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "JSON request based on Elasticsearch API.",
-            content = @Content(
-                mediaType = MediaType.APPLICATION_JSON_VALUE,
-                schema = @Schema(
-                    type = "object",
-                    additionalProperties = Schema.AdditionalPropertiesValue.TRUE,
-                    example = "{\"query\":{\"match\":{\"_id\":\"catalogue_uuid\"}}}")))
+            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, examples = {
+            @ExampleObject(value = "{\"query\":{\"match\":{\"_id\":\"catalogue_uuid\"}}}")
+        }))
         Map<String, Object> body) throws Exception {
         ServiceContext context = ApiUtils.createServiceContext(request);
         call(context, httpSession, request, response, MULTISEARCH_ENDPOINT, body, bucket, relatedTypes);
@@ -386,12 +380,9 @@ public class EsHTTPProxy {
         HttpServletResponse response,
         @RequestBody
         @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "JSON request based on Elasticsearch API.",
-            content = @Content(
-                mediaType = MediaType.APPLICATION_JSON_VALUE,
-                schema = @Schema(
-                    type = "object",
-                    additionalProperties = Schema.AdditionalPropertiesValue.TRUE,
-                    example = "{\"query\":{\"match\":{\"_id\":\"catalogue_uuid\"}}}")))
+            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, examples = {
+                @ExampleObject(value = "{\"query\":{\"match\":{\"_id\":\"catalogue_uuid\"}}}")
+            }))
         Map<String, Object> body) throws Exception {
 
         ServiceContext context = ApiUtils.createServiceContext(request);


### PR DESCRIPTION
Add missing @ApiResponse status for successful api search response.

Otherwise OpenAPI spec was missing response which caused issues when using codegen.

Fixed body parameters and removed httpEntity.getBody() 
Also added example value for body.


Before this PR search responce for /_msearch and /_search open api spec looks like this

```
      responses:
        "200":
          description: OK
```

After this PR the response will look like this

```
      responses:
        "200":
          content:
            application/json:
              schema:
                type: string
                example: null
          description: Search results.
```

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [x] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
