### PR TITLE
Spring doc - Set API enum as ref

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/model/related/RelatedItemType.java
+++ b/services/src/main/java/org/fao/geonet/api/records/model/related/RelatedItemType.java
@@ -1,6 +1,9 @@
 package org.fao.geonet.api.records.model.related;
 
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(enumAsRef = true)
 public enum RelatedItemType {
 
     /**

--- a/services/src/main/java/org/fao/geonet/config/PublicationOption.java
+++ b/services/src/main/java/org/fao/geonet/config/PublicationOption.java
@@ -44,6 +44,7 @@ public class PublicationOption {
     private String name;
 
     // Group to publish
+    @Schema(enumAsRef = true)
     private ReservedGroup publicationGroup;
 
     // List of operations to activate in the group to publish/unpublish.

--- a/services/src/main/java/org/fao/geonet/config/PublicationOption.java
+++ b/services/src/main/java/org/fao/geonet/config/PublicationOption.java
@@ -30,6 +30,8 @@ import java.util.EnumMap;
 import java.util.List;
 import java.util.Map;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
 /**
  * Defines a publication configuration.
  *
@@ -45,9 +47,11 @@ public class PublicationOption {
     private ReservedGroup publicationGroup;
 
     // List of operations to activate in the group to publish/unpublish.
-    List<ReservedOperation> publicationOperations;
+    @Schema(enumAsRef = true)
+    private List<ReservedOperation> publicationOperations;
 
     // Additional group(s)/operations(s) to publish/unpublish when the publication is selected.
+    @Schema(enumAsRef = true)
     private EnumMap<ReservedGroup, List<ReservedOperation>> additionalPublications = new EnumMap<>(ReservedGroup.class);
 
     PublicationOption(String name, ReservedGroup publicationGroup, List<ReservedOperation> publicationOperations) {


### PR DESCRIPTION
Set API enum as ref
- This will allow common reference to enum in the open api spec.

Note this also fixes and issue when attempting to build codegen.

`error: incompatible types: List<InnerEnum> cannot be converted to List<String>`

Here is an example reference for ReservedOperation after this fix.
```
 PublicationOption:
      type: object
      example: null
      properties:
        additionalPublications:
          type: object
          additionalProperties:
            type: array
            example: null
            items:
              $ref: '#/components/schemas/ReservedOperation'
          example: null
        name:
          type: string
          example: null
        publicationGroup:
          type: string
          enum:
          - all
          - intranet
          - guest
          example: null
        publicationOperations:
          type: array
          example: null
          items:
            $ref: '#/components/schemas/ReservedOperation'
```


```
    ReservedOperation:
      type: string
      enum:
      - view
      - download
      - editing
      - notify
      - dynamic
      - featured
```

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md))
- [ ] *User documentation* provided for new features or enhancements in [mannual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
