### PR TITLE
Using icon for call/phone

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/mdview/partials/contact.html
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/partials/contact.html
@@ -34,7 +34,8 @@
             {{c.address}}
           </div>
           <a href="tel:{{c.phone}}" data-ng-if="c.phone != ''">
-            <span data-translate="">call</span> {{c.phone}}
+            <i class="fa fa-fw fa-phone"></i>
+            {{c.phone}}
           </a>
         </address>
 
@@ -91,7 +92,8 @@
               {{c.address}}
             </div>
             <a href="tel:{{c.phone}}" data-ng-if="c.phone != ''">
-              <span data-translate="">call</span> {{c.phone}}
+              <i class="fa fa-fw fa-phone"></i>
+              {{c.phone}}
             </a>
           </address>
 
@@ -147,7 +149,8 @@
               {{c.address}}
             </div>
             <a href="tel:{{c.phone}}" data-ng-if="c.phone != ''">
-              <span data-translate="">call</span> {{c.phone}}
+              <i class="fa fa-fw fa-phone"></i>
+              {{c.phone}}
             </a>
           </address>
 
@@ -187,7 +190,8 @@
 
           <div data-ng-if="c.address != ''">{{c.address}}</div>
           <a href="tel:{{c.phone}}" data-ng-if="c.phone != ''">
-            <span data-translate="">call</span> {{c.phone}}
+            <i class="fa fa-fw fa-phone"></i>
+            {{c.phone}}
           </a>
         </address>
       </div>
@@ -226,7 +230,8 @@
           <span data-ng-repeat="c in contact | limitTo:1">
             <div data-ng-if="c.address != ''">{{c.address}}</div>
             <a href="tel:{{c.phone}}" data-ng-if="c.phone != ''">
-              <span data-translate="">call</span> {{c.phone}}
+              <i class="fa fa-fw fa-phone"></i>
+              {{c.phone}}
             </a>
           </span>
         </address>


### PR DESCRIPTION
We modified the visualisation of the _call_ element to be in line with the other elements: icon + text. This could be relevant for core too?

Before:
![image](https://github.com/geonetwork/core-geonetwork/assets/11455912/20e2185e-d3fc-4398-b1fd-b8b80ba3ac20)
Afer:
![image](https://github.com/geonetwork/core-geonetwork/assets/11455912/cd6da635-d865-4a90-a25c-5dd71d9323ed)


  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

