### PR TITLE
Fix linux specific file separator used for harvester transform option

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/site/SiteApi.java
+++ b/services/src/main/java/org/fao/geonet/api/site/SiteApi.java
@@ -93,6 +93,7 @@ import javax.servlet.ServletRegistration;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpSession;
 import java.awt.image.BufferedImage;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -876,7 +877,7 @@ public class SiteApi {
             )) {
                 for (Path sheet : sheets) {
                     String id = sheet.toString();
-                    if (id != null && id.contains("convert/from") && id.endsWith(".xsl")) {
+                    if (id != null && id.contains("convert" + File.separator + "from") && id.endsWith(".xsl")) {
                         String name = com.google.common.io.Files.getNameWithoutExtension(
                             sheet.getFileName().toString());
                         list.add(IMPORT_STYLESHEETS_SCHEMA_PREFIX + schema + ":convert/" + name);


### PR DESCRIPTION
The list of available transformations to apply during harvesting or importing is incomplete on Windows.  
This is caused by using a hardcoded "/" for file path comparison. The PR changes this to make it OS-agnostic.   

Before: 
![brave_imWjP8RW8p](https://github.com/geonetwork/core-geonetwork/assets/32705577/d441ffbe-1d14-43fc-b8bb-bf769ef2bf2d)

After: 
![brave_lJTJDBSyim](https://github.com/geonetwork/core-geonetwork/assets/32705577/d3ba96da-5fae-4262-aa40-173f97852bcf)

CC @fxprunayre 

