### PR TITLE
Vertical extent label modification

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
@@ -869,6 +869,7 @@
                 <xsl:if test="$max castable as xs:double
                               and xs:double($min) &lt; xs:double($max)">
                   ,"lte": <xsl:value-of select="normalize-space($max)"/>
+                  ,"unit": "m"
                 </xsl:if>
                 }</resourceVerticalRange>
             </xsl:if>

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/summary.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/summary.html
@@ -44,21 +44,17 @@
     </span>
     <div>
       <h3 data-translate="">resourceVerticalRange</h3>
-      <div
-        class="flex flex-row flex-align-center gn-vertical-range"
-        data-ng-repeat="range in mdView.current.record.resourceVerticalRange"
-      >
-        <div class="width-25">
-          <i class="fa fa-fw fa-chevron-up" />
-        </div>
-        <div class="width-75">
-          <div data-ng-show="range.lte">
-            <dt>{{range.lte}}</dt>
-          </div>
-          <div data-ng-show="range.gte">
-            <dt>{{range.gte}}</dt>
-          </div>
-        </div>
+      <div class="flex flex-col">
+        <p data-ng-repeat="range in mdView.current.record.resourceVerticalRange">
+          <span data-ng-show="range.gte || range.gte===0"> {{range.gte}}m </span>
+          <span
+            class="spacer"
+            data-ng-show="(range.gte || range.gte===0) && (range.lte || range.lte===0)"
+          >
+            <i class="fa fa-long-arrow-right"></i>
+          </span>
+          <span data-ng-show="range.lte || range.lte===0"> {{range.lte}}m </span>
+        </p>
       </div>
     </div>
   </div>

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/summary.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/summary.html
@@ -46,14 +46,14 @@
       <h3 data-translate="">resourceVerticalRange</h3>
       <div class="flex flex-col">
         <p data-ng-repeat="range in mdView.current.record.resourceVerticalRange">
-          <span data-ng-show="range.gte || range.gte===0"> {{range.gte}}m </span>
+          <span data-ng-show="range.gte || range.gte===0"> {{range.gte}}{{range.unit || 'm'}} </span>
           <span
             class="spacer"
             data-ng-show="(range.gte || range.gte===0) && (range.lte || range.lte===0)"
           >
             <i class="fa fa-long-arrow-right"></i>
           </span>
-          <span data-ng-show="range.lte || range.lte===0"> {{range.lte}}m </span>
+          <span data-ng-show="range.lte || range.lte===0"> {{range.lte}}{{range.unit || 'm'}} </span>
         </p>
       </div>
     </div>


### PR DESCRIPTION
We have modified the vertical extent label to:
- be visually in line with the temporal extent label
- contain the unit
- allow multiple values

This might also be applicable to the core, hence this PR!
  
Before:
![image](https://github.com/geonetwork/core-geonetwork/assets/11455912/67f6eb56-0baa-427b-a441-f37288bcc19a)

After:
![image](https://github.com/geonetwork/core-geonetwork/assets/11455912/1df87f2c-f473-493f-928d-f491f74f5103)


<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

