### PR TITLE
Remove default response from open api specification.

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/OpenApiController.java
+++ b/services/src/main/java/org/fao/geonet/api/OpenApiController.java
@@ -98,6 +98,9 @@ public class OpenApiController extends AbstractOpenApiResource {
         springDocConfigProperties.setWriterWithOrderByKeys(true);
         springDocConfigProperties.setWriterWithDefaultPrettyPrinter(true);
 
+        // remove default response
+        springDocConfigProperties.setOverrideWithGenericResponse(false);
+
         this.requestMappingHandlerMapping = requestMappingHandlerMapping;
         this.servletContextProvider = servletContextProvider;
         this.springSecurityOAuth2Provider = springSecurityOAuth2Provider;


### PR DESCRIPTION
Remove default response from open api specification.

This will remove the following default response that is added to all api's.

![image](https://github.com/geonetwork/core-geonetwork/assets/1868233/709d37bf-ede8-42df-ab64-969fd46f4e03)

And this is the related Yaml for all responses.

```
        default:
          content:
            application/json: {}
          description: default response
```

This default causes issue when using codegen because it will apply the default to all api's making it difficult to change the accept headers in the api calls as they will all default to application/json.

Tested with OpenApi codegenerator and the only option to set the accept headers is by using something like 

`.getApiClient().addDefaultHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_XML_VALUE);`

However, this fails to work when we want to use a mimetype other than `application/json` because the default headers will not overwrite this default from the spec. (possibly a bug in OpenApi Generator?)

Also, there is no real value in adding this default to all api's.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

