### PR TITLE
Update Springdoc so that it supports Map objects in the request parameters.

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/OpenApiConfig.java
+++ b/services/src/main/java/org/fao/geonet/api/OpenApiConfig.java
@@ -36,6 +36,7 @@ import io.swagger.v3.oas.models.servers.ServerVariable;
 import io.swagger.v3.oas.models.servers.ServerVariables;
 import org.fao.geonet.NodeInfo;
 import org.fao.geonet.kernel.setting.SettingManager;
+import org.springdoc.core.SpringDocUtils;
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cache.concurrent.ConcurrentMapCacheManager;
@@ -44,6 +45,7 @@ import org.springframework.context.annotation.Configuration;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 import static org.fao.geonet.kernel.setting.Settings.SYSTEM_PLATFORM_VERSION;
 
@@ -55,6 +57,16 @@ public class OpenApiConfig {
     private static OpenAPI openAPI = null;
 
     private static SettingManager settingManager = null;
+
+    static {
+        // By default, Spring Doc ignores injectable parameters supported by Spring MVC
+        //     https://springdoc.org/faq.html#_what_are_the_ignored_types_in_the_documentation
+        // This includes the following list.
+        //     https://docs.spring.io/spring-framework/docs/5.1.x/spring-framework-reference/web.html#mvc-ann-arguments
+        // As java.util.Map's are uses for JSON input and output values among other types, it is best to remove java.util.Map from this list.
+        // If we want to use java.util.Map as an injectable then we will need to ensure we hide the parameter.
+        SpringDocUtils.getConfig().removeRequestWrapperToIgnore(Map.class);
+    }
 
     @Bean(name = "cacheManager")
     public CacheManager cacheManager() {


### PR DESCRIPTION
Update Springdoc so that it supports Map objects in the request parameters.

By default injectable parameters are excluded from request parameters. Map is one of those object however it does occur where map objects are supplied as parameters and they should be added to open api spec.  There are currently no cases where a map is injected on purpose into the request parameters. This will fix issues with missing request parameters documentation which are based on Map objects.

Example: Before this PR if you try to test the following api

![image](https://github.com/geonetwork/core-geonetwork/assets/1868233/d70ae666-2707-4099-8e94-6cdb00f20c82)

It is not possible to supply the request body information which is defined as a HashMap here.

https://github.com/geonetwork/core-geonetwork/blob/23140d5c3a70e08e503810cb286894258e60b3c6/services/src/main/java/org/fao/geonet/api/records/MetadataSavedQueryApi.java#L135-L136

And the open api spec is missing documentation on the RequestBody

After this PR the swagger ui looks like the following which makes it possible to test the api by supplying a request body.

![image](https://github.com/geonetwork/core-geonetwork/assets/1868233/8f8e3194-44bb-4ad9-a5fb-9b18c1244671)

And the following was added to the open api spec:

```
      requestBody:
        content:
          application/json:
            example: null
            schema:
              type: object
              additionalProperties:
                type: string
                example: null
              description: The query parameters
              example: null
```



# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

