### PR TITLE
Make editor keyword picker max list size configurable

### DIFF
--- a/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
+++ b/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
@@ -255,6 +255,9 @@
           // Max number of tags allowed. Use 1 to restrict to only
           // on keyword.
           maxTags: "@",
+
+          // Max number of tags searched in thesaurus
+          maxSearched: "@",
           thesaurusTitle: "@",
           browsable: "@"
         },
@@ -457,7 +460,8 @@
                         thesaurusKey: scope.thesaurusKey,
                         dataToExclude: scope.selected,
                         lang: gnLangs.current,
-                        orderById: scope.orderById
+                        orderById: scope.orderById,
+                        max: scope.maxSearched
                       });
 
                     // Init typeahead


### PR DESCRIPTION
Currently, the keyword selector limits the number of returned keywords by its default value of 200.  
This change makes this limit configurable via an attribute.   

Our use case was to increase this number on one of the selectors of the DCAT editor. 

![image](https://github.com/geonetwork/core-geonetwork/assets/32705577/f2837e7f-28ea-45fa-854f-01679893b565)
