### PR TITLE
Fix javascript error accessing the metadata detail page in gnMetadataSocialLink directive

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/mdview/mdviewDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/mdviewDirective.js
@@ -573,11 +573,15 @@
         },
         link: function (scope, element, attrs) {
           scope.mdService = gnUtilityService;
-          $http
-            .get("../api/records/" + scope.md.getUuid() + "/permalink")
-            .then(function (r) {
-              scope.socialMediaLink = r.data;
-            });
+          scope.$watch(scope.md, function (newVal, oldVal) {
+            if (newVal !== null && newVal !== oldVal) {
+              $http
+                .get("../api/records/" + scope.md.getUuid() + "/permalink")
+                .then(function (r) {
+                  scope.socialMediaLink = r.data;
+                });
+            }
+          });
         }
       };
     }


### PR DESCRIPTION
Test case:

1) Load ISO19139 samples
2) Go to the search page and open the metadata page for one of the samples

  - Without the fix: a javascript error  is logged in the JS console:

    ```
    lib.js?v=23140d5c3a70e08e503810cb286894258e60b3c6:143 TypeError: Cannot read properties of null (reading 'getUuid')
        at Object.link (gn_search_default.js?v=23140d5c3a70e08e503810cb286894258e60b3c6&:730:32)
        at lib.js?v=23140d5c3a70e08e503810cb286894258e60b3c6:31:134
        at lib.js?v=23140d5c3a70e08e503810cb286894258e60b3c6:104:304
        at Ca (lib.js?v=23140d5c3a70e08e503810cb286894258e60b3c6:104:361)
        at p (lib.js?v=23140d5c3a70e08e503810cb286894258e60b3c6:88:340)
        at lib.js?v=23140d5c3a70e08e503810cb286894258e60b3c6:99:71
        at lib.js?v=23140d5c3a70e08e503810cb286894258e60b3c6:155:454
        at m.$digest (lib.js?v=23140d5c3a70e08e503810cb286894258e60b3c6:167:67)
        at m.$apply (lib.js?v=23140d5c3a70e08e503810cb286894258e60b3c6:170:484)
        at HTMLHtmlElement.<anonymous> (lib.js?v=23140d5c3a70e08e503810cb286894258e60b3c6:140:481) '<div gn-metadata-social-link="mdVi
    ```
  

- With the fix: no javascript error

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
