### PR TITLE
Fix error on edit page: elements with non-unique id #gnRemoteRecordUrl

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -204,6 +204,9 @@
             scope.isRemoteRecordPropertiesExtracted = false;
             scope.selectionList = undefined;
 
+            // Get the parent div's ID
+            scope.popupId = element.closest(".onlinesrc-popup").attr("id");
+
             scope.$on("resetSearch", function (event, args) {
               scope.remoteRecord = {
                 remoteUrl: "",

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/remote-record-selector.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/remote-record-selector.html
@@ -1,7 +1,10 @@
 <div data-ng-if="allowRemoteRecordLink">
   <form class="form-horizontal">
     <div class="form-group">
-      <label for="gnRemoteRecordUrl" class="control-label col-sm-2" data-translate=""
+      <label
+        ng-attr-for="{{ 'gnRemoteRecordUrl' + popupId }}"
+        class="control-label col-sm-2"
+        data-translate=""
         >orUseRemoteRecordUrl</label
       >
       <div class="col-sm-10">
@@ -9,7 +12,7 @@
           <input
             class="form-control"
             placeholder="https://catalog.sdi.org/csw?REQUEST=GetRecordById&..."
-            id="gnRemoteRecordUrl"
+            ng-attr-id="{{ 'gnRemoteRecordUrl' + popupId }}"
             autocomplete="off"
             data-ng-model="remoteRecord.remoteUrl"
             data-ng-model-options="{debounce: 300}"


### PR DESCRIPTION
Fix error on edit page:  elements with non-unique id gnRemoteRecordUrl

![image](https://github.com/geonetwork/core-geonetwork/assets/1868233/7fc8ec7d-ccda-4b57-ac11-4009c3cce983)

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

