### PR TITLE
Use Java 21 for Sonarcloud plugin

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -19,7 +19,7 @@ jobs:
           submodules: 'recursive'
           show-progress: 'false'
       - name: Set up JDK 11
-        uses: actions/setup-java@v3.12.0
+        uses: actions/setup-java@v4.0.0
         with:
           distribution: 'temurin'
           java-version: '11'
@@ -33,6 +33,12 @@ jobs:
       - name: Build GN
         run: mvn -B package -DskipTests
 
+      - name: Set up JDK 21 # Sonarcloud analyzer needs at least JDK 17
+        uses: actions/setup-java@v4.0.0
+        with:
+          distribution: 'temurin'
+          java-version: '21'
+          cache: 'maven'
       - name: Analyze with Sonar
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any


### PR DESCRIPTION
Sonarcloud analyzer now requires at least Java 17.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [x] *API Changes* are identified in commit messages
- [x] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation


- `Funded by GeoCat BV by way of GeoNetwork Enterprise product (thank you customers!)`

