### PR TITLE
Record view / Display WFS downloads for WFS online resources without a name defined

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/related.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/related.html
@@ -80,6 +80,13 @@
               data-typename="{{::isLayerProtocol(r) ? r.locTitle : ''}}"
               data-url="{{::r.locUrl}}"
             ></div>
+
+            <div
+              data-ng-if="::!isLayerProtocol(r)"
+              data-gn-wfs-download=""
+              data-typename=""
+              data-url="{{::r.locUrl}}"
+            ></div>
           </div>
 
           <div data-ng-switch-when="ATOM">


### PR DESCRIPTION
Online resources with `OGC:WFS` display a WFS selector to dowload the data in the metadata record view.

In `main` and `4.2.x` requires that the online resource has a name defined. Otherwise, it's not displayed:

![wfs-no-name-1](https://github.com/geonetwork/core-geonetwork/assets/1695003/b9a81eee-06ce-48ef-bcb6-19f6a8de4745)

This behaviour was available in `3.12` version, but seems was removed in `main`:

https://github.com/geonetwork/core-geonetwork/blob/5decddaa13e4bfac2b3696a656d584cfaa963f52/web-ui/src/main/resources/catalog/components/metadataactions/partials/related.html#L90-L94

This change restores the behaviour from `3.12` version:

![wfs-no-name-2](https://github.com/geonetwork/core-geonetwork/assets/1695003/fdaca313-671a-47b9-b73d-9f394f6e3010)

---

Test case:

1) Create an iso19139 metadata
2) And an online resource with protocol OGC:WFS, providing the URL of a WFS service. Leave empty the name and description fields.
3) Go to the metadata page:

  - Without the fix: The WFS download selector is not displayed.
  - With the fix: The WFS download selector is displayed.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

