### PR TITLE
Formatter / Withheld element not always hidden.

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/XmlSerializer.java
+++ b/core/src/main/java/org/fao/geonet/kernel/XmlSerializer.java
@@ -54,22 +54,6 @@ import jeeves.xlink.Processor;
  * (id, data, lastChangeDate).
  */
 public abstract class XmlSerializer {
-    private static InheritableThreadLocal<ThreadLocalConfiguration> configThreadLocal = new InheritableThreadLocal<XmlSerializer.ThreadLocalConfiguration>();
-
-    public static ThreadLocalConfiguration getThreadLocal(boolean setIfNotPresent) {
-        ThreadLocalConfiguration config = configThreadLocal.get();
-        if (config == null && setIfNotPresent) {
-            config = new ThreadLocalConfiguration();
-            configThreadLocal.set(config);
-        }
-
-        return config;
-    }
-
-    public static void clearThreadLocal() {
-        configThreadLocal.set(null);
-    }
-
     public static void removeFilteredElement(Element metadata,
                                              final MetadataSchemaOperationFilter filter,
                                              List<Namespace> namespaces) throws JDOMException {
@@ -82,6 +66,7 @@ public abstract class XmlSerializer {
         List<?> nodes = Xml.selectNodes(metadata,
             xpath,
             namespaces);
+
         for (Object object : nodes) {
             if (object instanceof Element) {
                 Element element = (Element) object;
@@ -125,7 +110,7 @@ public abstract class XmlSerializer {
             return false;
         }
 
-    String xlR = _settingManager.getValue(Settings.SYSTEM_XLINKRESOLVER_ENABLE);
+        String xlR = _settingManager.getValue(Settings.SYSTEM_XLINKRESOLVER_ENABLE);
         if (xlR != null) {
             boolean isEnabled = xlR.equals("true");
             if (isEnabled) Log.debug(Geonet.DATA_MANAGER, "XLink Resolver enabled.");
@@ -217,7 +202,8 @@ public abstract class XmlSerializer {
                     }
                 }
             }
-            if (filterEditOperationElements || (getThreadLocal(false) != null && getThreadLocal(false).forceFilterEditOperation)) {
+
+            if (filterEditOperationElements) {
                 removeFilteredElement(metadataXml, editFilter, namespaces);
             }
         }
@@ -292,7 +278,7 @@ public abstract class XmlSerializer {
     public abstract void delete(String id, ServiceContext context)
         throws Exception;
 
-	/* API to be overridden by extensions */
+    /* API to be overridden by extensions */
 
     public abstract void update(String id, Element xml,
                                 String changeDate, boolean updateDateStamp, String uuid, ServiceContext context)
@@ -310,16 +296,4 @@ public abstract class XmlSerializer {
 
     public abstract Element selectNoXLinkResolver(String id, boolean isIndexingTask, boolean applyOperationsFilters)
         throws Exception;
-
-    public static class ThreadLocalConfiguration {
-        private boolean forceFilterEditOperation = false;
-
-        public boolean isForceFilterEditOperation() {
-            return forceFilterEditOperation;
-        }
-
-        public void setForceFilterEditOperation(boolean forceFilterEditOperation) {
-            this.forceFilterEditOperation = forceFilterEditOperation;
-        }
-    }
 }

--- a/core/src/test/java/org/fao/geonet/kernel/XmlSerializerIntegrationTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/XmlSerializerIntegrationTest.java
@@ -143,17 +143,6 @@ public class XmlSerializerIntegrationTest extends AbstractCoreIntegrationTest {
         assertHiddenElements(false, false);
     }
 
-    @SuppressWarnings("unchecked")
-    @Test
-    public void testInternalSelectHidingWithheldNullServiceContext() throws Exception {
-        setSchemaFilters(true, true);
-        Field field = ServiceContext.class.getDeclaredField("THREAD_LOCAL_INSTANCE");
-        field.setAccessible(true);
-        InheritableThreadLocal<ServiceContext> threadLocalInstance = (InheritableThreadLocal<ServiceContext>) field.get(null);
-        threadLocalInstance.set(null);
-        assertHiddenElements(true);
-    }
-
     @Test
     public void testInternalSelectHidingWithheldAdministrator() throws Exception {
         try (Closeable ignored = configureXmlSerializerAndServiceContext(true, false, false)) {

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterApi.java
@@ -262,20 +262,18 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
         }
 
 
-        Boolean hideWithheld = true;
-//        final boolean hideWithheld = Boolean.TRUE.equals(hide_withheld) ||
-//            !context.getBean(AccessManager.class).canEdit(context, resolvedId);
+        final ServiceContext context = createServiceContext(
+            language,
+            formatType,
+            request.getNativeRequest(HttpServletRequest.class));
+
+        Boolean hideWithheld = !context.getBean(AccessManager.class).canEdit(context, String.valueOf(metadata.getId()));
         Key key = new Key(metadata.getId(), language, formatType, formatterId, hideWithheld, width);
         final boolean skipPopularityBool = false;
 
         ISODate changeDate = metadata.getDataInfo().getChangeDate();
 
         Validator validator;
-
-        final ServiceContext context = createServiceContext(
-            language,
-            formatType,
-            request.getNativeRequest(HttpServletRequest.class));
 
         if (changeDate != null) {
             final long changeDateAsTime = changeDate.toDate().getTime();
@@ -414,8 +412,6 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
      * @param id             the id, uuid or fileIdentifier of the metadata
      * @param xslid          the id of the formatter
      * @param skipPopularity if true then don't increment popularity
-     * @param hide_withheld  if true hideWithheld (private) elements even if the current user would
-     *                       normally have access to them.
      * @param width          the approximate size of the element that the formatter output will be
      *                       embedded in compared to the full device width.  Allowed options are the
      *                       enum values: {@link org.fao.geonet.api.records.formatters.FormatterWidth}
@@ -431,7 +427,6 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
         @RequestParam(value = "uuid", required = false) final String uuid,
         @RequestParam(value = "xsl", required = false) final String xslid,
         @RequestParam(defaultValue = "n") final String skipPopularity,
-        @RequestParam(value = "hide_withheld", required = false) final Boolean hide_withheld,
         @RequestParam(value = "width", defaultValue = "_100") final FormatterWidth width,
         final NativeWebRequest request) throws Exception {
         final FormatType formatType = FormatType.valueOf(type.toLowerCase());
@@ -440,8 +435,7 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
         ServiceContext context = createServiceContext(lang, formatType, request.getNativeRequest(HttpServletRequest.class));
         Lib.resource.checkPrivilege(context, resolvedId, ReservedOperation.view);
 
-        final boolean hideWithheld = Boolean.TRUE.equals(hide_withheld) ||
-            !context.getBean(AccessManager.class).canEdit(context, resolvedId);
+        final boolean hideWithheld = !context.getBean(AccessManager.class).canEdit(context, resolvedId);
         Key key = new Key(Integer.parseInt(resolvedId), lang, formatType, xslid, hideWithheld, width);
         final boolean skipPopularityBool = skipPopularity.equals("y");
 
@@ -609,11 +603,6 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
 
         Element metadata = serializer.removeHiddenElements(false, md, true);
         if (doXLinks) Processor.processXLink(metadata, context);
-
-        boolean withholdWithheldElements = hide_withheld != null && hide_withheld;
-        if (XmlSerializer.getThreadLocal(false) != null || withholdWithheldElements) {
-            XmlSerializer.getThreadLocal(true).setForceFilterEditOperation(withholdWithheldElements);
-        }
 
         return Pair.read(metadata, md);
 

--- a/services/src/main/java/org/fao/geonet/guiservices/util/Env.java
+++ b/services/src/main/java/org/fao/geonet/guiservices/util/Env.java
@@ -52,9 +52,6 @@ public class Env implements Service {
     //--------------------------------------------------------------------------
 
     public Element exec(Element params, ServiceContext context) throws Exception {
-        // reset the thread local
-        XmlSerializer.clearThreadLocal();
-
         GeonetContext gc = (GeonetContext) context.getHandlerContext(Geonet.CONTEXT_NAME);
 
         Element response = gc.getBean(SettingManager.class).getAllAsXML(true);

--- a/services/src/test/java/org/fao/geonet/api/records/formatters/AbstractFormatterTest.java
+++ b/services/src/test/java/org/fao/geonet/api/records/formatters/AbstractFormatterTest.java
@@ -118,7 +118,7 @@ public abstract class AbstractFormatterTest extends AbstractServiceIntegrationTe
         TestFunction testFunction = new TestFunction() {
             @Override
             public void exec() throws Exception {
-                formatService.exec(getUILang(), getOutputType().name(), "" + id, null, formatterId, "true", false, FormatterWidth._100,
+                formatService.exec(getUILang(), getOutputType().name(), "" + id, null, formatterId, "true", FormatterWidth._100,
                     webRequest);
             }
         };

--- a/services/src/test/java/org/fao/geonet/api/records/formatters/FormatterApiIntegrationTest.java
+++ b/services/src/test/java/org/fao/geonet/api/records/formatters/FormatterApiIntegrationTest.java
@@ -94,7 +94,7 @@ public class FormatterApiIntegrationTest extends AbstractServiceIntegrationTest 
             JeevesDelegatingFilterProxy.setApplicationContextAttributeKey(srvAppContext);
             RequestContextHolder.setRequestAttributes(new ServletRequestAttributes(request));
 
-            formatService.exec("eng", "html", "" + id, null, formatter.getId(), "true", false, _100, new ServletWebRequest(request, response));
+            formatService.exec("eng", "html", "" + id, null, formatter.getId(), "true", _100, new ServletWebRequest(request, response));
 
             final String view = response.getContentAsString();
             try {
@@ -105,7 +105,7 @@ public class FormatterApiIntegrationTest extends AbstractServiceIntegrationTest 
             }
             try {
                 response = new MockHttpServletResponse();
-                formatService.exec("eng", "testpdf", "" + id, null, formatter.getId(), "true", false, _100,
+                formatService.exec("eng", "testpdf", "" + id, null, formatter.getId(), "true", _100,
                     new ServletWebRequest(request, response));
 //                Files.write(Paths.get("e:/tmp/view.pdf"), response.getContentAsByteArray());
 //                System.exit(0);
@@ -138,7 +138,7 @@ public class FormatterApiIntegrationTest extends AbstractServiceIntegrationTest 
         JeevesDelegatingFilterProxy.setApplicationContextAttributeKey(applicationContextAttributeKey);
 
         final MockHttpServletResponse response = new MockHttpServletResponse();
-        formatService.exec("eng", "html", "" + id, null, formatterName, "true", false, _100, new ServletWebRequest(request, response));
+        formatService.exec("eng", "html", "" + id, null, formatterName, "true", _100, new ServletWebRequest(request, response));
         final String viewXml = response.getContentAsString();
         final Element view = Xml.loadString(viewXml, false);
         assertEqualsText("fromFunction", view, "*//p");

--- a/web/src/main/java/org/fao/geonet/Geonetwork.java
+++ b/web/src/main/java/org/fao/geonet/Geonetwork.java
@@ -394,7 +394,7 @@ public class Geonetwork implements ApplicationHandler {
                         final MockHttpServletResponse response = new MockHttpServletResponse();
                         try {
                             formatService.exec("eng", FormatType.html.toString(), mdId.toString(), null, formatterName,
-                                Boolean.TRUE.toString(), false, FormatterWidth._100, new ServletWebRequest(servletRequest, response));
+                                Boolean.TRUE.toString(), FormatterWidth._100, new ServletWebRequest(servletRequest, response));
                         } catch (Throwable t) {
                             Log.info(Geonet.GEONETWORK, "Error while initializing the Formatter with id: " + formatterName, t);
                         }


### PR DESCRIPTION
Affected API calls:
* http://localhost:8080/geonetwork/srv/api/records/720ceda7-a9ea-4bbe-896a-04925c44a7f0/formatters/xyz
* http://localhost:8080/geonetwork/srv/api/records/720ceda7-a9ea-4bbe-896a-04925c44a7f0/related?type=thumbnails&type=onlines

For testing, add a record with 2 online resources. Add withheld attribute to one of them, call the related API. Sometimes 1 or 2 links are returned (it does not happen always, but usually if accessing the same API call with a browser and Curl using the same session the problem can be observed). A variable was set using ThreadLocal which looks to be the cause of this. It was noticed while opening the editor not always listing all distribution links. Withheld elements are always hidden properly for anonymous user.

```
for i in {1..20}
do
 curl -s 'http://localhost:8080/geonetwork/srv/api/records/720ceda7-a9ea-4bbe-896a-04925c44a7f0/related?type=thumbnails&type=onlines' \
  -H "cookie: XSRF-TOKEN=4c2a7847-87f6-4cf6-bb55-173e43332729; JSESSIONID=$JSESSIONID.node0; " \
  -H 'x-xsrf-token: 4c2a7847-87f6-4cf6-bb55-173e43332729' | grep -o -i "<item>" | wc -l
done
1
2
1
2
1
1
```

The Formatter API has a `hide_withheld` parameter to hide with held elements even if the user is allowed to see them. The application is not using this parameter, and opening an incognito window can be used to check if with held elements are properly removed.

This change propose to remove the ThreadLocal variable and only rely on user session and edits rights of the current user to hide or not with held elements.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [x] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

