### PR TITLE
Metadata editor / Fix javascript error in the add thumbnail option when the metadata has 1 WMS layer

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -678,13 +678,6 @@
                 //   });
                 // }
                 // Add each WMS layer to the map
-                if (scope.gnCurrentEdit.layerConfig == undefined) {
-                  scope.layers = scope.gnCurrentEdit.layerConfig;
-                } else {
-                  scope.layers = Array.isArray(scope.gnCurrentEdit.layerConfig)
-                    ? scope.gnCurrentEdit.layerConfig
-                    : [scope.gnCurrentEdit.layerConfig];
-                }
                 angular.forEach(scope.gnCurrentEdit.layerConfig, function (layer) {
                   scope.map.addLayer(
                     new ol.layer.Tile({

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -678,7 +678,13 @@
                 //   });
                 // }
                 // Add each WMS layer to the map
-                scope.layers = scope.gnCurrentEdit.layerConfig;
+                if (scope.gnCurrentEdit.layerConfig == undefined) {
+                  scope.layers = scope.gnCurrentEdit.layerConfig;
+                } else {
+                  scope.layers = Array.isArray(scope.gnCurrentEdit.layerConfig)
+                    ? scope.gnCurrentEdit.layerConfig
+                    : [scope.gnCurrentEdit.layerConfig];
+                }
                 angular.forEach(scope.gnCurrentEdit.layerConfig, function (layer) {
                   scope.map.addLayer(
                     new ol.layer.Tile({

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
@@ -531,7 +531,7 @@
       <div
         id="gn-addonlinesrc-thumbnail-panel"
         class="panel panel-default"
-        data-ng-show="params.linkType.sources.thumbnailMaker"
+        data-ng-show="params.linkType.sources.thumbnailMaker && gnCurrentEdit.layerConfig.length > 0"
       >
         <div class="panel-heading" data-translate="">createAThumbnail</div>
         <div class="panel-body">
@@ -539,15 +539,7 @@
             id="gn-addonlinesrc-thumbnail-map"
             class="form-group gn-thumbnail-maker-panel"
           >
-            <div
-              id="gn-addonlinesrc-thumbnail-warning"
-              class="alert alert-warning"
-              data-ng-show="layers == undefined"
-              data-translate=""
-            >
-              noLayersForThumbnail
-            </div>
-            <div data-ng-hide="layers == undefined">
+            <div>
               <textarea
                 id="gn-addonlinesrc-thumbnail-json"
                 class="form-control hidden"

--- a/web-ui/src/main/resources/catalog/components/metadatamanager/EditorService.js
+++ b/web-ui/src/main/resources/catalog/components/metadatamanager/EditorService.js
@@ -376,6 +376,13 @@
               .val();
           };
 
+          // The list of layers in a record is defined in XSL template get-online-source-config
+          // and is depending on each schema. If emtpy an empty array is set.
+          var getLayerConfiguration = function () {
+            var configuration = angular.fromJson(getInputValue("layerConfig")) || [];
+            return Array.isArray(configuration) ? configuration : [configuration.resource];
+          };
+
           var extent = [],
             value = getInputValue("extent");
           try {
@@ -414,7 +421,7 @@
             extent: extent,
             dataFormats: dataFormats,
             isMinor: getInputValue("minor") === "true",
-            layerConfig: angular.fromJson(getInputValue("layerConfig")),
+            layerConfig: getLayerConfiguration(),
             saving: false
           });
 

--- a/web-ui/src/main/resources/catalog/locales/en-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/en-editor.json
@@ -185,7 +185,6 @@
     "generateThumbnail": "Generate thumbnail",
     "generateThumbnail-help": "Thumbnail will be created and saved in the filestore. Use the filestore to add the thumbnail in the metadata record.",
     "createAThumbnail": "Generate thumbnail using the view service",
-    "noLayersForThumbnail": "No layer defined in record to generate thumbnail from",
     "noTemplatesAvailable": "Warning! There is no templates available in the catalog. You should add or <a href='admin.console#/metadata'>import</a> some.",
     "none": "None",
     "notFoundInThesaurus": "<strong>Warning! Keywords {{invalid}} not found in thesaurus.</strong> Others {{found}} were found in the thesaurus. 2 reasons: <ul><li>keywords in this record are in a language that is not in the current user interface language</li><li>keywords does not exists in the thesaurus</li></ul><strong>Those keywords will not be modified by this editing session</strong> unless you remove this thesaurus section.",


### PR DESCRIPTION
Test case:

1) Create an iso19139 dataset metadata
2) Add an online resource with a WMS layer
3) Add an online resource and select the option `Add a thumbnail` in the dialog. Check the Javascript console:

  - Without the fix:

```
Error: [orderBy:notarray] http://errors.angularjs.org/1.8.2/orderBy/notarray\?p0\=%7B%22resource%22%3A%7B%22ref%22%3A%22172%22%2C%22refParent%22%3A%22171%22%2C%22name%22%3A%222%22%2C%22url%22%3A%22https%3A%2F%2Fmaps-cartes.ec.gc.ca%2Farcgis%2Fservices%2FDMS%2FStressCumulatifLittorales%2FMapServer%2FWMSServer%3Frequest%3DGetCapabilities%26service%3DWMS%22%2C%22title%22%3A%22Metadata%20WMS%20layer%22%2C%22abstract%22%3A%22The%20ISO19115%20metadata%20standard%20is%20the%20preferred%20metadata%20standard%20to%20use.%20If%20unsure%20what%20templates%20to%20start%20with%2C%20use%20this%20one.%22%2C%22protocol%22%3A%22OGC%3AWMS%22%7D%7D
    at lib.js?v=65b94734a63ca8491dba95d7439baf1be02c2450:21:168
```
  - With the fix: no javascript error is displayed

---

@fxprunayre not really related to this change, but to the Add thumbnails from map feature. Is this to hide the add thumbnails from map panel if the metadata doesn't have any WMS layer?

https://github.com/geonetwork/core-geonetwork/blob/65b94734a63ca8491dba95d7439baf1be02c2450/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html#L542-L549
 
This doesn't really work, independently of the value of `scope.layers` in https://github.com/geonetwork/core-geonetwork/blob/65b94734a63ca8491dba95d7439baf1be02c2450/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js#L681  (no matter if in that line it is `undefined`  or has a value), if you print that value in the HTML it is always prints `[]`.

Debugging the code, `scope.layers` are reset in https://github.com/geonetwork/core-geonetwork/blob/65b94734a63ca8491dba95d7439baf1be02c2450/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js#L1123 after executing https://github.com/geonetwork/core-geonetwork/blob/65b94734a63ca8491dba95d7439baf1be02c2450/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js#L681 

I don't know that much this code, but seems like an unwanted side-effect?

---

Should not be this set to `undefined` to be consistent with the HTML check?

https://github.com/geonetwork/core-geonetwork/blob/65b94734a63ca8491dba95d7439baf1be02c2450/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js#L617

If the purpose is to hide the panel if no WMS layers, I think we should unify the check either to `undefined` or empty array and check the side effect for reset protocol.

Doing some additional research, it seems `scope.layers` are used both in the WMS directive to select a WMS layer and also in the Add Thumbnail from map feature, that doesn't look good. I've changed 

https://github.com/geonetwork/core-geonetwork/blob/65b94734a63ca8491dba95d7439baf1be02c2450/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html#L542-L549

To

```
data-ng-show="gnCurrentEdit.layerConfig == undefined"
```

And looks working fine like this:

1) If the metadata has WMS layers, are loaded in the map viewer to create the thumbnail

2) If the metadata has no WMS layers, a message `No layer defined in record to generate thumbnail from` is displayed (although needs some styling).

I think the assignment changed in this PR can be also completely removed, `scope.layers` should be used only to select layers from a WMS service.




# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

