### PR TITLE
Harvester / Localfilesystem / Log properly to harvester log file.

### DIFF
--- a/common/src/main/java/org/fao/geonet/Logger.java
+++ b/common/src/main/java/org/fao/geonet/Logger.java
@@ -23,8 +23,6 @@
 
 package org.fao.geonet;
 
-//=============================================================================
-
 import org.apache.logging.log4j.core.appender.FileAppender;
 
 /**
@@ -37,35 +35,52 @@ public interface Logger {
      *
      * @return check if debug logging is enabled
      */
-    public boolean isDebugEnabled();
+    boolean isDebugEnabled();
 
     /**
      * Log debug message used indicate module troubleshoot module activity.
      *
      * @param message debug message used to provide in
      */
-    public void debug(String message);
+    void debug(String message);
+
+    void debug(String message, Throwable throwable);
+
+    void debug(String message, Object... object);
 
     /**
      * Log information message indicating module progress.
      *
      * @param message information message indicating progress
      */
-    public void info(String message);
+    void info(String message);
 
-    /** Log warning message indicating potentially harmful situation, module
+    void info(String message, Throwable throwable);
+
+    void info(String message, Object... object);
+
+    /**
+     * Log warning message indicating potentially harmful situation, module
      * will continue to try and complete current activity.
      *
      * @param message Warning message indicating potentially harmful situation
      */
-    public void warning(String message);
+    void warning(String message);
+
+    void warning(String message, Throwable throwable);
+
+    void warning(String message, Object... object);
 
     /**
      * Log error message indicating module cannot continue current activity.
      *
      * @param message Error message
      */
-    public void error(String message);
+    void error(String message);
+
+    void error(String message, Throwable throwable);
+
+    void error(String message, Object... object);
 
     /**
      * Log error message using provided throwable, indicating module cannot continue
@@ -73,51 +88,49 @@ public interface Logger {
      *
      * @param ex Cause of error condition.
      */
-    public void error(Throwable ex);
+    void error(Throwable ex);
 
     /**
      * Log severe message, indicating application cannot continue to operate.
      *
      * @param message severe message
      */
-    public void fatal(String message);
+    void fatal(String message);
 
     /**
      * Functional module used for logging messages (for example {@code jeeves.engine}).
      *
      * @return functional module used for logging messages.
      */
-    public String getModule();
+    String getModule();
 
     /**
      * Configure logger with log4j {@link FileAppender}, used for output.
-     *
+     * <p>
      * The file appender is also responsible for log file location provided by {@link #getFileAppender()}.
      *
      * @param fileAppender Log4j FileAppender
      */
-    public void setAppender(FileAppender fileAppender);
+    void setAppender(FileAppender fileAppender);
 
     /**
      * The log file name from the file appender for this module.
-     *
+     * <p>
      * Note both module and fallback module are provided allowing providing a better opportunity
      * to learn the log file location. Harvesters use the log file name parent directory as a good
      * location to create {@code /harvester_logs/} folder.
-     *
+     * <p>
      * Built-in configuration uses log file location {@code logs/geonetwork.log} relative to the current directory, or relative to system property {@code log_file}.
      *
      * @return logfile location of {@code logs/geonetwork.log} file
      */
-    public String getFileAppender();
+    String getFileAppender();
 
     /**
      * Access to omodule logging level, providing
+     *
      * @return
      */
-    public org.apache.logging.log4j.Level getThreshold();
+    org.apache.logging.log4j.Level getThreshold();
 
 }
-
-//=============================================================================
-

--- a/common/src/main/java/org/fao/geonet/utils/Log.java
+++ b/common/src/main/java/org/fao/geonet/utils/Log.java
@@ -24,22 +24,18 @@
 package org.fao.geonet.utils;
 
 
-import org.apache.log4j.Priority;
 import org.apache.log4j.bridge.AppenderWrapper;
 import org.apache.logging.log4j.Level;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.apache.logging.log4j.core.Appender;
+import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.appender.FileAppender;
 import org.apache.logging.log4j.core.appender.RollingFileAppender;
-import org.apache.logging.log4j.core.LoggerContext;
 import org.apache.logging.log4j.core.config.Configuration;
 import org.apache.logging.log4j.core.config.LoggerConfig;
 
 import java.io.File;
-import java.util.Enumeration;
-
-//=============================================================================
 
 /**
  * Jeeves logging integration, defining functional logger categories by module
@@ -125,8 +121,12 @@ public final class Log {
         LogManager.getLogger(module).debug(message);
     }
 
-    public static void debug(String module, Object message, Exception e) {
-        LogManager.getLogger(module).debug(message, e);
+    public static void debug(String module, String message, Object... objects) {
+        LogManager.getLogger(module).debug(message, objects);
+    }
+
+    public static void debug(String module, String message, Throwable throwable) {
+        LogManager.getLogger(module).debug(message, throwable);
     }
 
     public static boolean isDebugEnabled(String module) {
@@ -157,9 +157,14 @@ public final class Log {
         LogManager.getLogger(module).info(message);
     }
 
-    public static void info(String module, Object message, Throwable t) {
-        LogManager.getLogger(module).info(message, t);
+    public static void info(String module, String message, Object... objects) {
+        LogManager.getLogger(module).info(message, objects);
     }
+
+    public static void info(String module, String message, Throwable throwable) {
+        LogManager.getLogger(module).info(message, throwable);
+    }
+
 
     //---------------------------------------------------------------------------
 
@@ -180,6 +185,14 @@ public final class Log {
 
     public static void error(String module, Object message, Throwable t) {
         LogManager.getLogger(module).error(message, t);
+    }
+
+    public static void error(String module, String message, Object... objects) {
+        LogManager.getLogger(module).error(message, objects);
+    }
+
+    public static void error(String module, String message, Throwable throwable) {
+        LogManager.getLogger(module).error(message, throwable);
     }
 
     //---------------------------------------------------------------------------
@@ -225,16 +238,56 @@ public final class Log {
                 Log.debug(module, message);
             }
 
+            @Override
+            public void debug(String message, Throwable throwable) {
+                Log.debug(module, message, throwable);
+            }
+
+            @Override
+            public void debug(String message, Object... object) {
+                Log.debug(module, message, object);
+            }
+
             public void info(String message) {
                 Log.info(module, message);
+            }
+
+            @Override
+            public void info(String message, Throwable throwable) {
+                Log.info(module, message, throwable);
+            }
+
+            @Override
+            public void info(String message, Object... object) {
+                Log.info(module, message, object);
             }
 
             public void warning(String message) {
                 Log.warning(module, message);
             }
 
+            @Override
+            public void warning(String message, Throwable throwable) {
+                Log.warning(module, message, throwable);
+            }
+
+            @Override
+            public void warning(String message, Object... object) {
+
+            }
+
             public void error(String message) {
                 Log.error(module, message);
+            }
+
+            @Override
+            public void error(String message, Throwable throwable) {
+                Log.error(module, message, throwable);
+            }
+
+            @Override
+            public void error(String message, Object... object) {
+                Log.error(module, message, object);
             }
 
             public void fatal(String message) {
@@ -279,7 +332,7 @@ public final class Log {
                     }
                 }
                 LoggerConfig fallbackConfig = configuration.getLoggers().get(fallbackModule);
-                if( fallbackConfig != null) {
+                if (fallbackConfig != null) {
                     for (Appender appender : fallbackConfig.getAppenders().values()) {
                         File file = toLogFile(appender);
                         if (file != null && file.exists()) {

--- a/core/src/main/java/jeeves/server/context/BasicContext.java
+++ b/core/src/main/java/jeeves/server/context/BasicContext.java
@@ -144,8 +144,28 @@ public class BasicContext implements Logger {
     }
 
     @Override
+    public void debug(String message, Throwable throwable) {
+        logger.debug(message, throwable);
+    }
+
+    @Override
+    public void debug(String message, Object... object) {
+        logger.debug(message, object);
+    }
+
+    @Override
     public void info(final String message) {
         logger.info(message);
+    }
+
+    @Override
+    public void info(String message, Throwable throwable) {
+        logger.info(message, throwable);
+    }
+
+    @Override
+    public void info(String message, Object... object) {
+        logger.info(message, object);
     }
 
     @Override
@@ -154,8 +174,28 @@ public class BasicContext implements Logger {
     }
 
     @Override
+    public void warning(String message, Throwable throwable) {
+        logger.warning(message, throwable);
+    }
+
+    @Override
+    public void warning(String message, Object... object) {
+        logger.warning(message, object);
+    }
+
+    @Override
     public void error(final String message) {
         logger.error(message);
+    }
+
+    @Override
+    public void error(String message, Throwable throwable) {
+        logger.error(message, throwable);
+    }
+
+    @Override
+    public void error(String message, Object... object) {
+        logger.error(message, object);
     }
 
     @Override
@@ -200,6 +240,3 @@ public class BasicContext implements Logger {
         return NodeInfo.DEFAULT_NODE;
     }
 }
-
-//=============================================================================
-

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/BaseAligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/BaseAligner.java
@@ -119,9 +119,9 @@ public abstract class BaseAligner<P extends AbstractParams> extends AbstractAlig
             String name = localGroups.getName(priv.getGroupId());
 
             if (name == null) {
-                LOGGER.debug("    - Skipping removed group with id:{}", priv.getGroupId());
+                LOGGER.debug("    - Skipping removed group with id: {}", priv.getGroupId());
             } else {
-                LOGGER.debug("    - Setting privileges for group : {}", name);
+                LOGGER.debug("    - Setting privileges for group: {}", name);
                 for (int opId : priv.getOperations()) {
                     name = dataManager.getAccessManager().getPrivilegeName(opId);
                     //--- all existing operation

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/AbstractHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/AbstractHarvester.java
@@ -140,8 +140,12 @@ public abstract class AbstractHarvester<T extends HarvestResult, P extends Abstr
     protected P params;
     protected T result;
 
+
     protected Logger log = Log.createLogger(Geonet.HARVESTER);
 
+    public Logger getLogger() {
+        return log;
+    }
     private Element loadedInfo;
     private String id;
     private volatile Status status;

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFilesystemHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFilesystemHarvester.java
@@ -45,7 +45,6 @@ import org.fao.geonet.kernel.harvest.harvester.GroupMapper;
 import org.fao.geonet.kernel.harvest.harvester.HarvestResult;
 import org.fao.geonet.kernel.search.IndexingMode;
 import org.fao.geonet.repository.MetadataRepository;
-import org.fao.geonet.repository.OperationAllowedRepository;
 import org.fao.geonet.repository.specification.MetadataSpecs;
 import org.fao.geonet.utils.IO;
 import org.jdom.Element;

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFilesystemHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFilesystemHarvester.java
@@ -158,8 +158,6 @@ public class LocalFilesystemHarvester extends AbstractHarvester<HarvestResult, L
             metadataManager.save(metadata);
         }
 
-        OperationAllowedRepository repository = context.getBean(OperationAllowedRepository.class);
-        repository.deleteAllByMetadataId(Integer.parseInt(id));
         aligner.addPrivileges(id, params.getPrivileges(), localGroups, context);
 
         metadata.getCategories().clear();

--- a/web-ui/src/main/resources/catalog/components/admin/harvester/partials/privileges.html
+++ b/web-ui/src/main/resources/catalog/components/admin/harvester/partials/privileges.html
@@ -6,7 +6,7 @@
 
   <div
     id="gn-harvest-settings-gn-priviliges-ifRecordExistAppendPrivileges"
-    data-ng-show="harvester['@type'] == 'webdav' || harvester['@type'] == 'geonetwork' || harvester['@type'] == 'csw' "
+    data-ng-show="harvester['@type'] == 'webdav' || harvester['@type'] == 'geonetwork' || harvester['@type'] == 'csw' || harvester['@type'] == 'filesystem' "
   >
     <label class="control-label">
       <input type="checkbox" data-ng-model="harvester.ifRecordExistAppendPrivileges" />

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v3110/UpdateMetadataStatus.java
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v3110/UpdateMetadataStatus.java
@@ -316,7 +316,7 @@ public class UpdateMetadataStatus extends DatabaseMigrationTask {
             connection.rollback();
             Log.error(Geonet.DB, "  Exception while dropping old primary key constraint on table " + MetadataStatus.TABLE_NAME + ". Restart application and check logs for database errors.  If errors exists then may need to manually drop the primary key for this table." +
                     "Error is: " + e.getMessage());
-            Log.debug(Geonet.DB, e, e);
+            Log.debug(Geonet.DB, "Full stack", e);
         }
 
         connection.commit();
@@ -328,7 +328,7 @@ public class UpdateMetadataStatus extends DatabaseMigrationTask {
             connection.rollback();
             Log.error(Geonet.DB, "  Exception while dropping old primary key on table " + MetadataStatus.TABLE_NAME + ". Restart application and check logs for database errors.  If errors exists then may need to manually drop the primary key for this table. " +
                     "Error is: " + e.getMessage());
-            Log.debug(Geonet.DB, e, e);
+            Log.debug(Geonet.DB, "Full stack", e);
         }
 
         connection.commit();
@@ -340,7 +340,7 @@ public class UpdateMetadataStatus extends DatabaseMigrationTask {
             connection.rollback();
             Log.error(Geonet.DB, "  Exception while adding primary key on " + MetadataStatus_.id.getName() + " column for " + MetadataStatus.TABLE_NAME + ". " +
                     "Error is: " + e.getMessage());
-            Log.debug(Geonet.DB, e, e);
+            Log.debug(Geonet.DB, "Full stack", e);
         }
 
         connection.commit();


### PR DESCRIPTION
Follow up of https://github.com/geonetwork/core-geonetwork/pull/2765 and fix harvester logger which was not reporting any error anymore into the harvester logfile that user can download after harvest.

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/d84e643f-6713-4821-9d04-bde2e9c1c911)

It only reports:
```
2024-01-25T11:06:22,547 WARN  [geonetwork.harvester] - Start of alignment for : SEANOE
2024-01-25T11:08:25,135 INFO  [geonetwork.harvester] - Ended harvesting from node : SEANOE (LocalFilesystemHarvester)
```

If using the harvester logger as before, then the log file properly contains errors
```
2024-01-25T11:06:22,547 WARN  [geonetwork.harvester] - Start of alignment for : SEANOE
2024-01-25T11:06:55,675 ERROR [geonetwork.harvester] - Error transforming JSON into XML from file /data/75639.json, ignoring
2024-01-25T11:07:33,893 ERROR [geonetwork.harvester] - Error transforming JSON into XML from file /data/59178.json, ignoring
2024-01-25T11:08:25,135 INFO  [geonetwork.harvester] - Ended harvesting from node : SEANOE (LocalFilesystemHarvester)
```

To test, try to import a file which will trigger error like invalid XML.



Also adds append privileges options to this harvester type (see https://github.com/geonetwork/core-geonetwork/pull/4070). Remove useless double deletion of privileges.

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/26967da4-9013-42c7-bb7d-4f1f65fc7f08)

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

Funded by Ifremer
