### PR TITLE
[Backport 4.2.x] Bump advanced-security/maven-dependency-submission-action from 3 to 4

### DIFF
--- a/.github/workflows/mvn-dep-tree.yml
+++ b/.github/workflows/mvn-dep-tree.yml
@@ -30,4 +30,4 @@ jobs:
           cache: maven
 
       - name: Submit Dependency Snapshot
-        uses: advanced-security/maven-dependency-submission-action@v3
+        uses: advanced-security/maven-dependency-submission-action@v4


### PR DESCRIPTION
Backport #7655
 **Authored by:** @dependabot[bot]