### PR TITLE
Fix pdf link issue

### DIFF
--- a/web/src/main/webapp/xslt/skin/default/skin.xsl
+++ b/web/src/main/webapp/xslt/skin/default/skin.xsl
@@ -69,7 +69,7 @@
                                     else true()"/>
                 <xsl:if test="not($isLogoInHeader) or $isShowGNName">
                   <xsl:variable name="appUrl"
-                                select="if(util:getUiConfigurationJsonProperty(/root/request/ui, 'mods.home.appUrl'))
+                                select="if(output != 'pdf' and util:getUiConfigurationJsonProperty(/root/request/ui, 'mods.home.appUrl'))
                                     then geonet:updateUrlPlaceholder(util:getUiConfigurationJsonProperty(/root/request/ui, 'mods.home.appUrl'), /root/gui/nodeId, $lang)
                                     else /root/gui/nodeUrl"/>
                   <li>


### PR DESCRIPTION
This is to address the issue https://github.com/geonetwork/core-geonetwork/issues/7610

Applied the suggest code. Here is the result

![image](https://github.com/geonetwork/core-geonetwork/assets/74916635/162b4f09-c8b3-4b82-b221-ef3b9c70bc4c)


By click on the link in the pdf, it gets to the home page
![image](https://github.com/geonetwork/core-geonetwork/assets/74916635/cf639ba5-5e9c-475d-b519-d1f085100794)
