### PR TITLE
Fix springdoc so that enums names are used instead of toString

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/OpenApiController.java
+++ b/services/src/main/java/org/fao/geonet/api/OpenApiController.java
@@ -21,7 +21,11 @@
 package org.fao.geonet.api;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.SerializationFeature;
+
+import io.swagger.v3.core.util.Json;
 import io.swagger.v3.core.util.PathUtils;
+import io.swagger.v3.core.util.Yaml;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.models.OpenAPI;
 import org.springdoc.api.AbstractOpenApiResource;
@@ -105,6 +109,10 @@ public class OpenApiController extends AbstractOpenApiResource {
         this.servletContextProvider = servletContextProvider;
         this.springSecurityOAuth2Provider = springSecurityOAuth2Provider;
         this.routerFunctionProvider = routerFunctionProvider;
+
+        // Ensure all enums are written based on the enum name.
+        Json.mapper().configure(SerializationFeature.WRITE_ENUMS_USING_TO_STRING, false);
+        Yaml.mapper().configure(SerializationFeature.WRITE_ENUMS_USING_TO_STRING, false);
     }
 
     @Operation(hidden = true)


### PR DESCRIPTION
This fixes bug where some apis will not execute correctly from the swagger pager due to the wrong enum value being supplied. i.e.
visibility should be using enum values PUBLIC/PRIVATE instead of public/private

Before this fix.
![image](https://github.com/geonetwork/core-geonetwork/assets/1868233/6b221fd3-1c5d-4074-90fe-7c039831c723)

After this fix 

![image](https://github.com/geonetwork/core-geonetwork/assets/1868233/f7e17eb2-e674-462b-894c-e680c15d94c4)


 in formatters/zip api, the format should be SIMPLE/PARTIAL/FULL instead of simple/partial/full
Before
![image](https://github.com/geonetwork/core-geonetwork/assets/1868233/0b15512f-ff4c-4177-a294-bb78b87444bb)
After
![image](https://github.com/geonetwork/core-geonetwork/assets/1868233/332c07e4-17de-4cc8-b817-e8380e757968)




i.e. 

Before this fix.
![image](https://github.com/geonetwork/core-geonetwork/assets/1868233/6b221fd3-1c5d-4074-90fe-7c039831c723)


# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [x] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

