### PR TITLE
Fix MIME-types on attachments as some were incorrect

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsApi.java
@@ -111,15 +111,22 @@ public class AttachmentsApi {
                 case "png":
                 case "gif":
                 case "bmp":
-                case "tif":
-                case "tiff":
-                case "jpg":
-                case "jpeg":
                     contentType = "image/" + ext;
                     break;
+                case "tif":
+                case "tiff":
+                    contentType = "image/tiff";
+                    break;
+                case "jpg":
+                case "jpeg":
+                    contentType = "image/jpeg";
+                    break;
                 case "txt":
+                    contentType = "text/plain";
+                    break;
+                case "htm":
                 case "html":
-                    contentType = "text/" + ext;
+                    contentType = "text/html";
                     break;
                 default:
                     contentType = "application/" + ext;


### PR DESCRIPTION
Fix mimetypes on attachments as some were incorrect.

i.e. it could produce the following invalid mime types - text/txt, image/jpg, image/tif 

Also added htm to the list so that it would not produce application/htm


# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

