### PR TITLE
Thesaurus / Improve support of EU publication office SKOS format

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/AllThesaurus.java
+++ b/core/src/main/java/org/fao/geonet/kernel/AllThesaurus.java
@@ -27,15 +27,13 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Function;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
-
-import org.locationtech.jts.util.Assert;
-
 import org.fao.geonet.Constants;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.exceptions.TermNotFoundException;
 import org.fao.geonet.kernel.search.keyword.KeywordRelation;
 import org.fao.geonet.languages.IsoLanguagesMapper;
 import org.fao.geonet.utils.Log;
+import org.locationtech.jts.util.Assert;
 import org.openrdf.model.GraphException;
 import org.openrdf.model.URI;
 import org.openrdf.sesame.config.AccessDeniedException;
@@ -46,6 +44,8 @@ import org.openrdf.sesame.query.QueryResultsTable;
 import org.openrdf.sesame.repository.local.LocalRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
@@ -58,9 +58,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 /**
  * @author Jesse on 2/27/2015.
@@ -221,8 +218,7 @@ public class AllThesaurus extends Thesaurus {
     }
 
     @Override
-    public synchronized Thesaurus removeElement(KeywordBean keyword) throws MalformedQueryException, QueryEvaluationException,
-        IOException, AccessDeniedException {
+    public synchronized Thesaurus removeElement(KeywordBean keyword) throws AccessDeniedException {
         throw new UnsupportedOperationException();
     }
 
@@ -237,8 +233,7 @@ public class AllThesaurus extends Thesaurus {
     }
 
     @Override
-    public synchronized URI updateElement(KeywordBean keyword, boolean replace) throws AccessDeniedException, IOException,
-        MalformedQueryException, QueryEvaluationException, GraphException {
+    public synchronized URI updateElement(KeywordBean keyword, boolean replace) throws AccessDeniedException {
         throw new UnsupportedOperationException();
     }
 
@@ -266,12 +261,12 @@ public class AllThesaurus extends Thesaurus {
     }
 
     @Override
-    public synchronized Thesaurus updateCode(String namespace, String oldcode, String newcode) throws AccessDeniedException, IOException {
+    public synchronized Thesaurus updateCode(String namespace, String oldcode, String newcode) throws AccessDeniedException {
         throw new UnsupportedOperationException();
     }
 
     @Override
-    public synchronized Thesaurus updateCodeByURI(String olduri, String newuri) throws AccessDeniedException, IOException {
+    public synchronized Thesaurus updateCodeByURI(String olduri, String newuri) throws AccessDeniedException {
         throw new UnsupportedOperationException();
     }
 
@@ -287,8 +282,7 @@ public class AllThesaurus extends Thesaurus {
     }
 
     @Override
-    public synchronized void addRelation(String subject, KeywordRelation related, String relatedSubject) throws AccessDeniedException,
-        IOException, MalformedQueryException, QueryEvaluationException, GraphException {
+    public synchronized void addRelation(String subject, KeywordRelation related, String relatedSubject) throws AccessDeniedException {
         throw new UnsupportedOperationException();
     }
 

--- a/core/src/main/java/org/fao/geonet/kernel/Thesaurus.java
+++ b/core/src/main/java/org/fao/geonet/kernel/Thesaurus.java
@@ -959,7 +959,7 @@ public class Thesaurus {
                 "skos:ConceptScheme/dc:title|skos:ConceptScheme/dcterms:title" +
                     "|skos:ConceptScheme/rdfs:label|skos:ConceptScheme/skos:prefLabel" +
                     "|skos:Collection/dc:title|skos:Collection/dcterms:title" +
-                    "|rdf:Description/dc:title|rdf:Description/dcterms:title", getThesaurusNamespaces());
+                    "|rdf:Description/dc:title|rdf:Description/dcterms:title", theNSs);
 
             if (titleEl != null) {
                 this.title = titleEl.getValue();

--- a/core/src/main/java/org/fao/geonet/kernel/Thesaurus.java
+++ b/core/src/main/java/org/fao/geonet/kernel/Thesaurus.java
@@ -76,6 +76,7 @@ public class Thesaurus {
     private static final String DEFAULT_THESAURUS_NAMESPACE = "http://custom.shared.obj.ch/concept#";
 
     private static final String RDF_NAMESPACE = "http://www.w3.org/1999/02/22-rdf-syntax-ns#";
+    private static final String RDF_SCHEMA_NAMESPACE = "http://www.w3.org/2000/01/rdf-schema#";
 
     private static final String SKOS_NAMESPACE = "http://www.w3.org/2004/02/skos/core#";
 
@@ -360,7 +361,8 @@ public class Thesaurus {
         try {
             return performRequest(query).getRowCount() > 0;
         } catch (Exception e) {
-            Log.error(Geonet.THESAURUS_MAN, "Error retrieving concept scheme for " + thesaurusFile + ". Error is: " + e.getMessage());
+            Log.error(Geonet.THESAURUS_MAN,
+                String.format("Error retrieving concept scheme for %s. Error is: %s", thesaurusFile, e.getMessage()));
             throw new RuntimeException(e);
         }
     }
@@ -380,7 +382,8 @@ public class Thesaurus {
             }
             return ret;
         } catch (Exception e) {
-            Log.error(Geonet.THESAURUS_MAN, "Error retrieving concept schemes for " + thesaurusFile + ". Error is: " + e.getMessage());
+            Log.error(Geonet.THESAURUS_MAN, String.format(
+                "Error retrieving concept schemes for %s. Error is: %s", thesaurusFile, e.getMessage()));
             return Collections.emptyList();
         }
     }
@@ -452,8 +455,7 @@ public class Thesaurus {
     /**
      * Remove keyword from thesaurus.
      */
-    public synchronized Thesaurus removeElement(KeywordBean keyword) throws MalformedQueryException,
-        QueryEvaluationException, IOException, AccessDeniedException {
+    public synchronized Thesaurus removeElement(KeywordBean keyword) throws AccessDeniedException {
         String namespace = keyword.getNameSpaceCode();
         String code = keyword.getRelativeCode();
 
@@ -518,8 +520,7 @@ public class Thesaurus {
      *                languages) and the coordinates will only be updated if they are non-empty
      *                strings.
      */
-    public synchronized URI updateElement(KeywordBean keyword, boolean replace) throws AccessDeniedException, IOException,
-        MalformedQueryException, QueryEvaluationException, GraphException {
+    public synchronized URI updateElement(KeywordBean keyword, boolean replace) throws AccessDeniedException {
         THESAURUS_SEARCH_CACHE.invalidateAll();
 
         // Get thesaurus graph
@@ -661,7 +662,7 @@ public class Thesaurus {
      * Update concept code by creating URI from namespace and code. This is recommended when
      * thesaurus concept identifiers contains # eg. http://vocab.nerc.ac.uk/collection/P07/current#CFV13N44
      */
-    public synchronized Thesaurus updateCode(String namespace, String oldcode, String newcode) throws AccessDeniedException, IOException {
+    public synchronized Thesaurus updateCode(String namespace, String oldcode, String newcode) throws AccessDeniedException {
         Graph myGraph = repository.getGraph();
 
         ValueFactory myFactory = myGraph.getValueFactory();
@@ -679,7 +680,7 @@ public class Thesaurus {
      *
      * eg. http://vocab.nerc.ac.uk/collection/P07/current/CFV13N44/
      */
-    public synchronized Thesaurus updateCodeByURI(String olduri, String newuri) throws AccessDeniedException, IOException {
+    public synchronized Thesaurus updateCodeByURI(String olduri, String newuri) throws AccessDeniedException {
         Graph myGraph = repository.getGraph();
 
         ValueFactory myFactory = myGraph.getValueFactory();
@@ -894,7 +895,11 @@ public class Thesaurus {
     //  }
     private void retrieveMultiLingualTitles(Element thesaurusEl) {
         try {
-            String xpathTitles = "skos:ConceptScheme/dc:title[@xml:lang]|skos:ConceptScheme/dcterms:title[@xml:lang]|rdf:Description[rdf:type/@rdf:resource = 'http://www.w3.org/2004/02/skos/core#ConceptScheme']/dc:title[@xml:lang]";
+            String xpathTitles = "skos:ConceptScheme/dc:title[@xml:lang]" +
+                "|skos:ConceptScheme/dcterms:title[@xml:lang]" +
+                "|skos:ConceptScheme/rdfs:label[@xml:lang]" +
+                "|skos:ConceptScheme/skos:prefLabel[@xml:lang]" +
+                "|rdf:Description[rdf:type/@rdf:resource = 'http://www.w3.org/2004/02/skos/core#ConceptScheme']/dc:title[@xml:lang]";
             multilingualTitles.clear();
             multilingualTitles.putAll(retrieveMultilingualField(thesaurusEl, xpathTitles));
         } catch (Exception e) {
@@ -944,25 +949,23 @@ public class Thesaurus {
         try {
             Element thesaurusEl = Xml.loadFile(thesaurusFile);
 
-            List<Namespace> theNSs = new ArrayList<>();
-            Namespace rdfNamespace = Namespace.getNamespace("rdf", RDF_NAMESPACE);
-            theNSs.add(rdfNamespace);
-            theNSs.add(Namespace.getNamespace("skos", SKOS_NAMESPACE));
-            theNSs.add(Namespace.getNamespace("dc", DC_NAMESPACE));
-            theNSs.add(Namespace.getNamespace("dcterms", DCTERMS_NAMESPACE));
+            List<Namespace> theNSs = getThesaurusNamespaces();
 
             this.defaultNamespace = null;
             retrieveMultiLingualTitles(thesaurusEl);
             retrieveDublinCore(thesaurusEl);
 
             Element titleEl = Xml.selectElement(thesaurusEl,
-                "skos:ConceptScheme/dc:title|skos:ConceptScheme/dcterms:title|" +
-                    "skos:Collection/dc:title|skos:Collection/dcterms:title|" +
-                    "rdf:Description/dc:title|rdf:Description/dcterms:title", theNSs);
+                "skos:ConceptScheme/dc:title|skos:ConceptScheme/dcterms:title" +
+                    "|skos:ConceptScheme/rdfs:label|skos:ConceptScheme/skos:prefLabel" +
+                    "|skos:Collection/dc:title|skos:Collection/dcterms:title" +
+                    "|rdf:Description/dc:title|rdf:Description/dcterms:title", getThesaurusNamespaces());
 
             if (titleEl != null) {
                 this.title = titleEl.getValue();
-                this.defaultNamespace = titleEl.getParentElement().getAttributeValue("about", rdfNamespace);
+                this.defaultNamespace = titleEl
+                    .getParentElement()
+                    .getAttributeValue("about", Namespace.getNamespace("rdf", RDF_NAMESPACE));
             } else {
                 this.title = defaultTitle;
                 this.defaultNamespace = DEFAULT_THESAURUS_NAMESPACE;
@@ -1027,11 +1030,13 @@ public class Thesaurus {
             }
 
             if (Log.isDebugEnabled(Geonet.THESAURUS_MAN)) {
-                Log.debug(Geonet.THESAURUS_MAN, "Thesaurus information: " + this.title + " (" + this.date + ")");
+                Log.debug(Geonet.THESAURUS_MAN, String.format(
+                    "Thesaurus information: %s (%s)", this.title, this.date));
             }
         } catch (Exception ex) {
             if (!ignoreMissingError)
-                Log.error(Geonet.THESAURUS_MAN, "Error getting thesaurus info for " + thesaurusFile + ". Error is: " + ex.getMessage());
+                Log.error(Geonet.THESAURUS_MAN, String.format(
+                    "Error getting thesaurus info for %s. Error is: %s", thesaurusFile, ex.getMessage()));
         }
     }
 
@@ -1102,8 +1107,7 @@ public class Thesaurus {
      * @param subject the keyword that is related to the other keyword
      * @param related the relation between the two keywords
      */
-    public synchronized void addRelation(String subject, KeywordRelation related, String relatedSubject) throws AccessDeniedException, IOException,
-        MalformedQueryException, QueryEvaluationException, GraphException {
+    public synchronized void addRelation(String subject, KeywordRelation related, String relatedSubject) throws AccessDeniedException {
         THESAURUS_SEARCH_CACHE.invalidateAll();
 
         Graph myGraph = repository.getGraph();
@@ -1126,7 +1130,7 @@ public class Thesaurus {
      * @return keyword
      */
     public KeywordBean getKeyword(String uri, String... languages) {
-        String cacheKey = "getKeyword" + uri + Arrays.stream(languages).collect(Collectors.joining(""));
+        String cacheKey = "getKeyword" + uri + String.join("", languages);
         Object cacheValue = THESAURUS_SEARCH_CACHE.getIfPresent(cacheKey);
         if (cacheValue != null) {
             return (KeywordBean) cacheValue;
@@ -1370,6 +1374,7 @@ public class Thesaurus {
     private List<Namespace> getThesaurusNamespaces() {
         List<Namespace> theNSs = new ArrayList<>();
         theNSs.add(Namespace.getNamespace("rdf", RDF_NAMESPACE));
+        theNSs.add(Namespace.getNamespace("rdfs", RDF_SCHEMA_NAMESPACE));
         theNSs.add(Namespace.getNamespace("skos", SKOS_NAMESPACE));
         theNSs.add(Namespace.getNamespace("dc", DC_NAMESPACE));
         theNSs.add(Namespace.getNamespace("dcterms", DCTERMS_NAMESPACE));

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterApi.java
@@ -229,7 +229,7 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
         // if text/html > xsl_view
         // if application/pdf > xsl_view and PDF output
         // if application/x-gn-<formatterId>+(xml|html|pdf|text)
-        // Force PDF ouutput when URL parameter is set.
+        // Force PDF output when URL parameter is set.
         // This is useful when making GET link to PDF which
         // can not use headers.
         if (MediaType.ALL_VALUE.equals(acceptHeader)) {


### PR DESCRIPTION
When loading thesaurus downloadable from the EU publication office, title and namespace of the thesaurus are not extracted properly.

The SKOS format provided contains specificity

eg. https://op.europa.eu/en/web/eu-vocabularies/dataset/-/resource?uri=http://publications.europa.eu/resource/dataset/data-theme

Thesaurus title is stored in various properties ie. `at:prefLabel`, `rdfs:label`, `skos:prefLabel` but none of them were used so far for title extraction.
```xml
   <skos:ConceptScheme rdf:about="http://publications.europa.eu/resource/authority/data-theme"
                       at:table.id="data-theme"
                       at:table.version.number="20220715-0">
      <at:prefLabel xml:lang="en">Data theme</at:prefLabel>
      <rdfs:label xml:lang="en">Data theme</rdfs:label>
      <owl:versionInfo>20220715-0</owl:versionInfo>
      <skos:prefLabel xml:lang="en">Data theme</skos:prefLabel>
   </skos:ConceptScheme>
```

This change add them to the XPath.


Before/after (title and namespace are properly set)

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/1e5fc09f-9ed9-4138-b2f3-d03a16300095)


Also fix some sonar lint items.

Funded by Wallonia region (SPW)


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

