### PR TITLE
Add configuration to filter out Elasticsearch fields when download or dynamic privileges are not set

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/schema-ident.xml
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/schema-ident.xml
@@ -149,6 +149,7 @@ Ce schéma est également composé des normes :
                                   */cit:protocol/gco:CharacterString = 'FILE' or
                                   */cit:protocol/gco:CharacterString = 'DB' or
                                   */cit:protocol/gco:CharacterString = 'COPYFILE']"
+            jsonpath="$['link'][?(@.protocol =~ /(DOWNLOAD|FILE|DB|COPYFILE).*?/i)]"
             ifNotOperation="download"/>
 
     <!--
@@ -157,6 +158,7 @@ Ce schéma est également composé des normes :
     TODO: other type of services ?
     -->
     <filter xpath=".//mrd:onLine[starts-with(*/cit:protocol/gco:CharacterString, 'OGC:WMS')]"
+            jsonpath="$['link'][?(@.protocol =~ /OGC:WMS.*?/i)]"
             ifNotOperation="dynamic"/>
   </filters>
 </schema>

--- a/schemas/iso19139/src/main/plugin/iso19139/schema-ident.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/schema-ident.xml
@@ -89,8 +89,10 @@ of data.]]>
     </filter>
     <filter
       xpath=".//gmd:onLine[*/gmd:protocol/gco:CharacterString = 'WWW:DOWNLOAD-1.0-http--download']"
+      jsonpath="$['link'][?(@.protocol == 'WWW:DOWNLOAD-1.0-http--download')]"
       ifNotOperation="download"/>
     <filter xpath=".//gmd:onLine[starts-with(*/gmd:protocol/gco:CharacterString, 'OGC:WMS')]"
+            jsonpath="$['link'][?(@.protocol =~ /OGC:WMS.*?/i)]"
             ifNotOperation="dynamic"/>
   </filters>
 </schema>

--- a/services/src/main/java/org/fao/geonet/api/es/EsHTTPProxy.java
+++ b/services/src/main/java/org/fao/geonet/api/es/EsHTTPProxy.java
@@ -35,6 +35,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.Sets;
 import com.jayway.jsonpath.DocumentContext;
 import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.PathNotFoundException;
 import io.swagger.v3.oas.annotations.Hidden;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -902,7 +903,11 @@ public class EsHTTPProxy {
 
         for(String jsonPath : jsonPathFilters) {
             if (StringUtils.isNotBlank(jsonPath)) {
-                jsonContext = jsonContext.delete(jsonPath);
+                try {
+                    jsonContext = jsonContext.delete(jsonPath);
+                } catch (PathNotFoundException ex) {
+                    // The node to remove is not returned in the response, ignore the error
+                }
             }
         }
 


### PR DESCRIPTION
Follow up of #6869

Test case: 

1) Create an ISO19139 metadata and add 3 types of online resources:

  - Link
  - File to download
  - WMS

2) Set the `View` privilege only to the group `ALL`

3) The user should see in the metadata page all 3 links.

4) Logout

  - Without the change: the anonymous user see the File to download and WMS resources (not ok). These resources are not present in the XML, what is ok.

  - Without the change: the anonymous user doesn't see the File to download and WMS resources (ok). These resources are not present in the XML, what is ok.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation