### PR TITLE
Create a metadata / Add dynamic and download privileges to the users in the same group

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataOperations.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataOperations.java
@@ -1,5 +1,5 @@
 //=============================================================================
-//===	Copyright (C) 2001-2011 Food and Agriculture Organization of the
+//===	Copyright (C) 2001-2023 Food and Agriculture Organization of the
 //===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
 //===	and United Nations Environment Programme (UNEP)
 //===
@@ -167,7 +167,7 @@ public class BaseMetadataOperations implements IMetadataOperations, ApplicationE
      */
     @Override
     public boolean forceSetOperation(ServiceContext context, int mdId, int grpId, int opId) throws Exception {
-        Optional<OperationAllowed> opAllowed = _getOperationAllowedToAdd(context, mdId, grpId, opId, false);
+        Optional<OperationAllowed> opAllowed = getOperationAllowedToAddInternal(context, mdId, grpId, opId, false);
 
         if (opAllowed.isPresent()) {
             Log.trace(Geonet.DATA_MANAGER, "Operation is allowed");
@@ -199,11 +199,11 @@ public class BaseMetadataOperations implements IMetadataOperations, ApplicationE
     @Override
     public Optional<OperationAllowed> getOperationAllowedToAdd(final ServiceContext context, final int mdId, final int grpId,
                                                                final int opId) {
-        return _getOperationAllowedToAdd(context, mdId, grpId, opId, true);
+        return getOperationAllowedToAddInternal(context, mdId, grpId, opId, true);
     }
 
-    private Optional<OperationAllowed> _getOperationAllowedToAdd(final ServiceContext context, final int mdId, final int grpId,
-                                                                 final int opId, boolean shouldCheckPermission) {
+    private Optional<OperationAllowed> getOperationAllowedToAddInternal(final ServiceContext context, final int mdId, final int grpId,
+                                                                        final int opId, boolean shouldCheckPermission) {
         Log.trace(Geonet.DATA_MANAGER, "_getOperationAllowedToAdd(" + mdId + ", "
             + grpId + ", " + opId + ", " + shouldCheckPermission + ")");
         final OperationAllowed operationAllowed = opAllowedRepo.findOneById_GroupIdAndId_MetadataIdAndId_OperationId(grpId, mdId, opId);
@@ -340,14 +340,12 @@ public class BaseMetadataOperations implements IMetadataOperations, ApplicationE
 
         setOperation(context, id, groupId, ReservedOperation.view);
         setOperation(context, id, groupId, ReservedOperation.notify);
+        setOperation(context, id, groupId, ReservedOperation.download);
+        setOperation(context, id, groupId, ReservedOperation.dynamic);
         //
-        // Restrictive: new and inserted records should not be editable,
-        // their resources can't be downloaded and any interactive maps can't be
-        // displayed by users in the same group
+        // Restrictive: new and inserted records should not be editable by users in the same group,
         if (fullRightsForGroup) {
             setOperation(context, id, groupId, ReservedOperation.editing);
-            setOperation(context, id, groupId, ReservedOperation.download);
-            setOperation(context, id, groupId, ReservedOperation.dynamic);
         }
         // Ultimately this should be configurable elsewhere
     }

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataOperations.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataOperations.java
@@ -1,5 +1,5 @@
 //=============================================================================
-//===	Copyright (C) 2001-2023 Food and Agriculture Organization of the
+//===	Copyright (C) 2001-2024 Food and Agriculture Organization of the
 //===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
 //===	and United Nations Environment Programme (UNEP)
 //===


### PR DESCRIPTION
Currently when creating a metadata the user that creates it, by default, gets privileges to edit it  in the group owner, so other editors in the metadata can't edit it(what can be fine). This was changed in https://github.com/geonetwork/core-geonetwork/commit/003fda740bef3839a12403624a9b4781aa1812dd

Other members of the group can view the metadata, but not it's resources. It's unclear the reason, and doesn't make much sense.

This change request, only restricts the edit privilege for other editors in the metadata group, but allow any user in that group to visualise the metadata (no change here) and it's resources.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [X] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

