### PR TITLE
[Backport 4.2.x] Metadata editor / Fix javascript error in the add thumbnail option when the metadata has 1 WMS layer

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -680,7 +680,13 @@
                 //   });
                 // }
                 // Add each WMS layer to the map
-                scope.layers = scope.gnCurrentEdit.layerConfig;
+                if (scope.gnCurrentEdit.layerConfig == undefined) {
+                  scope.layers = scope.gnCurrentEdit.layerConfig;
+                } else {
+                  scope.layers = Array.isArray(scope.gnCurrentEdit.layerConfig)
+                    ? scope.gnCurrentEdit.layerConfig
+                    : [scope.gnCurrentEdit.layerConfig];
+                }
                 angular.forEach(scope.gnCurrentEdit.layerConfig, function (layer) {
                   scope.map.addLayer(
                     new ol.layer.Tile({

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -680,13 +680,6 @@
                 //   });
                 // }
                 // Add each WMS layer to the map
-                if (scope.gnCurrentEdit.layerConfig == undefined) {
-                  scope.layers = scope.gnCurrentEdit.layerConfig;
-                } else {
-                  scope.layers = Array.isArray(scope.gnCurrentEdit.layerConfig)
-                    ? scope.gnCurrentEdit.layerConfig
-                    : [scope.gnCurrentEdit.layerConfig];
-                }
                 angular.forEach(scope.gnCurrentEdit.layerConfig, function (layer) {
                   scope.map.addLayer(
                     new ol.layer.Tile({

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/addOnlinesrc.html
@@ -531,7 +531,7 @@
       <div
         id="gn-addonlinesrc-thumbnail-panel"
         class="panel panel-default"
-        data-ng-show="params.linkType.sources.thumbnailMaker"
+        data-ng-show="params.linkType.sources.thumbnailMaker && gnCurrentEdit.layerConfig.length > 0"
       >
         <div class="panel-heading" data-translate="">createAThumbnail</div>
         <div class="panel-body">
@@ -539,15 +539,7 @@
             id="gn-addonlinesrc-thumbnail-map"
             class="form-group gn-thumbnail-maker-panel"
           >
-            <div
-              id="gn-addonlinesrc-thumbnail-warning"
-              class="alert alert-warning"
-              data-ng-show="layers == undefined"
-              data-translate=""
-            >
-              noLayersForThumbnail
-            </div>
-            <div data-ng-hide="layers == undefined">
+            <div>
               <textarea
                 id="gn-addonlinesrc-thumbnail-json"
                 class="form-control hidden"

--- a/web-ui/src/main/resources/catalog/components/metadatamanager/EditorService.js
+++ b/web-ui/src/main/resources/catalog/components/metadatamanager/EditorService.js
@@ -386,6 +386,13 @@
               .val();
           };
 
+          // The list of layers in a record is defined in XSL template get-online-source-config
+          // and is depending on each schema. If emtpy an empty array is set.
+          var getLayerConfiguration = function () {
+            var configuration = angular.fromJson(getInputValue("layerConfig")) || [];
+            return Array.isArray(configuration) ? configuration : [configuration.resource];
+          };
+
           var extent = [],
             value = getInputValue("extent");
           try {
@@ -424,7 +431,7 @@
             extent: extent,
             dataFormats: dataFormats,
             isMinor: getInputValue("minor") === "true",
-            layerConfig: angular.fromJson(getInputValue("layerConfig")),
+            layerConfig: getLayerConfiguration(),
             saving: false
           });
 

--- a/web-ui/src/main/resources/catalog/locales/en-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/en-editor.json
@@ -185,7 +185,6 @@
     "generateThumbnail": "Generate thumbnail",
     "generateThumbnail-help": "Thumbnail will be created and saved in the filestore. Use the filestore to add the thumbnail in the metadata record.",
     "createAThumbnail": "Generate thumbnail using the view service",
-    "noLayersForThumbnail": "No layer defined in record to generate thumbnail from",
     "noTemplatesAvailable": "Warning! There is no templates available in the catalog. You should add or <a href='admin.console#/metadata'>import</a> some.",
     "none": "None",
     "notFoundInThesaurus": "<strong>Warning! Keywords {{invalid}} not found in thesaurus.</strong> Others {{found}} were found in the thesaurus. 2 reasons: <ul><li>keywords in this record are in a language that is not in the current user interface language</li><li>keywords does not exists in the thesaurus</li></ul><strong>Those keywords will not be modified by this editing session</strong> unless you remove this thesaurus section.",


### PR DESCRIPTION
Backport #7646
 **Authored by:** @josegar74