### PR TITLE
Addressing docs translation glitch #7687- fixes adding-static-pages and configuring-search-fields

### DIFF
--- a/docs/manual/docs/customizing-application/adding-static-pages.md
+++ b/docs/manual/docs/customizing-application/adding-static-pages.md
@@ -8,13 +8,13 @@ This feature allows to store the HTML content for static pages and show the link
 
 -   Each page can be in 3 states:
 
-    -   `EN`: visible to administrator.
-    -   `TE`: visible to logged users.
-    -   `IC`: visible to everyone.
+    -   `HIDDEN`: visible to administrator.
+    -   `PRIVATE`: visible to logged users.
+    -   `PUBLIC`: visible to everyone.
 
--   Pages can be added to different page sections. Currently the sections implemented are `OP` (top menu of the main page) and `ER` (footer of the main page).
+-   Pages can be added to different page sections. Currently the sections implemented are `TOP` (top menu of the main page) and `FOOTER` (footer of the main page).
 
--   Only the administrator can edit the pages and see the pages in `EN` status.
+-   Only the administrator can edit the pages and see the pages in `HIDDEN` status.
 
 -   The creation and the management of the content is done via the API.
 
@@ -80,10 +80,10 @@ curl -X DELETE "http://localhost:8080/geonetwork/srv/api/pages/eng/contactus?for
 
 The status of the page can be changed with the method PUT `/api/pages/{language}/{pageId}/{status}` where status could assume these values:
 
--   `IC` - Visible to every user
--   `LY` - Visible to not logged users
--   `TE` - Visible to logged users
--   `EN` - Hidden to anyone
+-   `PUBLIC` - Visible to every user
+-   `PUBLIC_ONLY` - Visible to not logged users
+-   `PRIVATE` - Visible to logged users
+-   `HIDDEN` - Hidden to anyone
 
 Other methods in the API are to change/delete a page and to GET the list of the pages or the info of a specific one.
 

--- a/docs/manual/docs/customizing-application/configuring-search-fields.md
+++ b/docs/manual/docs/customizing-application/configuring-search-fields.md
@@ -195,7 +195,7 @@ curl -X POST "localhost:8080/geonetwork/srv/api/search/records/_search" \
 
 To customize how the field is indexed see `web/src/main/webResources/WEB-INF/data/config/index/records.json`.
 
-To return it in the search response, use the `ce` parameter of the query. See <https://www.elastic.co/guide/en/elasticsearch/reference/current/search-fields.html>.
+To return it in the search response, use the `_source` parameter of the query. See <https://www.elastic.co/guide/en/elasticsearch/reference/current/search-fields.html>.
 
 ## Boosting at search time
 
@@ -248,4 +248,4 @@ By default, the search score is defined as (see `web-ui/src/main/resources/catal
 
 ## Language analyzer
 
-By default a `rd` analyzer is used. If the catalog content is english, it may make sense to change the analyzer to `sh`. To customize the analyzer see `web/src/main/webResources/WEB-INF/data/config/index/records.json`
+By default a `standard` analyzer is used. If the catalog content is english, it may make sense to change the analyzer to `english`. To customize the analyzer see `web/src/main/webResources/WEB-INF/data/config/index/records.json`

--- a/docs/manual/docs/customizing-application/editor-ui/creating-custom-editor.md
+++ b/docs/manual/docs/customizing-application/editor-ui/creating-custom-editor.md
@@ -59,7 +59,7 @@ The other option to define a more advanced field type is to catch the element us
 
 ## Grouping element from the standards {#creating-custom-editor-fieldsWithFieldset}
 
-List of elements to be displayed in a fieldset (i.e. boxed element). Those elements usually contain children elements and define major sections in the standard. For example, in ISO19139, `on` and `on` are major sections and should usually be displayed as a group of `on`.
+List of elements to be displayed in a fieldset (i.e. boxed element). Those elements usually contain children elements and define major sections in the standard. For example, in ISO19139, `identification` and `distribution` are major sections and should usually be displayed as a group of `information`.
 
 ``` xml
 <editor>
@@ -127,7 +127,7 @@ A view has a label and defines a specific rendering of the metadata records. A v
   </view>
 ```
 
-The view could be displayed or not according to the metadata record content or the current user session using the `rd` and `fo` attributes.
+The view could be displayed or not according to the metadata record content or the current user session using the `displayIfRecord` and `displayIfServiceInfo` attributes.
 
 Attributes:
 
@@ -334,7 +334,7 @@ e.g. only 2 INSPIRE themes:
 
 ## Adding a section to a tab {#creating-custom-editor-section}
 
-A section is a group of fields. If a `me` attribute is provided, then it will create an HTML fieldset which is collapsible. If no `me` attribute is provided, then it will just render the inner elements. For example, if you need a tab without a root fieldset, just create the mandatory section with no name and then the inner elements.
+A section is a group of fields. If a `name` attribute is provided, then it will create an HTML fieldset which is collapsible. If no `name` attribute is provided, then it will just render the inner elements. For example, if you need a tab without a root fieldset, just create the mandatory section with no name and then the inner elements.
 
 Attributes:
 
@@ -433,13 +433,13 @@ displayIfRecord and displayIfServiceInfo could be combined. An AND operator is u
 
 ## Adding a field {#creating-custom-editor-field}
 
-To display a simple element use the `th` attribute to point to the element to display:
+To display a simple element use the `xpath` attribute to point to the element to display:
 
 ``` xml
 <field xpath="/gmd:MD_Metadata/gmd:identificationInfo/*/gmd:citation/*/gmd:title"/>
 ```
 
-To override a field label use the `me` attribute and define that new label in `{schema}/loc/{lang}/strings.xml`:
+To override a field label use the `name` attribute and define that new label in `{schema}/loc/{lang}/strings.xml`:
 
 ``` xml
 <field name="myTitle"
@@ -455,7 +455,7 @@ To display a complex element which exists in the metadata document:
 
 In this case all children elements are also displayed.
 
-To display a field if it exists in the metadata document or to provide an `dd` button in case it does not exist (specify `in` and `or` attributes):
+To display a field if it exists in the metadata document or to provide an `add` button in case it does not exist (specify `in` and `or` attributes):
 
 ``` xml
 <field name="pointOfContact"
@@ -524,7 +524,7 @@ The element to search in for the geonet child.
 
 -   **del** (Optional)
 
-Relative XPath of the element to remove when the `ve` button is clicked.
+Relative XPath of the element to remove when the `remove` button is clicked.
 
 e.g. If a template field match linkage and allows editing of field URL, the remove control should remove the parent element gmd:onLine.
 
@@ -536,7 +536,7 @@ e.g. If a template field match linkage and allows editing of field URL, the remo
   <template>
 ```
 
-`el` attribute can be used in template mode or not. Example to remove `on` while only editing `or` or `ce`. `or` or `ce` are mandatory, but as the `el` element points to the `on` ancestor, there is no mandatory flag displayed and the remove control removes the `on` element.
+`del` attribute can be used in template mode or not. Example to remove `spatialResolution` while only editing `denominator` or `distance`. `denominator` or `distance` are mandatory, but as the `del` element points to the `spatialResolution` ancestor, there is no mandatory flag displayed and the remove control removes the `spatialResolution` element.
 
 ``` xml
 <field xpath="/gmd:MD_Metadata/gmd:identificationInfo/


### PR DESCRIPTION
<!--Include a few sentences describing the overall goals for this Pull Request-->

Addressing two-character literal doc translation glitch (PR #7687)
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

