### PR TITLE
API / Import does not overwrite metadata if any validation status

### DIFF
--- a/domain/src/main/java/org/fao/geonet/repository/MetadataValidationRepositoryCustom.java
+++ b/domain/src/main/java/org/fao/geonet/repository/MetadataValidationRepositoryCustom.java
@@ -51,7 +51,7 @@ public interface MetadataValidationRepositoryCustom {
      * @param metadataId the id of the metadata.
      * @return the number of rows deleted
      */
-    @Modifying(clearAutomatically=true)
+    @Modifying(flushAutomatically = true, clearAutomatically = true)
     @Transactional
     @Query(value="DELETE FROM MetadataValidation v where v.id.metadataId = ?1 AND valtype != 'inspire'")
     int deleteAllInternalValidationById_MetadataId(Integer metadataId);


### PR DESCRIPTION
Test:
* create record, validate
* export as MEF
* modify MEF
* import with overwrite mode fails to update.

If validation status table is empty, overwrite is working
```sql
TRUNCATE TABLE validation;
```

Not sure this is the proper fix for that issue.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

