### PR TITLE
Standard / ISO19115-3 / Batch edit may trigger error on creation date

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/update-fixed-info.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/update-fixed-info.xsl
@@ -130,7 +130,7 @@
           <xsl:copy-of select="gn-fn-iso19115-3.2018:write-date-or-dateTime(/root/env/createDate, 'creation')"/>
         </mdb:dateInfo>
       </xsl:if>
-      <xsl:if test="not($isRevisionDateAvailable)">
+      <xsl:if test="/root/env/changeDate != '' and not($isRevisionDateAvailable)">
         <mdb:dateInfo>
           <xsl:copy-of select="gn-fn-iso19115-3.2018:write-date-or-dateTime(/root/env/changeDate, 'revision')"/>
         </mdb:dateInfo>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/update-fixed-info.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/update-fixed-info.xsl
@@ -124,9 +124,8 @@
                     as="xs:boolean"/>
 
       <!-- Add creation date if it does not exist-->
-      <xsl:if test="not($isCreationDateAvailable)
-                    or (/root/env/createDate != ''
-                        and /root/env/newRecord = 'true')">
+      <xsl:if test="/root/env/createDate != '' and
+                    (not($isCreationDateAvailable) or /root/env/newRecord = 'true')">
         <mdb:dateInfo>
           <xsl:copy-of select="gn-fn-iso19115-3.2018:write-date-or-dateTime(/root/env/createDate, 'creation')"/>
         </mdb:dateInfo>


### PR DESCRIPTION
This should not happen when records are created using the editor but importing a record with no creation date and then directly applying a batch editing (which does not update dates) will trigger the following error: 

```
"; SystemID: file://web/src/main/webapp/WEB-INF/data/config/schema_plugins/iso19115-3.2018/update-fixed-info.xsl; Line#: 134; 
An empty sequence is not allowed as the first argument of gn-fn-iso19115-3.2018:write-date-or-dateTime()
```

Avoiding that case.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

Funded by Ifremer
