### PR TITLE
Using gn- icon definitions for all types in metadata creation

### DIFF
--- a/web-ui/src/main/resources/catalog/js/edit/NewMetadataController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/NewMetadataController.js
@@ -76,11 +76,12 @@
 
       // A map of icon to use for each types
       var icons = {
-        featureCatalog: "fa-table",
-        service: "fa-cog",
-        map: "fa-map",
-        staticMap: "fa-map",
-        dataset: "fa-file"
+        featureCatalog: "gn-icon-featureCatalog",
+        service: "gn-icon-service",
+        map: "gn-icon-maps",
+        staticMap: "gn-icon-staticMap",
+        dataset: "gn-icon-dataset",
+        series: "gn-icon-series"
       };
 
       var defaultType = "dataset";


### PR DESCRIPTION
Made use of the global .less definitions for the various record type icons, instead of the hardcoded `fa-` icons. We make use of `series` in our fork as well, I guess it won't hurt to include it here as well for futureproofing?

![image](https://github.com/geonetwork/core-geonetwork/assets/11455912/ac8b629a-7cd9-400e-a060-b7755f07a1b8)

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

