### PR TITLE
Remove unused jslint-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -112,11 +112,6 @@
           <version>3.1.2</version>
         </plugin>
         <plugin>
-          <groupId>org.codehaus.mojo</groupId>
-          <artifactId>jslint-maven-plugin</artifactId>
-          <version>1.0.1</version>
-        </plugin>
-        <plugin>
           <groupId>org.bsc.maven</groupId>
           <artifactId>maven-processor-plugin</artifactId>
           <version>3.3.3</version>

--- a/web-ui/pom.xml
+++ b/web-ui/pom.xml
@@ -47,14 +47,6 @@
     </license>
   </licenses>
 
-  <dependencies>
-    <dependency>
-      <groupId>org.codehaus.mojo</groupId>
-      <artifactId>jslint-maven-plugin</artifactId>
-      <version>1.0.1</version>
-    </dependency>
-  </dependencies>
-
   <build>
     <resources>
       <!-- The resource that are filtered should only be the fewest possible because


### PR DESCRIPTION
Removed unused dependency on jslint-maven-plugin from web-ui.

This dependency is in `web-ui` project since long time ago (2013) and doesn't seem to be used.
It is introducing some components with known vulnerabilities as transitive dependencies in the final GeoNetwork WAR. 

This PR removes the dependency from `web-ui` project.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [x] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation


