### PR TITLE
Reports / Fix extract user groups for non-admin users

### DIFF
--- a/web-ui/src/main/resources/catalog/js/admin/ReportController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/ReportController.js
@@ -163,7 +163,7 @@
               var groups = _.map(response.data, "group");
 
               // Get unique groups
-              $scope.groups = _.uniq(groups, function (e) {
+              $scope.groups = _.uniqBy(groups, function (e) {
                 return e.id;
               });
             },


### PR DESCRIPTION
Test case:

1) Create a new user with the roles: `UserAdmin` and `Reviewer` in the `Sample group`
2) Login as the new user
3) In the `Admin console` > `Reports` select a report

  - Without the fix: the group is listed 3 times (NO OK).
  - With the fix: the group is listed 1 time (OK).

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
