### PR TITLE
Address remaining two-character literal doc translation glitch

### DIFF
--- a/docs/manual/docs/administrator-guide/managing-users-and-groups/authentication-mode.md
+++ b/docs/manual/docs/administrator-guide/managing-users-and-groups/authentication-mode.md
@@ -392,7 +392,7 @@ GeoNetwork comes with a sample LDAP configuration that you can use in Apache Dir
 
 There are currently two ways to convert an LDAP group to GeoNetwork Groups/Profiles.
 
--   The `LDAPRoleConverterGroupNameParser`, which works the same as the original LDAP configuration. It uses a regular expression to parse the LDAP group name into a GeoNetwork Group/Profile. This will convert the LDAP role `OR` into the GeoNetwork group `AL` with Profile `r.`
+-   The `LDAPRoleConverterGroupNameParser`, which works the same as the original LDAP configuration. It uses a regular expression to parse the LDAP group name into a GeoNetwork Group/Profile. This will convert the LDAP role `GCAT_GENERAL_EDITOR` into the GeoNetwork group `GENERAL` with Profile `Editor`.
 
     ``` xml
     <bean id="ldapRoleConverterGroupNameParser"  class="LDAPRoleConverterGroupNameParser">

--- a/docs/manual/docs/administrator-guide/managing-users-and-groups/creating-group.md
+++ b/docs/manual/docs/administrator-guide/managing-users-and-groups/creating-group.md
@@ -1,6 +1,6 @@
 # Creating group
 
-The administrator can create new groups of users. User groups could correspond to logical units within an organisation, for example `es`, `re`, `nd`, `er`, `th` and so on.
+The administrator can create new groups of users. User groups could correspond to logical units within an organisation, for example `Fisheries`, `Agriculture`, `Land`, `Water`, `Health` and so on.
 
 To create new groups you should be logged on with an account that has administrative privileges.
 

--- a/docs/manual/docs/customizing-application/search-ui/enrichview.md
+++ b/docs/manual/docs/customizing-application/search-ui/enrichview.md
@@ -6,7 +6,7 @@ For that, you can include default view content, or build your own application on
 
 ## GeoNetwork components
 
-UI design is based on shared widgets, logic and components. In AngularJS terms, we talk about `es` and `es`.
+UI design is based on shared widgets, logic and components. In AngularJS terms, we talk about `services` and `directives`.
 
 All components are stored in the folder [components](https://github.com/geonetwork/core-geonetwork/tree/develop/web-ui/src/main/resources/catalog/components)
 

--- a/docs/manual/docs/customizing-application/search-ui/loadview.md
+++ b/docs/manual/docs/customizing-application/search-ui/loadview.md
@@ -33,7 +33,7 @@ To init AngularJS main module you have to use the directive ``ng-app`` and point
 <html ng-app="{$angularModule}" lang="{$lang}" id="ng-app">
 ```
 
-In the case of the search page (``catalog.search``), the `$angularApp` variable equals `gn_search`. And for the `lt` view the `$angularModule` equals `gn_search_default`.
+In the case of the search page (``catalog.search``), the `$angularApp` variable equals `gn_search`. And for the `default` view the `$angularModule` equals `gn_search_default`.
 
 So, by default, the main AngularJS module is loaded here from `gn_search_default` module declared here (See `web-ui/src/main/resources/catalog/views/default/module.js`.
 

--- a/docs/manual/docs/install-guide/configuring-database.md
+++ b/docs/manual/docs/install-guide/configuring-database.md
@@ -72,7 +72,7 @@ Setting configuration properties via environment variables is common in containe
         -e jdbc.port=5432 geonetwork:latest
     ```
 
-Within PostgreSQL it is possible to configure `es` or `is`. In the latter case GeoNetwork will use spatial capabilities of PostGIS to filter metadata. In the first case (and for other database dialects) a Shapefile is created for storage of metadata coverage.
+Within PostgreSQL it is possible to configure `postgres` or `postgis`. In the latter case GeoNetwork will use spatial capabilities of PostGIS to filter metadata. In the first case (and for other database dialects) a Shapefile is created for storage of metadata coverage.
 
 ## Logging
 

--- a/docs/manual/docs/install-guide/installing-from-war-file.md
+++ b/docs/manual/docs/install-guide/installing-from-war-file.md
@@ -65,7 +65,7 @@ For [Jetty](https://www.eclipse.org/jetty/) we the following versions: 9.4.x. Ne
 
     Open <http://localhost:9200> in your web browser to check that Elasticsearch is running.
 
-    To use an existing instance check `on` in [Installing search platform](installing-index.md).
+    To use an existing instance check Configure connection in [Installing search platform](installing-index.md).
 
 5.  Up and running?
 

--- a/docs/manual/docs/install-guide/map-print-setup.md
+++ b/docs/manual/docs/install-guide/map-print-setup.md
@@ -2,7 +2,7 @@
 
 This section describes how to configure the options to print maps. Printing a map generates a pdf file on the server which is downloaded by the client to be send to a printer. During pdf creation map data is downloaded from various sources to be included in the pdf.
 
-GeoNetwork needs to be able to access the external resource. Set up a webproxy in `gs` if your network requires a webproxy to be set up to access the internet.
+GeoNetwork needs to be able to access the external resource. Set up a webproxy in `system settings` if your network requires a webproxy to be set up to access the internet.
 
 Locate the file ``WEB-INF/config-print/print-config.yaml``, this configuration file has a lot of options to customise the print options. Read more about the various parameters at <http://www.mapfish.org/doc/print/configuration.html>
 

--- a/docs/manual/docs/install-guide/map-print-setup.md
+++ b/docs/manual/docs/install-guide/map-print-setup.md
@@ -11,4 +11,4 @@ The folder contains 3 template files:
 -   ``template.pdf`` and ``template-landscape.pdf`` which are used to generate the map viewer pdf
 -   ``template-thumbnail.pdf`` which is used to build a thumbnail in the metadata editor (see [Generating a thumbnail using WMS layers](../user-guide/associating-resources/linking-thumbnail.md#linking-thumbnail-from-wms)).
 
-These templates are created by exporting pdf from the included ``template.odf`` file in the folder.
+These templates are created by exporting pdf from the included ``template.pdf`` file in the folder.

--- a/docs/manual/docs/overview/change-log/version-4.0.2.md
+++ b/docs/manual/docs/overview/change-log/version-4.0.2.md
@@ -4,7 +4,7 @@ GeoNetwork 4.0.2 release is a minor release but adds a better multilingual suppo
 
 ## Database migration
 
-With the possibility to [restore deleted record](https://github.com/geonetwork/core-geonetwork/pull/4817), catalog maintainer has to update the database with the [following migration SQL script](https://github.com/geonetwork/core-geonetwork/blob/master/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v3110/migrate-default.sql#L10-L27).
+With the possibility to [restore deleted records](https://github.com/geonetwork/core-geonetwork/pull/4817), the catalog maintainer has to update the database with the [following migration SQL script](https://github.com/geonetwork/core-geonetwork/blob/master/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v3110/migrate-default.sql#L10-L27).
 
 ## Index migration
 
@@ -12,9 +12,9 @@ Index migration is only required if you created custom facets configuration in t
 
 ### Codelist
 
-`t_` is now `l_` and is an object composed of:
+``codelist`` is now ``cl_`` and is an object composed of:
 
-So `et` was:
+characterSet was:
 
 ``` js
 codelist_characterSet: [
@@ -39,13 +39,13 @@ cl_characterSet: [{
 }]
 ```
 
-So if using `xt` in a facet, use ``cl_characterSet.default`` with this new version.
+So if using ``codelist_characterSet_text`` in a facet, use ``cl_characterSet.default`` with this new version.
 
 ### Thesaurus
 
-The `ds` field is now only used for rendering (not for query) to limit the total number of field and avoid some errors on large catalogues.
+The ``allKeywords`` field is now only used for rendering (not for query) to limit the total number of field and avoid some errors on large catalogues.
 
-Use the per thesaurus fields which were named ``thesaurus_geonetwork+external/local+type+thesaurusid`` and are now `id`. The field is also an object composed of:
+Use the per thesaurus fields, which were named ``thesaurus_geonetwork+external/local+type+thesaurusid`` and are now ``th_thesaurusid``. The field is also an object composed of:
 
 ``` js
 thesaurus_geonetworkthesaurusexternalthemeeeatopics: [
@@ -73,11 +73,11 @@ th_eea-topics: [{
 
 ### Topic category
 
-`ic` is renamed to `ic` and has the same structure as a codelist.
+``topic`` is renamed to ``cl_topic`` and has the same structure as a codelist.
 
 ### GeoTag
 
-`ag` is now stored in the ``template field for keyword types](https://github.com/geonetwork/core-geonetwork/pull/5243) ie. [keywordType-place``
+``geotag`` is now stored in the [template field for keyword types](https://github.com/geonetwork/core-geonetwork/pull/5243) ie. ``keywordType-place``
 
 For more details check [Configuring search fields](../../customizing-application/configuring-search-fields.md) and [Configuring faceted search](../../customizing-application/configuring-faceted-search.md).
 

--- a/docs/manual/docs/tutorials/introduction/deployment/index.md
+++ b/docs/manual/docs/tutorials/introduction/deployment/index.md
@@ -2,7 +2,7 @@
 
 On this chapter, we will learn how to make GeoNetwork run on your machine or in the cloud.
 
-Up to version 3 GeoNetwork could easily be deployed locally, there is even a [Windows installer](https://my.geocat.net/download/category/6/GeoNetwork.html). But with the arrival of version 4, GeoNetwork has a number of dependencies that need to be deployed separately, which makes the deployment locally more challenging. Instead the GeoNetwork community provides `es` for automated deployment using Docker. [Docker](https://docker.com) is a virtualisation technology which facilitates deployment of a `on` of prepackaged `es` locally or in the cloud.
+Up to version 3 GeoNetwork could easily be deployed locally, there is even a [Windows installer](https://my.geocat.net/download/category/6/GeoNetwork.html). But with the arrival of version 4, GeoNetwork has a number of dependencies that need to be deployed separately, which makes the deployment locally more challenging. Instead the GeoNetwork community provides recipes for automated deployment using Docker. [Docker](https://docker.com) is a virtualisation technology which facilitates deployment of a composition of prepackaged images locally or in the cloud.
 
 For this workshop we will focus on the use of docker, but we also provide some guidance on how to set up the environment without docker, or even build the application from sources.
 

--- a/docs/manual/docs/user-guide/publishing/managing-privileges.md
+++ b/docs/manual/docs/user-guide/publishing/managing-privileges.md
@@ -20,7 +20,7 @@ Below is a brief description for each privilege to help you identify which ones 
 
 **Interactive Map**: Users in the specified group/s are able to get an interactive map. The interactive map has to be created separately using a Web Map Server such as GeoServer, which is distributed with GeoNetwork.
 
-**Featured**: When randomly selected by GeoNetwork, the metadata record can appear in the `ed` section of the GeoNetwork home page.
+**Featured**: When randomly selected by GeoNetwork, the metadata record can appear in the `Featured` section of the GeoNetwork home page.
 
 **Notify**: Users in the specified group receive notification if data attached to the metadata record is downloaded.
 


### PR DESCRIPTION
This gathers up pull-requests that got stuck from @archaeogeek, and a few files that were missed, into a PR so it can be cleanly backported.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [x] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

