### PR TITLE
Standards / Formatter / Citation / Pick latest date

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/citation/base.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/citation/base.xsl
@@ -92,7 +92,7 @@
                                     ('publication', 'revision')]/
                                     cit:date/gco:*[. != '']"/>
 
-    <xsl:variable name="publicationDates">
+    <xsl:variable name="publicationDates" as="node()*">
       <xsl:perform-sort select="$dates">
         <xsl:sort select="." order="descending"/>
       </xsl:perform-sort>

--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/citation/base.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/citation/base.xsl
@@ -91,7 +91,7 @@
                                     ('publication', 'revision')]/
                                     gmd:date/gco:*[. != '']"/>
 
-    <xsl:variable name="publicationDates">
+    <xsl:variable name="publicationDates" as="node()*">
       <xsl:perform-sort select="$dates">
         <xsl:sort select="." order="descending"/>
       </xsl:perform-sort>


### PR DESCRIPTION
Citation last date year was usually correct but if customizing the formatter and a user wants to display the full last date, xpath was not selecting only the last date but all.


![Pasted image](https://github.com/geonetwork/core-geonetwork/assets/1701393/40bfa189-c927-4ff2-932e-51533bfc1c71)


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

