### PR TITLE
Support metadata identifiers with URL special characters

### DIFF
--- a/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStoreResource.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStoreResource.java
@@ -85,7 +85,7 @@ public class FilesystemStoreResource implements MetadataResource {
 
     @Override
     public String getId() {
-        return UrlEscapers.urlFragmentEscaper().escape(metadataUuid) +
+        return UrlEscapers.urlPathSegmentEscaper().escape(metadataUuid) +
                 "/attachments/" +
                 UrlEscapers.urlFragmentEscaper().escape(filename);
     }

--- a/index/src/main/java/org/fao/geonet/index/es/EsRestClient.java
+++ b/index/src/main/java/org/fao/geonet/index/es/EsRestClient.java
@@ -435,11 +435,10 @@ public class EsRestClient implements InitializingBean {
                 final Hit hit = totalHits.get(0);
 
                 fields.forEach(f -> {
-                    final Object o = hit.fields().get(f);
-                    if (o instanceof String) {
-                        fieldValues.put(f, (String) o);
-                    } else if (o instanceof HashMap && f.endsWith("Object")) {
-                        fieldValues.put(f, (String) ((HashMap) o).get("default"));
+                    Map<String, Object> sourceAsMap = hit.fields();
+                    String fieldValue = getFieldValue(f, sourceAsMap);
+                    if (fieldValue != null) {
+                        fieldValues.put(f, fieldValue);
                     }
                 });
             } else {
@@ -458,6 +457,15 @@ public class EsRestClient implements InitializingBean {
         return fieldValues;
     }
 
+    public static String getFieldValue(String field, Map<String, Object> source) {
+        final Object o = source.get(field);
+        if (o instanceof String) {
+            return (String) o;
+        } else if (o instanceof HashMap && field.endsWith("Object")) {
+            return (String) ((HashMap) o).get("default");
+        }
+        return null;
+    }
 
     /**
      * Analyze a field and a value against the index

--- a/services/src/main/java/org/fao/geonet/api/mapservers/MapServersApi.java
+++ b/services/src/main/java/org/fao/geonet/api/mapservers/MapServersApi.java
@@ -352,7 +352,7 @@ public class MapServersApi {
 //            @Authorization(value = "basicAuth")
 //        }
     )
-    @RequestMapping(value = "/{mapserverId}/records/{metadataUuid}",
+    @RequestMapping(value = "/{mapserverId}/records/{metadataUuid:.+}",
         method = RequestMethod.GET,
         produces = {
             MediaType.TEXT_PLAIN_VALUE
@@ -406,7 +406,7 @@ public class MapServersApi {
 //            @Authorization(value = "basicAuth")
 //        }
     )
-    @RequestMapping(value = "/{mapserverId}/records/{metadataUuid}",
+    @RequestMapping(value = "/{mapserverId}/records/{metadataUuid:.+}",
         method = RequestMethod.PUT,
         produces = {
             MediaType.TEXT_PLAIN_VALUE
@@ -461,7 +461,7 @@ public class MapServersApi {
         //      })
     )
     @RequestMapping(
-        value = "/{mapserverId}/records/{metadataUuid}",
+        value = "/{mapserverId}/records/{metadataUuid:.+}",
         method = RequestMethod.DELETE,
         produces = {
             MediaType.TEXT_PLAIN_VALUE

--- a/services/src/main/java/org/fao/geonet/api/records/DoiApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/DoiApi.java
@@ -71,7 +71,7 @@ public class DoiApi {
     @io.swagger.v3.oas.annotations.Operation(
         summary = "Check that a record can be submitted to DataCite for DOI creation. " +
             "DataCite requires some fields to be populated.")
-    @RequestMapping(value = "/{metadataUuid}/doi/checkPreConditions",
+    @RequestMapping(value = "/{metadataUuid:.+}/doi/checkPreConditions",
         method = RequestMethod.GET,
         produces = {
             MediaType.APPLICATION_JSON_VALUE
@@ -137,7 +137,7 @@ public class DoiApi {
 
     @io.swagger.v3.oas.annotations.Operation(
         summary = "Submit a record to the Datacite metadata store in order to create a DOI.")
-    @RequestMapping(value = "/{metadataUuid}/doi",
+    @RequestMapping(value = "/{metadataUuid:.+}/doi",
         method = RequestMethod.PUT,
         produces = {
             MediaType.APPLICATION_JSON_VALUE
@@ -174,7 +174,7 @@ public class DoiApi {
 
     @io.swagger.v3.oas.annotations.Operation(
         summary = "Remove a DOI (this is not recommended, DOI are supposed to be persistent once created. This is mainly here for testing).")
-    @RequestMapping(value = "/{metadataUuid}/doi",
+    @RequestMapping(value = "/{metadataUuid:.+}/doi",
         method = RequestMethod.DELETE,
         produces = {
             MediaType.APPLICATION_JSON_VALUE

--- a/services/src/main/java/org/fao/geonet/api/records/InspireValidationApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/InspireValidationApi.java
@@ -127,7 +127,7 @@ public class InspireValidationApi {
     @io.swagger.v3.oas.annotations.Operation(
         summary = "Get test suites available.",
         description = "TG13, TG2, ...")
-    @GetMapping(value = "/{metadataUuid}/validate/inspire/testsuites",
+    @GetMapping(value = "/{metadataUuid:.+}/validate/inspire/testsuites",
         produces = {
             MediaType.APPLICATION_JSON_VALUE
         })
@@ -154,7 +154,7 @@ public class InspireValidationApi {
             + "An INSPIRE endpoint must be configured in Settings. "
             + "This activates an asyncronous process, this method does not return any report. "
             + "This method returns an id to be used to get the report.")
-    @PutMapping(value = "/{metadataUuid}/validate/inspire",
+    @PutMapping(value = "/{metadataUuid:.+}/validate/inspire",
         produces = {
             MediaType.TEXT_PLAIN_VALUE
         })

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataApi.java
@@ -32,6 +32,7 @@ import jeeves.services.ReadWriteController;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.ApplicationContextHolder;
+import org.fao.geonet.Constants;
 import org.fao.geonet.api.API;
 import org.fao.geonet.api.ApiParams;
 import org.fao.geonet.api.ApiUtils;
@@ -66,6 +67,7 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import java.net.URLEncoder;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.*;
@@ -184,22 +186,22 @@ public class MetadataApi {
         List<String> accept = Arrays.asList(acceptHeader.split(","));
 
         String defaultFormatter = "xsl-view";
+        String encodedUuid = URLEncoder.encode(metadataUuid, Constants.ENCODING);
         if (accept.contains(MediaType.TEXT_HTML_VALUE)
             || accept.contains(MediaType.APPLICATION_XHTML_XML_VALUE)
             || accept.contains("application/pdf")) {
-            return "forward:" + (metadataUuid + "/formatters/" + defaultFormatter);
+            return "redirect:" + (encodedUuid + "/formatters/" + defaultFormatter);
         } else if (accept.contains(MediaType.APPLICATION_XML_VALUE)
             || accept.contains(MediaType.APPLICATION_JSON_VALUE)) {
-            return "forward:" + (metadataUuid + "/formatters/xml");
+            return "redirect:" + (encodedUuid + "/formatters/xml");
         } else if (accept.contains("application/zip")
             || accept.contains(MEF_V1_ACCEPT_TYPE)
             || accept.contains(MEF_V2_ACCEPT_TYPE)) {
-            return "forward:" + (metadataUuid + "/formatters/zip");
+            return "redirect:" + (encodedUuid + "/formatters/zip");
         } else {
-            // FIXME this else is never reached because any of the accepted medias match one of the previous if conditions.
             response.setHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_XHTML_XML_VALUE);
             //response.sendRedirect(metadataUuid + "/formatters/" + defaultFormatter);
-            return "forward:" + (metadataUuid + "/formatters/" + defaultFormatter);
+            return "redirect:" + (encodedUuid + "/formatters/" + defaultFormatter);
         }
     }
 
@@ -240,8 +242,8 @@ public class MetadataApi {
         description = "")
     @RequestMapping(value =
         {
-            "/{metadataUuid}/formatters/xml",
-            "/{metadataUuid}/formatters/json"
+            "/{metadataUuid:.+}/formatters/xml",
+            "/{metadataUuid:.+}/formatters/json"
         },
         method = RequestMethod.GET,
         produces = {
@@ -368,7 +370,7 @@ public class MetadataApi {
         description = "Metadata Exchange Format (MEF) is returned. MEF is a ZIP file containing " +
             "the metadata as XML and some others files depending on the version requested. " +
             "See https://docs.geonetwork-opensource.org/latest/annexes/mef-format/.")
-    @RequestMapping(value = "/{metadataUuid}/formatters/zip",
+    @RequestMapping(value = "/{metadataUuid:.+}/formatters/zip",
         method = RequestMethod.GET,
         consumes = {
             MediaType.ALL_VALUE
@@ -649,8 +651,10 @@ public class MetadataApi {
 
     @io.swagger.v3.oas.annotations.Operation(
         summary = "Returns a map to decode attributes in a dataset (from the associated feature catalog)",
-        description = "")
-    @RequestMapping(value = "/{metadataUuid}/featureCatalog",
+        description = "Retrieve related services, datasets, onlines, thumbnails, sources, ... " +
+            "to this records.<br/>" +
+            "<a href='http://geonetwork-opensource.org/manuals/trunk/eng/users/user-guide/associating-resources/index.html'>More info</a>")
+    @RequestMapping(value = "/{metadataUuid:.+}/featureCatalog",
         method = RequestMethod.GET,
         produces = {
             MediaType.APPLICATION_XML_VALUE,

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataInsertDeleteApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataInsertDeleteApi.java
@@ -204,7 +204,7 @@ public class MetadataInsertDeleteApi {
         + "By default, a backup is made in ZIP format. After that, "
         + "the record attachments are removed, the document removed "
         + "from the index and then from the database.")
-    @RequestMapping(value = "/{metadataUuid}", method = RequestMethod.DELETE)
+    @RequestMapping(value = "/{metadataUuid:.+}", method = RequestMethod.DELETE)
     @ApiResponses(value = {
         @ApiResponse(responseCode = "204", description = "Record deleted."),
         @ApiResponse(responseCode = "401", description = "This template is referenced"),

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataProcessApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataProcessApi.java
@@ -85,7 +85,7 @@ public class MetadataProcessApi {
 
     @io.swagger.v3.oas.annotations.Operation(summary = "Get suggestions", description ="Analyze the record an suggest processes to improve the quality of the record.<br/>"
         + "<a href='https://docs.geonetwork-opensource.org/latest/user-guide/workflow/batchupdate-xsl/'>More info</a>")
-    @RequestMapping(value = "/{metadataUuid}/processes", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
+    @RequestMapping(value = "/{metadataUuid:.+}/processes", method = RequestMethod.GET, produces = MediaType.APPLICATION_JSON_VALUE)
     @PreAuthorize("hasAuthority('Editor')")
     @ResponseStatus(HttpStatus.OK)
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Record suggestions."),
@@ -133,7 +133,7 @@ public class MetadataProcessApi {
     }
 
     @io.swagger.v3.oas.annotations.Operation(summary = "Preview process result", description =API_OP_NOTE_PROCESS)
-    @RequestMapping(value = "/{metadataUuid}/processes/{process:.+}", method = {
+    @RequestMapping(value = "/{metadataUuid:.+}/processes/{process:.+}", method = {
         RequestMethod.GET}, produces = MediaType.APPLICATION_XML_VALUE)
     @PreAuthorize("hasAuthority('Editor')")
     @ResponseStatus(HttpStatus.OK)
@@ -158,7 +158,7 @@ public class MetadataProcessApi {
     }
 
     @io.swagger.v3.oas.annotations.Operation(summary = "Apply a process", description =API_OP_NOTE_PROCESS)
-    @RequestMapping(value = "/{metadataUuid}/processes/{process:.+}", method = {
+    @RequestMapping(value = "/{metadataUuid:.+}/processes/{process:.+}", method = {
         RequestMethod.POST,}, produces = MediaType.APPLICATION_XML_VALUE)
     @PreAuthorize("hasAuthority('Editor')")
     @ResponseStatus(HttpStatus.OK)

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataSavedQueryApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataSavedQueryApi.java
@@ -60,7 +60,7 @@ import static org.fao.geonet.api.ApiParams.API_CLASS_RECORD_TAG;
  */
 @Service
 @RequestMapping(value = {
-    "/{portal}/api/records/{metadataUuid}"
+    "/{portal}/api/records/{metadataUuid:.+}"
 })
 @Tag(name = API_CLASS_RECORD_TAG,
     description = API_CLASS_RECORD_OPS)

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataSharingApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataSharingApi.java
@@ -195,7 +195,7 @@ public class MetadataSharingApi {
     @io.swagger.v3.oas.annotations.Operation(
         summary = "Set privileges for ALL group to publish the metadata for all users.")
     @RequestMapping(
-        value = "/{metadataUuid}/publish",
+        value = "/{metadataUuid:.+}/publish",
         method = RequestMethod.PUT
     )
     @ApiResponses(value = {
@@ -234,7 +234,7 @@ public class MetadataSharingApi {
     @io.swagger.v3.oas.annotations.Operation(
         summary = "Unsets privileges for ALL group to publish the metadata for all users.")
     @RequestMapping(
-        value = "/{metadataUuid}/unpublish",
+        value = "/{metadataUuid:.+}/unpublish",
         method = RequestMethod.PUT
     )
     @ApiResponses(value = {
@@ -282,7 +282,7 @@ public class MetadataSharingApi {
             "administrator, a reviewer or the owner of the record.<br/>" +
             "<a href='https://geonetwork-opensource.org/manuals/trunk/eng/users/user-guide/publishing/managing-privileges.html'>More info</a>")
     @RequestMapping(
-        value = "/{metadataUuid}/sharing",
+        value = "/{metadataUuid:.+}/sharing",
         method = RequestMethod.PUT
     )
     @ApiResponses(value = {
@@ -612,7 +612,7 @@ public class MetadataSharingApi {
         summary = "Get record sharing settings",
         description = "Return current sharing options for a record.")
     @RequestMapping(
-        value = "/{metadataUuid}/sharing",
+        value = "/{metadataUuid:.+}/sharing",
         method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE
     )
@@ -713,7 +713,7 @@ public class MetadataSharingApi {
         summary = "Set record group",
         description = "A record is related to one group.")
     @RequestMapping(
-        value = "/{metadataUuid}/group",
+        value = "/{metadataUuid:.+}/group",
         method = RequestMethod.PUT
     )
     @ApiResponses(value = {
@@ -905,7 +905,7 @@ public class MetadataSharingApi {
         summary = "Set record group and owner",
         description = "")
     @RequestMapping(
-        value = "/{metadataUuid}/ownership",
+        value = "/{metadataUuid:.+}/ownership",
         method = RequestMethod.PUT
     )
     @ResponseStatus(HttpStatus.CREATED)

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataSocialApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataSocialApi.java
@@ -85,7 +85,7 @@ public class MetadataSocialApi {
             "When a remote rating is applied, the local rating is not updated. It will be updated on the next " +
             "harvest run (FIXME ?).")
     @RequestMapping(
-        value = "/{metadataUuid}/rate",
+        value = "/{metadataUuid:.+}/rate",
         method = RequestMethod.PUT
     )
     @ResponseStatus(HttpStatus.CREATED)

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataTagApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataTagApi.java
@@ -97,7 +97,7 @@ public class MetadataTagApi {
         description = "Tags are used to classify information.<br/>" +
             "<a href='https://docs.geonetwork-opensource.org/latest/user-guide/tag-information/tagging-with-categories/'>More info</a>")
     @GetMapping(
-        value = "/{metadataUuid}/tags",
+        value = "/{metadataUuid:.+}/tags",
         produces = {
             MediaType.APPLICATION_JSON_VALUE
         })
@@ -123,7 +123,7 @@ public class MetadataTagApi {
     @io.swagger.v3.oas.annotations.Operation(
         summary = "Add tags to a record",
         description = "")
-    @PutMapping(value = "/{metadataUuid}/tags")
+    @PutMapping(value = "/{metadataUuid:.+}/tags")
     @ResponseStatus(value = HttpStatus.CREATED)
     @ApiResponses(value = {
         @ApiResponse(responseCode = "201", description = "Record tags added."),
@@ -209,7 +209,7 @@ public class MetadataTagApi {
     @io.swagger.v3.oas.annotations.Operation(
         summary = "Delete tags of a record",
         description = "")
-    @DeleteMapping(value = "/{metadataUuid}/tags")
+    @DeleteMapping(value = "/{metadataUuid:.+}/tags")
     @ResponseStatus(value = HttpStatus.NO_CONTENT)
     @ApiResponses(value = {
         @ApiResponse(responseCode = "204", description = "Record tags removed."),

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataValidateApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataValidateApi.java
@@ -153,7 +153,7 @@ public class MetadataValidateApi {
 
     @io.swagger.v3.oas.annotations.Operation(summary = "Validate a record", description = "User MUST be able to edit the record to validate it. "
         + "FIXME : id MUST be the id of the current metadata record in session ?")
-    @RequestMapping(value = "/{metadataUuid}/validate/internal", method = RequestMethod.PUT, produces = {
+    @RequestMapping(value = "/{metadataUuid:.+}/validate/internal", method = RequestMethod.PUT, produces = {
         MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_XML_VALUE})
     @ResponseStatus(HttpStatus.CREATED)
     @PreAuthorize("hasAuthority('Editor')")

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataVersionningApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataVersionningApi.java
@@ -72,7 +72,7 @@ public class MetadataVersionningApi {
         summary = "(Experimental) Enable version control",
         description = "")
     @RequestMapping(
-        value = "/{metadataUuid}/versions",
+        value = "/{metadataUuid:.+}/versions",
         method = RequestMethod.PUT)
     @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("hasAuthority('Editor')")

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java
@@ -162,7 +162,7 @@ public class MetadataWorkflowApi {
 
 
     @io.swagger.v3.oas.annotations.Operation(summary = "Get record status history", description = "")
-    @RequestMapping(value = "/{metadataUuid}/status", produces = MediaType.APPLICATION_JSON_VALUE, method = RequestMethod.GET)
+    @RequestMapping(value = "/{metadataUuid:.+}/status", produces = MediaType.APPLICATION_JSON_VALUE, method = RequestMethod.GET)
     @ResponseStatus(value = HttpStatus.OK)
     @ResponseBody
     public List<MetadataStatusResponse> getRecordStatusHistory(
@@ -184,7 +184,7 @@ public class MetadataWorkflowApi {
     }
 
     @io.swagger.v3.oas.annotations.Operation(summary = "Get record status history by type", description = "")
-    @RequestMapping(value = "/{metadataUuid}/status/{type}", produces = MediaType.APPLICATION_JSON_VALUE, method = RequestMethod.GET)
+    @RequestMapping(value = "/{metadataUuid:.+}/status/{type}", produces = MediaType.APPLICATION_JSON_VALUE, method = RequestMethod.GET)
     @ResponseStatus(value = HttpStatus.OK)
     @ResponseBody
     public List<MetadataStatusResponse> getRecordStatusHistoryByType(
@@ -207,7 +207,7 @@ public class MetadataWorkflowApi {
     }
 
     @io.swagger.v3.oas.annotations.Operation(summary = "Get last workflow status for a record", description = "")
-    @RequestMapping(value = "/{metadataUuid}/status/workflow/last", method = RequestMethod.GET, produces = {
+    @RequestMapping(value = "/{metadataUuid:.+}/status/workflow/last", method = RequestMethod.GET, produces = {
         MediaType.APPLICATION_JSON_VALUE})
     @PreAuthorize("hasAuthority('Editor')")
     @ApiResponses(value = {@ApiResponse(responseCode = "200", description = "Record status."),
@@ -437,7 +437,7 @@ public class MetadataWorkflowApi {
     }
 
     @io.swagger.v3.oas.annotations.Operation(summary = "Set the record status", description = "")
-    @RequestMapping(value = "/{metadataUuid}/status", method = RequestMethod.PUT)
+    @RequestMapping(value = "/{metadataUuid:.+}/status", method = RequestMethod.PUT)
     @PreAuthorize("hasAuthority('Editor')")
     @ApiResponses(value = {@ApiResponse(responseCode = "201", description = "Status updated."),
         @ApiResponse(responseCode = "400", description = "Metadata workflow not enabled."),
@@ -562,7 +562,7 @@ public class MetadataWorkflowApi {
         summary = "Close a record task",
         description = "")
     @RequestMapping(
-        value = "/{metadataUuid}/status/{statusId:[0-9]+}.{userId:[0-9]+}.{changeDate}/close",
+        value = "/{metadataUuid:.+}/status/{statusId:[0-9]+}.{userId:[0-9]+}.{changeDate}/close",
         method = RequestMethod.PUT
     )
     @PreAuthorize("hasAuthority('Editor')")
@@ -592,7 +592,7 @@ public class MetadataWorkflowApi {
     }
 
     @io.swagger.v3.oas.annotations.Operation(summary = "Delete a record status", description = "")
-    @RequestMapping(value = "/{metadataUuid}/status/{statusId:[0-9]+}.{userId:[0-9]+}.{changeDate}", method = RequestMethod.DELETE)
+    @RequestMapping(value = "/{metadataUuid:.+}/status/{statusId:[0-9]+}.{userId:[0-9]+}.{changeDate}", method = RequestMethod.DELETE)
     @PreAuthorize("hasAuthority('Administrator')")
     @ApiResponses(value = {@ApiResponse(responseCode = "204", description = "Status removed."),
         @ApiResponse(responseCode = "404", description = "Status not found."),
@@ -619,7 +619,7 @@ public class MetadataWorkflowApi {
     }
 
     @io.swagger.v3.oas.annotations.Operation(summary = "Delete all record status", description = "")
-    @RequestMapping(value = "/{metadataUuid}/status", method = RequestMethod.DELETE)
+    @RequestMapping(value = "/{metadataUuid:.+}/status", method = RequestMethod.DELETE)
     @PreAuthorize("hasAuthority('Administrator')")
     @ApiResponses(value = {@ApiResponse(responseCode = "204", description = "Status removed."),
         @ApiResponse(responseCode = "404", description = "Status not found."),
@@ -783,7 +783,7 @@ public class MetadataWorkflowApi {
         summary = "Get saved content from the status record before changes",
         description = "")
     @RequestMapping(
-        value = "/{metadataUuid}/status/{statusId:[0-9]+}.{userId:[0-9]+}.{changeDate}/before",
+        value = "/{metadataUuid:.+}/status/{statusId:[0-9]+}.{userId:[0-9]+}.{changeDate}/before",
         method = RequestMethod.GET,
         produces = {
             MediaType.APPLICATION_XML_VALUE
@@ -813,7 +813,7 @@ public class MetadataWorkflowApi {
     @io.swagger.v3.oas.annotations.Operation(
         summary = "Get saved content from the status record after changes"
     )
-    @RequestMapping(value = "/{metadataUuid}/status/{statusId:[0-9]+}.{userId:[0-9]+}.{changeDate}/after",
+    @RequestMapping(value = "/{metadataUuid:.+}/status/{statusId:[0-9]+}.{userId:[0-9]+}.{changeDate}/after",
         method = RequestMethod.GET,
         produces = {
             MediaType.APPLICATION_XML_VALUE
@@ -843,7 +843,7 @@ public class MetadataWorkflowApi {
     @io.swagger.v3.oas.annotations.Operation(
         summary = "Restore saved content from a status record")
     @RequestMapping(
-        value = "/{metadataUuid}/status/{statusId:[0-9]+}.{userId:[0-9]+}.{changeDate}/restore",
+        value = "/{metadataUuid:.+}/status/{statusId:[0-9]+}.{userId:[0-9]+}.{changeDate}/restore",
         method = RequestMethod.POST
     )
     @PreAuthorize("hasAuthority('Editor')")

--- a/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsActionsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsActionsApi.java
@@ -97,7 +97,7 @@ public class AttachmentsActionsApi {
         //response = MetadataResource.class)
     )
     @RequestMapping(
-        value = "/{portal}/api/records/{metadataUuid}/attachments/print-thumbnail",
+        value = "/{portal}/api/records/{metadataUuid:.+}/attachments/print-thumbnail",
         method = RequestMethod.PUT)
     @ResponseStatus(HttpStatus.CREATED)
     @ApiResponses(value = {

--- a/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsApi.java
@@ -80,7 +80,7 @@ import java.util.List;
  */
 @EnableWebMvc
 @Service
-@RequestMapping(value = {"/{portal}/api/records/{metadataUuid}/attachments"})
+@RequestMapping(value = {"/{portal}/api/records/{metadataUuid:.+}/attachments"})
 @Tag(name = API_CLASS_RECORD_TAG,
     description = API_CLASS_RECORD_OPS)
 public class AttachmentsApi {

--- a/services/src/main/java/org/fao/geonet/api/records/editing/MetadataEditingApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/editing/MetadataEditingApi.java
@@ -110,7 +110,7 @@ public class MetadataEditingApi {
     private StatusValueRepository statusValueRepository;
 
     @io.swagger.v3.oas.annotations.Operation(summary = "Edit a record", description = "Return HTML form for editing.")
-    @RequestMapping(value = "/{metadataUuid}/editor", method = RequestMethod.GET, consumes = {
+    @RequestMapping(value = "/{metadataUuid:.+}/editor", method = RequestMethod.GET, consumes = {
         MediaType.ALL_VALUE}, produces = {MediaType.APPLICATION_XML_VALUE})
     @PreAuthorize("hasAuthority('Editor')")
     @ResponseStatus(HttpStatus.OK)
@@ -189,7 +189,7 @@ public class MetadataEditingApi {
     }
 
     @io.swagger.v3.oas.annotations.Operation(summary = "Save edits", description = "Save the HTML form content.")
-    @RequestMapping(value = "/{metadataUuid}/editor", method = RequestMethod.POST, consumes = {
+    @RequestMapping(value = "/{metadataUuid:.+}/editor", method = RequestMethod.POST, consumes = {
         MediaType.ALL_VALUE}, produces = {MediaType.APPLICATION_XML_VALUE})
     @PreAuthorize("hasAuthority('Editor')")
     @ResponseStatus(HttpStatus.OK)
@@ -528,7 +528,7 @@ public class MetadataEditingApi {
     }
 
     @io.swagger.v3.oas.annotations.Operation(summary = "Cancel edits", description = "Cancel current editing session.")
-    @RequestMapping(value = "/{metadataUuid}/editor", method = RequestMethod.DELETE, consumes = {
+    @RequestMapping(value = "/{metadataUuid:.+}/editor", method = RequestMethod.DELETE, consumes = {
         MediaType.ALL_VALUE}, produces = {MediaType.APPLICATION_XML_VALUE})
     @PreAuthorize("hasAuthority('Editor')")
     @ResponseStatus(HttpStatus.NO_CONTENT)
@@ -547,7 +547,7 @@ public class MetadataEditingApi {
     }
 
     @io.swagger.v3.oas.annotations.Operation(summary = "Add element", description = "")
-    @RequestMapping(value = "/{metadataUuid}/editor/elements", method = RequestMethod.PUT, consumes = {
+    @RequestMapping(value = "/{metadataUuid:.+}/editor/elements", method = RequestMethod.PUT, consumes = {
         MediaType.ALL_VALUE}, produces = {MediaType.APPLICATION_XML_VALUE})
     @PreAuthorize("hasAuthority('Editor')")
     @ResponseStatus(HttpStatus.OK)
@@ -589,7 +589,7 @@ public class MetadataEditingApi {
     }
 
     @io.swagger.v3.oas.annotations.Operation(summary = "Reorder element", description = "")
-    @RequestMapping(value = "/{metadataUuid}/editor/elements/{direction}", method = RequestMethod.PUT, consumes = {
+    @RequestMapping(value = "/{metadataUuid:.+}/editor/elements/{direction}", method = RequestMethod.PUT, consumes = {
         MediaType.ALL_VALUE}, produces = {MediaType.APPLICATION_XML_VALUE})
     @PreAuthorize("hasAuthority('Editor')")
     @ResponseStatus(HttpStatus.CREATED)
@@ -610,7 +610,7 @@ public class MetadataEditingApi {
     }
 
     @io.swagger.v3.oas.annotations.Operation(summary = "Delete element", description = "")
-    @RequestMapping(value = "/{metadataUuid}/editor/elements", method = RequestMethod.DELETE, consumes = {
+    @RequestMapping(value = "/{metadataUuid:.+}/editor/elements", method = RequestMethod.DELETE, consumes = {
         MediaType.ALL_VALUE}, produces = {MediaType.APPLICATION_XML_VALUE})
     @PreAuthorize("hasAuthority('Editor')")
     @ResponseStatus(HttpStatus.NO_CONTENT)
@@ -634,7 +634,7 @@ public class MetadataEditingApi {
     }
 
     @io.swagger.v3.oas.annotations.Operation(summary = "Delete attribute", description = "")
-    @RequestMapping(value = "/{metadataUuid}/editor/attributes", method = RequestMethod.DELETE, consumes = {
+    @RequestMapping(value = "/{metadataUuid:.+}/editor/attributes", method = RequestMethod.DELETE, consumes = {
         MediaType.ALL_VALUE}, produces = {MediaType.APPLICATION_XML_VALUE})
     @PreAuthorize("hasAuthority('Editor')")
     @ResponseStatus(HttpStatus.NO_CONTENT)

--- a/services/src/main/java/org/fao/geonet/api/records/extent/MetadataExtentApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/extent/MetadataExtentApi.java
@@ -119,7 +119,7 @@ public class MetadataExtentApi {
         summary = "Get record extents as image",
         description = API_EXTENT_DESCRIPTION)
     @RequestMapping(
-        value = "/{metadataUuid}/extents.png",
+        value = "/{metadataUuid:.+}/extents.png",
         produces = {
             MediaType.IMAGE_PNG_VALUE
         },
@@ -166,7 +166,7 @@ public class MetadataExtentApi {
         summary = "Get list of record extents",
         description = API_EXTENT_DESCRIPTION)
     @RequestMapping(
-        value = "/{metadataUuid}/extents.json",
+        value = "/{metadataUuid:.+}/extents.json",
         produces = {
             MediaType.APPLICATION_JSON_VALUE
         },
@@ -228,7 +228,7 @@ public class MetadataExtentApi {
         summary = "Get one record extent as image",
         description = API_EXTENT_DESCRIPTION)
     @RequestMapping(
-        value = "/{metadataUuid}/extents/{geometryIndex}.png",
+        value = "/{metadataUuid:.+}/extents/{geometryIndex}.png",
         produces = {
             MediaType.IMAGE_PNG_VALUE
         },

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterApi.java
@@ -168,7 +168,7 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
     }
 
     @RequestMapping(value = {
-        "/{portal}/api/records/{metadataUuid}/formatters/{formatterId:.+}"
+        "/{portal}/api/records/{metadataUuid:.+}/formatters/{formatterId:.+}"
     },
         method = RequestMethod.GET,
         produces = {

--- a/services/src/main/java/org/fao/geonet/api/userfeedback/UserFeedbackAPI.java
+++ b/services/src/main/java/org/fao/geonet/api/userfeedback/UserFeedbackAPI.java
@@ -177,7 +177,7 @@ public class UserFeedbackAPI {
      * @throws Exception the exception
      */
     @io.swagger.v3.oas.annotations.Operation(summary = "Provides an average rating for a metadata record")
-    @RequestMapping(value = "/records/{metadataUuid}/userfeedbackrating", produces = MediaType.APPLICATION_JSON_VALUE, method = RequestMethod.GET)
+    @RequestMapping(value = "/records/{metadataUuid:.+}/userfeedbackrating", produces = MediaType.APPLICATION_JSON_VALUE, method = RequestMethod.GET)
     @ResponseStatus(value = HttpStatus.OK)
     @ResponseBody
     public RatingAverage getMetadataRating(
@@ -306,7 +306,7 @@ public class UserFeedbackAPI {
         description = " This list will include also the draft user feedback if the client is logged as reviewer."
     )
     @RequestMapping(
-        value = "/records/{metadataUuid}/userfeedback",
+        value = "/records/{metadataUuid:.+}/userfeedback",
         produces = MediaType.APPLICATION_JSON_VALUE,
         method = RequestMethod.GET)
     @ResponseStatus(value = HttpStatus.OK)
@@ -541,7 +541,7 @@ public class UserFeedbackAPI {
         summary = "Send an email to catalogue administrator or record's contact",
         description = "")
     @RequestMapping(
-        value = "/records/{metadataUuid}/alert",
+        value = "/records/{metadataUuid:.+}/alert",
         produces = MediaType.APPLICATION_JSON_VALUE,
         method = RequestMethod.POST)
     @ResponseStatus(HttpStatus.CREATED)

--- a/web-ui/src/main/resources/catalog/components/catalog/CatalogService.js
+++ b/web-ui/src/main/resources/catalog/components/catalog/CatalogService.js
@@ -79,7 +79,9 @@
          * @return {HttpPromise} Future object
          */
         validate: function (id) {
-          return $http.put("../api/records/" + id + "/validate/internal");
+          return $http.put(
+            "../api/records/" + encodeURIComponent(id) + "/validate/internal"
+          );
         },
 
         /**
@@ -96,7 +98,9 @@
          */
         validateDirectoryEntry: function (id, newState) {
           var param = "?isvalid=" + (newState ? "true" : "false");
-          return $http.put("../api/records/" + id + "/validate/internal" + param);
+          return $http.put(
+            "../api/records/" + encodeURIComponent(id) + "/validate/internal" + param
+          );
         },
 
         /**

--- a/web-ui/src/main/resources/catalog/components/edit/directoryentryselector/DirectoryEntrySelector.js
+++ b/web-ui/src/main/resources/catalog/components/edit/directoryentryselector/DirectoryEntrySelector.js
@@ -352,7 +352,7 @@
                     checkState(c);
                   } else {
                     $http
-                      .get("../api/registries/entries/" + uuid, {
+                      .get("../api/registries/entries/" + encodeURIComponent(uuid), {
                         params: params
                       })
                       .then(function (response) {

--- a/web-ui/src/main/resources/catalog/components/edit/fieldupload/FieldUploadDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/fieldupload/FieldUploadDirective.js
@@ -167,7 +167,9 @@
             scope.filestoreUploadOptions = {
               autoUpload: true,
               url:
-                "../api/records/" + gnCurrentEdit.uuid + "/attachments?visibility=public",
+                "../api/records/" +
+                encodeURIComponent(gnCurrentEdit.uuid) +
+                "/attachments?visibility=public",
               dropZone: $("#gn-overview-dropzone"),
               singleUpload: true,
               // TODO: acceptFileTypes: /(\.|\/)(xml|skos|rdf)$/i,

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -425,6 +425,7 @@
           },
           link: function (scope, element, attrs) {
             scope.onlinesrcService = gnOnlinesrc;
+
             scope.gnCurrentEdit = gnCurrentEdit;
             scope.gnRelatedResources = gnRelatedResources;
             scope.allowEdits = true;
@@ -730,7 +731,7 @@
                 return $http
                   .put(
                     "../api/records/" +
-                      scope.gnCurrentEdit.uuid +
+                      encodeURIComponent(scope.gnCurrentEdit.uuid) +
                       "/attachments/print-thumbnail",
                     null,
                     {

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcService.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcService.js
@@ -242,7 +242,7 @@
          */
         getAllResources: function (types) {
           var linksAndRelatedPromises = [],
-            apiPrefix = "../api/records/" + gnCurrentEdit.uuid,
+            apiPrefix = "../api/records/" + encodeURIComponent(gnCurrentEdit.uuid),
             isArray = angular.isArray(types),
             defaultRelatedTypes = ["thumbnails", "onlines"],
             relatedTypes = [],

--- a/web-ui/src/main/resources/catalog/components/edit/validationreport/ValidationReportService.js
+++ b/web-ui/src/main/resources/catalog/components/edit/validationreport/ValidationReportService.js
@@ -33,7 +33,11 @@
     function ($http, gnCurrentEdit) {
       return {
         get: function () {
-          return $http.put("../api/records/" + gnCurrentEdit.uuid + "/validate/internal");
+          return $http.put(
+            "../api/records/" +
+              encodeURIComponent(gnCurrentEdit.uuid) +
+              "/validate/internal"
+          );
         },
         errorCheck: function () {
           return this.get().then(function (response) {

--- a/web-ui/src/main/resources/catalog/components/filestore/FileStoreDirective.js
+++ b/web-ui/src/main/resources/catalog/components/filestore/FileStoreDirective.js
@@ -39,7 +39,7 @@
         return {
           restrict: "A",
           templateUrl:
-            "../../catalog/components/filestore/" + "partials/dataUploaderButton.html",
+            "../../catalog/components/filestore/partials/dataUploaderButton.html",
           scope: {
             btnLabel: "=?gnDataUploaderButton",
             isOverview: "=?isOverview",
@@ -70,7 +70,7 @@
                   autoUpload: scope.autoUpload,
                   url:
                     "../api/records/" +
-                    gnCurrentEdit.uuid +
+                    encodeURIComponent(gnCurrentEdit.uuid) +
                     "/attachments?visibility=" +
                     (scope.visibility || "public"),
                   dropZone: $("#gn-upload-" + scope.id),

--- a/web-ui/src/main/resources/catalog/components/filestore/FileStoreDirective.js
+++ b/web-ui/src/main/resources/catalog/components/filestore/FileStoreDirective.js
@@ -237,7 +237,7 @@
                   autoUpload: scope.autoUpload,
                   url:
                     "../api/records/" +
-                    scope.uuid +
+                    encodeURIComponent(scope.uuid) +
                     "/attachments?visibility=" +
                     defaultStatus,
                   singleUpload: false

--- a/web-ui/src/main/resources/catalog/components/filestore/FileStoreService.js
+++ b/web-ui/src/main/resources/catalog/components/filestore/FileStoreService.js
@@ -33,13 +33,16 @@
     function ($http) {
       return {
         get: function (metadataUuid, filter) {
-          return $http.get("../api/records/" + metadataUuid + "/attachments", {
-            params: {
-              filter: filter,
-              _random: Math.floor(Math.random() * 10000),
-              approved: "false"
+          return $http.get(
+            "../api/records/" + encodeURIComponent(metadataUuid) + "/attachments",
+            {
+              params: {
+                filter: filter,
+                _random: Math.floor(Math.random() * 10000),
+                approved: "false"
+              }
             }
-          });
+          );
         },
         updateStatus: function (resource) {
           return $http.patch(

--- a/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionService.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionService.js
@@ -594,7 +594,7 @@
        * @param {Object} md
        */
       this.getPermalink = function (md) {
-        $http.get("../api/records/" + md.getUuid() + "/permalink").then(function (r) {
+        $http.get("../api/records/" + encodeURIComponent(md.getUuid()) + "/permalink").then(function (r) {
           gnUtilityService.displayPermalink(md.resourceTitle, r.data);
         });
       };

--- a/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionService.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionService.js
@@ -594,9 +594,11 @@
        * @param {Object} md
        */
       this.getPermalink = function (md) {
-        $http.get("../api/records/" + encodeURIComponent(md.getUuid()) + "/permalink").then(function (r) {
-          gnUtilityService.displayPermalink(md.resourceTitle, r.data);
-        });
+        $http
+          .get("../api/records/" + encodeURIComponent(md.getUuid()) + "/permalink")
+          .then(function (r) {
+            gnUtilityService.displayPermalink(md.resourceTitle, r.data);
+          });
       };
 
       /**

--- a/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionService.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionService.js
@@ -557,7 +557,12 @@
       this.assignCategories = function (metadataId, categories) {
         var defer = $q.defer();
         $http
-          .get("../records/" + metadataId + "/tags?id=" + categories.join("&id="))
+          .get(
+            "../records/" +
+              encodeURIComponent(metadataId) +
+              "/tags?id=" +
+              categories.join("&id=")
+          )
           .then(
             function (response) {
               defer.resolve(response.data);

--- a/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionsDirective.js
@@ -616,8 +616,7 @@
       return {
         restrict: "A",
         replace: true,
-        templateUrl:
-          "../../catalog/components/metadataactions/partials/" + "citation.html",
+        templateUrl: "../../catalog/components/metadataactions/partials/citation.html",
         scope: {
           md: "=gnMetadataCitation",
           format: "@"

--- a/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionsDirective.js
@@ -491,7 +491,10 @@
               method = "delete";
             }
             $http[method](
-              "../api/records/" + scope.metadataUuid + "/tags?id=" + c.id
+              "../api/records/" +
+                encodeURIComponent(scope.metadataUuid) +
+                "/tags?id=" +
+                c.id
             ).then(
               function () {
                 if (existIndex === -1) {
@@ -499,7 +502,6 @@
                   scope.currentCategories.values.push(c.name);
                 } else {
                   scope.ids.splice(existIndex, 1);
-
                   angular.forEach(scope.currentCategories.values, function (cat, idx) {
                     if (cat === c.name) {
                       scope.currentCategories.values.splice(idx, 1);

--- a/web-ui/src/main/resources/catalog/components/metadataactions/RelatedDirective.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/RelatedDirective.js
@@ -54,7 +54,7 @@
           method: "get",
           url:
             "../api/records/" +
-            uuidOrId +
+            encodeURIComponent(uuidOrId) +
             "/related?type=" +
             (types ? types.split("|").join("&type=") : "") +
             (approved === false ? "&approved=false" : ""),

--- a/web-ui/src/main/resources/catalog/components/metadatamanager/EditorService.js
+++ b/web-ui/src/main/resources/catalog/components/metadatamanager/EditorService.js
@@ -150,7 +150,9 @@
         buildEditUrlPrefix: function (service) {
           var params = [
             "../api/records/",
-            gnCurrentEdit.metadata ? gnCurrentEdit.metadata.uuid : gnCurrentEdit.id,
+            encodeURIComponent(
+              gnCurrentEdit.metadata ? gnCurrentEdit.metadata.uuid : gnCurrentEdit.id
+            ),
             "/",
             service,
             "?"

--- a/web-ui/src/main/resources/catalog/components/search/mdview/mdviewDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/mdviewDirective.js
@@ -70,13 +70,13 @@
                 "#/" +
                 (scope.md.draft == "y" ? "metadraf" : "metadata") +
                 "/" +
-                scope.md.uuid +
+                encodeURIComponent(scope.md.uuid) +
                 (scope.formatter === undefined || scope.formatter == "" ? "" : formatter);
 
               element.attr("href", url);
             } else {
               element.on("click", function (e) {
-                gnMdView.setLocationUuid(scope.md.uuid, formatter);
+                gnMdView.setLocationUuid(encodeURIComponent(scope.md.uuid), formatter);
               });
             }
             if (scope.records && scope.records.length) {

--- a/web-ui/src/main/resources/catalog/components/search/mdview/mdviewModule.js
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/mdviewModule.js
@@ -356,9 +356,10 @@
 
           gnMdViewObj.usingFormatter = f !== undefined;
 
-          if (f != undefined) {
+          if (gnMdViewObj.usingFormatter) {
+            var uuid = gnSearchLocation.getUuid();
             $scope.currentFormatter = f.replace(/.*(\/formatters.*)/, "$1");
-            $scope.loadFormatter(f);
+            $scope.loadFormatter(f.replace(uuid, encodeURIComponent(uuid)));
           }
         }
       }

--- a/web-ui/src/main/resources/catalog/components/search/mdview/mdviewService.js
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/mdviewService.js
@@ -200,7 +200,7 @@
 
         // Don't increase popularity for working copies
         if (!gnMdViewObj.usingFormatter && md.draft !== "y") {
-          $http.post("../api/records/" + md.uuid + "/popularity");
+          $http.post("../api/records/" + encodeURIComponent(md.uuid) + "/popularity");
         }
         this.setLocationUuid(md.uuid, formatter);
         gnMdViewObj.recordsLoaded = true;

--- a/web-ui/src/main/resources/catalog/components/search/searchmanager/LocationService.js
+++ b/web-ui/src/main/resources/catalog/components/search/searchmanager/LocationService.js
@@ -89,18 +89,18 @@
         return angular.isUndefined($location.path()) || $location.path() == "";
       };
       this.getFormatter = function () {
-        var tokens = $location.path().split("/");
-        if (tokens.length > 2 && tokens[3] === "formatters") {
-          return "/formatters/" + $location.url().split("/formatters/")[1];
+        var tokens = $location.path().split("/formatters/");
+        if (tokens.length === 2) {
+          return "/formatters/" + tokens[1];
         } else {
           return undefined;
         }
       };
       this.getFormatterPath = function (defaultFormatter) {
-        var tokens = $location.path().split("/");
-        if (tokens.length > 2 && tokens[3] === "formatters") {
-          return "../api/records/" + $location.url().split(/^\/(metadraf|metadata)\//)[2];
-        } else if (tokens.length > 2 && tokens[3] === "main") {
+        var tokens = $location.path().split("/formatters/");
+        if (tokens.length === 2) {
+          return "../api/records/" + $location.url().split(/^metadraf|metadata\//)[1];
+        } else if ($location.path().indexOf("/formatters/") === -1) {
           return undefined; // Angular view
         } else if (defaultFormatter) {
           return (
@@ -128,9 +128,10 @@
 
       this.getUuid = function () {
         if (this.isMdView()) {
-          return $location.path()
-            .split('/formatters')[0]
-            .replace(/\/metadata\/(.*)/, "$1");
+          return $location
+            .path()
+            .split("/formatters")[0]
+            .replace(/\/(metadraf|metadata)\/(.*)/, "$2");
         }
       };
 

--- a/web-ui/src/main/resources/catalog/components/search/searchmanager/LocationService.js
+++ b/web-ui/src/main/resources/catalog/components/search/searchmanager/LocationService.js
@@ -128,7 +128,9 @@
 
       this.getUuid = function () {
         if (this.isMdView()) {
-          return $location.path().replace(/\/metadata\/(.*)($|\/formatters.*)/, "$1");
+          return $location.path()
+            .split('/formatters')[0]
+            .replace(/\/metadata\/(.*)/, "$1");
         }
       };
 

--- a/web-ui/src/main/resources/catalog/components/search/searchmanager/LocationService.js
+++ b/web-ui/src/main/resources/catalog/components/search/searchmanager/LocationService.js
@@ -128,7 +128,7 @@
 
       this.getUuid = function () {
         if (this.isMdView()) {
-          return $location.path().split("/")[2];
+          return $location.path().replace(/\/metadata\/(.*)($|\/formatters.*)/, "$1");
         }
       };
 

--- a/web-ui/src/main/resources/catalog/components/userfeedback/GnUserfeedbackDirective.js
+++ b/web-ui/src/main/resources/catalog/components/userfeedback/GnUserfeedbackDirective.js
@@ -49,7 +49,7 @@
           method: "GET",
           url:
             "../api/records/" +
-            metatdataUUID +
+            encodeURIComponent(metatdataUUID) +
             "/userfeedback?size=" +
             numberOfCommentsDisplayed,
           isArray: true
@@ -59,7 +59,8 @@
       this.loadRating = function (metatdataUUID) {
         return $http({
           method: "GET",
-          url: "../api/records/" + metatdataUUID + "/userfeedbackrating",
+          url:
+            "../api/records/" + encodeURIComponent(metatdataUUID) + "/userfeedbackrating",
           isArray: false
         });
       };

--- a/web-ui/src/main/resources/catalog/components/validationtools/GnmdInspireValidationDirective.js
+++ b/web-ui/src/main/resources/catalog/components/validationtools/GnmdInspireValidationDirective.js
@@ -71,7 +71,10 @@
             scope.md = gnCurrentEdit.metadata;
             $http({
               method: "GET",
-              url: "../api/records/" + scope.inspMdUuid + "/validate/inspire/testsuites"
+              url:
+                "../api/records/" +
+                encodeURIComponent(scope.inspMdUuid) +
+                "/validate/inspire/testsuites"
             }).then(function (r) {
               scope.testsuites = r.data;
             });
@@ -96,7 +99,7 @@
               scope.token = null;
               var url =
                 "../api/records/" +
-                scope.inspMdUuid +
+                encodeURIComponent(scope.inspMdUuid) +
                 "/validate/inspire?testsuite=" +
                 test;
               if (angular.isDefined(mode) && mode !== "") {

--- a/web-ui/src/main/resources/catalog/style/gn_icons.less
+++ b/web-ui/src/main/resources/catalog/style/gn_icons.less
@@ -320,6 +320,11 @@
   word-wrap: break-word;
 }
 
+.gn-editor-container [data-gn-link-icon] .label {
+  display: unset;
+  vertical-align: middle;
+}
+
 [data-gn-link-label] {
   overflow: hidden;
   text-overflow: ellipsis;

--- a/web-ui/src/main/resources/catalog/views/default/directives/directive.js
+++ b/web-ui/src/main/resources/catalog/views/default/directives/directive.js
@@ -132,11 +132,13 @@
 
           scope.buildFormatter = function (url, uuid, isDraft) {
             if (url.indexOf("${uuid}") !== -1) {
-              return url.replace("${lang}", scope.lang).replace("${uuid}", uuid);
+              return url
+                .replace("${lang}", scope.lang)
+                .replace("${uuid}", encodeURIComponent(uuid));
             } else {
               return (
                 "../api/records/" +
-                uuid +
+                encodeURIComponent(uuid) +
                 url.replace("${lang}", scope.lang) +
                 (isDraft == "y"
                   ? (url.indexOf("?") !== -1 ? "&" : "?") + "approved=false"

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/summary.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/summary.html
@@ -46,14 +46,18 @@
       <h3 data-translate="">resourceVerticalRange</h3>
       <div class="flex flex-col">
         <p data-ng-repeat="range in mdView.current.record.resourceVerticalRange">
-          <span data-ng-show="range.gte || range.gte===0"> {{range.gte}}{{range.unit || 'm'}} </span>
+          <span data-ng-show="range.gte || range.gte===0">
+            {{range.gte}}{{range.unit || 'm'}}
+          </span>
           <span
             class="spacer"
             data-ng-show="(range.gte || range.gte===0) && (range.lte || range.lte===0)"
           >
             <i class="fa fa-long-arrow-right"></i>
           </span>
-          <span data-ng-show="range.lte || range.lte===0"> {{range.lte}}{{range.unit || 'm'}} </span>
+          <span data-ng-show="range.lte || range.lte===0">
+            {{range.lte}}{{range.unit || 'm'}}
+          </span>
         </p>
       </div>
     </div>

--- a/web/src/main/webapp/WEB-INF/config-security/config-security-core-default.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-core-default.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+<beans
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.springframework.org/schema/beans
+          http://www.springframework.org/schema/beans/spring-beans.xsd"
+  xmlns="http://www.springframework.org/schema/beans">
+
+  <bean id="filterChainProxy" class="org.springframework.security.web.FilterChainProxy">
+    <constructor-arg ref="filterChainPatterns"/>
+  </bean>
+</beans>

--- a/web/src/main/webapp/WEB-INF/config-security/config-security-core-encodeduuid.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-core-encodeduuid.xml
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+<beans
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://www.springframework.org/schema/beans
+          http://www.springframework.org/schema/beans/spring-beans.xsd"
+  xmlns="http://www.springframework.org/schema/beans">
+
+  <!--
+    UUID with URL special character support.
+    eg. info:doi:10.24396/ORDAR-56 or http://dada.moo/ORDAR-56
+
+    In order to support UUID with character like / or ; in it, you need
+    to configure a custom Spring HTTP Firewall which by default
+    consider those characters unsecure.
+    Error would look like "URL contained a potentially malicious String "%2F""
+
+    For this configure a custom StrictHttpFirewall configuration
+    and add it to the filterChainProxy.
+
+    Client side URL encode UUIDs and spring will not
+    decode path before matching URL (which would cause issue with request mapping).
+  -->
+
+  <bean id="filterChainProxy" class="org.springframework.security.web.FilterChainProxy">
+    <constructor-arg ref="filterChainPatterns"/>
+    <property name="firewall" ref="httpFirewall"/>
+  </bean>
+
+  <bean class="org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping" >
+    <property name="urlDecode" value="false"/>
+  </bean>
+
+  <bean id="httpFirewall"
+        class="org.springframework.security.web.firewall.StrictHttpFirewall">
+    <property name="allowUrlEncodedSlash" value="true"/>
+    <property name="allowUrlEncodedDoubleSlash" value="true"/>
+  </bean>
+
+  <bean id="coreFilterChain"
+        class="org.springframework.security.web.DefaultSecurityFilterChain">
+    <constructor-arg>
+      <bean class="org.springframework.security.web.util.matcher.AntPathRequestMatcher">
+        <constructor-arg value="/**"/>
+      </bean>
+    </constructor-arg>
+    <constructor-arg>
+      <ref bean="filterChainFilters"/>
+    </constructor-arg>
+  </bean>
+</beans>

--- a/web/src/main/webapp/WEB-INF/config-security/config-security-core.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-core.xml
@@ -65,8 +65,32 @@
         <ref bean="coreFilterChain"/>
       </list>
     </constructor-arg>
+<!--    <property name="firewall" ref="httpFirewall"/>-->
   </bean>
 
+<!--
+  UUID with URL special character support.
+  eg. info:doi:10.24396/ORDAR-56 or http://dada.moo/ORDAR-56
+
+  In order to support UUID with character like / or ; in it, you need
+  to disable default Spring HTTP Firewall behaviour which consider those characters unsecure.
+  Error would look like "URL contained a potentially malicious String "%2F""
+  For this uncomment the following and adjust StrictHttpFirewall configuration.
+  Also uncomment above firewall property of filterChainProxy.
+
+  Client side already URL encode UUIDs and with this, spring will not
+  decode path before matching URL (which would cause issue with request mapping)
+
+  <bean class="org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping">
+    <property name="urlDecode" value="false"/>
+  </bean>
+
+  <bean id="httpFirewall"
+        class="org.springframework.security.web.firewall.StrictHttpFirewall">
+    <property name="allowUrlEncodedSlash" value="true"/>
+    <property name="allowUrlEncodedDoubleSlash" value="true"/>
+  </bean>
+-->
 
   <bean id="coreFilterChain"
         class="org.springframework.security.web.DefaultSecurityFilterChain">

--- a/web/src/main/webapp/WEB-INF/config-security/config-security-core.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-core.xml
@@ -25,72 +25,69 @@
 <beans
   xmlns:sec="http://www.springframework.org/schema/security"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:util="http://www.springframework.org/schema/util"
   xsi:schemaLocation="http://www.springframework.org/schema/beans
           http://www.springframework.org/schema/beans/spring-beans.xsd
           http://www.springframework.org/schema/security
-          http://www.springframework.org/schema/security/spring-security.xsd"
+          http://www.springframework.org/schema/security/spring-security.xsd
+          http://www.springframework.org/schema/util
+          https://www.springframework.org/schema/util/spring-util.xsd"
   xmlns="http://www.springframework.org/schema/beans">
 
   <alias name="filterChainProxy" alias="springSecurityFilterChain"/>
 
-  <bean id="filterChainProxy" class="org.springframework.security.web.FilterChainProxy">
-    <constructor-arg>
-      <list>
-        <!-- TODO: This needs to be secured to not access private info -->
-        <sec:filter-chain pattern="/index/**" filters=""/>
-        <sec:filter-chain pattern="/jolokia" filters="securityContextPersistenceFilter, authenticatedUserFilter"/>
-        <sec:filter-chain pattern="/jolokia/read/geonetwork-**" filters="securityContextPersistenceFilter, authenticatedUserFilter"/>
-        <sec:filter-chain pattern="/dashboards/**" filters="securityContextPersistenceFilter, basicAuthenticationFilter, authenticatedUserFilter"/>
-        <sec:filter-chain pattern="/doc/**" filters=""/>
-        <sec:filter-chain pattern="/api/**" filters=""/>
-        <!-- wroAPI is protected for admin only
-        This is causing issue on node-change-warning page.
-        <sec:filter-chain pattern="/static/wroAPI" filters=""/>-->
-        <sec:filter-chain pattern="/static/**" filters=""/>
-        <sec:filter-chain pattern="/catalog/**" filters=""/>
-        <sec:filter-chain pattern="/" filters=""/>
-        <sec:filter-chain pattern="/*.html" filters=""/>
-        <sec:filter-chain pattern="/*.jsp" filters=""/>
-        <sec:filter-chain pattern="/*.css" filters=""/>
-        <sec:filter-chain pattern="/images/**" filters=""/>
-        <sec:filter-chain pattern="/map/**" filters=""/>
-        <sec:filter-chain pattern="/htmlcache/**" filters=""/>
-        <sec:filter-chain pattern="/pdf/**" filters=""/>
-        <sec:filter-chain pattern="/loc/**" filters=""/>
-        <sec:filter-chain pattern="/xml/csw/test/*" filters=""/>
-        <sec:filter-chain pattern="/xml/schemas/**" filters=""/>
-        <sec:filter-chain pattern="/xsl/harvesting/**" filters=""/>
-        <sec:filter-chain pattern="/xsl/ownership/**" filters=""/>
-        <sec:filter-chain pattern="/config/**" filters=""/>
-        <ref bean="coreFilterChain"/>
-      </list>
-    </constructor-arg>
-<!--    <property name="firewall" ref="httpFirewall"/>-->
-  </bean>
+  <util:list id="filterChainPatterns">
+    <!-- TODO: This needs to be secured to not access private info -->
+    <sec:filter-chain pattern="/index/**" filters=""/>
+    <sec:filter-chain pattern="/jolokia/**" filters="securityContextPersistenceFilter, authenticatedUserFilter"/>
+    <sec:filter-chain pattern="/dashboards/**"
+                      filters="securityContextPersistenceFilter, basicAuthenticationFilter, authenticatedUserFilter"/>
+    <sec:filter-chain pattern="/doc/**" filters=""/>
+    <sec:filter-chain pattern="/api/**" filters=""/>
+    <!-- wroAPI is protected for admin only
+    This is causing issue on node-change-warning page.
+    <sec:filter-chain pattern="/static/wroAPI" filters=""/>-->
+    <sec:filter-chain pattern="/static/**" filters=""/>
+    <sec:filter-chain pattern="/catalog/**" filters=""/>
+    <sec:filter-chain pattern="/" filters=""/>
+    <sec:filter-chain pattern="/*.html" filters=""/>
+    <sec:filter-chain pattern="/*.jsp" filters=""/>
+    <sec:filter-chain pattern="/*.css" filters=""/>
+    <sec:filter-chain pattern="/images/**" filters=""/>
+    <sec:filter-chain pattern="/map/**" filters=""/>
+    <sec:filter-chain pattern="/htmlcache/**" filters=""/>
+    <sec:filter-chain pattern="/pdf/**" filters=""/>
+    <sec:filter-chain pattern="/loc/**" filters=""/>
+    <sec:filter-chain pattern="/xml/csw/test/*" filters=""/>
+    <sec:filter-chain pattern="/xml/schemas/**" filters=""/>
+    <sec:filter-chain pattern="/xsl/harvesting/**" filters=""/>
+    <sec:filter-chain pattern="/xsl/ownership/**" filters=""/>
+    <sec:filter-chain pattern="/config/**" filters=""/>
+    <ref bean="coreFilterChain"/>
+  </util:list>
 
-<!--
-  UUID with URL special character support.
-  eg. info:doi:10.24396/ORDAR-56 or http://dada.moo/ORDAR-56
+  <!-- Security options
 
-  In order to support UUID with character like / or ; in it, you need
-  to disable default Spring HTTP Firewall behaviour which consider those characters unsecure.
-  Error would look like "URL contained a potentially malicious String "%2F""
-  For this uncomment the following and adjust StrictHttpFirewall configuration.
-  Also uncomment above firewall property of filterChainProxy.
+  geonetwork.security.coreconfig can be supplied
+  using the -Dgeonetwork.security.coreconfig
+  or via env as GEONETWORK_SECURITY_CORECONFIG
+  If not supplied it will default to "default" security configuration.
 
-  Client side already URL encode UUIDs and with this, spring will not
-  decode path before matching URL (which would cause issue with request mapping)
+  i.e.
 
-  <bean class="org.springframework.web.servlet.mvc.method.annotation.RequestMappingHandlerMapping">
-    <property name="urlDecode" value="false"/>
-  </bean>
+  Option include
+     default      - Default security
+     encodeduuid  - Required to UUID containing special character eg. /
 
-  <bean id="httpFirewall"
-        class="org.springframework.security.web.firewall.StrictHttpFirewall">
-    <property name="allowUrlEncodedSlash" value="true"/>
-    <property name="allowUrlEncodedDoubleSlash" value="true"/>
-  </bean>
--->
+  If encodeduuid is enabled, on Tomcat it will also require
+  -Dorg.apache.tomcat.util.buf.UDecoder.ALLOW_ENCODED_SLASH=true
+
+  and if using an Apache reverse proxy
+  AllowEncodedSlashes On
+  ProxyPass /geonetwork http://localhost:8080/geonetwork nocanon
+  ProxyPassReverse /geonetwork http://localhost:8080/geonetwork
+  -->
+  <import resource="config-security-core-${geonetwork.security.coreconfig:default}.xml"/>
 
   <bean id="coreFilterChain"
         class="org.springframework.security.web.DefaultSecurityFilterChain">
@@ -109,7 +106,7 @@
       <list>
         <ref bean="securityContextPersistenceFilter"/>
         <!-- To disable csrf security (not recommended) comment the following line -->
-        <ref bean="csrfFilter" />
+        <ref bean="csrfFilter"/>
         <!-- To disable csrf security (not recommended) comment the upper line -->
         <ref bean="logoutFilter"/>
         <!-- A filter that check if an external service already authenticated user
@@ -149,7 +146,7 @@
   <bean id="securityContextRepository"
         class='org.springframework.security.web.context.HttpSessionSecurityContextRepository'>
     <property name="allowSessionCreation" value="true"/>
-    <property name="disableUrlRewriting" value="true" />
+    <property name="disableUrlRewriting" value="true"/>
   </bean>
 
   <bean class="org.fao.geonet.web.GeoNetworkHttpSessionRequestCache"
@@ -162,7 +159,8 @@
     </property>
   </bean>
 
-  <bean id="formLoginFilter" class="org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter">
+  <bean id="formLoginFilter"
+        class="org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter">
     <property name="postOnly" value="true"/>
     <property name="usernameParameter" value="username"/>
     <property name="passwordParameter" value="password"/>
@@ -250,7 +248,7 @@
     <constructor-arg name="loginFormUrl" value="${loginForm}"/>
   </bean>
 
-  <bean id="ajaxEntryPoint" class="org.springframework.security.web.authentication.Http403ForbiddenEntryPoint" />
+  <bean id="ajaxEntryPoint" class="org.springframework.security.web.authentication.Http403ForbiddenEntryPoint"/>
 
   <bean id="authenticationEntryPoint"
         class="org.springframework.security.web.authentication.DelegatingAuthenticationEntryPoint">
@@ -259,18 +257,18 @@
         <entry key-ref="apiRequestMatcher" value-ref="ajaxEntryPoint"/>
       </map>
     </constructor-arg>
-    <property name="defaultEntryPoint" ref="defaultAuthenticationEntryPoint" />
+    <property name="defaultEntryPoint" ref="defaultAuthenticationEntryPoint"/>
   </bean>
 
   <bean id="apiRequestMatcher"
         class="org.springframework.security.web.util.matcher.AntPathRequestMatcher">
-    <constructor-arg name="pattern" value="/*/api/**" />
+    <constructor-arg name="pattern" value="/*/api/**"/>
   </bean>
 
   <bean id="accessDeniedHandler"
         class="jeeves.config.springutil.JeevesAccessDeniedHandler">
     <property name="errorPage" value="/accessDenied.jsp"/>
-    <property name="onlyStatusResponsePages" value="/*/api/**" />
+    <property name="onlyStatusResponsePages" value="/*/api/**"/>
   </bean>
 
   <!-- TODO remember me.
@@ -345,13 +343,13 @@
 
   <bean id="anonymousUser" class="org.springframework.security.core.userdetails.memory.UserAttribute">
     <property name="password" value="anonymousUser"/>
-    <property name="authoritiesAsString" value ="ROLE_ANONYMOUS"/>
+    <property name="authoritiesAsString" value="ROLE_ANONYMOUS"/>
   </bean>
   <bean id="anonymousFilter"
         class="org.springframework.security.web.authentication.AnonymousAuthenticationFilter">
-    <constructor-arg value="GeonetworkAnonymousUser" />
-    <constructor-arg value="#{anonymousUser.password}" />
-    <constructor-arg value="#{anonymousUser.authorities}" />
+    <constructor-arg value="GeonetworkAnonymousUser"/>
+    <constructor-arg value="#{anonymousUser.password}"/>
+    <constructor-arg value="#{anonymousUser.authorities}"/>
   </bean>
 
   <bean id="anonymousProvider"
@@ -381,7 +379,7 @@
       <ref bean="csrfTokenRepository"/>
     </constructor-arg>
 
-    <property name="requireCsrfProtectionMatcher" ref="geonetworkCsrfSecurityRequestMatcher" />
+    <property name="requireCsrfProtectionMatcher" ref="geonetworkCsrfSecurityRequestMatcher"/>
   </bean>
 
   <bean class="org.fao.geonet.security.web.csrf.CookieCsrfTokenRepository"


### PR DESCRIPTION
Supersede https://github.com/geonetwork/core-geonetwork/pull/5736

**To run**
- Run GN locally with /web>mvn jetty:run -Dgeonetwork.security.coreconfig=encodeduuid
- Disable auto UUID generation, see [documentation](https://docs.geonetwork-opensource.org/4.2/administrator-guide/managing-metadata-standards/metadata-identifier/)

**Tests that I've made**
- [ ] Create a new template with https://myorg.com::{UUID}
- [ ] Create a metadata with this template
- [ ] Open it in the editor
- [ ] Edit several fields
- [ ] Save
- [ ] Open it in the viewer
- [ ] Open it as advanced view
- [ ] Export it as XML
- [ ] Export it as MEF
- [ ] Permalinks work