### PR TITLE
Standard / ISO19115-3 / Quality report / Index descriptive results

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
@@ -1173,12 +1173,12 @@
         <xsl:for-each select="mdq:report/*[
                 normalize-space(mdq:measure/*/mdq:nameOfMeasure/gco:CharacterString) != ''
                 or normalize-space(mdq:measure/*/mdq:measureDescription/gco:CharacterString) != ''
-                ]/mdq:result/mdq:DQ_QuantitativeResult">
+                ]/mdq:result/(mdq:DQ_QuantitativeResult|mdq:DQ_DescriptiveResult)">
 
           <xsl:variable name="name"
                         select="(../../mdq:measure/*/mdq:nameOfMeasure/gco:CharacterString)[1]"/>
           <xsl:variable name="value"
-                        select="mdq:value"/>
+                        select="mdq:value/gco:Record[. != '']|mdq:statement/gco:CharacterString[. != '']"/>
           <xsl:variable name="unit"
                         select="mdq:valueUnit//gml:identifier"/>
           <xsl:variable name="description"
@@ -1196,7 +1196,7 @@
               "date": "<xsl:value-of select="util:escapeForJson($measureDate)"/>",
             </xsl:if>
             <!-- First value only. -->
-            "value": "<xsl:value-of select="util:escapeForJson($value/gco:Record[1])"/>",
+            "value": "<xsl:value-of select="util:escapeForJson($value[1])"/>",
             <xsl:if test="$unit != ''">
               "unit": "<xsl:value-of select="util:escapeForJson($unit)"/>",
             </xsl:if>
@@ -1204,7 +1204,7 @@
             }
           </measure>
 
-          <xsl:for-each select="mdq:value/gco:Record[. != '']">
+          <xsl:for-each select="$value">
             <xsl:element name="measure_{gn-fn-index:build-field-name($name)}">
               <xsl:value-of select="."/>
             </xsl:element>


### PR DESCRIPTION
ISO19115-3 adds possibility to provide descriptive results (and not only conformance and quantitative results). Properly index them in order to render them in measure table in record view (https://github.com/geonetwork/core-geonetwork/pull/7180)

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/589e5dc5-eef1-4882-a15e-28831d9450f6)

```xml
<mdb:dataQualityInfo>
      <mdq:DQ_DataQuality>
         <mdq:scope>
            <mcc:MD_Scope>
               <mcc:level>
                  <mcc:MD_ScopeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_ScopeCode"
                                    codeListValue="dataset"/>
               </mcc:level>
            </mcc:MD_Scope>
         </mdq:scope>
         <mdq:report>
            <mdq:DQ_QuantitativeAttributeAccuracy>
               <mdq:measure>
                  <mdq:DQ_MeasureReference>
                     <mdq:nameOfMeasure>
                        <gco:CharacterString>Accuracy - overall</gco:CharacterString>
                     </mdq:nameOfMeasure>
                     <mdq:measureDescription>
                        <gco:CharacterString>Assessment of accuracy, linked to a certain Data Set or domain, which is summarising the various components into one single measure.

This metadata element is used to describe the main sources of random and systematic error in the statistical outputs, and provide a summary assessment of all errors with special focus on the impact on key estimates. The bias assessment can be in quantitative or qualitative terms, or both. It should reflect the producer's best current understanding (sign and order of magnitude) including actions taken to reduce bias. Revision aspects should also be included here if considered relevant.</gco:CharacterString>
                     </mdq:measureDescription>
                  </mdq:DQ_MeasureReference>
               </mdq:measure>
               <mdq:result>
                  <mdq:DQ_DescriptiveResult>
                     <mdq:statement>
                        <gco:CharacterString>-text-</gco:CharacterString>
                     </mdq:statement>
                  </mdq:DQ_DescriptiveResult>
               </mdq:result>
               <mdq:result>
                  <mdq:DQ_QuantitativeResult>
                     <mdq:value>
                        <gco:Record>1111</gco:Record>
                     </mdq:value>
                  </mdq:DQ_QuantitativeResult>
               </mdq:result>
            </mdq:DQ_QuantitativeAttributeAccuracy>
         </mdq:report>
      </mdq:DQ_DataQuality>
  </mdb:dataQualityInfo>
```


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

