### PR TITLE
Fix ISO19139 German labels

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/loc/ger/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/ger/labels.xml
@@ -3269,7 +3269,7 @@
     <label>Maßstabszahl</label>
     <help/>
     <condition/>
-    <description>Angabe der Massstabszahl (mz) eines Massstabs 1 : mz der Ausgangskarte</description>
+    <description>Angabe der Maßstabszahl (mz) eines Maßstab 1 : mz der Ausgangskarte</description>
   </element>
   <element name="gmd:sourceReferenceSystem" context="gmd:LI_Source" id="95">
     <label>Bezugssystem</label>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/ger/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/ger/labels.xml
@@ -2966,7 +2966,7 @@
     <label>Vergleichsmaßstab</label>
     <help/>
     <condition>auszufüllen, wenn keine Distanz (Bodenauflösung) angegeben wird</condition>
-    <description>Detailliertheitsgrad, angegeben durch den Massstab einer vergleichbaren gedruckten
+    <description>Detailliertheitsgrad, angegeben durch den Maßstab einer vergleichbaren gedruckten
       Karte</description>
   </element>
   <element name="gmd:distance" context="gmd:MD_Resolution" id="61">

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/ger/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/ger/labels.xml
@@ -2925,8 +2925,8 @@
   </element>
   <element name="gmd:denominator" id="57">
     <label>Maßstabszahl</label>
-    <help>Empfehlung: Falls ein Massstabsbereich angegeben werden soll, ist die Klasse MD_Resolution
-      zweifach zu nutzen und jeweils die obere und untere Massstabszahl einzutragen.</help>
+    <help>Empfehlung: Falls ein Maßstabsbereich angegeben werden soll, ist die Klasse MD_Resolution
+      zweifach zu nutzen und jeweils die obere und untere Maßstabszahl einzutragen.</help>
     <condition>Soll ausgefüllt werden, falls keine Distanz (Bodenauflösung) angegeben wird</condition>
     <description>Angabe der Massstabszahl (mz) eines Massstabs 1 : mz</description>
     <helper>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/ger/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/ger/labels.xml
@@ -1094,7 +1094,7 @@
     <condition/>
     <description>Information zum Inhalt einer Rasterdatenzelle</description>
   </element>
-  <element name="gmd:citation" context="gmd:MD_Identification"
+  <element name="gmd:citation" context="gmd:MD_DataIdentification"
            id="24">
     <label>Bibliografische Angaben</label>
     <help>Ressourcen können z.B. Datensätze, digitale Karten, Messreihen,
@@ -1543,6 +1543,10 @@
     <help>z.B. Nummer, Datum</help>
     <condition>Obligatorisch</condition>
     <description>Version des Datenformats</description>
+  </element>
+  <element name="gmd:version">
+    <label>Version</label>
+    <description></description>
   </element>
   <element name="gmd:amendmentNumber" context="gmd:MD_Format" id="287">
     <label>Revisionsnummer</label>
@@ -2114,7 +2118,7 @@
     <condition/>
     <description>Einschränkungen bezüglich der Ressource</description>
   </element>
-  <element name="gmd:aggregationInfo" context="gmd:MD_Identification"
+  <element name="gmd:aggregationInfo" context="gmd:MD_DataIdentification"
            id="35.1">
     <label>Beziehungsinformation</label>
     <help/>
@@ -2286,7 +2290,7 @@
       Ressource gehört
     </description>
   </element>
-  <element name="gmd:spatialRepresentationType" context="gmd:MD_Identification"
+  <element name="gmd:spatialRepresentationType" context="gmd:MD_DataIdentification"
            id="37">
     <label>Räumliche Darstellungsart</label>
     <help/>
@@ -2401,7 +2405,7 @@
     <description>Adressangaben zur verantwortlichen Stelle</description>
   </element>
   <element name="gmd:deliveryPoint" context="gmd:CI_Address" id="381">
-    <label>Adresse</label>
+    <label>Straße und Hausnummer</label>
     <help/>
     <condition/>
     <description>Angabe der Strasse und Hausnummer (ggf. auch als
@@ -2734,6 +2738,11 @@
       gehört
     </description>
   </element>
+  <element name="gmd:name">
+    <label>Bezeichnung</label>
+    <description>
+    </description>
+  </element>
   <element name="gmd:issueIdentification" context="gmd:CI_Series"
            id="405">
     <label>Kennung</label>
@@ -2776,7 +2785,7 @@
     </description>
   </element>
   <element name="gmd:topicCategory" id="41">
-    <label>Thematik</label>
+    <label>ISO-Thematik</label>
     <help/>
     <condition>Obligatorisch wenn Hierarchieebene = Datenbestand, bzw. auf
       alle Fälle obligatorisch nach INSPIRE
@@ -2915,7 +2924,7 @@
       / Scale.measure Und Scale.targetUnits = Scale.sourceUnits</description>
   </element>
   <element name="gmd:denominator" id="57">
-    <label>Massstabszahl</label>
+    <label>Maßstabszahl</label>
     <help>Empfehlung: Falls ein Massstabsbereich angegeben werden soll, ist die Klasse MD_Resolution
       zweifach zu nutzen und jeweils die obere und untere Massstabszahl einzutragen.</help>
     <condition>Soll ausgefüllt werden, falls keine Distanz (Bodenauflösung) angegeben wird</condition>
@@ -2954,7 +2963,7 @@
       Hierarchieebenen sind dem ISO 19115 - Anhang H zu entnehmen)</description>
   </element>
   <element name="gmd:equivalentScale" context="gmd:MD_Resolution" id="60">
-    <label>Vergleichsmassstab</label>
+    <label>Vergleichsmaßstab</label>
     <help/>
     <condition>auszufüllen, wenn keine Distanz (Bodenauflösung) angegeben wird</condition>
     <description>Detailliertheitsgrad, angegeben durch den Massstab einer vergleichbaren gedruckten
@@ -3257,7 +3266,7 @@
     <description>Detaillierte Beschreibung der Ebene der Quelldaten</description>
   </element>
   <element name="gmd:scaleDenominator" context="gmd:LI_Source" id="94">
-    <label>Massstabszahl</label>
+    <label>Maßstabszahl</label>
     <help/>
     <condition/>
     <description>Angabe der Massstabszahl (mz) eines Massstabs 1 : mz der Ausgangskarte</description>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/ger/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/ger/labels.xml
@@ -2392,7 +2392,7 @@
   </element>
   <element name="gmd:spatialResolution" id="38">
     <label>Räumliche Auflösung</label>
-    <help>z.B. Massstab, Bodenauflösung, Gitterweite, Rasterauflösung</help>
+    <help>z.B. Maßstab, Bodenauflösung, Gitterweite, Rasterauflösung</help>
     <condition/>
     <description>Angaben über die räumliche Auflösung der geografischen
       Informationen
@@ -2920,7 +2920,7 @@
     <label>Representative Fraction</label>
     <help/>
     <condition/>
-    <description>Hergeleitet vom ISO 19103; Massstab, wobei MD_RepresentativFraction.denominator = 1
+    <description>Hergeleitet vom ISO 19103; Maßstab, wobei MD_RepresentativFraction.denominator = 1
       / Scale.measure Und Scale.targetUnits = Scale.sourceUnits</description>
   </element>
   <element name="gmd:denominator" id="57">
@@ -2952,7 +2952,7 @@
     <label>Auflösung</label>
     <help/>
     <condition/>
-    <description>Detailliertheitsgrad, angegeben durch eine Massstabszahl oder eine
+    <description>Detailliertheitsgrad, angegeben durch eine Maßstabszahl oder eine
       Bodenauflösung</description>
   </element>
   <element name="gmd:hierarchyLevel" id="6">
@@ -2972,7 +2972,7 @@
   <element name="gmd:distance" context="gmd:MD_Resolution" id="61">
     <label>Distanz</label>
     <help>Abstand der Rastermittelpunkte bzw. Gitterstützpunkte</help>
-    <condition>auszufüllen, wenn kein Vergleichsmassstab angegeben wird</condition>
+    <condition>auszufüllen, wenn kein Vergleichsmaßstab angegeben wird</condition>
     <description>Bodenauflösung</description>
     <helper>
       <option value="0.10">10 cm</option>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/ger/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/ger/labels.xml
@@ -2408,7 +2408,7 @@
     <label>Straße und Hausnummer</label>
     <help/>
     <condition/>
-    <description>Angabe der Strasse und Hausnummer (ggf. auch als
+    <description>Angabe der Straße und Hausnummer (ggf. auch als
       Postfach) gemäss ISO 11180, Anhang
       A
     </description>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/ger/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/ger/labels.xml
@@ -2928,7 +2928,7 @@
     <help>Empfehlung: Falls ein Maßstabsbereich angegeben werden soll, ist die Klasse MD_Resolution
       zweifach zu nutzen und jeweils die obere und untere Maßstabszahl einzutragen.</help>
     <condition>Soll ausgefüllt werden, falls keine Distanz (Bodenauflösung) angegeben wird</condition>
-    <description>Angabe der Massstabszahl (mz) eines Massstabs 1 : mz</description>
+    <description>Angabe der Maßstabszahl (mz) eines Maßstabs 1 : mz</description>
     <helper>
       <option value="5000">1:5´000</option>
       <option value="10000">1:10´000</option>


### PR DESCRIPTION
Update German ISO19139 labels:

- Fix wrong context element for some labels.
- Update translations.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation