### PR TITLE
Harvesters / Reset harvester history pagination when selecting a harvester

### DIFF
--- a/web-ui/src/main/resources/catalog/js/admin/HarvestSettingsController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/HarvestSettingsController.js
@@ -438,6 +438,12 @@
         $scope.harvesterHistory = {};
         $scope.searchResults = null;
         $scope.searchResultsTotal = null;
+        $scope.harvesterHistoryPaging = {
+          page: 1,
+          size: 3,
+          pages: 0,
+          total: 0
+        };
 
         loadHarvester(h["@id"]).then(function (data) {
           loadHistory();


### PR DESCRIPTION
Test case:

1) Select a harvester and move to the 2on page of the executions history.
2) Select another harvester:

  - Without the fix: the harvester executions history shows the 2on page (that could not exist), instead of the 1st page.
  - With the fix: the harvester executions history shows the 1st page.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation


