### PR TITLE
Thesaurus / Add support for codelist described using SDMX

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
@@ -141,7 +141,7 @@ public class KeywordsApi {
     @Autowired
     ThesaurusManager thesaurusManager;
 
-    List<String> allowedExtensions = Arrays.asList("rdf", "owl", "xml");
+    List<String> allowedExtensions = Arrays.asList("rdf", "owl", "xml", "sdmx");
 
     /**
      * Search keywords.
@@ -720,7 +720,7 @@ public class KeywordsApi {
      */
     @io.swagger.v3.oas.annotations.Operation(
         summary = "Uploads a new thesaurus from a file",
-        description = "Uploads a new thesaurus."
+        description = "Supported thesaurus are RDF/XML files using SKOS specification, OWL file describing NamedIndividual elements or SDMX file describing Codelist element. For RDF, extension must be .rdf or .xml, for OWL, .owl and for SDMX, .sdmx."
     )
     @RequestMapping(
         method = RequestMethod.POST,
@@ -826,7 +826,13 @@ public class KeywordsApi {
     }
 
     private static String getStylesheetForExtension(String stylesheet, String extension) {
-        return extension.equals("owl") ? "owl-to-skos" : stylesheet;
+        if (extension.equals("owl")) {
+            return "owl-to-skos";
+        } else if (extension.equals("sdmx")) {
+            return "sdmx-to-skos";
+        } else {
+            return stylesheet;
+        }
     }
 
 

--- a/web/src/main/webapp/xslt/services/thesaurus/sdmx-to-skos.xsl
+++ b/web/src/main/webapp/xslt/services/thesaurus/sdmx-to-skos.xsl
@@ -1,0 +1,74 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2001-2024 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:sdmx="http://www.w3.org/2002/07/sdmx#"
+                xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+                xmlns:dc="http://purl.org/dc/elements/1.1/"
+                xmlns:dcterms="http://purl.org/dc/terms/"
+                xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+                xmlns:sdmxm="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/message"
+                xmlns:sdmxs="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/structure"
+                xmlns:sdmxc="http://www.sdmx.org/resources/sdmxml/schemas/v2_1/common"
+                exclude-result-prefixes="#all"
+                version="2.0">
+
+  <!-- Convert sdmx codelist into SKOS RDF/XML format supported by GeoNetwork.  -->
+  <xsl:output method="xml" encoding="UTF-8" indent="yes"/>
+
+  <xsl:template match="/">
+    <xsl:apply-templates mode="sdmx-to-skos"
+                         select=".//sdmxs:Codelist"/>
+  </xsl:template>
+
+  <xsl:template mode="sdmx-to-skos"
+                match="sdmxs:Codelist">
+    <rdf:RDF xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+             xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+             xmlns:dc="http://purl.org/dc/elements/1.1/"
+             xmlns:dcterms="http://purl.org/dc/terms/">
+      <skos:ConceptScheme rdf:about="{@urn}">
+        <xsl:for-each select="sdmxc:Name">
+          <dc:title xml:lang="{@xml:lang}"><xsl:value-of select="."/></dc:title>
+        </xsl:for-each>
+
+        <xsl:for-each select="(sdmxc:Annotations/*[sdmxc:AnnotationType = 'LAST_UPDATED']/sdmxc:AnnotationTitle)[1]">
+          <dcterms:issued><xsl:value-of select="."/></dcterms:issued>
+          <dcterms:modified><xsl:value-of select="."/></dcterms:modified>
+        </xsl:for-each>
+      </skos:ConceptScheme>
+
+      <xsl:apply-templates mode="sdmx-to-skos"
+                           select="sdmxs:Code"/>
+    </rdf:RDF>
+  </xsl:template>
+
+  <xsl:template mode="sdmx-to-skos"
+                match="sdmxs:Code">
+    <skos:Concept rdf:about="{@urn}">
+      <xsl:for-each select="sdmxc:Name">
+        <skos:prefLabel xml:lang="{@xml:lang}"><xsl:value-of select="."/></skos:prefLabel>
+      </xsl:for-each>
+    </skos:Concept>
+  </xsl:template>
+</xsl:stylesheet>


### PR DESCRIPTION
SDMX is a common format used to statistical data and can be used to describe codelist. eg https://ec.europa.eu/eurostat/databrowser/bulk?lang=en&selectedTab=codeList


![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/1f53e4f5-975c-4db4-b966-796d8bce80cb)


Add possibility to import those codelist as SKOS format.

Filename must use extension `.sdmx`.

Similar to https://github.com/geonetwork/core-geonetwork/pull/7674


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

Funded by EEA

