### PR TITLE
Record view / ISO19139 / ISO19115-3.2008 display the unit part in @uom attribute, not the full url

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/xsl-view/view.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/xsl-view/view.xsl
@@ -1181,7 +1181,9 @@
 
     <xsl:if test="@uom">
       <!-- Display the unit value only -->
-      <xsl:comment select="'.'"/>&#160; <xsl:value-of select="tokenize(@uom, '#')[2]"/>
+      <xsl:comment select="'.'"/>&#160; <xsl:value-of select="if (contains(@uom, '#'))
+                                    then concat(., ' ', tokenize(@uom, '#')[2])
+                                    else  concat(., ' ', @uom)"/>
     </xsl:if>
   </xsl:template>
 

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/xsl-view/view.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/xsl-view/view.xsl
@@ -1180,7 +1180,8 @@
 
 
     <xsl:if test="@uom">
-      <xsl:comment select="'.'"/>&#160;<xsl:value-of select="@uom"/>
+      <!-- Display the unit value only -->
+      <xsl:comment select="'.'"/>&#160; <xsl:value-of select="tokenize(@uom, '#')[2]"/>
     </xsl:if>
   </xsl:template>
 

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
@@ -674,7 +674,9 @@
 
           <xsl:for-each select="mri:distance/gco:Distance[. != '']">
             <resolutionDistance>
-              <xsl:value-of select="concat(., ' ', @uom)"/>
+              <xsl:value-of select="if (contains(@uom, '#'))
+                                    then concat(., ' ', tokenize(@uom, '#')[2])
+                                    else  concat(., ' ', @uom)"/>
             </resolutionDistance>
           </xsl:for-each>
         </xsl:for-each>

--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
@@ -1152,7 +1152,9 @@
 
         <xsl:if test="@uom">
           <!-- Display the unit value only -->
-          &#160; <xsl:value-of select="tokenize(@uom, '#')[2]"/>
+          &#160; <xsl:value-of select="if (contains(@uom, '#'))
+                                    then concat(., ' ', tokenize(@uom, '#')[2])
+                                    else  concat(., ' ', @uom)"/>
         </xsl:if>
       </xsl:otherwise>
     </xsl:choose>

--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
@@ -1151,7 +1151,8 @@
         <xsl:value-of select="normalize-space(.)"/>
 
         <xsl:if test="@uom">
-          &#160;<xsl:value-of select="@uom"/>
+          <!-- Display the unit value only -->
+          &#160; <xsl:value-of select="tokenize(@uom, '#')[2]"/>
         </xsl:if>
       </xsl:otherwise>
     </xsl:choose>

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
@@ -623,7 +623,9 @@
 
           <xsl:for-each select="gmd:distance/gco:Distance[. != '']">
             <resolutionDistance>
-              <xsl:value-of select="concat(., ' ', @uom)"/>
+              <xsl:value-of select="if (contains(@uom, '#'))
+                                    then concat(., ' ', tokenize(@uom, '#')[2])
+                                    else  concat(., ' ', @uom)"/>
             </resolutionDistance>
           </xsl:for-each>
         </xsl:for-each>


### PR DESCRIPTION
Test case:

1) Create an ISO19139 metadata and with the following content:

```
<gmd:spatialResolution>
    <gmd:MD_Resolution>
        <gmd:distance>
            <gco:Distance uom="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/uom/ML_gmxUom.xml#m">150</gco:Distance>
        </gmd:distance>
    </gmd:MD_Resolution>
</gmd:spatialResolution>
```

2) From the record view access the full view or to http://localhost:8080/geonetwork/srv/metadata/UUID

Without the change:

![uom-before](https://github.com/geonetwork/core-geonetwork/assets/1695003/bfda4140-79c6-4bc5-9843-668dcb87cd48)

With the change:

![uom-after](https://github.com/geonetwork/core-geonetwork/assets/1695003/e9867f2a-fc3b-42b5-99fd-bdf8bbf82699)



<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
