### PR TITLE
Record view / Don't add the associated resources in the metadata static page, this page doesn't include JS libs

### DIFF
--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
@@ -295,7 +295,8 @@
               </div>
             </section>
 
-            <xsl:if test="$sideRelated != ''">
+            <!-- Don't add the associated resources in the metadata static page, this page doesn't include JS libs -->
+            <xsl:if test="$sideRelated != '' and $root != 'html'">
               <section class="gn-md-side-associated">
                 <h2>
                   <i class="fa fa-fw fa-link"><xsl:comment select="'icon'"/></i>


### PR DESCRIPTION
Test:

1) Create an ISO19139 metadata and add a parent relationship to another metadata
2) Go to the static page: http://localhost:8080/geonetwork/srv/api/records/UUID

Without this change a panel is displayed, as relationships are loaded with JS code, and that page doesn't load the JS libraries.

```
Associated resources 

Not available
```

With the change this panel is not displayed.


3) Check in the metadata full view that the relationship it is displayed: http://localhost:8080/geonetwork/srv/ger/catalog.search#/metadata/UUID/formatters/xsl-view?root=div&view=advanced


# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation