### PR TITLE
Make logo size bigger and set it to fixed position regardless of web pages

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -298,8 +298,8 @@ a {
  * Logo in nav bar can't be big
  */
 .gn-logo {
-  max-height: 24px;
-  margin: -12px 0px 0px 0px;
+  max-height: 36px;
+  vertical-align: top;
   @media (max-width: @screen-md-max) {
     margin-top: -6px;
   }

--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -300,9 +300,7 @@ a {
 .gn-logo {
   max-height: 36px;
   vertical-align: top;
-  @media (max-width: @screen-md-max) {
-    margin-top: -6px;
-  }
+  margin: -3px 0px 0px 12px;
   @media (max-width: @screen-xs-max) {
     margin-top: 0;
   }

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_login_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_login_default.less
@@ -71,6 +71,13 @@
 
 }
 
+.gn-logo {
+  @media (max-width: @screen-md-max) {
+              margin-top: 6px;
+  }
+  margin-top: -8px;
+}
+
 @media (max-width: @grid-float-breakpoint) {
   .navbar-nav {
     margin: 0;

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_navbar_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_navbar_default.less
@@ -83,9 +83,6 @@
   }
   .gn-logo-link {
     padding: 10px 15px;
-    .gn-logo {
-      margin-top: -3px;
-    }
     .gn-name {
       margin-top: 5px;
       display: inline-block;

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_navbar_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_navbar_default.less
@@ -84,7 +84,7 @@
   .gn-logo-link {
     padding: 10px 15px;
     .gn-logo {
-      margin-top: -12px;
+      margin-top: -3px;
     }
     .gn-name {
       margin-top: 5px;


### PR DESCRIPTION
Logo in the left corner usually changes its vertical positioning dependent on which page youre on. This fixes it and as well increase logo size without making the headerbar bigger


# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

