### PR TITLE
Update es instructions to 8.11.3

### DIFF
--- a/es/README.md
+++ b/es/README.md
@@ -2,8 +2,7 @@
 
 ## Manual installation
 
-1. Download Elasticsearch (at least 7.6.2 for Geonetwork 4.0.x) from https://www.elastic.co/downloads/elasticsearch
-and copy to the ES module, e.g., es/elasticsearch-7.6.2
+1. Download Elasticsearch 8.11.3 from https://www.elastic.co/downloads/elasticsearch and copy to the ES module
  
 2. Start ES using:
 
@@ -35,13 +34,13 @@ and copy to the ES module, e.g., es/elasticsearch-7.6.2
 1. Use docker pull to download the image (you can check version in the :file:`pom.xml` file):
 
    ```
-   docker pull docker.elastic.co/elasticsearch/elasticsearch:7.6.2
+   docker pull docker.elastic.co/elasticsearch/elasticsearch:8.11.3
    ```
 
 2. Use docker run, leaving 9200 available:
 
    ```
-   docker run -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:7.6.2
+   docker run -p 9200:9200 -p 9300:9300 -e "discovery.type=single-node" docker.elastic.co/elasticsearch/elasticsearch:8.11.3
    ```
 
 3. Check that elasticsearch is running by visiting http://localhost:9200 in a browser

--- a/es/docker-compose.yml
+++ b/es/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3'
 
 services:
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch:7.6.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:8.11.3
     container_name: elasticsearch
     environment:
       - cluster.name=docker-cluster
@@ -18,7 +18,7 @@ services:
     ports:
       - "9200:9200"
   kibana:
-    image: docker.elastic.co/kibana/kibana:7.6.2
+    image: docker.elastic.co/kibana/kibana:8.11.3
     container_name: kibana
     ports:
       - "5601:5601"


### PR DESCRIPTION
I am presently unable to build and develop against the `main` branch; it appears https://github.com/geonetwork/core-geonetwork/pull/7599 has left some work remaining for build stability.

This is a small PR to update the es/README and docker-compose.yml to the same version employed by the root `pom.xml`.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

I am unable to verify this fix, it is best viewed as a step towards repairing build stability.