### PR TITLE
OpenID / Cleaning up cached tokens

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/bearer/UserInfoCache.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/bearer/UserInfoCache.java
@@ -1,8 +1,5 @@
 package org.fao.geonet.kernel.security.openidconnect.bearer;
 
-import org.springframework.security.oauth2.core.OAuth2AccessToken;
-
-import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 

--- a/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/bearer/UserInfoCache.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/bearer/UserInfoCache.java
@@ -1,5 +1,8 @@
 package org.fao.geonet.kernel.security.openidconnect.bearer;
 
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+
+import java.time.Instant;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -10,19 +13,13 @@ import java.util.Map;
  */
 public class UserInfoCache {
 
-    static Object lockobj = new Object();
+    static final Object lockobj = new Object();
     Map<String, UserInfoCacheItem> cache = new HashMap<>();
 
     public UserInfoCacheItem getItem(String accessKey) {
         synchronized (lockobj) {
-            if (!cache.containsKey(accessKey))
-                return null;
-            UserInfoCacheItem item = cache.get(accessKey);
-            if (item.isExpired()) {
-                cache.remove(accessKey);
-                return null;
-            }
-            return item;
+            cache.entrySet().removeIf(e -> e.getValue().isExpired());
+            return cache.get(accessKey);
         }
     }
 

--- a/core/src/test/java/org/fao/geonet/kernel/security/openidconnect/bearer/UserInfoCacheTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/security/openidconnect/bearer/UserInfoCacheTest.java
@@ -1,0 +1,32 @@
+package org.fao.geonet.kernel.security.openidconnect.bearer;
+
+import com.google.common.collect.Lists;
+import junit.framework.TestCase;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+import java.time.Instant;
+import java.util.Collections;
+
+public class UserInfoCacheTest extends TestCase {
+
+    private OAuth2User user1 = new DefaultOAuth2User(Lists.newArrayList(), Collections.singletonMap("name", "frank"), "name");
+    private OAuth2User user2 = new DefaultOAuth2User(Lists.newArrayList(), Collections.singletonMap("name", "jeff"), "name");
+
+    public void testCache() {
+        UserInfoCacheItem item1 = new UserInfoCacheItem("a", Instant.now().plusSeconds(1000), user1, Lists.newArrayList());
+        UserInfoCacheItem item2 = new UserInfoCacheItem("b", Instant.now().plusSeconds(1000), user2, Lists.newArrayList());
+        UserInfoCacheItem item3 = new UserInfoCacheItem("c", Instant.now().minusSeconds(1000), user2, Lists.newArrayList());
+
+        UserInfoCache cache = new UserInfoCache();
+        cache.putItem(item1);
+        cache.putItem(item2);
+        cache.putItem(item3);
+
+        assertEquals(3, cache.cache.size());
+        assertEquals(item1, cache.getItem("a"));
+        assertEquals(item2, cache.getItem("b"));
+        assertNull(cache.getItem("c"));
+        assertEquals(2, cache.cache.size());
+    }
+}

--- a/core/src/test/java/org/fao/geonet/kernel/security/openidconnect/bearer/UserInfoCacheTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/security/openidconnect/bearer/UserInfoCacheTest.java
@@ -1,3 +1,25 @@
+/*
+ * Copyright (C) 2022 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
 package org.fao.geonet.kernel.security.openidconnect.bearer;
 
 import com.google.common.collect.Lists;


### PR DESCRIPTION
Cached tokens were only cleaned up when they were requested once more. Expired tokens that were not requested again remained in the cache indefinitely. @fxprunayre 
 
# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

