### PR TITLE
Record view / Add service type info and metadata standard name

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
@@ -926,14 +926,10 @@
               </inspireServiceType>
             </xsl:if>
           </xsl:if>
-          <xsl:if test="following-sibling::srv:serviceTypeVersion">
-            <serviceTypeAndVersion>
-              <xsl:value-of select="concat(
-                        text(),
-                        $separator,
-                        following-sibling::srv:serviceTypeVersion/gco:CharacterString/text())"/>
-            </serviceTypeAndVersion>
-          </xsl:if>
+        </xsl:for-each>
+
+        <xsl:for-each select="srv:serviceTypeVersion">
+          <serviceTypeVersion><xsl:value-of select="gco:CharacterString/text()"/></serviceTypeVersion>
         </xsl:for-each>
       </xsl:for-each>
 

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
@@ -872,14 +872,10 @@
               </inspireServiceType>
             </xsl:if>
           </xsl:if>
-          <xsl:if test="following-sibling::srv:serviceTypeVersion">
-            <serviceTypeAndVersion>
-              <xsl:value-of select="concat(
-                        text(),
-                        $separator,
-                        following-sibling::srv:serviceTypeVersion/gco:CharacterString/text())"/>
-            </serviceTypeAndVersion>
-          </xsl:if>
+        </xsl:for-each>
+
+        <xsl:for-each select="srv:serviceTypeVersion">
+          <serviceTypeVersion><xsl:value-of select="gco:CharacterString/text()"/></serviceTypeVersion>
         </xsl:for-each>
       </xsl:for-each>
 

--- a/web-ui/src/main/resources/catalog/locales/en-core.json
+++ b/web-ui/src/main/resources/catalog/locales/en-core.json
@@ -87,6 +87,7 @@
     "chi": "中文",
     "city": "City",
     "cl_status": "Status",
+    "cl_couplingType": "Coupling type",
     "associatedResources": "Associated resources",
     "brothersAndSisters": "Siblings",
     "moreInfoOnRecord": " more ...",

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/metadata.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/metadata.html
@@ -25,6 +25,22 @@
   </div>
 </div>
 
+
+<div data-ng-if="mdView.current.record.standardName"
+     class="gn-margin-bottom flex-row">
+  <span class="badge badge-rounded" title="{{'documentStandard' | translate}}">
+    <i class="fa fa-fw fa-certificate"></i>
+  </span>
+  <div>
+    <h3 data-translate="">documentStandard</h3>
+    <p>
+      {{mdView.current.record.standardName}}
+      <span data-ng-if="mdView.current.record.standardVersion"> ({{mdView.current.record.standardVersion}})</span>
+    </p>
+  </div>
+</div>
+
+
 <div class="gn-margin-bottom">
   <span class="badge badge-rounded" title="{{'sourceCatalog' | translate}}">
     <i class="fa fa-fw fa-cloud"></i>

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/technical.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/technical.html
@@ -22,6 +22,34 @@
     </ul>
   </section>
 
+  <div data-ng-if="mdView.current.record.serviceType" class="gn-margin-bottom flex-row">
+    <span class="badge badge-rounded" title="{{'serviceType' | translate}}">
+      <i class="fa fa-fw fa-cloud"></i>
+    </span>
+    <div>
+      <h3 data-translate="">serviceType</h3>
+      <p>
+        {{mdView.current.record.serviceType}}
+        <span data-ng-if="mdView.current.record.serviceTypeVersion">
+          ({{mdView.current.record.serviceTypeVersion}})</span
+        >
+      </p>
+    </div>
+  </div>
+
+  <div
+    data-ng-if="mdView.current.record.cl_couplingType"
+    class="gn-margin-bottom flex-row"
+  >
+    <span class="badge badge-rounded" title="{{'cl_couplingType' | translate}}">
+      <i class="fa fa-fw fa-cloud"></i>
+    </span>
+    <div data-ng-if="mdView.current.record.cl_couplingType">
+      <h3 data-translate="">cl_couplingType</h3>
+      <p data-ng-repeat="c in mdView.current.record.cl_couplingType">{{c.default}}</p>
+    </div>
+  </div>
+
   <div
     data-ng-if="mdView.current.record.cl_maintenanceAndUpdateFrequency.length > 0"
     class="gn-margin-bottom flex-row"


### PR DESCRIPTION
For services, service type (version if available) and coupling type are added:

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/dc444444-ea45-4c0c-88d8-f357db601fef)


And metadata standard name (and version if available):

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/6a38372e-f645-4049-9200-01cd569202fe)



Also fix indexing of `srv:serviceTypeVersion`

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

