### PR TITLE
[Backport 4.2.x] Bump actions/setup-java from 4.0.0 to 4.1.0

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,7 +43,7 @@ jobs:
         show-progress: 'false'
 
     - name: Setup Java JDK
-      uses: actions/setup-java@v4.0.0
+      uses: actions/setup-java@v4.1.0
       with:
         java-version: 8
         # Java distribution. See the list of supported distributions in README file

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -22,7 +22,7 @@ jobs:
         submodules: 'recursive'
         show-progress: 'false'
     - name: Set up JDK
-      uses: actions/setup-java@v4.0.0
+      uses: actions/setup-java@v4.1.0
       with:
         distribution: 'temurin'
         java-version: ${{ matrix.jdk }}
@@ -55,7 +55,7 @@ jobs:
         submodules: 'recursive'
         show-progress: 'false'
     - name: Set up JDK
-      uses: actions/setup-java@v4.0.0
+      uses: actions/setup-java@v4.1.0
       with:
         distribution: 'temurin'
         java-version: 8

--- a/.github/workflows/mvn-dep-tree.yml
+++ b/.github/workflows/mvn-dep-tree.yml
@@ -20,7 +20,7 @@ jobs:
           show-progress: 'false'
 
       - name: Setup Java JDK
-        uses: actions/setup-java@v4.0.0
+        uses: actions/setup-java@v4.1.0
         with:
           java-version: 8
           # Java distribution. See the list of supported distributions in README file

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -24,7 +24,7 @@ jobs:
       # So, first install JDK 8, build GeoNetwork, then install JDK21
       # and run SonarQube:
       - name: Set up JDK 8
-        uses: actions/setup-java@v4.0.0
+        uses: actions/setup-java@v4.1.0
         with:
           java-version: 8
           distribution: 'temurin'
@@ -39,7 +39,7 @@ jobs:
         run: mvn -B package -DskipTests
 
       - name: Set up JDK 21 # Sonarcloud analyzer needs at least JDK 17
-        uses: actions/setup-java@v4.0.0
+        uses: actions/setup-java@v4.1.0
         with:
           distribution: 'temurin'
           java-version: '21'


### PR DESCRIPTION
Backport of #7808.
Bumps [actions/setup-java](https://github.com/actions/setup-java) from 4.0.0 to 4.1.0.
- [Release notes](https://github.com/actions/setup-java/releases)
- [Commits](https://github.com/actions/setup-java/compare/v4.0.0...v4.1.0)

---
updated-dependencies:
- dependency-name: actions/setup-java dependency-type: direct:production update-type: version-update:semver-minor ...

