### PR TITLE
[Backport 3.12.x] Bump actions/setup-java from 4.0.0 to 4.1.0

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -22,7 +22,7 @@ jobs:
         submodules: 'recursive'
         show-progress: 'false'
     - name: Set up JDK
-      uses: actions/setup-java@v4.0.0
+      uses: actions/setup-java@v4.1.0
       with:
         distribution: 'temurin'
         java-version: ${{ matrix.jdk }}
@@ -55,7 +55,7 @@ jobs:
         submodules: 'recursive'
         show-progress: 'false'
     - name: Set up JDK
-      uses: actions/setup-java@v4.0.0
+      uses: actions/setup-java@v4.1.0
       with:
         distribution: 'temurin'
         java-version: 8


### PR DESCRIPTION
    Backport of #7808.
    Bumps [actions/setup-java](https://github.com/actions/setup-java) from 4.0.0 to 4.1.0.
    - [Release notes](https://github.com/actions/setup-java/releases)
    - [Commits](https://github.com/actions/setup-java/compare/v4.0.0...v4.1.0)

    ---
    updated-dependencies:
    - dependency-name: actions/setup-java
      dependency-type: direct:production
      update-type: version-update:semver-minor
    ...

    Signed-off-by: dependabot[bot] <support@github.com>
    Co-authored-by: dependabot[bot] <49699333+dependabot[bot]@users.noreply.github.com>