### PR TITLE
Editor / Distribution improvements - Update configuration for ISO19139 distributions as protocols are not categorized as ISO19115-3 protocols.

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/config/associated-panel/default.json
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/config/associated-panel/default.json
@@ -335,7 +335,7 @@
             "isMultilingual": false
           },
           "protocol": {
-            "value": "WWW:LINK",
+            "value": "WWW:DOWNLOAD",
             "hidden": true,
             "isMultilingual": false
           },

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
@@ -3218,11 +3218,11 @@
                                          {
                                            title: 'download',
                                            filter: 'protocol:.*DOWNLOAD.*|DB:.*|FILE:.*',
-                                           editActions: ['addOnlinesrc']},
+                                           editActions: []},
                                          {
                                             title: 'links',
                                             filter:'-protocol:OGC:.*|ESRI:.*|atom.*|.*DOWNLOAD.*|DB:.*|FILE:.* AND -function:legend|featureCatalogue|dataQualityReport',
-                                            editActions: ['addOnlinesrc']}]"
+                                            editActions: []}]"
         />
 
         <directive data-gn-onlinesrc-list=""


### PR DESCRIPTION
Follow up of #7468

With the previous pull request, the distributions can be classified in the metadata editor. That works fine in ISO19115-3 where protocols are categorized and the dialog to add a resource for each group only displays the related protocols (user can't specify the protocol, but select a category). 

But ISO19139 is not ready with that changes. When adding an online resource from each section, the resource can end in a different one depending on the protocol selected:

![iso19139-editor-distributions-1](https://github.com/geonetwork/core-geonetwork/assets/1695003/4049c402-c222-4723-895a-7db1bd53ff22)

To avoid confusion and simplify, only 1 button to add online resources is provided with this  pull request, instead of 1 per section. Depending on the protocol selected the resource is displayed in the related section:

![iso19139-editor-distributions-2](https://github.com/geonetwork/core-geonetwork/assets/1695003/3953e765-f432-4c28-8adc-951bf13b870e)


--- 

We should evaluate to change the protocol management in ISO19139 as done in ISO19115-3 in another pull request.

---

Includes non related fix: Fix download protocol value in iso19115-3.2018 editor configuration

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation