### PR TITLE
Add UI setting to enable / disable the metadata panel in the home page

### DIFF
--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
@@ -802,7 +802,7 @@
                 <!-- boolean -->
                 <div
                   class="row"
-                  data-ng-switch-when="is3DModeAllowed|isVegaEnabled|isSaveMapInCatalogAllowed|isAccessible|isExportMapAsImageEnabled|useOSM|isUserRecordsOnly|isFilterTagsDisplayed|isFilterTagsDisplayedInSearch|autoFitOnLayer|showSocialBarInFooter|isSocialbarEnabled|isLogoInHeader|isHeaderFixed|fluidLayout|fluidHeaderLayout|fluidEditorLayout|showGNName|humanizeDates|sortKeywordsAlphabetically|showMosaic|showMaps|showApplicationInfoAndLinksInFooter|showBatchDropdown|moreLikeThisSameType|allowRemoteRecordLink|singleTileWMS"
+                  data-ng-switch-when="is3DModeAllowed|isVegaEnabled|isSaveMapInCatalogAllowed|isAccessible|isExportMapAsImageEnabled|useOSM|isUserRecordsOnly|isFilterTagsDisplayed|isFilterTagsDisplayedInSearch|autoFitOnLayer|showSocialBarInFooter|isSocialbarEnabled|isLogoInHeader|isHeaderFixed|fluidLayout|fluidHeaderLayout|fluidEditorLayout|showGNName|humanizeDates|sortKeywordsAlphabetically|showMosaic|showMetadataPanel|showMaps|showApplicationInfoAndLinksInFooter|showBatchDropdown|moreLikeThisSameType|allowRemoteRecordLink|singleTileWMS"
                   data-ng-switch-when-separator="|"
                 >
                   <div class="col-lg-5 gn-nopadding-left">

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -129,6 +129,7 @@
             appUrl: "../../{{node}}/{{lang}}/catalog.search#/home",
             showSocialBarInFooter: true,
             showMosaic: true,
+            showMetadataPanel: true,
             showMaps: true,
             facetConfig: {
               "th_httpinspireeceuropaeutheme-theme_tree.key": {

--- a/web-ui/src/main/resources/catalog/locales/en-v4.json
+++ b/web-ui/src/main/resources/catalog/locales/en-v4.json
@@ -359,6 +359,7 @@
   "harvesterConfigIsNotValid": "The harvester config does not look to be a valid configuration.",
   "specificationConformance": "Specification conformance",
   "toggleOptions": "Toggle filter options (open or close filter tree)",
+  "ui-showMetadataPanel": "Show latest and most popular metadata in home page",
   "ui-showMosaic": "Show overview mosaic in home page",
   "ui-showMaps": "Show latest maps in home page",
   "ui-queryBaseOptions": "Search query options",

--- a/web-ui/src/main/resources/catalog/views/default/module.js
+++ b/web-ui/src/main/resources/catalog/views/default/module.js
@@ -203,6 +203,7 @@
       $scope.modelOptions = angular.copy(gnGlobalSettings.modelOptions);
       $scope.modelOptionsForm = angular.copy(gnGlobalSettings.modelOptions);
       $scope.showMosaic = gnGlobalSettings.gnCfg.mods.home.showMosaic;
+      $scope.showMetadataPanel = gnGlobalSettings.gnCfg.mods.home.showMetadataPanel;
       $scope.isFilterTagsDisplayedInSearch =
         gnGlobalSettings.gnCfg.mods.search.isFilterTagsDisplayedInSearch;
       $scope.searchMapPlacement = gnGlobalSettings.gnCfg.mods.search.searchMapPlacement;

--- a/web-ui/src/main/resources/catalog/views/default/templates/home.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/home.html
@@ -167,6 +167,7 @@
 
 <div
   class="row gn-row-info"
+  data-ng-if="showMetadataPanel || (isUserSearchesEnabled && displayFeaturedSearchesPanel) || isUserFeedbackEnabled"
   data-ng-show="searchInfo.hits.total.value > 0"
   data-ng-class="{'gn-info-list-blocks': type === 'blocks' || type === undefined, 'gn-info-list-large': type === 'large', 'gn-info-list-small': type === 'small'}"
 >
@@ -214,7 +215,11 @@
       </div>
 
       <tabset id="info-tabset" type="pills" justified="false" role="tablist">
-        <tab heading="{{'lastRecords' | translate}}" active="infoTabs.lastRecords.active">
+        <tab
+          heading="{{'lastRecords' | translate}}"
+          data-ng-if="showMetadataPanel"
+          active="infoTabs.lastRecords.active"
+        >
           <form
             class="form-horizontal"
             data-ng-controller="gnsSearchLatestController"
@@ -229,6 +234,7 @@
         </tab>
         <tab
           heading="{{'preferredRecords' | translate}}"
+          data-ng-if="showMetadataPanel"
           active="infoTabs.preferredRecords.active"
         >
           <form


### PR DESCRIPTION
Add a new UI setting to display in the home page the latest and most popular metadata panel:

![ui-setting](https://github.com/geonetwork/core-geonetwork/assets/1695003/bf367c00-4080-44e5-b1d2-0b9228ed4038)

By default is enabled, working as previously:

![ui-setting-enabled](https://github.com/geonetwork/core-geonetwork/assets/1695003/a055125e-8787-48bc-a178-11b51f73a2c2)


When disabled:

![ui-setting-disabled](https://github.com/geonetwork/core-geonetwork/assets/1695003/651af15c-bd37-4dcd-b80d-3fa3b020b113)


# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
