### PR TITLE
Fix startup error. Follow up #7456

### DIFF
--- a/web/src/main/java/org/fao/geonet/proxy/URITemplateProxyServlet.java
+++ b/web/src/main/java/org/fao/geonet/proxy/URITemplateProxyServlet.java
@@ -175,7 +175,7 @@ public class URITemplateProxyServlet extends ProxyServlet {
         // If not set externally try to use the value from web.xml
         if (StringUtils.isBlank(targetUriTemplate)) {
             targetUriTemplate = getConfigParam(P_TARGET_URI);
-            if (StringUtils.isBlank(targetUriTemplate)) {
+            if (targetUriTemplate == null) {
                 throw new ServletException(P_TARGET_URI + "  is required in web.xml or set externally");
             }
         }


### PR DESCRIPTION
Follow up of #7456. Fix startup error:


```
javax.servlet.ServletException: targetUri  is required in web.xml or set externally
    at org.fao.geonet.proxy.URITemplateProxyServlet.initTarget (URITemplateProxyServlet.java:179)
    at org.mitre.dsmiley.httpproxy.ProxyServlet.init (ProxyServlet.java:220)
```

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
