### PR TITLE
Send email notification after workflow events have been processed

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/metadata/DefaultStatusActions.java
+++ b/core/src/main/java/org/fao/geonet/kernel/metadata/DefaultStatusActions.java
@@ -181,15 +181,6 @@ public class DefaultStatusActions implements StatusActions {
             // we know we are allowed to do the change, apply any side effects
             boolean deleted = applyStatusChange(status.getMetadataId(), status, statusId);
 
-            // inform content reviewers if the status is submitted
-            try {
-                notify(getUserToNotify(status), status);
-            } catch (Exception e) {
-                context.warning(String.format(
-                    "Failed to send notification on status change for metadata %s with status %s. Error is: %s",
-                    status.getMetadataId(), status.getStatusValue().getId(), e.getMessage()));
-            }
-
             if (deleted) {
                 results.put(status.getMetadataId(), StatusChangeType.DELETED);
             } else {
@@ -206,6 +197,15 @@ public class DefaultStatusActions implements StatusActions {
                         status.getUserId()
                     ));
                 }
+            }
+
+            // inform content reviewers if the status is submitted
+            try {
+                notify(getUserToNotify(status), status);
+            } catch (Exception e) {
+                context.warning(String.format(
+                    "Failed to send notification on status change for metadata %s with status %s. Error is: %s",
+                    status.getMetadataId(), status.getStatusValue().getId(), e.getMessage()));
             }
 
         }


### PR DESCRIPTION
There is little issue in the current workflow status change. The email notification was sent in the middle of transaction before the  event publishing 

https://github.com/geonetwork/core-geonetwork/blob/d7d36bfb4163b5432dfdf6bfb1fa77b86bb18da0/core/src/main/java/org/fao/geonet/kernel/metadata/DefaultStatusActions.java#L185-L191

We have some customized code using the event publishing feature to throw some customized exception.

https://github.com/geonetwork/core-geonetwork/blob/d7d36bfb4163b5432dfdf6bfb1fa77b86bb18da0/core/src/main/java/org/fao/geonet/kernel/metadata/DefaultStatusActions.java#L203

The result is if there is exception been thrown. The user will get error dialog box. But the notification email stating status change will still been sent which confused the user.

Here is how you can test the code.

1) Enable Workflow
2) Setup proper email server
3) Place this code into this class https://github.com/geonetwork/core-geonetwork/blob/main/listeners/src/main/java/org/fao/geonet/listener/metadata/draft/ApproveRecord.java
````
@EventListener
    protected void handleMetadataChange(MetadataStatusChanged event){
        StatusValue status = event.getStatus();

        throw new NotAllowedException()
            .withMessageKey("test exception");

    }
````

![image](https://github.com/geonetwork/core-geonetwork/assets/74916635/9fa6310f-9b9b-4923-a015-2f01d0a5b8da)


4) Error message will show up but there wont be any email sent.
![image](https://github.com/geonetwork/core-geonetwork/assets/74916635/5904232f-1bea-450c-898c-c5c035b008d4)


