### PR TITLE
Enforce development environment instructions to Elasticsearch  8.11.3

### DIFF
--- a/docker/README.md
+++ b/docker/README.md
@@ -1,0 +1,3 @@
+# Docker Test Environments
+
+These docker images are intended for development and debugging. For production we recommend the official geonetwork docker images at https://github.com/geonetwork/docker-geonetwork.git repository.

--- a/docker/README.md
+++ b/docker/README.md
@@ -1,3 +1,3 @@
 # Docker Test Environments
 
-These docker images are intended for development and debugging. For production we recommend the official geonetwork docker images at https://github.com/geonetwork/docker-geonetwork.git repository.
+These docker images are intended for development and debugging. For production we recommend the official GeoNetwork docker images at https://github.com/geonetwork/docker-geonetwork.git repository.

--- a/docker/docker-geonetwork.txt
+++ b/docker/docker-geonetwork.txt
@@ -1,1 +1,0 @@
-Please see https://github.com/geonetwork/docker-geonetwork.git.

--- a/docker/gn-cas-ldap/README.md
+++ b/docker/gn-cas-ldap/README.md
@@ -6,7 +6,7 @@ GeoNetwork easier.
 This composition also integrates a LDAP, so that testing the
 config-spring-cas-ldap configuration is also possible.
 
-These docker images are intended for development and debugging. For production we recommend the official geonetwork docker images at https://github.com/geonetwork/docker-geonetwork.git repository.
+These docker images are intended for development and debugging. For production we recommend the official GeoNetwork docker images at https://github.com/geonetwork/docker-geonetwork.git repository.
 
 # Prerequisites
 

--- a/docker/gn-cas-ldap/README.md
+++ b/docker/gn-cas-ldap/README.md
@@ -1,10 +1,12 @@
-# Introduction
+# GeoNetwork CAS Test Environment
 
 This composition is meant to make runtime testing the CAS integration of
 GeoNetwork easier.
 
 This composition also integrates a LDAP, so that testing the
 config-spring-cas-ldap configuration is also possible.
+
+These docker images are intended for development and debugging. For production we recommend the official geonetwork docker images at https://github.com/geonetwork/docker-geonetwork.git repository.
 
 # Prerequisites
 
@@ -18,7 +20,6 @@ Then it can be launched:
 
 ```
 $ docker-compose up
-
 ```
 
 # Accessing the CAS login page from GeoNetwork

--- a/docker/gn-postgres/README.md
+++ b/docker/gn-postgres/README.md
@@ -1,0 +1,8 @@
+# GeoNetwork PostgreSQL Test Environment
+
+This composition is meant to make runtime testing the PostgreSQL integration of
+GeoNetwork easier.
+
+This folder provides a ``docker-compose.yml`` file for local testing.
+
+These docker images are intended for development and debugging. For production we recommend the official geonetwork docker images at https://github.com/geonetwork/docker-geonetwork.git repository.

--- a/docker/gn-postgres/README.md
+++ b/docker/gn-postgres/README.md
@@ -5,4 +5,4 @@ GeoNetwork easier.
 
 This folder provides a ``docker-compose.yml`` file for local testing.
 
-These docker images are intended for development and debugging. For production we recommend the official geonetwork docker images at https://github.com/geonetwork/docker-geonetwork.git repository.
+These docker images are intended for development and debugging. For production we recommend the official GeoNetwork docker images at https://github.com/geonetwork/docker-geonetwork.git repository.

--- a/docker/gn-postgres/docker-compose.yml
+++ b/docker/gn-postgres/docker-compose.yml
@@ -4,7 +4,7 @@ volumes:
 
 services:
   geonetwork:
-    image: geonetwork:3.99.0
+    image: geonetwork:latest
     restart: always
     ports:
       - 8080:8080

--- a/docker/gn-postgres/kibana/kibana.txt
+++ b/docker/gn-postgres/kibana/kibana.txt
@@ -1,0 +1,5 @@
+server.basePath: "/geonetwork/dashboards"
+server.rewriteBasePath: false
+kibana.index: ".dashboards"
+elasticsearch.hosts: ["http://elasticsearch:9200"]
+

--- a/es/README.md
+++ b/es/README.md
@@ -168,3 +168,22 @@ field expansion for [*] matches too many fields, limit: 1024
 An option is to restrict `queryBase` to limit the number of field to query on. `any:(${any}) resourceTitleObject.default:(${any})^2` is a good default. Using `${any}` will probably trigger the error if the number of records is high.
 
 The other option is to increase `indices.query.bool.max_clause_count`.
+
+
+## Disk space threshold
+
+The server application will refuse to write new content unless there is enough free space available (by default 1/4 of your hard drive).
+
+To turn off this check:
+
+```
+ curl -XPUT http://localhost:9200/_cluster/settings -H 'Content-Type: application/json' -d '{ "transient" : { "cluster.routing.allocation.disk.threshold_enabled" : false } }' 
+```
+
+## Blocked by index read-only / allow delete
+
+To recover:
+
+```
+curl -XPUT -H "Content-Type: application/json" http://localhost:9200/_all/_settings -d '{"index.blocks.read_only_allow_delete": null}'
+```

--- a/es/README.md
+++ b/es/README.md
@@ -1,50 +1,12 @@
 # Install, configure and start Elasticsearch
 
+## Installation options
+
 This section describes several methods for configuring Elasticsearch for development.
 
 These configurations should not be used for a production deployment.
 
-## Manual installation
-
-1. Download Elasticsearch 8.x (tested with 8.11.3 for Geonetwork 4.4.x) from https://www.elastic.co/downloads/elasticsearch
-and copy to the ES module, e.g., es/elasticsearch-8.11.3
-
-2. Disable the security
-
-Elasticsearch 8 has security enabled by default. To disable this configuration for development, update the file `config/elasticsearch.yml` adding at the end:
-
-```
-xpack.security.enabled: false
-xpack.security.enrollment.enabled: false
-```
-
-
-3. Start ES using:
-
-   ```shell script
-   ./bin/elasticsearch
-   ```
-
-4. Check that elasticsearch is running by visiting http://localhost:9200 in a browser
-
-## Maven installation
-
-1. Maven can take care of the installation steps:
-
-   * download
-   * initialize collection
-   * start
-
-2. Use the following commands:
-
-   ```shell script
-   cd es
-   mvn install -Pes-download
-   mvn exec:exec -Des-start
-   ```
-3. Check that elasticsearch is running by visiting http://localhost:9200 in a browser
-
-## Docker installation
+### Docker installation (Recommended)
 
 1. Use docker pull to download the image (you can check version in the :file:`pom.xml` file):
 
@@ -64,7 +26,7 @@ xpack.security.enrollment.enabled: false
 
 3. Check that elasticsearch is running by visiting http://localhost:9200 in a browser
 
-## Docker compose installation
+### Docker compose installation
 
 1. Use docker compose with the provided [docker-compose.yml](docker-compose.yml):
 
@@ -78,7 +40,50 @@ xpack.security.enrollment.enabled: false
    * Elasticsearch: http://localhost:9200
    * Kibana: http://localhost:5601
 
+### Maven installation
+
+Maven installation ensure you always are using the ``es.version`` version specified in ``pom.xml``.
+
+1. Maven can take care of the installation steps:
+
+   * download
+   * initialize collection
+   * start
+
+2. Use the following commands:
+
+   ```shell script
+   cd es
+   mvn install -Pes-download
+   mvn exec:exec -Des-start
+   ```
+3. Check that elasticsearch is running by visiting http://localhost:9200 in a browser
+
+## Manual installation
+
+1. Download Elasticsearch 8.11.3 from https://www.elastic.co/downloads/elasticsearch
+and copy to the ES module, e.g., ``es/elasticsearch-8.11.3`
+
+2. Disable the security
+
+   Elasticsearch 8 has security enabled by default. To disable this configuration for development, update the file `config/elasticsearch.yml` adding at the end:
+
+   ```
+   xpack.security.enabled: false
+   xpack.security.enrollment.enabled: false
+   ```
+
+3. Start ES using:
+
+   ```shell script
+   ./bin/elasticsearch
+   ```
+
+4. Check that elasticsearch is running by visiting http://localhost:9200 in a browser
+
 # Configuration
+
+## Index management
 
 Optionally you can manually create index but they will be created by the catalogue when 
 the Elastic instance is available and if index does not exist.
@@ -122,7 +127,7 @@ Don't hesitate to propose a Pull Request with the new language.
 
 1. Configure ES to start on server startup. It is recommended to protect `gn-records` index from the Internet access.
 
-   * Note that for debian-based servers the current deb download (7.3.2) can be installed rather than installing manually and can be configured to run as a service using the instructions here: https://www.elastic.co/guide/en/elasticsearch/reference/current/starting-elasticsearch.html
+   * Note that for debian-based servers the current deb download (8.11.3) can be installed rather than installing manually and can be configured to run as a service using the instructions here: https://www.elastic.co/guide/en/elasticsearch/reference/current/starting-elasticsearch.html
 
 
 # Troubleshoot

--- a/es/es-dashboards/README.md
+++ b/es/es-dashboards/README.md
@@ -2,7 +2,7 @@
 
 ## Installation options
 
-### Docker compose installation (Recomemnded)
+### Docker compose installation (Recommended)
 
 1. Use docker compose with the provided [docker-compose.yml](es/docker-compose.yml):
 

--- a/es/es-dashboards/README.md
+++ b/es/es-dashboards/README.md
@@ -1,24 +1,20 @@
 # Install, configure and start Kibana
 
-## Manual installation
+## Installation options
 
-Download Kibana from https://www.elastic.co/downloads/kibana. For Geonetwork 3.8.x download at least version 7.2.1
+### Docker compose installation (Recomemnded)
 
-Set Kibana base path and index name in config/kibana.yml:
+1. Use docker compose with the provided [docker-compose.yml](es/docker-compose.yml):
 
-```
-server.basePath: "/geonetwork/dashboards"
-server.rewriteBasePath: false
-```
+   ```
+   cd es
+   docker-compose up
+   ```
 
-Adapt if needed ```elasticsearch.url``` and ```server.host```.
-
-Start Kibana manually:
-
-```
-cd kibana/bin
-./kibana
-```
+3. Check that it is running using your browser:
+   
+   * Elasticsearch: http://localhost:9200
+   * Kabana: http://localhost:5601
 
 ## Maven installation
 
@@ -41,20 +37,26 @@ cd kibana/bin
    mvn exec:exec -Dkb-start
    ```
 
-## Docker compose installation
+## Manual installation
 
-1. Use docer compose with the provided [docker-compose.yml](docker-compose.yml):
+1. Download Kibana 8.11.3 from https://www.elastic.co/downloads/kibana
+
+2. Set Kibana base path and index name in config/kibana.yml:
 
    ```
-   cd es
-   docker-compose up
+   server.basePath: "/geonetwork/dashboards"
+   server.rewriteBasePath: false
    ```
 
-3. Check that it is running using your browser:
-   
-   * Elasticsearch: http://localhost:9200
-   * Kabana: http://localhost:5601
-   
+3. Adapt if needed ```elasticsearch.url``` and ```server.host```.
+
+4. Start Kibana manually:
+
+   ```
+   cd kibana/bin
+   ./kibana
+   ```
+
 ## Import Configuration
 
 1. Kibana should be running from:
@@ -69,16 +71,17 @@ cd kibana/bin
    http://localhost:8080/geonetwork/dashboards
    ```
 
+
 ## Troubleshoot
 
 If it does not start properly, check Kibana log files (eg. it may fail if Elasticsearch version
 is not compatible with Kibana version).
 
-Visit Kibana in a browser using one of the above links and go to 'Saved Objects'. Import export.ndjson from https://github.com/geonetwork/core-geonetwork/blob/4.0.x/es/es-dashboards/data/export.ndjson
+Visit Kibana in a browser using one of the above links and go to 'Saved Objects'. Import export.ndjson from https://github.com/geonetwork/core-geonetwork/blob/main/es/es-dashboards/data/export.ndjson
 
 ### Production Use
 
-Kibana can be installed from the debian files, and 7.3.2 is confirmed as working with Geonetwork 3.8.x.
+Kibana can be installed from the debian files, and Kibana 8.11.3 is confirmed as working with Geonetwork 4.4.x.
 
 Set Kibana to start when the server starts up, using the instructions at https://www.elastic.co/guide/en/kibana/current/start-stop.html
 

--- a/es/es-dashboards/pom.xml
+++ b/es/es-dashboards/pom.xml
@@ -24,12 +24,74 @@
   <modelVersion>4.0.0</modelVersion>
   <artifactId>gn-es-dashboards</artifactId>
   <name>GeoNetwork dashboard app based on Kibana</name>
-
   <parent>
     <artifactId>gn-es</artifactId>
     <groupId>org.geonetwork-opensource</groupId>
     <version>4.4.4-SNAPSHOT</version>
   </parent>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>check-readme</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration combine.self="override">
+              <rules>
+                <evaluateBeanshell>
+                  <message>Update README.md examples for Elasticsearch ${es.version}</message>
+                  <condition>
+                      import java.util.regex.Pattern;
+
+                      esVersion = "${es.version}";
+                      print("Scanning README for " + esVersion);
+
+                      docker = Pattern.compile("Kibana (\\d.\\d\\d.\\d)");
+                      download = Pattern.compile("Download Kibana (\\d.\\d\\d.\\d)");
+
+                      patterns = new Pattern[]{ docker, download};
+
+                      readme = new BufferedReader(new FileReader("README.md"));
+
+                      number = 0;
+                      while ((line = readme.readLine()) != null) {
+                        number++;
+                        for (pattern : patterns ){
+                          matcher = pattern.matcher(line);
+                          if (matcher.find()) {
+                            if (!esVersion.equals(matcher.group(1))) {
+                              print("README.md:"+number+" FAILURE: " + line);
+                              return false;
+                            }
+                          }
+                        }
+                      }
+                      readme.close();
+                    true;
+                  </condition>
+                </evaluateBeanshell>
+              </rules>
+            </configuration>
+          </execution>
+          <execution>
+            <id>check-docker</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration combine.self="override">
+              <skip>true</skip>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>kb-download</id>

--- a/es/pom.xml
+++ b/es/pom.xml
@@ -81,7 +81,7 @@
                         kibana = Pattern.compile("kibana:(\\d.\\d\\d.\\d)");
                         patterns = new Pattern[]{ docker, kibana};
 
-                        reader = new BufferedReader(new FileReader(filename));
+                        reader = new BufferedReader(new FileReader("${project.basedir}"+"/"+filename));
 
                         number = 0;
                         while ((line = reader.readLine()) != null) {

--- a/es/pom.xml
+++ b/es/pom.xml
@@ -12,6 +12,105 @@
   <name>GeoNetwork index using Elasticsearch</name>
   <packaging>pom</packaging>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-enforcer-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>check-readme</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <evaluateBeanshell>
+                  <message>Update README.md examples for Elasticsearch ${es.version}</message>
+                  <condition>
+                      import java.util.regex.Pattern;
+
+                      esVersion = "${es.version}";
+                      print("Scanning README for " + esVersion);
+
+                      docker = Pattern.compile("elasticsearch:(\\d.\\d\\d.\\d)");
+                      download = Pattern.compile("Download Elasticsearch (\\d.\\d\\d.\\d)");
+                      folder = Pattern.compile("es/elasticsearch-(\\d.\\d\\d.\\d)");
+
+                      patterns = new Pattern[]{ docker, download, folder};
+
+                      readme = new BufferedReader(new FileReader("README.md"));
+
+                      number = 0;
+                      while ((line = readme.readLine()) != null) {
+                        number++;
+                        for (pattern : patterns ){
+                          matcher = pattern.matcher(line);
+                          if (matcher.find()) {
+                            if (!esVersion.equals(matcher.group(1))) {
+                              print("README.md:"+number+" FAILURE: " + line);
+                              return false;
+                            }
+                          }
+                        }
+                      }
+                      readme.close();
+                    true;
+                  </condition>
+                </evaluateBeanshell>
+              </rules>
+            </configuration>
+          </execution>
+          <execution>
+            <id>check-docker</id>
+            <goals>
+              <goal>enforce</goal>
+            </goals>
+            <configuration>
+              <rules>
+                <evaluateBeanshell>
+                  <message>Update docker-compose.yml for Elasticsearch ${es.version}</message>
+                  <condition>
+                      import java.util.regex.Pattern;
+
+                      boolean scanDockerCompose(String filename){
+                        esVersion = "${es.version}";
+                        print("Scanning "+filename+" for " + esVersion);
+
+                        docker = Pattern.compile("elasticsearch:(\\d.\\d\\d.\\d)");
+                        kibana = Pattern.compile("kibana:(\\d.\\d\\d.\\d)");
+                        patterns = new Pattern[]{ docker, kibana};
+
+                        reader = new BufferedReader(new FileReader(filename));
+
+                        number = 0;
+                        while ((line = reader.readLine()) != null) {
+                          number++;
+                          for (pattern : patterns ){
+                            matcher = pattern.matcher(line);
+                            if (matcher.find()) {
+                              if (!esVersion.equals(matcher.group(1))) {
+                                print(filename+":"+number+" FAILURE: " + line);
+                                return false;
+                              }
+                            }
+                          }
+                        }
+                        reader.close();
+                        return true;
+                      }
+
+                      return scanDockerCompose("docker-compose.yml");
+                  </condition>
+                </evaluateBeanshell>
+              </rules>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
   <profiles>
     <profile>
       <id>es-download</id>


### PR DESCRIPTION
Thanks for the pointers in the PSC meeting about running Elasticsearch 8.11.3 (as defined in ``pom.xml`` "es.version" file).

* [x] Enforce check of es/README.md
* [x] Enforce check of es/docker-compose.yml

This PR gathers several outstanding PRs:

- https://github.com/geonetwork/core-geonetwork/pull/6284
  
  This is for the `docker` folder which contains development environments for testing.

- https://github.com/geonetwork/core-geonetwork/pull/5800
  
  This contained information on license change and troubleshooting information.
 
# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [x] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [x] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
