### PR TITLE
Fill in 4.2.x releases for maintenance page

### DIFF
--- a/docs/manual/docs/overview/change-log/maintenance/index.md
+++ b/docs/manual/docs/overview/change-log/maintenance/index.md
@@ -1,8 +1,21 @@
 # Maintenance
 
-The GeoNetwork 4.2.x series is stable and recommended for production use and new installations of GeoNetwork. 
+The GeoNetwork 4.2.x series has entered maintenance for continued support production systems.
+
 This series is under active use by our community, with regular improvements, documentation updates, bug reports, fixes, and releases.
 
 ## Latest
 
+- [Version 4.2.9](../version-4.2.9.md)
+
 ## History
+
+- [Version 4.2.8](../version-4.2.8.md)
+- [Version 4.2.7](../version-4.2.7.md)
+- [Version 4.2.6](../version-4.2.6.md)
+- [Version 4.2.5](../version-4.2.5.md)
+- [Version 4.2.4](../version-4.2.4.md)
+- [Version 4.2.3](../version-4.2.3.md)
+- [Version 4.2.2](../version-4.2.2.md)
+- [Version 4.2.1](../version-4.2.1.md)
+- [Version 4.2.0](../version-4.2.0.md)


### PR DESCRIPTION
The maintenance page is presently empty, and 4.2.x release notes are not linked to from anywhere...

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [x] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

