### PR TITLE
Map / Extent API / Background image failure if matrixset is not SRS code

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/extent/WMTSBaseMapRenderer.java
+++ b/services/src/main/java/org/fao/geonet/api/records/extent/WMTSBaseMapRenderer.java
@@ -193,7 +193,7 @@ public class WMTSBaseMapRenderer implements BaseMapRenderingEngine {
         BufferedImage image = wmtsClient.createImage(
             bbox.getMinX(), bbox.getMinY(), bbox.getMaxX(), bbox.getMaxY(),
             (int) imageDimensions.getWidth(), (int) imageDimensions.getHeight(),
-            matrixSet);
+            this.srs);
 
         return image;
     }


### PR DESCRIPTION
Follow up of https://github.com/geonetwork/core-geonetwork/pull/6650

Matrixset id is not always a SRS code eg. https://services.arcgisonline.com/arcgis/rest/services/Ocean/World_Ocean_Base/MapServer/WMTS/1.0.0/WMTSCapabilities.xml

Create image should use the SRS code. 

Test configuration
```xml
  <util:map id="regionGetMapBackgroundLayers">
    <entry key="osm"
           value="\${map.bbox.background.service}"/>
    <entry key='arcgis'
           value='{
                    "wmtsGetCapabilitiesURL":"https://services.arcgisonline.com/arcgis/rest/services/Ocean/World_Ocean_Base/MapServer/WMTS/1.0.0/WMTSCapabilities.xml",
                    "layerName":"Ocean_World_Ocean_Base",
                    "SRID2MatrixSet": {
                         "EPSG:3857":"GoogleMapsCompatible"
                    }
                  }'
    />
  </util:map>
```

Test URL http://localhost:8080/geonetwork/srv/api/regions/geom.png?geomsrs=EPSG:4326&geom=POLYGON((175.015%20-26.7199,175.015%20-14.83,156.25%20-14.83,156.25%20-26.7199,175.015%20-26.7199))&background=arcgis


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

