### PR TITLE
[Backport 4.2.x] Map / Extent API / Background image failure if matrixset is not SRS code

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/extent/WMTSBaseMapRenderer.java
+++ b/services/src/main/java/org/fao/geonet/api/records/extent/WMTSBaseMapRenderer.java
@@ -193,7 +193,7 @@ public class WMTSBaseMapRenderer implements BaseMapRenderingEngine {
         BufferedImage image = wmtsClient.createImage(
             bbox.getMinX(), bbox.getMinY(), bbox.getMaxX(), bbox.getMaxY(),
             (int) imageDimensions.getWidth(), (int) imageDimensions.getHeight(),
-            matrixSet);
+            this.srs);
 
         return image;
     }


### PR DESCRIPTION
Backport #7880
 **Authored by:** @fxprunayre