### PR TITLE
[Backport 4.2.x] Fix typo in Messages.properties for metadata_approved_published_record_text

### DIFF
--- a/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages.properties
+++ b/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages.properties
@@ -123,7 +123,7 @@ metadata_published_text=The following records have been processed:\n\
     <ul>%s</ul>
 metadata_published_record_text=<li>The metadata <a href="{{link}}">{{index:resourceTitleObject}}</a> has been published.</li>
 metadata_unpublished_record_text=<li>The metadata <a href="{{link}}">{{index:resourceTitleObject}}</a> has been unpublished.</li>
-metadata_approved_published_record_text=<li>The metadata <a href="{{link}}">{{index:resourceTitleObject}}</a> has been published a new version.</li>
+metadata_approved_published_record_text=<li>The metadata <a href="{{link}}">{{index:resourceTitleObject}}</a> has been published as a new version.</li>
 
 api.groups.group_not_found=Group with ID ''{0}'' not found in this catalog.
 user_watchlist_subject=%s / %d updates in your watch list since %s


### PR DESCRIPTION
Backport #7892
 **Authored by:** @zhngamy