### PR TITLE
Configure harvesters log to avoid application log duplicated in harvester_default.log file. 

### DIFF
--- a/web/src/main/webapp/WEB-INF/classes/log4j2-dev.xml
+++ b/web/src/main/webapp/WEB-INF/classes/log4j2-dev.xml
@@ -34,7 +34,6 @@
     <Logger name="geonetwork" level="debug" additivity="false">
       <AppenderRef ref="Console"/>
       <AppenderRef ref="File"/>
-      <AppenderRef ref="Harvester"/>
     </Logger>
     <Logger name="geonetwork.accessmanager" level="debug"/>
     <Logger name="geonetwork.atom" level="debug"/>
@@ -56,7 +55,9 @@
     <Logger name="geonetwork.geoserver.publisher" level="debug"/>
     <Logger name="geonetwork.geoserver.rest" level="debug"/>
     <Logger name="geonetwork.harvest.wfs.features"/>
-    <Logger name="geonetwork.harvester" level="debug"/>
+    <Logger name="geonetwork.harvester" level="debug">
+      <AppenderRef ref="Harvester"/>
+    </Logger>
     <Logger name="geonetwork.harvest-man" level="info"/>
     <Logger name="geonetwork.index" level="debug"/>
     <Logger name="geonetwork.ldap" level="debug"/>

--- a/web/src/main/webapp/WEB-INF/classes/log4j2-index.xml
+++ b/web/src/main/webapp/WEB-INF/classes/log4j2-index.xml
@@ -16,6 +16,18 @@
       </Policies>
       <DefaultRolloverStrategy max="3" fileIndex="min"/>
     </RollingFile>
+    <Routing name="Harvester">
+      <Routes pattern="$${ctx:logfile}">
+        <!-- value dynamically determines the name of the log file. -->
+        <Route>
+          <File name="harvester-${ctx:harvester}" fileName="${sys:log_dir:-log_dir}/${ctx:logfile:-harvester_default.log}">
+            <PatternLayout>
+              <pattern>%date{ISO8601}{${ctx:timeZone}} %-5level [%logger] - %message%n</pattern>
+            </PatternLayout>
+          </File>
+        </Route>
+      </Routes>
+    </Routing>
   </Appenders>
   <Loggers>
     <!-- Geonetwork module (and submodule) logging -->
@@ -43,7 +55,9 @@
     <Logger name="geonetwork.geoserver.publisher" level="error"/>
     <Logger name="geonetwork.geoserver.rest" level="error"/>
     <Logger name="geonetwork.harvest.wfs.features"/>
-    <Logger name="geonetwork.harvester" level="info"/>
+    <Logger name="geonetwork.harvester" level="info">
+      <AppenderRef ref="Harvester"/>
+    </Logger>
     <Logger name="geonetwork.harvest-man" level="info"/>
     <Logger name="geonetwork.index" level="error"/>
     <Logger name="geonetwork.ldap" level="error"/>

--- a/web/src/main/webapp/WEB-INF/classes/log4j2.xml
+++ b/web/src/main/webapp/WEB-INF/classes/log4j2.xml
@@ -34,7 +34,6 @@
     <Logger name="geonetwork" level="error" additivity="false">
       <AppenderRef ref="Console"/>
       <AppenderRef ref="File"/>
-      <AppenderRef ref="Harvester"/>
     </Logger>
     <Logger name="geonetwork.accessmanager" level="error"/>
     <Logger name="geonetwork.atom" level="info"/>
@@ -56,7 +55,9 @@
     <Logger name="geonetwork.geoserver.publisher" level="error"/>
     <Logger name="geonetwork.geoserver.rest" level="error"/>
     <Logger name="geonetwork.harvest.wfs.features" level="debug"/>
-    <Logger name="geonetwork.harvester" level="info"/>
+    <Logger name="geonetwork.harvester" level="info">
+      <AppenderRef ref="Harvester"/>
+    </Logger>
     <Logger name="geonetwork.harvest-man" level="error"/>
     <Logger name="geonetwork.index" level="error"/>
     <Logger name="geonetwork.ldap" level="error"/>


### PR DESCRIPTION
Fixes #7895

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
