### PR TITLE
Hide the typeahead search suggestions when hitting the ENTER key in the search field without selecting a suggested value

### DIFF
--- a/web-ui/src/main/resources/catalog/js/search/SearchController.js
+++ b/web-ui/src/main/resources/catalog/js/search/SearchController.js
@@ -229,6 +229,19 @@
       $scope.getCatScope = function () {
         return $scope;
       };
+
+      // Allow to display the typeahead suggestions when writing in the search field
+      $scope.$watch("searchObj.params.any", function (newVal, oldVal) {
+        if (newVal && newVal != oldVal) {
+          $(".gn-form-any > [typeahead-popup]").show();
+        }
+      });
+
+      // Used to hide the typeahead search suggestions when hitting the ENTER key in the search field
+      $scope.hideSearchSuggestions = function () {
+        $(".gn-form-any > [typeahead-popup]").hide();
+        return true;
+      };
     }
   ]);
 })();

--- a/web-ui/src/main/resources/catalog/templates/editor/batchedit.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/batchedit.html
@@ -78,7 +78,7 @@
                           autocomplete="off"
                           placeholder="{{'anyPlaceHolder' | translate}}"
                           aria-label="{{'anyPlaceHolder' | translate}}"
-                          data-ng-keyup="$event.keyCode == 13 && triggerSearch()"
+                          data-ng-keyup="$event.keyCode == 13 && hideSearchSuggestions() && triggerSearch()"
                           data-typeahead="md.label as md.label for md in getAnySuggestions($viewValue, searchObj)"
                           data-typeahead-template-url="../../catalog/templates/gn-typeahead-match.html"
                           data-typeahead-loading="anyLoading"

--- a/web-ui/src/main/resources/catalog/templates/editor/editorboard.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/editorboard.html
@@ -27,7 +27,7 @@
                   autocomplete="off"
                   placeholder="{{'anyPlaceHolder' | translate}}"
                   aria-label="{{'anyPlaceHolder' | translate}}"
-                  data-ng-keyup="$event.keyCode == 13 && triggerSearch()"
+                  data-ng-keyup="$event.keyCode == 13 && hideSearchSuggestions() && triggerSearch()"
                   data-typeahead="md.label as md.label for md in getAnySuggestions($viewValue, searchObj)"
                   data-typeahead-template-url="../../catalog/templates/gn-typeahead-match.html"
                   data-typeahead-loading="anyLoading"

--- a/web-ui/src/main/resources/catalog/views/default/templates/searchForm.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/searchForm.html
@@ -20,7 +20,7 @@
             autocomplete="off"
             placeholder="{{'anyPlaceHolder' | translate}}"
             aria-label="{{'anyPlaceHolder' | translate}}"
-            data-ng-keyup="$event.keyCode == 13 && triggerSearch()"
+            data-ng-keyup="$event.keyCode == 13 && hideSearchSuggestions() && triggerSearch()"
             data-typeahead="md.label as md.label for md in getAnySuggestions($viewValue, searchObj)"
             data-typeahead-template-url="../../catalog/templates/gn-typeahead-match.html"
             data-typeahead-loading="anyLoading"


### PR DESCRIPTION
Test case:

1) Load the ISO19139 samples
2) In the search field type `Africa` --> search suggestions are displayed
  - Without the change: hit `ENTER` key --> The search is triggered, but the search suggestions are not hidden.
  - With the change: hit `ENTER` key --> The search is triggered, the search suggestions are hidden.

Before:

[searchsuggestions-before.webm](https://github.com/geonetwork/core-geonetwork/assets/1695003/3399eac8-3a04-481f-887c-4c7a6006c898)

After:

[searchsuggestions-after.webm](https://github.com/geonetwork/core-geonetwork/assets/1695003/658e92d4-6aa5-4204-8e2e-b4de0ff7202b)

# Checklist


- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
