### PR TITLE
Editor board / Use metadata database change date instead of the metadata dateStamp (xml)

### DIFF
--- a/web-ui/src/main/resources/catalog/components/elasticsearch/EsFacet.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/EsFacet.js
@@ -142,6 +142,7 @@
               "valid",
               "isHarvested",
               "dateStamp",
+              "changeDate",
               "documentStandard",
               "mdStatus*",
               "*inspire*"

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/editor.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/editor.html
@@ -43,7 +43,7 @@
                 <small data-translate="">updatedOn</small>
                 <small
                   class="text-muted"
-                  data-gn-humanize-time="{{md.dateStamp}}"
+                  data-gn-humanize-time="{{md.changeDate}}"
                   data-from-now=""
                 ></small>
 

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -295,7 +295,7 @@
                 // Start boosting down records more than 3 months old
                 {
                   gauss: {
-                    dateStamp: {
+                    changeDate: {
                       scale: "365d",
                       offset: "90d",
                       decay: 0.5
@@ -629,7 +629,7 @@
                 sortOrder: ""
               },
               {
-                sortBy: "dateStamp",
+                sortBy: "changeDate",
                 sortOrder: "desc"
               },
               {
@@ -1108,7 +1108,7 @@
                 sortOrder: ""
               },
               {
-                sortBy: "dateStamp",
+                sortBy: "changeDate",
                 sortOrder: "desc"
               },
               {

--- a/web-ui/src/main/resources/catalog/locales/ca-core.json
+++ b/web-ui/src/main/resources/catalog/locales/ca-core.json
@@ -184,7 +184,7 @@
     "hitsPerPage": "Entrades per pàgina",
     "chooseRecordsPerPage": "Prem per seleccionar el nombre d'entrades per pàgina",
     "sortedBy": "Ordenat per {{field}}",
-    "sortBy-dateStampDesc": "last updates",
+    "sortBy-changeDateDesc": "last updates",
     "sortBy-createDateDesc": "new records",
     "sortBy-resourceTitleObject.default.sort": "title (ascending)",
     "sortBy-resourceTitleObject.default.sortDesc": "title (descending)",

--- a/web-ui/src/main/resources/catalog/locales/cs-core.json
+++ b/web-ui/src/main/resources/catalog/locales/cs-core.json
@@ -184,7 +184,7 @@
     "hitsPerPage": "Počet záznamů na stránku",
     "chooseRecordsPerPage": "Kliknutím zvolte počet záznamů na stránku",
     "sortedBy": "Tříděno dle {{field}}",
-    "sortBy-dateStampDesc": "poslední aktualizace",
+    "sortBy-changeDateDesc": "poslední aktualizace",
     "sortBy-createDateDesc": "nové záznamy",
     "sortBy-resourceTitleObject.default.sort": "titul (vzestupně)",
     "sortBy-resourceTitleObject.default.sortDesc": "titul (sestupně)",

--- a/web-ui/src/main/resources/catalog/locales/cy-core.json
+++ b/web-ui/src/main/resources/catalog/locales/cy-core.json
@@ -184,7 +184,7 @@
     "hitsPerPage": "Cofnodion fesul tudalen",
     "chooseRecordsPerPage": "Cliciwch i ddewis nifer y cofnodion fesul tudalen",
     "sortedBy": "Trefnwyd yn ôl {{field}}",
-    "sortBy-dateStampDesc": "diweddariadau diwethaf",
+    "sortBy-changeDateDesc": "diweddariadau diwethaf",
     "sortBy-createDateDesc": "cofnodion newydd",
     "sortBy-resourceTitleObject.default.sort": "teitl (esgynnol)",
     "sortBy-resourceTitleObject.default.sortDesc": "teitl (disgynnol)",

--- a/web-ui/src/main/resources/catalog/locales/da-core.json
+++ b/web-ui/src/main/resources/catalog/locales/da-core.json
@@ -184,7 +184,7 @@
     "hitsPerPage": "Poster per side",
     "chooseRecordsPerPage": "Klik for at vælge antallet af poster pr. side",
     "sortedBy": "Sorteret efter {{field}}",
-    "sortBy-dateStampDesc": "sidst opdateret",
+    "sortBy-changeDateDesc": "sidst opdateret",
     "sortBy-createDateDesc": "Nye metadata",
     "sortBy-resourceTitleObject.default.sort": "titel (stigende)",
     "sortBy-resourceTitleObject.default.sortDesc": "titel (faldende)",

--- a/web-ui/src/main/resources/catalog/locales/de-core.json
+++ b/web-ui/src/main/resources/catalog/locales/de-core.json
@@ -184,7 +184,7 @@
     "hitsPerPage": "Treffer pro Seite",
     "chooseRecordsPerPage": "Anzahl der Datensätze pro Seite wählen",
     "sortedBy": "Sortieren nach {{field}}",
-    "sortBy-dateStampDesc": "letztes Update",
+    "sortBy-changeDateDesc": "letztes Update",
     "sortBy-createDateDesc": "neue Datensätze",
     "sortBy-resourceTitleObject.default.sort": "Titel (aufsteigend)",
     "sortBy-resourceTitleObject.default.sortDesc": "Titel (absteigend)",

--- a/web-ui/src/main/resources/catalog/locales/en-core.json
+++ b/web-ui/src/main/resources/catalog/locales/en-core.json
@@ -184,7 +184,7 @@
     "hitsPerPage": "Records per page",
     "chooseRecordsPerPage": "Click to choose the number of records per page",
     "sortedBy": "Sorted by {{field}}",
-    "sortBy-dateStampDesc": "last updates",
+    "sortBy-changeDateDesc": "last updates",
     "sortBy-createDateDesc": "new records",
     "sortBy-resourceTitleObject.default.sort": "title (ascending)",
     "sortBy-resourceTitleObject.default.sortDesc": "title (descending)",

--- a/web-ui/src/main/resources/catalog/locales/es-core.json
+++ b/web-ui/src/main/resources/catalog/locales/es-core.json
@@ -184,7 +184,7 @@
     "hitsPerPage": "Entradas por página",
     "chooseRecordsPerPage": "Pulsa para seleccionar el número de entradas por página",
     "sortedBy": "Ordenado por {{field}}",
-    "sortBy-dateStampDesc": "ultimas actualizaciones",
+    "sortBy-changeDateDesc": "ultimas actualizaciones",
     "sortBy-createDateDesc": "nuevos registros",
     "sortBy-resourceTitleObject.default.sort": "title (ascending)",
     "sortBy-resourceTitleObject.default.sortDesc": "title (descending)",

--- a/web-ui/src/main/resources/catalog/locales/fi-core.json
+++ b/web-ui/src/main/resources/catalog/locales/fi-core.json
@@ -184,7 +184,7 @@
     "hitsPerPage": "Tietueita sivulla",
     "chooseRecordsPerPage": "Valitse tietueiden määrä sivulla",
     "sortedBy": "Lajittelukenttä: {{field}}",
-    "sortBy-dateStampDesc": "last updates",
+    "sortBy-changeDateDesc": "last updates",
     "sortBy-createDateDesc": "new records",
     "sortBy-resourceTitleObject.default.sort": "title (ascending)",
     "sortBy-resourceTitleObject.default.sortDesc": "title (descending)",

--- a/web-ui/src/main/resources/catalog/locales/fr-core.json
+++ b/web-ui/src/main/resources/catalog/locales/fr-core.json
@@ -184,7 +184,7 @@
     "hitsPerPage": "Fiches par page",
     "chooseRecordsPerPage": "Choisir le nombre de fiches par page",
     "sortedBy": "Trier par {{field}}",
-    "sortBy-dateStampDesc": "dernières mises à jour",
+    "sortBy-changeDateDesc": "dernières mises à jour",
     "sortBy-createDateDesc": "nouvelles fiches",
     "sortBy-resourceTitleObject.default.sort": "titre (croissant)",
     "sortBy-resourceTitleObject.default.sortDesc": "titre (décroissant)",

--- a/web-ui/src/main/resources/catalog/locales/is-core.json
+++ b/web-ui/src/main/resources/catalog/locales/is-core.json
@@ -184,7 +184,7 @@
     "hitsPerPage": "Fjöldi færsla á blaðsíðu",
     "chooseRecordsPerPage": "Smelltu til að velja fjölda færsla á hverri síðu",
     "sortedBy": "Raðað eftir {{field}}",
-    "sortBy-dateStampDesc": "last updates",
+    "sortBy-changeDateDesc": "last updates",
     "sortBy-createDateDesc": "new records",
     "sortBy-resourceTitleObject.default.sort": "title (ascending)",
     "sortBy-resourceTitleObject.default.sortDesc": "title (descending)",

--- a/web-ui/src/main/resources/catalog/locales/it-core.json
+++ b/web-ui/src/main/resources/catalog/locales/it-core.json
@@ -184,7 +184,7 @@
     "hitsPerPage": "Record per pagina",
     "chooseRecordsPerPage": "Scegli il numero di record per pagina",
     "sortedBy": "Ordina per {{field}}",
-    "sortBy-dateStampDesc": "last updates",
+    "sortBy-changeDateDesc": "last updates",
     "sortBy-createDateDesc": "new records",
     "sortBy-resourceTitleObject.default.sort": "title (ascending)",
     "sortBy-resourceTitleObject.default.sortDesc": "title (descending)",

--- a/web-ui/src/main/resources/catalog/locales/ko-core.json
+++ b/web-ui/src/main/resources/catalog/locales/ko-core.json
@@ -184,7 +184,7 @@
     "hitsPerPage": "페이지 당 레코드",
     "chooseRecordsPerPage": "클릭하여 페이지당 레코드 수를 선택하십시오.",
     "sortedBy": " {{field}} 정렬",
-    "sortBy-dateStampDesc": "last updates",
+    "sortBy-changeDateDesc": "last updates",
     "sortBy-createDateDesc": "new records",
     "sortBy-resourceTitleObject.default.sort": "title (ascending)",
     "sortBy-resourceTitleObject.default.sortDesc": "title (descending)",

--- a/web-ui/src/main/resources/catalog/locales/nl-core.json
+++ b/web-ui/src/main/resources/catalog/locales/nl-core.json
@@ -184,7 +184,7 @@
     "hitsPerPage": "Resultaten per pagina",
     "chooseRecordsPerPage": "Kies het aantal resultaten per pagina",
     "sortedBy": "Sortering: {{field}}",
-    "sortBy-dateStampDesc": "Laatste wijziging",
+    "sortBy-changeDateDesc": "Laatste wijziging",
     "sortBy-createDateDesc": "Aanmaak datum",
     "sortBy-resourceTitleObject.default.sort": "titel (oplopend)",
     "sortBy-resourceTitleObject.default.sortDesc": "titel (aflopend)",

--- a/web-ui/src/main/resources/catalog/locales/pt-core.json
+++ b/web-ui/src/main/resources/catalog/locales/pt-core.json
@@ -184,7 +184,7 @@
     "hitsPerPage": "Registros por página",
     "chooseRecordsPerPage": "Clique para escolher o número de registros por página",
     "sortedBy": "Ordenado por {{field}}",
-    "sortBy-dateStampDesc": "ultimas atualizações",
+    "sortBy-changeDateDesc": "ultimas atualizações",
     "sortBy-createDateDesc": "novos registros",
     "sortBy-resourceTitleObject.default.sort": "title (ascending)",
     "sortBy-resourceTitleObject.default.sortDesc": "title (descending)",

--- a/web-ui/src/main/resources/catalog/locales/ru-core.json
+++ b/web-ui/src/main/resources/catalog/locales/ru-core.json
@@ -184,7 +184,7 @@
     "hitsPerPage": "Количество записей на странице",
     "chooseRecordsPerPage": "Нажмите, чтобы выбрать количество записей на странице",
     "sortedBy": "Сортировать по {{field}}",
-    "sortBy-dateStampDesc": "последние обновления",
+    "sortBy-changeDateDesc": "последние обновления",
     "sortBy-createDateDesc": "новые записи",
     "sortBy-resourceTitleObject.default.sort": "title (ascending)",
     "sortBy-resourceTitleObject.default.sortDesc": "title (descending)",

--- a/web-ui/src/main/resources/catalog/locales/sk-core.json
+++ b/web-ui/src/main/resources/catalog/locales/sk-core.json
@@ -184,7 +184,7 @@
     "hitsPerPage": "Záznamy na stránku",
     "chooseRecordsPerPage": "Kliknite pre výber počtu záznamov na stránku",
     "sortedBy": "Usporiadané podľa {{field}}",
-    "sortBy-dateStampDesc": "last updates",
+    "sortBy-changeDateDescc": "last updates",
     "sortBy-createDateDesc": "new records",
     "sortBy-resourceTitleObject.default.sort": "title (ascending)",
     "sortBy-resourceTitleObject.default.sortDesc": "title (descending)",

--- a/web-ui/src/main/resources/catalog/locales/sv-core.json
+++ b/web-ui/src/main/resources/catalog/locales/sv-core.json
@@ -184,7 +184,7 @@
     "hitsPerPage": "Antal poster per sida",
     "chooseRecordsPerPage": "Klicka för att välja hur många poster som visas per sida",
     "sortedBy": "Sorterat på {{field}}",
-    "sortBy-dateStampDesc": "senaste uppdateringar",
+    "sortBy-changeDateDesc": "senaste uppdateringar",
     "sortBy-createDateDesc": "nya poster",
     "sortBy-resourceTitleObject.default.sort": "title (ascending)",
     "sortBy-resourceTitleObject.default.sortDesc": "title (descending)",

--- a/web-ui/src/main/resources/catalog/locales/zh-core.json
+++ b/web-ui/src/main/resources/catalog/locales/zh-core.json
@@ -184,7 +184,7 @@
     "hitsPerPage": "每页记录数",
     "chooseRecordsPerPage": "点击选择每页记录数",
     "sortedBy": "按照{{field}}进行排序",
-    "sortBy-dateStampDesc": "last updates",
+    "sortBy-changeDateDesc": "last updates",
     "sortBy-createDateDesc": "new records",
     "sortBy-resourceTitleObject.default.sort": "title (ascending)",
     "sortBy-resourceTitleObject.default.sortDesc": "title (descending)",


### PR DESCRIPTION
Some metadata schemas like the https://github.com/metadata101/iso19139.nl.geografie.2.0.0 store in the XML dateStamp element only the date without the time information.

When displaying the metadata in the editor board the information about the update date shows wrong information. creating a metadata at 16:00 PM, shows this wrong information due to the lack of time part:

![wrong-date](https://github.com/geonetwork/core-geonetwork/assets/1695003/33f32a88-7a19-4009-9f7c-23427ad581bd)

This change updates the editor board to display the metadata update date from the database. Usually is the same as the XML dateStamp, but as indicated some schemas doesn't store the time part in the XML dateStamp, so makes more sense to use the database field.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
