### PR TITLE
[Backport 3.12.x] Send email notification after workflow events have been processed #7864

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/metadata/DefaultStatusActions.java
+++ b/core/src/main/java/org/fao/geonet/kernel/metadata/DefaultStatusActions.java
@@ -169,18 +169,6 @@ public class DefaultStatusActions implements StatusActions {
                 continue;
             }
 
-            // --- set status, indexing is assumed to take place later
-            metadataStatusManager.setStatusExt(status);
-
-            // --- inform content reviewers if the status is submitted
-            try {
-                notify(getUserToNotify(status), status);
-            } catch (Exception e) {
-                context.warning(String.format(
-                    "Failed to send notification on status change for metadata %s with status %s. Error is: %s",
-                    status.getMetadataId(), status.getStatusValue().getId(), e.getMessage()));
-            }
-
             // Issue events
             Log.trace(Geonet.DATA_MANAGER, "Issue workflow events.");
 
@@ -218,6 +206,18 @@ public class DefaultStatusActions implements StatusActions {
 
                 throw statusChangeFailure;
 
+            }
+
+            // --- set status, indexing is assumed to take place later
+            metadataStatusManager.setStatusExt(status);
+
+            // --- inform content reviewers if the status is submitted
+            try {
+                notify(getUserToNotify(status), status);
+            } catch (Exception e) {
+                context.warning(String.format(
+                    "Failed to send notification on status change for metadata %s with status %s. Error is: %s",
+                    status.getMetadataId(), status.getStatusValue().getId(), e.getMessage()));
             }
         }
 

--- a/core/src/main/java/org/fao/geonet/kernel/metadata/DefaultStatusActions.java
+++ b/core/src/main/java/org/fao/geonet/kernel/metadata/DefaultStatusActions.java
@@ -169,6 +169,9 @@ public class DefaultStatusActions implements StatusActions {
                 continue;
             }
 
+            // --- set status, indexing is assumed to take place later
+            metadataStatusManager.setStatusExt(status);
+
             // Issue events
             Log.trace(Geonet.DATA_MANAGER, "Issue workflow events.");
 
@@ -207,9 +210,6 @@ public class DefaultStatusActions implements StatusActions {
                 throw statusChangeFailure;
 
             }
-
-            // --- set status, indexing is assumed to take place later
-            metadataStatusManager.setStatusExt(status);
 
             // --- inform content reviewers if the status is submitted
             try {


### PR DESCRIPTION
Manfully resolved backporting issue of https://github.com/geonetwork/core-geonetwork/pull/7864

The purpose of the pull request is to make sure indexing updates and email notification get sent at the very end of the transaction where there is no error and exception happening including anything happened in the events listeners.