### PR TITLE
Standard / ISO19115-3 / Feature catalogue improvements

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/xsl-view/view.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/xsl-view/view.xsl
@@ -394,18 +394,6 @@
 
 
   <!-- Most of the elements are ... -->
-  <!-- Most of the elements are ... -->
-  <xsl:template mode="render-field"
-                match="*[gco:CharacterString = '']|*[gco:Integer = '']|
-                       *[gco:Decimal = '']|*[gco:Boolean = '']|
-                       *[gco:Real = '']|*[gco:Measure = '']|*[gco:Length = '']|
-                       *[gco:Distance = '']|*[gco:Angle = '']|*[gco:Scale = '']|
-                       *[gco:Record = '']|*[gco:RecordType = '']|
-                       *[gco:LocalName = '']|*[lan:PT_FreeText = '']|
-                       *[gml:beginPosition = '']|*[gml:endPosition = '']|
-                       gml:description[. != '']|gml:timePosition[. != '']|
-                       *[gco:Date = '']|*[gco:DateTime = '']|*[gco:TM_PeriodDuration = '']"
-                priority="500"/>
   <xsl:template mode="render-field"
                 match="*[gco:CharacterString != '']|*[gcx:Anchor != '']|
                        *[gco:Integer != '']|
@@ -419,7 +407,8 @@
                        *[*/@codeListValue]|*[@codeListValue]|
                        gml:identifier[. != '']|gml:name[. != '']|
                        gml:description[. != '']|gml:timePosition[. != '']|
-                       gml:beginPosition[. != '']|gml:endPosition[. != '']"
+                       gml:beginPosition[. != '']|gml:endPosition[. != '']|
+                       gfc:memberName[. != '']|gfc:typeName[. != '']|gfc:aliases[. != '']"
                 priority="500">
     <xsl:param name="fieldName" select="''" as="xs:string"/>
 

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/evaluate.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/evaluate.xsl
@@ -21,6 +21,7 @@
                 xmlns:cit="http://standards.iso.org/iso/19115/-3/cit/2.0"
                 xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0"
                 xmlns:mac="http://standards.iso.org/iso/19115/-3/mac/2.0"
+                xmlns:cat="http://standards.iso.org/iso/19115/-3/cat/1.0"
                 xmlns:gfc="http://standards.iso.org/iso/19110/gfc/1.1"
                 xmlns:gts="http://www.isotc211.org/2005/gts"
                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/loc/fre/labels.xml
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/loc/fre/labels.xml
@@ -8814,11 +8814,11 @@ http://www.sandre.eaufrance.fr/?urn=urn:sandre:ensembledonnees:BDCarthage:FXX:::
     <description></description>
   </element>
   <element name="gfc:code">
-    <label>Code</label>
+    <label>Identifiant</label>
     <description></description>
   </element>
   <element name="gfc:isOrdered">
-    <label>Est prdonné</label>
+    <label>Est ordonné</label>
     <description></description>
   </element>
   <element name="gfc:isNavigable">
@@ -8882,7 +8882,7 @@ http://www.sandre.eaufrance.fr/?urn=urn:sandre:ensembledonnees:BDCarthage:FXX:::
     <description></description>
   </element>
   <element name="gfc:memberName">
-    <label>Nom</label>
+    <label>Libellé</label>
     <description></description>
   </element>
   <element name="gfc:FC_Constraint">


### PR DESCRIPTION
### Editor / Add missing namespace

When creating custom editor related to feature catalogue, the `cat` namespace may be used. Error is returned when evaluating XPath:

```
Error on line 41 of evaluate.xsl:
  XPST0003: Static error in XPath expression supplied to saxon:evaluate: XPath syntax error
  at char 37 in {...rc:featureCatalogue/*/cat:n...}:
    Prefix cat has not been declared
```

eg.

```xml

          <section forEach="/mdb:MD_Metadata/mdb:contentInfo"
                   name="sextant-datamodel"
                   del=".">
            <field xpath="*/mrc:featureCatalogue/*/cat:name"/>
            <section forEach="*/mrc:featureCatalogue/*/gfc:featureType"
                     name="sextant-table"
                     del=".">
              <field xpath="*/gfc:typeName"/>

              <field xpath="*/gfc:carrierOfCharacteristics" name="sextant-columns"/>

              <action type="add"
                      btnLabel="sextant-add-column"
                      or="carrierOfCharacteristics"
                      in="*">
                <template>
                  <snippet>
                    <gfc:carrierOfCharacteristics>
                      <gfc:FC_FeatureAttribute>
                        <gfc:memberName></gfc:memberName>
                        <gfc:definition gco:nilReason="missing">
                          <gco:CharacterString/>
                        </gfc:definition>
                        <gfc:code gco:nilReason="missing">
                          <gco:CharacterString></gco:CharacterString>
                        </gfc:code>
                        <gfc:valueType>
                          <gco:TypeName>
                            <gco:aName gco:nilReason="missing">
                              <gco:CharacterString/>
                            </gco:aName>
                          </gco:TypeName>
                        </gfc:valueType>
                      </gfc:FC_FeatureAttribute>
                    </gfc:carrierOfCharacteristics>
                  </snippet>
                </template>
              </action>
            </section>

            <action type="add"
                    btnLabel="sextant-add-table"
                    or="featureType"
                    in="*/mrc:featureCatalogue/*">
              <template>
                <snippet>
                  <gfc:featureType>
                    <gfc:FC_FeatureType>
                      <gfc:typeName>Nom de la table</gfc:typeName>
                      <gfc:isAbstract>
                        <gco:Boolean>false</gco:Boolean>
                      </gfc:isAbstract>
                      <gfc:carrierOfCharacteristics>
                        <gfc:FC_FeatureAttribute>
                          <gfc:memberName></gfc:memberName>
                          <gfc:definition gco:nilReason="missing">
                            <gco:CharacterString/>
                          </gfc:definition>
                          <gfc:code gco:nilReason="missing">
                            <gco:CharacterString></gco:CharacterString>
                          </gfc:code>
                          <gfc:valueType>
                            <gco:TypeName>
                              <gco:aName gco:nilReason="missing">
                                <gco:CharacterString/>
                              </gco:aName>
                            </gco:TypeName>
                          </gfc:valueType>
                        </gfc:FC_FeatureAttribute>
                      </gfc:carrierOfCharacteristics>
                      <gfc:featureCatalogue/>
                    </gfc:FC_FeatureType>
                  </gfc:featureType>
                </snippet>
              </template>
            </action>
          </section>

```

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/98767a27-6e5f-4630-afc7-081e5929ccfe)


### Formatter / Display feature catalogue and typename.

eg. Import https://geocatalogue.apur.org/catalogue/srv/api/records/urn:apur:ligne%20transport_od/formatters/xml

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/83a0d435-ea77-464c-9ff4-56294951c6c1)

`gfc:typeName` is not displayed in full view.

Funded by Ifremer


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

