### PR TITLE
[Backport 4.2.x] Hide the typeahead search suggestions when hitting the ENTER key in the search field without selecting a suggested value

### DIFF
--- a/web-ui/src/main/resources/catalog/js/search/SearchController.js
+++ b/web-ui/src/main/resources/catalog/js/search/SearchController.js
@@ -229,6 +229,19 @@
       $scope.getCatScope = function () {
         return $scope;
       };
+
+      // Allow to display the typeahead suggestions when writing in the search field
+      $scope.$watch("searchObj.params.any", function (newVal, oldVal) {
+        if (newVal && newVal != oldVal) {
+          $(".gn-form-any > [typeahead-popup]").show();
+        }
+      });
+
+      // Used to hide the typeahead search suggestions when hitting the ENTER key in the search field
+      $scope.hideSearchSuggestions = function () {
+        $(".gn-form-any > [typeahead-popup]").hide();
+        return true;
+      };
     }
   ]);
 })();

--- a/web-ui/src/main/resources/catalog/templates/editor/batchedit.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/batchedit.html
@@ -78,7 +78,7 @@
                           autocomplete="off"
                           placeholder="{{'anyPlaceHolder' | translate}}"
                           aria-label="{{'anyPlaceHolder' | translate}}"
-                          data-ng-keyup="$event.keyCode == 13 && triggerSearch()"
+                          data-ng-keyup="$event.keyCode == 13 && hideSearchSuggestions() && triggerSearch()"
                           data-typeahead="md.label as md.label for md in getAnySuggestions($viewValue, searchObj)"
                           data-typeahead-template-url="../../catalog/templates/gn-typeahead-match.html"
                           data-typeahead-loading="anyLoading"

--- a/web-ui/src/main/resources/catalog/templates/editor/editorboard.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/editorboard.html
@@ -27,7 +27,7 @@
                   autocomplete="off"
                   placeholder="{{'anyPlaceHolder' | translate}}"
                   aria-label="{{'anyPlaceHolder' | translate}}"
-                  data-ng-keyup="$event.keyCode == 13 && triggerSearch()"
+                  data-ng-keyup="$event.keyCode == 13 && hideSearchSuggestions() && triggerSearch()"
                   data-typeahead="md.label as md.label for md in getAnySuggestions($viewValue, searchObj)"
                   data-typeahead-template-url="../../catalog/templates/gn-typeahead-match.html"
                   data-typeahead-loading="anyLoading"

--- a/web-ui/src/main/resources/catalog/views/default/templates/searchForm.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/searchForm.html
@@ -20,7 +20,7 @@
             autocomplete="off"
             placeholder="{{'anyPlaceHolder' | translate}}"
             aria-label="{{'anyPlaceHolder' | translate}}"
-            data-ng-keyup="$event.keyCode == 13 && triggerSearch()"
+            data-ng-keyup="$event.keyCode == 13 && hideSearchSuggestions() && triggerSearch()"
             data-typeahead="md.label as md.label for md in getAnySuggestions($viewValue, searchObj)"
             data-typeahead-template-url="../../catalog/templates/gn-typeahead-match.html"
             data-typeahead-loading="anyLoading"


### PR DESCRIPTION
Backport #7898
 **Authored by:** @josegar74