### PR TITLE
Search Export CSV - Escape double-quotes with double-quotes instead of backslash

### DIFF
--- a/web/src/main/webapp/xslt/services/csv/csv-search.xsl
+++ b/web/src/main/webapp/xslt/services/csv/csv-search.xsl
@@ -173,12 +173,12 @@
       <xsl:choose>
         <xsl:when test="@name='geoBox'">
           <xsl:value-of
-            select="replace(replace(string-join($metadata/*[name(.)=$currentColumn]/*, $internalSep), '\n|\r\n', ''), '&quot;', '\\&quot;')"
+            select="replace(replace(string-join($metadata/*[name(.)=$currentColumn]/*, $internalSep), '\n|\r\n', ''), '&quot;', '&quot;&quot;')"
           />
         </xsl:when>
         <xsl:otherwise>
           <xsl:value-of
-            select="replace(replace(string-join($metadata/*[name(.)=$currentColumn]/normalize-space(), $internalSep), '\n|\r\n', ''), '&quot;', '\\&quot;')"
+            select="replace(replace(string-join($metadata/*[name(.)=$currentColumn]/normalize-space(), $internalSep), '\n|\r\n', ''), '&quot;', '&quot;&quot;')"
           />
         </xsl:otherwise>
       </xsl:choose>


### PR DESCRIPTION
<!--Include a few sentences describing the overall goals for this Pull Request-->
Alter search results csv export to escape double-quotes with double-quotes instead of backslashes.

When double quotes are used to enclose fields, applications parsing the csv results expect nested double-quotes to be escaped by another double-quote .

Ex: Importing the CSV into Excel results in data from a single column being spread over multiple columns.

[RFC 4180](https://www.ietf.org/rfc/rfc4180.txt#:~:text=If%20double-quotes%20are%20used%20to%20enclose%20fields%2c%20then%20a%20double-quote%0a%20%20%20%20%20%20%20appearing%20inside%20a%20field%20must%20be%20escaped%20by%20preceding%20it%20with%0a%20%20%20%20%20%20%20another%20double%20quote.): If double-quotes are used to enclose fields, then a double-quote appearing inside a field must be escaped by preceding it with another double quote.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

