### PR TITLE
API / XSL / Use XSL output configuration (formatter, editor).

### DIFF
--- a/common/src/main/java/org/fao/geonet/utils/Xml.java
+++ b/common/src/main/java/org/fao/geonet/utils/Xml.java
@@ -403,10 +403,14 @@ public final class Xml {
     /**
      * Transforms an xml tree putting the result to a stream (uses a stylesheet on disk).
      */
-    public static void transform(Element xml, Path styleSheetPath, OutputStream out) throws Exception {
+    public static void transform(Element xml, Path styleSheetPath, Map<String, Object> params, OutputStream out) throws Exception {
         StreamResult resStream = new StreamResult(out);
-        transform(xml, styleSheetPath, resStream, null);
+        transform(xml, styleSheetPath, resStream, params);
         out.flush();
+    }
+
+    public static void transform(Element xml, Path styleSheetPath, OutputStream out) throws Exception {
+        transform(xml, styleSheetPath, new HashMap<>(), out);
     }
 
 
@@ -515,13 +519,13 @@ public final class Xml {
                         t.setParameter(param.getKey(), param.getValue());
                     }
 
-                if (params.containsKey("geonet-force-xml")) {
-                    ((Controller) t).setOutputProperty("indent", "yes");
-                    ((Controller) t).setOutputProperty("method", "xml");
-                    ((Controller) t).setOutputProperty("{http://saxon.sf.net/}indent-spaces", "3");
+                    if (params.containsKey("geonet-force-xml")) {
+                        ((Controller) t).setOutputProperty("indent", "yes");
+                        ((Controller) t).setOutputProperty("method", "xml");
+                        ((Controller) t).setOutputProperty("{http://saxon.sf.net/}indent-spaces", "2");
+                    }
                 }
 
-                }
                 t.transform(srcXml, result);
             }
         }

--- a/common/src/main/java/org/fao/geonet/utils/Xml.java
+++ b/common/src/main/java/org/fao/geonet/utils/Xml.java
@@ -39,14 +39,7 @@ import org.fao.geonet.exceptions.XSDValidationErrorEx;
 import org.fao.geonet.utils.nio.NioPathAwareEntityResolver;
 import org.fao.geonet.utils.nio.NioPathHolder;
 import org.fao.geonet.utils.nio.PathStreamSource;
-import org.jdom.Attribute;
-import org.jdom.Content;
-import org.jdom.DocType;
-import org.jdom.Document;
-import org.jdom.Element;
-import org.jdom.JDOMException;
-import org.jdom.Namespace;
-import org.jdom.Text;
+import org.jdom.*;
 import org.jdom.filter.ElementFilter;
 import org.jdom.input.SAXBuilder;
 import org.jdom.output.Format;
@@ -64,27 +57,14 @@ import org.xml.sax.SAXException;
 import javax.xml.XMLConstants;
 import javax.xml.bind.JAXBContext;
 import javax.xml.bind.Unmarshaller;
-import javax.xml.transform.Result;
-import javax.xml.transform.Source;
-import javax.xml.transform.Transformer;
-import javax.xml.transform.TransformerException;
-import javax.xml.transform.TransformerFactory;
-import javax.xml.transform.URIResolver;
+import javax.xml.transform.*;
 import javax.xml.transform.sax.SAXResult;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
 import javax.xml.validation.SchemaFactory;
 import javax.xml.validation.ValidatorHandler;
-import java.io.BufferedOutputStream;
-import java.io.ByteArrayInputStream;
-import java.io.DataInputStream;
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.OutputStream;
-import java.io.PrintStream;
-import java.io.StringReader;
+import java.io.*;
 import java.net.HttpURLConnection;
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -99,14 +79,7 @@ import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -414,16 +387,6 @@ public final class Xml {
     }
 
 
-    public static void transformXml(Element xml, Path styleSheetPath, OutputStream out) throws Exception {
-        StreamResult resStream = new StreamResult(out);
-        Map<String, Object> map = new HashMap<>();
-        map.put("geonet-force-xml", "xml");
-        transform(xml, styleSheetPath, resStream, map);
-        out.flush();
-    }
-
-    //--------------------------------------------------------------------------
-
     /**
      * Transforms an xml tree putting the result to a stream  - no parameters.
      */
@@ -488,6 +451,9 @@ public final class Xml {
 
     /**
      * Transforms an xml tree putting the result to a stream with optional parameters.
+     * <p>
+     * Add a geonet-force-xml parameter to force the formatting to be xml.
+     * The preferred method is to define it using xsl:output.
      */
     public static void
     transform(Element xml, Path styleSheetPath, Result result, Map<String, Object> params) throws Exception {

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/citation/common.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/citation/common.xsl
@@ -26,12 +26,6 @@
   <xsl:param name="publisherRoles"
                 select="'publisher'"/>
 
-  <xsl:output omit-xml-declaration="yes"
-              method="xml"
-              indent="yes"
-              saxon:indent-spaces="2"
-              encoding="UTF-8"/>
-
   <xsl:variable name="publisherRolesList"
                 select="tokenize($publisherRoles, ',')"/>
 

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/citation/common.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/citation/common.xsl
@@ -12,6 +12,7 @@
                 extension-element-prefixes="saxon"
                 exclude-result-prefixes="#all">
 
+
   <xsl:param name="format"
              select="'html'"/>
 
@@ -24,6 +25,13 @@
   <!-- What entity is responsible for producing and/or distributing the data set?  Also, is there a physical location associated with the publisher? -->
   <xsl:param name="publisherRoles"
                 select="'publisher'"/>
+
+  <xsl:output omit-xml-declaration="yes"
+              method="xml"
+              indent="yes"
+              saxon:indent-spaces="2"
+              encoding="UTF-8"/>
+
   <xsl:variable name="publisherRolesList"
                 select="tokenize($publisherRoles, ',')"/>
 
@@ -115,7 +123,7 @@
     <blockquote>
       <div class="row">
         <div class="col-md-3">
-          <i class="fa fa-quote-left pull-right"><xsl:comment select="'icon'"/></i>
+          <i class="fa fa-quote-left pull-right"><xsl:comment/></i>
         </div>
         <div class="col-md-9">
           <p>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/citation/view.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/citation/view.xsl
@@ -13,6 +13,12 @@
                 extension-element-prefixes="saxon"
                 exclude-result-prefixes="#all">
 
+  <xsl:output omit-xml-declaration="yes"
+              method="xml"
+              indent="yes"
+              saxon:indent-spaces="2"
+              encoding="UTF-8"/>
+
   <xsl:import href="base.xsl"/>
   <xsl:import href="common.xsl"/>
 

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/xsl-view/view.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/xsl-view/view.xsl
@@ -150,8 +150,8 @@
     <xsl:if test="count($tags/*) > 0">
       <section class="gn-md-side-social">
         <h2>
-          <i class="fa fa-fw fa-tag"><xsl:comment select="'image'"/></i>
-          <span><xsl:comment select="name()"/>
+          <i class="fa fa-fw fa-tag"></i>
+          <span>
             <xsl:value-of select="$schemaStrings/noThesaurusName"/>
           </span>
         </h2>
@@ -219,8 +219,8 @@
     <xsl:if test=".//mdb:identificationInfo/*/mri:extent">
       <section class="gn-md-side-extent">
         <h2>
-          <i class="fa fa-fw fa-map-marker"><xsl:comment select="'image'"/></i>
-          <span><xsl:comment select="name()"/>
+          <i class="fa fa-fw fa-map-marker"></i>
+          <span>
             <xsl:value-of select="$schemaStrings/spatialExtent"/>
           </span>
         </h2>
@@ -243,7 +243,7 @@
     <xsl:if test="mdb:identificationInfo/*/mri:graphicOverview">
       <section class="gn-md-side-overview">
         <h2>
-          <i class="fa fa-fw fa-image"><xsl:comment select="'.'"/></i><xsl:comment select="'.'"/>
+          <i class="fa fa-fw fa-image"></i>
           <span>
             <xsl:value-of select="$schemaStrings/overviews"/>
           </span>
@@ -295,7 +295,7 @@
     <xsl:if test="$withJsonLd = 'true'">
       <script type="application/ld+json">
         <xsl:apply-templates mode="getJsonLD"
-                             select="$metadata"/><xsl:comment select="'.'"/>
+                             select="$metadata"/>
       </script>
     </xsl:if>
   </xsl:template>
@@ -332,10 +332,10 @@
           <blockquote>
             <div class="row">
               <div class="col-md-1">
-                <i class="fa fa-quote-left"><xsl:comment>Cite</xsl:comment></i>
+                <i class="fa fa-quote-left"></i>
               </div>
               <div class="col-md-11">
-                <h2 title="{$schemaStrings/citationProposal-help}"><xsl:comment select="name()"/>
+                <h2 title="{$schemaStrings/citationProposal-help}">
                   <xsl:value-of select="$schemaStrings/citationProposal"/>
                 </h2>
 
@@ -370,7 +370,7 @@
           <div data-ng-if="showCitation"
                data-gn-metadata-citation=""
                data-text="{$citation}">
-            <xsl:comment>citation</xsl:comment>
+            
           </div>
         </xsl:when>
         <xsl:otherwise>
@@ -444,7 +444,7 @@
           <xsl:otherwise>
             <xsl:apply-templates mode="render-value" select="."/>
           </xsl:otherwise>
-        </xsl:choose><xsl:comment select="'.'"/>
+        </xsl:choose>
         <xsl:apply-templates mode="render-value" select="@*"/>
       </dd>
     </dl>
@@ -554,9 +554,9 @@
             <xsl:with-param name="languages" select="$allLanguages"/>
           </xsl:call-template>
           <xsl:apply-templates mode="render-value"
-                               select="@*"/><xsl:comment select="'.'"/>
+                               select="@*"/>
         </h2>
-        <div class="target"><xsl:comment select="'.'"/>
+        <div class="target">
           <xsl:apply-templates mode="render-field" select="*"/>
         </div>
       </div>
@@ -627,7 +627,7 @@
       <xsl:otherwise>
         <div class="gn-contact">
           <h4>
-            <i class="fa fa-envelope"><xsl:comment select="'.'"/></i>
+            <i class="fa fa-fw fa-envelope"></i>
             <xsl:apply-templates mode="render-value"
                                  select="*/cit:role/*/@codeListValue"/>
           </h4>
@@ -678,7 +678,7 @@
       <xsl:for-each select=".//cit:electronicMailAddress[not(gco:nilReason)]">
         <xsl:apply-templates mode="render-value-no-breaklines"
                              select="."/>
-        <xsl:if test="position() != last()">,<xsl:comment select="'.'"/></xsl:if>
+        <xsl:if test="position() != last()">,</xsl:if>
       </xsl:for-each>
     </xsl:variable>
 
@@ -699,7 +699,7 @@
 
         <xsl:if test="$email != ''">
           <a href="mailto:{normalize-space($email)}">
-            <sup class="fa fa-envelope">&#160;</sup>
+            <sup class="fa fa-fw fa-envelope">&#160;</sup>
           </a>
         </xsl:if>
       </xsl:when>
@@ -712,11 +712,11 @@
                 <xsl:choose>
                   <xsl:when test="normalize-space($email) != ''">
                     <a href="mailto:{normalize-space($email)}">
-                      <xsl:value-of select="$displayName"/><xsl:comment select="'.'"/>
+                      <xsl:value-of select="$displayName"/>
                     </a>
                   </xsl:when>
                   <xsl:otherwise>
-                    <xsl:value-of select="$displayName"/><xsl:comment select="'.'"/>
+                    <xsl:value-of select="$displayName"/>
                   </xsl:otherwise>
                 </xsl:choose>
               </strong><br/>
@@ -741,7 +741,7 @@
                     <xsl:variable name="phoneNumber">
                       <xsl:apply-templates mode="render-value-no-breaklines" select="."/>
                     </xsl:variable>
-                    <i class="fa fa-phone"><xsl:comment select="'.'"/></i>
+                    <i class="fa fa-fw fa-phone"></i>
                     <a href="tel:{$phoneNumber}">
                       <xsl:value-of select="$phoneNumber"/>
                     </a>
@@ -752,9 +752,9 @@
                     <xsl:variable name="phoneNumber">
                       <xsl:apply-templates mode="render-value-no-breaklines" select="."/>
                     </xsl:variable>
-                    <i class="fa fa-fax"><xsl:comment select="'.'"/></i>
+                    <i class="fa fa-fw fa-fax"></i>
                     <a href="tel:{normalize-space($phoneNumber)}">
-                      <xsl:value-of select="normalize-space($phoneNumber)"/><xsl:comment select="'.'"/>(<xsl:value-of select="../cit:numberType/*/@codeListValue"/>)
+                      <xsl:value-of select="normalize-space($phoneNumber)"/> (<xsl:value-of select="../cit:numberType/*/@codeListValue"/>)
                     </a>
                   </div>
                 </xsl:for-each>
@@ -770,7 +770,7 @@
                   <xsl:variable name="linkage">
                     <xsl:apply-templates mode="render-value-no-breaklines" select="."/>
                   </xsl:variable>
-                  <i class="fa fa-link"><xsl:comment select="'.'"/></i>
+                  <i class="fa fa-fw fa-link"></i>
                   <a href="{normalize-space($linkage)}" target="_blank">
                     <xsl:value-of select="if (normalize-space($linkName) != '')
                                           then $linkName
@@ -838,7 +838,7 @@
         <xsl:apply-templates mode="render-value" select="@*"/>
 
         <a class="btn btn-link" href="{$nodeUrl}api/records/{$metadataId}/formatters/xml" target="_blank">
-          <i class="fa fa-file-code-o fa-2x"><xsl:comment select="'.'"/></i>
+          <i class="fa fa-fw fa-file-code-o fa-2x"></i>
           <span><xsl:value-of select="$schemaStrings/metadataInXML"/></span>
         </a>
       </dd>
@@ -862,7 +862,7 @@
         </xsl:variable>
         <a href="{*/cit:linkage/*}" target="_blank">
           <xsl:apply-templates mode="render-value"
-                               select="if (*/cit:name != '') then */cit:name else */cit:linkage"/><xsl:comment select="'.'"/>
+                               select="if (*/cit:name != '') then */cit:name else */cit:linkage"/>
         </a>
         <p>
           <xsl:value-of select="normalize-space($linkDescription)"/>
@@ -1097,7 +1097,7 @@
             <xsl:for-each select="parent::node()/*[name() = $nodeName]">
               <li>
                 <a href="{$nodeUrl}api/records/{@uuidref}">
-                  <i class="fa fa-link"><xsl:comment select="'.'"/></i>
+                  <i class="fa fa-fw fa-link"></i>
                   <xsl:value-of select="gn-fn-render:getMetadataTitle(@uuidref, $language)"/>
                 </a>
               </li>
@@ -1181,7 +1181,7 @@
 
     <xsl:if test="@uom">
       <!-- Display the unit value only -->
-      <xsl:comment select="'.'"/>&#160; <xsl:value-of select="if (contains(@uom, '#'))
+      &#160; <xsl:value-of select="if (contains(@uom, '#'))
                                     then concat(., ' ', tokenize(@uom, '#')[2])
                                     else  concat(., ' ', @uom)"/>
     </xsl:if>
@@ -1348,7 +1348,7 @@
   <xsl:template mode="render-value"
                 match="@gco:nilReason[. = 'withheld']"
                 priority="100">
-    <i class="fa fa-lock text-warning" title="{{{{'withheld' | translate}}}}"><xsl:comment select="'.'"/></i>
+    <i class="fa fa-fw fa-lock text-warning" title="{{{{'withheld' | translate}}}}"></i>
   </xsl:template>
   <xsl:template mode="render-value"
                 match="@*"/>

--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/citation/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/citation/view.xsl
@@ -18,6 +18,12 @@
                 extension-element-prefixes="saxon"
                 exclude-result-prefixes="#all">
 
+  <xsl:output omit-xml-declaration="yes"
+              method="xml"
+              indent="yes"
+              saxon:indent-spaces="2"
+              encoding="UTF-8"/>
+
   <xsl:include href="base.xsl"/>
   <xsl:include href="../../../iso19115-3.2018/formatter/citation/common.xsl"/>
 

--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
@@ -120,8 +120,8 @@
 
     <section class="gn-md-side-social">
       <h2>
-        <i class="fa fa-fw fa-tag"><xsl:comment select="'image'"/></i>
-        <span><xsl:comment select="name()"/>
+        <i class="fa fa-fw fa-tag"></i>
+        <span>
           <xsl:value-of select="$schemaStrings/noThesaurusName"/>
         </span>
       </h2>
@@ -195,8 +195,8 @@
   <xsl:template mode="getExtent" match="gmd:MD_Metadata|*[@gco:isoType = 'gmd:MD_Metadata']">
     <section class="gn-md-side-extent">
       <h2>
-        <i class="fa fa-fw fa-map-marker"><xsl:comment select="'image'"/></i>
-        <span><xsl:comment select="name()"/>
+        <i class="fa fa-fw fa-map-marker"></i>
+        <span>
           <xsl:value-of select="$schemaStrings/spatialExtent"/>
         </span>
       </h2>
@@ -217,8 +217,8 @@
   <xsl:template mode="getOverviews" match="gmd:MD_Metadata|*[@gco:isoType = 'gmd:MD_Metadata']">
     <section class="gn-md-side-overview">
       <h2>
-        <i class="fa fa-fw fa-image"><xsl:comment select="'image'"/></i>
-        <span><xsl:comment select="name()"/>
+        <i class="fa fa-fw fa-image"></i>
+        <span>
           <xsl:value-of select="$schemaStrings/overviews"/>
         </span>
       </h2>
@@ -299,10 +299,10 @@
           <blockquote>
             <div class="row">
               <div class="col-md-1">
-                <i class="fa fa-quote-left"><xsl:comment>Cite</xsl:comment></i>
+                <i class="fa fa-quote-left"></i>
               </div>
               <div class="col-md-11">
-                <h2 title="{$schemaStrings/citationProposal-help}"><xsl:comment select="name()"/>
+                <h2 title="{$schemaStrings/citationProposal-help}">
                   <xsl:value-of select="$schemaStrings/citationProposal"/>
                 </h2>
 
@@ -344,7 +344,7 @@
         <xsl:otherwise>
           <div data-ng-if="showCitation"
                data-gn-metadata-citation="md">
-            <xsl:comment>citation</xsl:comment>
+            
           </div>
         </xsl:otherwise>
       </xsl:choose>
@@ -370,7 +370,7 @@
             <xsl:with-param name="languages" select="$allLanguages"/>
           </xsl:call-template>
         </dt>
-        <dd><xsl:comment select="name()"/>
+        <dd>
           <xsl:apply-templates mode="render-value" select="*|*/@codeListValue"/>
           <xsl:apply-templates mode="render-value" select="@*"/>
         </dd>
@@ -392,7 +392,7 @@
             <xsl:with-param name="languages" select="$allLanguages"/>
           </xsl:call-template>
         </dt>
-        <dd><xsl:comment select="name()"/>
+        <dd>
           <xsl:choose>
             <xsl:when test="normalize-space(*/@codeListValue) != ''">
               <xsl:apply-templates mode="render-value" select="*/@codeListValue"/>
@@ -441,7 +441,7 @@
         </xsl:call-template>
       </dt>
       <dd>
-        <xsl:comment select="name()"/>
+        
         <xsl:apply-templates mode="render-value" select="."/>
         <xsl:apply-templates mode="render-value" select="@*"/>
       </dd>
@@ -535,7 +535,7 @@
         <xsl:apply-templates mode="render-value"
                              select="@*"/>
       </h2>
-      <div class="target"><xsl:comment select="name()"/>
+      <div class="target">
         <xsl:choose>
           <xsl:when test="count(*) > 0">
             <xsl:apply-templates mode="render-field" select="*"/>
@@ -589,7 +589,7 @@
         <xsl:apply-templates mode="render-value"
                              select="@*"/>
       </h2>
-      <div class="target"><xsl:comment select="name()"/>
+      <div class="target">
 
         <xsl:apply-templates mode="render-field"
                              select="gmd:description"/>
@@ -657,7 +657,7 @@
       <xsl:otherwise>
         <div class="gn-contact">
           <strong>
-            <xsl:comment select="'email'"/>
+            
             <xsl:apply-templates mode="render-value"
                                  select="*/gmd:role/*/@codeListValue"/>
           </strong>
@@ -666,11 +666,11 @@
                 <xsl:when test="$email">
                   <i class="fa fa-fw fa-envelope">&#160;</i>
                   <a href="mailto:{normalize-space($email)}">
-                    <xsl:copy-of select="$displayName"/><xsl:comment select="'email'"/>
+                    <xsl:copy-of select="$displayName"/>
                   </a>
                 </xsl:when>
                 <xsl:otherwise>
-                  <xsl:copy-of select="$displayName"/><xsl:comment select="'name'"/>
+                  <xsl:copy-of select="$displayName"/>
                 </xsl:otherwise>
               </xsl:choose>
             <br/>
@@ -682,7 +682,7 @@
                   gmd:postalCode[normalize-space(.) != ''] or
                   gmd:country[normalize-space(.) != '']]">
                 <div>
-                <i class="fa fa-fw fa-map-marker"><xsl:comment select="'address'"/></i>
+                <i class="fa fa-fw fa-map-marker"></i>
                   <xsl:for-each select="gmd:deliveryPoint[normalize-space(.) != '']">
                     <xsl:apply-templates mode="render-value-no-breaklines" select="."/>,
                   </xsl:for-each>
@@ -706,7 +706,7 @@
                   <xsl:variable name="phoneNumber">
                     <xsl:apply-templates mode="render-value-no-breaklines" select="."/>
                   </xsl:variable>
-                  <i class="fa fa-fw fa-phone"><xsl:comment select="'phone'"/></i>
+                  <i class="fa fa-fw fa-phone"></i>
                   <a href="tel:{translate($phoneNumber,' ','')}">
                     <xsl:value-of select="$phoneNumber"/>
                   </a>
@@ -716,7 +716,7 @@
                 <xsl:variable name="phoneNumber">
                   <xsl:apply-templates mode="render-value" select="."/>
                 </xsl:variable>
-                <i class="fa fa-fw fa-fax"><xsl:comment select="'fax'"/></i>
+                <i class="fa fa-fw fa-fax"></i>
                 <a href="tel:{translate($phoneNumber,' ','')}">
                   <xsl:value-of select="normalize-space($phoneNumber)"/>
                 </a>
@@ -725,7 +725,7 @@
               <xsl:for-each select="gmd:onlineResource/*/gmd:linkage/gmd:URL[normalize-space(.) != '']">
                 <xsl:variable name="web">
                   <xsl:apply-templates mode="render-value" select="."/></xsl:variable>
-                <i class="fa fa-fw fa-link"><xsl:comment select="'link'"/></i>
+                <i class="fa fa-fw fa-link"></i>
                 <a href="{normalize-space($web)}">
                   <xsl:value-of select="normalize-space($web)"/>
                 </a>
@@ -755,7 +755,7 @@
         <xsl:apply-templates mode="render-value" select="*"/>
         <xsl:apply-templates mode="render-value" select="@*"/>
         <a class="btn btn-default" href="{$nodeUrl}api/records/{$metadataUuid}/formatters/xml">
-          <i class="fa fa-file-code-o"><xsl:comment select="'file'"/></i>
+          <i class="fa fa-fw fa-file-code-o"></i>
           <span><xsl:value-of select="$schemaStrings/metadataInXML"/></span>
         </a>
       </dd>
@@ -791,17 +791,17 @@
           </xsl:choose>
         </xsl:variable>
         <a href="{$linkUrl}" title="{$linkName}">
-          <span><xsl:comment select="name()"/>
+          <span>
             <xsl:value-of select="$linkName"/>
           </span>
         </a>
         <xsl:if test="*/gmd:protocol[normalize-space(gco:CharacterString|gmx:Anchor) != '']">
-          (<span><xsl:comment select="name()"/>
+          (<span>
           <xsl:apply-templates mode="render-value-no-breaklines"
                                select="*/gmd:protocol"/>
         </span>)</xsl:if>
         <xsl:if test="*/gmd:description[normalize-space(gco:CharacterString|gmx:Anchor) != '' and * != $linkName]">
-          <p><xsl:comment select="name()"/>
+          <p>
             <xsl:apply-templates mode="render-value"
                                  select="*/gmd:description"/>
           </p>
@@ -836,7 +836,7 @@
                                select="*/gmd:version"/>
         </xsl:if>
         <xsl:if test="*/gmd:authority">
-          <p><xsl:comment select="name()"/>
+          <p>
             <xsl:apply-templates mode="render-value-no-breaklines"
                                  select="*/gmd:authority"/>
           </p>
@@ -941,7 +941,7 @@
                                     select="*/gmd:name"/>
                 (<xsl:apply-templates mode="render-value-no-breaklines"
                                       select="*/gmd:version"/>)
-                <p><xsl:comment select="name()"/>
+                <p>
                   <xsl:apply-templates mode="render-field"
                                       select="*/(gmd:amendmentNumber|gmd:specification|
                                 gmd:fileDecompressionTechnique|gmd:formatDistributor)"/>
@@ -1030,8 +1030,8 @@
               <li>
                 <a data-gn-api-link=""
                    href="{$nodeUrl}api/records/{@uuidref}">
-                  <i class="fa fa-fw fa-link"><xsl:comment select="'link'"/></i>
-                  <span><xsl:comment select="'dataset'"/>
+                  <i class="fa fa-fw fa-link"></i>
+                  <span>
                     <xsl:value-of select="gn-fn-render:getMetadataTitle(@uuidref, $langId)"/>
                   </span>
                 </a>
@@ -1066,11 +1066,11 @@
      <span>
       <xsl:if test="name() = 'gmd:parentIdentifier'">
         <a href="{$nodeUrl}api/records/{./gco:CharacterString}">
-          <i class="fa fa-fw fa-link"><xsl:comment select="'link'"/></i>
+          <i class="fa fa-fw fa-link"></i>
           <xsl:value-of select="gn-fn-render:getMetadataTitle(./gco:CharacterString, $langId)"/>
         </a>
       </xsl:if>
-       <xsl:comment select="name()"/>
+       
       <xsl:call-template name="addLineBreaksAndHyperlinks">
         <xsl:with-param name="txt" select="$txt"/>
       </xsl:call-template>
@@ -1082,11 +1082,11 @@
     <span>
       <xsl:if test="name() = 'gmd:parentIdentifier'">
         <a href="{$nodeUrl}api/records/{./gco:CharacterString}">
-          <i class="fa fa-fw fa-link"><xsl:comment select="'link'"/></i>
+          <i class="fa fa-fw fa-link"></i>
           <xsl:value-of select="gn-fn-render:getMetadataTitle(./gco:CharacterString, $langId)"/>
         </a>
       </xsl:if>
-      <xsl:comment select="name()"/>
+      
       <xsl:apply-templates mode="localised" select=".">
         <xsl:with-param name="langId" select="$langId"/>
       </xsl:apply-templates>
@@ -1191,7 +1191,7 @@
         <img src="{$href}" title="{$label}" alt="{$label}"/>
       </xsl:when>
       <xsl:otherwise>
-        <a href="{$href}"><xsl:comment select="name()"/>
+        <a href="{$href}">
           <xsl:value-of select="$label"/>
         </a>
       </xsl:otherwise>
@@ -1201,7 +1201,7 @@
   <!-- ... URL -->
   <xsl:template mode="render-value"
                 match="gmd:URL">
-    <a href="{.}"><xsl:comment select="name()"/>
+    <a href="{.}">
       <xsl:value-of select="."/>
     </a>
   </xsl:template>
@@ -1216,7 +1216,7 @@
 
   <xsl:template mode="render-value"
                 match="gco:Date[matches(., '[0-9]{4}-[0-9]{2}')]">
-    <span data-gn-humanize-time="{.}" data-format="MMM YYYY"><xsl:comment select="name()"/>
+    <span data-gn-humanize-time="{.}" data-format="MMM YYYY">
       <xsl:value-of select="."/>
     </span>
   </xsl:template>
@@ -1227,21 +1227,21 @@
                       |gml:endPosition[matches(., '[0-9]{4}-[0-9]{2}-[0-9]{2}')]
                       |gml:begin[matches(., '[0-9]{4}-[0-9]{2}-[0-9]{2}')]
                       |gml:end[matches(., '[0-9]{4}-[0-9]{2}-[0-9]{2}')]">
-    <span data-gn-humanize-time="{.}"><xsl:comment select="name()"/>
+    <span data-gn-humanize-time="{.}">
       <xsl:value-of select="."/>
     </span>
   </xsl:template>
 
   <xsl:template mode="render-value"
                 match="gco:DateTime[matches(., '[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}')]">
-    <span data-gn-humanize-time="{.}"><xsl:comment select="name()"/>
+    <span data-gn-humanize-time="{.}">
       <xsl:value-of select="."/>
     </span>
   </xsl:template>
 
   <xsl:template mode="render-value"
                 match="gco:Date|gco:DateTime">
-    <span data-gn-humanize-time="{.}"><xsl:comment select="name()"/>
+    <span data-gn-humanize-time="{.}">
       <xsl:value-of select="."/>
     </span>
   </xsl:template>
@@ -1311,7 +1311,7 @@
   <xsl:template mode="render-value"
                 match="@gco:nilReason[. = 'withheld']"
                 priority="100">
-    <i class="fa fa-lock text-warning" title="{{{{'withheld' | translate}}}}"><xsl:comment select="'warning'"/></i>
+    <i class="fa fa-fw fa-lock text-warning" title="{{{{'withheld' | translate}}}}"></i>
   </xsl:template>
 
   <xsl:template mode="render-value"

--- a/services/src/main/java/org/fao/geonet/api/records/editing/MetadataEditingApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/editing/MetadataEditingApi.java
@@ -688,7 +688,8 @@ public class MetadataEditingApi {
         GeonetworkDataDirectory dataDirectory = applicationContext.getBean(GeonetworkDataDirectory.class);
         Path xslt = dataDirectory.getWebappDir()
             .resolve(isEmbedded ? "xslt/ui-metadata/edit/edit-embedded.xsl" : "xslt/ui-metadata/edit/edit.xsl");
-        Xml.transformXml(root, xslt, response.getOutputStream());
+
+        Xml.transform(root, xslt, response.getOutputStream());
     }
 
     private Element buildResourceDocument(ApplicationContext applicationContext, ServiceContext context,

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/XsltFormatter.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/XsltFormatter.java
@@ -36,6 +36,8 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.stereotype.Component;
 
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -209,9 +211,11 @@ public class XsltFormatter implements FormatterImpl {
                 requestParameters.put(key, fparams.webRequest.getParameterMap().get(key));
             }
         }
-        Element transformed = Xml.transform(root, fparams.viewFile, requestParameters);
-        return "textResponse".equals(transformed.getName()) ?
-            transformed.getText() :
-            Xml.getString(transformed);
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        Xml.transform(root, fparams.viewFile, requestParameters, baos);
+        String transformed = baos.toString(StandardCharsets.UTF_8);
+        return transformed.startsWith("<textResponse") ?
+            Xml.loadString(transformed, false).getText() :
+            transformed;
     }
 }

--- a/services/src/test/resources/org/fao/geonet/api/records/formatters/iso19115-3.2018-citation-html.html
+++ b/services/src/test/resources/org/fao/geonet/api/records/formatters/iso19115-3.2018-citation-html.html
@@ -1,19 +1,15 @@
 <blockquote>
   <div class="row">
     <div class="col-md-3">
-      <i class="fa fa-quote-left pull-right">
-        <!--icon-->
-      </i>
+      <i class="fa fa-quote-left pull-right"><!----></i>
     </div>
     <div class="col-md-9">
       <p>
         <span>Production géomatique et traitement de données (SPW - Secrétariat général - SPW
-                  Digital - Département Données transversales - Production géomatique et traitement de données)</span>
-         (2020).
-        <span>Utilisation du Sol en Wallonie - WALOUS 2018.</span>
-        <br />
+                  Digital - Département Données transversales - Production géomatique et traitement de données)</span> (2020).<span>Utilisation du Sol en Wallonie - WALOUS 2018.</span>
+        <br/>
         <a href="http://localhost:8080/srv/api/records/{uuid}">http://localhost:8080/srv/api/records/{uuid}</a>
-        <br />
+        <br/>
       </p>
     </div>
   </div>

--- a/services/src/test/resources/org/fao/geonet/api/records/formatters/iso19139-citation-html.html
+++ b/services/src/test/resources/org/fao/geonet/api/records/formatters/iso19139-citation-html.html
@@ -1,18 +1,14 @@
 <blockquote>
   <div class="row">
     <div class="col-md-3">
-      <i class="fa fa-quote-left pull-right">
-        <!--icon-->
-      </i>
+      <i class="fa fa-quote-left pull-right"><!----></i>
     </div>
     <div class="col-md-9">
-      <p>
-        (2020).
-        <span>CORINE Land Cover Change 2012-2018 (vector), Europe, 6-yearly - version 2020_20u1, May
+      <p>(2020).<span>CORINE Land Cover Change 2012-2018 (vector), Europe, 6-yearly - version 2020_20u1, May
               2020.</span>
-        <br />
+        <br/>
         <a href="https://doi.org/10.2909/f30f1000-7cf8-43bb-872c-5eb093911b24">https://doi.org/10.2909/f30f1000-7cf8-43bb-872c-5eb093911b24</a>
-        <br />
+        <br/>
       </p>
     </div>
   </div>

--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
@@ -20,7 +20,8 @@
   <xsl:import href="render-functions.xsl"/>
   <xsl:import href="render-layout-fields.xsl"/>
 
-  <xsl:output method="html"/>
+  <xsl:output omit-xml-declaration="yes" method="html" doctype-system="html" indent="yes"
+              encoding="UTF-8"/>
 
   <!-- Those templates should be overriden in the schema plugin - start -->
   <xsl:template mode="getMetadataTitle" match="*"/>
@@ -155,7 +156,7 @@
 
             <header>
               <h1>
-                <i class="fa gn-icon-{$type}"><xsl:comment select="'icon'"/></i>
+                <i class="fa fa-fw gn-icon-{$type}"></i>
                 <xsl:copy-of select="$title"/>
               </h1>
 
@@ -167,7 +168,7 @@
                 <div gn-related="md"
                      data-user="user"
                      data-layout="card"
-                     data-types="{$related}"><xsl:comment select="'icon'"/></div>
+                     data-types="{$related}"></div>
               </xsl:if>
             </header>
 
@@ -210,7 +211,7 @@
             <br/>
             <section class="gn-md-side-providedby">
               <h2>
-                <i class="fa fa-fw fa-cog"><xsl:comment select="'icon'"/></i>
+                <i class="fa fa-fw fa-cog"></i>
                 <span><xsl:value-of select="$schemaStrings/providedBy"/></span>
               </h2>
               <img class="gn-source-logo"
@@ -221,32 +222,32 @@
             <xsl:if test="$isSocialbarEnabled">
               <section class="gn-md-side-social">
                 <h2>
-                  <i class="fa fa-fw fa-share-square-o"><xsl:comment select="'icon'"/></i>
+                  <i class="fa fa-fw fa-share-square-o"></i>
                   <span><xsl:value-of select="$schemaStrings/shareOnSocialSite"/></span>
                 </h2>
                 <a href="https://twitter.com/share?url={encode-for-uri($nodeUrl)}api%2Frecords%2F{$metadataUuid}"
                    target="_blank"
                    aria-label="Twitter"
                    class="btn btn-default">
-                  <i class="fa fa-fw fa-twitter"><xsl:comment select="'icon'"/></i>
+                  <i class="fa fa-fw fa-twitter"></i>
                 </a>
                 <a href="https://www.facebook.com/sharer.php?u={encode-for-uri($nodeUrl)}api%2Frecords%2F{$metadataUuid}"
                    target="_blank"
                    aria-label="Facebook"
                    class="btn btn-default">
-                  <i class="fa fa-fw fa-facebook"><xsl:comment select="'icon'"/></i>
+                  <i class="fa fa-fw fa-facebook"></i>
                 </a>
                 <a href="http://www.linkedin.com/shareArticle?mini=true&amp;summary=&amp;url={encode-for-uri($nodeUrl)}api%2Frecords%2F{$metadataUuid}"
                    target="_blank"
                    aria-label="LinkedIn"
                    class="btn btn-default">
-                  <i class="fa fa-fw fa-linkedin"><xsl:comment select="'icon'"/></i>
+                  <i class="fa fa-fw fa-linkedin"></i>
                 </a>
                 <a href="mailto:?subject={$title}&amp;body={encode-for-uri($nodeUrl)}api%2Frecords%2F{$metadataUuid}"
                    target="_blank"
                    aria-label="Email"
                    class="btn btn-default">
-                  <i class="fa fa-fw fa-envelope-o"><xsl:comment select="'icon'"/></i>
+                  <i class="fa fa-fw fa-envelope-o"></i>
                 </a>
               </section>
             </xsl:if>
@@ -256,7 +257,7 @@
             <xsl:if test="$viewMenu = 'true'">
               <section class="gn-md-side-viewmode">
                 <h2>
-                  <i class="fa fa-fw fa-eye"><xsl:comment select="'icon'"/></i>
+                  <i class="fa fa-fw fa-eye"></i>
                   <span><xsl:value-of select="$schemaStrings/viewMode"/></span>
                 </h2>
                 <xsl:for-each select="$configuration/editor/views/view[not(@disabled)]">
@@ -287,7 +288,7 @@
                  href="{if ($portalLink != '')
                         then replace($portalLink, '\$\{uuid\}', $metadataUuid)
                         else utils:getDefaultUrl($metadataUuid, $language)}">
-                <i class="fa fa-fw fa-link"><xsl:comment select="'icon'"/></i>
+                <i class="fa fa-fw fa-link"></i>
                 <xsl:value-of select="$schemaStrings/linkToPortal"/>
               </a>
               <div class="hidden-xs hidden-sm">
@@ -299,7 +300,7 @@
             <xsl:if test="$sideRelated != '' and $root != 'html'">
               <section class="gn-md-side-associated">
                 <h2>
-                  <i class="fa fa-fw fa-link"><xsl:comment select="'icon'"/></i>
+                  <i class="fa fa-fw fa-link"></i>
                   <span><xsl:value-of select="$schemaStrings/associatedResources"/></span>
                 </h2>
                 <div gn-related="md"
@@ -320,7 +321,6 @@
              data-watch=""
              data-filter="div > h3"/>-->
         <footer>
-          <xsl:comment>Not yet</xsl:comment>
         </footer>
       </article>
       <br/>
@@ -403,7 +403,7 @@
     <xsl:if test="$isDisplayed">
       <div id="gn-view-{generate-id()}" class="gn-tab-content">
         <xsl:apply-templates mode="render-view" select="@xpath"/>
-        <xsl:comment select="'icon'"/>
+        
       </div>
     </xsl:if>
   </xsl:template>

--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
@@ -20,7 +20,7 @@
   <xsl:import href="render-functions.xsl"/>
   <xsl:import href="render-layout-fields.xsl"/>
 
-  <xsl:output omit-xml-declaration="yes" method="html" doctype-system="html" indent="yes"
+  <xsl:output omit-xml-declaration="yes" method="xhtml" doctype-system="html" indent="yes"
               encoding="UTF-8"/>
 
   <!-- Those templates should be overriden in the schema plugin - start -->

--- a/web/src/main/webapp/xslt/base-layout.xsl
+++ b/web/src/main/webapp/xslt/base-layout.xsl
@@ -99,7 +99,7 @@
       -->
       <body data-ng-controller="GnCatController" data-ng-class="[isHeaderFixed ? 'gn-header-fixed' : 'gn-header-relative', isLogoInHeader ? 'gn-logo-in-header' : 'gn-logo-in-navbar', isFooterEnabled ? 'gn-show-footer' : 'gn-hide-footer']">
 
-        <div data-gn-alert-manager=""></div>
+        <div data-gn-alert-manager=""/>
 
         <xsl:choose>
           <xsl:when test="ends-with($service, 'nojs')">

--- a/web/src/main/webapp/xslt/common/render-html.xsl
+++ b/web/src/main/webapp/xslt/common/render-html.xsl
@@ -30,11 +30,6 @@
   <xsl:include href="../base-layout-cssjs-loader.xsl"/>
   <xsl:include href="../skin/default/skin.xsl"/>
 
-  <xsl:output omit-xml-declaration="yes"
-              method="html"
-              doctype-system="html"
-              indent="yes"
-              encoding="UTF-8"/>
 
   <xsl:template name="render-html">
     <xsl:param name="content"/>

--- a/web/src/main/webapp/xslt/ui-metadata/edit/edit-embedded.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/edit/edit-embedded.xsl
@@ -32,7 +32,10 @@
                 extension-element-prefixes="saxon"
                 exclude-result-prefixes="#all">
 
-  <xsl:output method="html" encoding="UTF-8" indent="yes"/>
+  <xsl:output omit-xml-declaration="yes"
+              method="html"
+              indent="yes"
+              encoding="UTF-8"/>
 
   <xsl:include href="../../common/base-variables-metadata-editor.xsl"/>
 

--- a/web/src/main/webapp/xslt/ui-metadata/form-builder-xml.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-builder-xml.xsl
@@ -39,11 +39,11 @@
         </xsl:variable>
 
         <!-- Render XML in textarea -->
-        <div id="xmleditor"
+        <pre id="xmleditor"
              ui-ace="{{useWrapMode:true,showGutter:true,mode:'xml',onLoad:xmlEditorLoaded,onChange:xmlEditorChange}}">
           <xsl:value-of
             select="saxon:serialize($strippedXml, 'default-indent-mode')"/>
-        </div>
+        </pre>
         <textarea name="data" class="hidden">
         </textarea>
       </xsl:when>

--- a/web/src/main/webapp/xslt/ui-metadata/menu-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/menu-builder.xsl
@@ -51,7 +51,7 @@
                 aria-label="{$i18n/selectView}"
                 title="{$i18n/selectView}"
                 aria-expanded="false">
-          <i class="fa fa-eye"></i>
+          <i class="fa fa-fw fa-eye"></i>
           <span class="caret"></span>
         </button>
         <ul class="dropdown-menu" role="menu">


### PR DESCRIPTION
Formatter API was using an XMLOutputter overriding all configuration made in `xsl:output`. This was producing "invalid" HTML and some workaround were used so far.

Now, return the output produced by saxon XMLIndenter or HTMLIndenter directly.

A good config for HTML output:
```xml
<xsl:output omit-xml-declaration="yes" method="html" doctype-system="html" indent="yes"
                     encoding="UTF-8"/>
```

It was only affecting the formatter API using the `XML.getString` which was doing the prettyPrint. 

For schema plugin maintainer, this change requires to check plugin formatter which may export HTML, XML or Text output. Adjust the `xsl:output` configuration if needed.

Also do not force editor API to output XML. It outputs HTML and XML view may contains a properly formatted XML snippet.

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

