### PR TITLE
WPS process parameters - support datetime / time formats

### DIFF
--- a/web-ui/src/main/resources/catalog/components/viewer/wps/WpsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wps/WpsDirective.js
@@ -248,14 +248,24 @@
                 });
               };
 
+              scope.getHtmlInputType = function (input) {
+                if (scope.isTime(input)) {
+                  return "time";
+                } else if (scope.isDate(input)) {
+                  return "date";
+                } if (scope.isDateTime(input)) {
+                  return "datetime-local";
+                } else
+                return "";
+              };
               scope.getDateBounds = function (input, isMin) {
                 if (!input) {
                   return;
                 } else if (isMin) {
                   return input.literalData.allowedValues.valueOrRange[0].minimumValue
-                    .value;
+                    .value || "";
                 }
-                return input.literalData.allowedValues.valueOrRange[0].maximumValue.value;
+                return input.literalData.allowedValues.valueOrRange[0].maximumValue.value || "";
               };
 
               // get values from wfs filters

--- a/web-ui/src/main/resources/catalog/components/viewer/wps/WpsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wps/WpsDirective.js
@@ -192,9 +192,45 @@
                 }
               }
 
-              scope.isDateTime = function (date) {
+              scope.isDateFormat = function (date) {
                 if (date.hasOwnProperty("metadata")) {
                   return date.metadata[0].href === "datetime";
+                }
+                return false;
+              };
+
+              scope.isDateTime = function (date) {
+                if (scope.isDateFormat(date)) {
+                  if (date.hasOwnProperty("literalData")) {
+                    return (
+                      date.literalData.hasOwnProperty("dataType") &&
+                      date.literalData.dataType.value === "dateTime"
+                    );
+                  }
+                }
+                return false;
+              };
+
+              scope.isDate = function (date) {
+                if (scope.isDateFormat(date)) {
+                  if (date.hasOwnProperty("literalData")) {
+                    return (
+                      date.literalData.hasOwnProperty("dataType") &&
+                      date.literalData.dataType.value === "date"
+                    );
+                  }
+                }
+                return false;
+              };
+
+              scope.isTime = function (date) {
+                if (scope.isDateFormat(date)) {
+                  if (date.hasOwnProperty("literalData")) {
+                    return (
+                      date.literalData.hasOwnProperty("dataType") &&
+                      date.literalData.dataType.value === "time"
+                    );
+                  }
                 }
                 return false;
               };

--- a/web-ui/src/main/resources/catalog/components/viewer/wps/WpsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wps/WpsDirective.js
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2024 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -682,7 +682,7 @@
             source.clear();
           };
 
-          scope.submit = function () {
+          scope.executeWPSProcess = function () {
             source.clear();
             scope.validation_messages = [];
             scope.exception = undefined;
@@ -710,7 +710,22 @@
               return;
             }
 
-            var inputs = scope.wpsLink.inputs;
+            var inputs = scope.wpsLink.inputs.map(function (input) {
+              // Deep clone to avoid changing the original fields in scope.wpsLink.inputs
+              // from dates to string
+              var inputClone = angular.copy(input);
+              // Process date fields
+              if (inputClone.name === "DATE" && inputClone.value) {
+                inputClone.value = inputClone.value.toISOString().split("T")[0];
+              } else if (inputClone.name === "DATETIME" && inputClone.value) {
+                inputClone.value = inputClone.value.toISOString();
+              } else if (inputClone.name === "TIME" && inputClone.value) {
+                inputClone.value = inputClone.value.toISOString().split("T")[1];
+              }
+
+              return inputClone;
+            });
+
             var output = scope.wpsLink.output;
 
             var updateStatus = function (statusLocation) {

--- a/web-ui/src/main/resources/catalog/components/viewer/wps/partials/processform.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/wps/partials/processform.html
@@ -68,23 +68,41 @@
                 >
               </label>
 
-              <!-- Date time -->
-              <div ng-if="isDateTime(input)">
-                <div
-                  ng-repeat="field in getInputsByName(input.identifier.value)"
-                  class="input-daterange input-group input-group-sm"
-                  gn-bootstrap-datepicker="pickerValues"
-                  config="{dateMin: getDateBounds(input, true), dateMax: getDateBounds(input, false)}"
-                  data-date-format="dd-mm-yyyy"
-                >
+              <div ng-if="isDateFormat(input)">
+                <!-- Date time -->
+                <div ng-if="isDateTime(input)">
                   <input
+                    ng-repeat="field in getInputsByName(input.identifier.value)"
                     ng-model="field.value"
                     data-ng-click="desactivateGeometryTool()"
-                    type="text"
+                    type="datetime-local"
                     ng-blur="onBlur($event)"
                     class="input-sm form-control"
                   />
-                  <span class="input-group-addon" translate>date</span>
+                </div>
+
+                <!-- Date -->
+                <div ng-if="isDate(input)">
+                  <input
+                    ng-repeat="field in getInputsByName(input.identifier.value)"
+                    ng-model="field.value"
+                    data-ng-click="desactivateGeometryTool()"
+                    type="date"
+                    ng-blur="onBlur($event)"
+                    class="input-sm form-control"
+                  />
+                </div>
+
+                <!-- Time -->
+                <div ng-if="isTime(input)">
+                  <input
+                    ng-repeat="field in getInputsByName(input.identifier.value)"
+                    ng-model="field.value"
+                    data-ng-click="desactivateGeometryTool()"
+                    type="time"
+                    ng-blur="onBlur($event)"
+                    class="input-sm form-control"
+                  />
                 </div>
               </div>
 
@@ -105,7 +123,9 @@
               </div>
 
               <!-- Basic form field (combo box or text field) -->
-              <div ng-if="::input.literalData && !isDateTime(input) && !isBoolean(input)">
+              <div
+                ng-if="::input.literalData && !isDateFormat(input) && !isBoolean(input)"
+              >
                 <div
                   class="input-group"
                   ng-repeat="field in getInputsByName(input.identifier.value)"

--- a/web-ui/src/main/resources/catalog/components/viewer/wps/partials/processform.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/wps/partials/processform.html
@@ -275,7 +275,7 @@
               <button
                 type="submit"
                 class="btn btn-primary"
-                ng-click="submit()"
+                ng-click="executeWPSProcess()"
                 ng-class="{disabled: running}"
                 ng-show="!hideExecuteButton"
               >

--- a/web-ui/src/main/resources/catalog/components/viewer/wps/partials/processform.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/wps/partials/processform.html
@@ -69,41 +69,16 @@
               </label>
 
               <div ng-if="isDateFormat(input)">
-                <!-- Date time -->
-                <div ng-if="isDateTime(input)">
-                  <input
-                    ng-repeat="field in getInputsByName(input.identifier.value)"
-                    ng-model="field.value"
-                    data-ng-click="desactivateGeometryTool()"
-                    type="datetime-local"
-                    ng-blur="onBlur($event)"
-                    class="input-sm form-control"
-                  />
-                </div>
-
-                <!-- Date -->
-                <div ng-if="isDate(input)">
-                  <input
-                    ng-repeat="field in getInputsByName(input.identifier.value)"
-                    ng-model="field.value"
-                    data-ng-click="desactivateGeometryTool()"
-                    type="date"
-                    ng-blur="onBlur($event)"
-                    class="input-sm form-control"
-                  />
-                </div>
-
-                <!-- Time -->
-                <div ng-if="isTime(input)">
-                  <input
-                    ng-repeat="field in getInputsByName(input.identifier.value)"
-                    ng-model="field.value"
-                    data-ng-click="desactivateGeometryTool()"
-                    type="time"
-                    ng-blur="onBlur($event)"
-                    class="input-sm form-control"
-                  />
-                </div>
+                <input
+                  ng-repeat="field in getInputsByName(input.identifier.value)"
+                  ng-model="field.value"
+                  data-ng-click="desactivateGeometryTool()"
+                  type="{{getHtmlInputType(input)}}"
+                  min="{{getDateBounds(input, true)}}"
+                  max="{{getDateBounds(input, false)}}"
+                  ng-blur="onBlur($event)"
+                  class="input-sm form-control"
+                />
               </div>
 
               <div ng-if="isBoolean(input)">


### PR DESCRIPTION
Datetime and time parameters were not supported in WPS, all were displayed with a calendar widget that only allowed to select dates without the time part).

This change processes the date fields to display the HTML control depending on the format:

![wps-dates](https://github.com/geonetwork/core-geonetwork/assets/1695003/0af10b2a-c49e-4c81-b04b-9f7ce5de3016)

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
