### PR TITLE
docs: fix image links in change-log(version-3.8.0.md and 4.0.0-alpha.1

### DIFF
--- a/docs/manual/docs/overview/change-log/version-3.8.0.md
+++ b/docs/manual/docs/overview/change-log/version-3.8.0.md
@@ -4,20 +4,15 @@
 
 -   Search experience
     -   [Saved searches](https://github.com/geonetwork/core-geonetwork/pull/3778)
-
-        <figure>
-        <img src="img/380-usersearches.png" alt="img/380-usersearches.png" />
-        <figcaption>Saved user searches</figcaption>
-        </figure>
+      
+        ![Screenshot where the star left of the search field expands in a dropdown menu with three options](img/380-usersearches.png "Saved user searches")
 
     -   [Improve PDF output](https://github.com/geonetwork/core-geonetwork/pull/3912)
 
     -   [Add template to display related record as list](https://github.com/geonetwork/core-geonetwork/pull/3908)
 
-        > <figure>
-        > <img src="img/380-related.png" alt="img/380-related.png" />
-        > <figcaption>Add template</figcaption>
-        > </figure>
+        > ![Screenshot showing two related map records below each other](img/380-related.png "Add template")
+  
 
     -   [Add support for negative query on any fields](https://github.com/geonetwork/core-geonetwork/pull/3683)
 -   Standards
@@ -33,10 +28,8 @@
 
     -   [Associated resource can now be filtered, sorted](https://github.com/geonetwork/core-geonetwork/pull/3804), add [support for WFS and Atom services](https://github.com/geonetwork/core-geonetwork/pull/3817).
 
-        > <figure>
-        > <img src="img/380-associated.png" alt="img/380-associated.png" />
-        > <figcaption>Filtering associated resources</figcaption>
-        > </figure>
+        > ![Screenshot of Associated resources dialog with filter options](img/380-associated.png "Filtering associated resources")
+
 -   Harvester
     -   [GeoNetwork / Add paging for better support of large catalogues](https://github.com/geonetwork/core-geonetwork/pull/3916)
     -   [THREDDS / Modernise and simplify harvester](https://github.com/geonetwork/core-geonetwork/pull/3936)

--- a/docs/manual/docs/overview/change-log/version-3.8.0.md
+++ b/docs/manual/docs/overview/change-log/version-3.8.0.md
@@ -5,13 +5,15 @@
 -   Search experience
     -   [Saved searches](https://github.com/geonetwork/core-geonetwork/pull/3778)
       
-        ![Screenshot where the star left of the search field expands in a dropdown menu with three options](img/380-usersearches.png "Saved user searches")
+        ![Screenshot where the star left of the search field expands in a dropdown menu with three options](img/380-usersearches.png)
+        *Saved user searches*
 
     -   [Improve PDF output](https://github.com/geonetwork/core-geonetwork/pull/3912)
 
     -   [Add template to display related record as list](https://github.com/geonetwork/core-geonetwork/pull/3908)
 
-        > ![Screenshot showing two related map records below each other](img/380-related.png "Add template")
+        > ![Screenshot showing two related map records below each other](img/380-related.png)
+        > *Add template*
   
 
     -   [Add support for negative query on any fields](https://github.com/geonetwork/core-geonetwork/pull/3683)
@@ -28,7 +30,8 @@
 
     -   [Associated resource can now be filtered, sorted](https://github.com/geonetwork/core-geonetwork/pull/3804), add [support for WFS and Atom services](https://github.com/geonetwork/core-geonetwork/pull/3817).
 
-        > ![Screenshot of Associated resources dialog with filter options](img/380-associated.png "Filtering associated resources")
+        > ![Screenshot of Associated resources dialog with filter options](img/380-associated.png)
+        *Filtering associated resources*
 
 -   Harvester
     -   [GeoNetwork / Add paging for better support of large catalogues](https://github.com/geonetwork/core-geonetwork/pull/3916)

--- a/docs/manual/docs/overview/change-log/version-4.0.0-alpha.1.md
+++ b/docs/manual/docs/overview/change-log/version-4.0.0-alpha.1.md
@@ -86,7 +86,8 @@ This version is a beta version and needs testing and feedback from the community
 -   Transifex / Support multiple branches translation
 -   Multilingual metadata / Records are indexed and displayed but no logic to display depending on user interface language or search on specific language
 
-![Part of a JSON file for string translations](img/3990-es-index-multilingual.png "Multilingual fields are stored as a JSON object with an optional link if using Anchor.")
+![Part of a JSON file for string translations](img/3990-es-index-multilingual.png)
+*Multilingual fields are stored as a JSON object with an optional link if using Anchor.*
 
 -   Indexing / Language specific analyzer (draft configuration made for French)
 -   Indexing / Spatial / Support for bounding polygons

--- a/docs/manual/docs/overview/change-log/version-4.0.0-alpha.1.md
+++ b/docs/manual/docs/overview/change-log/version-4.0.0-alpha.1.md
@@ -86,10 +86,7 @@ This version is a beta version and needs testing and feedback from the community
 -   Transifex / Support multiple branches translation
 -   Multilingual metadata / Records are indexed and displayed but no logic to display depending on user interface language or search on specific language
 
-<figure>
-<img src="img/3990-es-index-multilingual.png" alt="img/3990-es-index-multilingual.png" />
-<figcaption>Multilingual fields are stored as a JSON object with an optional link if using Anchor.</figcaption>
-</figure>
+![Part of a JSON file for string translations](img/3990-es-index-multilingual.png "Multilingual fields are stored as a JSON object with an optional link if using Anchor.")
 
 -   Indexing / Language specific analyzer (draft configuration made for French)
 -   Indexing / Spatial / Support for bounding polygons


### PR DESCRIPTION
 * remove use of HTML blocks instead of Markdown's image syntax to be
   more consistent and help mike and mkdocs to get relative links right.

resolve #7847 


# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [x] *API Changes* are identified in commit messages
- [x] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [x] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [x] *Build documentation* provided for development instructions in `README.md` files
- [x] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

