### PR TITLE
Search / Aggregations on related records.

### DIFF
--- a/web/src/main/webResources/WEB-INF/data/config/index/records.json
+++ b/web/src/main/webResources/WEB-INF/data/config/index/records.json
@@ -1048,6 +1048,14 @@
         }
       },
       {
+        "recordLink_": {
+          "match": "recordLink_*",
+          "mapping": {
+            "type": "keyword"
+          }
+        }
+      },
+      {
         "numbers": {
           "match": "*Number",
           "mapping": {

--- a/web/src/main/webapp/xslt/common/index-utils.xsl
+++ b/web/src/main/webapp/xslt/common/index-utils.xsl
@@ -108,7 +108,7 @@
     </xsl:element>
   </xsl:function>
 
-  <xsl:function name="gn-fn-index:build-record-link" as="node()?">
+  <xsl:function name="gn-fn-index:build-record-link" as="node()*">
     <xsl:param name="uuid" as="xs:string"/>
     <xsl:param name="url" as="xs:string?"/>
     <xsl:param name="title" as="xs:string?"/>
@@ -119,7 +119,7 @@
     <xsl:copy-of select="gn-fn-index:build-record-link($uuid, $url, $title, $type, $properties)"/>
   </xsl:function>
 
-  <xsl:function name="gn-fn-index:build-record-link" as="node()?">
+  <xsl:function name="gn-fn-index:build-record-link" as="node()*">
     <xsl:param name="uuid" as="xs:string"/>
     <xsl:param name="url" as="xs:string?"/>
     <xsl:param name="title" as="xs:string?"/>
@@ -153,6 +153,17 @@
       "title": "<xsl:value-of select="util:escapeForJson($recordTitle)"/>",
       "origin": "<xsl:value-of select="normalize-space($origin)"/>"
       }</recordLink>
+    <xsl:variable name="fieldName"
+                  select="concat('recordLink_', $type, string-join($otherProperties//p[@name != '']/concat(@name, @value), '_'))"/>
+    <xsl:element name="{$fieldName}">
+      <xsl:value-of select="util:escapeForJson($recordTitle)"/>
+    </xsl:element>
+    <xsl:element name="{$fieldName}_uuid">
+      <xsl:value-of select="normalize-space($uuid)"/>
+    </xsl:element>
+    <xsl:element name="{$fieldName}_url">
+      <xsl:value-of select="normalize-space($url)"/>
+    </xsl:element>
   </xsl:function>
 
   <!-- Add a multilingual field to the index.


### PR DESCRIPTION
More and more links between records (optionnaly remote) are created to identify source datasets, sensors, platforms, study, applications, ... With this information, user may want to configure search aggregations to provide filters by related records.

eg. at Ifremer, dataset may be linked to cruises using their DOI (https://doi.org/10.17600/4040050) and we need a way to easily filter all datasets produced in the context of a cruise. Same for datasets used in publications.

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/0509b18e-74d9-4709-bd99-5b23810ae9c2)



The `recordLink` index field contains the information needed. Nested aggregations (https://www.elastic.co/guide/en/elasticsearch/reference/current/search-aggregations-bucket-nested-aggregation.html) is working fine, but are not supported client side and can't be use in `query_string` search.

So dedicated `keyword` fields are created for aggregation configuration and search:

```json
"recordLink_siblingsassociationTypecrossReference_initiativeTypeplatform": [
  "OVIDE 3 cruise Maria S. Merian R/V",
  "OVIDE 1 cruise Thalassa R/V",
  "OVIDE 2 cruise Thalassa R/V",
  "OVIDE 4 cruise Thalassa R/V"
],
"recordLink_siblingsassociationTypecrossReference_initiativeTypeplatform_uuid": [
  "10.17600/6530010",
  "10.17600/2040070",
  "10.17600/4040050",
  "10.17600/8040060"
],
"recordLink_siblingsassociationTypecrossReference_initiativeTypeplatform_url": [
  "https://campagnes.flotteoceanographique.fr/campagnes/6530010/",
  "https://campagnes.flotteoceanographique.fr/campagnes/2040070/",
  "https://campagnes.flotteoceanographique.fr/campagnes/4040050/",
  "https://campagnes.flotteoceanographique.fr/campagnes/8040060/"
],
```

Sample configuration:
```js
            facetConfig: {
              recordLink_siblingsassociationTypecrossReference_initiativeTypeplatform: {
                terms: {
                  field:
                    "recordLink_siblingsassociationTypecrossReference_initiativeTypeplatform.keyword"
                }
              },
              recordLink_sources: {
                terms: {
                  field:
                      "recordLink_sources.keyword"
                }
              },
```

Funded by Ifremer


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

