### PR TITLE
Fix harvester URIMapper to handle local metadata

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/UriMapper.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/UriMapper.java
@@ -50,14 +50,14 @@ public class UriMapper {
     //---
     //--------------------------------------------------------------------------
 
-    public UriMapper(ServiceContext context, String harvestUuid)  {
+    public UriMapper(ServiceContext context, String harvestUuid) {
         final IMetadataUtils metadataRepository = context.getBean(IMetadataUtils.class);
         final List<? extends AbstractMetadata> metadataList = metadataRepository.findAll(MetadataSpecs.hasHarvesterUuid(harvestUuid));
 
         for (AbstractMetadata metadataRecord : metadataList) {
             String uri = Optional.ofNullable(metadataRecord.getHarvestInfo().getUri()).orElse("");
 
-            List<RecordInfo> records = hmUriRecords.computeIfAbsent(uri,k-> new ArrayList<>() );
+            List<RecordInfo> records = hmUriRecords.computeIfAbsent(uri, k -> new ArrayList<>());
 
             if (records == null) {
                 records = new ArrayList<>();

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/UriMapper.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/UriMapper.java
@@ -1,5 +1,5 @@
 //=============================================================================
-//===	Copyright (C) 2001-2007 Food and Agriculture Organization of the
+//===	Copyright (C) 2001-2024 Food and Agriculture Organization of the
 //===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
 //===	and United Nations Environment Programme (UNEP)
 //===
@@ -26,6 +26,7 @@ package org.fao.geonet.kernel.harvest.harvester;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 
 import org.fao.geonet.domain.AbstractMetadata;
 import org.fao.geonet.kernel.datamanager.IMetadataUtils;
@@ -41,7 +42,7 @@ import jeeves.server.context.ServiceContext;
  */
 
 public class UriMapper {
-    private HashMap<String, List<RecordInfo>> hmUriRecords = new HashMap<String, List<RecordInfo>>();
+    private HashMap<String, List<RecordInfo>> hmUriRecords = new HashMap<>();
 
     //--------------------------------------------------------------------------
     //---
@@ -49,21 +50,21 @@ public class UriMapper {
     //---
     //--------------------------------------------------------------------------
 
-    public UriMapper(ServiceContext context, String harvestUuid) throws Exception {
+    public UriMapper(ServiceContext context, String harvestUuid)  {
         final IMetadataUtils metadataRepository = context.getBean(IMetadataUtils.class);
         final List<? extends AbstractMetadata> metadataList = metadataRepository.findAll(MetadataSpecs.hasHarvesterUuid(harvestUuid));
 
-        for (AbstractMetadata record : metadataList) {
-            String uri = record.getHarvestInfo().getUri();
+        for (AbstractMetadata metadataRecord : metadataList) {
+            String uri = Optional.ofNullable(metadataRecord.getHarvestInfo().getUri()).orElse("");
 
-            List<RecordInfo> records = hmUriRecords.get(uri);
+            List<RecordInfo> records = hmUriRecords.computeIfAbsent(uri,k-> new ArrayList<>() );
 
             if (records == null) {
-                records = new ArrayList<RecordInfo>();
+                records = new ArrayList<>();
                 hmUriRecords.put(uri, records);
             }
 
-            records.add(new RecordInfo(record));
+            records.add(new RecordInfo(metadataRecord));
         }
     }
 


### PR DESCRIPTION
WebDav harvester failed with the following exception if trying to harvest metadata that was already assigned to the local catalogue, due to the `harvestUri` property been `null`:

```
2024-04-11T16:47:11,948 WARN  [geonetwork.harvester] - Raised exception while harvesting from : Test harvester (WebDavHarvester)
2024-04-11T16:47:11,949 WARN  [geonetwork.harvester] -  (C) Class   : NullPointerException
2024-04-11T16:47:11,949 WARN  [geonetwork.harvester] -  (C) Message : null
2024-04-11T16:47:11,949 ERROR [geonetwork.harvester] - null
java.lang.NullPointerException: null
	at org.fao.geonet.kernel.harvest.harvester.webdav.Harvester.exists(Harvester.java:205) ~[gn-harvesters-4.2.10-SNAPSHOT.jar:?]
	at org.fao.geonet.kernel.harvest.harvester.webdav.Harvester.align(Harvester.java:164) ~[gn-harvesters-4.2.10-SNAPSHOT.jar:?]
	at org.fao.geonet.kernel.harvest.harvester.webdav.Harvester.harvest(Harvester.java:141) ~[gn-harvesters-4.2.10-SNAPSHOT.jar:?]
	at org.fao.geonet.kernel.harvest.harvester.webdav.WebDavHarvester.doHarvest(WebDavHarvester.java:68) ~[gn-harvesters-4.2.10-SNAPSHOT.jar:?]
	at org.fao.geonet.kernel.harvest.harvester.AbstractHarvester$HarvestWithIndexProcessor.process(AbstractHarvester.java:558) ~[gn-harvesters-4.2.10-SNAPSHOT.jar:?]
	at org.fao.geonet.kernel.harvest.harvester.AbstractHarvester.harvest(AbstractHarvester.java:629) ~[gn-harvesters-4.2.10-SNAPSHOT.jar:?]
	at org.fao.geonet.kernel.harvest.harvester.HarvesterJob.execute(HarvesterJob.java:69) ~[gn-harvesters-4.2.10-SNAPSHOT.jar:?]
	at org.quartz.core.JobRunShell.run(JobRunShell.java:202) ~[quartz-2.3.2.jar:?]
	at org.quartz.simpl.SimpleThreadPool$WorkerThread.run(SimpleThreadPool.java:573) ~[quartz-2.3.2.jar:?]
2
```

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation