### PR TITLE
[Backport 3.12.x] Search Export CSV - Escape double-quotes with double-quotes instead of backslash

### DIFF
--- a/web/src/main/webapp/xslt/services/csv/csv-search.xsl
+++ b/web/src/main/webapp/xslt/services/csv/csv-search.xsl
@@ -172,12 +172,12 @@
       <xsl:choose>
         <xsl:when test="@name='geoBox'">
           <xsl:value-of
-            select="replace(replace(string-join($metadata/*[name(.)=$currentColumn]/*, $internalSep), '\n|\r\n', ''), '&quot;', '\\&quot;')"
+            select="replace(replace(string-join($metadata/*[name(.)=$currentColumn]/*, $internalSep), '\n|\r\n', ''), '&quot;', '&quot;&quot;')"
           />
         </xsl:when>
         <xsl:otherwise>
           <xsl:value-of
-            select="replace(replace(string-join($metadata/*[name(.)=$currentColumn]/normalize-space(), $internalSep), '\n|\r\n', ''), '&quot;', '\\&quot;')"
+            select="replace(replace(string-join($metadata/*[name(.)=$currentColumn]/normalize-space(), $internalSep), '\n|\r\n', ''), '&quot;', '&quot;&quot;')"
           />
         </xsl:otherwise>
       </xsl:choose>


### PR DESCRIPTION
Backport #7927
 **Authored by:** @tylerjmchugh