### PR TITLE
check docs and online help for warnings

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -40,12 +40,12 @@ jobs:
         run: |
           mkdocs build --no-directory-urls --strict --config-file help.yml
       - name: build docs without publishing them
-        if: ${{ github.event_name == 'pull_request' }}
+        if: github.event_name == 'pull_request' || github.ref != 'refs/heads/main'
         working-directory: docs/manual
         run: |
           mike deploy --title "4.4 Latest" --alias-type=copy --update-aliases 4.4 latest
-      - name: deploy latest docs to gh-pages branch
-        if: ${{ github.event_name != 'pull_request' }}
+      - name: deploy main docs to gh-pages 4.4 latest
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
         working-directory: docs/manual
         run: |
           mike deploy --push --title "4.4 Latest" --alias-type=copy --update-aliases 4.4 latest

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,9 +26,19 @@ jobs:
         with:
           python-version: 3.x
       - name: mkdocs install
-        run: pip install --upgrade pip && pip install -r docs/manual/requirements.txt
+        run: |
+          pip install --upgrade pip && pip install -r docs/manual/requirements.txt
       - name: git configuration
-        run: git config user.name 'github-actions[bot]' && git config user.email 'github-actions[bot]@users.noreply.github.com'
+        run: |
+          git config user.name 'github-actions[bot]' && git config user.email 'github-actions[bot]@users.noreply.github.com'
+      - name: check docs for warnings
+        working-directory: docs/manual
+        run: |
+          mkdocs build --no-directory-urls --strict
+      - name: check online help for warnings
+        working-directory: docs/manual
+        run: |
+          mkdocs build --no-directory-urls --strict --config-file help.yml
       - name: build docs without publishing them
         if: ${{ github.event_name == 'pull_request' }}
         working-directory: docs/manual


### PR DESCRIPTION
I noticed a change I did failed linux build (which uses maven to call ``mkdocs build --strict``) but passed the docs workflow check (which only uses ``mike``).

Updated the docs workflow to use ``mkdocs build --strict`` for docs and online help (so it can act as a quick check.
  
# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [x] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

