### PR TITLE
[Backport 4.2.x] Update Jetty to version 9.4.54.v20240208

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1554,7 +1554,7 @@
      request the list of hosts (but JPA cache db queries). -->
     <cors.allowedHosts>*</cors.allowedHosts>
 
-    <jetty.version>9.4.52.v20230823</jetty.version>
+    <jetty.version>9.4.54.v20240208</jetty.version>
     <jetty.file>jetty-distribution-${jetty.version}</jetty.file>
     <jetty.download>https://repo1.maven.org/maven2/org/eclipse/jetty/jetty-distribution/${jetty.version}/${jetty.file}.tar.gz</jetty.download>
 


### PR DESCRIPTION
Backport https://github.com/geonetwork/core-geonetwork/pull/7917