### PR TITLE
fix for nextrecord in csw getrecords response when using pagination

### DIFF
--- a/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/SearchController.java
+++ b/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/SearchController.java
@@ -489,7 +489,7 @@ public class SearchController {
             SearchResponse result = searchManager.query(esJsonQuery, new HashSet<>(), startPos - 1, maxRecords, sort);
 
             List<Hit> hits = result.hits().hits();
-            
+
             TotalHits total = result.hits().total();
             long numMatches = total != null ? total.value() : 0;
 
@@ -529,7 +529,7 @@ public class SearchController {
             results.setAttribute("elementSet", setName.toString());
 
 
-            if (numMatches > counter) {
+            if (numMatches > counter + (startPos -1)) {
                 results.setAttribute("nextRecord", Long.toString(counter + startPos));
             } else {
                 results.setAttribute("nextRecord", "0");


### PR DESCRIPTION
I encountered an issue whit the CSW's getRecords endpoint when using pagination:

under the following conditions:
- using CSW endpoint `getRecords`
- using pagination by providing `maxRecords` in the request
- results are returned over multiple pages (requested `maxRecords` < total matched records)

when requesting the last page the returned `nextRecord` is always `numberOfRecordsMatched` + 1 instead of being 0. And thus the `nextRecord` value exceeds the value of the `numberOfRecordsMatched`, which may not happen.

depending of the clients implementation when using the `nextRecord`, this can result in a follow up request of getting more records, which then results in the error:
```java.lang.RuntimeException: org.fao.geonet.csw.common.exceptions.InvalidParameterValueEx: code=InvalidParameterValue, locator=startPosition, message=Start position (4) can't be greater than number of matching records (3 for current search).```

I created also an issue for this: https://github.com/geonetwork/core-geonetwork/issues/7978

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

