### PR TITLE
Added missing permissions filter for group owner

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/search/EsFilterBuilder.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/EsFilterBuilder.java
@@ -47,13 +47,19 @@ public class EsFilterBuilder {
 
 
             String ownerFilter = "";
+            String groupOwnerFilter = "";
             if (userSession.getUserIdAsInt() > 0) {
                 // OR you are owner
                 ownerFilter = String.format("owner:%d", userSession.getUserIdAsInt());
                 // OR member of groupOwner
-                // TODOES
+                groupOwnerFilter = String.format("groupOwner:(%s)",
+                    // don't use groups 0, 1, -1 as groupOwner
+                    groups.stream().filter(g -> g > 1)
+                        .map(Object::toString)
+                        .collect(Collectors.joining(" OR ")));
+
             }
-            return String.format("(%s %s)", operationFilter, ownerFilter).trim();
+            return String.format("(%s %s %s)", operationFilter, ownerFilter, groupOwnerFilter).trim();
         }
     }
     /**


### PR DESCRIPTION
The following situation breaks due to this missing functionality:
- have a record with `groupOwner` `A` and `owner` `X`
- group `A` has users `X` and `Y`
- `Y` can see the edit button, but upon clicking it the UI reports the record cannot be found

I have added the missing check (marked as TODO) on `groupOwner` which solves the issue on our end. @fxprunayre , does this approach make sense, am I missing a potential case in the permissions filter?
  

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

