### PR TITLE
Update the default sort field name in editor board and batch editor.

### DIFF
--- a/web-ui/src/main/resources/catalog/js/edit/BatchEditController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/BatchEditController.js
@@ -59,7 +59,7 @@
         hitsperpageValues: gnSearchSettings.hitsperpageValues,
         selectionBucket: "e101",
         params: {
-          sortBy: "dateStamp",
+          sortBy: "changeDate",
           sortOrder: "desc",
           isTemplate: ["y", "n"],
           editable: "true",

--- a/web-ui/src/main/resources/catalog/js/edit/EditorBoardController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/EditorBoardController.js
@@ -80,7 +80,7 @@
         filters: gnSearchSettings.filters,
         configId: "editor",
         params: {
-          sortBy: "dateStamp",
+          sortBy: "changeDate",
           sortOrder: "desc",
           isTemplate: ["y", "n"],
           draft: gnGlobalSettings.gnCfg.mods.editor.workflowSearchRecordTypes || [
@@ -92,7 +92,7 @@
           to: 20
         },
         defaultParams: {
-          sortBy: "dateStamp",
+          sortBy: "changeDate",
           sortOrder: "desc",
           isTemplate: ["y", "n"],
           draft: gnGlobalSettings.gnCfg.mods.editor.workflowSearchRecordTypes || [


### PR DESCRIPTION
Follow up of #7910

Without the pull request the sorting option in the editor board and batch editor was using the field from the XML and displaying the translation key instead of the label:

![image_2024_04_26T12_10_12_843Z](https://github.com/geonetwork/core-geonetwork/assets/1695003/c677a2a5-d323-4578-9c19-ec10d494fa4f)


# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation


