### PR TITLE
Editor / Add custom element in distribution and associated record directive

### DIFF
--- a/schemas/config-editor.xsd
+++ b/schemas/config-editor.xsd
@@ -2164,6 +2164,19 @@ An XML snippet with replacement for each key defined in that field.
       </gmd:MD_Format>
     </gmd:distributionFormat>
 
+A snippet can also contains a `${uuid}` placeholder to be replaced when added to the form.
+This can allow to build dynamic snippet based on the current record.
+
+.. code-block:: xml
+
+      <template>
+        <snippet>
+          <mrd:onLine>
+            <cit:CI_OnlineResource>
+              <cit:linkage>
+                <gco:CharacterString>https://geoadata.wallonie.be/dataset/${uuid}</gco:CharacterString>
+              </cit:linkage>
+
 
         ]]></xs:documentation>
     </xs:annotation>
@@ -2362,12 +2375,18 @@ For example, create a table of contact:
 
 Include any custom directive with required attributes.
 
+When using `data-gn-distribution-resources-panel` or `data-gn-associated-resources-panel`
+a section element can be added to the directive to define additional form elements to be
+added in the directive panel eg. `text` for guidelines or add `action` to easily add new elements.
       ]]></xs:documentation>
     </xs:annotation>
     <xs:complexType>
       <xs:attribute ref="displayIfServiceInfo"/>
       <xs:attribute ref="displayIfRecord"/>
       <xs:anyAttribute/>
+      <xs:sequence>
+        <xs:element ref="section"/>
+      </xs:sequence>
     </xs:complexType>
   </xs:element>
 </xs:schema>

--- a/web-ui/src/main/resources/catalog/components/metadataactions/RelatedDirective.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/RelatedDirective.js
@@ -197,6 +197,7 @@
     function () {
       return {
         restrict: "A",
+        transclude: true,
         templateUrl: function (elem, attrs) {
           return (
             attrs.template ||
@@ -1299,6 +1300,7 @@
     function (gnCurrentEdit) {
       return {
         restrict: "A",
+        transclude: true,
         templateUrl: function (elem, attrs) {
           return (
             attrs.template ||

--- a/web-ui/src/main/resources/catalog/components/metadataactions/RelatedResourcesService.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/RelatedResourcesService.js
@@ -309,7 +309,7 @@
           action: addEsriRestToMap
         },
         ATOM: {
-          iconClass: "fa-globe",
+          iconClass: "fa-feed",
           label: "download",
           action: openLink
         },

--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/associatedResourcesPanel.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/associatedResourcesPanel.html
@@ -3,14 +3,13 @@
   class="panel panel-default gn-onlinesrc-panel"
   data-ng-class="getClass()"
 >
-  <!-- /.panel-heading -->
   <div class="panel-heading" data-gn-slide-toggle="">
     <i class="fa fa-fw"></i>&nbsp;
     <span data-translate="">associatedResourcesPanel</span>
   </div>
 
-  <!-- /.panel-body -->
   <div class="panel-body">
+    <div data-ng-transclude="" class="row"></div>
     <div data-gn-associated-resources-container="md" data-mode="mode"></div>
   </div>
 </div>

--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/distributionResourcesPanel.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/distributionResourcesPanel.html
@@ -3,14 +3,13 @@
   class="panel panel-default"
   data-ng-class="getClass()"
 >
-  <!-- /.panel-heading -->
   <div class="panel-heading" data-gn-slide-toggle="">
     <i class="fa fa-fw"></i>&nbsp;
     <span data-translate="">distributionPanel</span>
   </div>
 
-  <!-- /.panel-body -->
   <div class="panel-body">
+    <div data-ng-transclude="" class="row"></div>
     <div
       data-gn-distribution-resources-container="md"
       data-mode="mode"

--- a/web/src/main/webapp/xslt/ui-metadata/edit/edit.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/edit/edit.xsl
@@ -158,17 +158,18 @@
             </xsl:otherwise>
           </xsl:choose>
         </div>
-      </form>
-      <xsl:if test="$hasSidePanel">
-        <div class="col-md-4 gn-editor-sidebar">
-          <div class="gn-editor-tools-container">
-            <xsl:apply-templates mode="form-builder"
-                                 select="$viewConfig/sidePanel/*">
-              <xsl:with-param name="base" select="$metadata"/>
-            </xsl:apply-templates>
+
+        <xsl:if test="$hasSidePanel">
+          <div class="col-md-4 gn-editor-sidebar">
+            <div class="gn-editor-tools-container">
+              <xsl:apply-templates mode="form-builder"
+                                   select="$viewConfig/sidePanel/*">
+                <xsl:with-param name="base" select="$metadata"/>
+              </xsl:apply-templates>
+            </div>
           </div>
-        </div>
-      </xsl:if>
+        </xsl:if>
+      </form>
     </div>
   </xsl:template>
 

--- a/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
@@ -493,10 +493,15 @@
       id="gn-el-{if ($refToDelete) then $refToDelete/@ref else generate-id()}"
       data-gn-field-highlight="">
 
-      <label class="col-sm-2 control-label">
-        <xsl:value-of select="$name"/>&#160;
-      </label>
-      <div class="col-sm-9">
+      <xsl:variable name="hasLabel"
+                    select="normalize-space($name) != ''"
+                    as="xs:boolean"/>
+      <xsl:if test="$hasLabel">
+        <label class="col-sm-2 control-label">
+          <xsl:value-of select="$name"/>&#160;
+        </label>
+      </xsl:if>
+      <div class="{if ($hasLabel) then 'col-sm-9' else 'col-sm-12'}">
         <!-- Create an empty input to contain the data-gn-field-tooltip
         key which is used to check if an element
         is the first element of its kind in the form. The key for a template
@@ -800,7 +805,9 @@
               <xsl:if test="$hasMultipleChoice">
                 <xsl:for-each select="$snippets">
                   <textarea id="{concat($id, @label, '-value')}">
-                    <xsl:value-of select="saxon:serialize(*, 'default-serialize-mode')"/>
+                    <xsl:call-template name="build-snippet">
+                      <xsl:with-param name="snippet" select="*"/>
+                    </xsl:call-template>
                   </textarea>
                 </xsl:for-each>
               </xsl:if>
@@ -814,7 +821,9 @@
                 <xsl:if test="$isMissingLabel != ''">
                   <xsl:attribute name="data-not-set-check" select="$tagId"/>
                 </xsl:if>
-                <xsl:value-of select="saxon:serialize($snippets[1]/*, 'default-serialize-mode')"/>
+                <xsl:call-template name="build-snippet">
+                  <xsl:with-param name="snippet" select="$snippets[1]/*"/>
+                </xsl:call-template>
               </textarea>
             </div>
           </xsl:if>
@@ -828,6 +837,12 @@
         </div>
       </xsl:if>
     </div>
+  </xsl:template>
+
+  <xsl:template name="build-snippet" as="xs:string?">
+    <xsl:param name="snippet" as="node()?"/>
+
+    <xsl:value-of select="replace(saxon:serialize($snippet, 'default-serialize-mode'), '\$\{uuid\}', $metadataUuid)"/>
   </xsl:template>
 
   <!--

--- a/web/src/main/webapp/xslt/ui-metadata/form-configurator.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-configurator.xsl
@@ -34,6 +34,7 @@
     -->
 
   <xsl:template mode="form-builder" match="directive">
+    <xsl:param name="base" as="node()"/>
 
     <xsl:variable name="isDisplayed"
                   as="xs:boolean"
@@ -43,6 +44,9 @@
     <xsl:if test="$isDisplayed">
       <div>
         <xsl:copy-of select="@*"/>
+        <xsl:apply-templates mode="form-builder" select="*">
+          <xsl:with-param name="base" select="$base"/>
+        </xsl:apply-templates>
       </div>
     </xsl:if>
   </xsl:template>


### PR DESCRIPTION
    
Add the possibility to add custom elements in the panel of
`data-gn-distribution-resources-panel` or
`data-gn-associated-resources-panel`.

Common use case is to add explanatory text or add action for shortcuts

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/13f7a01b-c0b4-47ee-80e9-5f9bd5c3e822)


eg.

```xml
<directive data-gn-distribution-resources-panel="gnCurrentEdit.metadata"
                   data-mode="viewConfig.distributionConfig.layout || ''"
                   data-editor-config="default" ...
        >
          <section>
            <text>
              <div class="alert alert-info">
                This represents a general availability of a dataset. It implies no information about the actual access method of the data, i.e., whether by direct download, API, or through a Web page.
              </div>
            </text>
            <action type="add"
                    name=" "
                    btnLabel="mw-addAtomFeed"
                    or="onLine"
                    in="/mdb:MD_Metadata/mdb:distributionInfo/*/mrd:transferOptions/*"
                    if="count(mdb:MD_Metadata/mdb:distributionInfo/*/mrd:transferOptions/*/mrd:onLine[*/cit:protocol/*/text() = 'atom:feed']) = 0">
              <template>
                <snippet>
                  <mrd:onLine>
                    <cit:CI_OnlineResource>
                      <cit:linkage>
                        <gco:CharacterString>https://geoservices.wallonie.be/geotraitement/spwdatadownload/get/${uuid}/atom_service.xml</gco:CharacterString>
                      </cit:linkage>
                      <cit:protocol>
                        <gco:CharacterString>atom:feed</gco:CharacterString>
                      </cit:protocol>
                      <cit:name>
                        <gco:CharacterString>Service de téléchargement ATOM Feed</gco:CharacterString>
                      </cit:name>
                      <cit:description>
                        <gco:CharacterString>Ce service de téléchargement ATOM Feed permet de télécharger la série de couches de données</gco:CharacterString>
                      </cit:description>
                      <cit:function>
                        <cit:CI_OnLineFunctionCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_OnLineFunctionCode" codeListValue="download"/>
                      </cit:function>
                    </cit:CI_OnlineResource>
                  </mrd:onLine>
                </snippet>
              </template>
            </action>
```

Also add support for `${uuid}` placeholder in snippet to dynamically
create snippet for current record.

<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

Funded by Service Public de Wallonie (SPW)
