### PR TITLE
Editor / Add list mode

### DIFF
--- a/schemas/config-editor.xsd
+++ b/schemas/config-editor.xsd
@@ -1086,6 +1086,7 @@ the mandatory section with no name and then the inner elements.
         <xs:element ref="xsl"/>
         <xs:element ref="section"/>
         <xs:element ref="fieldset"/>
+        <xs:element ref="list"/>
       </xs:choice>
       <xs:attribute ref="mode"/>
       <xs:attribute name="name" type="xs:string">
@@ -1154,6 +1155,119 @@ Note: Only sections with forEach support del attribute.
     </xs:unique>
   </xs:element>
 
+
+
+  <xs:element name="list">
+    <xs:annotation>
+      <xs:documentation><![CDATA[
+Adding a list
+-------------
+
+The list can be used to display a list of contact with only organisation name for example.
+This can facilitate building simple form hiding the details of ISO elements. In this case,
+use a contact directory to add new contact makes sense.
+
+This mode can be also more efficient when record contains lots of contacts which in some case
+can create large HTML form which can take time to build, download and render in the browser
+(eg. when having more than 100 contacts in a record). If only `label` are used the form will be faster to render.
+
+eg.
+
+..code-block:: xml
+
+
+        <action type="add"
+                forceLabel="true"
+                addDirective="data-gn-directory-entry-selector"
+                or="pointOfContact"
+                in="/gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification">
+          <directiveAttributes
+                  data-template-add-action="false"
+                  data-search-action="true"
+                  data-popup-action="true"
+                  data-template-type="contact"
+                  data-variables="gmd:role/gmd:CI_RoleCode/@codeListValue~{role}"/>
+        </action>
+
+        <list name="Contact point"
+              xpath="/gmd:MD_Metadata/gmd:identificationInfo/*/gmd:pointOfContact[*/gmd:role/*/@codeListValue = 'pointOfContact']"
+              del="."
+              sortBy="gmd:organisationName/gco:CharacterString">
+          <item href="*[1]/@uuid">
+            <label xpath="*/gmd:organisationName/gco:CharacterString/text()"/>
+          </item>
+        </list>
+
+        <list name="Originator"
+              xpath="/gmd:MD_Metadata/gmd:identificationInfo/*/gmd:pointOfContact[*/gmd:role/*/@codeListValue = 'originator']"
+              sortBy="gmd:organisationName/gco:CharacterString">
+          <item>
+            <field xpath="*/gmd:organisationName"/>
+          </item>
+        </list>
+        ]]></xs:documentation>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:choice minOccurs="1">
+        <xs:element name="item">
+          <xs:annotation>
+            <xs:documentation><![CDATA[
+              An item in the list.
+              ]]></xs:documentation>
+            </xs:annotation>
+            <xs:complexType>
+              <xs:sequence>
+                <xs:element ref="label"/>
+                <xs:element ref="text"/>
+                <xs:element ref="field"/>
+              </xs:sequence>
+              <xs:attribute name="href" type="xs:string">
+                <xs:annotation>
+                  <xs:documentation>Add a hyperlink on the item</xs:documentation>
+                </xs:annotation>
+              </xs:attribute>
+            </xs:complexType>
+        </xs:element>
+      </xs:choice>
+      <xs:attribute name="name" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>An optional name to override the default one base on field name for the
+            section. The name must be defined in ``{schema}/loc/{lang}/strings.xml``.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="xpath" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>The XPath of the element to create list items.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute ref="del"/>
+      <xs:attribute ref="or"/>
+      <xs:attribute ref="in"/>
+      <xs:attribute name="sortBy">
+        <xs:annotation>
+          <xs:documentation>XPath of the element to sort the list by. Must use full name of each nodes eg. gmd:organisationName/gco:CharacterString</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute ref="displayIfRecord"/>
+      <xs:attribute ref="displayIfServiceInfo"/>
+      <xs:attribute name="collapsed" type="xs:boolean" fixed="true">
+        <xs:annotation>
+          <xs:documentation>An optional attribute to collapse the section. If not set the section is expanded.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="collapsible" type="xs:boolean" fixed="false">
+        <xs:annotation>
+          <xs:documentation>An optional attribute to not allow collapse for the section. If not set the section is expandable.
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+
+
   <xs:attribute name="or" type="xs:string">
     <xs:annotation>
       <xs:documentation>Local name to match if the element does not exist.</xs:documentation>
@@ -1164,6 +1278,46 @@ Note: Only sections with forEach support del attribute.
     <xs:annotation>
       <xs:documentation>XPath of the geonet:child element with the or name to look for. Usually
         points to the parent of last element of the XPath attribute.
+      </xs:documentation>
+    </xs:annotation>
+  </xs:attribute>
+
+  <xs:attribute name="del" type="xs:string">
+    <xs:annotation>
+      <xs:documentation>
+        <![CDATA[
+Relative XPath of the element to remove when the `remove` button is clicked.
+
+e.g. If a template field match linkage and allows editing of field URL,
+the remove control should remove the parent element gmd:onLine.
+
+.. code-block:: xml
+
+    <field name="url"
+           xpath="/gmd:MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions
+                    /gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource/gmd:linkage"
+           del="ancestor::gmd:onLine">
+      <template>
+
+`del` attribute can be used in template mode or not. Example to remove
+`spatialResolution` while only editing `denominator` or `distance`. `denominator` or `distance`
+are mandatory, but as the `del` element points to the `spatialResolution`
+ancestor, there is no mandatory flag displayed and the remove control
+removes the `spatialResolution` element.
+
+
+.. code-block:: xml
+
+
+    <field xpath="/gmd:MD_Metadata/gmd:identificationInfo/
+                    */gmd:spatialResolution/*/gmd:distance"
+            del="ancestor::gmd:spatialResolution"/>
+    <field xpath="/gmd:MD_Metadata/gmd:identificationInfo/
+                    */gmd:spatialResolution/
+                      */gmd:equivalentScale/*/gmd:denominator"
+            del="ancestor::gmd:spatialResolution"/>
+
+            ]]>
       </xs:documentation>
     </xs:annotation>
   </xs:attribute>
@@ -1311,45 +1465,7 @@ The local name of the geonet child (i.e. non-existing element) to match.
           <xs:documentation>The element to search in for the geonet child.</xs:documentation>
         </xs:annotation>
       </xs:attribute>
-      <xs:attribute name="del" type="xs:string">
-        <xs:annotation>
-          <xs:documentation>
-            <![CDATA[
-Relative XPath of the element to remove when the `remove` button is clicked.
-
-e.g. If a template field match linkage and allows editing of field URL,
-the remove control should remove the parent element gmd:onLine.
-
-.. code-block:: xml
-
-    <field name="url"
-      xpath="/gmd:MD_Metadata/gmd:distributionInfo/gmd:MD_Distribution/gmd:transferOptions
-                /gmd:MD_DigitalTransferOptions/gmd:onLine/gmd:CI_OnlineResource/gmd:linkage"
-      del="../..">
-      <template>
-
-`del` attribute can be used in template mode or not. Example to remove
-`spatialResolution` while only editing `denominator` or `distance`. `denominator` or `distance`
-are mandatory, but as the `del` element points to the `spatialResolution`
-ancestor, there is no mandatory flag displayed and the remove control
-removes the `spatialResolution` element.
-
-
-.. code-block:: xml
-
-
-    <field xpath="/gmd:MD_Metadata/gmd:identificationInfo/
-                    */gmd:spatialResolution/*/gmd:distance"
-            del="../.."/>
-    <field xpath="/gmd:MD_Metadata/gmd:identificationInfo/
-                    */gmd:spatialResolution/
-                      */gmd:equivalentScale/*/gmd:denominator"
-            del="../../../.."/>
-
-            ]]>
-          </xs:documentation>
-        </xs:annotation>
-      </xs:attribute>
+      <xs:attribute ref="del"/>
       <xs:attribute name="templateModeOnly" fixed="true" type="xs:boolean">
         <xs:annotation>
           <xs:documentation><![CDATA[
@@ -1366,6 +1482,17 @@ displayed based on the XML template snippet field configuration. Default is fals
         </xs:annotation>
       </xs:attribute>
       <xs:attribute ref="use"/>
+    </xs:complexType>
+  </xs:element>
+
+
+  <xs:element name="label">
+    <xs:complexType>
+      <xs:attribute name="xpath" use="required">
+        <xs:annotation>
+          <xs:documentation>The xpath of the text to display as label. eg. `*/gmd:organisationName/gco:CharacterString/text()`</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
     </xs:complexType>
   </xs:element>
 

--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
@@ -419,7 +419,7 @@
     <xsl:if test="$isDisplayed">
       <xsl:variable name="content">
         <xsl:apply-templates mode="render-view"
-                             select="section|field|xsl"/>&#160;
+                             select="section|field|xsl|list"/>&#160;
       </xsl:variable>
 
       <xsl:if test="count($content/*) > 0">
@@ -459,7 +459,7 @@
 
   <!-- Render metadata elements defined by XPath -->
   <xsl:template mode="render-view"
-                match="field[not(template)]">
+                match="field[not(template)]|list[@xpath]">
     <xsl:param name="base" select="$metadata"/>
 
     <!-- Matching nodes -->

--- a/web/src/main/webapp/xslt/ui-metadata/form-configurator.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-configurator.xsl
@@ -602,6 +602,132 @@
   </xsl:template>
 
 
+  <xsl:template mode="form-builder"
+                match="list">
+    <xsl:param name="base" as="node()"/>
+
+    <xsl:variable name="isDisplayed"
+                  as="xs:boolean"
+                  select="gn-fn-metadata:check-elementandsession-visibility(
+                  $schema, $metadata, $serviceInfo, @displayIfRecord, @displayIfServiceInfo)"/>
+
+    <xsl:if test="$isDisplayed">
+      <xsl:variable name="del" select="@del"/>
+      <xsl:variable name="href" select="item/@href"/>
+      <xsl:variable name="listConfig" select="."/>
+      <xsl:variable name="xpathPrefix"
+                    select="if (starts-with(@xpath, '/'))
+                                    then '/..'
+                                    else '/'"/>
+
+      <xsl:variable name="items">
+        <saxon:call-template name="{concat('evaluate-', $schema)}">
+          <xsl:with-param name="base" select="$base"/>
+          <xsl:with-param name="in" select="concat($xpathPrefix, @xpath)"/>
+        </saxon:call-template>
+      </xsl:variable>
+
+      <xsl:variable name="listItems">
+        <xsl:if test="count($items/*) > 0">
+          <ul class="list-group">
+
+            <xsl:for-each select="$items/*">
+              <xsl:sort select=".//*[ends-with(string-join(ancestor-or-self::*/name(), '/'), $listConfig/@sortBy)]"
+                        order="{($listConfig/@sortOrder, 'ascending')[1]}"/>
+              <xsl:variable name="base" select="."/>
+
+              <li class="list-group-item flex-row flex-align-center">
+                <div class="flex-grow">
+                  <xsl:variable name="itemLink">
+                    <xsl:if test="$href">
+                      <saxon:call-template name="{concat('evaluate-', $schema)}">
+                        <xsl:with-param name="base" select="$base"/>
+                        <xsl:with-param name="in" select="concat('/', $href)"/>
+                      </saxon:call-template>
+                    </xsl:if>
+                  </xsl:variable>
+
+                  <xsl:variable name="itemText">
+                    <xsl:for-each select="$listConfig/item/(field|label|text)">
+                      <xsl:choose>
+                        <xsl:when test="name() = ('field', 'text')">
+                          <xsl:apply-templates mode="form-builder" select=".">
+                            <xsl:with-param name="base" select="$base"/>
+                          </xsl:apply-templates>
+                        </xsl:when>
+                        <xsl:otherwise>
+                          <saxon:call-template name="{concat('evaluate-', $schema)}">
+                            <xsl:with-param name="base" select="$base"/>
+                            <xsl:with-param name="in" select="concat('/', @xpath)"/>
+                          </saxon:call-template>
+                        </xsl:otherwise>
+                      </xsl:choose>
+                    </xsl:for-each>
+                  </xsl:variable>
+
+                  <xsl:choose>
+                    <xsl:when test="$itemLink != ''">
+                      <a href="{$itemLink}" target="_blank">
+                        <xsl:copy-of select="$itemText"/>
+                      </a>
+                    </xsl:when>
+                    <xsl:otherwise>
+                      <xsl:copy-of select="$itemText"/>
+                    </xsl:otherwise>
+                  </xsl:choose>
+                </div>
+
+                <xsl:if test="$del != ''">
+                  <div class="">
+                    <xsl:variable name="refToDelete">
+                      <xsl:call-template name="get-ref-element-to-delete">
+                        <xsl:with-param name="node" select="$base"/>
+                        <xsl:with-param name="delXpath" select="$del"/>
+                      </xsl:call-template>
+                    </xsl:variable>
+
+                    <xsl:call-template name="render-form-field-control-remove">
+                      <xsl:with-param name="editInfo" select="gn:element"/>
+                    </xsl:call-template>
+                  </div>
+                </xsl:if>
+              </li>
+            </xsl:for-each>
+          </ul>
+        </xsl:if>
+      </xsl:variable>
+
+      <xsl:variable name="sectionName" select="@name"/>
+      <xsl:choose>
+        <xsl:when test="$sectionName">
+        <fieldset data-gn-field-highlight="" class="gn-{@name}">
+          <legend>
+            <xsl:if test="not(@collapsible)">
+              <xsl:attribute name="data-gn-slide-toggle" select="exists(@collapsed)"/>
+            </xsl:if>
+            <xsl:value-of
+                    select="if (contains($sectionName, ':'))
+                      then gn-fn-metadata:getLabel($schema, $sectionName, $labels)/label
+                      else if ($strings/*[name() = $sectionName] != '')
+                      then $strings/*[name() = $sectionName]
+                      else $sectionName"
+            />
+          </legend>
+          <div class="row">
+            <div class="col-md-12">
+              <xsl:copy-of select="$listItems"/>
+            </div>
+          </div>
+        </fieldset>
+        </xsl:when>
+        <xsl:otherwise>
+          <xsl:copy-of select="$listItems"/>
+        </xsl:otherwise>
+      </xsl:choose>
+    </xsl:if>
+  </xsl:template>
+
+
   <!-- Get the reference of the element to delete if delete is allowed. -->
   <xsl:template name="get-ref-element-to-delete">
     <xsl:param name="node" as="node()?"/>


### PR DESCRIPTION
The list can be used to display a list of contact with only organisation name for example. This can facilitate building simple form hiding the details of ISO elements. In this case, use a contact directory to add new contact makes sense.

This mode can be also more efficient when record contains lots of contacts which in some case can create large HTML form which can take time to build, download and render in the browser (eg. when having more than 100 contacts in a record). If only `label` are used the form will be faster to render.

For large XML record, form may trigger error like `Form with too many keys [1001 > 1000]` when submitted. The list mode allows to deal with such situation.

eg.

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/d3932aee-92ee-4291-9b80-c78f037c414e)



```xml
<action type="add"
        forceLabel="true"
        addDirective="data-gn-directory-entry-selector"
        or="pointOfContact"
        in="/gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification">
  <directiveAttributes
          data-template-add-action="false"
          data-search-action="true"
          data-popup-action="true"
          data-template-type="contact"
          data-variables="gmd:role/gmd:CI_RoleCode/@codeListValue~{role}"/>
</action>

<list name="Contact point"
      xpath="/gmd:MD_Metadata/gmd:identificationInfo/*/gmd:pointOfContact[*/gmd:role/*/@codeListValue = 'pointOfContact']"
      del="."
      sortBy="gmd:organisationName/gco:CharacterString">
  <item href="*[1]/@uuid">
    <label xpath="*/gmd:organisationName/gco:CharacterString/text()"/>
  </item>
</list>

<list name="Originator"
      xpath="/gmd:MD_Metadata/gmd:identificationInfo/*/gmd:pointOfContact[*/gmd:role/*/@codeListValue = 'originator']"
      sortBy="gmd:organisationName/gco:CharacterString">
  <item>
    <field xpath="*/gmd:organisationName"/>
  </item>
</list>
```

Funded by Ifremer


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

