### PR TITLE
[Backport 4.2.x] Standard / ISO19115-3 / Ensure dqm namespace is on top of the document

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ISO19139/utility/create19115-3Namespaces.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ISO19139/utility/create19115-3Namespaces.xsl
@@ -54,6 +54,7 @@
     <xsl:namespace name="msr" select="'http://standards.iso.org/iso/19115/-3/msr/2.0'"/>
     <!-- Data Quality Measures (ISO 19157-2) -->
     <xsl:namespace name="mdq" select="'http://standards.iso.org/iso/19157/-2/mdq/1.0'"/>
+    <xsl:namespace name="dqm" select="'http://standards.iso.org/iso/19157/-2/dqm/1.0'"/>
     <!-- Metadata for Acquisition (ISO 19115-2) -->
     <xsl:namespace name="mac" select="'http://standards.iso.org/iso/19115/-3/mac/2.0'"/>
     <!-- other ISO namespaces -->

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/config-editor.xml
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/config-editor.xml
@@ -23,7 +23,6 @@
         xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0"
         xmlns:mac="http://standards.iso.org/iso/19115/-3/mac/2.0"
         xmlns:gfc="http://standards.iso.org/iso/19110/gfc/1.1"
-        xmlns:gts="http://www.isotc211.org/2005/gts"
         xmlns:gml="http://www.opengis.net/gml/3.2"
         xmlns:xlink="http://www.w3.org/1999/xlink">
 

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/evaluate.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/evaluate.xsl
@@ -22,7 +22,6 @@
                 xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0"
                 xmlns:mac="http://standards.iso.org/iso/19115/-3/mac/2.0"
                 xmlns:gfc="http://standards.iso.org/iso/19110/gfc/1.1"
-                xmlns:gts="http://www.isotc211.org/2005/gts"
                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                 xmlns:gml="http://www.opengis.net/gml/3.2"
                 xmlns:xlink="http://www.w3.org/1999/xlink"

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/layout-custom-fields.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/layout-custom-fields.xsl
@@ -7,7 +7,6 @@
   xmlns:cit="http://standards.iso.org/iso/19115/-3/cit/2.0"
   xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0"
   xmlns:mrs="http://standards.iso.org/iso/19115/-3/mrs/1.0"
-  xmlns:gts="http://www.isotc211.org/2005/gts"
   xmlns:gml="http://www.opengis.net/gml/3.2"
   xmlns:xlink="http://www.w3.org/1999/xlink"
   xmlns:gn="http://www.fao.org/geonetwork"

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/layout.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/layout.xsl
@@ -18,7 +18,6 @@
   xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0"
   xmlns:gfc="http://standards.iso.org/iso/19110/gfc/1.1"
   xmlns:gmx="http://standards.iso.org/iso/19115/-3/gmx"
-  xmlns:gts="http://www.isotc211.org/2005/gts"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xmlns:gml="http://www.opengis.net/gml/3.2"
   xmlns:xlink="http://www.w3.org/1999/xlink"
@@ -39,7 +38,7 @@
   <!-- Visit all XML tree recursively -->
   <xsl:template mode="mode-iso19115-3.2018"
                 match="mds:*|mcc:*|mri:*|mrs:*|mrc:*|mrd:*|mco:*|msr:*|lan:*|
-                       gcx:*|gex:*|dqm:*|mdq:*|cit:*|srv:*|gml:*|gts:*|gfc:*"
+                       gcx:*|gex:*|dqm:*|mdq:*|cit:*|srv:*|gml:*|gfc:*"
                 priority="2">
     <xsl:param name="schema" select="$schema" required="no"/>
     <xsl:param name="labels" select="$labels" required="no"/>


### PR DESCRIPTION
Backport #7960
 **Authored by:** @fxprunayre