### PR TITLE
ISO19139 metadata full view / display citation titles

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
@@ -88,7 +88,7 @@
 
   <!-- Ignore some fields displayed in header or in right column -->
   <xsl:template mode="render-field"
-                match="gmd:graphicOverview|gmd:abstract|gmd:title"
+                match="gmd:graphicOverview|gmd:abstract|gmd:identificationInfo/*/gmd:citation/*/gmd:title"
                 priority="2000"/>
 
   <!-- Specific schema rendering -->
@@ -344,7 +344,7 @@
         <xsl:otherwise>
           <div data-ng-if="showCitation"
                data-gn-metadata-citation="md">
-            
+
           </div>
         </xsl:otherwise>
       </xsl:choose>
@@ -441,7 +441,7 @@
         </xsl:call-template>
       </dt>
       <dd>
-        
+
         <xsl:apply-templates mode="render-value" select="."/>
         <xsl:apply-templates mode="render-value" select="@*"/>
       </dd>
@@ -657,7 +657,7 @@
       <xsl:otherwise>
         <div class="gn-contact">
           <strong>
-            
+
             <xsl:apply-templates mode="render-value"
                                  select="*/gmd:role/*/@codeListValue"/>
           </strong>
@@ -1007,6 +1007,19 @@
                 priority="100"/>
 
 
+  <!-- Use gmd:specification label for the specification title -->
+  <xsl:template mode="render-field"
+                match="gmd:specification/*/gmd:title"
+                priority="100">
+    <dl>
+      <dt><xsl:value-of select="tr:nodeLabel(tr:create($schema, @code), 'gmd:specification', 'gmd:CI_Citation')"/></dt>
+      <dd>
+        <xsl:apply-templates mode="render-value" select="."/>
+      </dd>
+    </dl>
+  </xsl:template>
+
+
   <!-- Link to other metadata records -->
   <xsl:template mode="render-field"
                 match="srv:operatesOn[@uuidref]|gmd:featureCatalogueCitation[@uuidref]|gmd:source[@uuidref]|gmd:aggregateDataSetIdentifier/*/gmd:code[@uuidref]"
@@ -1070,7 +1083,7 @@
           <xsl:value-of select="gn-fn-render:getMetadataTitle(./gco:CharacterString, $langId)"/>
         </a>
       </xsl:if>
-       
+
       <xsl:call-template name="addLineBreaksAndHyperlinks">
         <xsl:with-param name="txt" select="$txt"/>
       </xsl:call-template>
@@ -1086,7 +1099,7 @@
           <xsl:value-of select="gn-fn-render:getMetadataTitle(./gco:CharacterString, $langId)"/>
         </a>
       </xsl:if>
-      
+
       <xsl:apply-templates mode="localised" select=".">
         <xsl:with-param name="langId" select="$langId"/>
       </xsl:apply-templates>

--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
@@ -1007,19 +1007,6 @@
                 priority="100"/>
 
 
-  <!-- Use gmd:specification label for the specification title -->
-  <xsl:template mode="render-field"
-                match="gmd:specification/*/gmd:title"
-                priority="100">
-    <dl>
-      <dt><xsl:value-of select="tr:nodeLabel(tr:create($schema, @code), 'gmd:specification', 'gmd:CI_Citation')"/></dt>
-      <dd>
-        <xsl:apply-templates mode="render-value" select="."/>
-      </dd>
-    </dl>
-  </xsl:template>
-
-
   <!-- Link to other metadata records -->
   <xsl:template mode="render-field"
                 match="srv:operatesOn[@uuidref]|gmd:featureCatalogueCitation[@uuidref]|gmd:source[@uuidref]|gmd:aggregateDataSetIdentifier/*/gmd:code[@uuidref]"


### PR DESCRIPTION


In ISO19139 metadata, the full view was not displaying any title element:
![full-view-conformance-report-1](https://github.com/geonetwork/core-geonetwork/assets/1695003/a6ebb551-be01-4f30-9cd8-1fdb42c0ee95)


After the fix:

![full-view-conformance-report-2](https://github.com/geonetwork/core-geonetwork/assets/1695003/f14923e1-6cb4-4d91-9cbd-5b6783a51f8b)

---

Additionally, has been improved the specification title label.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation