### PR TITLE
Add MD_SecurityConstraintsUserNote search capability

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/search/EsSearchManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/EsSearchManager.java
@@ -584,6 +584,8 @@ public class EsSearchManager implements ISearchManager {
             .add("MD_LegalConstraintsUseLimitationObject")
             .add("MD_SecurityConstraintsUseLimitation")
             .add("MD_SecurityConstraintsUseLimitationObject")
+            .add("MD_SecurityConstraintsUserNote")
+            .add("MD_SecurityConstraintsUserNoteObject")
             .add("overview")
             .add("sourceDescription")
             .add("MD_ConstraintsUseLimitation")

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
@@ -659,6 +659,9 @@
           <xsl:for-each select="gmd:useLimitation">
             <xsl:copy-of select="gn-fn-index:add-multilingual-field(concat($fieldPrefix, 'UseLimitation'), ., $allLanguages)"/>
           </xsl:for-each>
+          <xsl:for-each select="gmd:userNote">
+            <xsl:copy-of select="gn-fn-index:add-multilingual-field(concat($fieldPrefix, 'UserNote'), ., $allLanguages)"/>
+          </xsl:for-each>
         </xsl:for-each>
 
         <xsl:for-each select="gmd:resourceConstraints/gmd:MD_LegalConstraints/gmd:otherConstraints">


### PR DESCRIPTION
The UserNote (http://www.datypic.com/sc/niem21/e-gmd_userNote-1.html) was used in some Shema to store security information in this case it's https://github.com/metadata101/iso19139.ca.HNAP which stores specific level of security for Canadian Government.

It will be used for searching by external client to track the security level. So it will be nice to add such capability to search. The search result will be like:
![image](https://github.com/geonetwork/core-geonetwork/assets/74916635/47c07dcf-bdee-46fe-a224-ab5d95b7944b)
