### PR TITLE
Synchronize Messages.properties from web and test

### DIFF
--- a/core/src/test/resources/org/fao/geonet/api/Messages.properties
+++ b/core/src/test/resources/org/fao/geonet/api/Messages.properties
@@ -118,6 +118,12 @@ Message: \n\
 View record: \n\
 {{link}}
 # TODO: Link to DOI creation panel
+metadata_published_subject=%s / Metadata publication
+metadata_published_text=The following records have been processed:\n\
+    <ul>%s</ul>
+metadata_published_record_text=<li>The metadata <a href="{{link}}">{{index:resourceTitleObject}}</a> has been published.</li>
+metadata_unpublished_record_text=<li>The metadata <a href="{{link}}">{{index:resourceTitleObject}}</a> has been unpublished.</li>
+metadata_approved_published_record_text=<li>The metadata <a href="{{link}}">{{index:resourceTitleObject}}</a> has been published as a new version.</li>
 
 api.groups.group_not_found=Group with ID ''{0}'' not found in this catalog.
 user_watchlist_subject=%s / %d updates in your watch list since %s
@@ -171,9 +177,9 @@ exception.doi.missingSavedquery.description="Record ''{0}'' is in schema ''{1}''
 exception.doi.recordNotConformantMissingInfo=Record is not conform with DataCite format
 exception.doi.recordNotConformantMissingInfo.description=Record ''{0}'' is not conform with DataCite format. {1} mandatory field(s) missing. {2}
 exception.doi.recordNotConformantMissingMandatory=Record is not conform with DataCite validation rules for mandatory fields
-exception.doi.recordNotConformantMissingMandatory.description=Record ''{0}'' is not conform with DataCite validation rules for mandatory fields. Error is: {1}. Required fields in DataCite are: identifier, creators, titles, publisher, publicationYear, resourceType. <a href=''{2}api/records/%s/formatters/datacite?output=xml''>Check the DataCite format output</a> and adapt the record content to add missing information.
+exception.doi.recordNotConformantMissingMandatory.description=Record ''{0}'' is not conform with DataCite validation rules for mandatory fields. Error is: {1}. Required fields in DataCite are: identifier, creators, titles, publisher, publicationYear, resourceType. <a href=''{2}api/records/{3}/formatters/datacite?output=xml''>Check the DataCite format output</a> and adapt the record content to add missing information.
 exception.doi.recordInvalid=Record converted to DataCite format is invalid.
-exception.doi.recordInvalid.description=Record ''{0}'' converted to DataCite format is invalid. Error is: {1}. Required fields in DataCite are: identifier, creators, titles, publisher, publicationYear, resourceType. <a href='{2}api/records/{3}/formatters/datacite?output=xml'>Check the DataCite format output</a> and adapt the record content to add missing information.
+exception.doi.recordInvalid.description=Record ''{0}'' converted to DataCite format is invalid. Error is: {1}. Required fields in DataCite are: identifier, creators, titles, publisher, publicationYear, resourceType. <a href=''{2}api/records/{3}/formatters/datacite?output=xml''>Check the DataCite format output</a> and adapt the record content to add missing information.
 api.metadata.import.importedWithId=Metadata imported with ID '%s'
 api.metadata.import.importedWithUuid=Metadata imported with UUID '%s'
 api.metadata.import.importedFromXMLWithUuid=Metadata imported from XML with UUID '%s'

--- a/core/src/test/resources/org/fao/geonet/api/Messages.properties
+++ b/core/src/test/resources/org/fao/geonet/api/Messages.properties
@@ -54,8 +54,8 @@ user_password_changed='%s' password was updated.
 user_password_notchanged=A problem occurred trying to change '%s' password. Contact the helpdesk.
 user_password_invalid_changekey='%s' is an invalid change key for '%s'. Change keys are only valid for one day.
 user_registered=User '%s' registered.
-user_with_that_email_found=A user with this email '%s' already exists.
-user_with_that_username_found=A user with this username '%s' already exists.
+user_with_that_email_found=A user with this email or username already exists.
+user_with_that_username_found=A user with this email or username already exists.
 register_email_admin_subject=%s / New account for %s as %s
 register_email_admin_message=Dear Admin,\n\
   Newly registered user %s has requested %s access for %s.\n\

--- a/core/src/test/resources/org/fao/geonet/api/Messages_fre.properties
+++ b/core/src/test/resources/org/fao/geonet/api/Messages_fre.properties
@@ -45,8 +45,8 @@ user_password_sent=Si l''utilisateur existe, vous recevrez un courriel contenant
 user_password_changed=Le mot de passe de %s a \u00E9t\u00E9 mis \u00E0 jour.
 user_password_notchanged=\u00C9chec lors du changement de mot de passe de %s. Contactez le support.
 user_password_invalid_changekey=%s est une cl\u00E9 invalide pour %s. Les cl\u00E9s ne sont valides que pendant une journ\u00E9e.
-user_with_that_email_found=Un utilisateur avec cette adresse email %s existe d\u00E9j\u00E0.
-user_with_that_username_found=Un utilisateur avec ce nom d''utilisateur %s existe d\u00E9j\u00E0.
+user_with_that_email_found=Un utilisateur avec cette adresse email ou ce nom d''utilisateur existe d\u00E9j\u00E0.
+user_with_that_username_found=Un utilisateur avec cette adresse email ou ce nom d''utilisateur existe d\u00E9j\u00E0.
 register_email_admin_subject=%s / Cr\u00E9ation de compte pour %s en tant que %s
 register_email_admin_message=Cher administrateur,\n\
   L'utilisateur %s vient de demander une cr\u00E9ation de compte pour %s.\n\

--- a/core/src/test/resources/org/fao/geonet/api/Messages_fre.properties
+++ b/core/src/test/resources/org/fao/geonet/api/Messages_fre.properties
@@ -112,6 +112,7 @@ metadata_published_text=Les fiches suivantes ont \u00E9t\u00E9 trait\u00E9es:\n\
     <ul>%s</ul>
 metadata_published_record_text=<li>La m\u00E9tadonn\u00E9e <a href="{{link}}">{{index:resourceTitleObject}}</a> a \u00E9t\u00E9 publi\u00E9e.</li>
 metadata_unpublished_record_text=<li>La m\u00E9tadonn\u00E9e <a href="{{link}}">{{index:resourceTitleObject}}</a> a \u00E9t\u00E9 d\u00E9publi\u00E9e.</li>
+metadata_approved_published_record_text=<li>Une nouvelle version de la m\u00E9tadonn\u00E9e <a href="{{link}}">{{index:resourceTitleObject}}</a> a \u00E9t\u00E9 publi\u00E9e.</li>
 
 api.groups.group_not_found=Le groupe avec l''identifiant ''{0}'' n''a pas \u00E9t\u00E9 trouv\u00E9 dans le catalogue.
 user_watchlist_subject=%s / %d mises \u00e0 jour dans vos fiches surveill\u00E9es %s

--- a/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages.properties
+++ b/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages.properties
@@ -54,8 +54,8 @@ user_password_changed='%s' password was updated.
 user_password_notchanged=A problem occurred trying to change '%s' password. Contact the helpdesk.
 user_password_invalid_changekey='%s' is an invalid change key for '%s'. Change keys are only valid for one day.
 user_registered=User '%s' registered.
-user_with_that_email_found=A user with this email or username already exists.
-user_with_that_username_found=A user with this email or username already exists.
+user_with_that_email_found=A user with this email '%s' already exists.
+user_with_that_username_found=A user with this username '%s' already exists.
 register_email_admin_subject=%s / New account for %s as %s
 register_email_admin_message=Dear Admin,\n\
   Newly registered user %s has requested %s access for %s.\n\
@@ -90,7 +90,7 @@ user_feedback_text=User %s (%s - %s)\n\
   \n\
   %s \n\
   \n\
-  See record %sapi/records/%s
+  See record %s
 status_email_text=GeoNetwork user %s (%s) edited metadata record #%s
 metadata_save_submit_text=Save and submit metadata
 metadata_save_approve_text=Save and approve metadata

--- a/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages.properties
+++ b/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages.properties
@@ -54,8 +54,8 @@ user_password_changed='%s' password was updated.
 user_password_notchanged=A problem occurred trying to change '%s' password. Contact the helpdesk.
 user_password_invalid_changekey='%s' is an invalid change key for '%s'. Change keys are only valid for one day.
 user_registered=User '%s' registered.
-user_with_that_email_found=A user with this email '%s' already exists.
-user_with_that_username_found=A user with this username '%s' already exists.
+user_with_that_email_found=A user with this email or username already exists.
+user_with_that_username_found=A user with this email or username already exists.
 register_email_admin_subject=%s / New account for %s as %s
 register_email_admin_message=Dear Admin,\n\
   Newly registered user %s has requested %s access for %s.\n\

--- a/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages_fre.properties
+++ b/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages_fre.properties
@@ -45,8 +45,8 @@ user_password_sent=Si l''utilisateur existe, vous recevrez un courriel contenant
 user_password_changed=Le mot de passe de %s a \u00E9t\u00E9 mis \u00E0 jour.
 user_password_notchanged=\u00C9chec lors du changement de mot de passe de %s. Contactez le support.
 user_password_invalid_changekey=%s est une cl\u00E9 invalide pour %s. Les cl\u00E9s ne sont valides que pendant une journ\u00E9e.
-user_with_that_email_found=Un utilisateur avec cette adresse email ou ce nom d''utilisateur existe d\u00E9j\u00E0.
-user_with_that_username_found=Un utilisateur avec cette adresse email ou ce nom d''utilisateur existe d\u00E9j\u00E0.
+user_with_that_email_found=Un utilisateur avec cette adresse email %s existe d\u00E9j\u00E0.
+user_with_that_username_found=Un utilisateur avec ce nom d''utilisateur %s existe d\u00E9j\u00E0.
 register_email_admin_subject=%s / Cr\u00E9ation de compte pour %s en tant que %s
 register_email_admin_message=Cher administrateur,\n\
   L'utilisateur %s vient de demander une cr\u00E9ation de compte pour %s.\n\
@@ -78,7 +78,7 @@ user_feedback_text=Utilisateur %s (%s - %s)\n\
   \n\
   %s \n\
   \n\
-  Consulter la fiche %sapi/records/%s
+  Consulter la fiche %s
 status_email_text=L''utilisateur %s (%s) a \u00E9dit\u00E9 une fiche #%s
 metadata_save_submit_text=Enregistrer et soumettre les m\u00E9tadonn\u00E9es
 metadata_save_approve_text=Enregistrer et approuver les m\u00E9tadonn\u00E9es
@@ -136,7 +136,7 @@ username.field.required=Le nom d''utilisateur est requis
 password.field.length=Le mot de passe doit contenir entre {min} et {max} caract\u00E8res
 password.field.invalid=Le mot de passe doit contenir a minima 1 lettre majuscule, 1 minuscule, 1 chiffre et 1 symbole (ie. `~!@#$%^&*()-_=+[]{}\\|;:'",.<>/?'));
 api.exception.forbidden=L''acc\u00E8s est refus\u00E9
-api.exception.forbidden.description=L'acc\u00E8s est refus\u00E9. Pour y acc\u00E9der, r\u00E9essayez avec un utilisateur disposant de plus de privil\u00E8ges.
+api.exception.forbidden.description=L''acc\u00E8s est refus\u00E9. Pour y acc\u00E9der, r\u00E9essayez avec un utilisateur disposant de plus de privil\u00E8ges.
 api.exception.resourceNotFound=Ressource introuvable
 api.exception.resourceNotFound.description=Ressource n''a pas pu \u00EAtre localis\u00E9e.
 api.exception.resourceAlreadyExists=La ressource existe d\u00E9j\u00E0

--- a/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages_fre.properties
+++ b/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages_fre.properties
@@ -45,8 +45,8 @@ user_password_sent=Si l''utilisateur existe, vous recevrez un courriel contenant
 user_password_changed=Le mot de passe de %s a \u00E9t\u00E9 mis \u00E0 jour.
 user_password_notchanged=\u00C9chec lors du changement de mot de passe de %s. Contactez le support.
 user_password_invalid_changekey=%s est une cl\u00E9 invalide pour %s. Les cl\u00E9s ne sont valides que pendant une journ\u00E9e.
-user_with_that_email_found=Un utilisateur avec cette adresse email %s existe d\u00E9j\u00E0.
-user_with_that_username_found=Un utilisateur avec ce nom d''utilisateur %s existe d\u00E9j\u00E0.
+user_with_that_email_found=Un utilisateur avec cette adresse email ou ce nom d''utilisateur existe d\u00E9j\u00E0.
+user_with_that_username_found=Un utilisateur avec cette adresse email ou ce nom d''utilisateur existe d\u00E9j\u00E0.
 register_email_admin_subject=%s / Cr\u00E9ation de compte pour %s en tant que %s
 register_email_admin_message=Cher administrateur,\n\
   L'utilisateur %s vient de demander une cr\u00E9ation de compte pour %s.\n\


### PR DESCRIPTION
<!--Include a few sentences describing the overall goals for this Pull Request-->
Synchronize the Messages.properties files in the web and test directory.
Messages.properties was updated in core/src/test but some changes are missing in web.

Without this fix the arguments in messages do not match the arguments provided.

Ex. user_feedback_text requires 11 arguments in Messages.properties in web but only 10 are provided. Only 10 arguments are required in Messages.properties in core/test.

![image](https://github.com/geonetwork/core-geonetwork/assets/163562062/1515ee24-9848-4b7d-a468-ab3deb9cd62b)

![image](https://github.com/geonetwork/core-geonetwork/assets/163562062/36d63262-9f61-4710-b541-15012d4b1260)

![image](https://github.com/geonetwork/core-geonetwork/assets/163562062/b525dc68-7565-4927-a729-b08a6e6d2732)
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

