### PR TITLE
Standard / ISO19115-3 / Improve linking to parent

### DIFF
--- a/schemas/iso19115-3.2018/src/main/java/org/fao/geonet/schema/iso19115_3_2018/ISO19115_3_2018SchemaPlugin.java
+++ b/schemas/iso19115-3.2018/src/main/java/org/fao/geonet/schema/iso19115_3_2018/ISO19115_3_2018SchemaPlugin.java
@@ -135,6 +135,8 @@ public class ISO19115_3_2018SchemaPlugin
             collectAssociatedResources(metadata, "mdb:parentMetadata");
 
         if (StringUtils.isNotEmpty(parentAssociatedResourceType)) {
+            associatedResources.forEach(parent -> parent.setAssociationType(parentAssociatedResourceType));
+
             try {
                 String XPATH_FOR_PARENT_IN_AGGRGATIONINFO =
                     "*//mri:associatedResource/*" +

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/config/associated-panel/default.json
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/config/associated-panel/default.json
@@ -993,6 +993,20 @@
       }
     ],
     "associatedResourcesTypes": [{
+      "type": "parent",
+      "label": "linkToParent",
+      "config": {
+        "fields": {"associationType": "partOfSeamlessDatabase", "initiativeType": "" },
+        "sources": {
+          "metadataStore": {
+            "params": {
+              "isTemplate": "n"
+            }
+          },
+          "remoteurl": {"multiple": true}
+        }
+      }
+    }, {
       "type": "siblings",
       "label": "linkToSibling",
       "config": {

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcService.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcService.js
@@ -362,6 +362,11 @@
          * @param {string} type of the directive that calls it.
          */
         onOpenPopup: function (type, additionalParams) {
+          if (type === "parent" && additionalParams.fields.associationType) {
+            // In ISO19115-3, parents are usually encoded using the association records
+            // Configured in config/associated-panel/default.json
+            type = "siblings";
+          }
           var fn = openCb[type];
           if (angular.isFunction(fn)) {
             openCb[type](additionalParams);

--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/associatedResourcesContainer.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/associatedResourcesContainer.html
@@ -17,7 +17,6 @@
           <span data-translate="">{{ config.label | translate}}</span>
         </a>
       </h2>
-
       <div
         data-ng-init="mainType = relatedResourcesConfig.getType(md, mapUIRelationToApi(config.type));
                          icon = relatedResourcesConfig.getClassIcon(mainType);"


### PR DESCRIPTION
In ISO19115-3, linking to parent are most of the time done using associated resources with specific association type (partOfSeamlessDatabase by default, but also series or largerWorkCitation). This can be configured in the plugin but some users have a mix of "old" encoding using parentMetadata element.
```xml
   <mdb:parentMetadata uuidref="fa6e13d4-5700-4391-a472-dd29b82ba3db"
                       xlink:title="REMI Network Observation and Monitoring Locations"/>
```

Now the default encoding is:

```xml
   <mri:associatedResource>
      <mri:MD_AssociatedResource>
         <mri:associationType>
            <mri:DS_AssociationTypeCode codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#DS_AssociationTypeCode"
                                        codeListValue="partOfSeamlessDatabase"/>
         </mri:associationType>
         <mri:metadataReference uuidref="0aa26e4e-4e10-4986-a433-986c2d247669"
                                xlink:href="http://localhost:8080/geonetwork/srv/api/records/0aa26e4e-4e10-4986-a433-986c2d247669"/>
      </mri:MD_AssociatedResource>
   </mri:associatedResource>
```

This fix the case of a mix of encoding is used for encoding parent relationships and display in the editor associated resource panel a parent block with either `parentMetadata` or `associatedResource`. When removing a parent relation, the `parent-remove.xsl` process handle both encoding. New links are created based on the current plugin configuration. Record view shows both.

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/5dabf6c5-6533-4399-be12-82182cab6a26)



Funded by Ifremer


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

