### PR TITLE
WMS GetMap HEAD request error response - check response status defined

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -900,7 +900,7 @@
                   imageTile.getImage().src = src;
                 },
                 function (r) {
-                  if (r.status === 414) {
+                  if (r.status && r.status === 414) {
                     // Request URI too large, try POST
                     convertGetMapRequestToPost(src, function (response) {
                       var arrayBufferView = new Uint8Array(response.data);

--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -895,7 +895,7 @@
             };
 
             var loadFunction = function (imageTile, src) {
-              $http.head(src, { nointercept: true }).then(
+              $http.head(src).then(
                 function (r) {
                   imageTile.getImage().src = src;
                 },
@@ -1660,7 +1660,7 @@
                     var _url = url.split("/");
                     _url = _url[0] + "/" + _url[1] + "/" + _url[2] + "/";
                     if (
-                      $.inArray(_url, gnGlobalSettings.requireProxy) >= 0 &&
+                      $.inArray(_url + "#GET", gnGlobalSettings.requireProxy) >= 0 &&
                       url.indexOf(gnGlobalSettings.proxyUrl) != 0
                     ) {
                       capL.useProxy = true;

--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -895,12 +895,12 @@
             };
 
             var loadFunction = function (imageTile, src) {
-              $http.head(src).then(
+              $http.head(src, { nointercept: true }).then(
                 function (r) {
                   imageTile.getImage().src = src;
                 },
                 function (r) {
-                  if (r.status && r.status === 414) {
+                  if (r.status === 414) {
                     // Request URI too large, try POST
                     convertGetMapRequestToPost(src, function (response) {
                       var arrayBufferView = new Uint8Array(response.data);

--- a/web-ui/src/main/resources/catalog/components/utility/CORSInterceptor.js
+++ b/web-ui/src/main/resources/catalog/components/utility/CORSInterceptor.js
@@ -81,10 +81,15 @@
                 if (mapservice !== null) {
                   if (mapservice.useProxy) {
                     // If we need to use the proxy then add it to requireProxy list.
-                    if ($.inArray(config.url, gnGlobalSettings.requireProxy) === -1) {
+                    if (
+                      $.inArray(
+                        config.url + "#" + config.method,
+                        gnGlobalSettings.requireProxy
+                      ) === -1
+                    ) {
                       var url = config.url.split("/");
                       url = url[0] + "/" + url[1] + "/" + url[2] + "/";
-                      gnGlobalSettings.requireProxy.push(url);
+                      gnGlobalSettings.requireProxy.push(url + "#" + config.method);
                     }
                   } else {
                     // If we are not using a proxy then add the headers.
@@ -113,7 +118,10 @@
                 var url = config.url.split("/");
                 url = url[0] + "/" + url[1] + "/" + url[2] + "/";
 
-                if ($.inArray(url, gnGlobalSettings.requireProxy) !== -1) {
+                if (
+                  $.inArray(url + "#" + config.method, gnGlobalSettings.requireProxy) !==
+                  -1
+                ) {
                   // require proxy
                   config.url = gnGlobalSettings.proxyUrl + encodeURIComponent(config.url);
                 }
@@ -156,8 +164,13 @@
                     var url = config.url.split("/");
                     url = url[0] + "/" + url[1] + "/" + url[2] + "/";
 
-                    if ($.inArray(url, gnGlobalSettings.requireProxy) === -1) {
-                      gnGlobalSettings.requireProxy.push(url);
+                    if (
+                      $.inArray(
+                        url + "#" + config.method,
+                        gnGlobalSettings.requireProxy
+                      ) === -1
+                    ) {
+                      gnGlobalSettings.requireProxy.push(url + "#" + config.method);
                     }
 
                     $injector.invoke([

--- a/web-ui/src/main/resources/catalog/components/viewer/wmsimport/WmsImportDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wmsimport/WmsImportDirective.js
@@ -87,7 +87,7 @@
               var url = $scope.url.split("/");
               getCapLayer.useProxy = false;
               url = url[0] + "/" + url[1] + "/" + url[2] + "/";
-              if ($.inArray(url, gnGlobalSettings.requireProxy) >= 0) {
+              if ($.inArray(url + "#GET", gnGlobalSettings.requireProxy) >= 0) {
                 getCapLayer.useProxy = true;
               }
               if ($scope.format == "wms") {


### PR DESCRIPTION
If CORS is not allowed for WMS GetMap HEAD request, the error response doesn't contain the status property. Protect the related check.

Follow up of #7000

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
