### PR TITLE
search menu size

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/less/gn_search_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_search_default.less
@@ -205,11 +205,10 @@ a {
 
 // advanced search
 .gn-search-filter {
-  position: absolute;
   z-index: 110;
   padding: 15px;
   background-color: @panel-default-heading-bg;
-  width: calc(~"100% - 30px");
+  width: 100%;
   border: 1px solid @input-border;
   border-top: 0;
   [class*=col-md] {


### PR DESCRIPTION
This menu overlapped the search result which makes them not very readable.

![image](https://github.com/geonetwork/core-geonetwork/assets/74916635/302f11c6-c0ee-4369-bc90-e180347dbaa0)


The solution to auto sizing the menu as:
![image](https://github.com/geonetwork/core-geonetwork/assets/74916635/c7b1a620-82f9-4fd7-98ee-38bbc65bf5f2)

