### PR TITLE
Workflow / Edit action / Fix link in search results

### DIFF
--- a/web-ui/src/main/resources/catalog/components/elasticsearch/EsFacet.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/EsFacet.js
@@ -47,6 +47,7 @@
           "resourceTitle*",
           "resourceAbstract*",
           "draft",
+          "draftId",
           "owner",
           "link",
           "status*",

--- a/web-ui/src/main/resources/catalog/views/default/directives/directive.js
+++ b/web-ui/src/main/resources/catalog/views/default/directives/directive.js
@@ -81,12 +81,16 @@
 
   module.directive("gnLinksBtn", [
     "gnTplResultlistLinksbtn",
-    function (gnTplResultlistLinksbtn) {
+    "gnMetadataActions",
+    function (gnTplResultlistLinksbtn, gnMetadataActions) {
       return {
         restrict: "E",
         replace: true,
         scope: true,
-        templateUrl: gnTplResultlistLinksbtn
+        templateUrl: gnTplResultlistLinksbtn,
+        link: function linkFn(scope) {
+          scope.gnMetadataActions = gnMetadataActions;
+        }
       };
     }
   ]);

--- a/web-ui/src/main/resources/catalog/views/default/directives/partials/linksbtn.html
+++ b/web-ui/src/main/resources/catalog/views/default/directives/partials/linksbtn.html
@@ -2,7 +2,7 @@
   <a
     class="gn-md-edit-btn btn btn-default btn-sm"
     data-ng-show="user.canEditRecord(md)"
-    data-ng-href="catalog.edit#/metadata/{{md.id}}?redirectUrl=catalog.search%23%2Fmetadata%2F{{md.uuid}}"
+    data-ng-href="catalog.edit#/metadata/{{gnMetadataActions.getMetadataIdToEdit(md)}}?redirectUrl=catalog.search%23%2Fmetadata%2F{{md.uuid}}"
     title="{{'edit' | translate}}"
     aria-label="{{'edit' | translate}}"
   >


### PR DESCRIPTION
Follow up of https://github.com/geonetwork/core-geonetwork/pull/6321

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/3130d309-af3a-42c3-98ec-e47494a8e9eb)

This was noticed because then when an approved record is found, the edit action in the search result page was opening the editor with a link http://localhost:8080/geonetwork/srv/eng/catalog.edit#/metadata/ApprovedID

Then the editor was opening the editor form with the UUID.

And in such case the editor does not do the redirection (in MetadataEditingApi.java#L153).


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

