### PR TITLE
update last changed date when restore metadata

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java
@@ -924,7 +924,7 @@ public class MetadataWorkflowApi {
             Element mdNoGeonetInfo = metadataUtils.removeMetadataInfo(md);
 
             metadataManager.updateMetadata(context, String.valueOf(metadata.getId()), mdNoGeonetInfo, false, true, context.getLanguage(),
-                null, false, IndexingMode.full);
+                null, true, IndexingMode.full);
             recoveredMetadataId = metadata.getId();
         } else {
             // Recover from delete


### PR DESCRIPTION
The issue is that when restoring metadata 

![image](https://github.com/geonetwork/core-geonetwork/assets/74916635/d204e4e9-9792-4214-b0fe-9e84b71d09db)


The transaction does not change the last updated date.
![image](https://github.com/geonetwork/core-geonetwork/assets/74916635/a843e5fd-76d0-40be-86ab-b135f3d37a11)


Here the data is restored to the previous status which considered as data change. So the transaction in this restore API need small adjustment.

