### PR TITLE
Map / Switch from GET to POST request improved in case of missing CORS header on HTTP errors

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -907,7 +907,7 @@
                   // On CORS error, status is -1.
                   // Check client side if the URI is too large according to default Apache LimitRequestFieldSize
                   // and switch to POST in this case.
-                  var uriTooLarge = r.status === -1 && src.length >= 8190;
+                  var uriTooLarge = (r.status === undefined || r.status === -1) && src.length >= 8190;
 
                   if (r.status === 414 || uriTooLarge) {
                     // Request URI too large, try POST

--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -900,7 +900,16 @@
                   imageTile.getImage().src = src;
                 },
                 function (r) {
-                  if (r.status === 414) {
+                  // Apache may not set CORS header in case of HTTP errors
+                  // This depends on virtual hosts configuration,
+                  // usage of Header always set Access-Control-Allow-Origin "*",
+                  // and virtual host resolution (by server name, ip or wildcard).
+                  // On CORS error, status is -1.
+                  // Check client side if the URI is too large according to default Apache LimitRequestFieldSize
+                  // and switch to POST in this case.
+                  var uriTooLarge = r.status === -1 && src.length >= 8190;
+
+                  if (r.status === 414 || uriTooLarge) {
                     // Request URI too large, try POST
                     convertGetMapRequestToPost(src, function (response) {
                       var arrayBufferView = new Uint8Array(response.data);


### PR DESCRIPTION
Complementary to https://github.com/geonetwork/core-geonetwork/pull/8023

Some servers may not provide CORS header if an HTTP error occurs. eg. https://stackoverflow.com/questions/28584891/cors-header-not-being-served-by-apache-if-theres-a-404 On Apache, it depends on the usage of `always` in
```
Header always set Access-Control-Allow-Origin "*"
```
but it also depends on the list of virtual host in the configuration. A virtual host matching `*` or an IP corresponding to the domain may resolve first and the `Header` directive may not be the same in all virtual host.

Can be tested, with https://sextant.ifremer.fr/services/wms/environnement_marin. When indexing features, large GET request may be generated when adding many filters eg.

```
angular.injector(["ng"]).get("$http").head("https://sextant.ifremer.fr/services/wms/environnement_marin?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetMap&FORMAT=image%2Fpng&TRANSPARENT=true&LAYERS=surval_lieux_actifs_REPHY_REPHYTOX_point&STYLES=&FILTER=(%3Cogc%3AFilter%20xmlns%3Axs%3D%22http%3A%2F%2Fwww.w3.org%2F2001%2FXMLSchema%22%20xmlns%3Agml%3D%22http%3A%2F%2Fwww.opengis.net%2Fgml%22%20xmlns%3Aogc%3D%22http%3A%2F%2Fwww.opengis.net%2Fogc%22%3E%3Cogc%3AAnd%3E%3Cogc%3AOr%3E%3Cogc%3APropertyIsLike%20escapeChar%3D%22%5C%22%20matchCase%3D%22false%22%20singleChar%3D%22%3F%22%20wildCard%3D%22*%22%3E%3Cogc%3APropertyName%3EQUADRIGE_ZONEMARINE%3C%2Fogc%3APropertyName%3E%3Cogc%3ALiteral%3E079%20-%20Pertuis%20d'Antioche*%3C%2Fogc%3ALiteral%3E%3C%2Fogc%3APropertyIsLike%3E%3Cogc%3APropertyIsLike%20escapeChar%3D%22%5C%22%20matchCase%3D%22false%22%20singleChar%3D%22%3F%22%20wildCard%3D%22*%22%3E%3Cogc%3APropertyName%3EQUADRIGE_ZONEMARINE%3C%2Fogc%3APropertyName%3E%3Cogc%3ALiteral%3E*079%20-%20Pertuis%20d'Antioche%3C%2Fogc%3ALiteral%3E%3C%2Fogc%3APropertyIsLike%3E%3Cogc%3APropertyIsLike%20escapeChar%3D%22%5C%22%20matchCase%3D%22false%22%20singleChar%3D%22%3F%22%20wildCard%3D%22*%22%3E%3Cogc%3APropertyName%3EQUADRIGE_ZONEMARINE%3C%2Fogc%3APropertyName%3E%3Cogc%3ALiteral%3E*079%20-%20Pertuis%20d'Antioche*%3C%2Fogc%3ALiteral%3E%3C%2Fogc%3APropertyIsLike%3E%3Cogc%3APropertyIsLike%20escapeChar%3D%22%5C%22%20matchCase%3D%22false%22%20singleChar%3D%22%3F%22%20wildCard%3D%22*%22%3E%3Cogc%3APropertyName%3EQUADRIGE_ZONEMARINE%3C%2Fogc%3APropertyName%3E%3Cogc%3ALiteral%3E079%20-%20Pertuis%20d'Antioche%3C%2Fogc%3ALiteral%3E%3C%2Fogc%3APropertyIsLike%3E%3C%2Fogc%3AOr%3E%3Cogc%3AOr%3E%3Cogc%3APropertyIsLike%20escapeChar%3D%22%5C%22%20matchCase%3D%22false%22%20singleChar%3D%22%3F%22%20wildCard%3D%22*%22%3E%3Cogc%3APropertyName%3ELIEU_LIBELLE%3C%2Fogc%3APropertyName%3E%3Cogc%3ALiteral%3E079-P-002%20-%20Le%20Martray*%3C%2Fogc%3ALiteral%3E%3C%2Fogc%3APropertyIsLike%3E%3Cogc%3APropertyIsLike%20escapeChar%3D%22%5C%22%20matchCase%3D%22false%22%20singleChar%3D%22%3F%22%20wildCard%3D%22*%22%3E%3Cogc%3APropertyName%3ELIEU_LIBELLE%3C%2Fogc%3APropertyName%3E%3Cogc%3ALiteral%3E*079-P-002%20-%20Le%20Martray%3C%2Fogc%3ALiteral%3E%3C%2Fogc%3APropertyIsLike%3E%3Cogc%3APropertyIsLike%20escapeChar%3D%22%5C%22%20matchCase%3D%22false%22%20singleChar%3D%22%3F%22%20wildCard%3D%22*%22%3E%3Cogc%3APropertyName%3ELIEU_LIBELLE%3C%2Fogc%3APropertyName%3E%3Cogc%3ALiteral%3E*079-P-002%20-%20Le%20Martray*%3C%2Fogc%3ALiteral%3E%3C%2Fogc%3APropertyIsLike%3E%3Cogc%3APropertyIsLike%20escapeChar%3D%22%5C%22%20matchCase%3D%22false%22%20singleChar%3D%22%3F%22%20wildCard%3D%22*%22%3E%3Cogc%3APropertyName%3ELIEU_LIBELLE%3C%2Fogc%3APropertyName%3E%3Cogc%3ALiteral%3E079-P-002%20-%20Le%20Martray%3C%2Fogc%3ALiteral%3E%3C%2Fogc%3APropertyIsLike%3E%3Cogc%3APropertyIsLike%20escapeChar%3D%22%5C%22%20matchCase%3D%22false%22%20singleChar%3D%22%3F%22%20wildCard%3D%22*%22%3E%3Cogc%3APropertyName%3ELIEU_LIBELLE%3C%2Fogc%3APropertyName%3E%3Cogc%3ALiteral%3E079-P-010%20-%20Nord%20Saumonards*%3C%2Fogc%3ALiteral%3E%3C%2Fogc%3APropertyIsLike%3E%3Cogc%3APropertyIsLike%20escapeChar%3D%22%5C%22%20matchCase%3D%22false%22%20singleChar%3D%22%3F%22%20wildCard%3D%22*%22%3E%3Cogc%3APropertyName%3ELIEU_LIBELLE%3C%2Fogc%3APropertyName%3E%3Cogc%3ALiteral%3E*079-P-010%20-%20Nord%20Saumonards%3C%2Fogc%3ALiteral%3E%3C%2Fogc%3APropertyIsLike%3E%3Cogc%3APropertyIsLike%20escapeChar%3D%22%5C%22%20matchCase%3D%22false%22%20singleChar%3D%22%3F%22%20wildCard%3D%22*%22%3E%3Cogc%3APropertyName%3ELIEU_LIBELLE%3C%2Fogc%3APropertyName%3E%3Cogc%3ALiteral%3E*079-P-010%20-%20Nord%20Saumonards*%3C%2Fogc%3ALiteral%3E%3C%2Fogc%3APropertyIsLike%3E%3Cogc%3APropertyIsLike%20escapeChar%3D%22%5C%22%20matchCase%3D%22false%22%20singleChar%3D%22%3F%22%20wildCard%3D%22*%22%3E%3Cogc%3APropertyName%3ELIEU_LIBELLE%3C%2Fogc%3APropertyName%3E%3Cogc%3ALiteral%3E079-P-010%20-%20Nord%20Saumonards%3C%2Fogc%3ALiteral%3E%3C%2Fogc%3APropertyIsLike%3E%3Cogc%3APropertyIsLike%20escapeChar%3D%22%5C%22%20matchCase%3D%22false%22%20singleChar%3D%22%3F%22%20wildCard%3D%22*%22%3E%3Cogc%3APropertyName%3ELIEU_LIBELLE%3C%2Fogc%3APropertyName%3E%3Cogc%3ALiteral%3E079-P-024%20-%20Baie%20d'Yves%20(a)*%3C%2Fogc%3ALiteral%3E%3C%2Fogc%3APropertyIsLike%3E%3Cogc%3APropertyIsLike%20escapeChar%3D%22%5C%22%20matchCase%3D%22false%22%20singleChar%3D%22%3F%22%20wildCard%3D%22*%22%3E%3Cogc%3APropertyName%3ELIEU_LIBELLE%3C%2Fogc%3APropertyName%3E%3Cogc%3ALiteral%3E*079-P-024%20-%20Baie%20d'Yves%20(a)%3C%2Fogc%3ALiteral%3E%3C%2Fogc%3APropertyIsLike%3E%3Cogc%3APropertyIsLike%20escapeChar%3D%22%5C%22%20matchCase%3D%22false%22%20singleChar%3D%22%3F%22%20wildCard%3D%22*%22%3E%3Cogc%3APropertyName%3ELIEU_LIBELLE%3C%2Fogc%3APropertyName%3E%3Cogc%3ALiteral%3E*079-P-024%20-%20Baie%20d'Yves%20(a)*%3C%2Fogc%3ALiteral%3E%3C%2Fogc%3APropertyIsLike%3E%3Cogc%3APropertyIsLike%20escapeChar%3D%22%5C%22%20matchCase%3D%22false%22%20singleChar%3D%22%3F%22%20wildCard%3D%22*%22%3E%3Cogc%3APropertyName%3ELIEU_LIBELLE%3C%2Fogc%3APropertyName%3E%3Cogc%3ALiteral%3E079-P-024%20-%20Baie%20d'Yves%20(a)%3C%2Fogc%3ALiteral%3E%3C%2Fogc%3APropertyIsLike%3E%3Cogc%3APropertyIsLike%20escapeChar%3D%22%5C%22%20matchCase%3D%22false%22%20singleChar%3D%22%3F%22%20wildCard%3D%22*%22%3E%3Cogc%3APropertyName%3ELIEU_LIBELLE%3C%2Fogc%3APropertyName%3E%3Cogc%3ALiteral%3E079-P-026%20-%20Le%20Cornard*%3C%2Fogc%3ALiteral%3E%3C%2Fogc%3APropertyIsLike%3E%3Cogc%3APropertyIsLike%20escapeChar%3D%22%5C%22%20matchCase%3D%22false%22%20singleChar%3D%22%3F%22%20wildCard%3D%22*%22%3E%3Cogc%3APropertyName%3ELIEU_LIBELLE%3C%2Fogc%3APropertyName%3E%3Cogc%3ALiteral%3E*079-P-026%20-%20Le%20Cornard%3C%2Fogc%3ALiteral%3E%3C%2Fogc%3APropertyIsLike%3E%3Cogc%3APropertyIsLike%20escapeChar%3D%22%5C%22%20matchCase%3D%22false%22%20singleChar%3D%22%3F%22%20wildCard%3D%22*%22%3E%3Cogc%3APropertyName%3ELIEU_LIBELLE%3C%2Fogc%3APropertyName%3E%3Cogc%3ALiteral%3E*079-P-026%20-%20Le%20Cornard*%3C%2Fogc%3ALiteral%3E%3C%2Fogc%3APropertyIsLike%3E%3Cogc%3APropertyIsLike%20escapeChar%3D%22%5C%22%20matchCase%3D%22false%22%20singleChar%3D%22%3F%22%20wildCard%3D%22*%22%3E%3Cogc%3APropertyName%3ELIEU_LIBELLE%3C%2Fogc%3APropertyName%3E%3Cogc%3ALiteral%3E079-P-026%20-%20Le%20Cornard%3C%2Fogc%3ALiteral%3E%3C%2Fogc%3APropertyIsLike%3E%3Cogc%3APropertyIsLike%20escapeChar%3D%22%5C%22%20matchCase%3D%22false%22%20singleChar%3D%22%3F%22%20wildCard%3D%22*%22%3E%3Cogc%3APropertyName%3ELIEU_LIBELLE%3C%2Fogc%3APropertyName%3E%3Cogc%3ALiteral%3E079-P-029%20-%20Aytr%C3%A9*%3C%2Fogc%3ALiteral%3E%3C%2Fogc%3APropertyIsLike%3E%3Cogc%3APropertyIsLike%20escapeChar%3D%22%5C%22%20matchCase%3D%22false%22%20singleChar%3D%22%3F%22%20wildCard%3D%22*%22%3E%3Cogc%3APropertyName%3ELIEU_LIBELLE%3C%2Fogc%3APropertyName%3E%3Cogc%3ALiteral%3E*079-P-029%20-%20Aytr%C3%A9%3C%2Fogc%3ALiteral%3E%3C%2Fogc%3APropertyIsLike%3E%3Cogc%3APropertyIsLike%20escapeChar%3D%22%5C%22%20matchCase%3D%22false%22%20singleChar%3D%22%3F%22%20wildCard%3D%22*%22%3E%3Cogc%3APropertyName%3ELIEU_LIBELLE%3C%2Fogc%3APropertyName%3E%3Cogc%3ALiteral%3E*079-P-029%20-%20Aytr%C3%A9*%3C%2Fogc%3ALiteral%3E%3C%2Fogc%3APropertyIsLike%3E%3Cogc%3APropertyIsLike%20escapeChar%3D%22%5C%22%20matchCase%3D%22false%22%20singleChar%3D%22%3F%22%20wildCard%3D%22*%22%3E%3Cogc%3APropertyName%3ELIEU_LIBELLE%3C%2Fogc%3APropertyName%3E%3Cogc%3ALiteral%3E079-P-029%20-%20Aytr%C3%A9%3C%2Fogc%3ALiteral%3E%3C%2Fogc%3APropertyIsLike%3E%3Cogc%3APropertyIsLike%20escapeChar%3D%22%5C%22%20matchCase%3D%22false%22%20singleChar%3D%22%3F%22%20wildCard%3D%22*%22%3E%3Cogc%3APropertyName%3ELIEU_LIBELLE%3C%2Fogc%3APropertyName%3E%3Cogc%3ALiteral%3E079-P-027%20-%20Chatelaillon%20(a)*%3C%2Fogc%3ALiteral%3E%3C%2Fogc%3APropertyIsLike%3E%3Cogc%3APropertyIsLike%20escapeChar%3D%22%5C%22%20matchCase%3D%22false%22%20singleChar%3D%22%3F%22%20wildCard%3D%22*%22%3E%3Cogc%3APropertyName%3ELIEU_LIBELLE%3C%2Fogc%3APropertyName%3E%3Cogc%3ALiteral%3E*079-P-027%20-%20Chatelaillon%20(a)%3C%2Fogc%3ALiteral%3E%3C%2Fogc%3APropertyIsLike%3E%3Cogc%3APropertyIsLike%20escapeChar%3D%22%5C%22%20matchCase%3D%22false%22%20singleChar%3D%22%3F%22%20wildCard%3D%22*%22%3E%3Cogc%3APropertyName%3ELIEU_LIBELLE%3C%2Fogc%3APropertyName%3E%3Cogc%3ALiteral%3E*079-P-027%20-%20Chatelaillon%20(a)*%3C%2Fogc%3ALiteral%3E%3C%2Fogc%3APropertyIsLike%3E%3Cogc%3APropertyIsLike%20escapeChar%3D%22%5C%22%20matchCase%3D%22false%22%20singleChar%3D%22%3F%22%20wildCard%3D%22*%22%3E%3Cogc%3APropertyName%3ELIEU_LIBELLE%3C%2Fogc%3APropertyName%3E%3Cogc%3ALiteral%3E079-P-027%20-%20Chatelaillon%20(a)%3C%2Fogc%3ALiteral%3E%3C%2Fogc%3APropertyIsLike%3E%3C%2Fogc%3AOr%3E%3C%2Fogc%3AAnd%3E%3C%2Fogc%3AFilter%3E)&CRS=EPSG%3A3857&WIDTH=1183&HEIGHT=1050&BBOX=-165448.08519230082%2C5777401.481768884%2C-121888.37819306905%2C5816063.943602521", {}).then(
function(c) {console.log("success", c)},
function(c) {console.log("error", c)})
```

When possible, it is better to improve the webserver configuration for the WMS.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

Funded by Ifremer
