### PR TITLE
XSL / Utility / Add multilingual support to getIndexField

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/search/EsSearchManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/EsSearchManager.java
@@ -811,8 +811,8 @@ public class EsSearchManager implements ISearchManager {
         return client.query(defaultIndex, jsonRequest, null, includedFields, from, size);
     }
 
-    public Map<String, String> getFieldsValues(String id, Set<String> fields) throws IOException {
-        return client.getFieldsValues(defaultIndex, id, fields);
+    public Map<String, String> getFieldsValues(String id, Set<String> fields, String language) throws Exception {
+        return client.getFieldsValues(defaultIndex, id, fields, language);
     }
 
 

--- a/core/src/main/java/org/fao/geonet/util/XslUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/XslUtil.java
@@ -843,11 +843,9 @@ public final class XslUtil {
         try {
             Set<String> fields = new HashSet<>();
             fields.add(fieldname);
-            // TODO: Multilingual fields
-            final Map<String, String> values = searchManager.getFieldsValues(id, fields);
+            final Map<String, String> values = searchManager.getFieldsValues(id, fields, language);
             return values.get(fieldname);
         } catch (Exception e) {
-            e.printStackTrace();
             Log.error(Geonet.GEONETWORK, "Failed to get index field '" + fieldname + "' value on '" + id + "', caused by " + e.getMessage());
         }
         return "";

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java
@@ -1024,7 +1024,7 @@ public class MetadataWorkflowApi {
                         fields.add(titleField);
                         Optional<Metadata> metadata = metadataRepository.findById(s.getMetadataId());
                         final Map<String, String> values =
-                            searchManager.getFieldsValues(metadata.get().getUuid(), fields);
+                            searchManager.getFieldsValues(metadata.get().getUuid(), fields, language);
                         title = values.get(titleField);
                         titles.put(s.getMetadataId(), title);
                     } catch (Exception e1) {

--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-functions.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-functions.xsl
@@ -159,7 +159,7 @@
   <xsl:function name="gn-fn-render:getMetadataTitle">
     <xsl:param name="uuid" as="xs:string"/>
     <xsl:param name="language" as="xs:string"/>
-    <!-- TODOES: Fallback to default language -->
+
     <xsl:variable name="metadataTitle"
                   select="util:getIndexField(
                   $language,
@@ -168,20 +168,7 @@
                   $language)"/>
     <xsl:choose>
       <xsl:when test="$metadataTitle=''">
-        <xsl:variable name="metadataDefaultTitle"
-                      select="util:getIndexField(
-                      $language,
-                      $uuid,
-                      'resourceTitleObject',
-                      $language)"/>
-        <xsl:choose>
-          <xsl:when test="$metadataDefaultTitle=''">
-            <xsl:value-of select="$uuid"/>
-          </xsl:when>
-          <xsl:otherwise>
-            <xsl:value-of select="$metadataDefaultTitle"/>
-          </xsl:otherwise>
-        </xsl:choose>
+        <xsl:value-of select="$uuid"/>
       </xsl:when>
       <xsl:otherwise>
         <xsl:value-of select="$metadataTitle"/>

--- a/web/src/main/webapp/xslt/base-layout.xsl
+++ b/web/src/main/webapp/xslt/base-layout.xsl
@@ -49,10 +49,10 @@
         <xsl:variable name="htmlHeadTitle"
                       select="if ($discoveryServiceRecordUuid != '')
                               then util:getIndexField(
-                                        $lang,
+                                        string($lang),
                                         $discoveryServiceRecordUuid,
                                         'resourceTitleObject',
-                                        $lang)
+                                        string($lang))
                               else if (contains($nodeName, '|'))
                               then substring-before($nodeName, '|')
                               else $nodeName"/>
@@ -61,10 +61,10 @@
         <xsl:variable name="htmlHeadDescription"
                       select="if ($discoveryServiceRecordUuid != '')
                               then util:getIndexField(
-                                        $lang,
+                                        string($lang),
                                         $discoveryServiceRecordUuid,
                                         'resourceAbstractObject',
-                                        $lang)
+                                        string($lang))
                               else if (contains($nodeName, '|'))
                               then substring-after($nodeName, '|')
                               else $nodeName"/>


### PR DESCRIPTION
The function is not much used but can be tested by configuring a multilingual metadata as CSW service.

Then the document title is the title of the metadata record and should match UI language or use default if not found.

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/e9b1617c-ad1e-4ed8-97f9-aa57babc5d8b)

It is also use in workflow message.



<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

Funded by Vlaanderen