### PR TITLE
Editor / Map / Use main context to have a better default on new extent

### DIFF
--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -845,9 +845,9 @@
               geodesicExtents: false
             },
             "map-editor": {
-              context: "",
+              context: "../../map/config-viewer.xml",
               extent: [0, 0, 0, 0],
-              layers: [{ type: "osm" }]
+              layers: []
             },
             "map-thumbnail": {
               context: "../../map/config-viewer.xml",


### PR DESCRIPTION
The map configuration was not using a context and the map extent was centered on coordinate 0 0.

Use the default map context which will center on the context map extent which depends on each catalogue configuration.

Before

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/073265f8-398e-4d9c-90d9-604af44c4511)

After

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/298c4f28-8e95-48c0-83f0-a3a8b0358bfc)

Configure the default map to properly focus on your area of interest.

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

Funded by Ifremer
