### PR TITLE
Editor / Remove wrong ERROR log message on multilingual records

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/editing/AjaxEditUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/records/editing/AjaxEditUtils.java
@@ -195,6 +195,7 @@ public class AjaxEditUtils extends EditUtils {
                 ref = ref.substring(1);
                 xmlInputs.put(ref, value);
             } else if (ref.startsWith("P") && ref.endsWith("_xml")) {
+                // P{key}=xpath works with P{key}_xml=XML snippet, see next condition
             } else if (ref.startsWith("P") && !ref.endsWith("_xml")) {
                 // Catch element starting with a P for xpath update mode
                 String snippet = changes.get(ref + "_xml");

--- a/services/src/main/java/org/fao/geonet/api/records/editing/AjaxEditUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/records/editing/AjaxEditUtils.java
@@ -151,8 +151,12 @@ public class AjaxEditUtils extends EditUtils {
                 continue;
             }
 
-            // Ignore element if ref starts with "P" or "X"
-            if (originalRef.startsWith("X") || originalRef.startsWith("P")) {
+            // No pre processes for ref starting
+            // with "P" (for XPath mode)
+            // or "X" (for XML mode)
+            // or "lang_" (for multilingual fields)
+            // Updates for these refs are handled in next step
+            if (originalRef.startsWith("X") || originalRef.startsWith("P") || originalRef.startsWith("lang_")) {
                 continue;
             }
 
@@ -190,9 +194,7 @@ public class AjaxEditUtils extends EditUtils {
             if (ref.startsWith("X")) {
                 ref = ref.substring(1);
                 xmlInputs.put(ref, value);
-                continue;
             } else if (ref.startsWith("P") && ref.endsWith("_xml")) {
-                continue;
             } else if (ref.startsWith("P") && !ref.endsWith("_xml")) {
                 // Catch element starting with a P for xpath update mode
                 String snippet = changes.get(ref + "_xml");
@@ -207,45 +209,42 @@ public class AjaxEditUtils extends EditUtils {
                 } else {
                     Log.warning(Geonet.EDITOR, "No XML snippet or value found for xpath " + value + " and element ref " + ref);
                 }
-                continue;
-            }
-
-            if (updatedLocalizedTextElement(md, schema, ref, value, editLib)) {
-                continue;
-            }
-
-            int at = ref.indexOf('_');
-            if (at != -1) {
-                attribute = ref.substring(at + 1);
-                ref = ref.substring(0, at);
-            }
-
-            Element el = editLib.findElement(md, ref);
-            if (el == null) {
-                Log.error(Geonet.EDITOR, EditLib.MSG_ELEMENT_NOT_FOUND_AT_REF + ref);
-                continue;
-            }
-
-            // Process attribute
-            if (attribute != null) {
-                Pair<Namespace, String> attInfo = parseAttributeName(attribute, EditLib.COLON_SEPARATOR, id, md, editLib);
-                String localname = attInfo.two();
-                Namespace attrNS = attInfo.one();
-                if (el.getAttribute(localname, attrNS) != null) {
-                    el.setAttribute(new Attribute(localname, value, attrNS));
-                }
+            } else if (ref.startsWith("lang_")) {
+                updatedLocalizedTextElement(md, schema, ref, value, editLib);
             } else {
-                // Process element value
-                @SuppressWarnings("unchecked")
-                List<Content> content = el.getContent();
-
-                for (Iterator<Content> iterator = content.iterator(); iterator.hasNext(); ) {
-                    Content content2 = iterator.next();
-                    if (content2 instanceof Text) {
-                        iterator.remove();
-                    }
+                int at = ref.indexOf('_');
+                if (at != -1) {
+                    attribute = ref.substring(at + 1);
+                    ref = ref.substring(0, at);
                 }
-                el.addContent(value);
+
+                Element el = editLib.findElement(md, ref);
+                if (el == null) {
+                    Log.error(Geonet.EDITOR, EditLib.MSG_ELEMENT_NOT_FOUND_AT_REF + ref);
+                    continue;
+                }
+
+                // Process attribute
+                if (attribute != null) {
+                    Pair<Namespace, String> attInfo = parseAttributeName(attribute, EditLib.COLON_SEPARATOR, id, md, editLib);
+                    String localname = attInfo.two();
+                    Namespace attrNS = attInfo.one();
+                    if (el.getAttribute(localname, attrNS) != null) {
+                        el.setAttribute(new Attribute(localname, value, attrNS));
+                    }
+                } else {
+                    // Process element value
+                    @SuppressWarnings("unchecked")
+                    List<Content> content = el.getContent();
+
+                    for (Iterator<Content> iterator = content.iterator(); iterator.hasNext(); ) {
+                        Content content2 = iterator.next();
+                        if (content2 instanceof Text) {
+                            iterator.remove();
+                        }
+                    }
+                    el.addContent(value);
+                }
             }
         }
 


### PR DESCRIPTION
This type of errors were reported but are wrong on multilingual records:

```
2024-05-16T10:45:08,952 ERROR [geonetwork.editor] - Element not found at ref = 554
2024-05-16T10:45:08,953 ERROR [geonetwork.editor] - Element not found at ref = 556
```

Multilingual elements have reference like `_lang_EN_123` and are managed by `updatedLocalizedTextElement` method and the schema plugin. There is no need to search for them in the preprocess phase.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

Funded by Ifremer
