### PR TITLE
Editor / Associated resource / Avoid scrollbar

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/remote-record-selector.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/remote-record-selector.html
@@ -97,7 +97,7 @@
         <div class="col-sm-10">
           <textarea
             class="form-control"
-            rows="10"
+            rows="4"
             id="gn-remoteRecordsList"
             data-ng-model="multipleSelectionModel.remoteRecordsList"
           ></textarea>


### PR DESCRIPTION
Reduce the textarea size to add multiple links at a time to avoid having scrollbar on common screen size.
Then we still have a strange offset in the associated resource panel in the editor

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/fb76ffca-dd49-48c2-8a21-19ab69ddd2d7)

Maybe related to https://github.com/geonetwork/core-geonetwork/pull/5573

@MichelGabriel could you have a look if you've ideas ?


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

Funded by Ifremer