### PR TITLE
Editor / Associated resource / Update panel based on type config

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/linktosibling.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/linktosibling.html
@@ -36,7 +36,7 @@
       </div>
       <div
         class="form-group gn-nomargin-bottom"
-        data-ng-show="::config.sources['metadataStore']"
+        data-ng-show="config.sources['metadataStore']"
       >
         <label class="col-sm-2 control-label">
           <span


### PR DESCRIPTION
If one config was using the `metadataStore` source, then this source was never hidden when other types are opening the panel.

Follow up of https://github.com/geonetwork/core-geonetwork/pull/7669


eg. in the following config, `linkToParent` allows `metadataStore` source, but opening `linkToPlatform` will also show it even if it is only configured with DOI or remote URL sources.

```xml
<section>

          <action type="associatedResource"
                  name="linkToParent"
                  btnClass="fa gn-icon-series"
                  process="siblings">
            <directiveAttributes>{"fields": {"associationType": "largerWorkCitation", "initiativeType": "" },
              "sources": {"metadataStore": {"params": {"isTemplate": "n"}},
              "remoteurl": {"multiple": true}
              }}</directiveAttributes>
          </action>


          <action type="associatedResource"
                  name="sextant-linkToPlatform"
                  btnClass="fa fa-ship"
                  process="siblings">
            <directiveAttributes>{"fields": {"associationType": "crossReference", "initiativeType": "platform" },
              "sources": {"doiapi": {"url": "https://api.datacite.org/dois",
              "params": {"prefix": "10.17600", "query": "titles.title:{query}* OR doi:{query}"}}
              }}</directiveAttributes>
          </action>

          <directive data-gn-associated-resources-panel="gnCurrentEdit.metadata"
                     data-editor-config="sextant"/>
        </section>
```


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

Funded by Ifremer