### PR TITLE
Database / Default content / Remove categories.

### DIFF
--- a/core/src/test/java/org/fao/geonet/kernel/DataManagerIntegrationTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/DataManagerIntegrationTest.java
@@ -124,6 +124,9 @@ public class DataManagerIntegrationTest extends AbstractDataManagerIntegrationTe
         ServiceContext serviceContext = createContextAndLogAsAdmin();
         User principal = serviceContext.getUserSession().getPrincipal();
         Group group = groupRepository.findAll().get(0);
+        MetadataCategory testCategory = new MetadataCategory();
+        testCategory.setName("test-category");
+        metadataCategoryRepository.save(testCategory);
         MetadataCategory category = metadataCategoryRepository.findAll().get(0);
         Source source = sourceRepository.save(new Source().setType(SourceType.portal).setName("GN").setUuid("sourceuuid"));
 

--- a/core/src/test/java/org/fao/geonet/kernel/DataManagerWorksWithoutTransactionIntegrationTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/DataManagerWorksWithoutTransactionIntegrationTest.java
@@ -33,6 +33,7 @@ import java.util.UUID;
 import org.fao.geonet.AbstractCoreIntegrationTest;
 import org.fao.geonet.domain.AbstractMetadata;
 import org.fao.geonet.domain.ISODate;
+import org.fao.geonet.domain.MetadataCategory;
 import org.fao.geonet.domain.MetadataType;
 import org.fao.geonet.kernel.search.IndexingMode;
 import org.fao.geonet.repository.MetadataCategoryRepository;
@@ -54,6 +55,9 @@ public class DataManagerWorksWithoutTransactionIntegrationTest extends AbstractD
                 public void run() throws Exception {
                     ServiceContext serviceContext = createContextAndLogAsAdmin();
 
+                    MetadataCategory category = new MetadataCategory();
+                    category.setName("sample");
+                    metadataCategoryRepository.save(category);
                     String metadataCategory = metadataCategoryRepository.findAll().get(0).getName();
                     Element sampleMetadataXml = getSampleMetadataXml();
                     UserSession userSession = serviceContext.getUserSession();

--- a/core/src/test/java/org/fao/geonet/kernel/datamanager/BaseMetadataCategoryTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/datamanager/BaseMetadataCategoryTest.java
@@ -115,6 +115,9 @@ public class BaseMetadataCategoryTest extends AbstractCoreIntegrationTest {
         md.getSourceInfo().setSourceId("test-faking");
         md.getDataInfo().setSchemaId("isoFake");
 
+        MetadataCategory category = new MetadataCategory();
+        category.setName("test-category");
+        metadataCategoryRepository.save(category);
         mdc = metadataCategoryRepository.findAll().get(0);
     }
 

--- a/docs/manual/docs/administrator-guide/managing-classification-systems/managing-categories.md
+++ b/docs/manual/docs/administrator-guide/managing-classification-systems/managing-categories.md
@@ -1,9 +1,13 @@
 # Managing categories
 
-GeoNetwork has a concept of categories that can be assigned to metadata documents, but these are not represented in the metadata. So when the metadata is exported, the category will be lost. You can use these categories to separate documents into groups, without changing the actual content of the metadata. Categories can be used to filter a search result, or limit the output of a custom csw endpoint.
+The catalog has a concept of categories that can be assigned to metadata documents, but these are not represented in the metadata (not encoded in the XML document). So when the metadata is exported or harvested, the category is not available. You can use these categories to separate documents into groups, without changing the actual content of the metadata.
+
+Categories can be used to filter a search result, or limit the output of a custom portal.
 
 To assign a category to a metadata document. Go to the metadata modification form and select the requested category from the pull down in the menu. Then save your metadata.
 
 To modify the available categories in the catalog, from the admin page, open the "classification systems" and then the "category" tab.
 
 Note: If you add or modify categories, they may not obtain an appropriate icon. These icon are managed in `/catalog/style/gn_icons.less`. In this file category-classes are mapped to font-awesome variables that map to a certain [font-awesome icon](https://fontawesome.io).
+
+Usually, it is recommended to use keywords with a thesaurus instead of categories. The main benefit of categories is that it is not encoded in the metadata. 

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
@@ -1,22 +1,5 @@
 
 -- ======================================================================
--- === Table: Categories
--- ======================================================================
-
-INSERT INTO Categories (id, name) VALUES (1,'maps');
-INSERT INTO Categories (id, name) VALUES (2,'datasets');
-INSERT INTO Categories (id, name) VALUES (3,'interactiveResources');
-INSERT INTO Categories (id, name) VALUES (4,'applications');
-INSERT INTO Categories (id, name) VALUES (5,'caseStudies');
-INSERT INTO Categories (id, name) VALUES (6,'proceedings');
-INSERT INTO Categories (id, name) VALUES (7,'photo');
-INSERT INTO Categories (id, name) VALUES (8,'audioVideo');
-INSERT INTO Categories (id, name) VALUES (9,'directories');
-INSERT INTO Categories (id, name) VALUES (10,'otherResources');
-INSERT INTO Categories (id, name) VALUES (12,'registers');
-INSERT INTO Categories (id, name) VALUES (13,'physicalSamples');
-
--- ======================================================================
 -- === Table: Groups
 -- ======================================================================
 

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-ara-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-ara-default.sql
@@ -1,18 +1,6 @@
 INSERT INTO Languages (id, name, isinspire) VALUES ('ara','العربية', 'n');
 
 -- Take care to table ID (related to other loc files)
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (1,'ara','Maps & graphics');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (2,'ara','Datasets');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (3,'ara','Interactive resources');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (4,'ara','Applications');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (5,'ara','Case studies, best practices');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (6,'ara','Conference proceedings');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (7,'ara','Photo');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (8,'ara','Audio/Video');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (9,'ara','Directories');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (10,'ara','Other information resources');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (12,'ara','Registers');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (13,'ara','Physical Samples');
 
 INSERT INTO GroupsDes (iddes, langid, label)VALUES (-1,'ara','Guest');
 INSERT INTO GroupsDes (iddes, langid, label)VALUES (0,'ara','Intranet');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-cat-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-cat-default.sql
@@ -1,18 +1,6 @@
 INSERT INTO Languages (id, name, isinspire) VALUES ('cat','català', 'n');
 
 -- Take care to table ID (related to other loc files)
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (1,'cat','Mapes i gràfics');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (2,'cat','Conjunts de dades');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (3,'cat','Recursos interactius');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (4,'cat','Aplicacions');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (5,'cat','Casos d''ús, bones pràctiques');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (6,'cat','Actes de conferències');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (7,'cat','Foto');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (8,'cat','Àudio/Vídeo');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (9,'cat','Directoris');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (10,'cat','Altres recursos d''informació');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (12,'cat','Registers');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (13,'cat','Physical Samples');
 
 INSERT INTO GroupsDes (iddes, langid, label) VALUES (-1,'cat','Guest');
 INSERT INTO GroupsDes (iddes, langid, label) VALUES (0,'cat','Intranet');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-chi-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-chi-default.sql
@@ -1,18 +1,6 @@
 INSERT INTO Languages (id, name, isinspire) VALUES ('chi','中文', 'n');
 
 -- Take care to table ID (related to other loc files)
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (1,'chi','Maps & graphics');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (2,'chi','Datasets');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (3,'chi','Interactive resources');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (4,'chi','Applications');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (5,'chi','Case studies, best practices');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (6,'chi','Conference proceedings');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (7,'chi','Photo');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (8,'chi','Audio/Video');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (9,'chi','Directories');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (10,'chi','Other information resources');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (12,'chi','Registers');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (13,'chi','Physical Samples');
 
 INSERT INTO GroupsDes (iddes, langid, label) VALUES (-1,'chi','Guest');
 INSERT INTO GroupsDes (iddes, langid, label) VALUES (0,'chi','Intranet');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-dan-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-dan-default.sql
@@ -1,18 +1,6 @@
 INSERT INTO Languages (id, name, isinspire) VALUES ('dan','Dansk', 'y');
 
 -- Take care to table ID (related to other loc files)
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (1,'dan','Kort & grafik');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (2,'dan','Datasæt');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (3,'dan','Interaktive ressourcer');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (4,'dan','Applikationer');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (5,'dan','Case studies, best practices');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (6,'dan','Konference proceedings');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (7,'dan','Foto');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (8,'dan','Audio/Video');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (9,'dan','Kataloger');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (10,'dan','Andre information ressourcer');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (12,'dan','Registere');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (13,'dan','Fysiske prøver');
 
 INSERT INTO GroupsDes (iddes, langid, label) VALUES (-1,'dan','Gæst');
 INSERT INTO GroupsDes (iddes, langid, label) VALUES (0,'dan','Intranet');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-dut-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-dut-default.sql
@@ -1,18 +1,6 @@
 INSERT INTO Languages (id, name, isinspire) VALUES ('dut','Nederlands', 'y');
 
 -- Take care to table ID (related to other loc files)
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (1,'dut','Kaarten & afbeeldingen');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (2,'dut','Datasets');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (3,'dut','Interactieve kaarten');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (4,'dut','Toepassingen');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (5,'dut','Case studies, best practices');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (6,'dut','Conferentie handelingen');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (7,'dut','Fotos');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (8,'dut','Audio/Video');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (9,'dut','Catalogi');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (10,'dut','Andere informatie bronnen');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (12,'dut','Registers');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (13,'dut','Fysieke monsters');
 
 INSERT INTO GroupsDes (iddes, langid, label) VALUES (-1,'dut','Gast');
 INSERT INTO GroupsDes (iddes, langid, label) VALUES (0,'dut','Intranet');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-eng-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-eng-default.sql
@@ -1,18 +1,6 @@
 INSERT INTO Languages (id, name, isinspire) VALUES ('eng','English', 'y');
 
 -- Take care to table ID (related to other loc files)
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (1,'eng','Maps & graphics');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (2,'eng','Datasets');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (3,'eng','Interactive resources');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (4,'eng','Applications');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (5,'eng','Case studies, best practices');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (6,'eng','Conference proceedings');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (7,'eng','Photo');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (8,'eng','Audio/Video');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (9,'eng','Directories');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (10,'eng','Other information resources');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (12,'eng','Registers');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (13,'eng','Physical Samples');
 
 INSERT INTO GroupsDes (iddes, langid, label) VALUES (-1,'eng','Guest');
 INSERT INTO GroupsDes (iddes, langid, label) VALUES (0,'eng','Intranet');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-fin-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-fin-default.sql
@@ -1,18 +1,6 @@
 INSERT INTO Languages (id, name, isinspire) VALUES ('fin','suomi', 'y');
 
 -- Take care to table ID (related to other loc files)
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (1,'fin','Kartat & kuvat');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (2,'fin','Tietoaineistot');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (3,'fin','Vuorovaikutteiset resurssit');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (4,'fin','Sovellukset');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (5,'fin','Esimerkkitapaukset, parhaat käytännöt');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (6,'fin','Konferenssijulkaisut');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (7,'fin','Valokuvat');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (8,'fin','Äänitteet / Videot');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (9,'fin','Hakemistot');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (10,'fin','Other information resources');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (12,'fin','Registers');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (13,'fin','Fyysisiä näytteitä');
 
 INSERT INTO GroupsDes (iddes, langid, label) VALUES (-1,'fin','Vierailija');
 INSERT INTO GroupsDes (iddes, langid, label) VALUES (0,'fin','Intranet');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-fre-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-fre-default.sql
@@ -1,18 +1,6 @@
 INSERT INTO Languages (id, name, isinspire) VALUES ('fre','Français', 'y');
 
 -- Take care to table ID (related to other loc files)
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (2,'fre','Jeux de données');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (1,'fre','Cartes & graphiques');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (7,'fre','Photographies');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (10,'fre','Autres ressources');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (5,'fre','Etude de cas, meilleures pratiques');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (8,'fre','Vidéo/Audio');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (9,'fre','Répertoires');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (4,'fre','Applications');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (3,'fre','Ressources interactives');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (6,'fre','Conférences');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (12,'fre','Annuaires');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (13,'fre','Echantillons physiques');
 
 INSERT INTO GroupsDes (iddes, langid, label) VALUES (-1,'fre','Invité');
 INSERT INTO GroupsDes (iddes, langid, label) VALUES (0,'fre','Intranet');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-ger-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-ger-default.sql
@@ -1,18 +1,6 @@
 INSERT INTO Languages (id, name, isinspire) VALUES ('ger','Deutsch', 'y');
 
 -- Take care to table ID (related to other loc files)
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (1,'ger','Karten & Grafiken');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (2,'ger','Datensets');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (3,'ger','Interaktive Resourcen');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (4,'ger','Applikationen');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (5,'ger','Fallstudien');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (6,'ger','Konferenz Ergebnisse');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (7,'ger','Photo');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (8,'ger','Audio/Video');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (9,'ger','Verzeichnisse');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (10,'ger','Andere Resourcen');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (12,'ger','Registers');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (13,'ger','Physischen Proben');
 
 INSERT INTO GroupsDes (iddes, langid, label) VALUES (-1,'ger','Gast');
 INSERT INTO GroupsDes (iddes, langid, label) VALUES (0,'ger','Intranet');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-ita-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-ita-default.sql
@@ -1,18 +1,6 @@
 INSERT INTO Languages (id, name, isinspire)  VALUES ('ita','Italiano', 'y');
 
 -- Take care to table ID (related to other loc files)
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (1,'ita','Mappe e grafici');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (2,'ita','Datasets');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (3,'ita','Risorse interattive');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (4,'ita','Applicazioni');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (5,'ita','Casi di studio');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (6,'ita','Atti di conferenze');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (7,'ita','Fotografie');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (8,'ita','Audio/Video');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (9,'ita','Archivi');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (10,'ita','Altre risorse di informazione');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (12,'ita','Registri');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (13,'ita','campioni fisici');
 
 INSERT INTO GroupsDes (iddes, langid, label) VALUES (-1,'ita','Visitatore');
 INSERT INTO GroupsDes (iddes, langid, label) VALUES (0,'ita','Intranet');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-nor-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-nor-default.sql
@@ -1,18 +1,6 @@
 INSERT INTO Languages (id, name, isinspire) VALUES ('nor','norsk', 'n');
 
 -- Take care to table ID (related to other loc files)
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (1,'nor','Kart og grafikk');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (2,'nor','Datasett');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (3,'nor','Interakive ressurser');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (4,'nor','Applikasjoner');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (5,'nor','Studier og anbefalinger');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (6,'nor','Konferanseresultater');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (7,'nor','Fotografier');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (8,'nor','Audio/Video');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (9,'nor','Kataloger');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (10,'nor','Andre ressurser');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (12,'nor','Registers');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (13,'nor','Physical Samples');
 
 INSERT INTO GroupsDes (iddes, langid, label) VALUES (-1,'nor','Gjest');
 INSERT INTO GroupsDes (iddes, langid, label) VALUES (0,'nor','Intranett');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-pol-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-pol-default.sql
@@ -1,18 +1,6 @@
 INSERT INTO Languages (id, name, isinspire) VALUES ('pol','Polski', 'n');
 
 -- Take care to table ID (related to other loc files)
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (1,'pol','Mapy i grafika');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (2,'pol','Zbiory danych');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (3,'pol','Źródła interaktywne');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (4,'pol','Aplikacje');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (5,'pol','Badania, najlepsze praktyki');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (6,'pol','Materiały konferencyjne');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (7,'pol','Zdjęcia');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (8,'pol','Audio/Wideo');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (9,'pol','Katalogi');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (10,'pol','Inne źródła informacji');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (12,'pol','Rejestry');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (13,'pol','Physical Samples');
 
 INSERT INTO GroupsDes (iddes, langid, label) VALUES (-1,'pol','Gość');
 INSERT INTO GroupsDes (iddes, langid, label) VALUES (0,'pol','Intranet');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-por-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-por-default.sql
@@ -1,18 +1,6 @@
 INSERT INTO Languages (id, name, isinspire) VALUES ('por','português', 'y');
 
 -- Take care to table ID (related to other loc files)
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (1,'por','Mapas & Graficos');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (2,'por','Datasets');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (3,'por','Fontes Interactivas');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (4,'por','Aplicações');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (5,'por','Estudos de Caso, Boas Praticas');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (6,'por','Procedimentos de Validação');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (7,'por','Foto');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (8,'por','Audio/Video');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (9,'por','Directorios');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (10,'por','Outra Informação sobre Fontes');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (12,'por','Registers');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (13,'por','Amostras físicas');
 
 INSERT INTO GroupsDes (iddes, langid, label) VALUES (-1,'por','Convidado');
 INSERT INTO GroupsDes (iddes, langid, label) VALUES (0,'por','Intranet');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-rus-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-rus-default.sql
@@ -1,18 +1,6 @@
 INSERT INTO Languages (id, name, isinspire) VALUES ('rus','русский язык', 'n');
 
 -- Take care to table ID (related to other loc files)
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (1,'rus','Карты и графика');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (2,'rus','Наборы данных');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (3,'rus','Интерактивные ресурсы');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (4,'rus','Компьютерные программы');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (5,'rus','Практические ситуации');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (6,'rus','Материалы конференций');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (7,'rus','Фотографии');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (8,'rus','Аудио/Видео');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (9,'rus','Каталоги/справочники');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (10,'rus','Другие ресурсы');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (12,'rus','Registers');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (13,'rus','Физические образцы');
 
 INSERT INTO GroupsDes (iddes, langid, label) VALUES (-1,'rus','Guest');
 INSERT INTO GroupsDes (iddes, langid, label) VALUES (0,'rus','Пример группы');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-slo-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-slo-default.sql
@@ -1,18 +1,6 @@
 INSERT INTO Languages (id, name, isinspire) VALUES ('slo','Slovenčina', 'n');
 
 -- Take care to table ID (related to other loc files)
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (1,'slo','Maps & graphics [SK]');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (2,'slo','Datasets [SK]');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (3,'slo','Interactive resources [SK]');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (4,'slo','Applications [SK]');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (5,'slo','Case studies, best practices [SK]');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (6,'slo','Conference proceedings [SK]');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (7,'slo','Photo [SK]');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (8,'slo','Audio/Video [SK]');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (9,'slo','Directories [SK]');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (10,'slo','Other information resources [SK]');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (12,'slo','Registers [SK]');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (13,'slo','Physical Samples [SK]');
 
 INSERT INTO GroupsDes (iddes, langid, label) VALUES (-1,'slo','Guest [SK]');
 INSERT INTO GroupsDes (iddes, langid, label) VALUES (0,'slo','Intranet [SK]');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-spa-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-spa-default.sql
@@ -1,18 +1,6 @@
 INSERT INTO Languages (id, name, isinspire) VALUES ('spa','español', 'y');
 
 -- Take care to table ID (related to other loc files)
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (2,'spa','Conjuntos de datos');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (3,'spa','Recursos interactivos');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (5,'spa','Casos de Uso, buenas prácticas');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (4,'spa','Aplicaciones');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (6,'spa','Resúmenes de conferencias');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (7,'spa','Fotografías');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (9,'spa','Directorios');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (8,'spa','Audio/Vídeo');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (10,'spa','Otros recursos de información');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (1,'spa','Mapas & gráficos');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (12,'spa','Registers');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (13,'spa','Muestras físicas');
 
 INSERT INTO GroupsDes (iddes, langid, label) VALUES (-1,'spa','Guest');
 INSERT INTO GroupsDes (iddes, langid, label) VALUES (0,'spa','Intranet');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-swe-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-swe-default.sql
@@ -1,18 +1,6 @@
 INSERT INTO Languages (id, name, isinspire) VALUES ('swe','swedish', 'y');
 
 -- Take care to table ID (related to other loc files)
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (1,'swe','Kartor och grafik');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (2,'swe','Datamängder');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (3,'swe','Interaktiva resurser');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (4,'swe','Applikationer');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (5,'swe','Typfall, god praxis');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (6,'swe','Konferensmaterial');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (7,'swe','Foto');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (8,'swe','Ljud/Film');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (9,'swe','Kataloger');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (10,'swe','Andra källor');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (12,'swe','Register');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (13,'swe','Fysiska exemplar');
 
 INSERT INTO GroupsDes (iddes, langid, label) VALUES (-1,'swe','Gäst');
 INSERT INTO GroupsDes (iddes, langid, label) VALUES (0,'swe','Intranät');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-tur-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-tur-default.sql
@@ -1,18 +1,6 @@
 INSERT INTO Languages (id, name, isinspire) VALUES ('tur','Türkçe', 'n');
 
 -- Take care to table ID (related to other loc files)
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (1,'tur','Haritalar & grafikler');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (2,'tur','Verisetleri');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (3,'tur','Interaktif kaynaklar');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (4,'tur','Uygulamalar');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (5,'tur','Örnek çalışmalar, başarılı uygulamalar');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (6,'tur','Konferans bildirileri');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (7,'tur','Fotoğraf');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (8,'tur','Ses/Video');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (9,'tur','Dizinler');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (10,'tur','Diğer bilgi kaynakları');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (12,'tur','Kayıtlar');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (13,'tur','Fiziksel Örnekleri');
 
 
 INSERT INTO GroupsDes (iddes, langid, label) VALUES (-1,'tur','Misafir');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-vie-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-vie-default.sql
@@ -1,18 +1,6 @@
 INSERT INTO Languages (id, name, isinspire) VALUES ('vie','Tiếng Việt', 'n');
 
 -- Take care to table ID (related to other loc files)
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (1,'vie','Maps & graphics');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (2,'vie','Datasets');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (3,'vie','Interactive resources');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (4,'vie','Applications');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (5,'vie','Case studies, best practices');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (6,'vie','Conference proceedings');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (7,'vie','Photo');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (8,'vie','Audio/Video');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (9,'vie','Directories');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (10,'vie','Other information resources');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (12,'vie','Registers');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (13,'vie','Physical Samples');
 
 INSERT INTO GroupsDes (iddes, langid, label) VALUES (-1,'vie','Guest');
 INSERT INTO GroupsDes (iddes, langid, label) VALUES (0,'vie','Intranet');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-wel-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/loc-wel-default.sql
@@ -1,18 +1,6 @@
 INSERT INTO Languages (id, name, isinspire) VALUES ('wel','Cymraeg', 'y');
 
 -- Take care to table ID (related to other loc files)
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (1,'wel','Mapiau & graffeg');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (2,'wel','Setiau data');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (3,'wel','Adnoddau rhyngweithiol');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (4,'wel','Ceisiadau');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (5,'wel','Astudiaethau achos, arferion gorau');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (6,'wel','Trafodion y gynhadledd');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (7,'wel','Llun');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (8,'wel','Sain/Fideo');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (9,'wel','Cyfeirlyfrau');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (10,'wel','Adnoddau gwybodaeth eraill');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (12,'wel','Cofrestri');
-INSERT INTO CategoriesDes (iddes, langid, label) VALUES (13,'wel','Samplau Corfforol');
 
 INSERT INTO GroupsDes (iddes, langid, label) VALUES (-1,'wel','Gwestai');
 INSERT INTO GroupsDes (iddes, langid, label) VALUES (0,'wel','Mewnrwyd');


### PR DESCRIPTION
The default categories provided in GeoNetwork since the early beginning are quite overlapping hierarchy level in ISO (eg. dataset, application, map) and in practice they are never used with the default values. It was making sense at the start to have a common grouping systems for the initial standards available in GeoNetwork like dublin core, FGDC, iso19115. Nowadays it is not recommended to use this default category list.

Here we propose to not populate the default database with any category (and we do not alter databases which may be using them). 

* Before

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/41aba852-d946-4e00-8961-18e03b5fa947)

* After

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/0ac3c55f-d391-41e6-a756-f440d39fd9b9)


This will also keep the UI simple. eg. If there is no category, no menu available in the editor (so users are not tempted to use the non recommended default values provided).

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/ee355f9d-1037-4a95-bd15-41c6a7a6a5a3)


We should highlight that the main (only) benefit of using category mechanism is to group records without adding the information in the metadata document. The documentation was updated.



<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [x] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

