### PR TITLE
Record view / Fix JS error related to publication options display.

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/directives/directive.js
+++ b/web-ui/src/main/resources/catalog/views/default/directives/directive.js
@@ -251,6 +251,7 @@
            */
           scope.displayPublicationOption = function (md, user, pubOption) {
             return (
+              md &&
               md.canReview &&
               md.draft != "y" &&
               md.mdStatus != 3 &&


### PR DESCRIPTION
In the JS console switching between views in the metadata page:

```
lib.js?v=03a72d6723af7bf6b99d6a6669f76036c997f661:1345 TypeError: Cannot read properties of null (reading 'canReview')
    at c.displayPublicationOption (gn_search_default.js?v=03a72d6723af7bf6b99d6a6669f76036c997f661&:1897:435)
    at fn (eval at compile (lib.js?v=03a72d6723af7bf6b99d6a6669f76036c997f661:1469:164), <anonymous>:4:402)
```
Updated the related code to check if the metadata information is available when the code is executed.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation