### PR TITLE
CSW Harvester / Avoid increment 2 metrics for a single metadata in certain conditions

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
@@ -418,13 +418,13 @@ public class Aligner extends BaseAligner<CswParams> {
             }
         }
     }
-    private void updateMetadata(RecordInfo ri, String id, Boolean force) throws Exception {
+    private void updateMetadata(RecordInfo ri, String id, boolean force) throws Exception {
         String date = localUuids.getChangeDate(ri.uuid);
 
         if (date == null && !force) {
             log.debug("  - Skipped metadata managed by another harvesting node. uuid:" + ri.uuid + ", name:" + params.getName());
         } else {
-            if (Boolean.TRUE.equals(!force) && !ri.isMoreRecentThan(date)) {
+            if (!force && !ri.isMoreRecentThan(date)) {
                 log.debug("  - Metadata XML not changed for uuid:" + ri.uuid);
                 result.unchangedMetadata++;
             } else {
@@ -437,7 +437,7 @@ public class Aligner extends BaseAligner<CswParams> {
         }
     }
     @Transactional(value = TxType.REQUIRES_NEW)
-    boolean updatingLocalMetadata(RecordInfo ri, String id, Boolean force) throws Exception {
+    boolean updatingLocalMetadata(RecordInfo ri, String id, boolean force) throws Exception {
         Element md = retrieveMetadata(ri.uuid);
 
         if (md == null) {
@@ -472,8 +472,8 @@ public class Aligner extends BaseAligner<CswParams> {
         String language = context.getLanguage();
         final AbstractMetadata metadata = metadataManager.updateMetadata(context, id, md, validate, ufo, language, ri.changeDate, true, IndexingMode.none);
 
-        if (Boolean.TRUE.equals(force) || updateSchema) {
-            if (Boolean.TRUE.equals(force)) {
+        if (force || updateSchema) {
+            if (force) {
                 //change ownership of metadata to new harvester
                 metadata.getHarvestInfo().setUuid(params.getUuid());
                 metadata.getSourceInfo().setSourceId(params.getUuid());

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
@@ -1,5 +1,5 @@
 //=============================================================================
-//===	Copyright (C) 2001-2007 Food and Agriculture Organization of the
+//===	Copyright (C) 2001-2024 Food and Agriculture Organization of the
 //===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
 //===	and United Nations Environment Programme (UNEP)
 //===
@@ -232,7 +232,7 @@ public class Aligner extends BaseAligner<CswParams> {
                 }
 
                 result.totalMetadata++;
-            } catch (Throwable t) {
+            } catch (Exception t) {
                 errors.add(new HarvestError(this.context, t));
                 log.error("Unable to process record from csw (" + this.params.getName() + ")");
                 log.error("   Record failed: " + ri.uuid + ". Error is: " + t.getMessage());
@@ -285,7 +285,6 @@ public class Aligner extends BaseAligner<CswParams> {
         Element md = retrieveMetadata(ri.uuid);
 
         if (md == null) {
-            result.unretrievable++;
             return;
         }
 
@@ -399,7 +398,7 @@ public class Aligner extends BaseAligner<CswParams> {
                     if (StringUtils.isNotEmpty(batchEditParameter.getCondition())) {
                         applyEdit = false;
                         final Object node = Xml.selectSingle(md, batchEditParameter.getCondition(), metadataSchema.getNamespaces());
-                        if (node != null && node instanceof Boolean && (Boolean)node == true) {
+                        if (node instanceof Boolean && Boolean.TRUE.equals(node)) {
                             applyEdit = true;
                         }
                     }
@@ -425,7 +424,7 @@ public class Aligner extends BaseAligner<CswParams> {
         if (date == null && !force) {
             log.debug("  - Skipped metadata managed by another harvesting node. uuid:" + ri.uuid + ", name:" + params.getName());
         } else {
-            if (!force && !ri.isMoreRecentThan(date)) {
+            if (Boolean.TRUE.equals(!force) && !ri.isMoreRecentThan(date)) {
                 log.debug("  - Metadata XML not changed for uuid:" + ri.uuid);
                 result.unchangedMetadata++;
             } else {
@@ -442,7 +441,6 @@ public class Aligner extends BaseAligner<CswParams> {
         Element md = retrieveMetadata(ri.uuid);
 
         if (md == null) {
-            result.unchangedMetadata++;
             return false;
         }
 
@@ -474,8 +472,8 @@ public class Aligner extends BaseAligner<CswParams> {
         String language = context.getLanguage();
         final AbstractMetadata metadata = metadataManager.updateMetadata(context, id, md, validate, ufo, language, ri.changeDate, true, IndexingMode.none);
 
-        if (force || updateSchema) {
-            if (force) {
+        if (Boolean.TRUE.equals(force) || updateSchema) {
+            if (Boolean.TRUE.equals(force)) {
                 //change ownership of metadata to new harvester
                 metadata.getHarvestInfo().setUuid(params.getUuid());
                 metadata.getSourceInfo().setSourceId(params.getUuid());
@@ -495,8 +493,11 @@ public class Aligner extends BaseAligner<CswParams> {
     }
 
     /**
-     * Does CSW GetRecordById request. If validation is requested and the metadata does not
-     * validate, null is returned.
+     * Does CSW GetRecordById request. Returns null on error conditions:
+     *  - If validation is requested and the metadata does not validate.
+     *  - No metadata is retrieved.
+     *  - If metadata resource is duplicated.
+     *  - An exception occurs retrieving the metadata.
      *
      * @param uuid uuid of metadata to request
      * @return metadata the metadata
@@ -519,6 +520,7 @@ public class Aligner extends BaseAligner<CswParams> {
             //--- maybe the metadata has been removed
 
             if (list.isEmpty()) {
+                result.unretrievable++;
                 return null;
             }
 
@@ -539,11 +541,10 @@ public class Aligner extends BaseAligner<CswParams> {
                 return null;
             }
 
-            if (params.rejectDuplicateResource) {
-                if (foundDuplicateForResource(uuid, response)) {
+            if (params.rejectDuplicateResource && (foundDuplicateForResource(uuid, response))) {
                     result.unchangedMetadata++;
                     return null;
-                }
+
             }
 
             return response;
@@ -607,7 +608,7 @@ public class Aligner extends BaseAligner<CswParams> {
                         }
                     }
                 }
-            } catch (Throwable e) {
+            } catch (Exception e) {
                 log.warning("      - Error when searching for resource duplicate " + uuid + ". Error is: " + e.getMessage());
             }
         }


### PR DESCRIPTION
Retrieve metadata method increments metrics under certain conditions and returns null. Methods calling the retrieve metadata method increments additionally the unretrievable metric if null is returned. Sonarlint fixeas are already applied. 

Fixes #8039


# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
