### PR TITLE
CSW harvester / Performance improvements

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/RecordInfo.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/RecordInfo.java
@@ -1,5 +1,5 @@
 //=============================================================================
-//===	Copyright (C) 2001-2007 Food and Agriculture Organization of the
+//===	Copyright (C) 2001-2024 Food and Agriculture Organization of the
 //===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
 //===	and United Nations Environment Programme (UNEP)
 //===
@@ -57,12 +57,20 @@ public class RecordInfo {
     //---------------------------------------------------------------------------
     public String isTemplate;
 
+    //---------------------------------------------------------------------------
+
+    public String data;
+
     //-----------------------------------------------------------------------------
     private boolean dateWasNull;
     //---------------------------------------------------------------------------
 
     public RecordInfo(String uuid, String changeDate) {
-        this(uuid, changeDate, null, null);
+        this(uuid, changeDate, null, null, null);
+    }
+
+    public RecordInfo(String uuid, String changeDate, String data) {
+        this(uuid, changeDate, null, null, data);
     }
 
     //---------------------------------------------------------------------------
@@ -72,6 +80,10 @@ public class RecordInfo {
     //---------------------------------------------------------------------------
 
     public RecordInfo(String uuid, String changeDate, String schema, String source) {
+      this(uuid, changeDate, schema, source, null);
+    }
+
+    public RecordInfo(String uuid, String changeDate, String schema, String source, String data) {
         if (changeDate == null) {
             dateWasNull = true;
             changeDate = new ISODate().toString();
@@ -81,6 +93,7 @@ public class RecordInfo {
         this.changeDate = changeDate;
         this.schema = schema;
         this.source = source;
+        this.data = data;
     }
     public RecordInfo(Element record) {
         id = record.getChildText("id");

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
@@ -1,5 +1,5 @@
 //=============================================================================
-//===	Copyright (C) 2001-2007 Food and Agriculture Organization of the
+//===	Copyright (C) 2001-2024 Food and Agriculture Organization of the
 //===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
 //===	and United Nations Environment Programme (UNEP)
 //===
@@ -282,7 +282,7 @@ public class Aligner extends BaseAligner<CswParams> {
             return;
         }
 
-        Element md = retrieveMetadata(ri.uuid);
+        Element md = retrieveMetadata(ri);
 
         if (md == null) {
             result.unretrievable++;
@@ -439,7 +439,7 @@ public class Aligner extends BaseAligner<CswParams> {
     }
     @Transactional(value = TxType.REQUIRES_NEW)
     boolean updatingLocalMetadata(RecordInfo ri, String id, Boolean force) throws Exception {
-        Element md = retrieveMetadata(ri.uuid);
+        Element md = retrieveMetadata(ri);
 
         if (md == null) {
             result.unchangedMetadata++;
@@ -495,36 +495,25 @@ public class Aligner extends BaseAligner<CswParams> {
     }
 
     /**
-     * Does CSW GetRecordById request. If validation is requested and the metadata does not
+     * Returns the metadata xml. If validation is requested and the metadata does not
      * validate, null is returned.
      *
-     * @param uuid uuid of metadata to request
-     * @return metadata the metadata
+     * @param recordInfo metadata information
+     * @return the metadata JDOM Element
      */
-    private Element retrieveMetadata(String uuid) {
+    private Element retrieveMetadata(RecordInfo recordInfo) {
+        String uuid = recordInfo.uuid;
+
         request.clearIds();
         request.addId(uuid);
 
         try {
+            Element xml = Xml.loadString(recordInfo.data, false);
             log.debug("Getting record from : " + request.getHost() + " (uuid:" + uuid + ")");
 
-            Element response = request.execute();
             if (log.isDebugEnabled()) {
-                log.debug("Record got: " + Xml.getString(response) + "\n");
+                log.debug(String.format("Record uuid %s: %s"), uuid, Xml.getString(xml));
             }
-
-            @SuppressWarnings("unchecked")
-            List<Element> list = response.getChildren();
-
-            //--- maybe the metadata has been removed
-
-            if (list.isEmpty()) {
-                return null;
-            }
-
-            response = list.get(0);
-            response = (Element) response.detach();
-
 
             try {
                 Integer groupIdVal = null;
@@ -532,7 +521,7 @@ public class Aligner extends BaseAligner<CswParams> {
                     groupIdVal = getGroupOwner();
                 }
 
-                params.getValidate().validate(dataMan, context, response, groupIdVal);
+                params.getValidate().validate(dataMan, context, xml, groupIdVal);
             } catch (Exception e) {
                 log.debug("Ignoring invalid metadata with uuid " + uuid);
                 result.doesNotValidate++;
@@ -540,13 +529,13 @@ public class Aligner extends BaseAligner<CswParams> {
             }
 
             if (params.rejectDuplicateResource) {
-                if (foundDuplicateForResource(uuid, response)) {
+                if (foundDuplicateForResource(uuid, xml)) {
                     result.unchangedMetadata++;
                     return null;
                 }
             }
 
-            return response;
+            return xml;
         } catch (Exception e) {
             log.error("Raised exception while getting record : " + e);
             log.error(e);


### PR DESCRIPTION
- Increase GetRecords max records parameter to 100
- Use GetRecords with ElementSetName FULL to retrieve the full xml and avoid individual GetRecordById requests

Includes Sonarlint improvements.

Fixes #7995

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
