### PR TITLE
Cleanup onbeforeunload event when loading the editorboard controller

### DIFF
--- a/web-ui/src/main/resources/catalog/js/edit/EditorBoardController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/EditorBoardController.js
@@ -156,6 +156,9 @@
     "gnSearchSettings",
     "gnGlobalSettings",
     function ($scope, $rootScope, $route, $location, gnSearchSettings, gnGlobalSettings) {
+      // Cleanup onbeforeunload event
+      window.onbeforeunload = null;
+
       // https://github.com/angular/angular.js/issues/1699#issuecomment-11496428
       var lastRoute = $route.current;
       $scope.$on("$locationChangeSuccess", function (event) {


### PR DESCRIPTION
Test case:

1) Go to the editor board
2) Edit a metadata and use the back button in the browser.
3) In the editor board, click on a metadata to access the metadata page. 

  - Without the change, the following dialog is displayed (no ok):

![confirm-exit](https://github.com/geonetwork/core-geonetwork/assets/1695003/5519e32f-17db-4604-aa4d-2dca93e8a3c9)

  - With the change, no dialog is displayed (ok)

The editor controller defines this:

https://github.com/geonetwork/core-geonetwork/blob/ca92682a9b758e76346289a100bf35de57d024ca/web-ui/src/main/resources/catalog/js/edit/EditorController.js#L366-L372

When using the back button, the event handler was not cleanup.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

