### PR TITLE
Users / reset form status when creating a user

### DIFF
--- a/web-ui/src/main/resources/catalog/js/admin/UserGroupController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/UserGroupController.js
@@ -278,6 +278,8 @@
         $scope.userUpdated = false;
         $scope.$broadcast("clearResults");
         $scope.userOperation = "editinfo";
+
+        $scope.gnUserEdit.$setPristine();
       };
 
       /**


### PR DESCRIPTION
Test case:

1) Create a new user and save it.
2) In the application menu, select an option.

  - Without the fix, the following dialog is displayed (no ok)
 
![confirm-changes](https://github.com/geonetwork/core-geonetwork/assets/1695003/6ef1b774-5083-4d67-8165-3c84575b6bef)

  - With the fix, no dialog is displayed (ok)
 

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

