### PR TITLE
[Backport 4.2.x] Cleanup onbeforeunload event when loading the editorboard controller

### DIFF
--- a/web-ui/src/main/resources/catalog/js/edit/EditorBoardController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/EditorBoardController.js
@@ -147,6 +147,9 @@
     "gnSearchSettings",
     "gnGlobalSettings",
     function ($scope, $rootScope, $route, $location, gnSearchSettings, gnGlobalSettings) {
+      // Cleanup onbeforeunload event
+      window.onbeforeunload = null;
+
       // https://github.com/angular/angular.js/issues/1699#issuecomment-11496428
       var lastRoute = $route.current;
       $scope.$on("$locationChangeSuccess", function (event) {


### PR DESCRIPTION
Backport #8071
 **Authored by:** @josegar74