### PR TITLE
Association type / Consistent labels

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/popup/partials/popup.html
+++ b/web-ui/src/main/resources/catalog/components/common/popup/partials/popup.html
@@ -4,7 +4,7 @@
       <button type="button" class="close" data-dismiss="modal" aria-hidden="true">
         &times;
       </button>
-      <h4 class="modal-title" id="myModalLabel">
+      <h4 class="modal-title" id="modal-{{options.title}}">
         <span data-translate="">{{options.title}}</span>
       </h4>
     </div>

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcService.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcService.js
@@ -362,7 +362,11 @@
          * @param {string} type of the directive that calls it.
          */
         onOpenPopup: function (type, additionalParams) {
-          if (type === "parent" && additionalParams.fields.associationType) {
+          if (
+            type === "parent" &&
+            additionalParams.fields &&
+            additionalParams.fields.associationType
+          ) {
             // In ISO19115-3, parents are usually encoded using the association records
             // Configured in config/associated-panel/default.json
             type = "siblings";

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/linktosibling.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/linktosibling.html
@@ -2,38 +2,56 @@
   <form class="form-horizontal" role="form" data-ng-search-form="">
     <input type="hidden" name="_csrf" value="{{csrf}}" />
     <div class="onlinesrc-container">
-      <div class="form-group gn-required" ng-show="::ctrl.associationTypes.length">
-        <label class="col-sm-2 control-label">
+      <div class="row">
+        <div class="col-sm-offset-2 col-sm-10"></div>
+      </div>
+
+      <div class="form-group">
+        <label class="col-sm-2 control-label gn-required">
           <span data-translate="">associationType</span>
         </label>
         <div class="col-sm-10">
-          <div
-            data-schema-info-combo="codelist"
-            data-schema-info-combo-values="ctrl.associationTypes"
-            data-allow-blank="false"
-            data-selected-info="config.associationType"
-            data-gn-schema-info="associationType"
-            data-ng-disabled="config.associationTypeForced"
-            lang="lang"
-          ></div>
+          <div class="row">
+            <div
+              class="col-sm-6 gn-required"
+              ng-show="!config.associationTypeForced && ctrl.associationTypes.length"
+              title="{{'associationType' | translate}}"
+            >
+              <div
+                data-schema-info-combo="codelist"
+                data-schema-info-combo-values="ctrl.associationTypes"
+                data-allow-blank="false"
+                data-selected-info="config.associationType"
+                data-gn-schema-info="associationType"
+                data-ng-disabled="config.associationTypeForced"
+                lang="lang"
+              ></div>
+            </div>
+            <div
+              class="col-sm-6 form-group"
+              ng-show="!config.initiativeTypeForced && ctrl.initiativeTypes.length"
+              title="{{'initiativeType' | translate}}"
+            >
+              <div
+                data-schema-info-combo="codelist"
+                data-schema-info-combo-values="ctrl.initiativeTypes"
+                data-selected-info="config.initiativeType"
+                data-gn-schema-info="initiativeType"
+                lang="lang"
+                data-allow-blank="true"
+                data-ng-disabled="config.initiativeTypeForced"
+              ></div>
+            </div>
+          </div>
+          <label
+            class="col-sm-4 control-label"
+            style="text-align: left"
+            data-gn-associated-record-label="config"
+          >
+          </label>
         </div>
       </div>
-      <div class="form-group" ng-show="::ctrl.initiativeTypes.length">
-        <label class="col-sm-2 control-label">
-          <span data-translate="">initiativeType</span>
-        </label>
-        <div class="col-sm-10">
-          <div
-            data-schema-info-combo="codelist"
-            data-schema-info-combo-values="ctrl.initiativeTypes"
-            data-selected-info="config.initiativeType"
-            data-gn-schema-info="initiativeType"
-            lang="lang"
-            data-allow-blank="true"
-            data-ng-disabled="config.initiativeTypeForced"
-          ></div>
-        </div>
-      </div>
+
       <div
         class="form-group gn-nomargin-bottom"
         data-ng-show="::config.sources['metadataStore']"
@@ -117,27 +135,19 @@
           <table class="table table-striped table-bordered">
             <thead>
               <tr>
-                <th data-translate="">metadata</th>
                 <th data-translate="">associationType</th>
-                <th data-translate="">initiativeType</th>
+                <th data-translate="">metadata</th>
                 <th></th>
               </tr>
             </thead>
             <tbody>
               <tr data-ng-repeat="obj in selection">
+                <td>
+                  <span
+                    data-gn-associated-record-label="{associationType: obj.associationType, initiativeType: obj.initiativeType}"
+                  ></span>
+                </td>
                 <td>{{obj.md.resourceTitle}}</td>
-                <td>
-                  <i
-                    class="fa fa-fw gn-icon-association-{{obj.associationType}} gn-margin-right-sm"
-                  ></i
-                  >{{obj.associationType | translate}}
-                </td>
-                <td>
-                  <i
-                    class="fa fa-fw gn-icon-initiative-{{obj.initiativeType}} gn-margin-right-sm"
-                  ></i
-                  >{{obj.initiativeType | translate}}
-                </td>
                 <td class="text-center">
                   <a
                     title="{{'removeFromSelection' | translate}}"

--- a/web-ui/src/main/resources/catalog/components/metadataactions/RelatedDirective.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/RelatedDirective.js
@@ -785,14 +785,21 @@
                   scope.relations.siblings = [];
                   siblings
                     .map(function (r) {
-                      return (r.properties && r.properties.initiativeType) || "";
+                      return r.properties
+                        ? r.properties.associationType + "-" + r.properties.initiativeType
+                        : "";
                     })
                     .filter(function (value, index, self) {
                       return self.indexOf(value) === index;
                     })
                     .forEach(function (type) {
                       scope.relations["siblings" + type] = siblings.filter(function (r) {
-                        return r.properties && r.properties.initiativeType === type;
+                        var key = r.properties
+                          ? r.properties.associationType +
+                            "-" +
+                            r.properties.initiativeType
+                          : "";
+                        return key === type;
                       });
                       siblingsCount += scope.relations["siblings" + type].length;
                     });

--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/associatedResourcesContainer.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/associatedResourcesContainer.html
@@ -23,9 +23,11 @@
         data-ng-if="config.relations.length > 0"
         data-ng-repeat-start="(key, records) in config.relations | groupBy:'[properties.associationType,properties.initiativeType]'"
       >
-        <strong data-ng-if="key" data-ng-init="keyToken = key.split(',')">
-          {{keyToken[0] | translate}}
-          <span data-ng-if="keyToken[1] !== ''">({{keyToken[1] | translate}})</span>
+        <strong
+          data-ng-if="key && key !== ','"
+          data-ng-init="keyToken = key.split(',')"
+          data-gn-associated-record-label="{associationType: keyToken[0], initiativeType: keyToken[1]}"
+        >
         </strong>
         <ul class="list-group">
           <li
@@ -61,16 +63,6 @@
                     title="{{'remoteRecord' | translate}}"
                   ></i>
                 </a>
-                <span
-                  data-ng-if="record.properties && record.properties.associationType != ''"
-                >
-                  - {{record.properties.associationType | translate}}
-                </span>
-                <span
-                  data-ng-if="record.properties && record.properties.initiativeType != ''"
-                >
-                  ({{record.properties.initiativeType | translate}})
-                </span>
               </div>
               <div class="col-md-1 text-right">
                 <a

--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/metadataCard.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/metadataCard.html
@@ -15,7 +15,7 @@
         gn-formatter="formatter.defaultUrl"
       >
         <h1>
-          <span class="clamp-2">{{md.resourceTitle}}</span>
+          <span class="clamp-2"> {{md.resourceTitle}} </span>
         </h1>
       </a>
       <a
@@ -26,7 +26,14 @@
         title="{{md.resourceTitle}}"
       >
         <h1>
-          <span class="clamp-2">{{md.resourceTitle || md.remoteUrl}}</span>
+          <span class="clamp-2">
+            {{md.resourceTitle || md.remoteUrl}}
+            <i
+              data-ng-if="md.origin === 'remote'"
+              class="fa fa-external-link"
+              title="{{'remoteRecord' | translate}}"
+            ></i>
+          </span>
         </h1>
       </a>
     </div>

--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/related.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/related.html
@@ -202,7 +202,7 @@
           target="_blank"
           title="{{md.resourceTitle}}"
         >
-          {{md.resourceTitle}}
+          {{md.resourceTitle || md.remoteUrl}}
           <i
             data-ng-if="md.origin === 'remote'"
             class="fa fa-external-link"

--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/related.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/related.html
@@ -178,10 +178,11 @@
                     badge = config.getBadgeLabel(mainType, md);
                     icon = config.getClassIcon(mainType);"
   >
-    <h3 data-ng-if="groupSiblingsByType && items.length > 0" class="gn-related-title">
-      <i class="fa fa-fw {{icon}}"></i>
-      {{type.replace('siblings', '') | translate}}
-    </h3>
+    <h3
+      data-ng-if="groupSiblingsByType && items.length > 0"
+      data-ng-init="keyToken = type.replace('siblings', '').split('-')"
+      data-gn-associated-record-label="{associationType: keyToken[0], initiativeType: keyToken[1]}"
+    ></h3>
 
     <ul class="gn-related-list list-group">
       <li class="list-group-item" data-ng-repeat="md in items | orderBy:getOrderBy">
@@ -220,9 +221,12 @@
                     badge = config.getBadgeLabel(mainType, md);
                     icon = config.getClassIcon(mainType);"
   >
-    <h3 data-ng-if="groupSiblingsByType && items.length > 0">
-      {{type.replace('siblings', '') | translate}}
-    </h3>
+    <h3
+      data-ng-if="groupSiblingsByType && items.length > 0"
+      data-ng-init="keyToken = type.replace('siblings', '').split('-')"
+      data-gn-associated-record-label="{associationType: keyToken[0], initiativeType: keyToken[1]}"
+    ></h3>
+
     <ul class="row list-group gn-info-list">
       <gn-metadata-card
         data-ng-repeat="md in items | orderBy:getOrderBy"
@@ -230,50 +234,6 @@
         md="md"
         formatter-url="formatter.defaultUrl"
       >
-        <span
-          class="gn-card-badge"
-          data-ng-class="{
-            'gn-card-series': type === 'parent',
-            'gn-card-nonGeographicDataset': type === 'nonGeographicDataset',
-            'gn-card-service': type === 'services' || type === 'application',
-            'gn-card-dataset': type !== 'parent' && type !== 'services' && type !== 'application' && type !== 'nonGeographicDataset'
-            }"
-        >
-          <span>
-            <span
-              data-ng-if="!md.properties || (md.properties && md.properties.associationType == '')"
-            >
-              {{(config.getLabel(mainType, type)) | translate}}</span
-            >
-            <span
-              data-ng-if="md.properties && md.properties.associationType"
-              data-ng-show="md.properties && md.properties.associationType"
-              title="{{(config.getLabel(mainType, type)) | translate}}"
-            >
-              {{'associatedTo' | translate}}
-              <b title="{{'associationType' | translate}}">
-                <i
-                  class="fa fa-fw {{icon}} gn-icon-association-{{md.properties.associationType}}"
-                ></i>
-                {{md.properties.associationType | translate}}
-              </b>
-              <span data-ng-if="md.properties && md.properties.initiativeType">
-                >
-                <b title="{{'initiativeType' | translate}}">
-                  <i
-                    class="fa fa-fw {{icon}} gn-icon-initiative-{{md.properties.initiativeType}}"
-                  ></i>
-                  {{md.properties.initiativeType | translate}}
-                </b>
-              </span>
-            </span>
-          </span>
-          <i
-            data-ng-if="md.origin === 'remote'"
-            class="fa fa-fw fa-external-link"
-            title="{{'remoteRecord' | translate}}"
-          ></i>
-        </span>
       </gn-metadata-card>
       <button
         class="btn btn-link"

--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -1488,7 +1488,6 @@
       require: "ngInclude",
       restrict: "A",
       link: function (scope, el, attrs) {
-        console.log("gnIncludeAndReplace");
         el.replaceWith(el.children());
       }
     };

--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -1476,7 +1476,23 @@
       };
     }
   ]);
-
+  /**
+   * @ngdoc directive
+   *
+   * @description
+   * Directive to include a template and replace the element with its content.
+   * ng-include always append the content.
+   */
+  module.directive("gnIncludeAndReplace", function () {
+    return {
+      require: "ngInclude",
+      restrict: "A",
+      link: function (scope, el, attrs) {
+        console.log("gnIncludeAndReplace");
+        el.replaceWith(el.children());
+      }
+    };
+  });
   /**
    * @ngdoc directive
    * @name gn_utility.directive:gnAutogrow
@@ -2269,6 +2285,69 @@
       };
     }
   ]);
+
+  /**
+   * Compute a translated status label for an associated record
+   * based on initiative type and association type.
+   *
+   * If association type is crossReference,
+   * then "Cross reference" is used as a label in english.
+   * If an initiative type is provided eg. study,
+   * then "Cross reference (Study)" is returned
+   * If a custom translation is set in the translation file,
+   * eg. "crossReference-study": "Publication"
+   * then "Publication" is returned.
+   */
+  module.filter("getAssociatedRecordLabel", [
+    "$translate",
+    function ($translate) {
+      return function (associationType, initiativeType) {
+        if (!associationType) {
+          return;
+        }
+        var translationKey = associationType + "-" + initiativeType;
+        var translation = $translate.instant(translationKey);
+        if (translationKey === translation) {
+          return (
+            $translate.instant(associationType) +
+            (initiativeType ? " (" + $translate.instant(initiativeType) + ")" : "")
+          );
+        } else {
+          return translation;
+        }
+      };
+    }
+  ]);
+
+  module.directive("gnAssociatedRecordLabel", [
+    "$translate",
+    function ($translate) {
+      return {
+        restrict: "A",
+        scope: {
+          type: "=gnAssociatedRecordLabel"
+        },
+        templateUrl:
+          "../../catalog/components/utility/partials/associated-record-label.html",
+        link: function (scope) {
+          function updateCustomLabel(n, o) {
+            var translationKey =
+              scope.type.associationType + "-" + scope.type.initiativeType;
+            var translation = $translate.instant(translationKey);
+            if (translationKey !== translation) {
+              scope.customLabel = translation;
+            } else {
+              scope.customLabel = undefined;
+            }
+          }
+          scope.icon = "fa-puzzle-piece";
+          scope.$watch("type.associationType", updateCustomLabel);
+          scope.$watch("type.initiativeType", updateCustomLabel);
+        }
+      };
+    }
+  ]);
+
   /**
    * Append size parameter to request a smaller thumbnail.
    */

--- a/web-ui/src/main/resources/catalog/components/utility/partials/associated-record-label.html
+++ b/web-ui/src/main/resources/catalog/components/utility/partials/associated-record-label.html
@@ -1,0 +1,16 @@
+<span data-ng-if="customLabel" title="{{'associationType' | translate}}">
+  <i
+    data-ng-if="type.initiativeType"
+    class="fa fa-fw {{icon}} gn-icon-initiative-{{type.initiativeType}}"
+  ></i>
+  {{customLabel}}
+</span>
+<span data-ng-if="!customLabel" title="{{'associationType' | translate}}">
+  <i class="fa fa-fw {{icon}} gn-icon-association-{{type.associationType}}"></i>
+  {{type.associationType | translate}}
+  <span data-ng-if="type.initiativeType" title="{{'initiativeType' | translate}}"
+    >>
+    <i class="fa fa-fw {{icon}} gn-icon-initiative-{{type.initiativeType}}"></i>
+    {{type.initiativeType | translate}}
+  </span>
+</span>

--- a/web-ui/src/main/resources/catalog/templates/editor/editor.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/editor.html
@@ -112,7 +112,7 @@
 <div
   data-gn-modal=""
   class="onlinesrc-popup"
-  data-gn-popup-options="{title:'linkToSiblingTitle'}"
+  data-gn-popup-options="{title: 'linkToSiblingTitle'}"
   id="linktosibling-popup"
 >
   <div

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_card_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_card_default.less
@@ -92,6 +92,11 @@
         padding: 10px;
         vertical-align: middle;
       }
+      .fa-external-link {
+        display: unset !important;
+        font-size: unset !important;
+        padding: unset !important;
+      }
       h1 {
         margin: 0;
         padding: 0 10px 0 0;

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/related.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/related.html
@@ -22,15 +22,6 @@
     data-ng-if="mdView.current.record.related.uuids"
     data-gn-related="mdView.current.record"
     data-user="user"
-    data-layout="title"
-    data-types="siblings|associated"
-    data-group-siblings-by-type="true"
-    data-title="{{'siblings' | translate}}"
-  ></div>
-  <div
-    data-ng-if="mdView.current.record.related.uuids"
-    data-gn-related="mdView.current.record"
-    data-user="user"
     data-layout="card"
     data-types="siblings|associated"
     data-group-siblings-by-type="true"

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/related.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/related.html
@@ -22,6 +22,15 @@
     data-ng-if="mdView.current.record.related.uuids"
     data-gn-related="mdView.current.record"
     data-user="user"
+    data-layout="title"
+    data-types="siblings|associated"
+    data-group-siblings-by-type="true"
+    data-title="{{'siblings' | translate}}"
+  ></div>
+  <div
+    data-ng-if="mdView.current.record.related.uuids"
+    data-gn-related="mdView.current.record"
+    data-user="user"
     data-layout="card"
     data-types="siblings|associated"
     data-group-siblings-by-type="true"

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/sources.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/sources.html
@@ -1,4 +1,5 @@
 <div
+  class="gn-md-side"
   data-ng-class="[].concat(mdView.current.record.related.sources, mdView.current.record.related.hassources).length > 3 ? 'col-md-12' : 'col-md-4'"
 >
   <div

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/type-dataset.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/type-dataset.html
@@ -169,11 +169,10 @@
     ></div>
   </div>
   <!-- /.col-md-8 gn-record -->
-  <div class="gn-md-side gn-page-break-avoid">
-    <div
-      ng-include="'../../catalog/views/default/templates/recordView/sources.html'"
-    ></div>
-  </div>
+  <div
+    ng-include="'../../catalog/views/default/templates/recordView/sources.html'"
+    data-gn-include-and-replace=""
+  ></div>
 </div>
 
 <div

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/type-series.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/type-series.html
@@ -149,11 +149,7 @@
       ng-include="'../../catalog/views/default/templates/recordView/lineage.html'"
     ></div>
   </div>
-  <div class="gn-md-side">
-    <div
-      ng-include="'../../catalog/views/default/templates/recordView/sources.html'"
-    ></div>
-  </div>
+  <div ng-include="'../../catalog/views/default/templates/recordView/sources.html'"></div>
 </div>
 
 <!-- contact -->


### PR DESCRIPTION
Create one directive to display associated resources labels with icon to have same layout/labels in search and editor apps.

The directive is used in all places:


* Record view (list and card layout)
![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/77f47d17-cf6f-4c57-a634-947c91f93f58)

* Editor side panel

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/e777f989-9e55-4b8e-8da0-ff7f7c550092)

* Editor popup
![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/9ba086e8-6c35-4f03-a774-5534f04f54aa)


Add the possibility to customize an association label by adding custom translation key in `${lang}-custom.json`

eg.
```json
{
  "crossReference-study": "Publication",
  "crossReference-campaign": "Campaign",
  "crossReference-reuse": "Reuse"
}
```

* Editor / Associated resource popup / Fix element using same DOM id.
* Record view / Improve alignement of source datasets


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

Funded by Ifremer