### PR TITLE
Record view / ISO19139 / ISO19115-3.2008 display the unit part in @uom attribute - avoid duplicated value

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/xsl-view/view.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/xsl-view/view.xsl
@@ -368,7 +368,7 @@
           <div data-ng-if="showCitation"
                data-gn-metadata-citation=""
                data-text="{$citation}">
-            
+
           </div>
         </xsl:when>
         <xsl:otherwise>
@@ -1170,9 +1170,9 @@
 
     <xsl:if test="@uom">
       <!-- Display the unit value only -->
-      &#160; <xsl:value-of select="if (contains(@uom, '#'))
-                                    then concat(., ' ', tokenize(@uom, '#')[2])
-                                    else  concat(., ' ', @uom)"/>
+      &#160;<xsl:value-of select="if (contains(@uom, '#'))
+                                    then tokenize(@uom, '#')[2]
+                                    else @uom"/>
     </xsl:if>
   </xsl:template>
 

--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
@@ -1153,9 +1153,9 @@
 
         <xsl:if test="@uom">
           <!-- Display the unit value only -->
-          &#160; <xsl:value-of select="if (contains(@uom, '#'))
-                                    then concat(., ' ', tokenize(@uom, '#')[2])
-                                    else  concat(., ' ', @uom)"/>
+          &#160;<xsl:value-of select="if (contains(@uom, '#'))
+                                    then tokenize(@uom, '#')[2]
+                                    else @uom"/>
         </xsl:if>
       </xsl:otherwise>
     </xsl:choose>


### PR DESCRIPTION
Follow up of https://github.com/geonetwork/core-geonetwork/pull/7791

Without the change, the value is displayed twice:

![duplicated-value](https://github.com/geonetwork/core-geonetwork/assets/1695003/872170cf-a662-44b2-b101-9c6cabc19715)


# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
