### PR TITLE
Editor / Geopublication / Misc fix.

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/mapservers/GeoServerRest.java
+++ b/services/src/main/java/org/fao/geonet/api/mapservers/GeoServerRest.java
@@ -476,18 +476,20 @@ public class GeoServerRest {
             }
             if (sldbody.isEmpty() || (!sldbody.isEmpty() && status != 200)) {
                 String info = getLayerInfo(layer);
-                Element layerProperties = Xml.loadString(info, false);
-                String styleName = layerProperties.getChild("defaultStyle")
-                    .getChild("name").getText();
+                if (info != null) {
+                    Element layerProperties = Xml.loadString(info, false);
+                    String styleName = layerProperties.getChild("defaultStyle")
+                        .getChild("name").getText();
 
-                Log.debug(Geonet.GEOPUBLISH, "Getting default style for " + styleName + " to apply to layer " + layer + " in workspace " + ws);
-                /* get the default style (polygon, line, point) from the global styles */
-                status = sendREST(GeoServerRest.METHOD_GET, "/styles/" + styleName
-                    + ".sld?quietOnNotFound=true", null, null, null, true);
+                    Log.debug(Geonet.GEOPUBLISH, "Getting default style for " + styleName + " to apply to layer " + layer + " in workspace " + ws);
+                    /* get the default style (polygon, line, point) from the global styles */
+                    status = sendREST(GeoServerRest.METHOD_GET, "/styles/" + styleName
+                        + ".sld?quietOnNotFound=true", null, null, null, true);
 
-                status = sendREST(GeoServerRest.METHOD_PUT, url + "/" + layer
-                        + "_style", getResponse(), null,
-                    "application/vnd.ogc.sld+xml", true);
+                    status = sendREST(GeoServerRest.METHOD_PUT, url + "/" + layer
+                            + "_style", getResponse(), null,
+                        "application/vnd.ogc.sld+xml", true);
+                }
             }
             checkResponseCode(status);
 

--- a/services/src/main/java/org/fao/geonet/api/mapservers/GeoServerRest.java
+++ b/services/src/main/java/org/fao/geonet/api/mapservers/GeoServerRest.java
@@ -346,11 +346,14 @@ public class GeoServerRest {
         } else if (file.startsWith("file://")) {
             type = "external";
         }
+        boolean isZip = ".zip".equals(extension);
 
         Log.debug(Geonet.GEOPUBLISH, "Creating datastore " + ds + " in workspace " + ws + " from file " + file);
-        int status = sendREST(GeoServerRest.METHOD_PUT, "/workspaces/" + ws
-                + "/datastores/" + ds + "/" + type + extension, file, null,
-            "text/plain", false);
+        int status = sendREST(GeoServerRest.METHOD_PUT,
+                "/workspaces/" + ws + "/datastores/" + ds + "/" + type + (isZip ? ".shp" : extension),
+                file, null,
+                (isZip ? "application/zip" : "text/plain"),
+                false);
 
         return status == 201;
     }

--- a/services/src/main/java/org/fao/geonet/api/mapservers/MapServersUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/mapservers/MapServersUtils.java
@@ -259,7 +259,10 @@ public class MapServersUtils {
                 if (!g.deleteLayer(dsName))
                     report += "Layer: " + g.getStatus();
                 if (isRaster) {
-
+                    if (!g.deleteCoverage(dsName, dsName))
+                        report += "Coverage: " + g.getStatus();
+                    if (!g.deleteCoverageStore(dsName))
+                        report += "Coveragestore: " + g.getStatus();
                 } else {
                     if (!g.deleteFeatureType(dsName, dsName))
                         report += "Feature type: " + g.getStatus();

--- a/web-ui/src/main/resources/catalog/components/edit/geopublisher/GeoPublisherDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/geopublisher/GeoPublisherDirective.js
@@ -194,16 +194,16 @@
               gnMap
                 .addWmsFromScratch(map, scope.gsNode.wmsurl, scope.layerName, false)
                 .then(
-                  function (o) {
-                    if (o.layer) {
-                      gnMap.zoomLayerToExtent(o.layer, map);
-                      scope.layer = o.layer;
+                  function (layer) {
+                    if (layer) {
+                      gnMap.zoomLayerToExtent(layer, map);
+                      scope.layer = layer;
                     }
                   },
-                  function (o) {
-                    if (o.layer) {
-                      gnMap.zoomLayerToExtent(o.layer, map);
-                      scope.layer = o.layer;
+                  function (layer) {
+                    if (layer) {
+                      gnMap.zoomLayerToExtent(layer, map);
+                      scope.layer = layer;
                     }
                   }
                 );
@@ -218,7 +218,12 @@
             scope.$watch("gsNode", function (n, o) {
               if (n != o) {
                 scope.checkNode(scope.gsNode.id);
-                scope.hasStyler = !angular.isArray(scope.gsNode.stylerurl);
+                scope.hasStyler = scope.gsNode.stylerurl !== "";
+              }
+            });
+            scope.$watch("layerName", function (n, o) {
+              if (n != o) {
+                scope.checkNode(scope.gsNode.id);
               }
             });
 
@@ -307,7 +312,6 @@
                 scope.hidden = false;
               }
               scope.mapId = "map-geopublisher";
-              // FIXME: only one publisher in a page ?
               scope.ref = r.ref;
               scope.refParent = r.refParent;
               scope.name = r.name;
@@ -323,14 +327,17 @@
               }
 
               // Build layer name based on file name
-              scope.layerName = r.name.replace(/.zip$|.gpkg$|.tif$|.tiff$|.ecw$/, "");
-              scope.wmsLayerName = scope.layerName;
+              scope.layerName = r.name
+                .split("/")
+                .pop()
+                .replace(/.zip$|.gpkg$|.tif$|.tiff$|.ecw$/, "");
               if (scope.layerName.match("^jdbc")) {
                 scope.wmsLayerName = scope.layerName.split("#")[1];
-              } else if (scope.layerName.match("^file")) {
-                scope.wmsLayerName = scope.layerName
-                  .replace(/.*\//, "")
-                  .replace(/.zip$|.gpkg$|.tif$|.tiff$|.ecw$/, "");
+              } else {
+                scope.wmsLayerName =
+                  (scope.gsNode.namespacePrefix !== ""
+                    ? scope.gsNode.namespacePrefix + ":"
+                    : "") + scope.layerName;
               }
             };
           }

--- a/web-ui/src/main/resources/catalog/templates/admin/settings/mapservers.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/settings/mapservers.html
@@ -51,6 +51,7 @@
           <button
             type="button"
             class="btn btn-default"
+            data-ng-hide="mapserverSelected.id === ''"
             data-ng-click="resetMapServerPassword(mapserverSelected.id)"
           >
             <i class="fa fa-lock"></i>&nbsp;
@@ -134,41 +135,10 @@
                   class="form-control"
                   required=""
                   data-ng-model="mapserverSelected.configurl"
-                  placeholder="http://"
+                  placeholder="http://localhost/geoserver/rest"
                 />
               </div>
             </div>
-
-            <fieldset data-ng-show="operation === 'ADD_NODE'">
-              <legend data-translate="">useAccount</legend>
-
-              <div class="form-group">
-                <label class="control-label col-sm-3" data-translate="">username</label>
-
-                <div class="col-sm-9">
-                  <input
-                    type="text"
-                    class="form-control"
-                    required=""
-                    data-ng-model="mapserverSelected.username"
-                  />
-                </div>
-              </div>
-
-              <div class="form-group">
-                <label class="control-label col-sm-3" data-translate="">password</label>
-
-                <div class="col-sm-9">
-                  <input
-                    type="password"
-                    class="form-control"
-                    required="required"
-                    autocomplete="new-password"
-                    data-ng-model="mapserverSelected.password"
-                  />
-                </div>
-              </div>
-            </fieldset>
 
             <div class="form-group">
               <label class="control-label col-sm-3" data-translate="">workspace</label>
@@ -222,7 +192,7 @@
                   class="form-control"
                   required=""
                   data-ng-model="mapserverSelected.wmsurl"
-                  placeholder="http://"
+                  placeholder="http://localhost/geoserer/wms"
                 />
               </div>
             </div>
@@ -237,7 +207,7 @@
                   class="form-control"
                   required=""
                   data-ng-model="mapserverSelected.wfsurl"
-                  placeholder="http://"
+                  placeholder="http://localhost/geoserver/wfs"
                 />
               </div>
             </div>
@@ -252,7 +222,7 @@
                   class="form-control"
                   required=""
                   data-ng-model="mapserverSelected.wcsurl"
-                  placeholder="http://"
+                  placeholder="http://localhost/geoserver/wcs"
                 />
               </div>
             </div>


### PR DESCRIPTION
* Admin configuration / Show reset password only once the mapserver is created. Removed unused code

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/3ecbf9c4-d9ec-43fd-b426-7b0d432d250d)



* API / Fix ZIP file publication and coverage removal (probably related to GeoServer API changes - tested with version 2.25.1)
* Editor / Fix zoom to layer due to mapservice change, do not show styler if not configured

[geopublication.webm](https://github.com/geonetwork/core-geonetwork/assets/1701393/ac77bcfd-420e-46df-9a36-180a2377535e)


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

