### PR TITLE
Update DOI exceptions to be multilingual exceptions

### DIFF
--- a/core/src/test/resources/org/fao/geonet/api/Messages.properties
+++ b/core/src/test/resources/org/fao/geonet/api/Messages.properties
@@ -180,6 +180,16 @@ exception.doi.recordNotConformantMissingMandatory=Record is not conform with Dat
 exception.doi.recordNotConformantMissingMandatory.description=Record ''{0}'' is not conform with DataCite validation rules for mandatory fields. Error is: {1}. Required fields in DataCite are: identifier, creators, titles, publisher, publicationYear, resourceType. <a href=''{2}api/records/{3}/formatters/datacite?output=xml''>Check the DataCite format output</a> and adapt the record content to add missing information.
 exception.doi.recordInvalid=Record converted to DataCite format is invalid.
 exception.doi.recordInvalid.description=Record ''{0}'' converted to DataCite format is invalid. Error is: {1}. Required fields in DataCite are: identifier, creators, titles, publisher, publicationYear, resourceType. <a href=''{2}api/records/{3}/formatters/datacite?output=xml''>Check the DataCite format output</a> and adapt the record content to add missing information.
+exception.doi.serverErrorCreate=Error creating DOI
+exception.doi.serverErrorCreate.description=Error creating DOI: {0}
+exception.doi.serverErrorRetrieve=Error retrieving DOI
+exception.doi.serverErrorRetrieve.description=Error retrieving DOI: {0}
+exception.doi.serverErrorDelete=Error deleting DOI
+exception.doi.serverErrorDelete.description=Error deleting DOI: {0}
+exception.doi.serverErrorUnregister=Error unregistering DOI
+exception.doi.serverErrorUnregister.description=Error unregistering DOI: {0}
+exception.doi.notSupportedOperationError=Operation not supported
+exception.doi.notSupportedOperationError.description={0}
 api.metadata.import.importedWithId=Metadata imported with ID '%s'
 api.metadata.import.importedWithUuid=Metadata imported with UUID '%s'
 api.metadata.import.importedFromXMLWithUuid=Metadata imported from XML with UUID '%s'

--- a/core/src/test/resources/org/fao/geonet/api/Messages_fre.properties
+++ b/core/src/test/resources/org/fao/geonet/api/Messages_fre.properties
@@ -167,15 +167,15 @@ exception.doi.recordNotConformantMissingMandatory=La fiche n''est pas conforme a
 exception.doi.recordNotConformantMissingMandatory.description=La fiche ''{0}'' n''est pas conforme aux r\u00E8gles de validation DataCite pour les champs obligatoires. L''erreur est: {1}. Les champs obligatoires dans DataCite sont : identifiant, cr\u00E9ateurs, titres, \u00E9diteur, publicationYear, resourceType. <a href=''{2}api/records/{3}/formatters/datacite?output=xml''>V\u00E9rifiez la sortie au format DataCite</a> et adaptez le contenu de la fiche pour ajouter les informations manquantes.
 exception.doi.recordInvalid=Le fiche converti n''est pas conforme au format DataCite
 exception.doi.recordInvalid.description=Le fiche ''{0}'' converti  n''est pas conforme au format DataCite. L''erreur est: {1}. Les champs obligatoires dans DataCite sont : identifiant, cr\u00E9ateurs, titres, \u00E9diteur, ann\u00E9e de publication, type de ressource. <a href=''{2}api/records/{3}/formatters/datacite?output=xml''>V\u00E9rifier la sortie au format DataCite</a> et adapter le contenu de la fiche pour ajouter les informations manquantes.
-exception.doi.serverErrorCreate=Error creating DOI
-exception.doi.serverErrorCreate.description=Error creating DOI: {0}
-exception.doi.serverErrorRetrieve=Error retrieving DOI
-exception.doi.serverErrorRetrieve.description=Error retrieving DOI: {0}
-exception.doi.serverErrorDelete=Error deleting DOI
-exception.doi.serverErrorDelete.description=Error deleting DOI: {0}
-exception.doi.serverErrorUnregister=Error unregistering DOI
-exception.doi.serverErrorUnregister.description=Error unregistering DOI: {0}
-exception.doi.notSupportedOperationError=Operation not supported
+exception.doi.serverErrorCreate=Erreur lors de la cr\u00E9ation du DOI
+exception.doi.serverErrorCreate.description=Erreur lors de la cr\u00E9ation du DOI : {0}
+exception.doi.serverErrorRetrieve=Erreur lors de la r\u00E9cup\u00E9ration du DOI
+exception.doi.serverErrorRetrieve.description=Erreur lors de la r\u00E9cup\u00E9ration du DOI : {0}
+exception.doi.serverErrorDelete=Erreur lors de la suppression du DOI
+exception.doi.serverErrorDelete.description=Erreur lors de la suppression du DOI : {0}
+exception.doi.serverErrorUnregister=Erreur lors de la d\u00E9sinscription du DOI
+exception.doi.serverErrorUnregister.description=Erreur lors de la d\u00E9sinscription du DOI {0}
+exception.doi.notSupportedOperationError=Op\u00E9ration non prise en charge
 exception.doi.notSupportedOperationError.description={0}
 api.metadata.import.importedWithId=Fiche import\u00E9e avec l'ID '%s'
 api.metadata.import.importedWithUuid=Fiche import\u00E9e avec l'UUID '%s'

--- a/core/src/test/resources/org/fao/geonet/api/Messages_fre.properties
+++ b/core/src/test/resources/org/fao/geonet/api/Messages_fre.properties
@@ -167,6 +167,16 @@ exception.doi.recordNotConformantMissingMandatory=La fiche n''est pas conforme a
 exception.doi.recordNotConformantMissingMandatory.description=La fiche ''{0}'' n''est pas conforme aux r\u00E8gles de validation DataCite pour les champs obligatoires. L''erreur est: {1}. Les champs obligatoires dans DataCite sont : identifiant, cr\u00E9ateurs, titres, \u00E9diteur, publicationYear, resourceType. <a href=''{2}api/records/{3}/formatters/datacite?output=xml''>V\u00E9rifiez la sortie au format DataCite</a> et adaptez le contenu de la fiche pour ajouter les informations manquantes.
 exception.doi.recordInvalid=Le fiche converti n''est pas conforme au format DataCite
 exception.doi.recordInvalid.description=Le fiche ''{0}'' converti  n''est pas conforme au format DataCite. L''erreur est: {1}. Les champs obligatoires dans DataCite sont : identifiant, cr\u00E9ateurs, titres, \u00E9diteur, ann\u00E9e de publication, type de ressource. <a href=''{2}api/records/{3}/formatters/datacite?output=xml''>V\u00E9rifier la sortie au format DataCite</a> et adapter le contenu de la fiche pour ajouter les informations manquantes.
+exception.doi.serverErrorCreate=Error creating DOI
+exception.doi.serverErrorCreate.description=Error creating DOI: {0}
+exception.doi.serverErrorRetrieve=Error retrieving DOI
+exception.doi.serverErrorRetrieve.description=Error retrieving DOI: {0}
+exception.doi.serverErrorDelete=Error deleting DOI
+exception.doi.serverErrorDelete.description=Error deleting DOI: {0}
+exception.doi.serverErrorUnregister=Error unregistering DOI
+exception.doi.serverErrorUnregister.description=Error unregistering DOI: {0}
+exception.doi.notSupportedOperationError=Operation not supported
+exception.doi.notSupportedOperationError.description={0}
 api.metadata.import.importedWithId=Fiche import\u00E9e avec l'ID '%s'
 api.metadata.import.importedWithUuid=Fiche import\u00E9e avec l'UUID '%s'
 api.metadata.import.importedFromXMLWithUuid=Fiche import\u00E9e depuis le fichier XML avec l'UUID '%s'

--- a/doi/src/main/java/org/fao/geonet/doi/client/BaseDoiClient.java
+++ b/doi/src/main/java/org/fao/geonet/doi/client/BaseDoiClient.java
@@ -1,5 +1,5 @@
 //=============================================================================
-//===	Copyright (C) 2001-2023 Food and Agriculture Organization of the
+//===	Copyright (C) 2001-2024 Food and Agriculture Organization of the
 //===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
 //===	and United Nations Environment Programme (UNEP)
 //===
@@ -94,14 +94,22 @@ public class BaseDoiClient {
                     url, body, status,
                     httpResponse.getStatusText(), responseBody);
                 Log.info(LOGGER_NAME, message);
-                throw new DoiClientException(message);
+                throw new DoiClientException(String.format(
+                    "Error creating DOI: %s",
+                    message))
+                    .withMessageKey("exception.doi.serverErrorCreate")
+                    .withDescriptionKey("exception.doi.serverErrorCreate.description", new String[]{message});
             } else {
                 Log.info(LOGGER_NAME, String.format(
                     successMessage, url));
             }
         } catch (Exception ex) {
             Log.error(LOGGER_NAME, "   -- Error (exception): " + ex.getMessage(), ex);
-            throw new DoiClientException(ex.getMessage());
+            throw new DoiClientException(String.format(
+                "Error creating DOI: %s",
+                ex.getMessage()))
+                .withMessageKey("exception.doi.serverErrorCreate")
+                .withDescriptionKey("exception.doi.serverErrorCreate.description", new String[]{ex.getMessage()});
 
         } finally {
             if (postMethod != null) {
@@ -139,13 +147,24 @@ public class BaseDoiClient {
             } else {
                 Log.info(LOGGER_NAME, "Retrieve DOI metadata end -- Error: " + httpResponse.getStatusText());
 
-                throw new DoiClientException( httpResponse.getStatusText() +
-                    CharStreams.toString(new InputStreamReader(httpResponse.getBody())));
+                String message = httpResponse.getStatusText() +
+                    CharStreams.toString(new InputStreamReader(httpResponse.getBody()));
+
+                throw new DoiClientException(String.format(
+                    "Error retrieving DOI: %s",
+                    message))
+                    .withMessageKey("exception.doi.serverErrorRetrieve")
+                    .withDescriptionKey("exception.doi.serverErrorRetrieve.description", new String[]{message});
+
             }
 
         } catch (Exception ex) {
             Log.error(LOGGER_NAME, "   -- Error (exception): " + ex.getMessage(), ex);
-            throw new DoiClientException(ex.getMessage());
+            throw new DoiClientException(String.format(
+                "Error retrieving DOI: %s",
+                ex.getMessage()))
+                .withMessageKey("exception.doi.serverErrorRetrieve")
+                .withDescriptionKey("exception.doi.serverErrorRetrieve.description", new String[]{ex.getMessage()});
 
         } finally {
             if (getMethod != null) {

--- a/doi/src/main/java/org/fao/geonet/doi/client/DoiDataciteClient.java
+++ b/doi/src/main/java/org/fao/geonet/doi/client/DoiDataciteClient.java
@@ -1,5 +1,5 @@
 //=============================================================================
-//===	Copyright (C) 2001-2023 Food and Agriculture Organization of the
+//===	Copyright (C) 2001-2024 Food and Agriculture Organization of the
 //===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
 //===	and United Nations Environment Programme (UNEP)
 //===
@@ -24,8 +24,6 @@ package org.fao.geonet.doi.client;
 
 import org.apache.commons.httpclient.HttpStatus;
 import org.apache.commons.io.IOUtils;
-import org.apache.http.auth.AuthScope;
-import org.apache.http.auth.UsernamePasswordCredentials;
 import org.apache.http.client.methods.HttpDelete;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.utils.GeonetHttpRequestFactory;
@@ -179,14 +177,24 @@ public class DoiDataciteClient extends BaseDoiClient implements IDoiClient {
             if ((status != HttpStatus.SC_NOT_FOUND) && (status != HttpStatus.SC_OK)) {
                 Log.info(LOGGER_NAME, "Delete DOI metadata end -- Error: " + httpResponse.getStatusText());
 
-                throw new DoiClientException( httpResponse.getStatusText() );
+                String message = httpResponse.getStatusText();
+
+                throw new DoiClientException(String.format(
+                    "Error deleting DOI: %s",
+                    message))
+                    .withMessageKey("exception.doi.serverErrorDelete")
+                    .withDescriptionKey("exception.doi.serverErrorDelete.description", new String[]{message});
             } else {
                 Log.info(LOGGER_NAME, "DeleteDOI metadata end");
             }
 
         } catch (Exception ex) {
             Log.error(LOGGER_NAME, "   -- Error (exception): " + ex.getMessage(), ex);
-            throw new DoiClientException(ex.getMessage());
+            throw new DoiClientException(String.format(
+                "Error deleting DOI: %s",
+                ex.getMessage()))
+                .withMessageKey("exception.doi.serverErrorDelete")
+                .withDescriptionKey("exception.doi.serverErrorDelete.description", new String[]{ex.getMessage()});
 
         } finally {
             if (deleteMethod != null) {
@@ -219,14 +227,25 @@ public class DoiDataciteClient extends BaseDoiClient implements IDoiClient {
             if ((status != HttpStatus.SC_NOT_FOUND) && (status != HttpStatus.SC_OK)) {
                 Log.info(LOGGER_NAME, "Delete DOI end -- Error: " + httpResponse.getStatusText());
 
-                throw new DoiClientException( httpResponse.getStatusText() );
+                String message = httpResponse.getStatusText();
+
+                throw new DoiClientException(String.format(
+                    "Error deleting DOI: %s",
+                    message))
+                    .withMessageKey("exception.doi.serverErrorDelete")
+                    .withDescriptionKey("exception.doi.serverErrorDelete.description", new String[]{message});
             } else {
                 Log.info(LOGGER_NAME, "DeleteDOI end");
             }
 
         } catch (Exception ex) {
             Log.error(LOGGER_NAME, "   -- Error (exception): " + ex.getMessage(), ex);
-            throw new DoiClientException(ex.getMessage());
+
+            throw new DoiClientException(String.format(
+                "Error deleting DOI: %s",
+                ex.getMessage()))
+                .withMessageKey("exception.doi.serverErrorDelete")
+                .withDescriptionKey("exception.doi.serverErrorDelete.description", new String[]{ex.getMessage()});
 
         } finally {
             if (deleteMethod != null) {

--- a/doi/src/main/java/org/fao/geonet/doi/client/DoiManager.java
+++ b/doi/src/main/java/org/fao/geonet/doi/client/DoiManager.java
@@ -1,5 +1,5 @@
 //=============================================================================
-//===	Copyright (C) 2001-2010 Food and Agriculture Organization of the
+//===	Copyright (C) 2001-2024 Food and Agriculture Organization of the
 //===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
 //===	and United Nations Environment Programme (UNEP)
 //===
@@ -475,7 +475,11 @@ public class DoiManager {
             dm.updateMetadata(context, metadata.getId() + "", recordWithoutDoi, false, true,
                 context.getLanguage(), new ISODate().toString(), true, IndexingMode.full);
         } catch (Exception ex) {
-            throw new DoiClientException(ex.getMessage());
+            throw new DoiClientException(String.format(
+                "Error unregistering DOI: %s",
+                ex.getMessage()))
+                .withMessageKey("exception.doi.serverErrorUnregister")
+                .withDescriptionKey("exception.doi.serverErrorUnregister.description", new String[]{ex.getMessage()});
         }
     }
 
@@ -487,8 +491,14 @@ public class DoiManager {
         Path styleSheet = dm.getSchemaDir(schema).resolve(DOI_ADD_XSL_PROCESS);
         boolean exists = Files.exists(styleSheet);
         if (!exists) {
-            throw new DoiClientException(String.format("To create a DOI, the schema has to defined how to insert a DOI in the record. The schema_plugins/%s/process/%s was not found. Create the XSL transformation.",
-                schema, DOI_ADD_XSL_PROCESS));
+            String message = String.format("To create a DOI, the schema has to defined how to insert a DOI in the record. The schema_plugins/%s/process/%s was not found. Create the XSL transformation.",
+                schema, DOI_ADD_XSL_PROCESS);
+
+            throw new DoiClientException(String.format(
+                "Error creating  DOI: %s",
+                message))
+                .withMessageKey("exception.doi.serverErrorCreate")
+                .withDescriptionKey("exception.doi.serverErrorCreate.description", new String[]{message});
         }
 
         String doiPublicUrl = client.createPublicUrl("");
@@ -507,8 +517,15 @@ public class DoiManager {
         Path styleSheet = dm.getSchemaDir(schema).resolve(DOI_REMOVE_XSL_PROCESS);
         boolean exists = Files.exists(styleSheet);
         if (!exists) {
-            throw new DoiClientException(String.format("To remove a DOI, the schema has to defined how to remove a DOI in the record. The schema_plugins/%s/process/%s was not found. Create the XSL transformation.",
-                schema, DOI_REMOVE_XSL_PROCESS));
+            String message = String.format("To remove a DOI, the schema has to defined how to remove a DOI in the record. The schema_plugins/%s/process/%s was not found. Create the XSL transformation.",
+                schema, DOI_REMOVE_XSL_PROCESS);
+
+            throw new DoiClientException(String.format(
+                "Error deleting  DOI: %s",
+                message))
+                .withMessageKey("exception.doi.serverErrorDelete")
+                .withDescriptionKey("exception.doi.serverErrorDelete.description", new String[]{message});
+
         }
 
         Map<String, Object> params = new HashMap<>(1);
@@ -528,8 +545,14 @@ public class DoiManager {
             isMedra ? DATACITE_MEDRA_XSL_CONVERSION_FILE : DATACITE_XSL_CONVERSION_FILE);
         final boolean exists = Files.exists(styleSheet);
         if (!exists) {
-            throw new DoiClientException(String.format("To create a DOI, the record needs to be converted to the DataCite format (https://schema.datacite.org/). You need to create a formatter for this in schema_plugins/%s/%s. If the standard is a profile of ISO19139, you can simply point to the ISO19139 formatter.",
-                schema, DATACITE_XSL_CONVERSION_FILE));
+            String message = String.format("To create a DOI, the record needs to be converted to the DataCite format (https://schema.datacite.org/). You need to create a formatter for this in schema_plugins/%s/%s. If the standard is a profile of ISO19139, you can simply point to the ISO19139 formatter.",
+                schema, DATACITE_XSL_CONVERSION_FILE);
+
+            throw new DoiClientException(String.format(
+                "Error creating  DOI: %s",
+                message))
+                .withMessageKey("exception.doi.serverErrorCreate")
+                .withDescriptionKey("exception.doi.serverErrorCreate.description", new String[]{message});
         }
 
         Map<String,Object> params = new HashMap<>();
@@ -539,7 +562,9 @@ public class DoiManager {
 
     private void checkInitialised() throws DoiClientException {
         if (!initialised) {
-            throw new DoiClientException("DOI configuration is not complete. Check System Configuration and set the DOI configuration.");
+            throw new DoiClientException("DOI configuration is not complete. Check System Configuration and set the DOI configuration.")
+                .withMessageKey("exception.doi.configurationMissing")
+                .withDescriptionKey("exception.doi.configurationMissing.description", new String[]{});
         }
     }
 

--- a/doi/src/main/java/org/fao/geonet/doi/client/DoiMedraClient.java
+++ b/doi/src/main/java/org/fao/geonet/doi/client/DoiMedraClient.java
@@ -1,5 +1,5 @@
 //=============================================================================
-//===	Copyright (C) 2001-2010 Food and Agriculture Organization of the
+//===	Copyright (C) 2001-2024 Food and Agriculture Organization of the
 //===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
 //===	and United Nations Environment Programme (UNEP)
 //===
@@ -58,7 +58,10 @@ public class DoiMedraClient extends BaseDoiClient implements IDoiClient {
 
     @Override
     public String retrieveAllDoi(String doi) throws DoiClientException {
-        throw new DoiClientException(MEDRA_NOT_SUPPORTED_EXCEPTION_MESSAGE);
+        throw new DoiClientException(MEDRA_NOT_SUPPORTED_EXCEPTION_MESSAGE)
+            .withMessageKey("exception.doi.operationNotSupported")
+            .withDescriptionKey("exception.doi.operationNotSupported.description",
+                new String[]{ MEDRA_NOT_SUPPORTED_EXCEPTION_MESSAGE });
     }
 
     /**

--- a/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages.properties
+++ b/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages.properties
@@ -180,6 +180,18 @@ exception.doi.recordNotConformantMissingMandatory=Record is not conform with Dat
 exception.doi.recordNotConformantMissingMandatory.description=Record ''{0}'' is not conform with DataCite validation rules for mandatory fields. Error is: {1}. Required fields in DataCite are: identifier, creators, titles, publisher, publicationYear, resourceType. <a href=''{2}api/records/{3}/formatters/datacite?output=xml''>Check the DataCite format output</a> and adapt the record content to add missing information.
 exception.doi.recordInvalid=Record converted to DataCite format is invalid.
 exception.doi.recordInvalid.description=Record ''{0}'' converted to DataCite format is invalid. Error is: {1}. Required fields in DataCite are: identifier, creators, titles, publisher, publicationYear, resourceType. <a href=''{2}api/records/{3}/formatters/datacite?output=xml''>Check the DataCite format output</a> and adapt the record content to add missing information.
+exception.doi.serverErrorCreate=Error creating DOI
+exception.doi.serverErrorCreate.description=Error creating DOI: {0}
+exception.doi.serverErrorRetrieve=Error retrieving DOI
+exception.doi.serverErrorRetrieve.description=Error retrieving DOI: {0}
+exception.doi.serverErrorDelete=Error deleting DOI
+exception.doi.serverErrorDelete.description=Error deleting DOI: {0}
+exception.doi.serverErrorUnregister=Error unregistering DOI
+exception.doi.serverErrorUnregister.description=Error unregistering DOI: {0}
+exception.doi.configurationMissing=DOI configuration is not complete
+exception.doi.configurationMissing.description=DOI configuration is not complete. Check System Configuration and set the DOI configuration.
+exception.doi.notSupportedOperationError=Operation not supported
+exception.doi.notSupportedOperationError.description={0}
 api.metadata.import.importedWithId=Metadata imported with ID '%s'
 api.metadata.import.importedWithUuid=Metadata imported with UUID '%s'
 api.metadata.import.importedFromXMLWithUuid=Metadata imported from XML with UUID '%s'

--- a/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages_fre.properties
+++ b/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages_fre.properties
@@ -167,6 +167,16 @@ exception.doi.recordNotConformantMissingMandatory=La fiche n''est pas conforme a
 exception.doi.recordNotConformantMissingMandatory.description=La fiche ''{0}'' n''est pas conforme aux r\u00E8gles de validation DataCite pour les champs obligatoires. L''erreur est: {1}. Les champs obligatoires dans DataCite sont : identifiant, cr\u00E9ateurs, titres, \u00E9diteur, publicationYear, resourceType. <a href=''{2}api/records/{3}/formatters/datacite?output=xml''>V\u00E9rifiez la sortie au format DataCite</a> et adaptez le contenu de la fiche pour ajouter les informations manquantes.
 exception.doi.recordInvalid=Le fiche converti n''est pas conforme au format DataCite
 exception.doi.recordInvalid.description=Le fiche ''{0}'' converti  n''est pas conforme au format DataCite. L''erreur est: {1}. Les champs obligatoires dans DataCite sont : identifiant, cr\u00E9ateurs, titres, \u00E9diteur, ann\u00E9e de publication, type de ressource. <a href=''{2}api/records/{3}/formatters/datacite?output=xml''>V\u00E9rifier la sortie au format DataCite</a> et adapter le contenu de la fiche pour ajouter les informations manquantes.
+exception.doi.serverErrorCreate=Error creating DOI
+exception.doi.serverErrorCreate.description=Error creating DOI: {0}
+exception.doi.serverErrorRetrieve=Error retrieving DOI
+exception.doi.serverErrorRetrieve.description=Error retrieving DOI: {0}
+exception.doi.serverErrorDelete=Error deleting DOI
+exception.doi.serverErrorDelete.description=Error deleting DOI: {0}
+exception.doi.serverErrorUnregister=Error unregistering DOI
+exception.doi.serverErrorUnregister.description=Error unregistering DOI: {0}
+exception.doi.notSupportedOperationError=Operation not supported
+exception.doi.notSupportedOperationError.description={0}
 api.metadata.import.importedWithId=Fiche import\u00E9e avec l'ID '%s'
 api.metadata.import.importedWithUuid=Fiche import\u00E9e avec l'UUID '%s'
 api.metadata.import.importedFromXMLWithUuid=Fiche import\u00E9e depuis le fichier XML avec l'UUID '%s'


### PR DESCRIPTION
Follow up of #6472

When trying to publish a DOI the exception reported to the user was `Unsatisfied request parameter` instead of the real cause of the exception. This was caused as not all the places throwing a `DOIClientException` were setting the required multilingual properties, causing the exception manager to use a generic message.

@fxprunayre would you mind to add the French translations?

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
