### PR TITLE
Documentation / Add information about the type of users that can request a DOI

### DIFF
--- a/docs/manual/docs/user-guide/associating-resources/doi.md
+++ b/docs/manual/docs/user-guide/associating-resources/doi.md
@@ -15,7 +15,13 @@ A record can be downloaded using the DataCite format from the API using: <http:/
 
 ## Creating the DOI
 
-Once configured, DOI can be created using the interface. DOI is created on demand. It means that a user must ask for creation of a DOI. When created, the task is notified by email to the reviewer of the group (by default, can be configured for administrator only using the notification level of the task).
+Once configured, DOI can be created using the interface. DOI is created on demand. It means that a user must ask for creation of a DOI. It can be created by:
+
+- The user who created the metadata.
+- A user with Reviewer profile in the metadata group owner.
+- A user with Administrator profile.
+
+When created, the task is notified by email to the reviewer of the group (by default, can be configured for administrator only using the notification level of the task).
 
 ![](img/doi-request-menu.png)
 


### PR DESCRIPTION
Small improvement of the DOI documentation page.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [X] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

