### PR TITLE
Editor / Keywords / Add option to configure keyword encoding for a view.

### DIFF
--- a/schemas/config-editor.xsd
+++ b/schemas/config-editor.xsd
@@ -1004,6 +1004,15 @@ e.g. only 2 INSPIRE themes:
       ]]></xs:documentation>
     </xs:annotation>
     <xs:complexType>
+      <xs:attribute name="defaultTransformation" minOccurs="0" type="xs:string">
+        <xs:annotation>
+          <xs:documentation><![CDATA[
+The default encoding for all thesaurus eg. to-iso19139-keyword-with-anchor.
+Conversion are defined in `convert/thesaurus-transformation.xsl`.
+          ]]>
+          </xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
       <xs:sequence>
         <xs:element name="thesaurus" minOccurs="1" maxOccurs="unbounded">
           <xs:complexType>
@@ -2177,7 +2186,7 @@ This can allow to build dynamic snippet based on the current record.
           <mrd:onLine>
             <cit:CI_OnlineResource>
               <cit:linkage>
-                <gco:CharacterString>https://geoadata.wallonie.be/dataset/${uuid}</gco:CharacterString>
+                <gco:CharacterString>https://geodata.wallonie.be/dataset/${uuid}</gco:CharacterString>
               </cit:linkage>
 
 

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/config-editor.xml
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/config-editor.xml
@@ -720,13 +720,8 @@
         <for name="cit:CI_Organisation"/>
         <for name="gfc:listedValue"/>
       </flatModeExceptions>
-      <thesaurusList>
-        <thesaurus key="external.theme.httpinspireeceuropaeutheme-theme" transformations="to-iso19115-3.2018-keyword-with-anchor"/>
-        <thesaurus key="external.theme.httpinspireeceuropaeumetadatacodelistIACSData-IACSData" transformations="to-iso19115-3.2018-keyword-with-anchor"/>
-        <thesaurus key="external.theme.httpinspireeceuropaeumetadatacodelistSpatialScope-SpatialScope" transformations="to-iso19115-3.2018-keyword-with-anchor"/>
-        <thesaurus key="external.theme.httpinspireeceuropaeumetadatacodelistPriorityDataset-PriorityDataset" transformations="to-iso19115-3.2018-keyword-with-anchor"/>
-        <thesaurus key="external.theme.httpinspireeceuropaeufeatureconcept-featureconcept" transformations="to-iso19115-3.2018-keyword-with-anchor"/>
-      </thesaurusList>
+
+      <thesaurusList defaultTransformation="to-iso19115-3.2018-keyword-with-anchor"/>
     </view>
 
 
@@ -861,13 +856,8 @@
         <section xpath="/mdb:MD_Metadata/mdb:applicationSchemaInfo" or="applicationSchemaInfo"
                  in="/mdb:MD_Metadata"/>
       </tab>
-      <thesaurusList>
-        <thesaurus key="external.theme.httpinspireeceuropaeutheme-theme" transformations="to-iso19115-3.2018-keyword-with-anchor"/>
-        <thesaurus key="external.theme.httpinspireeceuropaeumetadatacodelistIACSData-IACSData" transformations="to-iso19115-3.2018-keyword-with-anchor"/>
-        <thesaurus key="external.theme.httpinspireeceuropaeumetadatacodelistSpatialScope-SpatialScope" transformations="to-iso19115-3.2018-keyword-with-anchor"/>
-        <thesaurus key="external.theme.httpinspireeceuropaeumetadatacodelistPriorityDataset-PriorityDataset" transformations="to-iso19115-3.2018-keyword-with-anchor"/>
-        <thesaurus key="external.theme.httpinspireeceuropaeufeatureconcept-featureconcept" transformations="to-iso19115-3.2018-keyword-with-anchor"/>
-      </thesaurusList>
+
+      <thesaurusList defaultTransformation="to-iso19115-3.2018-keyword-with-anchor"/>
     </view>
     <view name="xml">
       <sidePanel>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/layout-custom-fields-keywords.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/layout-custom-fields-keywords.xsl
@@ -184,15 +184,28 @@
                   else mri:keyword/*[1][. != '']/replace(text(), ',', ',,'), ',')"/>
 
         <!-- Define the list of transformation mode available. -->
+        <xsl:variable name="listOfTransformation"
+                      select="if ($thesaurusConfig/@transformations)
+                              then tokenize($thesaurusConfig/@transformations, ',')
+                              else if ($thesaurusList/@defaultTransformation)
+                              then ($thesaurusList/@defaultTransformation)
+                              else ()"
+                      as="xs:string*"/>
+
         <xsl:variable name="transformations"
                       as="xs:string"
-                      select="if ($thesaurusConfig/@transformations != '')
-                              then $thesaurusConfig/@transformations
-                              else 'to-iso19115-3.2018-keyword,to-iso19115-3.2018-keyword-with-anchor,to-iso19115-3.2018-keyword-as-xlink'"/>
+                      select="if (count($listOfTransformation) > 0)
+                              then string-join($listOfTransformation, ',')
+                              else if ($isXlinkEnabled)
+                              then 'to-iso19115-3.2018-keyword,to-iso19115-3.2018-keyword-with-anchor,to-iso19115-3.2018-keyword-as-xlink'
+                              else 'to-iso19115-3.2018-keyword,to-iso19115-3.2018-keyword-with-anchor'"/>
 
-        <!-- Get current transformation mode based on XML fragement analysis -->
+        <!-- Current transformation is the editor configuration if only one mode is allowed
+         and if not then the mode is based on the XML fragment analysis -->
         <xsl:variable name="transformation"
-          select="if (parent::node()/@xlink:href)
+          select="if (count($listOfTransformation) = 1)
+                  then $listOfTransformation[1]
+                  else if (parent::node()/@xlink:href)
                   then 'to-iso19115-3.2018-keyword-as-xlink'
                   else if (count(mri:keyword/gcx:Anchor) > 0)
                   then 'to-iso19115-3.2018-keyword-with-anchor'

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
@@ -3233,7 +3233,7 @@
                                             editActions: []}]"
         />
 
-        <directive data-gn-associated-resources-panel="gnCurrentEdit.metadata" />
+        <directive data-gn-associated-resources-panel="gnCurrentEdit.metadata"/>
 
         <directive gn-geo-publisher=""
                    data-ng-if="gnCurrentEdit.geoPublisherConfig"
@@ -3334,12 +3334,7 @@
                    transformations="to-iso19139-keyword-with-anchor"/>
       </thesaurusList>
       -->
-
-      <thesaurusList>
-        <thesaurus key="external.none.allThesaurus"
-                   fieldset="false"/>
-      </thesaurusList>
-
+      <thesaurusList defaultTransformation="to-iso19139-keyword-with-anchor"/>
     </view>
     <view name="advanced"
           class="gn-label-above-input gn-indent-bluescale">
@@ -3441,6 +3436,8 @@
         <section xpath="/gmd:MD_Metadata/gmd:applicationSchemaInfo" or="applicationSchemaInfo"
                  in="/gmd:MD_Metadata"/>
       </tab>
+
+      <thesaurusList defaultTransformation="to-iso19139-keyword-with-anchor"/>
     </view>
     <view name="xml">
       <sidePanel>

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields-keywords.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields-keywords.xsl
@@ -220,19 +220,35 @@
                     gmd:keyword//*[@locale = concat('#', $guiLangId)][. != '']/replace(text(), ',', ',,')
                   else gmd:keyword/*[1][. != '']/replace(text(), ',', ',,'), ',')"/>
 
+
         <!-- Define the list of transformation mode available. -->
+        <xsl:variable name="listOfTransformation"
+                      select="if ($thesaurusConfig/@transformations)
+                              then tokenize($thesaurusConfig/@transformations, ',')
+                              else if ($thesaurusList/@defaultTransformation)
+                              then ($thesaurusList/@defaultTransformation)
+                              else ()"
+                      as="xs:string*"/>
+
         <xsl:variable name="transformations"
                       as="xs:string"
-                      select="if ($thesaurusConfig/@transformations != '')
-                              then $thesaurusConfig/@transformations
-                              else 'to-iso19139-keyword,to-iso19139-keyword-with-anchor,to-iso19139-keyword-as-xlink'"/>
+                      select="if (count($listOfTransformation) > 0)
+                              then string-join($listOfTransformation, ',')
+                              else if ($isXlinkEnabled)
+                              then 'to-iso19139-keyword,to-iso19139-keyword-with-anchor,to-iso19139-keyword-as-xlink'
+                              else 'to-iso19139-keyword,to-iso19139-keyword-with-anchor'"/>
 
-        <!-- Get current transformation mode based on XML fragment analysis -->
+        <!-- Current transformation is the editor configuration if only one mode is allowed
+         and if not then the mode is based on the XML fragment analysis -->
         <xsl:variable name="transformation"
-                      select="if (parent::node()/@xlink:href) then 'to-iso19139-keyword-as-xlink'
-          else if (count(gmd:keyword/gmx:Anchor) > 0)
-          then 'to-iso19139-keyword-with-anchor'
-          else 'to-iso19139-keyword'"/>
+                      select="if (count($listOfTransformation) = 1)
+                  then $listOfTransformation[1]
+                  else if (parent::node()/@xlink:href)
+                  then 'to-iso19139-keyword-as-xlink'
+                  else if (count(gmd:keyword/gmx:Anchor) > 0)
+                  then 'to-iso19139-keyword-with-anchor'
+                  else 'to-iso19139-keyword'"/>
+
 
         <xsl:variable name="parentName" select="name(..)"/>
 

--- a/web/src/main/webapp/xslt/common/base-variables-metadata-editor.xsl
+++ b/web/src/main/webapp/xslt/common/base-variables-metadata-editor.xsl
@@ -24,6 +24,8 @@
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:saxon="http://saxon.sf.net/"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:util="java:org.fao.geonet.util.XslUtil"
                 version="2.0" extension-element-prefixes="saxon"
 >
   <!--
@@ -34,6 +36,10 @@
   <xsl:variable name="isMinorEdit" select="/root/request/minor"/>
 
   <xsl:variable name="showValidationErrors" select="/root/request/showvalidationerrors"/>
+
+  <xsl:variable name="isXlinkEnabled"
+                as="xs:boolean"
+                select="util:getSettingValue('system/xlinkResolver/enable') = 'true'"/>
 
   <!-- Default form field type is text input. -->
   <xsl:variable name="defaultFieldType" select="'text'"/>


### PR DESCRIPTION
More and more the default encoding for keywords is using `Anchor` instead of `CharacterString`. It is even mandatory in a number of case like INSPIRE/IACS validation.

Quite often, all editor views are configured using:

```xml
      <thesaurusList>
        <thesaurus key="external.theme.httpinspireeceuropaeutheme-theme"
                   transformations="to-iso19115-3.2018-keyword-with-anchor"/>
        <thesaurus key="external.theme.httpinspireeceuropaeumetadatacodelistSpatialScope-SpatialScope"
                   transformations="to-iso19115-3.2018-keyword-with-anchor"/>
      ...
```
to enable usage of `Anchor` for a number of thesaurus.

This change propose to be able to configure the default keyword encoding for all thesaurus using:

```xml
      <thesaurusList defaultTransformation="to-iso19115-3.2018-keyword-with-anchor"/>
    </view>
```

If defined, it takes priority over the current encoding in the metadata record. If defined, the encoding selector is not displayed.


![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/87844008-8812-4687-aa10-c6eaecc99631)


It also hide the XLink encoding mode in the encoding selector if the XLink resolver is not enabled.

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/ebec26de-dd2c-4124-9091-5fe85fea257c)



Funded by Service Public de Wallonie


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

