### PR TITLE
Remove link from admin-guide to schematron details as inappropriate

### DIFF
--- a/docs/manual/docs/administrator-guide/managing-metadata-standards/configure-validation.md
+++ b/docs/manual/docs/administrator-guide/managing-metadata-standards/configure-validation.md
@@ -1,6 +1,6 @@
 # Configuring validation levels {#configure-validation}
 
-Each standard defines validation levels (using schematron - see [Implementing schema plugins](../../customizing-application/implementing-a-schema-plugin.md)). By default, ISO19139 proposes validation using:
+Each standard defines validation levels. By default, ISO19139 proposes validation using:
 
 -   ISO rules
 -   INSPIRE rules (TG v1.3)


### PR DESCRIPTION
These are two different audiences. When deploying admin guide in isolation this produces a broken link.

If configuration of validation levels requires customization then the activity should move to the customization section.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [x] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

Thanks to GeoCat Live for the opportunity to assist with documentation. 