### PR TITLE
Improve tooltips for facet filter items

### DIFF
--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/FacetDirective.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/FacetDirective.js
@@ -284,8 +284,10 @@
    * @param $scope
    * @constructor
    */
-  var FacetController = function ($scope) {
+  var FacetController = function ($scope, $translate, $filter) {
     this.$scope = $scope;
+    this.$translate = $translate;
+    this.$filter = $filter;
   };
 
   FacetController.prototype.$onInit = function () {
@@ -321,6 +323,14 @@
     return this.searchCtrl.isInSearch(item.path);
   };
 
+  FacetController.prototype.getTooltip = function (item) {
+    if (item.definition) {
+      return this.$translate.instant(item.definition + "-tooltip");
+    } else {
+      return this.$filter("facetTranslator")(item.value);
+    }
+  };
+
   FacetController.prototype.toggleCollapse = function () {
     this.item.collapsed = !this.item.collapsed;
   };
@@ -331,7 +341,7 @@
     this.filter(this.facet, item);
   };
 
-  FacetController.$inject = ["$scope"];
+  FacetController.$inject = ["$scope", "$translate", "$filter"];
 
   module.directive("esFacet", [
     "gnLangs",

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/FacetDirective.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/FacetDirective.js
@@ -187,6 +187,23 @@
     }
   ]);
 
+  module.filter("facetTooltip", [
+    "$translate",
+    "$filter",
+    function ($translate, $filter) {
+      return function (item) {
+        if (item.definition) {
+          var key = item.definition + "-tooltip",
+            tooltip = $translate.instant(key);
+          if (tooltip !== key) {
+            return tooltip;
+          }
+        }
+        return $filter("facetTranslator")(item.value);
+      };
+    }
+  ]);
+
   module.filter("facetTranslator", [
     "$translate",
     "$filter",
@@ -321,14 +338,6 @@
 
   FacetController.prototype.isInSearch = function (facet, item) {
     return this.searchCtrl.isInSearch(item.path);
-  };
-
-  FacetController.prototype.getTooltip = function (item) {
-    if (item.definition) {
-      return this.$translate.instant(item.definition + "-tooltip");
-    } else {
-      return this.$filter("facetTranslator")(item.value);
-    }
   };
 
   FacetController.prototype.toggleCollapse = function () {

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facet-cards.html
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facet-cards.html
@@ -12,7 +12,7 @@
     <div class="panel-body">
       <a
         class="clearfix"
-        title="{{::facetValue}}"
+        title="{{::(facet | facetTooltip)}}"
         role="link"
         data-ng-init="response = aggregations[key];
                       decorator = (response.meta && response.meta.decorator) || undefined"

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facet.html
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facet.html
@@ -13,11 +13,12 @@
       >
       </span>
     </a>
+
     <a
       href
       class="flex-row flex-align-center flex-shrink width-100"
       ng-class="ctrl.isInSearch(ctrl.facet, ctrl.item) ? 'gn-facet-checked' + (ctrl.item.inverted ? '-inverted' : '') : ''"
-      title="{{::ctrl.item.value}}"
+      title="{{::ctrl.getTooltip(ctrl.item)}}"
       ng-click="ctrl.filter(ctrl.facet, ctrl.item)"
     >
       <span

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facet.html
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facet.html
@@ -18,7 +18,7 @@
       href
       class="flex-row flex-align-center flex-shrink width-100"
       ng-class="ctrl.isInSearch(ctrl.facet, ctrl.item) ? 'gn-facet-checked' + (ctrl.item.inverted ? '-inverted' : '') : ''"
-      title="{{::ctrl.getTooltip(ctrl.item)}}"
+      title="{{::(ctrl.item | facetTooltip)}}"
       ng-click="ctrl.filter(ctrl.facet, ctrl.item)"
     >
       <span

--- a/web-ui/src/main/resources/catalog/components/utility/UtilityService.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityService.js
@@ -677,7 +677,8 @@
           if (!newNode) {
             newNode = {
               name: group,
-              value: group
+              value: group,
+              definition: group
               //selected: themesInSearch.indexOf(t['@name']) >= 0 ? true : false
             };
             if (!node.nodes) node.nodes = [];
@@ -795,12 +796,19 @@
         if (Object.keys(translationsToLoad[fieldId]).length > 0) {
           loadTranslation(fieldId, meta && meta.thesaurus).then(function (translations) {
             if (angular.isObject(translations)) {
+              var translationToAdd = {};
+              var keys = Object.keys(translations);
+              for (var i = 0; i < keys.length; i++) {
+                translationToAdd[keys[i]] = translations[keys[i]].label;
+                translationToAdd[keys[i] + "-tooltip"] = translations[keys[i]].definition;
+              }
+
               var t = {};
               t[gnLangs.current] = {};
               t[gnLangs.current] = angular.extend(
                 {},
                 gnLangs.provider.translations()[gnLangs.current],
-                translations
+                translationToAdd
               );
               gnLangs.provider.useLoader("inlineLoaderFactory", t);
               $translate.refresh();

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -448,9 +448,9 @@
                 }
               },
               // GEMET configuration for non multilingual catalog
-              "th_gemet_tree.default": {
+              "th_gemet_tree.key": {
                 terms: {
-                  field: "th_gemet_tree.default",
+                  field: "th_gemet_tree.key",
                   size: 100,
                   order: { _key: "asc" },
                   include: "[^^]+^?[^^]+"


### PR DESCRIPTION
Improve the facet items tooltips.

- For keyword items, display the definition if available.

Before:
![facet-keyword-tooltip-before](https://github.com/geonetwork/core-geonetwork/assets/1695003/abc66a63-a195-4d23-b94c-a7fa713dc8bd)

After:
![facet-keyword-tooltip-after](https://github.com/geonetwork/core-geonetwork/assets/1695003/61d56a1e-8bf7-4a7a-b411-90cd7587fc9d)

- For other items, display the translation instead of the key.

Before:
![facet-other-before](https://github.com/geonetwork/core-geonetwork/assets/1695003/73548746-563d-4f4a-acd9-b66d62bd0a44)

After:
![facet-other-after](https://github.com/geonetwork/core-geonetwork/assets/1695003/6bc9049b-98e3-4689-9536-20bdee58bbf9)

---

Includes Sonarlint improvements.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation


Funded by: 

- IFremer