### PR TITLE
Metadata workflow API / Update security exceptions to use translations

### DIFF
--- a/core/src/test/resources/org/fao/geonet/api/Messages.properties
+++ b/core/src/test/resources/org/fao/geonet/api/Messages.properties
@@ -204,3 +204,5 @@ api.metadata.share.errorMetadataNotApproved=The metadata '%s' it's not approved,
 api.metadata.share.ErrorUserNotAllowedToPublish=User not allowed to publish the metadata %s. %s
 api.metadata.share.strategy.groupOwnerOnly=You need to be administrator, or reviewer of the metadata group.
 api.metadata.share.strategy.reviewerInGroup=You need to be administrator, or reviewer of the metadata group or reviewer with edit privilege on the metadata.
+api.metadata.status.errorGetStatusNotAllowed=Only the owner of the metadata can get the status. User is not the owner of the metadata.
+api.metadata.status.errorSetStatusNotAllowed=Only the owner of the metadata can set the status of this record. User is not the owner of the metadata.

--- a/core/src/test/resources/org/fao/geonet/api/Messages_fre.properties
+++ b/core/src/test/resources/org/fao/geonet/api/Messages_fre.properties
@@ -191,3 +191,5 @@ api.metadata.share.errorMetadataNotApproved=La fiche '%s' n'est pas approuv\u00E
 api.metadata.share.ErrorUserNotAllowedToPublish=L'utilisateur n'est pas autoris\u00E9 \u00E0 publier la fiche %s. %s
 api.metadata.share.strategy.groupOwnerOnly=Vous devez \u00EAtre administrateur ou relecteur du groupe de la fiche.
 api.metadata.share.strategy.reviewerInGroup=Vous devez \u00EAtre administrateur ou relecteur du groupe de la fiche ou relecteur avec un privil\u00E8ge de modification sur les fiches.
+api.metadata.status.errorGetStatusNotAllowed=Seul le propri\u00E9taire des m\u00E9tadonn\u00E9es peut obtenir le statut de cet enregistrement. L'utilisateur n'est pas le propri\u00E9taire des m\u00E9tadonn\u00E9es
+api.metadata.status.errorSetStatusNotAllowed=Seul le propri\u00E9taire des m\u00E9tadonn\u00E9es peut d\u00E9finir le statut de cet enregistrement. L'utilisateur n'est pas le propri\u00E9taire des m\u00E9tadonn\u00E9es

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2023 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2024 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -60,7 +60,6 @@ import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.kernel.setting.Settings;
 import org.fao.geonet.repository.*;
 import org.fao.geonet.util.MetadataPublicationMailNotifier;
-import org.fao.geonet.util.UserUtil;
 import org.fao.geonet.utils.Log;
 import org.fao.geonet.utils.Xml;
 import org.jdom.Element;
@@ -224,12 +223,13 @@ public class MetadataWorkflowApi {
         HttpServletRequest request) throws Exception {
         AbstractMetadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
         Locale locale = languageUtils.parseAcceptLanguage(request.getLocales());
+        ResourceBundle messages = ApiUtils.getMessagesResourceBundle(request.getLocales());
         ServiceContext context = ApiUtils.createServiceContext(request, locale.getISO3Language());
 
         // --- only allow the owner of the record to set its status
         if (!accessManager.isOwner(context, String.valueOf(metadata.getId()))) {
             throw new SecurityException(
-                "Only the owner of the metadata can get the status. User is not the owner of the metadata");
+                messages.getString("api.metadata.status.errorGetStatusNotAllowed"));
         }
 
         MetadataStatus recordStatus = metadataStatus.getStatus(metadata.getId());
@@ -476,7 +476,7 @@ public class MetadataWorkflowApi {
         // --- only allow the owner of the record to set its status
         if (!accessManager.isOwner(context, String.valueOf(metadata.getId()))) {
             throw new SecurityException(
-                "Only the owner of the metadata can set the status of this record. User is not the owner of the metadata.");
+                messages.getString("api.metadata.status.errorSetStatusNotAllowed"));
         }
 
         boolean isAllowedSubmitApproveInvalidMd = settingManager
@@ -526,13 +526,13 @@ public class MetadataWorkflowApi {
 
         if ((status.getStatus() == Integer.parseInt(StatusValue.Status.APPROVED) && notifyByEmail)
             && (this.metadataUtils.isMetadataPublished(metadataIdApproved))) {
-                MetadataPublicationNotificationInfo metadataNotificationInfo = new MetadataPublicationNotificationInfo();
-                metadataNotificationInfo.setMetadataUuid(metadata.getUuid());
-                metadataNotificationInfo.setMetadataId(metadataIdApproved);
-                metadataNotificationInfo.setGroupId(metadata.getSourceInfo().getGroupOwner());
-                metadataNotificationInfo.setPublished(true);
-                metadataNotificationInfo.setPublicationDateStamp(new ISODate());
-                metadataNotificationInfo.setReapproval(metadataIdApproved != metadata.getId());
+            MetadataPublicationNotificationInfo metadataNotificationInfo = new MetadataPublicationNotificationInfo();
+            metadataNotificationInfo.setMetadataUuid(metadata.getUuid());
+            metadataNotificationInfo.setMetadataId(metadataIdApproved);
+            metadataNotificationInfo.setGroupId(metadata.getSourceInfo().getGroupOwner());
+            metadataNotificationInfo.setPublished(true);
+            metadataNotificationInfo.setPublicationDateStamp(new ISODate());
+            metadataNotificationInfo.setReapproval(metadataIdApproved != metadata.getId());
 
 
             // If the metadata workflow is enabled retrieve the submitter and reviewer users information

--- a/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages.properties
+++ b/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages.properties
@@ -204,3 +204,5 @@ api.metadata.share.errorMetadataNotApproved=The metadata '%s' it's not approved,
 api.metadata.share.ErrorUserNotAllowedToPublish=User not allowed to publish the metadata %s. %s
 api.metadata.share.strategy.groupOwnerOnly=You need to be administrator, or reviewer of the metadata group.
 api.metadata.share.strategy.reviewerInGroup=You need to be administrator, or reviewer of the metadata group or reviewer with edit privilege on the metadata.
+api.metadata.status.errorGetStatusNotAllowed=Only the owner of the metadata can get the status. User is not the owner of the metadata.
+api.metadata.status.errorSetStatusNotAllowed=Only the owner of the metadata can set the status of this record. User is not the owner of the metadata.

--- a/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages_fre.properties
+++ b/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages_fre.properties
@@ -191,3 +191,5 @@ api.metadata.share.errorMetadataNotApproved=La fiche '%s' n'est pas approuv\u00E
 api.metadata.share.ErrorUserNotAllowedToPublish=L'utilisateur n'est pas autoris\u00E9 \u00E0 publier la fiche %s. %s
 api.metadata.share.strategy.groupOwnerOnly=Vous devez \u00EAtre administrateur ou relecteur du groupe de la fiche.
 api.metadata.share.strategy.reviewerInGroup=Vous devez \u00EAtre administrateur ou relecteur du groupe de la fiche ou relecteur avec un privil\u00E8ge de modification sur les fiches.
+api.metadata.status.errorGetStatusNotAllowed=Seul le propri\u00E9taire des m\u00E9tadonn\u00E9es peut obtenir le statut de cet enregistrement. L'utilisateur n'est pas le propri\u00E9taire des m\u00E9tadonn\u00E9es
+api.metadata.status.errorSetStatusNotAllowed=Seul le propri\u00E9taire des m\u00E9tadonn\u00E9es peut d\u00E9finir le statut de cet enregistrement. L'utilisateur n'est pas le propri\u00E9taire des m\u00E9tadonn\u00E9es


### PR DESCRIPTION
Use translations from `Messages.properties` for security exceptions thrown in the metadata workflow API.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
