### PR TITLE
Don't capitalize the labels for the facet filter values

### DIFF
--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facet.html
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facet.html
@@ -32,7 +32,7 @@
       ></span>
       <span class="gn-facet-label flex-shrink text-ellipsis">
         {{::ctrl.item.value | facetTranslator: (ctrl.facet.meta && ctrl.facet.meta.field)
-        || ctrl.facet.key | capitalize}}
+        || ctrl.facet.key}}
       </span>
       <span
         ng-if="ctrl.item.count"

--- a/web-ui/src/main/resources/catalog/components/search/mdview/partials/keywordBadges.html
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/partials/keywordBadges.html
@@ -17,7 +17,7 @@
       class="pull-left"
     >
       <button gn-popover-anchor="" class="btn btn-default btn-xs">
-        {{::k.default | capitalize}}
+        {{::k.default}}
       </button>
       <div gn-popover-content="">
         <a data-ng-href="{{::k.link}}" data-ng-if="::!!k.link">


### PR DESCRIPTION
Test case:

1. Create a metadata with a keyword `World`
2. Create another metadata with a keyword `world`

Before:
![keyword-facet-before](https://github.com/geonetwork/core-geonetwork/assets/1695003/3f3fefc9-d508-4a04-b09a-02acb1583969)

It's confusing that 2 filters `World` are displayed, the first one corresponds to the keyword `World` and the second one to the keyword `world`.

After:

![keyword-facet-after](https://github.com/geonetwork/core-geonetwork/assets/1695003/13c17278-8ae3-4c6e-82a6-27db44e8983a)

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
