### PR TITLE
Transfer ownership / fix translation key for Save button

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/transferownership.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/transferownership.html
@@ -26,7 +26,7 @@
       data-ng-disabled="!selectedUserGroup"
     >
       <i class="fa fa-save"></i>&nbsp
-      <span data-translate="" class="ng-scope">Save</span>
+      <span data-translate="" class="ng-scope">save</span>
     </button>
   </div>
 


### PR DESCRIPTION
Without the fix, the `Save` button displayed the text `Save` in all languages, instead of the translation.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation