### PR TITLE
Standard / ISO19115-3 / Only search for associated record with UUID

### DIFF
--- a/schemas/iso19115-3.2018/src/main/java/org/fao/geonet/schema/iso19115_3_2018/ISO19115_3_2018SchemaPlugin.java
+++ b/schemas/iso19115-3.2018/src/main/java/org/fao/geonet/schema/iso19115_3_2018/ISO19115_3_2018SchemaPlugin.java
@@ -181,7 +181,7 @@ public class ISO19115_3_2018SchemaPlugin
 
     @Override
     public Set<AssociatedResource> getAssociatedFeatureCatalogues(Element metadata) {
-        return collectAssociatedResources(metadata, "*//mrc:featureCatalogueCitation[@uuidref]");
+        return collectAssociatedResources(metadata, "*//mrc:featureCatalogueCitation[@uuidref != '']");
     }
 
     public Set<String> getAssociatedSourceUUIDs(Element metadata) {
@@ -193,7 +193,7 @@ public class ISO19115_3_2018SchemaPlugin
 
     @Override
     public Set<AssociatedResource> getAssociatedSources(Element metadata) {
-        return collectAssociatedResources(metadata, "*//mrl:source");
+        return collectAssociatedResources(metadata, "*//mrl:source[@uuidref != '']");
     }
 
     private Set<AssociatedResource> collectAssociatedResources(Element metadata, String xpath) {


### PR DESCRIPTION
Sources or feature catalogue reference may be described using description or uuidref.

Do not consider text description while searching for associated records. eg.

```xml
   <mdb:resourceLineage >
      <mrl:LI_Lineage>
         <mrl:source>
            <mrl:LI_Source>
               <mrl:description xsi:type="lan:PT_FreeText_PropertyType">
                  <gco:CharacterString>Le référentiel utilisé comme trait de côte est celui de Ifremer-Shom au 1/25 000 (date de révision 1995).</gco:CharacterString>
```

This is not really visible but avoid to do search with an empty id in `MetadataUtils#getAssociated`


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

