### PR TITLE
Fix issue with Map Attribution not being toggled correctly in data preview.

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/less/gn_result_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_result_default.less
@@ -479,7 +479,6 @@
     ul {
       margin-top: 2px;
       max-width: none;
-      display: block;
       a {
         color: @link-color;
       }


### PR DESCRIPTION
Before the fix, when using custom map (something other than open streetmap), going in the Discover Data section

![image](https://github.com/geonetwork/core-geonetwork/assets/1868233/4856f82d-f59d-49d8-9024-aefcf67ff59b)

The attribution show/hide button is not working.

![image](https://github.com/geonetwork/core-geonetwork/assets/1868233/4ac1f83c-8a15-44dc-9f0e-764d03eb3b2a)

And if the button was clicked

![image](https://github.com/geonetwork/core-geonetwork/assets/1868233/06355649-a990-4ce5-948e-cd9ae2cb1a15)

After the fix

![image](https://github.com/geonetwork/core-geonetwork/assets/1868233/34d147e6-671a-480d-9554-a365441328a8)

And if clicked

![image](https://github.com/geonetwork/core-geonetwork/assets/1868233/fa761479-47e6-4034-a6db-97961279dd59)

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

