### PR TITLE
Fix canViewRecord function so that it returned the workflow record.

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/ApiUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/ApiUtils.java
@@ -119,15 +119,16 @@ public class ApiUtils {
             id = String.valueOf(metadata.getId());
         }
 
-        if (!StringUtils.hasLength(id) && Lib.type.isInteger(id)) {
-            //It wasn't a UUID
-            id = String.valueOf(metadataUtils.findOne(uuidOrInternalId).getId());
+        AbstractMetadata foundMetadata = null;
+        if (!StringUtils.hasLength(id) && Lib.type.isInteger(uuidOrInternalId)) {
+            //It wasn't a UUID so assume it is an internalId which should be a number
+            foundMetadata = metadataUtils.findOne(uuidOrInternalId);
         } else if (Boolean.TRUE.equals(approved)) {
             //It was a UUID, check if draft or approved version
-            AbstractMetadata approvedMetadata = ApplicationContextHolder.get().getBean(MetadataRepository.class).findOneByUuid(uuidOrInternalId);
-            if (approvedMetadata != null) {
-                id = String.valueOf(approvedMetadata.getId());
-            }
+            foundMetadata = ApplicationContextHolder.get().getBean(MetadataRepository.class).findOneByUuid(uuidOrInternalId);
+        }
+        if (foundMetadata != null) {
+            id = String.valueOf(foundMetadata.getId());
         }
 
         if (!StringUtils.hasLength(id)) {

--- a/services/src/main/java/org/fao/geonet/api/ApiUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/ApiUtils.java
@@ -119,13 +119,15 @@ public class ApiUtils {
             id = String.valueOf(metadata.getId());
         }
 
-        if (StringUtils.isEmpty(id)) {
+        if (!StringUtils.hasLength(id) && Lib.type.isInteger(id)) {
             //It wasn't a UUID
             id = String.valueOf(metadataUtils.findOne(uuidOrInternalId).getId());
         } else if (Boolean.TRUE.equals(approved)) {
             //It was a UUID, check if draft or approved version
-            id = String.valueOf(ApplicationContextHolder.get().getBean(MetadataRepository.class)
-                .findOneByUuid(uuidOrInternalId).getId());
+            AbstractMetadata approvedMetadata = ApplicationContextHolder.get().getBean(MetadataRepository.class).findOneByUuid(uuidOrInternalId);
+            if (approvedMetadata != null) {
+                id = String.valueOf(approvedMetadata.getId());
+            }
         }
 
         if (StringUtils.isEmpty(id)) {
@@ -295,13 +297,7 @@ public class ApiUtils {
      */
     public static AbstractMetadata canViewRecord(String metadataUuid, boolean approved, HttpServletRequest request) throws Exception {
         String metadataId;
-        if (!approved) {
-            // If the record is not approved then we need to get the id of the record.
-            metadataId = getInternalId(metadataUuid, approved);
-        } else {
-            // Otherwise use the uuid or id that was supplied.
-            metadataId = metadataUuid;
-        }
+        metadataId = getInternalId(metadataUuid, approved);
 
         AbstractMetadata metadata = getRecord(metadataId);
         try {

--- a/services/src/main/java/org/fao/geonet/api/ApiUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/ApiUtils.java
@@ -130,7 +130,7 @@ public class ApiUtils {
             }
         }
 
-        if (StringUtils.isEmpty(id)) {
+        if (!StringUtils.hasLength(id)) {
             throw new ResourceNotFoundException(String.format(
                 "Record with UUID '%s' not found in this catalog",
                 uuidOrInternalId));


### PR DESCRIPTION
Prior to this fix, it would always return working copy record if it exists.

Regression caused by https://github.com/geonetwork/core-geonetwork/pull/7248

I had assumed that getRecord() was going to get the approved copy but it does not.  It can return working copy if they exists.

This is causing apis like 
![image](https://github.com/geonetwork/core-geonetwork/assets/1868233/5a6d7932-2c90-497a-97c9-bf5b054cfcfd)

and 

![image](https://github.com/geonetwork/core-geonetwork/assets/1868233/c396e34d-d844-4510-815c-af24b721d687)

to return the status history on the working copy records instead of the approved records.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

