### PR TITLE
Add support for multilingual thesaurus titles in the index

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
@@ -574,6 +574,12 @@
                     id="{$thesaurusId}"
                     uri="{$thesaurusUri}"
                     title="{$thesaurusTitle}">
+                <xsl:if test="not(starts-with($thesaurusTitle, 'otherKeywords'))">
+                  <multilingualTitle>
+                    <xsl:copy-of select="gn-fn-index:add-multilingual-field('multilingualTitle',
+                            mri:thesaurusName/*/cit:title, $allLanguages, false(), true())"/>
+                  </multilingualTitle>
+                </xsl:if>
               </info>
               <keywords>
                 <xsl:for-each select="$keywords">
@@ -1015,7 +1021,7 @@
         </xsl:apply-templates>
       </xsl:if>
 
-      
+
       <xsl:variable name="jsonFeatureTypes">[
         <xsl:for-each select="mdb:contentInfo//gfc:FC_FeatureCatalogue/gfc:featureType">{
 

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
@@ -526,6 +526,12 @@
                     id="{$thesaurusId}"
                     uri="{$thesaurusUri}"
                     title="{$thesaurusTitle}">
+                <xsl:if test="not(starts-with($thesaurusTitle, 'otherKeywords'))">
+                  <multilingualTitle>
+                    <xsl:copy-of select="gn-fn-index:add-multilingual-field('multilingualTitle',
+                            gmd:thesaurusName/*/gmd:title, $allLanguages, false(), true())"/>
+                  </multilingualTitle>
+                </xsl:if>
               </info>
               <keywords>
                 <xsl:for-each select="$keywords">

--- a/web-ui/src/main/resources/catalog/components/catalog/CatalogService.js
+++ b/web-ui/src/main/resources/catalog/components/catalog/CatalogService.js
@@ -748,6 +748,9 @@
               Object.keys(field).forEach(
                 function (th) {
                   this.translateMultilingualObjects.call(this, field[th].keywords);
+                  if (field[th].multilingualTitle != null) {
+                    this.translateMultilingualObjects(field[th].multilingualTitle);
+                  }
                 }.bind(this)
               );
             } else if (

--- a/web-ui/src/main/resources/catalog/components/search/mdview/partials/keywordBadges.html
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/partials/keywordBadges.html
@@ -1,7 +1,7 @@
 <div
   data-ng-repeat="(key, t) in allKeywords"
   data-ng-if="thesaurus && thesaurus.indexOf(key) !== -1"
-  title="{{t.title}}"
+  title="{{t.multilingualTitle.default || t.title}}"
   class="row"
 >
   <div

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/technical.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/technical.html
@@ -79,7 +79,7 @@
       <i class="fa fa-fw fa-tags"></i>
     </span>
     <div>
-      <h3 data-translate="">{{(t.title || key) | translate}}</h3>
+      <h3 data-translate="">{{(t.multilingualTitle.default || t.title || key) | translate}}</h3>
 
       <div data-gn-keyword-badges="mdView.current.record" data-thesaurus="key"></div>
     </div>

--- a/web/src/main/webapp/xslt/common/index-utils.xsl
+++ b/web/src/main/webapp/xslt/common/index-utils.xsl
@@ -447,7 +447,16 @@
         <xsl:if test="info/@id != ''">
           "id": "<xsl:value-of select="util:escapeForJson(info/@id)"/>",
         </xsl:if>
-        "title": "<xsl:value-of select="util:escapeForJson(info/@title)"/>",
+        <xsl:choose>
+          <xsl:when test="exists(info/multilingualTitle)">
+            "multilingualTitle": {
+              <xsl:value-of select="string-join(info/multilingualTitle/value, ', ')"/>
+            },
+          </xsl:when>
+          <xsl:otherwise>
+            "title": "<xsl:value-of select="util:escapeForJson(info/@title)"/>",
+          </xsl:otherwise>
+        </xsl:choose>
         "theme": "<xsl:value-of select="util:escapeForJson(info/@type)"/>",
         <xsl:if test="info/@uri != ''">
           "link": "<xsl:value-of select="util:escapeForJson(info/@uri)"/>",


### PR DESCRIPTION
Fix for issue [#384](https://github.com/metadata101/iso19139.ca.HNAP/issues/384)

In the geonetwork 4 record "default view", the keywords thesaurus titles only show in the main language of the record regardless of the UI language.

Example scenario:

- Add a new iso19139.ca.HNAP record with a main language of English and alternate language of French
- Add some keywords from a thesaurus to the record (Ex. Government of Canada Core Subject Thesaurus)
- Open the record in the default view with the UI language set to French
![image](https://github.com/geonetwork/core-geonetwork/assets/163562062/0aafb7ec-3cee-47bc-a734-9543f939850e)
- Under Technical Information / Informations techniques the thesaurus title appears in English
![image](https://github.com/geonetwork/core-geonetwork/assets/163562062/2dc0ae5c-cb67-44fa-a3c3-0ede07592b92)

This PR aims to solve this issue by introducing support for multilingual values for thesaurus titles in the index. These changes maintain functionality for unilingual titles by falling back to title instead of multilingualTitle.

The multilingualTitle element must be implemented in the schema plugin's index.xsl for these changes to have any effect.

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

