### PR TITLE
Harvester / ISO19115-3 / Better support missing metadata date info

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/extract-date-modified.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/extract-date-modified.xsl
@@ -3,27 +3,21 @@
   version="2.0"
   xmlns:cit="http://standards.iso.org/iso/19115/-3/cit/2.0"
   xmlns:mdb="http://standards.iso.org/iso/19115/-3/mdb/2.0"
-  xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+  xmlns:xs="http://www.w3.org/2001/XMLSchema">
+
+  <xsl:variable name="dateFormat"
+                as="xs:string"
+                select="'[Y0001]-[M01]-[D01]T[H01]:[m01]:[s01][ZN]'"/>
 
   <xsl:template
     match="mdb:MD_Metadata">
-    <xsl:variable name="revisionDate"
-                  select="(mdb:dateInfo/cit:CI_Date
-      [cit:dateType/cit:CI_DateTypeCode/@codeListValue='revision']
-      /cit:date/*)[1]"/>
     <dateStamp>
-      <xsl:choose>
-        <xsl:when test="normalize-space($revisionDate)">
-          <xsl:value-of select="$revisionDate"/>
-        </xsl:when>
-        <xsl:otherwise>
-          <xsl:value-of select="mdb:dateInfo/cit:CI_Date
-            [cit:dateType/cit:CI_DateTypeCode/@codeListValue='creation']
-            /cit:date/*"/>
-          <!-- TODO: Should we handle when no creation nor revision date
-          defined ? -->
-        </xsl:otherwise>
-      </xsl:choose>
+      <xsl:value-of select="(
+        mdb:dateInfo/*[cit:dateType/*/@codeListValue = 'revision']/cit:date/*[. != ''],
+        mdb:dateInfo/*[cit:dateType/*/@codeListValue = 'creation']/cit:date/*[. != ''],
+        format-dateTime(current-dateTime(), $dateFormat)
+      )[1]"/>
     </dateStamp>
   </xsl:template>
 </xsl:stylesheet>


### PR DESCRIPTION
While harvesting, `extract-date-modified.xsl` is used to retrieve last update of the record. If empty, harvester will fail with:

```
[geonetwork.harvester] - Invalid ISO date: 
java.lang.IllegalArgumentException: Invalid ISO date: 
	at org.fao.geonet.domain.ISODate.parseDate(ISODate.java:426) ~[gn-domain-4.4.5-SNAPSHOT.jar:?]
	at org.fao.geonet.domain.ISODate.setDateAndTime(ISODate.java:239) ~[gn-domain-4.4.5-SNAPSHOT.jar:?]
	at org.fao.geonet.domain.ISODate.<init>(ISODate.java:117) ~[gn-domain-4.4.5-SNAPSHOT.jar:?]
	at org.fao.geonet.kernel.harvest.harvester.simpleurl.Aligner.addMetadata(Aligner.java:237) ~[gn-harvesters-4.4.5-SNAPSHOT.jar:?]
	at org.fao.geonet.kernel.harvest.harvester.simpleurl.Aligner.lambda$insertOrUpdate$0(Aligner.java:126) ~[gn-harvesters-4.4.5-SNAPSHOT.jar:?]
```


Fallback to now.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

