### PR TITLE
Record view / display WMS resources button label to open the link when the map viewer is not enabled

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/recordLinkButton.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/recordLinkButton.html
@@ -38,5 +38,8 @@
   data-ng-href="{{link.url}}"
 >
   <i class="fa" data-ng-if="iconMode !== 'none'" data-ng-class="icon"></i>
-  <span class="visible-lg-*"> {{::link.title | gnLocalized: lang}} </span>
+  <span class="visible-lg-*">
+    {{::(link.title ? (link.title | gnLocalized: lang) : (service.getLabel(null, type) |
+    translate))}}
+  </span>
 </a>


### PR DESCRIPTION
Test case:

1) Import the iso19139 metadata samples
2) In the UI settings, disable the map application
3) Go to the `Hydrological Basins in Africa` record view

Without the fix:

![button-no-fix](https://github.com/geonetwork/core-geonetwork/assets/1695003/01281571-b5db-471a-9fbe-19d3099030c7)

With the fix:

![button-fix](https://github.com/geonetwork/core-geonetwork/assets/1695003/63d36a3c-de35-427c-9f55-83881917071c)

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
