### PR TITLE
Record view / don't display the add to map button for WFS resources when the map viewer is disabled.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/RelatedResourcesService.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/RelatedResourcesService.js
@@ -135,56 +135,9 @@
       var addEsriRestToMap =
         gnViewerSettings.resultviewFns && gnViewerSettings.resultviewFns.addMdLayerToMap;
 
-      var addWFSToMap = function (link, md) {
-        var url = $filter("gnLocalized")(link.url) || link.url;
-        gnWebAnalyticsService.trackLink(url, link.protocol);
-
-        var isServiceLink =
-          gnSearchSettings.mapProtocols.services.indexOf(link.protocol) > -1;
-
-        var isGetFeatureLink = url.toLowerCase().indexOf("request=getfeature") > -1;
-
-        var featureName;
-        if (isGetFeatureLink) {
-          var name = "typename";
-          var regex = new RegExp("[\\?&]" + name + "=([^&#]*)");
-          var results = regex.exec(url);
-
-          if (results) {
-            featureName = decodeURIComponent(results[1].replace(/\+/g, " "));
-          }
-        } else {
-          featureName = $filter("gnLocalized")(link.title) || link.name;
-        }
-
-        // if an external viewer is defined, use it here
-        if (gnExternalViewer.isEnabled()) {
-          gnExternalViewer.viewService(
-            {
-              id: md ? md.id : null,
-              uuid: md ? md.uuid : null
-            },
-            {
-              type: "wfs",
-              url: url,
-              name: featureName
-            }
-          );
-          return;
-        }
-        if (featureName && (!isServiceLink || isGetFeatureLink)) {
-          gnMap.addWfsFromScratch(
-            gnSearchSettings.viewerMap,
-            url,
-            featureName,
-            false,
-            md
-          );
-        } else {
-          gnMap.addOwsServiceToMap(url, "WFS");
-        }
-        gnSearchLocation.setMap();
-      };
+      var addWFSToMap =
+        gnViewerSettings.resultviewFns &&
+        gnViewerSettings.resultviewFns.addMdWFSLayerToMap;
 
       var addWMTSToMap =
         gnViewerSettings.resultviewFns && gnViewerSettings.resultviewFns.addMdLayerToMap;

--- a/web-ui/src/main/resources/catalog/views/default/module.js
+++ b/web-ui/src/main/resources/catalog/views/default/module.js
@@ -437,6 +437,56 @@
             add: encodeURIComponent(angular.toJson([config]))
           });
         },
+        addMdWFSLayerToMap: function (link, md) {
+          var url = $filter("gnLocalized")(link.url) || link.url;
+          gnWebAnalyticsService.trackLink(url, link.protocol);
+
+          var isServiceLink =
+            gnSearchSettings.mapProtocols.services.indexOf(link.protocol) > -1;
+
+          var isGetFeatureLink = url.toLowerCase().indexOf("request=getfeature") > -1;
+
+          var featureName;
+          if (isGetFeatureLink) {
+            var name = "typename";
+            var regex = new RegExp("[\\?&]" + name + "=([^&#]*)");
+            var results = regex.exec(url);
+
+            if (results) {
+              featureName = decodeURIComponent(results[1].replace(/\+/g, " "));
+            }
+          } else {
+            featureName = $filter("gnLocalized")(link.title) || link.name;
+          }
+
+          // if an external viewer is defined, use it here
+          if (gnExternalViewer.isEnabled()) {
+            gnExternalViewer.viewService(
+              {
+                id: md ? md.id : null,
+                uuid: md ? md.uuid : null
+              },
+              {
+                type: "wfs",
+                url: url,
+                name: featureName
+              }
+            );
+            return;
+          }
+          if (featureName && (!isServiceLink || isGetFeatureLink)) {
+            gnMap.addWfsFromScratch(
+              gnSearchSettings.viewerMap,
+              url,
+              featureName,
+              false,
+              md
+            );
+          } else {
+            gnMap.addOwsServiceToMap(url, "WFS");
+          }
+          gnSearchLocation.setMap();
+        },
         addAllMdLayersToMap: function (layers, md) {
           var config = layers
             .map(function (layer) {
@@ -448,7 +498,7 @@
           if (config.length === 0) {
             return;
           }
-          
+
           config.forEach(function (c) {
             gnWebAnalyticsService.trackLink(c.url, c.type);
           });


### PR DESCRIPTION
It works fine in debug mode, but not in production mode.

Test case:

1) Create an iso19139 or iso19115-3.2008 metadata and add a WFS layer.
2) With the map application enabled (default) go to the record view page --> The `Add to map` button is displayed and adding the layer to the map viewer, should open it and load the layer.
3) Disable in the UI settings the map application.
4) In the record view:

  - Without the fix, the `Add to map` button is displayed, but it should show an `Open link` button instead

![add-to-map](https://github.com/geonetwork/core-geonetwork/assets/1695003/0ac1db71-7a68-4e32-a1f7-3341b13c4214)

  - With the fix, the `Open link` button is displayed, clicking on it, opens the WFS capabilities document

![open-link](https://github.com/geonetwork/core-geonetwork/assets/1695003/a0a9f153-6b76-4053-b80b-eda840df0339)

---

It seems related to wroj4j renaming due to the function defined inline, to fix it has been refactor in a similar way of the other functions used to add WMS / WMTS / ... map resources.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
