### PR TITLE
Fix html <i> elements defined in javascript with wrong self-closing

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/crsselector/partials/crsselector.html
+++ b/web-ui/src/main/resources/catalog/components/edit/crsselector/partials/crsselector.html
@@ -23,11 +23,7 @@
       <li href="" class="list-group-item" data-ng-repeat="crs in crsResults">
         {{crs.description}}
         <span class="pull-right">
-          <a
-            href=""
-            data-ng-click="addCRS(crs)"
-            title="{{'addCRS-help' | translate}}"
-          >
+          <a href="" data-ng-click="addCRS(crs)" title="{{'addCRS-help' | translate}}">
             <i class="fa fa-fw fa-plus"></i>
           </a>
         </span>

--- a/web-ui/src/main/resources/catalog/components/metadatamanager/EditorService.js
+++ b/web-ui/src/main/resources/catalog/components/metadatamanager/EditorService.js
@@ -414,9 +414,10 @@
             version: getInputValue("version"),
             tab: getInputValue("currTab"),
             geoPublisherConfig: angular.fromJson(getInputValue("geoPublisherConfig")),
-            resourceContainerDescription: getInputValue("resourceContainerDescription") ==''? null : angular.fromJson(
-              getInputValue("resourceContainerDescription")
-            ),
+            resourceContainerDescription:
+              getInputValue("resourceContainerDescription") == ""
+                ? null
+                : angular.fromJson(getInputValue("resourceContainerDescription")),
             resourceManagementExternalProperties: angular.fromJson(
               getInputValue("resourceManagementExternalProperties")
             ),

--- a/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
+++ b/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
@@ -866,7 +866,7 @@
                 var conceptIdElement = angular.element(
                   '<div class="well well-sm gn-keyword-picker-concept-id row">' +
                     '  <div class="form-group">' +
-                    '    <label class="col-sm-4"><i class="fa fa-link fa-fw"/><span data-translate>URL</span></label>' +
+                    '    <label class="col-sm-4"><i class="fa fa-link fa-fw"></i><span data-translate>URL</span></label>' +
                     '    <div class="col-sm-6"><input ' +
                     inputPropertyName +
                     '="' +

--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -1223,7 +1223,7 @@
           '           href=""' +
           '           title="{{::title | translate}}">' +
           '  <i class="fa fa-fw" ' +
-          "   ng-class=\"{'fa-copy': !copied, 'fa-check': copied}\"/>" +
+          "   ng-class=\"{'fa-copy': !copied, 'fa-check': copied}\"></i>" +
           "</a>",
         scope: {
           btnClass: "@",
@@ -2533,7 +2533,7 @@
                   '">' +
                   '<div class="modal-dialog gn-img-modal in">' +
                   '  <button type=button class="btn btn-danger gn-btn-modal-img">' +
-                  '<i class="fa fa-times"/></button>' +
+                  '<i class="fa fa-times"></i></button>' +
                   '  <img src="' +
                   (attr.ngSrc || img.lUrl || img.url || img.id) +
                   '"/>' +

--- a/web-ui/src/main/resources/catalog/js/admin/DashboardWfsIndexingController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/DashboardWfsIndexingController.js
@@ -354,7 +354,7 @@
                         "</span>" +
                         "  </a>" +
                         '  <div class="alert alert-danger small" style="display: none" role="alert"></div>' +
-                        '  <i class="fa fa-spinner fa-spin"/>' +
+                        '  <i class="fa fa-spinner fa-spin"></i>' +
                         "</div>" +
                         "<code>" +
                         row.mdUuid +

--- a/web-ui/src/main/resources/catalog/views/default/module.js
+++ b/web-ui/src/main/resources/catalog/views/default/module.js
@@ -448,7 +448,7 @@
           if (config.length === 0) {
             return;
           }
-          
+
           config.forEach(function (c) {
             gnWebAnalyticsService.trackLink(c.url, c.type);
           });


### PR DESCRIPTION
Follow up of #8015

Includes also prettier formatting fixes for other files

---

No need to backport this pull request as the changes are applied to the jQuery 3.7.1 backport PR (https://github.com/geonetwork/core-geonetwork/pull/8105)

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
