### PR TITLE
Map viewer / fix TMS layer persistence in map context

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -2323,7 +2323,8 @@
                   source: new ol.source.XYZ({
                     url: opt.url
                   }),
-                  title: title || "TMS Layer"
+                  title: title || "TMS Layer",
+                  name: opt.name
                 });
               case "bing_aerial":
                 return new ol.layer.Tile({

--- a/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextService.js
@@ -601,6 +601,19 @@
                 service: "urn:ogc:serviceType:WMS"
               }
             ];
+          } else if (source instanceof ol.source.TileImage) {
+            name = "{type=tms,name=" + layer.get("name") + "}";
+
+            params.server = [
+              {
+                onlineResource: [
+                  {
+                    href: layer.getSource().getUrls()[0]
+                  }
+                ],
+                service: "urn:ogc:serviceType:WMTS"
+              }
+            ];
           } else {
             return;
           }


### PR DESCRIPTION
TMS layers in the context file were not persisted when using for the map 
 persistence the option `sessionStorage` or `localStorage`, causing the layers not being displayed when reloading the browser.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
