### PR TITLE
Map viewer / Add layer with styles from a metadata doesn't show the styles selector

### DIFF
--- a/web-ui/src/main/resources/catalog/components/viewer/layermanager/partials/layermanageritem.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/layermanager/partials/layermanageritem.html
@@ -110,7 +110,7 @@
         <h6 ng-if="layer.get('attribution')" data-translate="">Attribution</h6>
         <p ng-if="layer.get('attribution')"><em>{{layer.get('attribution')}}</em></p>
 
-        <div data-ng-if="::!layer.get('wfs') && layer.get('style').length > 0">
+        <div data-ng-if="::layer.get('style').length > 0">
           <div
             data-gn-layer-styles="layer.get('style')"
             data-gn-layer-styles-on-click="setLayerStyle(layer, style)"


### PR DESCRIPTION
The display of the style selector was linked to a layer property that is used for:

- the filter panel to work with WFS features
- and the data download

It's unclear why the layer styling was linked to that property as doesn't seem to be related.

---

Test case:

1) Create a metadata with WMS layer that has multiple styles

2) From the metadata page add the layer to the map viewer.

   - Without the fix: No style selector is displayed
![wrong-no-styles](https://github.com/geonetwork/core-geonetwork/assets/1695003/d6ea302c-ee5b-4fb3-91bd-91b69a85b9a4)

   - With the fix: The style selector is displayed
![fix-styles](https://github.com/geonetwork/core-geonetwork/assets/1695003/8f6834bf-bc77-4094-a12b-f62297d6b94c)


# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation


