### PR TITLE
Metadata extents API - fix service for metadata with working copy

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/extent/MetadataExtentApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/extent/MetadataExtentApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2021 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2024 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -45,7 +45,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
-import org.springframework.stereotype.Controller;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.context.request.NativeWebRequest;
@@ -65,7 +64,7 @@ import static org.fao.geonet.api.ApiParams.*;
 })
 @Tag(name = API_CLASS_RECORD_TAG,
     description = API_CLASS_RECORD_OPS)
-@Controller("recordExtent")
+@RestController("recordExtent")
 @ReadWriteController
 public class MetadataExtentApi {
 
@@ -118,12 +117,11 @@ public class MetadataExtentApi {
     @io.swagger.v3.oas.annotations.Operation(
         summary = "Get record extents as image",
         description = API_EXTENT_DESCRIPTION)
-    @RequestMapping(
+    @GetMapping(
         value = "/{metadataUuid}/extents.png",
         produces = {
             MediaType.IMAGE_PNG_VALUE
-        },
-        method = RequestMethod.GET)
+        })
     public HttpEntity<byte[]> getAllRecordExtentAsImage(
         @Parameter(
             description = API_PARAM_RECORD_UUID,
@@ -144,6 +142,8 @@ public class MetadataExtentApi {
         @Parameter(description = API_PARAM_STROKE_DESCRIPTION)
         @RequestParam(value = "", required = false, defaultValue = "0,0,0,255")
         String strokeColor,
+        @RequestParam(required = false, defaultValue = "true")
+        Boolean approved,
         @Parameter(hidden = true)
             NativeWebRequest nativeWebRequest,
         @Parameter(hidden = true)
@@ -157,7 +157,7 @@ public class MetadataExtentApi {
                 "EPSG:4326");
         }
 
-        return getExtent(metadataUuid, srs, width, height, background, fillColor, strokeColor, null, nativeWebRequest, request);
+        return getExtent(metadataUuid, srs, width, height, background, fillColor, strokeColor, null, approved, nativeWebRequest, request);
     }
 
 
@@ -165,13 +165,11 @@ public class MetadataExtentApi {
     @io.swagger.v3.oas.annotations.Operation(
         summary = "Get list of record extents",
         description = API_EXTENT_DESCRIPTION)
-    @RequestMapping(
+    @GetMapping(
         value = "/{metadataUuid}/extents.json",
         produces = {
             MediaType.APPLICATION_JSON_VALUE
-        },
-        method = RequestMethod.GET)
-    @ResponseBody
+        })
     public List<ExtentDto> getAllRecordExtentAsJson(
         @Parameter(
             description = API_PARAM_RECORD_UUID,
@@ -215,7 +213,7 @@ public class MetadataExtentApi {
                     String.format("%sapi/records/%s/extents/%d.png",
                         settingManager.getNodeURL(), metadataUuid, index),
                     extentElement.getName(),
-                    XPath.getXPath(xmlData, (Element) extent),
+                    XPath.getXPath(xmlData, extent),
                     description));
                 index ++;
             }
@@ -227,12 +225,11 @@ public class MetadataExtentApi {
     @io.swagger.v3.oas.annotations.Operation(
         summary = "Get one record extent as image",
         description = API_EXTENT_DESCRIPTION)
-    @RequestMapping(
+    @GetMapping(
         value = "/{metadataUuid}/extents/{geometryIndex}.png",
         produces = {
             MediaType.IMAGE_PNG_VALUE
-        },
-        method = RequestMethod.GET)
+        })
     public HttpEntity<byte[]> getOneRecordExtentAsImage(
         @Parameter(
             description = API_PARAM_RECORD_UUID,
@@ -256,6 +253,8 @@ public class MetadataExtentApi {
         @Parameter(description = API_PARAM_STROKE_DESCRIPTION)
         @RequestParam(value = "", required = false, defaultValue = "0,0,0,255")
             String strokeColor,
+        @RequestParam(required = false, defaultValue = "true")
+        Boolean approved,
         @Parameter(hidden = true)
             NativeWebRequest nativeWebRequest,
         @Parameter(hidden = true)
@@ -269,11 +268,13 @@ public class MetadataExtentApi {
                 "EPSG:4326");
         }
 
-        return getExtent(metadataUuid, srs, width, height, background, fillColor, strokeColor, geometryIndex, nativeWebRequest, request);
+        return getExtent(metadataUuid, srs, width, height, background, fillColor, strokeColor, geometryIndex, approved, nativeWebRequest, request);
     }
 
-    private HttpEntity<byte[]> getExtent(String metadataUuid, String srs, Integer width, Integer height, String background, String fillColor, String strokeColor, Integer extentOrderOfAppearance, NativeWebRequest nativeWebRequest, HttpServletRequest request) throws Exception {
-        AbstractMetadata metadata = ApiUtils.canViewRecord(metadataUuid, request);
+    private HttpEntity<byte[]> getExtent(String metadataUuid, String srs, Integer width, Integer height, String background, String fillColor, String strokeColor,
+                                         Integer extentOrderOfAppearance, Boolean approved,
+                                         NativeWebRequest nativeWebRequest, HttpServletRequest request) throws Exception {
+        AbstractMetadata metadata = ApiUtils.canViewRecord(metadataUuid, approved, request);
         ServiceContext context = ApiUtils.createServiceContext(request);
 
         if (width != null && height != null) {

--- a/services/src/main/java/org/fao/geonet/api/regions/metadata/MetadataRegionSearchRequest.java
+++ b/services/src/main/java/org/fao/geonet/api/regions/metadata/MetadataRegionSearchRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2024 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -24,14 +24,12 @@
 package org.fao.geonet.api.regions.metadata;
 
 import com.google.common.base.Optional;
-import com.google.common.collect.Lists;
 import jeeves.server.context.ServiceContext;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.GeonetContext;
 import org.fao.geonet.api.regions.MetadataRegion;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.ISODate;
-import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.ReservedOperation;
 import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.datamanager.IMetadataSchemaUtils;
@@ -39,9 +37,9 @@ import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.kernel.region.Region;
 import org.fao.geonet.kernel.region.Request;
 import org.fao.geonet.kernel.schema.MetadataSchema;
+import org.fao.geonet.kernel.search.EsSearchManager;
 import org.fao.geonet.kernel.search.spatial.ErrorHandler;
 import org.fao.geonet.lib.Lib;
-import org.fao.geonet.repository.MetadataRepository;
 import org.fao.geonet.util.GMLParsers;
 import org.fao.geonet.utils.Log;
 import org.fao.geonet.utils.Xml;
@@ -97,16 +95,16 @@ public class MetadataRegionSearchRequest extends Request {
         if (label == null && id == null || (id != null && !id.startsWith(PREFIX))) {
             return Collections.emptySet();
         }
-        List<Region> regions = new ArrayList<Region>();
+        List<Region> regions = new ArrayList<>();
         if (label != null) {
             loadAll(regions, Id.create(label));
         } else if (id != null) {
             String[] parts = id.split(":", 3);
             String mdId = parts[1];
-            String id;
+            String identifier;
             if (parts.length > 2) {
-                id = parts[2];
-                loadOnly(regions, Id.create(mdId), id);
+                identifier = parts[2];
+                loadOnly(regions, Id.create(mdId), identifier);
             } else {
                 loadSpatialExtent(regions, Id.create(mdId));
             }
@@ -189,13 +187,13 @@ public class MetadataRegionSearchRequest extends Request {
             }
         }
         return 0;
-    };
+    }
 
     Region parseRegion(Id mdId, Element extentObj) throws Exception {
         GeonetContext gc = (GeonetContext) context.getHandlerContext(Geonet.CONTEXT_NAME);
         gc.getBean(DataManager.class).getEditLib().removeEditingInfo(extentObj);
 
-        String id = null;
+        String regionId = null;
         Geometry geometry = null;
         Namespace objNamespace = extentObj.getNamespace();
         if ("polygon".equals(extentObj.getName())) {
@@ -227,9 +225,9 @@ public class MetadataRegionSearchRequest extends Request {
         if (geometry != null) {
             Element element = extentObj.getChild("element", Geonet.Namespaces.GEONET);
             if (element != null) {
-                id = element.getAttributeValue("ref");
+                regionId = element.getAttributeValue("ref");
             }
-            return new MetadataRegion(mdId, id, geometry);
+            return new MetadataRegion(mdId, regionId, geometry);
         } else {
             return null;
         }
@@ -281,9 +279,7 @@ public class MetadataRegionSearchRequest extends Request {
             final String mdId = MetadataRegionSearchRequest.Id.create(idParts[0]).getMdId();
 
             if (mdId != null) {
-                Metadata metadata = ApplicationContextHolder.get().getBean(MetadataRepository.class).findOneById(Integer.valueOf(mdId));
-
-                final ISODate docChangeDate = metadata.getDataInfo().getChangeDate();
+                final ISODate docChangeDate =  ApplicationContextHolder.get().getBean(EsSearchManager.class).getDocChangeDate(mdId);
                 if (docChangeDate != null) {
                     return Optional.of(docChangeDate.toDate().getTime());
                 }


### PR DESCRIPTION
Extents API for metadata with a working copy fails with a `NullPoiinterException` at: https://github.com/geonetwork/core-geonetwork/blob/3605e9f6dd28af798979b286101802586a6371a9/services/src/main/java/org/fao/geonet/api/regions/metadata/MetadataRegionSearchRequest.java#L286, as was trying to find the working copy metadata in the `Metadata` table. 

Changes:

- Updated the code to retrieve the date from the search index (as in version 3.12.x). 
- The API accepts now an optional parameter to retrieve the approved or the working copy versions.

Test case:

1) Enable the metadata workflow
2) Create an iso19139 metadata, approve it and edit it to create a working copy
3) Access the extents.png API: http://localhost:8080/geonetwork/srv/api/UUID/extents.png

  - Without the fix: an error is returned.
  - With the fix: the image is returned:
    -  http://localhost:8080/geonetwork/srv/api/UUID/extents.png: Extent for the approved version
    -  http://localhost:8080/geonetwork/srv/api/UUID/extents.png?approved=false: Extent for the working copy version
    
---

The change request includes also Sonarlint improvements.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [X] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
