### PR TITLE
Double translation can lead to infinite stack

### DIFF
--- a/web-ui/src/main/resources/catalog/components/admin/harvester/partials/extras.html
+++ b/web-ui/src/main/resources/catalog/components/admin/harvester/partials/extras.html
@@ -8,17 +8,17 @@
                      || harvester['@type'] == 'filesystem'"
   >
     <label class="control-label">
-      <span data-translate="">{{"harvesterOverrideUUID" | translate}}</span>
+      <span>{{"harvesterOverrideUUID" | translate}}</span>
     </label>
     <select data-ng-model="harvester.options.overrideUuid" class="form-control">
       <option value="SKIP">
-        <span data-translate="">{{"harvesterOverrideUUID-skip" | translate}}</span>
+        <span>{{"harvesterOverrideUUID-skip" | translate}}</span>
       </option>
       <option value="OVERRIDE">
-        <span data-translate="">{{"harvesterOverrideUUID-overwrite" | translate}}</span>
+        <span>{{"harvesterOverrideUUID-overwrite" | translate}}</span>
       </option>
       <option value="RANDOM">
-        <span data-translate="">{{"harvesterOverrideUUID-random" | translate}}</span>
+        <span>{{"harvesterOverrideUUID-random" | translate}}</span>
       </option>
     </select>
     <span class="help-block ng-scope" data-translate="">harvesterOverrideUUIDHelp</span>

--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/associatedResourcesContainer.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/associatedResourcesContainer.html
@@ -14,7 +14,7 @@
           data-ng-click="onlinesrcService.onOpenPopup(config.type, config.config)"
         >
           <i class="fa fa-fw fa-plus"></i>
-          <span data-translate="">{{ config.label | translate}}</span>
+          <span>{{ config.label | translate}}</span>
         </a>
       </h2>
       <div

--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/distributionResourcesContainer.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/distributionResourcesContainer.html
@@ -21,7 +21,7 @@
           data-ng-click="onlinesrcService.onOpenPopup('onlinesrc', action)"
         >
           <i class="fa fa-fw fa-plus"></i>
-          <span data-translate="">{{ action | translate}}</span>
+          <span>{{ action | translate}}</span>
         </a>
       </div>
     </div>

--- a/web-ui/src/main/resources/catalog/views/default/directives/partials/mdactionmenu.html
+++ b/web-ui/src/main/resources/catalog/views/default/directives/partials/mdactionmenu.html
@@ -229,14 +229,14 @@
           target="_blank"
         >
           <span class="fa fa-fw {{f.class}}"></span>&nbsp;
-          <span data-translate="">{{f.label | translate}}</span>
+          <span>{{f.label | translate}}</span>
         </a>
         <a
           data-ng-if="!!f.url === false && f.label.indexOf('PDF') !== -1"
           href="javascript:print();"
         >
           <span class="fa fa-fw {{f.class}}"></span>&nbsp;
-          <span data-translate="">{{f.label | translate}}</span>
+          <span>{{f.label | translate}}</span>
         </a>
       </li>
     </ul>

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/technical.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/technical.html
@@ -15,7 +15,7 @@
           ></i>
         </div>
         <span>
-          <h3 data-translate>{{date.type | translate}}</h3>
+          <h3>{{date.type | translate}}</h3>
           <span data-gn-humanize-time="{{date.date}}"></span>
         </span>
       </li>

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/technical.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/technical.html
@@ -79,7 +79,7 @@
       <i class="fa fa-fw fa-tags"></i>
     </span>
     <div>
-      <h3 data-translate="">{{(t.multilingualTitle.default || t.title || key) | translate}}</h3>
+      <h3>{{(t.multilingualTitle.default || t.title || key) | translate}}</h3>
 
       <div data-gn-keyword-badges="mdView.current.record" data-thesaurus="key"></div>
     </div>


### PR DESCRIPTION
I have seen the combination of `data-translate` and the `translate` pipe lead to an infinite stack in angularjs when there's a missing translation. Previously I fixed this in our own fork, but we identified a number of other occurrences that might be fixed as well. 

I tried replicating the issue but I'm having trouble identifying the exact situation. It doesn't happen for all types of translations, it seems, though I do recall that it went wrong with external thesauri labels. To avoid too much time on trying to figure out the specific failing situation: does it make sense to remove these duplicate translations? @fxprunayre 
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

