### PR TITLE
[Backport 4.2.x] Add support for multilingual thesaurus titles in the index (#8154)

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
@@ -565,6 +565,12 @@
                     id="{$thesaurusId}"
                     uri="{$thesaurusUri}"
                     title="{$thesaurusTitle}">
+                <xsl:if test="not(starts-with($thesaurusTitle, 'otherKeywords'))">
+                  <multilingualTitle>
+                    <xsl:copy-of select="gn-fn-index:add-multilingual-field('multilingualTitle',
+                            mri:thesaurusName/*/cit:title, $allLanguages, false(), true())"/>
+                  </multilingualTitle>
+                </xsl:if>
               </info>
               <keywords>
                 <xsl:for-each select="$keywords">
@@ -981,7 +987,7 @@
         </xsl:apply-templates>
       </xsl:if>
 
-      
+
       <xsl:variable name="jsonFeatureTypes">[
         <xsl:for-each select="mdb:contentInfo//gfc:FC_FeatureCatalogue/gfc:featureType">{
 

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
@@ -515,6 +515,12 @@
                     id="{$thesaurusId}"
                     uri="{$thesaurusUri}"
                     title="{$thesaurusTitle}">
+                <xsl:if test="not(starts-with($thesaurusTitle, 'otherKeywords'))">
+                  <multilingualTitle>
+                    <xsl:copy-of select="gn-fn-index:add-multilingual-field('multilingualTitle',
+                            gmd:thesaurusName/*/gmd:title, $allLanguages, false(), true())"/>
+                  </multilingualTitle>
+                </xsl:if>
               </info>
               <keywords>
                 <xsl:for-each select="$keywords">

--- a/web-ui/src/main/resources/catalog/components/catalog/CatalogService.js
+++ b/web-ui/src/main/resources/catalog/components/catalog/CatalogService.js
@@ -747,6 +747,9 @@
               Object.keys(field).forEach(
                 function (th) {
                   this.translateMultilingualObjects(field[th].keywords);
+                  if (field[th].multilingualTitle != null) {
+                    this.translateMultilingualObjects(field[th].multilingualTitle);
+                  }
                 }.bind(this)
               );
             } else if (

--- a/web-ui/src/main/resources/catalog/components/search/mdview/partials/keywordBadges.html
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/partials/keywordBadges.html
@@ -1,7 +1,7 @@
 <div
   data-ng-repeat="(key, t) in allKeywords"
   data-ng-if="thesaurus && thesaurus.indexOf(key) !== -1"
-  title="{{t.title}}"
+  title="{{t.multilingualTitle.default || t.title}}"
   class="row"
 >
   <div

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/technical.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/technical.html
@@ -79,7 +79,7 @@
       <i class="fa fa-fw fa-tags"></i>
     </span>
     <div>
-      <h3 data-translate="">{{(t.title || key) | translate}}</h3>
+      <h3 data-translate="">{{(t.multilingualTitle.default || t.title || key) | translate}}</h3>
 
       <div data-gn-keyword-badges="mdView.current.record" data-thesaurus="key"></div>
     </div>

--- a/web/src/main/webapp/xslt/common/index-utils.xsl
+++ b/web/src/main/webapp/xslt/common/index-utils.xsl
@@ -436,7 +436,16 @@
         <xsl:if test="info/@id != ''">
           "id": "<xsl:value-of select="util:escapeForJson(info/@id)"/>",
         </xsl:if>
-        "title": "<xsl:value-of select="util:escapeForJson(info/@title)"/>",
+        <xsl:choose>
+          <xsl:when test="exists(info/multilingualTitle)">
+            "multilingualTitle": {
+              <xsl:value-of select="string-join(info/multilingualTitle/value, ', ')"/>
+            },
+          </xsl:when>
+          <xsl:otherwise>
+            "title": "<xsl:value-of select="util:escapeForJson(info/@title)"/>",
+          </xsl:otherwise>
+        </xsl:choose>
         "theme": "<xsl:value-of select="util:escapeForJson(info/@type)"/>",
         <xsl:if test="info/@uri != ''">
           "link": "<xsl:value-of select="util:escapeForJson(info/@uri)"/>",


### PR DESCRIPTION
Backport #8154

* Add logic to allow multilingual thesaurus titles in the index and translate them when being displayed

* Implement multilingual thesaurus titles in iso19139 and iso19115-3.2018

