### PR TITLE
broadcasting error when delete record

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionService.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionService.js
@@ -286,6 +286,10 @@
               deferred.resolve(data);
             },
             function (data) {
+              gnAlertService.addAlert({
+                msg: data.data.message || data.data.description,
+                type: "danger"
+              });
               deferred.reject(data);
             }
           );

--- a/web-ui/src/main/resources/catalog/js/edit/EditorBoardController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/EditorBoardController.js
@@ -135,7 +135,8 @@
           },
           function (reason) {
             $rootScope.$broadcast("StatusUpdated", {
-              title: reason.data.description, //returned error JSON obj
+              title: reason.data.message, //returned error JSON obj
+              error: reason.data.description,
               timeout: 0,
               type: "danger"
             });


### PR DESCRIPTION
The error when delete metadata is not broadcasted correctly on the editor board page. There are two issues:

1) When select some metadata to delete, if there is some error from the API (i.e. Some customized event listener to process extra business logic or some unhandled exception). The error is not broadcasted at all.

![image](https://github.com/geonetwork/core-geonetwork/assets/74916635/f8dbe405-8874-415a-85d5-4850cf466bea)


2) This delete button is not adapting error correctly. It should be same as what the editorController https://github.com/geonetwork/core-geonetwork/blob/e3f92aac98e74614b5b487be1881ed019af95cb2/web-ui/src/main/resources/catalog/js/edit/EditorController.js#L674-L677

![image](https://github.com/geonetwork/core-geonetwork/assets/74916635/350a08f5-e72c-4b9e-8999-b52ba08d85ee)



In order to test the error, you can go to this API https://github.com/geonetwork/core-geonetwork/blob/e3f92aac98e74614b5b487be1881ed019af95cb2/services/src/main/java/org/fao/geonet/api/records/MetadataInsertDeleteApi.java#L266

Place some mocked error like:

![image](https://github.com/geonetwork/core-geonetwork/assets/74916635/d43dda9b-753a-4352-bfbd-ac819678130c)

```java
boolean throwError = true;
        if (throwError) {
            throw new NotAllowedException()
                .withMessageKey("api.metadata.import.errorEventStore", new String[]{""});

        }
```