### PR TITLE
API / Client code generation / Avoid reserved word

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/processing/ProcessApi.java
+++ b/services/src/main/java/org/fao/geonet/api/processing/ProcessApi.java
@@ -105,7 +105,7 @@ public class ProcessApi {
     @ResponseBody
     @ResponseStatus(HttpStatus.NO_CONTENT)
     @PreAuthorize("isAuthenticated()")
-    public void delete() throws Exception {
+    public void deleteProcessReport() throws Exception {
         registry.clear();
     }
 


### PR DESCRIPTION
When using tools to convert OpenAPI to client code eg.

```bash
npx openapi-ts -i ./src/gapi/gapi.json -o src/gapi
```

Some reserved word may create invalid generated code. eg. when building typescript:

```
 TS1102: 'delete' cannot be called on an identifier in strict mode. [
```


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

