### PR TITLE
[8096] Bug in AudienceAccessTokenValidator

### DIFF
--- a/core/src/test/java/org/fao/geonet/kernel/security/openidconnect/bearer/AudienceAccessTokenValidatorTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/security/openidconnect/bearer/AudienceAccessTokenValidatorTest.java
@@ -26,8 +26,12 @@ package org.fao.geonet.kernel.security.openidconnect.bearer;
 import org.fao.geonet.kernel.security.openidconnect.OIDCConfiguration;
 import org.junit.Test;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class AudienceAccessTokenValidatorTest {
 
@@ -35,20 +39,36 @@ public class AudienceAccessTokenValidatorTest {
     String clientId = "MYCLIENTID";
 
 
-
-
-    public  AudienceAccessTokenValidator   getValidator(){
+    public AudienceAccessTokenValidator getValidator() {
         AudienceAccessTokenValidator validator = new AudienceAccessTokenValidator();
         validator.oidcConfiguration = new OIDCConfiguration();
         validator.oidcConfiguration.setClientId(clientId);
         return validator;
     }
 
+    @Test
+    public void testContainsGood() {
+        assertTrue(AudienceAccessTokenValidator.contains("dave", "dave"));
+        assertTrue(AudienceAccessTokenValidator.contains(Arrays.asList("dave"), "dave"));
+        assertTrue(AudienceAccessTokenValidator.contains(Arrays.asList("dave", "ted"), "dave"));
+        assertTrue(AudienceAccessTokenValidator.contains(Arrays.asList("ted", "dave"), "dave"));
+    }
+
+
+    @Test
+    public void testContainsBad() {
+        assertFalse(AudienceAccessTokenValidator.contains("ted", "dave"));
+        assertFalse(AudienceAccessTokenValidator.contains("", "dave"));
+        assertFalse(AudienceAccessTokenValidator.contains(Arrays.asList(), "dave"));
+        assertFalse(AudienceAccessTokenValidator.contains(Arrays.asList("ted"), "dave"));
+        assertFalse(AudienceAccessTokenValidator.contains(Arrays.asList("pam", "ted"), "dave"));
+    }
+
 
     @Test
     public void testAzureGood() throws Exception {
         Map claims = new HashMap();
-        claims.put("appid",clientId);
+        claims.put("appid", clientId);
 
         AudienceAccessTokenValidator validator = getValidator();
         validator.verifyToken(claims, null);
@@ -57,7 +77,7 @@ public class AudienceAccessTokenValidatorTest {
     @Test
     public void testKeyCloakGood() throws Exception {
         Map claims = new HashMap();
-        claims.put("azp",clientId);
+        claims.put("azp", clientId);
 
         AudienceAccessTokenValidator validator = getValidator();
         validator.verifyToken(claims, null);
@@ -66,7 +86,7 @@ public class AudienceAccessTokenValidatorTest {
     @Test
     public void testSelfCreatedGood() throws Exception {
         Map claims = new HashMap();
-        claims.put("aud",clientId);
+        claims.put("aud", clientId);
 
         AudienceAccessTokenValidator validator = getValidator();
         validator.verifyToken(claims, null);
@@ -75,7 +95,7 @@ public class AudienceAccessTokenValidatorTest {
     @Test(expected = Exception.class)
     public void testBad1() throws Exception {
         Map claims = new HashMap();
-        claims.put("aud","badaud");
+        claims.put("aud", "badaud");
 
         AudienceAccessTokenValidator validator = getValidator();
         validator.verifyToken(claims, null);
@@ -84,7 +104,7 @@ public class AudienceAccessTokenValidatorTest {
     @Test(expected = Exception.class)
     public void testBad2() throws Exception {
         Map claims = new HashMap();
-        claims.put("azp","badaud");
+        claims.put("azp", "badaud");
 
         AudienceAccessTokenValidator validator = getValidator();
         validator.verifyToken(claims, null);
@@ -94,7 +114,7 @@ public class AudienceAccessTokenValidatorTest {
     @Test(expected = Exception.class)
     public void testBad3() throws Exception {
         Map claims = new HashMap();
-        claims.put("appid","badaud");
+        claims.put("appid", "badaud");
 
         AudienceAccessTokenValidator validator = getValidator();
         validator.verifyToken(claims, null);


### PR DESCRIPTION
<!--Include a few sentences describing the overall goals for this Pull Request-->

This is for https://github.com/geonetwork/core-geonetwork/issues/8096 

I've made it so that it accepts claims of type `String `or `List<String>` for the audience testing (for the 3 claim).

Original bug report was that only 1 of the 3 types were checking for `List<String>` (and the incorrect one).  I am pretty sure I saw actual examples of seeing a `List<String>` returned by Keycloak.  

In order to be maximally functional, I accept either `String` or `List<String>` for the 3 audience claims even if the spec says that there should only be `String` values.
  

<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [n/a] *API Changes* are identified in commit messages
- [x] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [n/a] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [n/a] *Build documentation* provided for development instructions in `README.md` files
- [n/a] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

