### PR TITLE
Admin / Source / Improve dirty state

### DIFF
--- a/web-ui/src/main/resources/catalog/templates/admin/settings/sources.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/settings/sources.html
@@ -169,6 +169,20 @@
               </p>
             </div>
 
+            <table class="table table-striped">
+              <tr data-ng-repeat="(key, value) in source.label">
+                <td>{{key | translate}}</td>
+                <td>
+                  <input
+                    type="text"
+                    class="form-control"
+                    value="{{value}}"
+                    data-ng-model="source.label[key]"
+                  />
+                </td>
+              </tr>
+            </table>
+
             <label data-translate="">sourceFilter</label>
             <input type="text" class="form-control" data-ng-model="source.filter" />
             <p class="help-block" data-translate="">sourceFilter-help</p>
@@ -177,130 +191,116 @@
               <span data-translate="">displayInHeaderSwitcher</span>
             </label>
             <p class="help-block" data-translate="">displayInHeaderSwitcher-help</p>
+
+            <label data-translate="">sourceUiConfig</label>
+            <select
+              id="uiConfigurationList"
+              class="form-control"
+              data-ng-options="c.id as c.id for (key, c) in uiConfigurations | orderBy: 'id'"
+              data-ng-model="source.uiConfig"
+            ></select>
+            <p class="help-block" data-translate="">sourceUiConfig-help</p>
+
+            <div>
+              <label for="serviceList"
+                >{{'system/csw/capabilityRecordUuid' | translate}}</label
+              >
+
+              <div
+                data-gn-suggest="serviceRecordSearchObj"
+                data-gn-suggest-model="source.serviceRecord"
+                data-gn-suggest-property="_id"
+                data-gn-suggest-display-title="span"
+              ></div>
+
+              <p class="help-block">
+                {{'system/csw/capabilityRecordUuid-help' | translate}}
+              </p>
+            </div>
+
+            <div data-ng-show="groups.length">
+              <label class="control-label" data-translate="">subPortalGroupOwner</label>
+              <div
+                data-groups-combo=""
+                data-owner-group="source.groupOwner"
+                data-set-default-value="false"
+                data-optional="{{::$parent.user.isAdministrator()}}"
+                lang="lang"
+                groups="groups"
+                data-exclude-special-groups="true"
+              ></div>
+
+              <p class="help-block" data-translate="">subPortalGroupOwnerHelp</p>
+            </div>
+
+            <div>
+              <label data-translate="">sourceLogo</label>
+
+              <div class="row" data-ng-show="source.logo">
+                <div class="col-md-6 gn-nopadding-left">
+                  <img
+                    data-ng-show="source.logo"
+                    src="../../images/harvesting/{{ source.logo }}"
+                    class="img-thumbnail form-group"
+                    data-ng-attr-title="{{ source.logo }}"
+                  />
+                </div>
+                <div class="col-md-6 gn-nopadding-left">
+                  <a href="" data-ng-click="deleteSourceLogo()" class="text-danger">
+                    <i data-ng-show="source.logo" class="fa fa-times delete"></i>
+                  </a>
+                </div>
+              </div>
+            </div>
           </form>
 
-          <div>
-            <label data-translate="">sourceLogo</label>
-
-            <div class="row" data-ng-show="source.logo">
-              <div class="col-md-6 gn-nopadding-left">
-                <img
-                  data-ng-show="source.logo"
-                  src="../../images/harvesting/{{ source.logo }}"
-                  class="img-thumbnail form-group"
-                  data-ng-attr-title="{{ source.logo }}"
-                />
-              </div>
-              <div class="col-md-6 gn-nopadding-left">
-                <a href="" data-ng-click="deleteSourceLogo()" class="text-danger">
-                  <i data-ng-show="source.logo" class="fa fa-times delete"></i>
-                </a>
-              </div>
+          <!--Display logo picker from harvester logos-->
+          <div class="row" data-ng-show="queue.length == 0">
+            <div class="col-md-12 gn-nopadding-left gn-margin-bottom" translate>
+              selectExistingLogo
             </div>
+            <div class="col-md-12 gn-nopadding-left gn-margin-bottom">
+              <div class="form-group" gn-logo-picker="source.logo"></div>
+            </div>
+          </div>
 
-            <!--Display logo picker from harvester logos-->
-            <div class="row" data-ng-show="queue.length == 0">
+          <!--Display logo upload input-->
+          <form
+            id="gn-group-edit"
+            name="gnGroupEdit"
+            method="POST"
+            data-file-upload="logoUploadOptions"
+            role="form"
+          >
+            <input type="hidden" name="_csrf" value="{{csrf}}" />
+            <div class="row" data-ng-show="!source.logo" id="group-logo-upload">
               <div class="col-md-12 gn-nopadding-left gn-margin-bottom" translate>
-                selectExistingLogo
+                addNewLogo
               </div>
-              <div class="col-md-12 gn-nopadding-left gn-margin-bottom">
-                <div class="form-group" gn-logo-picker="source.logo"></div>
-              </div>
-            </div>
-
-            <!--Display logo upload input-->
-            <form
-              id="gn-group-edit"
-              name="gnGroupEdit"
-              method="POST"
-              data-file-upload="logoUploadOptions"
-              role="form"
-            >
-              <input type="hidden" name="_csrf" value="{{csrf}}" />
-              <div class="row" data-ng-show="!source.logo" id="group-logo-upload">
-                <div class="col-md-12 gn-nopadding-left gn-margin-bottom" translate>
-                  addNewLogo
-                </div>
-                <div class="col-md-12 gn-nopadding-left gn-nopadding-right">
-                  <div class="panel panel-default">
-                    <div class="panel-heading" data-translate="">upload</div>
-                    <div class="panel-body">
-                      <span class="btn btn-success btn-block fileinput-button">
-                        <i class="fa fa-plus fa-white"></i>
-                        <span data-translate="">chooseLogos</span>
-                        <input type="file" id="source-logo" name="file" />
-                      </span>
-                      <ul style="list-style: none">
-                        <li data-ng-repeat="file in queue">
-                          <div class="preview" data-file-upload-preview="file"></div>
-                          {{file.name}} ({{file.type}} / {{file.size | formatFileSize}})
-                          <i class="fa fa-trash-o" data-ng-click="clear(file)"></i>
-                        </li>
-                      </ul>
-                    </div>
+              <div class="col-md-12 gn-nopadding-left gn-nopadding-right">
+                <div class="panel panel-default">
+                  <div class="panel-heading" data-translate="">upload</div>
+                  <div class="panel-body">
+                    <span class="btn btn-success btn-block fileinput-button">
+                      <i class="fa fa-plus fa-white"></i>
+                      <span data-translate="">chooseLogos</span>
+                      <input type="file" id="source-logo" name="file" />
+                    </span>
+                    <ul style="list-style: none">
+                      <li data-ng-repeat="file in queue">
+                        <div class="preview" data-file-upload-preview="file"></div>
+                        {{file.name}} ({{file.type}} / {{file.size | formatFileSize}})
+                        <i class="fa fa-trash-o" data-ng-click="clear(file)"></i>
+                      </li>
+                    </ul>
                   </div>
                 </div>
               </div>
-            </form>
+            </div>
+          </form>
 
-            <p class="help-block" data-translate="">sourceLogo-help</p>
-          </div>
-
-          <label data-translate="">sourceUiConfig</label>
-          <select
-            id="uiConfigurationList"
-            class="form-control"
-            data-ng-options="c.id as c.id for (key, c) in uiConfigurations | orderBy: 'id'"
-            data-ng-model="source.uiConfig"
-          ></select>
-          <p class="help-block" data-translate="">sourceUiConfig-help</p>
-
-          <div>
-            <label for="serviceList"
-              >{{'system/csw/capabilityRecordUuid' | translate}}</label
-            >
-
-            <div
-              data-gn-suggest="serviceRecordSearchObj"
-              data-gn-suggest-model="source.serviceRecord"
-              data-gn-suggest-property="_id"
-              data-gn-suggest-display-title="span"
-            ></div>
-
-            <p class="help-block">
-              {{'system/csw/capabilityRecordUuid-help' | translate}}
-            </p>
-          </div>
-
-          <div data-ng-show="groups.length">
-            <label class="control-label" data-translate="">subPortalGroupOwner</label>
-            <div
-              data-groups-combo=""
-              data-owner-group="source.groupOwner"
-              data-set-default-value="false"
-              data-optional="{{::$parent.user.isAdministrator()}}"
-              lang="lang"
-              groups="groups"
-              data-exclude-special-groups="true"
-            ></div>
-
-            <p class="help-block" data-translate="">subPortalGroupOwnerHelp</p>
-          </div>
+          <p class="help-block" data-translate="">sourceLogo-help</p>
         </div>
-
-        <table class="table table-striped">
-          <tr data-ng-repeat="(key, value) in source.label">
-            <td>{{key | translate}}</td>
-            <td>
-              <input
-                type="text"
-                class="form-control"
-                value="{{value}}"
-                data-ng-model="source.label[key]"
-              />
-            </td>
-          </tr>
-        </table>
       </div>
     </div>
   </div>


### PR DESCRIPTION
Due to wrong `form` tag placement, dirty state was only set when changing portal id and filter - not UI config, service or logo.

Reorganize the form to improve this, so that save action is enabled when changing the form. Also keep the logo form upload not nested (because it would not work)

![image](https://github.com/geonetwork/core-geonetwork/assets/1701393/896aff1a-3ee0-4066-bbf0-1996835db3ed)


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

Funded by Service Public de Wallonie
