### PR TITLE
Standard / ISO19115-3 / Formatters / ISO19139 / Ignore mcc linkage for overview

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ISO19139/toISO19139.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ISO19139/toISO19139.xsl
@@ -1109,5 +1109,6 @@
                        mcc:MD_Identifier/mcc:description|
                        mrl:LI_Source/mrl:scope|
                        mrl:sourceSpatialResolution|
-                       mdq:derivedElement" priority="2"/>
+                       mdq:derivedElement|
+                       mri:graphicOverview/mcc:MD_BrowseGraphic/mcc:linkage" priority="2"/>
 </xsl:stylesheet>


### PR DESCRIPTION
`MD_BrowseGraphic_Type` contains 2 properties that can be used to store overview file path
* mandatory `fileName` which we are using to store the URL of the overview ("name of the file that contains a graphic that provides an illustration of the dataset")
* and option unbounded `linkage` "link to browse graphic"


Proposal to only convert `mcc:fileName` when producing ISO19139 (which only define `gmd:fileName`)


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

