### PR TITLE
Formatters / Properly detect URL ending in 1,2,3 or 5

### DIFF
--- a/web/src/main/webapp/xslt/common/utility-tpl.xsl
+++ b/web/src/main/webapp/xslt/common/utility-tpl.xsl
@@ -125,8 +125,10 @@
 
   <xsl:template name="hyperlink">
     <xsl:param name="string" select="." />
+    <xsl:variable name="regex" as="xs:string">((http|https|ftp)://[^\s()]+[^\s\[\]`!(){};:'\\".,?«»“”‘’])</xsl:variable>
+
     <xsl:analyze-string select="$string"
-                        regex="(http|https|ftp)://[^\s()&gt;&lt;]+[^\s`!()\[\]&amp;#123;&amp;#125;;:'&apos;&quot;.,&gt;&lt;?«»“”‘’]">
+                        regex="{$regex}">
       <xsl:matching-substring>
         <a href="{.}">
           <xsl:value-of select="." />

--- a/web/src/main/webapp/xslt/common/utility-tpl.xsl
+++ b/web/src/main/webapp/xslt/common/utility-tpl.xsl
@@ -22,6 +22,7 @@
   -->
 
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 version="2.0">
 
   <xsl:template name="replaceString">


### PR DESCRIPTION
Fixes https://github.com/geonetwork/core-geonetwork/issues/8226


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

