### PR TITLE
[Backport 4.2.x] ISO19115-3.2018  / Remove duplicated fields for metadata identifier and uuid in CSV export

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/tpl-csv.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/tpl-csv.xsl
@@ -29,12 +29,6 @@
                 priority="2">
     <metadata>
       <xsl:variable name="langId" select="gn-fn-iso19115-3.2018:getLangId(., $lang)"/>
-      <id>
-        <xsl:value-of select="gn:info/id"/>
-      </id>
-      <uuid>
-        <xsl:value-of select="gn:info/uuid"/>
-      </uuid>
       <title>
         <xsl:apply-templates mode="localised"
                              select="mdb:identificationInfo/*/mri:citation/*/cit:title">


### PR DESCRIPTION
Backport #8238
 **Authored by:** @josegar74