### PR TITLE
Editor / Configuration / Improve deletion in forEach section

### DIFF
--- a/schemas/config-editor.xsd
+++ b/schemas/config-editor.xsd
@@ -906,7 +906,7 @@ Define if this tab is the default one for the view. Only one tab should be the d
         <xs:annotation>
           <xs:documentation><![CDATA[
 The tab key used in URL parameter to activate that tab. The key is also use for the tab label as defined in ``{schema}/loc/{lang}/strings.xml``.
-It has to be unique for all views. A good practice is to use same prefix for all tabs in the same view.            
+It has to be unique for all views. A good practice is to use same prefix for all tabs in the same view.
             ]]></xs:documentation>
         </xs:annotation>
       </xs:attribute>
@@ -1128,9 +1128,11 @@ Note: Only sections with forEach support del attribute.
 
             <section forEach="/gmd:MD_Metadata/gmd:distributionInfo">
               <text><h2>Distribution</h2></text>
-              <section forEach="*/gmd:transferOptions/*/gmd:onLine/gmd:CI_OnlineResource" name="A link">
-                <field xpath="gmd:linkage"/>
-                <field xpath="gmd:name" or="name" in="."/>
+              <section forEach="*/gmd:transferOptions/*/gmd:onLine"
+                       name="A link"
+                       del=".">
+                <field xpath="*/gmd:linkage"/>
+                <field xpath="*/gmd:name" or="name" in="."/>
               </section>
               <text><hr/></text>
             </section>
@@ -2111,9 +2113,9 @@ An autocompletion list based on a thesaurus.
 This field facilitates users in selecting a `subtemplate` (also known as xml-snippet) from the catalogue. Subtemplates are mostly used to store contact details,
 but can also be used to store snippets of xml having Quality reports, Access constraints, CRS definitions, etc.
 
-                  
-`data-insert-modes` can be `text` and/or `xlink` depending on how the subtemplate is encoded. 
-Contact can be forced to be `xlink` but some other type of subtemplates (eg. DQ report) are usually just simple default values 
+
+`data-insert-modes` can be `text` and/or `xlink` depending on how the subtemplate is encoded.
+Contact can be forced to be `xlink` but some other type of subtemplates (eg. DQ report) are usually just simple default values
 that need to be detailed by editors and in that case `text` mode is recommended. For `xlink`, the XLink resolver needs to be enabled in the admin settings.
 
 

--- a/web/src/main/webapp/xslt/ui-metadata/form-configurator.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-configurator.xsl
@@ -151,7 +151,7 @@
                   <xsl:variable name="originalNode"
                                 select="gn-fn-metadata:getOriginalNode($metadata, .)"/>
 
-                  <xsl:variable name="refToDelete">
+                  <xsl:variable name="refToDelete" as="node()?">
                     <xsl:call-template name="get-ref-element-to-delete">
                       <xsl:with-param name="node" select="$originalNode"/>
                       <xsl:with-param name="delXpath" select="$del"/>
@@ -159,7 +159,7 @@
                   </xsl:variable>
 
                   <xsl:call-template name="render-form-field-control-remove">
-                    <xsl:with-param name="editInfo" select="gn:element"/>
+                    <xsl:with-param name="editInfo" select="$refToDelete"/>
                   </xsl:call-template>
                 </xsl:if>
               </legend>
@@ -329,7 +329,7 @@
                     select="gn-fn-metadata:check-elementandsession-visibility(
                   $schema, $base, $serviceInfo, @if, @displayIfServiceInfo)"/>
 
-      <!-- 
+      <!--
       <xsl:message> Field: <xsl:value-of select="@name"/></xsl:message>
       <xsl:message>Xpath: <xsl:copy-of select="@xpath"/></xsl:message>
       <xsl:message>TemplateModeOnly: <xsl:value-of select="@templateModeOnly"/></xsl:message>


### PR DESCRIPTION
Improve documentation and properly target node to delete in case the forEach loop element is not the one to remove.

eg.
```xml
<section name="Axe - Time"
         forEach="/mdb:MD_Metadata/mdb:spatialRepresentationInfo/*/msr:axisDimensionProperties/*[msr:dimensionName/*/@codeListValue = 'time']"
         del="ancestor::msr:axisDimensionProperties">
   <field xpath="msr:dimensionSize"/>
   <field xpath="msr:resolution"/>
</section>
```

Before the change, the remove button was not displayed. Most of the time the loop element is the one to delete and this case was fine.

Follow up of https://github.com/geonetwork/core-geonetwork/pull/6907


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

Funded by Ifremer