### PR TITLE
Fix infinite "Please wait" message on error

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionService.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionService.js
@@ -275,24 +275,28 @@
           );
         } else {
           $rootScope.$broadcast("operationOnSelectionStart");
-          $http.delete("../api/records?" + "bucket=" + bucket).then(
-            function (data) {
-              $rootScope.$broadcast("mdSelectNone");
-              $rootScope.$broadcast("operationOnSelectionStop");
-              $rootScope.$broadcast("search");
-              $timeout(function () {
+          $http
+            .delete("../api/records?" + "bucket=" + bucket)
+            .then(
+              function (data) {
+                $rootScope.$broadcast("mdSelectNone");
                 $rootScope.$broadcast("search");
-              }, 5000);
-              deferred.resolve(data);
-            },
-            function (data) {
-              gnAlertService.addAlert({
-                msg: data.data.message || data.data.description,
-                type: "danger"
-              });
-              deferred.reject(data);
-            }
-          );
+                $timeout(function () {
+                  $rootScope.$broadcast("search");
+                }, 5000);
+                deferred.resolve(data);
+              },
+              function (data) {
+                gnAlertService.addAlert({
+                  msg: data.data.message || data.data.description,
+                  type: "danger"
+                });
+                deferred.reject(data);
+              }
+            )
+            .finally(function () {
+              $rootScope.$broadcast("operationOnSelectionStop");
+            });
         }
         return deferred.promise;
       };
@@ -644,8 +648,10 @@
           })
           .then(function (data) {
             $rootScope.$broadcast("inspireMdValidationStop");
-            $rootScope.$broadcast("operationOnSelectionStop");
             $rootScope.$broadcast("search");
+          })
+          .finally(function () {
+            $rootScope.$broadcast("operationOnSelectionStop");
           });
       };
 
@@ -657,8 +663,10 @@
             method: "DELETE"
           })
           .then(function (data) {
-            $rootScope.$broadcast("operationOnSelectionStop");
             $rootScope.$broadcast("search");
+          })
+          .finally(function () {
+            $rootScope.$broadcast("operationOnSelectionStop");
           });
       };
 


### PR DESCRIPTION
If an error happens while using the delete, validate or other option of the editor dashboard metadata actions menu then remove the text "Please wait" and the spinner from the button to allow to perform a new action.

![image](https://github.com/geonetwork/core-geonetwork/assets/826920/dc63ef98-224e-483c-8593-c51aa166bf03)


In order to test the error, you can go to this API https://github.com/geonetwork/core-geonetwork/blob/e3f92aac98e74614b5b487be1881ed019af95cb2/services/src/main/java/org/fao/geonet/api/records/MetadataInsertDeleteApi.java#L266

Place some mocked error like:

![image](https://github.com/geonetwork/core-geonetwork/assets/74916635/d43dda9b-753a-4352-bfbd-ac819678130c)

```java
boolean throwError = true;
        if (throwError) {
            throw new NotAllowedException()
                .withMessageKey("api.metadata.import.errorEventStore", new String[]{""});

        }
```

