### PR TITLE
Formatter / Use portal filter

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataUtils.java
@@ -1,5 +1,5 @@
 //=============================================================================
-//===	Copyright (C) 2001-2011 Food and Agriculture Organization of the
+//===	Copyright (C) 2001-2024 Food and Agriculture Organization of the
 //===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
 //===	and United Nations Environment Programme (UNEP)
 //===
@@ -549,4 +549,12 @@ public interface IMetadataUtils {
      * @param dest
      */
     void replaceFiles(AbstractMetadata original, AbstractMetadata dest);
+
+    /**
+     * Checks if the metadata is available in the current portal.
+     *
+     * @param id
+     * @return
+     */
+    boolean isMetadataAvailableInPortal(int id);
 }

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataUtils.java
@@ -1,5 +1,5 @@
 //=============================================================================
-//===	Copyright (C) 2001-2011 Food and Agriculture Organization of the
+//===	Copyright (C) 2001-2024 Food and Agriculture Organization of the
 //===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
 //===	and United Nations Environment Programme (UNEP)
 //===
@@ -23,6 +23,9 @@
 
 package org.fao.geonet.kernel.datamanager.base;
 
+import co.elastic.clients.elasticsearch.core.search.TotalHits;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Optional;
 import jeeves.server.UserSession;
 import jeeves.server.context.ServiceContext;
@@ -40,6 +43,7 @@ import org.fao.geonet.kernel.XmlSerializer;
 import org.fao.geonet.kernel.datamanager.*;
 import org.fao.geonet.kernel.schema.MetadataSchema;
 import org.fao.geonet.kernel.schema.SavedQuery;
+import org.fao.geonet.kernel.search.EsFilterBuilder;
 import org.fao.geonet.kernel.search.EsSearchManager;
 import org.fao.geonet.kernel.search.IndexingMode;
 import org.fao.geonet.kernel.search.index.IndexingList;
@@ -114,6 +118,9 @@ public class BaseMetadataUtils implements IMetadataUtils {
     private Path stylePath;
 
     protected IMetadataManager metadataManager;
+
+    @Autowired
+    private NodeInfo nodeInfo;
 
     @Override
     public void setMetadataManager(IMetadataManager metadataManager) {
@@ -483,7 +490,7 @@ public class BaseMetadataUtils implements IMetadataUtils {
     @Override
     public List<Integer> findAllIdsBy(Specification<? extends AbstractMetadata> specs) {
         try {
-            return metadataRepository.findIdsBy((Specification<Metadata>) specs);
+            return metadataRepository.findIdsBy(specs);
         } catch (ClassCastException t) {
             // Maybe it is not a Specification<Metadata>
         }
@@ -1012,7 +1019,7 @@ public class BaseMetadataUtils implements IMetadataUtils {
     @Override
     public Map<Integer, MetadataSourceInfo> findAllSourceInfo(Specification<? extends AbstractMetadata> spec) {
         try {
-            return metadataRepository.findSourceInfo((Specification<Metadata>) spec);
+            return metadataRepository.findSourceInfo(spec);
         } catch (Throwable t) {
             // Maybe it is not a Specification<Metadata>
         }
@@ -1027,5 +1034,39 @@ public class BaseMetadataUtils implements IMetadataUtils {
     @Override
     public void replaceFiles(AbstractMetadata original, AbstractMetadata dest) {
         // Empty implementation for non-draft mode as not used
+    }
+
+    @Override
+    public boolean isMetadataAvailableInPortal(int id) {
+        // Check if the metadata is available in the portal
+        String elasticSearchQuery = "{ \"bool\": {\n" +
+            "            \"must\": [\n" +
+            "        {" +
+            "          \"term\": {" +
+            "            \"id\": {" +
+            "              \"value\": \"%s\"" +
+            "            }" +
+            "          }" +
+            "        } " +
+            "            ]%s}}";
+
+        String portalFilter = "          ,\"filter\":{\"query_string\":{\"query\":\"%s\"}}";
+
+        JsonNode esJsonQuery;
+
+        try {
+            String filterQueryString = EsFilterBuilder.buildPortalFilter(nodeInfo);
+            String jsonQueryFilter = StringUtils.isNotEmpty(filterQueryString) ? String.format(portalFilter, filterQueryString): "";
+            String jsonQuery = String.format(elasticSearchQuery, id, jsonQueryFilter);
+
+            ObjectMapper objectMapper = new ObjectMapper();
+            esJsonQuery = objectMapper.readTree(jsonQuery);
+
+            TotalHits total = searchManager.query(esJsonQuery, new HashSet<>(), 0, 0).hits().total();
+
+            return (java.util.Optional.ofNullable(total).map(TotalHits::value).orElse(0L) > 0);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
     }
 }

--- a/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/SearchController.java
+++ b/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/SearchController.java
@@ -111,37 +111,9 @@ public class SearchController {
                                     boolean checkMetadataAvailableInPortal) throws CatalogException {
 
         if (checkMetadataAvailableInPortal) {
-            // Check if the metadata is available in the portal
-            String elasticSearchQuery = "{ \"bool\": {\n" +
-                "            \"must\": [\n" +
-                "        {" +
-                "          \"term\": {" +
-                "            \"id\": {" +
-                "              \"value\": \"%s\"" +
-                "            }" +
-                "          }" +
-                "        } " +
-                "            ]\n" +
-                "          ,\"filter\":{\"query_string\":{\"query\":\"%s\"}}}}";
-
-            JsonNode esJsonQuery;
-
-            try {
-                String filterQueryString = esFilterBuilder.build(context, "metadata", false, node);
-                String jsonQuery = String.format(elasticSearchQuery, id, filterQueryString);
-
-                ObjectMapper objectMapper = new ObjectMapper();
-                esJsonQuery = objectMapper.readTree(jsonQuery);
-
-                TotalHits total = searchManager.query(esJsonQuery, new HashSet<>(), 0, 0).hits().total();
-
-                if (Optional.ofNullable(total).map(TotalHits::value).orElse(0L) == 0) {
-                    return null;
-                }
-            } catch (Exception e) {
-                throw new RuntimeException(e);
+            if (!metadataUtils.isMetadataAvailableInPortal(Integer.parseInt(id))) {
+                return null;
             }
-
         }
 
         try {

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataApi.java
@@ -405,7 +405,10 @@ public class MetadataApi {
         }
 
         if (!metadataUtils.isMetadataAvailableInPortal(Integer.parseInt(mdId))) {
-            throw new NotAllowedException(ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_VIEW);
+            Log.debug(API.LOG_MODULE_NAME, String.format("Metadata with UUID '%s' is not available in the portal", metadataUuid));
+            throw new ResourceNotFoundException(String.format("Metadata with UUID '%s' not found.", metadataUuid))
+                .withMessageKey("exception.resourceNotFound.metadata")
+                .withDescriptionKey("exception.resourceNotFound.metadata.description", new String[]{ metadataUuid });
         }
 
         Element xml = withInfo ?

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2023 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2024 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -402,6 +402,10 @@ public class MetadataApi {
             if (increasePopularity) {
                 dataManager.increasePopularity(context, mdId + "");
             }
+        }
+
+        if (!metadataUtils.isMetadataAvailableInPortal(Integer.parseInt(mdId))) {
+            throw new NotAllowedException(ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_VIEW);
         }
 
         Element xml = withInfo ?

--- a/services/src/test/java/org/fao/geonet/api/records/MetadataApiTest.java
+++ b/services/src/test/java/org/fao/geonet/api/records/MetadataApiTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2024 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -27,8 +27,13 @@ import jeeves.server.context.ServiceContext;
 import org.fao.geonet.NodeInfo;
 import org.fao.geonet.api.ApiParams;
 import org.fao.geonet.domain.AbstractMetadata;
+import org.fao.geonet.domain.Source;
+import org.fao.geonet.domain.SourceType;
 import org.fao.geonet.kernel.SpringLocalServiceInvoker;
+import org.fao.geonet.kernel.datamanager.IMetadataIndexer;
+import org.fao.geonet.kernel.search.IndexingMode;
 import org.fao.geonet.repository.MetadataRepository;
+import org.fao.geonet.repository.SourceRepository;
 import org.fao.geonet.services.AbstractServiceIntegrationTest;
 import org.jdom.Element;
 import org.junit.Assert;
@@ -67,6 +72,12 @@ public class MetadataApiTest extends AbstractServiceIntegrationTest {
     private EntityManager _entityManager;
     @Autowired
     private MetadataRepository metadataRepository;
+    @Autowired
+    private IMetadataIndexer metadataIndexer;
+    @Autowired
+    private SourceRepository sourceRepository;
+    @Autowired
+    private NodeInfo nodeInfo;
 
     private int id;
     private String uuid;
@@ -83,6 +94,15 @@ public class MetadataApiTest extends AbstractServiceIntegrationTest {
         AbstractMetadata metadata = injectMetadataInDb(getSampleMetadataXml(), context, true);
         id = metadata.getId();
         uuid = metadata.getUuid();
+
+        metadataIndexer.indexMetadata(String.valueOf(id), true, IndexingMode.full);
+
+        Source subportal = new Source();
+        subportal.setName("external");
+        subportal.setType(SourceType.subportal);
+        subportal.setFilter("-uuid:" + uuid);
+        subportal.setUuid(UUID.randomUUID().toString());
+        sourceRepository.save(subportal);
     }
 
     @Test
@@ -329,6 +349,35 @@ public class MetadataApiTest extends AbstractServiceIntegrationTest {
             .andExpect(xpath("/apiError/code").string(equalTo("forbidden")))
             .andExpect(xpath("/apiError/message").string(equalTo(ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_VIEW)));
     }
+
+    @Test
+    public void getNonAvailableRecordInSubportalAsXml() throws Exception {
+        MockMvc mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
+        MockHttpSession mockHttpSession = loginAsAdmin();
+
+        // Set the current node to the subportal
+        Source subportal = sourceRepository.findOneByName("external");
+        Assert.assertNotNull(subportal);
+        nodeInfo.setId(subportal.getUuid());
+        nodeInfo.setDefaultNode(false);
+
+        mockMvc.perform(get("/external/api/records/" + this.uuid + "/formatters/json")
+                .session(mockHttpSession)
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNotFound())
+            .andExpect(content().contentType(API_JSON_EXPECTED_ENCODING))
+            .andExpect(jsonPath("$.code").value(equalTo("resource_not_found")))
+            .andExpect(jsonPath("$.message").value(equalTo("Metadata not found")));
+
+        mockMvc.perform(get("/external/api/records/" + this.uuid + "/formatters/xml")
+                .session(mockHttpSession)
+                .accept(MediaType.APPLICATION_XML))
+            .andExpect(status().isNotFound())
+            .andExpect(content().contentType(MediaType.APPLICATION_XML))
+            .andExpect(xpath("/apiError/code").string(equalTo("resource_not_found")))
+            .andExpect(xpath("/apiError/message").string(equalTo("Metadata not found")));
+    }
+
 
     @Test
     public void getNonExistentRecordAsXml() throws Exception {


### PR DESCRIPTION
Analog to https://github.com/geonetwork/core-geonetwork/pull/7890, but for formatters.

Refactored the code to reuse it in CSW and formatters.

Test case:

1) Load the iso19139 samples
2) Create an iso19139 metadata
3) Create a portal with the name `external` and a filter `-uuid:UUIDVALUE`, with the UUID of the metadata from 2), to display all metadata except the one created in 2).
4) In the portal switcher, select the `external` portal -> The metadata created in 2) is not displayed
5) In the portal switcher, select the main `srv` portal -> The metadata created in 2) is displayed
6) Request a formatter in the main `srv` portal --> The metadata formatter is displayed

http://localhost:8080/geonetwork/srv/api/records/UUIDVALUE/formatters/json?addSchemaLocation=true&increasePopularity=true&approved=true

6) Request a formatter in the main `external` portal

http://localhost:8080/geonetwork/external/api/records/UUIDVALUE/formatters/json?addSchemaLocation=true&increasePopularity=true&approved=true

  - Without the fix: the formatter is displayed
  - With the fix: an error 403 is returned


# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
