### PR TITLE
Add get /api/sources/{sourceIdentifier} to be able to get a source by id.

### DIFF
--- a/domain/src/main/java/org/fao/geonet/repository/SourceRepository.java
+++ b/domain/src/main/java/org/fao/geonet/repository/SourceRepository.java
@@ -70,8 +70,11 @@ public interface SourceRepository extends GeonetRepository<Source, String>, JpaS
 
     public
     @Nullable
-    List<Source> findByGroupOwner(@Nonnull int groupOwner);
+    List<Source> findByGroupOwner(@Nonnull int groupOwner, Sort sort);
 
+    public
+    @Nullable
+    List<Source> findByGroupOwnerAndType(@Nonnull int groupOwner, @Nonnull SourceType sourceType, Sort sort);
     public
     @Nullable
     List<Source> findByGroupOwnerIn(Set<Integer> groupOwner);

--- a/services/src/main/java/org/fao/geonet/api/sources/SourcesApi.java
+++ b/services/src/main/java/org/fao/geonet/api/sources/SourcesApi.java
@@ -33,6 +33,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import jeeves.server.context.ServiceContext;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.fao.geonet.api.ApiError;
 import org.fao.geonet.api.ApiParams;
 import org.fao.geonet.api.ApiUtils;
 import org.fao.geonet.api.exception.ResourceNotFoundException;
@@ -108,6 +109,10 @@ public class SourcesApi {
             value = "group",
             required = false)
         Integer group,
+        @RequestParam(
+            value = "type",
+            required = false)
+        SourceType type,
         @Parameter(hidden = true)
         HttpServletResponse response,
         @Parameter(hidden = true)
@@ -115,8 +120,12 @@ public class SourcesApi {
     ) throws Exception {
         setHeaderVaryOnAccept(response);
         List<Source> sources;
-        if (group != null) {
-            sources = sourceRepository.findByGroupOwner(group);
+        if (group != null && type != null) {
+            sources = sourceRepository.findByGroupOwnerAndType(group, type, SortUtils.createSort(Source_.name));
+        } else if (group != null) {
+            sources = sourceRepository.findByGroupOwner(group, SortUtils.createSort(Source_.name));
+        } else if (type != null) {
+            sources = sourceRepository.findByType(type, SortUtils.createSort(Source_.name));
         } else {
             sources = sourceRepository.findAll(SortUtils.createSort(Source_.name));
         }
@@ -145,15 +154,35 @@ public class SourcesApi {
     }
 
     @io.swagger.v3.oas.annotations.Operation(
-        summary = "Get all sources by type",
-        description = "Sources are the local catalogue, subportal, external catalogue (when importing MEF files) or harvesters.")
+        summary = "Get a source",
+        description = "")
     @RequestMapping(
-        value = "/{type}",
+        value = "/{sourceIdentifier}",
         produces = MediaType.APPLICATION_JSON_VALUE,
         method = RequestMethod.GET)
+    @ResponseStatus(HttpStatus.OK)
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Source found."),
+        @ApiResponse(responseCode = "404", description = "Source not found.",
+            content = @Content(schema = @Schema(implementation = ApiError.class)))
+    })
     @ResponseBody
-    public List<Source> getSourcesByType(@PathVariable SourceType type) throws Exception {
-        return sourceRepository.findByType(type, SortUtils.createSort(Source_.name));
+    public Source getSource(
+        @Parameter(
+            description = "Source identifier",
+            required = true
+        )
+        @PathVariable
+        String sourceIdentifier) throws Exception {
+        Optional<Source> existingSource = sourceRepository.findById(sourceIdentifier);
+        if (existingSource.isPresent()) {
+            return existingSource.get();
+        } else {
+            throw new ResourceNotFoundException(String.format(
+                "Source with uuid '%s' does not exist.",
+                sourceIdentifier
+            ));
+        }
     }
 
     @io.swagger.v3.oas.annotations.Operation(

--- a/services/src/test/java/org/fao/geonet/api/sources/SourcesApiTest.java
+++ b/services/src/test/java/org/fao/geonet/api/sources/SourcesApiTest.java
@@ -71,6 +71,38 @@ public class SourcesApiTest extends AbstractServiceIntegrationTest {
     }
 
     @Test
+    public void getSource() throws Exception {
+        Source source = sourceRepo.findOneByName("source-test");
+        Assert.assertNotNull(source);
+
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
+
+        this.mockHttpSession = loginAsAdmin();
+
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
+        this.mockMvc.perform(get("/srv/api/sources/" + source.getUuid())
+                .accept(MediaType.parseMediaType("application/json")))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(API_JSON_EXPECTED_ENCODING));
+    }
+
+    @Test
+    public void getNonExistingSource() throws Exception {
+        Source sourceToUpdate = sourceRepo.findOneByName("source-test-2");
+        Assert.assertNull(sourceToUpdate);
+
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
+
+        this.mockHttpSession = loginAsAdmin();
+
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
+        this.mockMvc.perform(get("/srv/api/sources/source-test-2")
+                .accept(MediaType.parseMediaType("application/json")))
+            .andExpect(content().contentType(API_JSON_EXPECTED_ENCODING))
+            .andExpect(status().is(404));
+    }
+
+    @Test
     public void getSources() throws Exception {
         Long sourcesCount = sourceRepo.count();
 

--- a/web-ui/src/main/resources/catalog/components/usersearches/UserSearchesDirective.js
+++ b/web-ui/src/main/resources/catalog/components/usersearches/UserSearchesDirective.js
@@ -39,7 +39,7 @@
             gnGlobalSettings.gnCfg.mods.header.showPortalSwitcher;
 
           function getPortals() {
-            var url = "../api/sources/subportal";
+            var url = "../api/sources?type=subportal";
             $http.get(url).then(function (response) {
               scope.portals = response.data.filter(function (p) {
                 return p.uuid != scope.nodeId;

--- a/web-ui/src/main/resources/catalog/components/usersearches/UserSearchesService.js
+++ b/web-ui/src/main/resources/catalog/components/usersearches/UserSearchesService.js
@@ -35,7 +35,7 @@
           usersearches = $http.get("../api/usersearches/featured?type=" + type);
         var apiCalls = [usersearches];
         if (withPortal) {
-          apiCalls.push($http.get("../api/sources/subportal"));
+          apiCalls.push($http.get("../api/sources?type=subportal"));
         }
         $q.all(apiCalls).then(function (alldata) {
           var usersearches = [];

--- a/web-ui/src/main/resources/catalog/js/admin/CSWTestController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/CSWTestController.js
@@ -50,7 +50,7 @@
           $scope.cswTests = response.data;
         });
 
-        $http.get("../api/sources/subportal").then(function (response) {
+        $http.get("../api/sources?type=subportal").then(function (response) {
           $scope.cswVirtual = response.data;
         });
       }


### PR DESCRIPTION
Add get /api/sources/{sourceIdentifier} to be able to get a source by id.

![image](https://github.com/user-attachments/assets/80716a9a-7af3-4784-8cee-40cc31b15ac0)

Moved /api/sources/{type} to Moved /api/sources?type=type as it conflicted with /api/sources/{sourceIdentifier}

![image](https://github.com/user-attachments/assets/5515b303-9b55-4c05-aff0-dd5073420d9e)


# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [x] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

