### PR TITLE
Zoom to map popup remains active on non-map pages. 

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/alert/AlertDirective.js
+++ b/web-ui/src/main/resources/catalog/components/common/alert/AlertDirective.js
@@ -69,6 +69,12 @@
           }
         }
       };
+
+      this.closeAlerts = function () {
+        if (gnAlertValue.length) {
+          gnAlertValue.splice(0, gnAlertValue.length);
+        }
+      };
     }
   ]);
 

--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -1390,7 +1390,7 @@
               } else {
                 gnAlertService.addAlert({
                   msg: $translate.instant("layerCRSNotFound"),
-                  delay: 5000,
+                  delay: 5,
                   type: "warning"
                 });
               }
@@ -1400,7 +1400,7 @@
                   msg: $translate.instant("layerNotAvailableInMapProj", {
                     proj: mapProjection
                   }),
-                  delay: 5000,
+                  delay: 5,
                   type: "warning"
                 });
               }
@@ -1981,7 +1981,7 @@
                         type: "wmts",
                         url: encodeURIComponent(url)
                       }),
-                      delay: 20000,
+                      delay: 20,
                       type: "warning"
                     });
                     var o = {
@@ -2079,7 +2079,7 @@
                       type: "wfs",
                       url: encodeURIComponent(url)
                     }),
-                    delay: 20000,
+                    delay: 20,
                     type: "warning"
                   });
                   var o = {
@@ -2159,7 +2159,7 @@
               } catch (e) {
                 gnAlertService.addAlert({
                   msg: $translate.instant("wmtsLayerNoUsableMatrixSet"),
-                  delay: 5000,
+                  delay: 5,
                   type: "danger"
                 });
                 return;

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/SelectionDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/SelectionDirective.js
@@ -99,7 +99,7 @@
                   function (r) {
                     gnAlertService.addAlert({
                       msg: r.data.message || r.data.description,
-                      delay: 20000,
+                      delay: 20,
                       type: "danger"
                     });
                     if (r.id) {

--- a/web-ui/src/main/resources/catalog/components/search/searchmanager/LocationService.js
+++ b/web-ui/src/main/resources/catalog/components/search/searchmanager/LocationService.js
@@ -77,12 +77,14 @@
         return p.indexOf(this.METADATA) == 0 || p.indexOf(this.DRAFT) == 0;
       };
 
-      this.isMap = function () {
-        return $location.path() == this.MAP;
+      this.isMap = function (path) {
+        var p = path || $location.path();
+        return p == this.MAP;
       };
 
-      this.isHome = function () {
-        return $location.path() == this.HOME;
+      this.isHome = function (path) {
+        var p = path || $location.path();
+        return p == this.HOME;
       };
 
       this.isUndefined = function () {

--- a/web-ui/src/main/resources/catalog/components/viewer/ViewerDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/ViewerDirective.js
@@ -255,7 +255,7 @@
                             }),
                             type: "success"
                           },
-                          5000
+                          5
                         );
                       }
                     },
@@ -293,7 +293,7 @@
                           url: config.url,
                           extent: extent ? extent.join(",") : ""
                         }),
-                        delay: 5000,
+                        delay: 5,
                         type: "warning"
                       });
                       // TODO: You may want to add more than one time

--- a/web-ui/src/main/resources/catalog/components/viewer/wmsimport/WmsImportDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wmsimport/WmsImportDirective.js
@@ -105,7 +105,7 @@
                     }),
                     type: "success"
                   },
-                  4
+                  15
                 );
                 gnMap.feedLayerMd(layer);
                 return layer;

--- a/web-ui/src/main/resources/catalog/js/edit/DirectoryController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/DirectoryController.js
@@ -455,7 +455,7 @@
           .then(refreshEntriesInfo, function (e) {
             gnAlertService.addAlert({
               msg: $translate.instant("directoryEntry-removeError-referenced"),
-              delay: 5000,
+              delay: 5,
               type: "danger"
             });
           });

--- a/web-ui/src/main/resources/catalog/views/default/module.js
+++ b/web-ui/src/main/resources/catalog/views/default/module.js
@@ -536,7 +536,7 @@
       setActiveTab();
       $scope.$on("$locationChangeSuccess", setActiveTab);
 
-      $scope.$on("$locationChangeSuccess", function (next, current) {
+      $scope.$on("$locationChangeSuccess", function (event, next, current) {
         if (
           gnSearchLocation.isSearch() &&
           (!angular.isArray(searchMap.getSize()) || searchMap.getSize()[0] < 0)
@@ -546,7 +546,10 @@
           }, 0);
         }
 
-        if (gnSearchLocation.isSearch()) {
+        // Changing from the map to search pages, hide alerts
+        var currentUrlHash =
+          current.indexOf("#") > -1 ? current.slice(current.indexOf("#") + 1) : "";
+        if (gnSearchLocation.isMap(currentUrlHash)) {
           setTimeout(function () {
             gnAlertService.closeAlerts();
           }, 0);

--- a/web-ui/src/main/resources/catalog/views/default/module.js
+++ b/web-ui/src/main/resources/catalog/views/default/module.js
@@ -412,7 +412,7 @@
             msg: $translate.instant("layerProtocolNotSupported", {
               type: link.protocol
             }),
-            delay: 20000,
+            delay: 20,
             type: "warning"
           });
           return;
@@ -543,6 +543,12 @@
         ) {
           setTimeout(function () {
             searchMap.updateSize();
+          }, 0);
+        }
+
+        if (gnSearchLocation.isSearch()) {
+          setTimeout(function () {
+            gnAlertService.closeAlerts();
           }, 0);
         }
       });


### PR DESCRIPTION
Fixes #8260

Fixes also wrong values for add alert delay, provided in some pages in milliseconds, but the method expects seconds.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
