### PR TITLE
Editor / Add keywords even if thesaurus not available in record languages

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/search/KeywordsSearcher.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/KeywordsSearcher.java
@@ -101,9 +101,11 @@ public class KeywordsSearcher {
 
         elKeyword.addContent(elSelected);
         elKeyword.addContent(new Element("id").addContent(Integer.toString(kb.getId())));
-        elKeyword.addContent(new Element("value").addContent(kb.getDefaultValue()).setAttribute("language", defaultLang));
-        elKeyword.addContent(new Element("definition").addContent(kb.getDefaultDefinition()).setAttribute("language", defaultLang));
-        elKeyword.addContent(new Element("defaultLang").addContent(defaultLang));
+        if (defaultLang != null) {
+            elKeyword.addContent(new Element("value").addContent(kb.getDefaultValue()).setAttribute("language", defaultLang));
+            elKeyword.addContent(new Element("definition").addContent(kb.getDefaultDefinition()).setAttribute("language", defaultLang));
+            elKeyword.addContent(new Element("defaultLang").addContent(defaultLang));
+        }
         Element thesaurusElement = new Element("thesaurus");
         thesaurusElement.addContent(new Element("key").setText(kb.getThesaurusKey()));
         thesaurusElement.addContent(new Element("title").setText(kb.getThesaurusTitle()));

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/layout-custom-fields-keywords.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/layout-custom-fields-keywords.xsl
@@ -179,7 +179,7 @@
         in default language
         -->
         <xsl:variable name="keywords" select="string-join(
-                  if ($guiLangId and mri:keyword//*[@locale = concat('#', $guiLangId)])
+                  if ($guiLangId and mri:keyword//*[@locale = concat('#', $guiLangId)][*/text() != ''])
                   then mri:keyword//*[@locale = concat('#', $guiLangId)][. != '']/replace(text(), ',', ',,')
                   else mri:keyword/*[1][. != '']/replace(text(), ',', ',,'), ',')"/>
 

--- a/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
@@ -501,7 +501,12 @@ public class KeywordsApi {
         if (langs == null) {
             langs = context.getLanguage().split(",");
         }
-        String[] iso3langCodes = Arrays.copyOf(langs, langs.length);
+        List<String> langList = new ArrayList<>(List.of(langs));
+        if (!langList.contains("'eng'")) {
+            langList.add("eng");
+        }
+
+        String[] iso3langCodes = langList.toArray(String[]::new);
         for (int i = 0; i < langs.length; i++) {
             if (StringUtils.isNotEmpty(langs[i])) {
                 langs[i] = mapper.iso639_2_to_iso639_1(langs[i], langs[i].substring(0,2));  //default: fra -> fr
@@ -593,12 +598,7 @@ public class KeywordsApi {
 
             Element requestParams = new Element("request");
             for (Map.Entry<String, String> e : allRequestParams.entrySet()) {
-                if (e.getKey().equals("lang")) {
-                    requestParams.addContent(new Element(e.getKey())
-                        .setText(String.join(",", iso3langCodes)));
-                } else {
-                    requestParams.addContent(new Element(e.getKey()).setText(e.getValue()));
-                }
+                requestParams.addContent(new Element(e.getKey()).setText(e.getValue()));
             }
             if (langConversion != null) {
                 requestParams.addContent(langConversion);

--- a/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
@@ -46,7 +46,6 @@ import org.fao.geonet.api.ApiUtils;
 import org.fao.geonet.api.exception.ResourceNotFoundException;
 import org.fao.geonet.api.exception.WebApplicationException;
 import org.fao.geonet.api.registries.model.ThesaurusInfo;
-import org.fao.geonet.api.tools.i18n.LanguageUtils;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.ISODate;
 import org.fao.geonet.exceptions.BadParameterEx;
@@ -110,12 +109,6 @@ import static org.fao.geonet.kernel.rdf.Selectors.SKOS_NAMESPACE;
     description = ApiParams.API_CLASS_REGISTRIES_OPS)
 public class KeywordsApi {
 
-    /**
-     * The language utils.
-     */
-    @Autowired
-    LanguageUtils languageUtils;
-
     @Autowired
     SettingManager settingManager;
 
@@ -161,8 +154,7 @@ public class KeywordsApi {
      * @throws Exception the exception
      */
     @io.swagger.v3.oas.annotations.Operation(
-        summary = "Search keywords",
-        description = "")
+        summary = "Search keywords")
     @RequestMapping(
         path = "/search",
         method = RequestMethod.GET,
@@ -175,16 +167,14 @@ public class KeywordsApi {
     @ResponseBody
     public Object searchKeywords(
         @Parameter(
-            description = "Query",
-            required = false
+            description = "Query"
         )
         @RequestParam(
             required = false
         )
             String q,
         @Parameter(
-            description = "Query in that language",
-            required = false
+            description = "Query in that language"
         )
         @RequestParam(
             value = "lang",
@@ -192,8 +182,7 @@ public class KeywordsApi {
         )
             String lang,
         @Parameter(
-            description = "Number of rows",
-            required = false
+            description = "Number of rows"
         )
         @RequestParam(
             required = false,
@@ -201,8 +190,7 @@ public class KeywordsApi {
         )
             int rows,
         @Parameter(
-            description = "Start from",
-            required = false
+            description = "Start from"
         )
         @RequestParam(
             defaultValue = "0",
@@ -210,8 +198,7 @@ public class KeywordsApi {
         )
             int start,
         @Parameter(
-            description = "Return keyword information in one or more languages",
-            required = false
+            description = "Return keyword information in one or more languages"
         )
         @RequestParam(
             value = XmlParams.pLang,
@@ -219,8 +206,7 @@ public class KeywordsApi {
         )
             List<String> targetLangs,
         @Parameter(
-            description = "Thesaurus identifier",
-            required = false
+            description = "Thesaurus identifier"
         )
         @RequestParam(
             required = false
@@ -235,24 +221,21 @@ public class KeywordsApi {
 //        )
 //            String thesauriDomainName,
         @Parameter(
-            description = "Type of search",
-            required = false
+            description = "Type of search"
         )
         @RequestParam(
             defaultValue = "CONTAINS"
         )
             KeywordSearchType type,
         @Parameter(
-            description = "URI query",
-            required = false
+            description = "URI query"
         )
         @RequestParam(
             required = false
         )
             String uri,
         @Parameter(
-            description = "Sort by",
-            required = false
+            description = "Sort by"
         )
         @RequestParam(
             required = false,
@@ -354,23 +337,19 @@ public class KeywordsApi {
         @RequestParam(name = "thesaurus")
             String sThesaurusName,
         @Parameter(
-            description = "Languages.",
-            required = false)
+            description = "Languages.")
         @RequestParam(name = "lang", required = false)
             String[] langs,
         @Parameter(
-            description = "Only print the keyword, no thesaurus information.",
-            required = false)
+            description = "Only print the keyword, no thesaurus information.")
         @RequestParam(required = false, defaultValue = "false")
             boolean keywordOnly,
         @Parameter(
-            description = "XSL template to use (ISO19139 keyword by default, see convert.xsl).",
-            required = false)
+            description = "XSL template to use (ISO19139 keyword by default, see convert.xsl).")
         @RequestParam(required = false)
             String transformation,
         @Parameter(
-            description = "langMap, that converts the values in the 'lang' parameter to how they will be actually represented in the record. {'fre':'fra'} or {'fre':'fr'}.  Missing/empty means to convert to iso 2 letter.",
-            required = false)
+            description = "langMap, that converts the values in the 'lang' parameter to how they will be actually represented in the record. {'fre':'fra'} or {'fre':'fr'}.  Missing/empty means to convert to iso 2 letter.")
         @RequestParam (name = "langMap", required = false)
             String  langMapJson,
         @Parameter(hidden = true)
@@ -428,23 +407,19 @@ public class KeywordsApi {
         @RequestParam(name = "thesaurus")
             String sThesaurusName,
         @Parameter(
-            description = "Languages.",
-            required = false)
+            description = "Languages.")
         @RequestParam(name = "lang", required = false)
             String[] langs,
         @Parameter(
-            description = "Only print the keyword, no thesaurus information.",
-            required = false)
+            description = "Only print the keyword, no thesaurus information.")
         @RequestParam(required = false, defaultValue = "false")
             boolean keywordOnly,
         @Parameter(
-            description = "XSL template to use (ISO19139 keyword by default, see convert.xsl).",
-            required = false)
+            description = "XSL template to use (ISO19139 keyword by default, see convert.xsl).")
         @RequestParam(required = false)
             String transformation,
         @Parameter(
-            description = "langMap, that converts the values in the 'lang' parameter to how they will be actually represented in the record. {'fre':'fra'} or {'fre':'fr'}.  Missing/empty means to convert to iso 2 letter.",
-            required = false)
+            description = "langMap, that converts the values in the 'lang' parameter to how they will be actually represented in the record. {'fre':'fra'} or {'fre':'fr'}.  Missing/empty means to convert to iso 2 letter.")
         @RequestParam (name = "langMap", required = false)
             String  langMapJson,
         @Parameter(hidden = true)
@@ -489,7 +464,7 @@ public class KeywordsApi {
         if (thesaurus == null) {
             String finalSThesaurusName = sThesaurusName;
             Optional<Thesaurus> thesaurusEntry = thesaurusManager.getThesauriMap().values().stream().filter(t -> t.getKey().endsWith(finalSThesaurusName)).findFirst();
-            if (!thesaurusEntry.isPresent()) {
+            if (thesaurusEntry.isEmpty()) {
                 throw new IllegalArgumentException(String.format(
                     "Thesaurus '%s' not found.", sThesaurusName));
             } else {
@@ -516,7 +491,7 @@ public class KeywordsApi {
         Element descKeys;
         Map<String, Map<String, String>> jsonResponse = new HashMap<>();
 
-        uri = URLDecoder.decode(uri, "UTF-8");
+        uri = URLDecoder.decode(uri, StandardCharsets.UTF_8);
 
         if (uri == null) {
             descKeys = new Element("descKeys");
@@ -571,8 +546,8 @@ public class KeywordsApi {
             JSONObject obj = JSONObject.fromObject(langMapJson);
             langConversion = new Element("languageConversions");
             for(Object entry : obj.entrySet()) {
-                String key = ((Map.Entry) entry).getKey().toString();
-                String value = ((Map.Entry) entry).getValue().toString();
+                String key = ((Map.Entry<?, ?>) entry).getKey().toString();
+                String value = ((Map.Entry<?, ?>) entry).getValue().toString();
                 Element conv = new Element("conversion");
                 conv.setAttribute("from", key);
                 conv.setAttribute("to", value.replace("#",""));
@@ -618,7 +593,6 @@ public class KeywordsApi {
      *
      * @param thesaurus the thesaurus
      * @param response  the response
-     * @return the thesaurus
      * @throws Exception the exception
      */
     @io.swagger.v3.oas.annotations.Operation(
@@ -672,7 +646,6 @@ public class KeywordsApi {
      * Delete thesaurus.
      *
      * @param thesaurus the thesaurus
-     * @return the element
      * @throws Exception the exception
      */
     @io.swagger.v3.oas.annotations.Operation(
@@ -703,7 +676,7 @@ public class KeywordsApi {
             throw new ResourceNotFoundException(String.format(
                 "Thesaurus with identifier '%s' not found in the catalogue. Should be one of: %s",
                 thesaurus,
-                thesaurusMan.getThesauriMap().keySet().toString()
+                thesaurusMan.getThesauriMap().keySet()
             ));
         }
         Path item = thesaurusObject.getFile();
@@ -767,9 +740,9 @@ public class KeywordsApi {
         boolean fileUpload = file != null && !file.isEmpty();
 
         // Upload RDF file
-        Path rdfFile = null;
-        String fname = null;
-        File tempDir = null;
+        Path rdfFile;
+        String fname;
+        File tempDir;
 
         if (fileUpload) {
 
@@ -795,7 +768,7 @@ public class KeywordsApi {
             }
 
             long fsize;
-            if (rdfFile != null && Files.exists(rdfFile)) {
+            if (Files.exists(rdfFile)) {
                 fsize = Files.size(rdfFile);
             } else {
                 throw new MissingServletRequestParameterException("Thesaurus file doesn't exist", "file");
@@ -1012,7 +985,7 @@ public class KeywordsApi {
             CSVParser csvParser = new CSVParser(reader, CSVFormat.DEFAULT
                 .withFirstRecordAsHeader()
                 .withIgnoreHeaderCase()
-                .withTrim());
+                .withTrim())
         ) {
 
             Map<String, KeywordBean> allConcepts = new LinkedHashMap<>();
@@ -1075,7 +1048,7 @@ public class KeywordsApi {
             }
 
             Element scheme = buildConceptScheme(csvFile, thesaurusTitle, thesaurusNamespaceUrl);
-            if(broaderLinks.size() > 0 && !topConcepts.isEmpty()) {
+            if(!broaderLinks.isEmpty() && !topConcepts.isEmpty()) {
                 topConcepts.forEach(t -> {
                     Element topConcept = new Element("hasTopConcept", SKOS_NAMESPACE);
                     topConcept.setAttribute("resource", t, RDF_NAMESPACE);
@@ -1210,7 +1183,7 @@ public class KeywordsApi {
         boolean registryUpload = !StringUtils.isEmpty(registryUrl);
 
         // Upload RDF file
-        Path rdfFile = null;
+        Path rdfFile;
         String fname = null;
 
         // Specific upload steps
@@ -1307,9 +1280,9 @@ public class KeywordsApi {
     /**
      * Update the information related to a local thesaurus .
      *
-     * @param thesaurusInfo
-     * @return
-     * @throws Exception
+     * @param thesaurus     name of the thesaurus to update.
+     * @param thesaurusInfo thesaurus information to update.
+     * @throws Exception the exception
      */
     @io.swagger.v3.oas.annotations.Operation(
         summary = "Updates the information of a local thesaurus",
@@ -1368,11 +1341,11 @@ public class KeywordsApi {
      * Download for each language the codelist from the registry. Combine
      * them into one XML document which is then XSLT processed for SKOS conversion.
      *
-     * @param registryUrl the registry url
-     * @param registryType
-     * @param itemName    the item name
-     * @param lang        the selected languages
-     * @param context     the context
+     * @param registryUrl  the registry url
+     * @param registryType type of registry
+     * @param itemName     the item name
+     * @param lang         the selected languages
+     * @param context      the context
      * @return the path
      * @throws Exception the exception
      */
@@ -1448,7 +1421,6 @@ public class KeywordsApi {
      * @param fname   the fname
      * @param type    the type
      * @param dir     the dir
-     * @return Element thesaurus uploaded
      * @throws Exception the exception
      */
     private void uploadThesaurus(Path rdfFile, String style,

--- a/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
@@ -502,7 +502,7 @@ public class KeywordsApi {
             langs = context.getLanguage().split(",");
         }
         List<String> langList = new ArrayList<>(List.of(langs));
-        if (!langList.contains("'eng'")) {
+        if (!langList.contains("eng")) {
             langList.add("eng");
         }
 

--- a/services/src/main/java/org/fao/geonet/services/thesaurus/GetKeywordByIdAsConcept.java
+++ b/services/src/main/java/org/fao/geonet/services/thesaurus/GetKeywordByIdAsConcept.java
@@ -73,7 +73,7 @@ public class GetKeywordByIdAsConcept implements Service {
             searcher = new KeywordsSearcher(context, thesaurusMan);
             KeywordBean kb = null;
 
-            kb = searcher.searchById(uri, sThesaurusName, langForThesaurus);
+            kb = searcher.searchById(uri, sThesaurusName, langForThesaurus, "eng");
             if (kb == null) {
                 root = new Element("descKeys");
             } else {
@@ -93,11 +93,11 @@ public class GetKeywordByIdAsConcept implements Service {
                         reqType = KeywordRelation.RELATED;
                     }
 
-                    searcher.searchForRelated(params, reqType, KeywordSort.defaultLabelSorter(SortDirection.DESC), lang);
+                    searcher.searchForRelated(params, reqType, KeywordSort.defaultLabelSorter(SortDirection.DESC), lang, "eng");
                     // build response for each request type
                     Element keywordType = new Element(request);
                     for (KeywordBean kbr : searcher.getResults()) {
-                        keywordType.addContent(kbr.toElement(context.getLanguage()));
+                        keywordType.addContent(kbr.toElement(context.getLanguage(), "eng"));
                     }
                     root.addContent(keywordType);
                 }

--- a/services/src/main/java/org/fao/geonet/services/thesaurus/GetTopConcept.java
+++ b/services/src/main/java/org/fao/geonet/services/thesaurus/GetTopConcept.java
@@ -70,7 +70,7 @@ public class GetTopConcept implements Service {
         searcher = new KeywordsSearcher(context, thesaurusMan);
 
         try {
-            searcher.searchTopConcepts(sThesaurusName, langForThesaurus);
+            searcher.searchTopConcepts(sThesaurusName, langForThesaurus, "eng");
 
             KeywordBean topConcept = new KeywordBean(the.getIsoLanguageMapper());
             topConcept.setThesaurusInfo(the);

--- a/web-ui/src/main/resources/catalog/components/ng-skos/templates/skos-concept.html
+++ b/web-ui/src/main/resources/catalog/components/ng-skos/templates/skos-concept.html
@@ -71,11 +71,9 @@
             ng-mouseleave="c.over = false"
           >
             <i title="{{c.help.broader}}"></i>
-            <span
-              skos-label="c"
-              lang="{{mainLanguage}}"
-              title="{{'makeConceptCurrent' | translate}}"
-            ></span>
+            <span title="{{'makeConceptCurrent' | translate}}">
+              {{c.prefLabel[mainLanguage] || c.prefLabel['eng']}}
+            </span>
           </a>
         </li>
       </ul>
@@ -95,11 +93,9 @@
             ng-mouseleave="c.over = false"
           >
             <i title="{{c.help.narrower}}"></i>
-            <span
-              skos-label="c"
-              lang="{{mainLanguage}}"
-              title="{{'makeConceptCurrent' | translate}}"
-            ></span>
+            <span title="{{'makeConceptCurrent' | translate}}">
+              {{c.prefLabel[mainLanguage] || c.prefLabel['eng']}}
+            </span>
           </a>
         </li>
       </ul>

--- a/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusService.js
+++ b/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusService.js
@@ -44,7 +44,7 @@
           var foundLang = _.find(UILangs, function (l) {
             return props.values[l] !== undefined;
           });
-          if (foundLang) return props.values[foundLang];
+          if (foundLang) return props.values[foundLang] || props.values["eng"];
         }
         return this.props.value["#text"] || this.props.value;
       }
@@ -152,6 +152,11 @@
           if (outputLang) {
             parameters["pLang"] = outputLang;
           }
+          if (lang !== "eng") {
+            // Fallback in english if thesaurus has no translation in current record language
+            parameters["pLang"] = ["eng", lang];
+          }
+
           return gnUrlUtils.append(
             "../api/registries/vocabularies/search",
             gnUrlUtils.toKeyValue(parameters)

--- a/web/src/main/webapp/xslt/services/thesaurus/to-jskos.xsl
+++ b/web/src/main/webapp/xslt/services/thesaurus/to-jskos.xsl
@@ -22,7 +22,10 @@
   ~ Rome - Italy. email: geonetwork@osgeo.org
   -->
 
-<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" version="2.0">
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:util="java:org.fao.geonet.util.XslUtil"
+                version="2.0"
+                exclude-result-prefixes="#all">
 
   <xsl:template match="/root">
     <xsl:choose>
@@ -45,8 +48,8 @@
       <xsl:variable name="contents">
         <xsl:copy-of select="uri"/>
         <prefLabel>
-          <xsl:for-each select="value">
-            <xsl:element name="{$iso3code}">
+          <xsl:for-each select="value[. != '']">
+            <xsl:element name="{util:threeCharLangCode(@lang|@language)}">
               <xsl:value-of select="text()"/>
             </xsl:element>
             <xsl:element name="{lower-case(substring(@lang|@language, 1, 2))}">


### PR DESCRIPTION

Add english as default language for thesaurus searches in order to populate metadata with english label if the thesaurus is not available in the current record language. For example, this can happen when using DCAT-AP related vocabularies only avilable in english that have to be used in Member States records not in english.

Display english label if UI and record language is not available in thesaurus
After/Before
![image](https://github.com/user-attachments/assets/2574eb19-22e5-4b40-b572-2f7a03fef114)

Use the english label when encoding the keyword in the metadata (API changes):

http://localhost:8080/geonetwork/srv/api/registries/vocabularies/keyword?thesaurus=external.theme.gemet&id=http:%2F%2Fwww.eionet.europa.eu%2Fgemet%2Fconcept%2F3599,http:%2F%2Fwww.eionet.europa.eu%2Fgemet%2Fconcept%2F15034,http:%2F%2Fwww.eionet.europa.eu%2Fgemet%2Fconcept%2F105,http:%2F%2Fwww.eionet.europa.eu%2Fgemet%2Fconcept%2F10170,http:%2F%2Fwww.eionet.europa.eu%2Fgemet%2Fconcept%2F10140&transformation=to-iso19115-3.2018-keyword-with-anchor&langMap=%7B%22fre%22:%22%23FR%22%7D&lang=fre&textgroupOnly=false
will return keyword in french (if GEMET is loaded with french)
```xml
<mri:keyword>
<gcx:Anchor xmlns:gcx="http://standards.iso.org/iso/19115/-3/gcx/1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.eionet.europa.eu/gemet/concept/3599">alimentation en gaz</gcx:Anchor>
</mri:keyword>
```
but requesting ukrainian will return english terms
http://localhost:8080/geonetwork/srv/api/registries/vocabularies/keyword?thesaurus=external.theme.gemet&id=http:%2F%2Fwww.eionet.europa.eu%2Fgemet%2Fconcept%2F3599,http:%2F%2Fwww.eionet.europa.eu%2Fgemet%2Fconcept%2F15034,http:%2F%2Fwww.eionet.europa.eu%2Fgemet%2Fconcept%2F105,http:%2F%2Fwww.eionet.europa.eu%2Fgemet%2Fconcept%2F10170,http:%2F%2Fwww.eionet.europa.eu%2Fgemet%2Fconcept%2F10140&transformation=to-iso19115-3.2018-keyword-with-anchor&langMap=%7B%22ukr%22:%22%23UK%22%7D&lang=ukr&textgroupOnly=false
```xml
<mri:keyword>
<gcx:Anchor xmlns:gcx="http://standards.iso.org/iso/19115/-3/gcx/1.0" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http://www.eionet.europa.eu/gemet/concept/15034">alternative fuel</gcx:Anchor>
</mri:keyword>
```

This will also avoid the message box when keywords are not found due to language mismatch. The message will still be displayed if a keyword in the metadata is not found in the thesaurus, proposing the user to only keep keywords from the thesaurus.

![image](https://github.com/user-attachments/assets/a40d3e31-fde5-48ea-a12f-cfa1de0aa759)



Funded by Service Public de Wallonie


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

