### PR TITLE
Standard / ISO19139 / Fix removal of online source when multiple transfer options block are used.

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/extract-relations.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/extract-relations.xsl
@@ -35,7 +35,6 @@
                 xmlns:xlink="http://www.w3.org/1999/xlink"
                 xmlns:util="java:org.fao.geonet.util.XslUtil"
                 xmlns:digestUtils="java:org.apache.commons.codec.digest.DigestUtils"
-                xmlns:exslt="http://exslt.org/common"
                 xmlns:gn-fn-rel="http://geonetwork-opensource.org/xsl/functions/relations"
                 version="2.0"
                 exclude-result-prefixes="#all">
@@ -110,7 +109,7 @@
               <xsl:value-of select="position()"/>
             </idx>
             <hash>
-              <xsl:value-of select="digestUtils:md5Hex(string(exslt:node-set(normalize-space(.))))"/>
+              <xsl:value-of select="digestUtils:md5Hex(normalize-space(.))"/>
             </hash>
             <url>
               <xsl:apply-templates mode="get-iso19139-localized-string"
@@ -142,7 +141,7 @@
                 <xsl:value-of select="position()"/>
               </idx>
               <hash>
-                <xsl:value-of select="digestUtils:md5Hex(string(exslt:node-set(normalize-space(.))))"/>
+                <xsl:value-of select="digestUtils:md5Hex(normalize-space(.))"/>
               </hash>
               <title>
                 <xsl:apply-templates mode="get-iso19139-localized-string"

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
@@ -34,7 +34,6 @@
                 xmlns:gn-fn-index="http://geonetwork-opensource.org/xsl/functions/index"
                 xmlns:index="java:org.fao.geonet.kernel.search.EsSearchManager"
                 xmlns:digestUtils="java:org.apache.commons.codec.digest.DigestUtils"
-                xmlns:exslt="http://exslt.org/common"
                 xmlns:util="java:org.fao.geonet.util.XslUtil"
                 xmlns:date-util="java:org.fao.geonet.utils.DateUtil"
                 xmlns:daobs="http://daobs.org"
@@ -1122,8 +1121,7 @@
           <xsl:copy-of select="gn-fn-index:add-multilingual-field('orderingInstructions', ., $allLanguages)"/>
         </xsl:for-each>
 
-        <xsl:for-each select="gmd:transferOptions/*/
-                                gmd:onLine/*[gmd:linkage/gmd:URL != '']">
+        <xsl:for-each select=".//gmd:onLine/*[gmd:linkage/gmd:URL != '']">
 
           <xsl:variable name="transferGroup"
                         select="count(ancestor::gmd:transferOptions/preceding-sibling::gmd:transferOptions)"/>
@@ -1147,7 +1145,7 @@
             <atomfeed><xsl:value-of select="gmd:linkage/gmd:URL"/></atomfeed>
           </xsl:if>
           <link type="object">{
-            "hash": "<xsl:value-of select="digestUtils:md5Hex(string(exslt:node-set(normalize-space(.))))"/>",
+            "hash": "<xsl:value-of select="digestUtils:md5Hex(normalize-space(.))"/>",
             "idx": <xsl:value-of select="position()"/>,
             "protocol":"<xsl:value-of select="util:escapeForJson((gmd:protocol/*/text())[1])"/>",
             "mimeType":"<xsl:value-of select="if (*/gmx:MimeFileType)

--- a/schemas/iso19139/src/main/plugin/iso19139/process/onlinesrc-add.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/process/onlinesrc-add.xsl
@@ -187,18 +187,28 @@ Note: It assumes that it will be adding new items in
   <!-- Updating the gmd:onLine based on update parameters -->
   <!-- Note: first part of the match needs to match the xsl:for-each select from extract-relations.xsl in order to get the position() to match -->
   <!-- The unique identifier is marked with resourceIdx which is the position index and resourceHash which is hash code of the current node (combination of url, resource name, and description) -->
-  <xsl:template
-    match="*//gmd:MD_DigitalTransferOptions/gmd:onLine
-        [gmd:CI_OnlineResource[gmd:linkage/gmd:URL!=''] and ($resourceIdx = '' or position() = xs:integer($resourceIdx))]
-        [($resourceHash != '' or ($updateKey != '' and normalize-space($updateKey) = concat(
+  <!-- Template to match all gmd:onLine elements -->
+  <xsl:template match="//gmd:MD_DigitalTransferOptions/gmd:onLine" priority="2">
+    <!-- Calculate the global position of the current gmd:onLine element -->
+    <xsl:variable name="position" select="count(//gmd:MD_DigitalTransferOptions/gmd:onLine[current() >> .]) + 1" />
+
+    <xsl:choose>
+      <xsl:when test="gmd:CI_OnlineResource[gmd:linkage/gmd:URL != ''] and
+                      ($resourceIdx = '' or $position = xs:integer($resourceIdx)) and
+                      ($resourceHash != '' or ($updateKey != '' and normalize-space($updateKey) = concat(
                           gmd:CI_OnlineResource/gmd:linkage/gmd:URL,
                           gmd:CI_OnlineResource/gmd:protocol/*,
                           gmd:CI_OnlineResource/gmd:name/gco:CharacterString)))
-                     and ($resourceHash = '' or digestUtils:md5Hex(string(exslt:node-set(normalize-space(.)))) = $resourceHash)]"
-    priority="2">
-    <xsl:call-template name="createOnlineSrc"/>
+                     and ($resourceHash = '' or digestUtils:md5Hex(normalize-space(.)) = $resourceHash)">
+        <xsl:call-template name="createOnlineSrc"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:copy>
+          <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
-
 
   <xsl:template name="createOnlineSrc">
     <!-- Add all online source from the target metadata to the
@@ -243,7 +253,7 @@ Note: It assumes that it will be adding new items in
                   </gmd:URL>
                 </gmd:linkage>
                 <gmd:protocol>
-                 <xsl:call-template name="setProtocol"/>
+                  <xsl:call-template name="setProtocol"/>
                 </gmd:protocol>
 
                 <xsl:if test="$applicationProfile != ''">

--- a/schemas/iso19139/src/main/plugin/iso19139/process/onlinesrc-remove.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/process/onlinesrc-remove.xsl
@@ -53,15 +53,25 @@ Stylesheet used to remove a reference to a online resource.
   <!-- Remove the gmd:onLine define in url parameter  -->
   <!-- Note: first part of the match needs to match the xsl:for-each select from extract-relations.xsl in order to get the position() to match -->
   <!-- The unique identifier is marked with resourceIdx which is the position index and resourceHash which is hash code of the current node (combination of url, resource name, and description) -->
-  <xsl:template
-    match="*//gmd:MD_DigitalTransferOptions/gmd:onLine
-        [gmd:CI_OnlineResource[gmd:linkage/gmd:URL!=''] and ($resourceIdx = '' or (count(preceding::gmd:onLine) + 1) = xs:integer($resourceIdx))]
-        [($resourceHash != '' or ($url != null and (normalize-space(gmd:CI_OnlineResource/gmd:linkage/gmd:URL) = $url and normalize-space(gmd:CI_OnlineResource/gmd:name/gco:CharacterString) = normalize-space($name)
+  <xsl:template match="//gmd:MD_DigitalTransferOptions/gmd:onLine" priority="2">
+
+    <!-- Calculate the global position of the current gmd:onLine element -->
+    <xsl:variable name="position" select="count(//gmd:MD_DigitalTransferOptions/gmd:onLine[current() >> .]) + 1" />
+
+    <xsl:if test="not(
+                      gmd:CI_OnlineResource[gmd:linkage/gmd:URL != ''] and
+                      ($resourceIdx = '' or $position = xs:integer($resourceIdx)) and
+                      ($resourceHash != '' or ($url != null and (normalize-space(gmd:CI_OnlineResource/gmd:linkage/gmd:URL) = $url and normalize-space(gmd:CI_OnlineResource/gmd:name/gco:CharacterString) = normalize-space($name)
                                                                 or normalize-space(gmd:CI_OnlineResource/gmd:linkage/gmd:URL) = $url and count(gmd:CI_OnlineResource/gmd:name/gmd:PT_FreeText/gmd:textGroup[gmd:LocalisedCharacterString = $name]) > 0
                                                                 or normalize-space(gmd:CI_OnlineResource/gmd:linkage/gmd:URL) = $url and normalize-space(gmd:CI_OnlineResource/gmd:protocol/*) = 'WWW:DOWNLOAD-1.0-http--download'))
                         )
-                        and ($resourceHash = '' or digestUtils:md5Hex(string(exslt:node-set(normalize-space(.)))) = $resourceHash)]"
-    priority="2"/>
+                        and ($resourceHash = '' or digestUtils:md5Hex(normalize-space(.)) = $resourceHash)
+                   )">
+      <xsl:copy>
+        <xsl:apply-templates select="@*|node()"/>
+      </xsl:copy>
+    </xsl:if>
+  </xsl:template>
 
   <!-- Do a copy of every node and attribute -->
   <xsl:template match="@*|node()">


### PR DESCRIPTION
Follow up of https://github.com/geonetwork/core-geonetwork/pull/7431

Address the case when multiple transfer option groups are used. Following discussion in https://github.com/geonetwork/core-geonetwork/pull/7431#discussion_r1694869644


Can be tested with https://gist.github.com/fxprunayre/5641c474514a9d5159ef1479a030a117

![image](https://github.com/user-attachments/assets/c7431b02-1e76-43e2-acdc-07aecad33c49)

Also add support for online sources in distributor blocks.

For ISO19115-3, it is a bit more complicated as online resources can be used in portrayal, feature catalogue, dq report, ... https://github.com/geonetwork/core-geonetwork/blob/main/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/link-utility.xsl#L78-L90



<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

Funded by EEA

