### PR TITLE
Visual and UX changes for WFS previews

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/mdview/partials/datapreview.html
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/partials/datapreview.html
@@ -1,7 +1,7 @@
 <div data-ng-if="hasExtent" ol-map="map"></div>
 
 <div class="row">
-  <div class="col-md-3">
+  <div class="col-md-3 gn-nopadding-left gn-padding-top-lg">
     <div
       data-gn-wfs-filter-facets=""
       data-layer="currentLayer"
@@ -9,7 +9,7 @@
       data-boot-mode="index"
     ></div>
   </div>
-  <div class="col-md-9">
+  <div class="col-md-9 gn-nopadding-right gn-padding-top-lg">
     <gn-features-tables
       gn-features-tables-map="map"
       data-show-close="false"

--- a/web-ui/src/main/resources/catalog/components/viewer/gfi/partials/featurestables.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/gfi/partials/featurestables.html
@@ -63,12 +63,11 @@
     data-ng-show="ctrl.currentTable == table"
     ng-repeat="table in ctrl.tables"
   >
-    <div class="pull-left">
-      <strong>
-        <span>{{table.name}}</span>&nbsp; {{table.loader.getCount()}}
-        <span data-translate="">features</span>
-      </strong>
-    </div>
+<!--    <div class="pull-left">-->
+      <h4>
+        <span>{{table.name}}</span>
+      </h4>
+<!--    </div>-->
     <gn-features-table
       gn-features-table-loader="table.loader"
       gn-features-table-loader-map="ctrl.map"

--- a/web-ui/src/main/resources/catalog/components/viewer/wfsfilter/partials/wfsfilterfacet.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/wfsfilter/partials/wfsfilterfacet.html
@@ -17,21 +17,19 @@
 
   <div data-ng-show="isWfsAvailable">
     <!--admin buttons-->
+    <!--Facet count-->
+    <h4
+      data-ng-if="isFeaturesIndexed"
+      class="count"
+      data-ng-if="showCount"
+    >
+      {{count | number}}&nbsp;/&nbsp;{{countTotal | number}}&nbsp;<span translate=""
+    >features</span
+    >
+    </h4>
     <div class="btn-group dropup wfs-filter-group">
-      <!--Facet count-->
-      <div
-        class="btn btn-default btn-xs disabled"
-        data-ng-if="isFeaturesIndexed"
-        class="count text-center"
-        data-ng-if="showCount"
-      >
-        {{count | number}}&nbsp;/&nbsp;{{countTotal | number}}&nbsp;<span translate=""
-          >features</span
-        >
-      </div>
-
       <button
-        class="btn btn-default btn-xs"
+        class="btn btn-default"
         data-ng-if="!managerOnly
                           && isFeaturesIndexed
                           && displayTableOnLoad != 'true'"
@@ -41,7 +39,7 @@
         <i class="fa fa-table"></i>
       </button>
       <button
-        class="btn btn-default btn-xs"
+        class="btn btn-default"
         data-ng-disabled="!indexObject.isPointOnly"
         data-ng-if="!managerOnly
                           && isFeaturesIndexed"
@@ -52,7 +50,7 @@
         <i class="fa fa-th-large"></i>
       </button>
       <button
-        class="btn btn-default btn-xs"
+        class="btn btn-default"
         ng-class="{ disabled: !filtersChanged }"
         data-ng-if="!managerOnly && isFeaturesIndexed"
         title="{{::'applyFilter' | translate}}"
@@ -62,7 +60,7 @@
         <i class="fa fa-filter"></i>
       </button>
       <button
-        class="btn btn-default btn-xs"
+        class="btn btn-default"
         title="{{::'refresh' | translate}}"
         data-ng-if="(user.canEditRecord(md)
                       || (user.isAdministrator() && md.isHarvested == 'true'))"
@@ -74,7 +72,7 @@
         data-ng-if="(user.canEditRecord(md)
                       || (user.isAdministrator() && md.isHarvested == 'true'))"
         type="button"
-        class="btn btn-default btn-xs dropdown-toggle"
+        class="btn btn-default dropdown-toggle"
         data-toggle="dropdown"
         aria-haspopup="true"
         aria-expanded="false"
@@ -105,7 +103,7 @@
         data-ng-if="managerOnly"
         title="{{'addToMap' | translate}}"
         data-ng-href="catalog.search#/map?add={{mapAddCmd | encodeURIComponent}}"
-        class="btn btn-default btn-xs"
+        class="btn btn-default"
       >
         <i class="fa fa-globe"></i>
       </a>
@@ -133,43 +131,49 @@
     ></gn-heatmap>
 
     <!-- Search -->
-    <div
-      data-ng-if="!managerOnly && isFeaturesIndexed"
-      class="input-group input-group-sm"
-    >
-      <input
-        class="form-control input-xs"
-        data-ng-keyup="$event.keyCode == 13 && filterFacets()"
-        type="text"
-        placeholder="{{::'anyPlaceHolder' | translate}}"
-        data-ng-model="ctrl.filter.fullTextSearch"
-      />
-      <span class="input-group-btn">
-        <button
-          data-ng-if="!managerOnly && isFeaturesIndexed"
-          data-gn-click-and-spin="resetFacets(false).then(filterWMS)"
-          title="{{'reset' | translate}}"
-          class="btn btn-default btn-xs gn-reset-facets"
-        >
-          <i class="fa fa-fw fa-times"></i>
-        </button>
-        <button
-          data-ng-if="!managerOnly && isFeaturesIndexed"
-          title="{{'featuresInMapExtent' | translate}}"
-          data-ng-click="setFeaturesInMapExtent()"
-          data-ng-class="{'active': featuresInMapExtent}"
-          class="btn btn-default btn-xs"
-        >
-          <i class="fa fa-pencil-square-o fa-fw"></i>
-        </button>
-        <button
-          class="btn btn-default btn-xs"
-          title="{{'search' | translate}}"
-          data-ng-click="filterFacets()"
-        >
-          <i class="fa fa-fw fa-search"></i>
-        </button>
-      </span>
+    <div class="flex-row flex-align-center gn-margin-bottom">
+      <div
+        data-ng-if="!managerOnly && isFeaturesIndexed"
+        class="input-group flex-grow gn-margin-right-sm"
+      >
+        <input
+          class="form-control"
+          data-ng-keyup="$event.keyCode == 13 && filterFacets()"
+          type="text"
+          placeholder="{{::'anyPlaceHolder' | translate}}"
+          data-ng-model="ctrl.filter.fullTextSearch"
+        />
+        <div class="input-group-btn">
+
+            <button
+              data-ng-if="!managerOnly && isFeaturesIndexed"
+              data-gn-click-and-spin="resetFacets(false).then(filterWMS)"
+              title="{{'reset' | translate}}"
+              class="btn btn-default gn-reset-facets"
+            >
+              <i class="fa fa-fw fa-times"></i>
+            </button>
+
+            <button
+              class="btn btn-default"
+              title="{{'search' | translate}}"
+              data-ng-click="filterFacets()"
+            >
+              <i class="fa fa-fw fa-search"></i>
+            </button>
+
+        </div>
+
+      </div>
+      <button
+        data-ng-if="!managerOnly && isFeaturesIndexed"
+        title="{{'featuresInMapExtent' | translate}}"
+        data-ng-click="setFeaturesInMapExtent()"
+        data-ng-class="{'active': featuresInMapExtent}"
+        class="btn btn-default"
+      >
+        <i class="fa fa-pencil-square-o fa-fw"></i>
+      </button>
     </div>
 
     <!-- Facets -->
@@ -185,7 +189,7 @@
           data-ng-class="{'text-primary': isFilterActive(field.name, field)}"
         >
           <span
-            class="fa fa-arrow-circle-right"
+            class="fa fa-chevron-right"
             data-ng-class="{
               'fa-rotate-90': field.expanded,
               'gn-field-empty': !isFilterActive(field.name, field)
@@ -208,7 +212,7 @@
           ></span>
           <input
             type="text"
-            class="form-control input-sm layerfilter"
+            class="form-control layerfilter"
             placeholder="{{ 'filter' | translate }}"
             ng-model="facetFilters[field.name]"
             ng-model-options="{debounce: 300}"
@@ -266,7 +270,7 @@
           data-ng-class="{'text-primary': isFilterActive('geometry')}"
         >
           <span
-            class="fa fa-arrow-circle-right"
+            class="fa fa-chevron-right"
             data-ng-class="{
               'fa-rotate-90': indexObject.geomField.expanded,
               'gn-field-empty': !isFilterActive('geometry')

--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -1604,6 +1604,9 @@ gn-indexing-task-status {
 .text-large {
   font-size: 30px;
 }
+.width-auto {
+  width: auto;
+}
 .width-100 {
   width: 100%;
 }

--- a/web-ui/src/main/resources/catalog/style/gn_viewer.less
+++ b/web-ui/src/main/resources/catalog/style/gn_viewer.less
@@ -341,7 +341,7 @@
     .list-group-item {
       transition: max-height @transition-params;
       padding: 5px 15px;
-      min-height: 42px;
+      border: 0;
       &:hover,
       &:focus {
         .fa-arrows-alt,
@@ -418,10 +418,11 @@
       }
     }
     h4 {
-      margin: 1em 0 0.5em 0;
+      margin: 1em 0 0 0;
+      font-size: 16px;
     }
     h5 {
-      margin: 0.2em 0;
+      margin: 0.7em 0;
     }
     [data-gn-layer-dimensions] {
       overflow: unset !important;
@@ -841,11 +842,47 @@ gn-features-tables,
   .tab-content {
     background: white;
     min-height: 5em;
-    padding: 1em;
+    padding: 0 0 @gn-spacing-lg 0;
   }
   .gn-features-table {
-    padding: 0.25em;
-    box-shadow: 0px 0px 4px 2px rgba(0, 0, 0, 0.1);
+    box-shadow: 0 0 4px 2px rgba(0, 0, 0, 0.1);
+    .bootstrap-table {
+      display: grid;
+      grid-template-columns: auto 0fr;
+      grid-template-rows: auto;
+      grid-template-areas:
+        "main toolbar"
+        "footer toolbar";
+      .fixed-table-toolbar {
+        grid-area: toolbar;
+        .columns-right {
+          margin: 0 0 0 @gn-spacing;
+          display: inline-block;
+          vertical-align: middle;
+          .btn, .btn-group {
+            display: block;
+            float: none;
+            width: 100%;
+            max-width: 100%;
+            margin-top: -1px;
+            margin-left: 0;
+            border-radius: 0;
+          }
+          .btn:first-child:not(:last-child) {
+            border-radius: 4px 4px 0 0;
+          }
+          .btn-group:last-child:not(:first-child) > .btn:first-child {
+            border-radius: 0 0 4px 4px;
+            }
+        }
+      }
+      .fixed-table-container {
+        grid-area: main;
+      }
+      .fixed-table-pagination {
+        grid-area: footer;
+      }
+    }
   }
   .layername {
     display: inline-block;
@@ -891,6 +928,32 @@ gn-features-tables,
   [data-gn-wfs-filter-facets] .gn-facet-container {
     overflow: auto;
     max-height: 550px;
+    .list-group {
+      margin-bottom: 0;
+      .list-group-item {
+        border: 0;
+        padding: 8px 15px;
+      }
+    }
+  }
+}
+.gn-editor-sidebar {
+  .gn-related-resources {
+    p {
+      margin-top: @gn-spacing-sm;
+    }
+  }
+  .gn-related-item {
+    h4 {
+      font-size: 14px;
+    }
+  }
+  .wfs-filter-group {
+    margin-top: @gn-spacing;
+    margin-bottom: 0;
+    .btn {
+      .btn-xs();
+    }
   }
 }
 

--- a/web-ui/src/main/resources/catalog/style/gn_viewer.less
+++ b/web-ui/src/main/resources/catalog/style/gn_viewer.less
@@ -341,7 +341,6 @@
     .list-group-item {
       transition: max-height @transition-params;
       padding: 5px 15px;
-      border: 0;
       &:hover,
       &:focus {
         .fa-arrows-alt,
@@ -358,6 +357,11 @@
         .gn-layer-ordering {
           visibility: visible;
         }
+      }
+    }
+    .gn-facet-container {
+      .list-group-item {
+        border: 0;
       }
     }
     .gn-baselayer-switcher-menu {
@@ -842,7 +846,7 @@ gn-features-tables,
   .tab-content {
     background: white;
     min-height: 5em;
-    padding: 0 0 @gn-spacing-lg 0;
+    padding: 0 @gn-spacing-lg;
   }
   .gn-features-table {
     box-shadow: 0 0 4px 2px rgba(0, 0, 0, 0.1);
@@ -915,6 +919,11 @@ gn-features-tables,
 }
 
 .gn-md-view {
+  .tab-content {
+    background: white;
+    min-height: 5em;
+    padding: 0 0 @gn-spacing-lg 0;
+  }
   gn-features-tables {
     position: unset;
     .gn-features-table {

--- a/web-ui/src/main/resources/catalog/style/gn_viewer.less
+++ b/web-ui/src/main/resources/catalog/style/gn_viewer.less
@@ -846,7 +846,7 @@ gn-features-tables,
   .tab-content {
     background: white;
     min-height: 5em;
-    padding: 0 @gn-spacing-lg;
+    padding: 0 15px;
   }
   .gn-features-table {
     box-shadow: 0 0 4px 2px rgba(0, 0, 0, 0.1);
@@ -860,10 +860,11 @@ gn-features-tables,
       .fixed-table-toolbar {
         grid-area: toolbar;
         .columns-right {
-          margin: 0 0 0 @gn-spacing;
+          margin: 0 0 0 10px;
           display: inline-block;
           vertical-align: middle;
-          .btn, .btn-group {
+          .btn,
+          .btn-group {
             display: block;
             float: none;
             width: 100%;
@@ -877,7 +878,7 @@ gn-features-tables,
           }
           .btn-group:last-child:not(:first-child) > .btn:first-child {
             border-radius: 0 0 4px 4px;
-            }
+          }
         }
       }
       .fixed-table-container {
@@ -922,7 +923,7 @@ gn-features-tables,
   .tab-content {
     background: white;
     min-height: 5em;
-    padding: 0 0 @gn-spacing-lg 0;
+    padding: 0 0 15px 0;
   }
   gn-features-tables {
     position: unset;
@@ -949,7 +950,7 @@ gn-features-tables,
 .gn-editor-sidebar {
   .gn-related-resources {
     p {
-      margin-top: @gn-spacing-sm;
+      margin-top: 5px;
     }
   }
   .gn-related-item {
@@ -958,7 +959,7 @@ gn-features-tables,
     }
   }
   .wfs-filter-group {
-    margin-top: @gn-spacing;
+    margin-top: 10px;
     margin-bottom: 0;
     .btn {
       .btn-xs();


### PR DESCRIPTION
This PR adds visual and UX improvements to the WFS preview:
- added whitespace
- remove border for the selection lists
- re-order buttons
- toolbar positioned on the right of the table
- larger buttons in the metadata page and map

**The new look in the map:**

<img width="1671" alt="gn-wfspreview-map" src="https://github.com/user-attachments/assets/5a370085-8553-4ff3-b52a-9ad6c91c6919">


**The new look in the metadata page:**

<img width="1099" alt="gn-wfspreview-metadata-page" src="https://github.com/user-attachments/assets/670ef446-9ec4-4ff7-93f0-8b2877e7b59b">


# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

