### PR TITLE
Fix a problem with recaptcha not shown sometimes

### DIFF
--- a/web-ui/src/main/resources/catalog/components/userfeedback/GnUserfeedbackDirective.js
+++ b/web-ui/src/main/resources/catalog/components/userfeedback/GnUserfeedbackDirective.js
@@ -303,6 +303,7 @@
     "Metadata",
     "vcRecaptchaService",
     "gnConfig",
+    "gnConfigService",
     function (
       $http,
       gnUserfeedbackService,
@@ -311,7 +312,8 @@
       $rootScope,
       Metadata,
       vcRecaptchaService,
-      gnConfig
+      gnConfig,
+      gnConfigService
     ) {
       return {
         restrict: "AEC",
@@ -322,10 +324,12 @@
         templateUrl:
           "../../catalog/components/" + "userfeedback/partials/userfeedbacknew.html",
         link: function (scope) {
-          scope.recaptchaEnabled =
-            gnConfig["system.userSelfRegistration.recaptcha.enable"];
-          scope.recaptchaKey =
-            gnConfig["system.userSelfRegistration.recaptcha.publickey"];
+          gnConfigService.loadPromise.then(function () {
+            scope.recaptchaEnabled =
+              gnConfig["system.userSelfRegistration.recaptcha.enable"];
+            scope.recaptchaKey =
+              gnConfig["system.userSelfRegistration.recaptcha.publickey"];
+          });
           scope.resolveRecaptcha = false;
           scope.userName = null;
 

--- a/web-ui/src/main/resources/catalog/components/userfeedback/GnmdFeedbackDirective.js
+++ b/web-ui/src/main/resources/catalog/components/userfeedback/GnmdFeedbackDirective.js
@@ -139,6 +139,9 @@
                   scope.mdFeedbackOpen = false;
                 } else {
                   scope.success = false;
+                  if (scope.recaptchaEnabled) {
+                    vcRecaptchaService.reload();
+                  }
                 }
               });
             }

--- a/web-ui/src/main/resources/catalog/js/LoginController.js
+++ b/web-ui/src/main/resources/catalog/js/LoginController.js
@@ -45,6 +45,7 @@
     "$window",
     "$timeout",
     "gnUtilityService",
+    "gnConfigService",
     "gnConfig",
     "gnGlobalSettings",
     "vcRecaptchaService",
@@ -59,6 +60,7 @@
       $window,
       $timeout,
       gnUtilityService,
+      gnConfigService,
       gnConfig,
       gnGlobalSettings,
       vcRecaptchaService,
@@ -73,8 +75,23 @@
       $scope.userToRemind = null;
       $scope.changeKey = null;
 
-      $scope.recaptchaEnabled = gnConfig["system.userSelfRegistration.recaptcha.enable"];
-      $scope.recaptchaKey = gnConfig["system.userSelfRegistration.recaptcha.publickey"];
+      gnConfigService.loadPromise.then(function () {
+        $scope.recaptchaEnabled =
+          gnConfig["system.userSelfRegistration.recaptcha.enable"];
+        $scope.recaptchaKey = gnConfig["system.userSelfRegistration.recaptcha.publickey"];
+
+        // take the bigger of the two values
+        $scope.passwordMinLength = Math.max(
+          gnConfig["system.security.passwordEnforcement.minLength"],
+          6
+        );
+        $scope.passwordMaxLength = Math.max(
+          gnConfig["system.security.passwordEnforcement.maxLength"],
+          6
+        );
+        $scope.passwordPattern = gnConfig["system.security.passwordEnforcement.pattern"];
+      });
+
       $scope.resolveRecaptcha = false;
 
       $scope.redirectUrl = gnUtilityService.getUrlParameter("redirect");
@@ -83,17 +100,6 @@
       $scope.isDisableLoginForm = gnGlobalSettings.isDisableLoginForm;
       $scope.isShowLoginAsLink = gnGlobalSettings.isShowLoginAsLink;
       $scope.isUserProfileUpdateEnabled = gnGlobalSettings.isUserProfileUpdateEnabled;
-
-      // take the bigger of the two values
-      $scope.passwordMinLength = Math.max(
-        gnConfig["system.security.passwordEnforcement.minLength"],
-        6
-      );
-      $scope.passwordMaxLength = Math.max(
-        gnConfig["system.security.passwordEnforcement.maxLength"],
-        6
-      );
-      $scope.passwordPattern = gnConfig["system.security.passwordEnforcement.pattern"];
 
       function initForm() {
         if ($window.location.pathname.indexOf("new.password") !== -1) {
@@ -196,6 +202,9 @@
                 timeout: 0,
                 type: "danger"
               });
+              if ($scope.recaptchaEnabled) {
+                vcRecaptchaService.reload();
+              }
             }
           );
       };


### PR DESCRIPTION
In the register user, metadata feedback and user feedback forms, sometimes the settings with the recaptcha keys takes a bit longer to load making the recaptcha widget not to load. This commit fixes that updating the values of the recaptcha settings when the settings have finished loading.

It also resets the recaptcha widget if there is any problem returned by the server
after sending the form.
