### PR TITLE
Restyled `default` address block

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/mdview/partials/contact.html
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/partials/contact.html
@@ -9,12 +9,12 @@
     >
       <div gn-popover-anchor class="row">
         <div
-          class="col-md-4"
+          class="col-md-3 gn-nopadding-left"
           data-gn-circle-letter-icon="c.organisation"
           data-org-key="c.email | getMailDomain"
         ></div>
 
-        <div class="col-md-8">
+        <div class="col-md-9">
           <div class="gn-contact-card-role">{{c.role | translate}}</div>
           <div class="gn-contact-card-org">{{c.organisation}}</div>
         </div>
@@ -57,22 +57,22 @@
       gn-popover
       gn-popover-dismiss=".content"
     >
-      <div gn-popover-anchor class="row">
-        <div class="col-md-12">
-          <div class="gn-contact-card-role">{{cnts[0].role | translate}}</div>
-          <div class="col-md-12" data-ng-repeat="c in cnts | orderBy:'organisation'">
-            <div class="row">
+      <div gn-popover-anchor>
+<!--        <div class="col-md-12">-->
+          <div class="row" data-ng-repeat="c in cnts | orderBy:'organisation'">
+<!--            <div class="row">-->
               <div
-                class="col-md-4"
+                class="col-md-3 gn-nopadding-left"
                 data-gn-circle-letter-icon="c.organisation"
                 data-org-key="c.email | getMailDomain"
               ></div>
-              <div class="col-md-8">
+              <div class="col-md-9">
+                <div class="gn-contact-card-role">{{cnts[0].role | translate}}</div>
                 <div class="gn-contact-card-org-group">{{c.organisation}}</div>
               </div>
             </div>
-          </div>
-        </div>
+<!--          </div>-->
+<!--        </div>-->
       </div>
 
       <div gn-popover-content>
@@ -120,12 +120,12 @@
     >
       <div gn-popover-anchor class="row">
         <div
-          class="col-md-4"
+          class="col-md-3 gn-nopadding-left"
           data-gn-circle-letter-icon="org"
           data-org-key="contactByOrgRole[0].email | getMailDomain"
         ></div>
 
-        <div class="col-md-8" ng-repeat="c in contactByOrgRole">
+        <div class="col-md-9" ng-repeat="c in contactByOrgRole">
           <div class="gn-contact-card-org-group">{{c.organisation}}</div>
 
           <div class="gn-contact-card-group-role" data-ng-repeat="r in ::c.roles">
@@ -174,29 +174,42 @@
     data-ng-if="mode == 'default'"
     data-ng-repeat="c in mdContacts track by $index"
   >
-    <h3>
-      <i class="fa fa-envelope"></i>
-      {{c.role | translate}}
-    </h3>
-    <div class="row">
-      <div class="col-md-8">
+    <div class="panel panel-address">
+      <div class="panel-heading">
+        <h3>
+          <i class="fa fa-fw fa-address-card-o"></i>
+          {{c.role | translate}}
+        </h3>
+      </div>
+      <div class="panel-body">
+        <img data-ng-if="c.logo" class="gn-source-logo" data-ng-src="{{::c.logo}}" />
         <address>
-          <strong data-ng-if="::c.website">
-            <a data-ng-href="{{::c.website}}">{{c.organisation}}</a><br />
-          </strong>
-          <strong data-ng-if="::!c.website"> {{c.organisation}}<br /> </strong>
+
+          <div data-ng-if="::c.website">
+            <label data-translate="">mdWebsite</label>
+            <a data-ng-href="{{::c.website}}">
+              <i class="fa fa-fw fa-link"></i>
+              {{c.organisation}}
+            </a>
+          </div>
+          <div data-ng-if="::!c.website">
+            <label data-translate="">mdOrganization</label>
+            {{c.organisation}}
+          </div>
 
           <div data-gn-metadata-individual="c"></div>
 
-          <div data-ng-if="c.address != ''">{{c.address}}</div>
+          <div data-ng-if="c.address != ''">
+            <label data-translate="">mdAddress</label>
+            {{c.address}}
+          </div>
           <a href="tel:{{c.phone}}" data-ng-if="c.phone != ''">
+            <label data-translate="">mdPhone</label>
             <i class="fa fa-fw fa-phone"></i>
             {{c.phone}}
           </a>
         </address>
-      </div>
-      <div class="col-md-4">
-        <img data-ng-if="c.logo" class="gn-source-logo" data-ng-src="{{::c.logo}}" />
+
       </div>
     </div>
   </div>
@@ -207,38 +220,58 @@
     data-ng-if="mode == 'role'"
     data-ng-repeat="(roles, contactByRole) in mdContactsByRole"
   >
-    <h3>
-      <i class="fa fa-envelope"></i>
-      <span> {{translateRoles(roles)}} </span>
-    </h3>
-    <div
-      class="row"
-      data-ng-repeat="(organisation, contact) in contactByRole | groupBy:'organisation'"
-    >
-      <div class="col-md-8">
-        <address>
-          <strong data-ng-if="::c.website">
-            <a data-ng-href="{{::c.website}}">{{c.organisation}}</a><br />
-          </strong>
-          <strong data-ng-if="::!c.website"> {{c.organisation}}<br /> </strong>
-
-          <span data-ng-repeat="c in contact track by $index">
-            <div data-gn-metadata-individual="c"></div>
-          </span>
-
-          <!-- Address for organisation: display for 1st contact in organisation -->
-          <span data-ng-repeat="c in contact | limitTo:1">
-            <div data-ng-if="c.address != ''">{{c.address}}</div>
-            <a href="tel:{{c.phone}}" data-ng-if="c.phone != ''">
-              <i class="fa fa-fw fa-phone"></i>
-              {{c.phone}}
-            </a>
-          </span>
-        </address>
+    <div class="panel panel-address">
+      <div class="panel-heading">
+        <h3>
+          <i class="fa fa-fw fa-address-card-o"></i>
+          <span> {{translateRoles(roles)}} </span>
+        </h3>
       </div>
-      <!-- Logo for organisation: display for 1st contact in organisation -->
-      <div class="col-md-4" data-ng-repeat="c in contact | limitTo:1">
-        <img data-ng-if="c.logo" class="gn-source-logo" data-ng-src="{{::c.logo}}" />
+      <div class="panel-body">
+
+        <div
+          data-ng-repeat="(organisation, contact) in contactByRole | groupBy:'organisation'"
+        >
+
+          <!-- Logo for organisation: display for 1st contact in organisation -->
+          <div data-ng-repeat="c in contact | limitTo:1">
+            <img data-ng-if="c.logo" class="gn-source-logo" data-ng-src="{{::c.logo}}" />
+          </div>
+          <address>
+            <div data-ng-if="::c.website">
+              <label data-translate="">mdWebsite</label>
+              <a data-ng-href="{{::c.website}}">
+                <i class="fa fa-fw fa-link"></i>
+                {{c.organisation}}
+              </a>
+            </div>
+            <div data-ng-if="::!c.website">
+              <label data-translate="">mdOrganization</label>
+              {{c.organisation}}
+            </div>
+
+            <div data-ng-repeat="c in contact track by $index">
+              <div data-gn-metadata-individual="c"></div>
+            </div>
+
+            <!-- Address for organisation: display for 1st contact in organisation -->
+            <div data-ng-repeat="c in contact | limitTo:1">
+              <div data-ng-if="c.address != ''">
+                <label data-translate="">mdAddress</label>
+                {{c.address}}
+              </div>
+
+              <div data-ng-if="c.phone != ''">
+                <label data-translate="">mdPhone</label>
+                <a href="tel:{{c.phone}}">
+                  <i class="fa fa-fw fa-phone"></i>
+                  {{c.phone}}
+                </a>
+              </div>
+            </div>
+          </address>
+
+        </div>
       </div>
     </div>
   </div>
@@ -249,32 +282,43 @@
     data-ng-if="mode == 'org-role'"
     data-ng-repeat="(org, contactByOrgRole) in mdContactsByOrgRole"
   >
-    <address>
-      <strong data-ng-if="::orgWebsite[org]">
-        <i class="fa fa-fw fa-link"></i>
-        <a data-ng-href="{{::orgWebsite[org]}}">{{org}}</a><br />
-      </strong>
-      <strong data-ng-if="::!orgWebsite[org]"> {{org}} </strong>
+    <div class="panel panel-address">
+      <div class="panel-body">
+        <address>
+          <div data-ng-if="::orgWebsite[org]">
+            <label data-translate="">mdWebsite</label>
+            <a data-ng-href="{{::orgWebsite[org]}}">
+              <i class="fa fa-fw fa-link"></i>
+              {{org}}
+            </a>
+          </div>
+          <div data-ng-if="::!orgWebsite[org]">
+            <label data-translate="">mdOrganization</label>
+            {{org}}
+          </div>
 
-      <div
-        ng-repeat="(key, contactGroupByAddress) in contactByOrgRole | groupBy:'address'"
-      >
-        <span data-ng-if="key != ''">
-          <i class="fa fa-fw fa-map-marker"></i>
-          {{key}}<br />
-        </span>
-        <ul>
-          <li
-            ng-repeat="(roles, contactGroupByRole) in contactGroupByAddress | groupBy:'roles'"
+          <div
+            ng-repeat="(key, contactGroupByAddress) in contactByOrgRole | groupBy:'address'"
           >
-            {{translateRoles(roles)}}:<br />
-            <span data-ng-repeat="c in contactGroupByRole track by $index">
-              <div data-gn-metadata-individual="c"></div>
-              <span data-ng-if="!$last"><hr /></span>
+            <span data-ng-if="key != ''">
+              <i class="fa fa-fw fa-map-marker"></i>
+              {{key}}<br />
             </span>
-          </li>
-        </ul>
+            <ul>
+              <li
+                ng-repeat="(roles, contactGroupByRole) in contactGroupByAddress | groupBy:'roles'"
+              >
+                {{translateRoles(roles)}}:<br />
+                <div data-ng-repeat="c in contactGroupByRole track by $index">
+                  <div data-gn-metadata-individual="c"></div>
+                  <span data-ng-if="!$last"><hr /></span>
+                </div>
+              </li>
+            </ul>
+          </div>
+        </address>
+
       </div>
-    </address>
+    </div>
   </div>
 </div>

--- a/web-ui/src/main/resources/catalog/components/search/mdview/partials/contact.html
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/partials/contact.html
@@ -76,7 +76,9 @@
         <!--     Removing for now, because if you close open popup
    the title disappear. <h3 class="popover-title">{{cnts[0].role | translate}}</h3>-->
         <div data-ng-repeat="c in cnts | orderBy:'organisation'">
-          <label class="visible-print" data-ng-if="::c.website" data-translate="">mdWebsite</label>
+          <label class="visible-print" data-ng-if="::c.website" data-translate=""
+            >mdWebsite</label
+          >
           <a data-ng-href="{{::c.website}}" data-ng-if="::c.website">
             <i class="fa fa-fw fa-link"></i>
             {{c.organisation}}

--- a/web-ui/src/main/resources/catalog/components/search/mdview/partials/contact.html
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/partials/contact.html
@@ -29,6 +29,7 @@
         <div data-gn-metadata-individual="c"></div>
 
         <address data-ng-if="c.address != '' || c.phone != ''">
+          <label class="visible-print" data-translate="">mdAddress</label>
           <div data-ng-if="c.address != ''">
             <i class="fa fa-fw fa-map-marker"></i>
             {{c.address}}
@@ -58,27 +59,24 @@
       gn-popover-dismiss=".content"
     >
       <div gn-popover-anchor>
-<!--        <div class="col-md-12">-->
-          <div class="row" data-ng-repeat="c in cnts | orderBy:'organisation'">
-<!--            <div class="row">-->
-              <div
-                class="col-md-3 gn-nopadding-left"
-                data-gn-circle-letter-icon="c.organisation"
-                data-org-key="c.email | getMailDomain"
-              ></div>
-              <div class="col-md-9">
-                <div class="gn-contact-card-role">{{cnts[0].role | translate}}</div>
-                <div class="gn-contact-card-org-group">{{c.organisation}}</div>
-              </div>
-            </div>
-<!--          </div>-->
-<!--        </div>-->
+        <div class="row" data-ng-repeat="c in cnts | orderBy:'organisation'">
+          <div
+            class="col-md-3 gn-nopadding-left"
+            data-gn-circle-letter-icon="c.organisation"
+            data-org-key="c.email | getMailDomain"
+          ></div>
+          <div class="col-md-9">
+            <div class="gn-contact-card-role">{{cnts[0].role | translate}}</div>
+            <div class="gn-contact-card-org-group">{{c.organisation}}</div>
+          </div>
+        </div>
       </div>
 
       <div gn-popover-content>
         <!--     Removing for now, because if you close open popup
    the title disappear. <h3 class="popover-title">{{cnts[0].role | translate}}</h3>-->
         <div data-ng-repeat="c in cnts | orderBy:'organisation'">
+          <label class="visible-print" data-ng-if="::c.website" data-translate="">mdWebsite</label>
           <a data-ng-href="{{::c.website}}" data-ng-if="::c.website">
             <i class="fa fa-fw fa-link"></i>
             {{c.organisation}}
@@ -87,6 +85,7 @@
           <div data-gn-metadata-individual="c"></div>
 
           <address data-ng-if="c.address != '' || c.phone != ''">
+            <label class="visible-print" data-translate="">mdAddress</label>
             <div data-ng-if="c.address != ''">
               <i class="fa fa-fw fa-map-marker"></i>
               {{c.address}}
@@ -144,6 +143,7 @@
           <div data-gn-metadata-individual="c"></div>
 
           <address data-ng-if="c.address != '' || c.phone != ''">
+            <label class="visible-print" data-translate="">mdAddress</label>
             <div data-ng-if="c.address != ''">
               <i class="fa fa-fw fa-map-marker"></i>
               {{c.address}}
@@ -184,7 +184,6 @@
       <div class="panel-body">
         <img data-ng-if="c.logo" class="gn-source-logo" data-ng-src="{{::c.logo}}" />
         <address>
-
           <div data-ng-if="::c.website">
             <label data-translate="">mdWebsite</label>
             <a data-ng-href="{{::c.website}}">
@@ -209,7 +208,6 @@
             {{c.phone}}
           </a>
         </address>
-
       </div>
     </div>
   </div>
@@ -228,11 +226,9 @@
         </h3>
       </div>
       <div class="panel-body">
-
         <div
           data-ng-repeat="(organisation, contact) in contactByRole | groupBy:'organisation'"
         >
-
           <!-- Logo for organisation: display for 1st contact in organisation -->
           <div data-ng-repeat="c in contact | limitTo:1">
             <img data-ng-if="c.logo" class="gn-source-logo" data-ng-src="{{::c.logo}}" />
@@ -270,7 +266,6 @@
               </div>
             </div>
           </address>
-
         </div>
       </div>
     </div>
@@ -317,7 +312,6 @@
             </ul>
           </div>
         </address>
-
       </div>
     </div>
   </div>

--- a/web-ui/src/main/resources/catalog/components/search/mdview/partials/individual.html
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/partials/individual.html
@@ -1,4 +1,5 @@
 <div data-ng-if="c.email != ''">
+  <label data-translate="">mdEmail</label>
   <a href="mailto:{{c.email}}">
     <i class="fa fa-fw fa-envelope"></i>
     <span data-ng-hide="c.individual">{{c.email}}</span>

--- a/web-ui/src/main/resources/catalog/locales/en-v4.json
+++ b/web-ui/src/main/resources/catalog/locales/en-v4.json
@@ -449,5 +449,10 @@
   "linkStatus": "Link status",
   "requestStatus": "Request status",
   "linkUrl": "Link url",
-  "associatedUuid": "Associated to metadata UUID"
+  "associatedUuid": "Associated to metadata UUID",
+  "mdEmail": "Email",
+  "mdWebsite": "Website",
+  "mdOrganization": "Organization",
+  "mdAddress": "Address",
+  "mdPhone": "Phone"
 }

--- a/web-ui/src/main/resources/catalog/style/gn_metadata.less
+++ b/web-ui/src/main/resources/catalog/style/gn_metadata.less
@@ -622,16 +622,11 @@ ul.container-list {
         padding-left: 0px;
         padding-right: 0px;
       }
-      .gn-contact-card-org {
+      .gn-contact-card-org, .gn-contact-card-org-group {
         padding: 5px 0;
         margin-bottom: 10px;
       }
       .gn-contact-card-role {
-        font-style: italic;
-        font-weight: bolder;
-      }
-      .gn-contact-card-org-group {
-        font-style: italic;
         font-weight: bolder;
       }
       .gn-contact-card-group-role {

--- a/web-ui/src/main/resources/catalog/style/gn_metadata.less
+++ b/web-ui/src/main/resources/catalog/style/gn_metadata.less
@@ -619,10 +619,11 @@ ul.container-list {
       }
       .col-md-6,
       .col-md-4 {
-        padding-left: 0px;
-        padding-right: 0px;
+        padding-left: 0;
+        padding-right: 0;
       }
-      .gn-contact-card-org, .gn-contact-card-org-group {
+      .gn-contact-card-org,
+      .gn-contact-card-org-group {
         padding: 5px 0;
         margin-bottom: 10px;
       }
@@ -631,6 +632,27 @@ ul.container-list {
       }
       .gn-contact-card-group-role {
         padding: 5px;
+      }
+      @media print {
+        [gn-popover-content] {
+          .make-md-column-offset(3);
+          padding: 0 @gn-spacing-lg;
+          display: block !important;
+          label, a {
+            display: block;
+            margin-bottom: @gn-spacing;
+          }
+          [data-label="focusOnFrom"] {
+            display: none;
+          }
+          .fa {
+            display: none;
+          }
+          [data-ng-href] {
+            margin-bottom: @gn-spacing;
+            display: inline-block;
+          }
+        }
       }
     }
   }

--- a/web-ui/src/main/resources/catalog/style/gn_metadata.less
+++ b/web-ui/src/main/resources/catalog/style/gn_metadata.less
@@ -1,4 +1,5 @@
 @import "gn_search.less";
+@import "gn_variables.less";
 
 .panel-body .gn-metadata-view {
   width: 100%;

--- a/web-ui/src/main/resources/catalog/style/gn_metadata.less
+++ b/web-ui/src/main/resources/catalog/style/gn_metadata.less
@@ -634,11 +634,16 @@ ul.container-list {
         padding: 5px;
       }
       @media print {
+        svg {
+          max-width: 75px;
+          margin: 15px;
+        }
         [gn-popover-content] {
           .make-md-column-offset(3);
           padding: 0 @gn-spacing-lg;
           display: block !important;
-          label, a {
+          label,
+          a {
             display: block;
             margin-bottom: @gn-spacing;
           }

--- a/web-ui/src/main/resources/catalog/style/gn_variables.less
+++ b/web-ui/src/main/resources/catalog/style/gn_variables.less
@@ -1,0 +1,6 @@
+// variables used in custom styles
+// -------------------------------
+
+@gn-spacing: 10px;
+@gn-spacing-sm: 5px;
+@gn-spacing-lg: 15px;

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_print_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_print_default.less
@@ -1,4 +1,5 @@
 @import "../../../lib/style/bootstrap/less/variables.less";
+@import "../../../lib/style/bootstrap/less/mixins/grid.less";
 @import "gn_view.less";
 
 // special print classes

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_print_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_print_default.less
@@ -1,4 +1,5 @@
 @import "../../../lib/style/bootstrap/less/variables.less";
+@import "gn_view.less";
 
 // special print classes
 .gn-new-page {
@@ -104,6 +105,26 @@ a[href]:after {
     }
     svg {
       max-width: 100px;
+    }
+    [gn-popover-content] {
+      .make-md-column-offset(3);
+      padding: 0 @gn-spacing-lg;
+      display: block !important;
+      label,
+      a {
+        display: block;
+        margin-bottom: @gn-spacing;
+      }
+      [data-label="focusOnFrom"] {
+        display: none;
+      }
+      .fa {
+        display: none;
+      }
+      [data-ng-href] {
+        margin-bottom: @gn-spacing;
+        display: inline-block;
+      }
     }
   }
   .gn-md-side-crs {

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_result_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_result_default.less
@@ -1,4 +1,5 @@
 @import "../../../style/gn_search.less";
+@import "../../../style/gn_variables.less";
 // variables for manipulating the theme
 @import "gn_variables_default.less"; // must be last
 

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_result_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_result_default.less
@@ -97,6 +97,39 @@
       background-color: @brand-danger !important;
     }
   }
+  // address card
+  .panel-address {
+    padding-bottom: 0;
+    box-shadow: none;
+    border: 1px solid @panel-default-border;
+    .panel-heading {
+      padding: @gn-spacing-lg;
+      border-bottom: 1px solid @panel-default-border;
+      background-color: @panel-default-heading-bg;
+      height: auto;
+      line-height: normal;
+      h3 {
+        margin: 0;
+        padding: 0;
+        font-size: 14px;
+        font-weight: bold;
+      }
+    }
+    .panel-body {
+      padding: 0;
+      address {
+        padding: @gn-spacing-lg;
+
+        border-radius: @panel-border-radius;
+        margin: 0;
+        label {
+          min-width: 20%;
+          margin-right: @gn-spacing;
+        }
+      }
+    }
+
+  }
   // card
   .gn-card-view-header {
     padding: 15px;

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_view.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_view.less
@@ -1,12 +1,9 @@
 @import "../../../lib/style/bootstrap/less/variables.less";
+@import "../../../style/gn_variables.less";
 
 /* Defined here any custom style for the view
    which has to be applied for all apps
    (ie. admin, search, login, editor). */
-
-@gn-spacing: 10px;
-@gn-spacing-sm: 5px;
-@gn-spacing-lg: 15px;
 
 //  padding
 .gn-padding-top {


### PR DESCRIPTION
This PR adds a different style for the `default` address block in the metadata page:

- labels are added
- it now has a bordered address card
- the title is in a header
- an address card icon is added to the heading

**Screenshot of the restyled default layout**

---
<img width="729" alt="gn-default-layout" src="https://github.com/user-attachments/assets/739d223b-d669-4d2d-a7bf-c031e25f520d">
---

Furthermore, it changes the style for the `icon` layout a bit:
- the circled letter is smaller in size
- texts are now all right of the circle
- italic is changed to bold

**Screenshot of the smaller circles**

---
<img width="718" alt="gn-icon-layout" src="https://github.com/user-attachments/assets/27d45999-6797-400b-b893-b54b6f366d8d">
---


# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

