### PR TITLE
Fix online resource update/delete so that it supports multiple gmd:MD_DigitalTransferOptions blocks.

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/process/onlinesrc-add.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/process/onlinesrc-add.xsl
@@ -187,18 +187,28 @@ Note: It assumes that it will be adding new items in
   <!-- Updating the gmd:onLine based on update parameters -->
   <!-- Note: first part of the match needs to match the xsl:for-each select from extract-relations.xsl in order to get the position() to match -->
   <!-- The unique identifier is marked with resourceIdx which is the position index and resourceHash which is hash code of the current node (combination of url, resource name, and description) -->
-  <xsl:template
-    match="*//gmd:MD_DigitalTransferOptions/gmd:onLine
-        [gmd:CI_OnlineResource[gmd:linkage/gmd:URL!=''] and ($resourceIdx = '' or position() = xs:integer($resourceIdx))]
-        [($resourceHash != '' or ($updateKey != '' and normalize-space($updateKey) = concat(
+  <!-- Template to match all gmd:onLine elements -->
+  <xsl:template match="//gmd:MD_DigitalTransferOptions/gmd:onLine" priority="2">
+    <!-- Calculate the global position of the current gmd:onLine element -->
+    <xsl:variable name="position" select="count(//gmd:MD_DigitalTransferOptions/gmd:onLine[current() >> .]) + 1" />
+
+    <xsl:choose>
+      <xsl:when test="gmd:CI_OnlineResource[gmd:linkage/gmd:URL != ''] and
+                      ($resourceIdx = '' or $position = xs:integer($resourceIdx)) and
+                      ($resourceHash != '' or ($updateKey != '' and normalize-space($updateKey) = concat(
                           gmd:CI_OnlineResource/gmd:linkage/gmd:URL,
                           gmd:CI_OnlineResource/gmd:protocol/*,
                           gmd:CI_OnlineResource/gmd:name/gco:CharacterString)))
-                     and ($resourceHash = '' or digestUtils:md5Hex(string(exslt:node-set(normalize-space(.)))) = $resourceHash)]"
-    priority="2">
-    <xsl:call-template name="createOnlineSrc"/>
+                     and ($resourceHash = '' or digestUtils:md5Hex(normalize-space(.)) = $resourceHash)">
+        <xsl:call-template name="createOnlineSrc"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:copy>
+          <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
-
 
   <xsl:template name="createOnlineSrc">
     <!-- Add all online source from the target metadata to the
@@ -243,7 +253,7 @@ Note: It assumes that it will be adding new items in
                   </gmd:URL>
                 </gmd:linkage>
                 <gmd:protocol>
-                 <xsl:call-template name="setProtocol"/>
+                  <xsl:call-template name="setProtocol"/>
                 </gmd:protocol>
 
                 <xsl:if test="$applicationProfile != ''">

--- a/schemas/iso19139/src/main/plugin/iso19139/process/onlinesrc-remove.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/process/onlinesrc-remove.xsl
@@ -53,15 +53,25 @@ Stylesheet used to remove a reference to a online resource.
   <!-- Remove the gmd:onLine define in url parameter  -->
   <!-- Note: first part of the match needs to match the xsl:for-each select from extract-relations.xsl in order to get the position() to match -->
   <!-- The unique identifier is marked with resourceIdx which is the position index and resourceHash which is hash code of the current node (combination of url, resource name, and description) -->
-  <xsl:template
-    match="*//gmd:MD_DigitalTransferOptions/gmd:onLine
-        [gmd:CI_OnlineResource[gmd:linkage/gmd:URL!=''] and ($resourceIdx = '' or (count(preceding::gmd:onLine) + 1) = xs:integer($resourceIdx))]
-        [($resourceHash != '' or ($url != null and (normalize-space(gmd:CI_OnlineResource/gmd:linkage/gmd:URL) = $url and normalize-space(gmd:CI_OnlineResource/gmd:name/gco:CharacterString) = normalize-space($name)
+  <xsl:template match="//gmd:MD_DigitalTransferOptions/gmd:onLine" priority="2">
+
+    <!-- Calculate the global position of the current gmd:onLine element -->
+    <xsl:variable name="position" select="count(//gmd:MD_DigitalTransferOptions/gmd:onLine[current() >> .]) + 1" />
+
+    <xsl:if test="not(
+                      gmd:CI_OnlineResource[gmd:linkage/gmd:URL != ''] and
+                      ($resourceIdx = '' or $position = xs:integer($resourceIdx)) and
+                      ($resourceHash != '' or ($url != null and (normalize-space(gmd:CI_OnlineResource/gmd:linkage/gmd:URL) = $url and normalize-space(gmd:CI_OnlineResource/gmd:name/gco:CharacterString) = normalize-space($name)
                                                                 or normalize-space(gmd:CI_OnlineResource/gmd:linkage/gmd:URL) = $url and count(gmd:CI_OnlineResource/gmd:name/gmd:PT_FreeText/gmd:textGroup[gmd:LocalisedCharacterString = $name]) > 0
                                                                 or normalize-space(gmd:CI_OnlineResource/gmd:linkage/gmd:URL) = $url and normalize-space(gmd:CI_OnlineResource/gmd:protocol/*) = 'WWW:DOWNLOAD-1.0-http--download'))
                         )
-                        and ($resourceHash = '' or digestUtils:md5Hex(string(exslt:node-set(normalize-space(.)))) = $resourceHash)]"
-    priority="2"/>
+                        and ($resourceHash = '' or digestUtils:md5Hex(normalize-space(.)) = $resourceHash)
+                   )">
+      <xsl:copy>
+        <xsl:apply-templates select="@*|node()"/>
+      </xsl:copy>
+    </xsl:if>
+  </xsl:template>
 
   <!-- Do a copy of every node and attribute -->
   <xsl:template match="@*|node()">


### PR DESCRIPTION
@fxprunayre 
Here are the changes that should fix the update/delete logic for the online resources.

Unfortunately, I have only had time to test this on the 4.2 branch and it seems to work correctly - I did not have time to test this on the main branch.

You may test these changes to see if it fixes the problem - otherwise, I don't believe I will have time to test this until middle of next week.
