### PR TITLE
Update batch PDF export to skip working copies

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/CatalogApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/CatalogApi.java
@@ -389,8 +389,8 @@ public class CatalogApi {
 
         final SearchResponse searchResponse = searchManager.query(
             String.format(
-                "uuid:(\"%s\") and not draft:\"y\"", // Skip working copies as duplicate UUIDs cause the PDF xslt to fail
-                String.join("\" or \"", uuidList)),
+                "uuid:(\"%s\") AND NOT draft:\"y\"", // Skip working copies as duplicate UUIDs cause the PDF xslt to fail
+                String.join("\" OR \"", uuidList)),
             EsFilterBuilder.buildPermissionsFilter(ApiUtils.createServiceContext(httpRequest)),
             searchFieldsForPdf, 0, maxhits);
 

--- a/services/src/main/java/org/fao/geonet/api/records/CatalogApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/CatalogApi.java
@@ -389,7 +389,7 @@ public class CatalogApi {
 
         final SearchResponse searchResponse = searchManager.query(
             String.format(
-                "uuid:(\"%s\")",
+                "uuid:(\"%s\") and not draft:\"y\"", // Skip working copies as duplicate UUIDs cause the PDF xslt to fail
                 String.join("\" or \"", uuidList)),
             EsFilterBuilder.buildPermissionsFilter(ApiUtils.createServiceContext(httpRequest)),
             searchFieldsForPdf, 0, maxhits);


### PR DESCRIPTION
<!--Include a few sentences describing the overall goals for this Pull Request-->
Records with working copies are causing the batch PDF export xslt to fail. The UUIDs are used as an ID resulting in duplicate ID values where there must only be unique values.

CSV export seems to handle this by processing the results after they are received and removing any working copies but there is not similar logic for PDF.

Ex.

- Select at least one record with a working copy from the search page
- Export as PDF

This results in a 400 and the below error:

![image](https://github.com/user-attachments/assets/d9d0d53a-bb81-4105-b662-6fdb5ecdf701)
```
Error at xsl:value-of on line 235 of metadata-fop.xsl:
  SXCH0003: org.apache.fop.fo.ValidationException: Property ID
  "section-37aecae5-7783-4274-b595-df02aa003ac3" (found on "fo:block") previously used; ID
  values must be unique within a document! (See position 234:-1)
 ```

This PR aims to fix this issue by omitting the working copies from the elasticsearch results.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

