### PR TITLE
option to force xsd schema check for required field

### DIFF
--- a/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
@@ -102,12 +102,11 @@
 
     <xsl:param name="isReadOnly" required="no" as="xs:boolean" select="false()"/>
 
-    <!-- Forcing the check for xsd schema for required field -->
-    <xsl:param name="forceXsdSchemaCheck" required="no" as="xs:boolean" select="true()"/>
-
     <xsl:variable name="isMultilingual" select="count($value/values) > 0"/>
 
     <xsl:variable name="isoType" select="if (../@gco:isoType) then ../@gco:isoType else ''"/>
+
+    <xsl:variable name="elementCondition" select="gn-fn-metadata:getLabel($schema, name(), $labels, name(..),$isoType, $xpath)/condition" />
 
     <!-- Required status is defined in parent element for
     some profiles like ISO19139. If not set, the element
@@ -116,12 +115,7 @@
     -->
     <xsl:variable name="isRequired" as="xs:boolean">
       <xsl:choose>
-        <xsl:when
-          test="($forceXsdSchemaCheck and $parentEditInfo and $parentEditInfo/@min = 1 and $parentEditInfo/@max = 1) or
-          (not($parentEditInfo) and $editInfo and $editInfo/@min = 1 and $editInfo/@max = 1)">
-          <xsl:value-of select="true()"/>
-        </xsl:when>
-        <xsl:when test="gn-fn-metadata:getLabel($schema, name(), $labels, name(..),$isoType, $xpath)/condition = 'mandatory'">
+        <xsl:when test="$elementCondition = 'mandatory'">
           <xsl:value-of select="true()"/>
         </xsl:when>
         <xsl:otherwise>

--- a/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
@@ -118,6 +118,14 @@
         <xsl:when test="$elementCondition = 'mandatory'">
           <xsl:value-of select="true()"/>
         </xsl:when>
+        <xsl:when test="$elementCondition = 'optional'">
+          <xsl:value-of select="false()"/>
+        </xsl:when>
+        <xsl:when
+          test="($parentEditInfo and $parentEditInfo/@min = 1 and $parentEditInfo/@max = 1) or
+          (not($parentEditInfo) and $editInfo and $editInfo/@min = 1 and $editInfo/@max = 1)">
+          <xsl:value-of select="true()"/>
+        </xsl:when>
         <xsl:otherwise>
           <xsl:value-of select="false()"/>
         </xsl:otherwise>

--- a/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
@@ -102,6 +102,9 @@
 
     <xsl:param name="isReadOnly" required="no" as="xs:boolean" select="false()"/>
 
+    <!-- Forcing the check for xsd schema for required field -->
+    <xsl:param name="forceXsdSchemaCheck" required="no" as="xs:boolean" select="true()"/>
+
     <xsl:variable name="isMultilingual" select="count($value/values) > 0"/>
 
     <xsl:variable name="isoType" select="if (../@gco:isoType) then ../@gco:isoType else ''"/>
@@ -114,7 +117,7 @@
     <xsl:variable name="isRequired" as="xs:boolean">
       <xsl:choose>
         <xsl:when
-          test="($parentEditInfo and $parentEditInfo/@min = 1 and $parentEditInfo/@max = 1) or
+          test="($forceXsdSchemaCheck and $parentEditInfo and $parentEditInfo/@min = 1 and $parentEditInfo/@max = 1) or
           (not($parentEditInfo) and $editInfo and $editInfo/@min = 1 and $editInfo/@max = 1)">
           <xsl:value-of select="true()"/>
         </xsl:when>


### PR DESCRIPTION
This feature and extra param in the render-element function gives option for the sub schema to either force xsd check for required field or not.

![image](https://github.com/user-attachments/assets/7942c69d-1d54-4504-93cd-a89ba01b208a)
