### PR TITLE
Standard / ISO19139 / i18n / Missing french translation

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/loc/fre/labels.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/fre/labels.xml
@@ -359,7 +359,10 @@
       n’est pas respectée.
     </help>
     <condition/>
-
+  </element>
+  <element name="gmd:DQ_EvaluationMethodTypeCode">
+    <label>Code du type de méthode d'évaluation</label>
+    <description>Type de méthode d'évaluation d'une mesure de qualité de données identifiée</description>
   </element>
   <element name="gmd:DQ_FormatConsistency" id="114.0">
     <label>Cohérence du format</label>


### PR DESCRIPTION
On application startup, the translation pack may report an error like the following

```
org.fao.geonet.api.exception.ResourceNotFoundException
        at org.fao.geonet.api.standards.StandardsUtils.getCodelistOrLabel(StandardsUtils.java:72)
        at org.fao.geonet.api.standards.StandardsUtils.getLabel(StandardsUtils.java:55)
        at org.fao.geonet.api.tools.i18n.TranslationPackBuilder.getStandardLabel(TranslationPackBuilder.java:217)
```
due to a missing french translation for element `DQ_EvaluationMethodTypeCode`

Follow up of https://github.com/geonetwork/core-geonetwork/pull/7180


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

Funded by Ifremer
