### PR TITLE
ui option to show last modified date instead of etag in version column

### DIFF
--- a/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStoreResource.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStoreResource.java
@@ -26,6 +26,7 @@
 package org.fao.geonet.api.records.attachments;
 
 
+import com.fasterxml.jackson.annotation.JsonFormat;
 import com.google.common.net.UrlEscapers;
 import org.fao.geonet.domain.MetadataResource;
 import org.fao.geonet.domain.MetadataResourceExternalManagementProperties;
@@ -42,6 +43,7 @@ public class FilesystemStoreResource implements MetadataResource {
     private final String url;
     private final MetadataResourceVisibility metadataResourceVisibility;
     private final long size;
+    @JsonFormat(pattern="yyyy-MM-dd")
     private final Date lastModification;
     private final int metadataId;
     private final String metadataUuid;

--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
@@ -802,7 +802,7 @@
                 <!-- boolean -->
                 <div
                   class="row"
-                  data-ng-switch-when="is3DModeAllowed|isVegaEnabled|isSaveMapInCatalogAllowed|isAccessible|isExportMapAsImageEnabled|useOSM|isUserRecordsOnly|isFilterTagsDisplayed|isFilterTagsDisplayedInSearch|autoFitOnLayer|showSocialBarInFooter|isSocialbarEnabled|isLogoInHeader|isHeaderFixed|fluidLayout|fluidHeaderLayout|fluidEditorLayout|showGNName|humanizeDates|sortKeywordsAlphabetically|showMosaic|showMaps|showApplicationInfoAndLinksInFooter|showBatchDropdown|moreLikeThisSameType|allowRemoteRecordLink|singleTileWMS|showSearch|hotkeys"
+                  data-ng-switch-when="is3DModeAllowed|isVegaEnabled|isSaveMapInCatalogAllowed|isAccessible|isExportMapAsImageEnabled|useOSM|isUserRecordsOnly|isFilterTagsDisplayed|isFilterTagsDisplayedInSearch|autoFitOnLayer|showSocialBarInFooter|isSocialbarEnabled|isLogoInHeader|isHeaderFixed|fluidLayout|fluidHeaderLayout|fluidEditorLayout|showGNName|humanizeDates|sortKeywordsAlphabetically|showMosaic|showMaps|showApplicationInfoAndLinksInFooter|showBatchDropdown|moreLikeThisSameType|allowRemoteRecordLink|singleTileWMS|showSearch|hotkeys|showFileStoreLastmodified"
                   data-ng-switch-when-separator="|"
                 >
                   <div class="col-lg-5 gn-nopadding-left">

--- a/web-ui/src/main/resources/catalog/components/filestore/FileStoreDirective.js
+++ b/web-ui/src/main/resources/catalog/components/filestore/FileStoreDirective.js
@@ -131,6 +131,7 @@
       }
     ])
     .directive("gnFileStore", [
+      "gnGlobalSettings",
       "gnFileStoreService",
       "gnOnlinesrc",
       "gnCurrentEdit",
@@ -138,6 +139,7 @@
       "$rootScope",
       "$parse",
       function (
+        gnGlobalSettings,
         gnfilestoreService,
         gnOnlinesrc,
         gnCurrentEdit,
@@ -164,6 +166,9 @@
             scope.gnCurrentEdit = gnCurrentEdit;
             scope.selectOptions = { current: undefined };
             scope.metadataResources = [];
+
+            scope.showFileStoreLastmodified = gnGlobalSettings.gnCfg.mods.recordview.showFileStoreLastmodified;
+
 
             scope.setResource = function (r) {
               scope.selectCallback({ selected: r });

--- a/web-ui/src/main/resources/catalog/components/filestore/partials/filestore.html
+++ b/web-ui/src/main/resources/catalog/components/filestore/partials/filestore.html
@@ -46,7 +46,8 @@
               {{r.id.split('/').splice(2).join('/') | decodeURIComponent}}
             </a>
           </td>
-          <td data-ng-if="r.version.length > 0">{{r.version}}</td>
+          <td data-ng-if="!showFileStoreLastmodified && r.version.length > 0">{{r.version}}</td>
+          <td data-ng-if="showFileStoreLastmodified> 0">{{r.lastModification}}</td>
           <td
             data-ng-if="gnCurrentEdit.resourceManagementExternalProperties.enabled && r.metadataResourceExternalManagementProperties.url.length > 0"
           >

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -905,6 +905,7 @@
             // appUrl: "https://sextant.ifremer.fr/Donnees/Catalogue",
             isSocialbarEnabled: true,
             showStatusWatermarkFor: "",
+            showFileStoreLastmodified: false,
             showStatusTopBarFor: "",
             showCitation: {
               enabled: false,

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1348,6 +1348,8 @@
     "ui-showStatusWatermarkFor-help": "List of codelist values (eg. completed,historicalArchive,obsolete,superseded) for which the record status as a watermark displayed through the text",
     "ui-showStatusTopBarFor": "Show status bar",
     "ui-showStatusTopBarFor-help": "List of codelist values (eg. completed,historicalArchive,obsolete,superseded) for which the record status as a bar at the top of the record",
+    "ui-showFileStoreLastmodified": "Show File last modified date",
+    "ui-showFileStoreLastmodified-help": "Show File last modified date as its status instead of version",
     "ui-isLogoInHeader": "Show the logo in header",
     "ui-isLogoInHeader-help": "Show the logo in the header, above the navigation bar. The logo in the navigation bar will be removed. Only for the public pages (not the editor or admin).",
     "ui-logoInHeaderPosition": "Position of logo",


### PR DESCRIPTION
On the UI, the file version display is using the eTag when in JCloud mode

https://github.com/geonetwork/core-geonetwork/blob/79c57690ea604da26c3ea97db7adb4bad7867ed9/datastorages/jcloud/src/main/java/org/fao/geonet/api/records/attachments/JCloudStore.java#L132

![image](https://github.com/user-attachments/assets/731813d0-101c-4b91-b0fb-79c906e12848)


However this ETag is not very friendly to those none technical users. The last modified date makes more sense in this case.

This pull request gives the option to the system admin to display "last modified date" instead of ETag
![image](https://github.com/user-attachments/assets/14d1f6f7-1d98-493a-bb69-a08bf90c7665)


So as result, the file store will have "last modified date"
![image](https://github.com/user-attachments/assets/e94f4f3c-4217-4915-b802-22d6f8d032ec)
