### PR TITLE
Set UUID correctly in "recordNotFound" message

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/mdview/mdviewModule.js
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/mdviewModule.js
@@ -85,7 +85,7 @@
       $scope.gnMetadataActions = gnMetadataActions;
       $scope.url = location.href;
       $scope.compileScope = $scope.$new();
-      $scope.recordIdentifierRequested = gnSearchLocation.uuid;
+      $scope.recordIdentifierRequested = gnSearchLocation.getUuid();
       $scope.isUserFeedbackEnabled = false;
       $scope.isRatingEnabled = false;
       $scope.showCitation = false;


### PR DESCRIPTION
When the record not found alert message is shown the UUID is always empty. The UUID should be shown in the strong tag following "identifier".

![image](https://github.com/user-attachments/assets/f84dfcc1-d9a7-4093-93e7-1c33d87f68f5)
![image](https://github.com/user-attachments/assets/c486e4a3-1795-4d1f-a377-058116a8e741)

This PR aims to fix this issue by setting `recordIdentifierRequested` to the requested UUID using the `gnSearchLocation.getUuid()` function.

**Error message with this fix:**
![image](https://github.com/user-attachments/assets/d81a6df0-f8bf-4506-9a53-829b79edf5e6)

  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
