### PR TITLE
Fix the overlapping filter settings and the customize options

### DIFF
--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
@@ -3,14 +3,12 @@
     id="gn-uiconfig-customize"
     class="col-lg-6 col-lg-offset-6 gn-nopadding-right height-70-px"
   >
-    <div class="pull-right">
-      <label class="d-block" data-translate="">chooseOptionsToCustomize</label>
-      <select
-        class="form-control"
-        data-ng-options="o.label group by o.group for o in configOptions"
-        data-ng-model="optionsToAdd"
-      ></select>
-    </div>
+    <label class="d-block" data-translate="">chooseOptionsToCustomize</label>
+    <select
+      class="form-control"
+      data-ng-options="o.label group by o.group for o in configOptions"
+      data-ng-model="optionsToAdd"
+    ></select>
   </div>
 
   <p class="help-block" data-translate="">ui/config-help</p>

--- a/web-ui/src/main/resources/catalog/templates/admin/settings/ui.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/settings/ui.html
@@ -45,7 +45,7 @@
 
           <div class="row">
             <!-- add UI config -->
-            <div class="col-md-6 gn-nopadding-left">
+            <div class="col-lg-6 gn-nopadding-left">
               <div class="input-group">
                 <input
                   class="form-control"
@@ -70,7 +70,7 @@
             </div>
 
             <!-- delete and save-->
-            <div class="col-md-6 gn-nopadding-left gn-nopadding-right">
+            <div class="col-lg-6 gn-nopadding-left gn-nopadding-right">
               <div class="btn-toolbar pull-right">
                 <button
                   type="submit"
@@ -78,8 +78,9 @@
                   id="gn-btn-settings-delete"
                   data-ng-disabled="!uiConfiguration"
                   data-ng-click="deleteUiConfig()"
+                  title="{{'deleteUiSettings'|translate}}"
                 >
-                  <span class="fa fa-times"></span>
+                  <span class="fa fa-fw fa-times"></span>
                   {{"deleteUiSettings"|translate}}
                 </button>
                 <button
@@ -88,8 +89,9 @@
                   id="gn-btn-settings-save"
                   data-ng-disabled="!gnSettings.$valid"
                   data-ng-click="updateUiConfig()"
+                  title="{{'saveSettings'|translate}}"
                 >
-                  <span class="fa fa-save"></span>
+                  <span class="fa fa-fw fa-save"></span>
                   {{"saveSettings"|translate}}
                 </button>
               </div>
@@ -104,7 +106,7 @@
       data-ng-show="uiConfiguration.configuration !== undefined"
     >
       <div class="panel-heading">
-        <h1><span data-translate="">ui</span> <strong>{{uiConfiguration.id}}</strong></h1>
+        <h1><span data-translate="" class="gn-margin-right-sm">ui</span> <strong>{{uiConfiguration.id}}</strong></h1>
 
         <div data-gn-need-help="user-interface-configuration" class="pull-right"></div>
       </div>

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_admin_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_admin_default.less
@@ -515,6 +515,18 @@ ul.gn-resultview li.list-group-item {
         margin-bottom: 10px;
         border-color: #ccc;
       }
+      .col-md-4, .col-md-6 {
+        @media (max-width: @screen-sm-max) {
+          padding-right: 0 !important;
+        }
+      }
+      .col-lg-6, #gn-uiconfig-customize {
+        @media (max-width: 1024px) {
+          padding-right: 0 !important;
+          margin-bottom: @gn-spacing;
+        }
+      }
+
       // checkbox (Bootstrap 5.2)
       input[type="checkbox"],
       input[type="radio"] {
@@ -656,7 +668,16 @@ ul.gn-resultview li.list-group-item {
         z-index: 901;
       }
       #gn-uiconfig-customize {
-        margin-top: -85px;
+
+        @media (max-width: @screen-md-max) {
+          padding-left: 0 !important;
+        }
+
+        @media (min-width: @screen-lg-min) {
+          margin-top: -85px;
+        }
+
+
         .dropdown-menu {
           padding: 0 !important;
           li {


### PR DESCRIPTION
This PR fixes the overlapping filter settings and the customize options dropdown on the `User Interface` page. The 2 buttons (save and delete) got an improvement alignment.

Further improvements:
- spacing between title and UI config name
- fix paddings on smaller screens
- whitespace between buttons and inputs

**Before the changes**

<img width="650" alt="gn-config-overlap" src="https://github.com/user-attachments/assets/cfd4214a-4a3a-4228-a880-57fc20ca6859">

**After the changes**

<img width="1023" alt="gn-config-no-overlap" src="https://github.com/user-attachments/assets/9d201ea3-5945-4b51-b842-0072aabbb7e9">


# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

