### PR TITLE
Fix Clipboard copy/paste on Firefox

### DIFF
--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -1143,45 +1143,35 @@
       return {
         copy: function (toCopy) {
           var deferred = $q.defer();
-          navigator.permissions.query({ name: "clipboard-write" }).then(
-            function (result) {
-              if (result.state == "granted" || result.state == "prompt") {
-                navigator.clipboard.writeText(toCopy).then(
-                  function () {
-                    deferred.resolve();
-                  },
-                  function (r) {
-                    console.warn(r);
-                    deferred.reject();
-                  }
-                );
+          if (navigator.clipboard?.writeText) {
+            navigator.clipboard.writeText(toCopy).then(
+              function () {
+                deferred.resolve();
+              },
+              function (r) {
+                console.warn(r);
+                deferred.reject();
               }
-            },
-            function () {
-              deferred.reject();
-            }
-          );
+            );
+          } else {
+            deferred.reject();
+          }
           return deferred.promise;
         },
         paste: function () {
           var deferred = $q.defer();
-          navigator.permissions.query({ name: "clipboard-read" }).then(
-            function (result) {
-              if (result.state == "granted" || result.state == "prompt") {
-                navigator.clipboard.readText().then(
-                  function (text) {
-                    deferred.resolve(text);
-                  },
-                  function () {
-                    deferred.reject();
-                  }
-                );
+          if (navigator.clipboard?.readText) {
+            navigator.clipboard.readText().then(
+              function (text) {
+                deferred.resolve(text);
+              },
+              function () {
+                deferred.reject();
               }
-            },
-            function () {
-              deferred.reject();
-            }
-          );
+            );
+          } else {
+            deferred.reject();
+          }
           return deferred.promise;
         }
       };


### PR DESCRIPTION
Clipboard permissions are only implemented in Chromium-based browsers. See https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/Interact_with_the_clipboard for more details.
Chrome also changed their behaviour in recent versions, so that these permissions are no longer needed (see https://chromestatus.com/feature/5167870134976512 ). The W3 Spec also specifies that the permission is in the process of being removed: https://w3c.github.io/clipboard-apis/#dom-clipboard-write
Clipboard read is already supported for a longer time to work without requesting the permission if the clipboard copy originates from a user handler (like a button on click), which is the case for all copy calls.

Instead, check if the browser supports the writeText/readText clipboard functions (some mobile browsers do not). With these change, both Chromium-based browsers and other browsers such as firefox work correctly.

Fixes #7192
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->
 # Checklist

 - [x] I have read the [contribution guidelines]([https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md])
 - [x] *Pull request* provided for `main` branch, backports managed with label
 - [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
 - [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
 - [x] *Clean commit message*s, longer verbose messages are encouraged
 - [ ] *API Changes* are identified in commit messages
 - [ ] *Testing* provided for features or enhancements using [automatic tests]([https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md])
 - [ ] *User documentation* provided for new features or enhancements in [manual]([https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual])
 - [ ] *Build documentation* provided for development instructions in `README.md` files
 - [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

---
Funded by [LGL BW](https://www.lgl-bw.de/index.html)