### PR TITLE
Social links in metadata page doesn't have the metadata page permalink.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/mdview/mdviewDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/mdviewDirective.js
@@ -588,15 +588,20 @@
         },
         link: function (scope, element, attrs) {
           scope.mdService = gnUtilityService;
-          scope.$watch(scope.md, function (newVal, oldVal) {
-            if (newVal !== null && newVal !== oldVal) {
-              $http
-                .get("../api/records/" + scope.md.getUuid() + "/permalink")
-                .then(function (r) {
-                  scope.socialMediaLink = r.data;
-                });
-            }
-          });
+
+          scope.$watch(
+            "md",
+            function (newVal, oldVal) {
+              if (newVal !== null && newVal !== oldVal) {
+                $http
+                  .get("../api/records/" + scope.md.getUuid() + "/permalink")
+                  .then(function (r) {
+                    scope.socialMediaLink = r.data;
+                  });
+              }
+            },
+            true
+          );
         }
       };
     }


### PR DESCRIPTION
Fixes #8322

Test case:


1. Load ISO19139 metadata samples
2. Go to the metadata page of the `Hydrological Basins in Africa (Sample record, please remove!) sample`
3. Scroll down to the social links and click the mail icon

  - Without the fix: it contains `body=undefined` instead of the metadata page permalink
  - With the fix: it contains `body=http://....` with the metadata page permalink


# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
