### PR TITLE
Fix Clipboard copy/paste on Firefox - use ES5

### DIFF
--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -1143,7 +1143,7 @@
       return {
         copy: function (toCopy) {
           var deferred = $q.defer();
-          if (navigator.clipboard?.writeText) {
+          if (navigator.clipboard && navigator.clipboard.writeText) {
             navigator.clipboard.writeText(toCopy).then(
               function () {
                 deferred.resolve();
@@ -1160,7 +1160,7 @@
         },
         paste: function () {
           var deferred = $q.defer();
-          if (navigator.clipboard?.readText) {
+          if (navigator.clipboard && navigator.clipboard.readText) {
             navigator.clipboard.readText().then(
               function (text) {
                 deferred.resolve(text);


### PR DESCRIPTION
Follow up of #8320, that causes issues in 4.2.x. 

Added the change to `main` branch to avoid issues in future backports of changes in this file.


# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
