### PR TITLE
[Backport 4.2.x] Fix Clipboard copy/paste on Firefox - use ES5

### DIFF
--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -1143,7 +1143,7 @@
       return {
         copy: function (toCopy) {
           var deferred = $q.defer();
-          if (navigator.clipboard?.writeText) {
+          if (navigator.clipboard && navigator.clipboard.writeText) {
             navigator.clipboard.writeText(toCopy).then(
               function () {
                 deferred.resolve();
@@ -1160,7 +1160,7 @@
         },
         paste: function () {
           var deferred = $q.defer();
-          if (navigator.clipboard?.readText) {
+          if (navigator.clipboard && navigator.clipboard.readText) {
             navigator.clipboard.readText().then(
               function (text) {
                 deferred.resolve(text);


### PR DESCRIPTION
Backport #8332
 **Authored by:** @josegar74