### PR TITLE
Editor / DOI search / Improve label

### DIFF
--- a/web-ui/src/main/resources/catalog/locales/en-v4.json
+++ b/web-ui/src/main/resources/catalog/locales/en-v4.json
@@ -435,7 +435,7 @@
   "overviewUrl": "Overview URL",
   "restApiUrl": "REST API URL",
   "filterHelp": "Please click on one of the buttons below to activate the filter",
-  "selectDOIResource": "Choose a DOI resource",
+  "selectDOIResource": "Search for a DOI",
   "httpStatus--200": "Invalid status",
   "httpStatus-200": "200: Valid status",
   "httpStatus-404": "404: Not found",


### PR DESCRIPTION
Before 

![image](https://github.com/user-attachments/assets/f194c58f-004f-4fbb-a18b-ec561873ccfe)


After

![image](https://github.com/user-attachments/assets/dbce9cf7-c47d-4bbb-be14-7aa732936af6)

More meaningful label indicating that user has to search for something (and not only choose)


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

Funded by ifremer
