### PR TITLE
Editor / Associated resource / Avoid empty label

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/linkToMd.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/linkToMd.html
@@ -62,7 +62,7 @@
         ng-disabled="!canEnableLinkButton(selectRecords)"
       >
         <i class="fa gn-icon-{{mode}}"></i>
-        <i class="icon-external-link"></i>&nbsp; {{btn.label}}
+        <i class="icon-external-link"></i>&nbsp; {{btn.label || ('saveLinkToSibling' | translate)}}
       </button>
       <div data-gn-need-help="linking-records" class="pull-right"></div>
     </div>


### PR DESCRIPTION
When adding a source for example, the button label may be empty. Add a default one.

Before

![image](https://github.com/user-attachments/assets/4c6e4c6b-e1ca-48ab-837b-750455fb1d9a)

After

![image](https://github.com/user-attachments/assets/824a31ff-a04d-4f49-9919-ffb2efa24ef4)


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

Funded by Ifremer