### PR TITLE
publish status not refreshing fix

### DIFF
--- a/listeners/src/main/java/org/fao/geonet/listener/metadata/draft/ApprovePublishedRecord.java
+++ b/listeners/src/main/java/org/fao/geonet/listener/metadata/draft/ApprovePublishedRecord.java
@@ -121,7 +121,7 @@ public class ApprovePublishedRecord implements ApplicationListener<MetadataPubli
         status.setChangeDate(new ISODate());
         status.setUserId(ServiceContext.get().getUserSession().getUserIdAsInt());
 
-        metadataStatus.setStatusExt(status, false);
+        metadataStatus.setStatusExt(status, true);
 
         Log.trace(Geonet.DATA_MANAGER, "Metadata with id " + md.getId() + " automatically approved due to publishing.");
     }

--- a/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionService.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/MetadataActionService.js
@@ -537,6 +537,7 @@
               }
 
               if (md) {
+                gnMetadataManager.updateMdObj(md);
                 md.publish(publicationType);
               }
             },


### PR DESCRIPTION
To fix https://github.com/geonetwork/core-geonetwork/issues/8341

The direct publish should have approved status at the end. The issue is update status was part of another thread not totally sync with the main API. So we need to update the index as well. The UI part is also lack of refreshing mechanism to refresh the current status.