### PR TITLE
iso19139 - Update thumbnail add/update and remove to support index update/removal

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/process/thumbnail-add.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/process/thumbnail-add.xsl
@@ -27,7 +27,9 @@
                 xmlns:srv="http://www.isotc211.org/2005/srv"
                 xmlns:gco="http://www.isotc211.org/2005/gco"
                 xmlns:geonet="http://www.fao.org/geonetwork"
-                exclude-result-prefixes="#all"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:digestUtils="java:org.apache.commons.codec.digest.DigestUtils"
+                 exclude-result-prefixes="#all"
                 version="2.0">
 
   <!--
@@ -41,11 +43,22 @@
   <xsl:param name="thumbnail_desc" select="''"/>
   <xsl:param name="thumbnail_type" select="''"/>
 
-  <!-- Target element to update. The key is based on the concatenation
-  of URL+Name -->
-  <xsl:param name="updateKey"/>
+  <!-- Target element to update.
+    updateKey is used to identify the resource name to be updated - it is for backwards compatibility.  Will not be used if resourceHash is set.
+              The key is based on the concatenation of URL+Name
+    resourceHash is hash value of the object to be removed which will ensure the correct value is removed. It will override the usage of updateKey
+    resourceIdx is the index location of the object to be removed - can be used when duplicate entries exists to ensure the correct one is removed.
+-->
+  <xsl:param name="updateKey" select="''"/>
+  <xsl:param name="resourceHash" select="''"/>
+  <xsl:param name="resourceIdx" select="''"/>
 
-  <xsl:template match="gmd:identificationInfo/*">
+  <xsl:variable name="update_flag">
+    <xsl:value-of select="boolean($updateKey != '' or $resourceHash != '' or $resourceIdx != '')"/>
+  </xsl:variable>
+
+  <!--  Add new gmd:graphicOverview -->
+  <xsl:template match="gmd:identificationInfo/*[$update_flag = false()]">
     <xsl:copy>
       <xsl:copy-of select="@*"/>
       <xsl:apply-templates select="gmd:citation"/>
@@ -56,9 +69,7 @@
       <xsl:apply-templates select="gmd:pointOfContact"/>
       <xsl:apply-templates select="gmd:resourceMaintenance"/>
 
-      <xsl:if test="$updateKey = ''">
-        <xsl:call-template name="fill"/>
-      </xsl:if>
+      <xsl:call-template name="fill"/>
 
       <xsl:apply-templates select="gmd:graphicOverview"/>
 
@@ -83,12 +94,19 @@
     </xsl:copy>
   </xsl:template>
 
-
-  <xsl:template match="gmd:graphicOverview[concat(
-                         */gmd:fileName/gco:CharacterString,
-                         */gmd:fileName/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale = '#DE'],
-                         */gmd:fileDescription/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale = '#DE'],
-                         */gmd:fileDescription/gco:CharacterString) = normalize-space($updateKey)]">
+  <!-- Updating the gmd:graphicOverview based on update parameters -->
+  <!-- Note: first part of the match needs to match the xsl:for-each select from extract-relations.xsl in order to get the position() to match -->
+  <!-- The unique identifier is marked with resourceIdx which is the position index and resourceHash which is hash code of the current node (combination of url, resource name, and description) -->
+  <xsl:template
+    priority="2"
+    match="*//gmd:graphicOverview
+         [$resourceIdx = '' or position() = xs:integer($resourceIdx)]
+         [    ($resourceHash != '' or ($updateKey != '' and normalize-space($updateKey) = concat(
+                           */gmd:fileName/gco:CharacterString,
+                           */gmd:fileName/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale = '#DE'],
+                           */gmd:fileDescription/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale = '#DE'],
+                           */gmd:fileDescription/gco:CharacterString)))
+          and ($resourceHash = '' or digestUtils:md5Hex(normalize-space(.)) = $resourceHash)]">
     <xsl:call-template name="fill"/>
   </xsl:template>
 

--- a/schemas/iso19139/src/main/plugin/iso19139/process/thumbnail-remove.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/process/thumbnail-remove.xsl
@@ -25,22 +25,48 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:gmd="http://www.isotc211.org/2005/gmd"
                 xmlns:gco="http://www.isotc211.org/2005/gco"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:geonet="http://www.fao.org/geonetwork" exclude-result-prefixes="#all"
+                xmlns:digestUtils="java:org.apache.commons.codec.digest.DigestUtils"
                 version="2.0">
 
   <!--
       Usage:
+        thumbnail_url is the url to be removed - it is for backwards compatibility.  Will not be used if resourceHash is set.
+        resourceHash is hash value of the object to be removed which will ensure the correct value is removed. It will override the usage of thumbnail_url
+        resourceIdx is the index location of the object to be removed - can be used when duplicate entries exists to ensure the correct one is removed.
+
+      example:
         thumbnail-from-url-remove?thumbnail_url=http://geonetwork.org/thumbnails/image.png
     -->
 
-  <xsl:param name="thumbnail_url"/>
+  <xsl:param name="thumbnail_url" select="''"/>
+  <xsl:param name="resourceHash" select="''"/>
+  <xsl:param name="resourceIdx" select="''"/>
 
   <!-- Remove the thumbnail define in thumbnail_url parameter -->
-  <xsl:template
-    priority="2"
-    match="gmd:graphicOverview[normalize-space(gmd:MD_BrowseGraphic/gmd:fileName/gco:CharacterString) = normalize-space($thumbnail_url)]"/>
+  <!-- Note: first part of the match needs to match the xsl:for-each select from extract-relations.xsl in order to get the position() to match -->
+  <!-- The unique identifier is marked with resourceIdx which is the position index and resourceHash which is hash code of the current node (combination of url, resource name, and description) -->
 
-  <!-- Do a copy of every nodes and attributes -->
+  <xsl:template match="//gmd:graphicOverview" priority="2">
+
+    <!-- Calculate the global position of the current gmd:onLine element -->
+    <xsl:variable name="position" select="count(//gmd:graphicOverview[current() >> .]) + 1" />
+
+    <xsl:if test="not(
+                      gmd:MD_BrowseGraphic[gmd:fileName/gco:CharacterString != ''] and
+                      ($resourceIdx = '' or $position = xs:integer($resourceIdx)) and
+                      ($resourceHash != '' or ($thumbnail_url != null and (normalize-space(gmd:MD_BrowseGraphic/gmd:fileName/gco:CharacterString) = normalize-space($thumbnail_url))))
+                        and ($resourceHash = '' or digestUtils:md5Hex(normalize-space(.)) = $resourceHash)
+                   )">
+      <xsl:copy>
+        <xsl:apply-templates select="@*|node()"/>
+      </xsl:copy>
+    </xsl:if>
+  </xsl:template>
+
+
+  <!-- Do a copy of every node and attribute -->
   <xsl:template match="@*|node()">
     <xsl:copy>
       <xsl:apply-templates select="@*|node()"/>


### PR DESCRIPTION
In the case where we have the following list of images that were imported.

```
         <gmd:graphicOverview>
            <gmd:MD_BrowseGraphic>
               <gmd:fileName>
                  <gco:CharacterString>http://localhost:8080/geonetwork/srv/api/records/d14ed343-96a9-4e36-a639-b71def9f6cc0/attachments/test1.png</gco:CharacterString>
               </gmd:fileName>
               <gmd:fileDescription>
                  <gco:CharacterString>Image 1</gco:CharacterString>
               </gmd:fileDescription>
            </gmd:MD_BrowseGraphic>
         </gmd:graphicOverview>
         <gmd:graphicOverview>
            <gmd:MD_BrowseGraphic>
               <gmd:fileName>
                  <gco:CharacterString>http://localhost:8080/geonetwork/srv/api/records/d14ed343-96a9-4e36-a639-b71def9f6cc0/attachments/test2.png</gco:CharacterString>
               </gmd:fileName>
               <gmd:fileDescription>
                  <gco:CharacterString>Image 2</gco:CharacterString>
               </gmd:fileDescription>
            </gmd:MD_BrowseGraphic>
         </gmd:graphicOverview>
         <gmd:graphicOverview>
            <gmd:MD_BrowseGraphic>
               <gmd:fileName>
                  <gco:CharacterString>http://localhost:8080/geonetwork/srv/api/records/d14ed343-96a9-4e36-a639-b71def9f6cc0/attachments/test1.png</gco:CharacterString>
               </gmd:fileName>
               <gmd:fileDescription>
                  <gco:CharacterString>Image 3</gco:CharacterString>
               </gmd:fileDescription>
            </gmd:MD_BrowseGraphic>
         </gmd:graphicOverview>
         <gmd:graphicOverview>
            <gmd:MD_BrowseGraphic>
               <gmd:fileName>
                  <gco:CharacterString>http://localhost:8080/geonetwork/srv/api/records/d14ed343-96a9-4e36-a639-b71def9f6cc0/attachments/test2.png</gco:CharacterString>
               </gmd:fileName>
               <gmd:fileDescription>
                  <gco:CharacterString>Image 4</gco:CharacterString>
               </gmd:fileDescription>
            </gmd:MD_BrowseGraphic>
         </gmd:graphicOverview>
```

We want to edit the images and remove the duplicates similar to the online resources.

If we edit the resource, before this fix, it would only edit the first occurrence.  And if we deleted the resource it would delete the first occurrence.

With this fix, it will delete/update the correct version.

In the default editor, it deletes the resources and the file from the store.  A future enhancement could be to only delete the file from the store if there are no more duplicates.

Also default editor does not allow editing the descriptions or file type but in other schemas editing is allowed.  Using this as a sample on how editing could be used.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

