### PR TITLE
Batch editing - In XPATH replace mode don't try to add a node if doesn't exist

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/AddElemValue.java
+++ b/core/src/main/java/org/fao/geonet/kernel/AddElemValue.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2026 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -37,10 +37,12 @@ import java.io.IOException;
 public class AddElemValue {
     private final String stringValue;
     private final Element nodeValue;
+    private final boolean isAddMode;
 
     public AddElemValue(String stringValue) throws JDOMException, IOException {
         Element finalNodeVal = null;
         String finalStringVal = stringValue.replaceAll("</?gn_(add|replace)>", "");
+        boolean isAddElement = !stringValue.startsWith("<gn_replace>");
         if (Xml.isXMLLike(finalStringVal)) {
             try {
                 finalNodeVal = Xml.loadString(stringValue, false);
@@ -55,11 +57,13 @@ public class AddElemValue {
         }
         this.nodeValue = finalNodeVal;
         this.stringValue = finalStringVal;
+        this.isAddMode = isAddElement;
     }
 
     public AddElemValue(Element nodeValue) {
         this.nodeValue = nodeValue;
         this.stringValue = null;
+        isAddMode = false;
     }
 
     public boolean isXml() {
@@ -72,5 +76,9 @@ public class AddElemValue {
 
     public Element getNodeValue() {
         return nodeValue;
+    }
+
+    public boolean isAddMode() {
+        return isAddMode;
     }
 }

--- a/services/src/main/java/org/fao/geonet/api/records/editing/BatchEditsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/editing/BatchEditsApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2024 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -37,7 +37,6 @@ import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.api.ApiParams;
 import org.fao.geonet.api.ApiUtils;
-import org.fao.geonet.api.exception.NotAllowedException;
 import org.fao.geonet.api.processing.report.IProcessingReport;
 import org.fao.geonet.api.processing.report.SimpleMetadataProcessingReport;
 import org.fao.geonet.domain.AbstractMetadata;
@@ -110,24 +109,21 @@ public class BatchEditsApi implements ApplicationContextAware {
     @ResponseStatus(HttpStatus.OK)
     @ResponseBody
     public Object previewBatchEdit(
-        @Parameter(description = ApiParams.API_PARAM_RECORD_UUIDS_OR_SELECTION,
-            required = false)
+        @Parameter(description = ApiParams.API_PARAM_RECORD_UUIDS_OR_SELECTION)
         @RequestParam(required = false) String[] uuids,
         @Parameter(
-            description = ApiParams.API_PARAM_BUCKET_NAME,
-            required = false)
+            description = ApiParams.API_PARAM_BUCKET_NAME)
         @RequestParam(
             required = false
         )
-            String bucket,
+        String bucket,
         @Parameter(
-            description = "Return differences with diff, diffhtml or patch",
-            required = false
+            description = "Return differences with diff, diffhtml or patch"
         )
         @RequestParam(
             required = false
         )
-            DiffType diffType,
+        DiffType diffType,
         @RequestBody BatchEditParameter[] edits,
         HttpServletRequest request)
         throws Exception {
@@ -153,25 +149,22 @@ public class BatchEditsApi implements ApplicationContextAware {
     @ResponseStatus(HttpStatus.CREATED)
     @ResponseBody
     public IProcessingReport batchEdit(
-        @Parameter(description = ApiParams.API_PARAM_RECORD_UUIDS_OR_SELECTION,
-            required = false)
+        @Parameter(description = ApiParams.API_PARAM_RECORD_UUIDS_OR_SELECTION)
         @RequestParam(required = false) String[] uuids,
         @Parameter(
-            description = ApiParams.API_PARAM_BUCKET_NAME,
-            required = false)
+            description = ApiParams.API_PARAM_BUCKET_NAME)
         @RequestParam(
             required = false
         )
-            String bucket,
+        String bucket,
         @Parameter(
-            description = ApiParams.API_PARAM_UPDATE_DATESTAMP,
-            required = false
+            description = ApiParams.API_PARAM_UPDATE_DATESTAMP
         )
         @RequestParam(
             required = false,
             defaultValue = "false"
         )
-            boolean updateDateStamp,
+        boolean updateDateStamp,
         @RequestBody BatchEditParameter[] edits,
         HttpServletRequest request)
         throws Exception {
@@ -185,7 +178,7 @@ public class BatchEditsApi implements ApplicationContextAware {
         HttpServletRequest request,
         boolean previewOnly, DiffType diffType) throws Exception {
         List<BatchEditParameter> listOfUpdates = Arrays.asList(edits);
-        if (listOfUpdates.size() == 0) {
+        if (listOfUpdates.isEmpty()) {
             throw new IllegalArgumentException("At least one edit must be defined.");
         }
 
@@ -206,7 +199,7 @@ public class BatchEditsApi implements ApplicationContextAware {
             setOfUuidsToEdit = Sets.newHashSet(Arrays.asList(uuids));
         }
 
-        if (setOfUuidsToEdit.size() == 0) {
+        if (setOfUuidsToEdit.isEmpty()) {
             throw new IllegalArgumentException("At least one record should be defined or selected for updates.");
         }
 
@@ -214,10 +207,9 @@ public class BatchEditsApi implements ApplicationContextAware {
         DataManager dataMan = appContext.getBean(DataManager.class);
         SchemaManager _schemaManager = context.getBean(SchemaManager.class);
         AccessManager accessMan = context.getBean(AccessManager.class);
-        final String settingId = Settings.SYSTEM_CSW_TRANSACTION_XPATH_UPDATE_CREATE_NEW_ELEMENTS;
-        boolean createXpathNodeIfNotExists =
-            context.getBean(SettingManager.class).getValueAsBool(settingId);
-
+        // This value is used in replace mode to create the node if it doesn't exist.
+        // We don't want to create a node in replace mode, just replace the element if it exists, otherwise ignore it.
+        boolean createXpathNodeIfNotExists = false;
 
         SimpleMetadataProcessingReport report = new SimpleMetadataProcessingReport();
         report.setTotalRecords(setOfUuidsToEdit.size());
@@ -254,7 +246,7 @@ public class BatchEditsApi implements ApplicationContextAware {
                         if (StringUtils.isNotEmpty(batchEditParameter.getCondition())) {
                             applyEdit = false;
                             final Object node = Xml.selectSingle(metadata, batchEditParameter.getCondition(), metadataSchema.getNamespaces());
-                            if (node != null && node instanceof Boolean && (Boolean)node == true) {
+                            if (node != null && node instanceof Boolean && (Boolean) node == true) {
                                 applyEdit = true;
                             }
                         }

--- a/services/src/main/java/org/fao/geonet/api/records/editing/BatchEditsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/editing/BatchEditsApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2024 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2026 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -207,9 +207,7 @@ public class BatchEditsApi implements ApplicationContextAware {
         DataManager dataMan = appContext.getBean(DataManager.class);
         SchemaManager _schemaManager = context.getBean(SchemaManager.class);
         AccessManager accessMan = context.getBean(AccessManager.class);
-        // This value is used in replace mode to create the node if it doesn't exist.
-        // We don't want to create a node in replace mode, just replace the element if it exists, otherwise ignore it.
-        boolean createXpathNodeIfNotExists = false;
+
 
         SimpleMetadataProcessingReport report = new SimpleMetadataProcessingReport();
         report.setTotalRecords(setOfUuidsToEdit.size());
@@ -241,6 +239,10 @@ public class BatchEditsApi implements ApplicationContextAware {
 
                         AddElemValue propertyValue =
                             new AddElemValue(batchEditParameter.getValue());
+
+                        // This value is used in replace mode to create the node if it doesn't exist.
+                        // We don't want to create a node in replace mode, just replace the element if it exists, otherwise ignore it.
+                        boolean createXpathNodeIfNotExists = propertyValue.isAddMode();
 
                         boolean applyEdit = true;
                         if (StringUtils.isNotEmpty(batchEditParameter.getCondition())) {


### PR DESCRIPTION
The Batch Edit API uses the following setting to add an element in **XPATH replace mode**, if the XML node doesn't exist:

![add-non-existing-element](https://github.com/user-attachments/assets/c98682a1-3195-4b5c-a8b5-1a608182c60c)

This doesn't make much sense, since in replacement mode you want to update an element if it exists, otherwise do nothing.

This pull request updates the code to not use that setting and never try to add the element in XPATH replace mode.

Test case:

1) Create an ISO19139 metadata and add a dataset contact with the name `John` and role `owner`
2) In the batch edit configure a XPATH replacement:
  - Title: Replace individual name
  - Type: Replace the element or value (in all matching parents)
  - XPATH: `/gmd:MD_Metadata/gmd:identificationInfo/*/gmd:pointOfContact[*/gmd:role/gmd:CI_RoleCode/@codeListValue='owner' and */gmd:individualName/*/text()='John']/*/gmd:individualName/gco:CharacterString`
  - Value: Mary
 
![batch-edit-form](https://github.com/user-attachments/assets/c382ec3f-9a67-4b52-977b-57bae96b9bea)

The previous change match the element and changes the individual name to Mary

```
       <gmd:pointOfContact>
          <gmd:CI_ResponsibleParty>
            <gmd:individualName>
              <gco:CharacterString>Mary</gco:CharacterString>
            </gmd:individualName>
```

3) Edit XPATH expression to match another role: `pointOfContact`, that doesn't exist in the metadata:

`/gmd:MD_Metadata/gmd:identificationInfo/*/gmd:pointOfContact[*/gmd:role/gmd:CI_RoleCode/@codeListValue='pointOfContact' and */gmd:individualName/*/text()='John']/*/gmd:individualName/gco:CharacterString`

  - Without the fix, produces an invalid ISO19139 element: `<gmd:pointOfContact>Mary</gmd:pointOfContact>`

  - With the fix, the individual name is not updated (stays with the value John) as the XPATH expression does not match.

---

The pull request includes Sonarlint improvements.

---

For existing installations, a workaround to avoid this problem is to disable the settings listed at the beginning, unde r `Admin console` > `Settings` > `CSW`

---

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
