### PR TITLE
proxy url caching fix

### DIFF
--- a/web-ui/src/main/resources/catalog/components/utility/CORSInterceptor.js
+++ b/web-ui/src/main/resources/catalog/components/utility/CORSInterceptor.js
@@ -137,7 +137,7 @@
               Reset requireProxy array. This prevent same host of map server and catalouge deployment affecting together.
               For example: One online resource of wms https://example.com/mapserver/ows?service=WMS&request=GetCapabilities&layers=roads
               and another online resource of file store https://example.com/geonetwork/srv/api/records/c90c284d-171f-41a9-bc92-b2533970cdc8/attachments/sample.txt
-              The will confuse the proxy to think the filestore has same hostname and will use proxy url. But due to the staight security meansure the proxy url will not work for the backend store
+              This will confuse the proxy to think the filestore has same hostname and will use proxy url. But due to the staight security meansure the proxy url will not work for the backend store
               */
               gnGlobalSettings.requireProxy = [];
 

--- a/web-ui/src/main/resources/catalog/components/utility/CORSInterceptor.js
+++ b/web-ui/src/main/resources/catalog/components/utility/CORSInterceptor.js
@@ -133,6 +133,14 @@
                   gnGlobalSettings.gnUrl + (gnLangs.current || "eng") + "/" + config.url;
               }
 
+              /*
+              Reset requireProxy array. This prevent same host of map server and catalouge deployment affecting together.
+              For example: One online resource of wms https://example.com/mapserver/ows?service=WMS&request=GetCapabilities&layers=roads
+              and another online resource of file store https://example.com/geonetwork/srv/api/records/c90c284d-171f-41a9-bc92-b2533970cdc8/attachments/sample.txt
+              The will confuse the proxy to think the filestore has same hostname and will use proxy url. But due to the staight security meansure the proxy url will not work for the backend store
+              */
+              gnGlobalSettings.requireProxy = [];
+
               return config;
             },
             responseError: function (response) {

--- a/web-ui/src/main/resources/catalog/components/utility/CORSInterceptor.js
+++ b/web-ui/src/main/resources/catalog/components/utility/CORSInterceptor.js
@@ -137,7 +137,7 @@
               Reset requireProxy array. This prevent same host of map server and catalouge deployment affecting together.
               For example: One online resource of wms https://example.com/mapserver/ows?service=WMS&request=GetCapabilities&layers=roads
               and another online resource of file store https://example.com/geonetwork/srv/api/records/c90c284d-171f-41a9-bc92-b2533970cdc8/attachments/sample.txt
-              This will confuse the proxy to think the filestore has same hostname and will use proxy url. But due to the staight security meansure the proxy url will not work for the backend store
+              This will confuse the proxy to think the filestore has same hostname and will use proxy url. But due to the straight security measure the proxy url will not work for the backend store
               */
               gnGlobalSettings.requireProxy = [];
 


### PR DESCRIPTION
As some issue from the previous pull request, https://github.com/geonetwork/core-geonetwork/pull/8023/files#diff-405607f9a6b1d5a720e92fc151da34b8e919b54af47397fe923152feb44c3543

The map server proxy url are cached within the metadata editing session and causing some issue to other file store urls.

Here is the senario.

if we define two online resources

1) One wms map resource https://example.com/mapserver/wms?service=WMS&request=GetCapabilities&layers=roads

![image](https://github.com/user-attachments/assets/b85400e7-e689-47d8-92ae-24f4bff7ccf9)

2) One file store resource https://example.com/geonetwork/srv/api/records/c90c284d-171f-41a9-bc92-b2533970cdc8/attachments/sample.txt

![image](https://github.com/user-attachments/assets/8b1134e9-9e7e-4a45-974d-1121fb73817c)


So once the resource from 1) are cached into the https://github.com/geonetwork/core-geonetwork/blob/05b2e43dd5ce5a340081269461560af480b85af1/web-ui/src/main/resources/catalog/components/utility/CORSInterceptor.js#L92

there is no way to reset this array. So when 2) resource editing kicks in and the requireProxy already has "example.com" as the proxy requiring host, then it will add such proxy to the file store resource which is not accessible. Then the http request will fail and causing this warning

![image](https://github.com/user-attachments/assets/f62da432-fa6b-4330-824d-61cbf2c22efe)


In fact, the file store url should never supposed to use proxy url.  