### PR TITLE
Record view / Improve support of HTML in abstract

### DIFF
--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -2363,6 +2363,7 @@
       };
     }
   ]);
+
   module.filter("signInLink", [
     "$location",
     "$filter",
@@ -2376,6 +2377,23 @@
       };
     }
   ]);
+
+  module.filter("isHtml", [
+    "$location",
+    "$filter",
+    function ($location, $filter) {
+      return function (str) {
+        var a = new DOMParser().parseFromString(str, "text/html");
+
+        for (var c = a.body.childNodes, i = c.length; i--; ) {
+          if (c[i].nodeType == 1) return true;
+        }
+
+        return false;
+      };
+    }
+  ]);
+
   module.filter("getMailDomain", [
     function () {
       return function (mail) {

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/title.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/title.html
@@ -42,5 +42,12 @@
     data-types="parent"
   ></div>
 
-  <p data-ng-bind-html="(mdView.current.record.resourceAbstract) | linky | newlines"></p>
+  <p
+    data-ng-if="mdView.current.record.resourceAbstract | isHtml"
+    data-ng-bind-html="mdView.current.record.resourceAbstract"
+  ></p>
+  <p
+    data-ng-if="!(mdView.current.record.resourceAbstract | isHtml)"
+    data-ng-bind-html="(mdView.current.record.resourceAbstract) | linky | newlines"
+  ></p>
 </div>


### PR DESCRIPTION
When harvesting some ODS portal eg. (copy/paste the harvester config for testing)

```
{"@id":"4284","@type":"simpleurl","owner":["70"],"ownerGroup":[14697],"ownerUser":["70"],"site":{"name":"odwb","uuid":"1f4e3e33-be43-486e-a371-f9fed31d4df1","account":{"use":false,"username":[],"password":[]},"url":"https://www.odwb.be/api/explore/v2.0/catalog/datasets?limit=10&offset=0&timezone=UTC&include_links=false&include_app_metas=false","icon":"blank.png","loopElement":"/datasets","numberOfRecordPath":"/total_count","recordIdPath":"/dataset/dataset_id","pageSizeParam":"limit","pageFromParam":"offset","toISOConversion":"schema:iso19115-3.2018:convert/fromJsonOpenDataSoft"},"content":{"validate":"NOVALIDATION","importxslt":"none","batchEdits":"[]"},"options":{"every":"0 0 0 ? * *","oneRunOnly":false,"overrideUuid":"SKIP","status":"active"},"privileges":[{"@id":"1","operation":[{"@name":"view"},{"@name":"dynamic"},{"@name":"download"}]}],"ifRecordExistAppendPrivileges":false,"info":{"lastRun":"2024-09-09T08:21:08.124161Z","running":false,"result":{"added":"1036","atomicDatasetRecords":"0","badFormat":"0","collectionDatasetRecords":"0","datasetUuidExist":"0","privilegesAppendedOnExistingRecord":"0","doesNotValidate":"0","xpathFilterExcluded":"0","duplicatedResource":"0","fragmentsMatched":"0","fragmentsReturned":"0","fragmentsUnknownSchema":"0","incompatible":"0","recordsBuilt":"0","recordsUpdated":"0","removed":"0","serviceRecords":"0","subtemplatesAdded":"0","subtemplatesRemoved":"0","subtemplatesUpdated":"0","total":"1036","unchanged":"0","unknownSchema":"0","unretrievable":"0","updated":"0","thumbnails":"0","thumbnailsFailed":"0"}}}
```

Some records use HTML in abstract
eg. https://www.odwb.be/explore/dataset/ares-referentiel-des-bassins-enseignement-qualifiant-formation-emploi-efe/information/?disjunctive.te_arrond_adm&disjunctive.te_province&disjunctive.te_region

Linky directive breaks the HTML and should not be used when the text is HTML.

After/Before

![image](https://github.com/user-attachments/assets/51c61ff8-a296-4094-b24f-b3f911b15eb5)


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->


Funded by Service Public de Wallonie
