### PR TITLE
Don't add file content to the exception when requesting XML documents, if the content is not XML

### DIFF
--- a/common/src/main/java/org/fao/geonet/utils/XmlRequest.java
+++ b/common/src/main/java/org/fao/geonet/utils/XmlRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2024 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -124,13 +124,13 @@ public class XmlRequest extends AbstractHttpRequest {
                 " -- Response Code: " + httpResponse.getRawStatusCode());
         }
 
-        byte[] data = null;
+        byte[] data;
 
         try {
             data = IOUtils.toByteArray(httpResponse.getBody());
             return Xml.loadStream(new ByteArrayInputStream(data));
         } catch (JDOMException e) {
-            throw new BadXmlResponseEx("Response: '" + new String(data, "UTF8") + "' (from URI " + httpMethod.getURI() + ")");
+            throw new BadXmlResponseEx("Invalid XML document from URI: " + httpMethod.getURI());
         } finally {
             httpMethod.releaseConnection();
 


### PR DESCRIPTION
When an http request is made that expects an XML document, if this is not the case, the content of the file is added to the exception. If the file is very large or is a binary file, the log is overloaded.

Adding the file content to the exception / log seems useless. The pull request adds a generic message, reporting the problematic URL.

For remote ATOM Feeds, the exception is added to the result report of the collector, producing an invalid response.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation