### PR TITLE
Editor / Associated resource / DOI search.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcService.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcService.js
@@ -265,9 +265,9 @@
             linksAndRelatedPromises.push(
               $http.get(
                 apiPrefix +
-                  "/related?type=" +
-                  relatedTypes.join("&type=") +
-                  (!isApproved ? "&approved=false" : ""),
+                "/related?type=" +
+                relatedTypes.join("&type=") +
+                (!isApproved ? "&approved=false" : ""),
                 {
                   headers: {
                     Accept: "application/json"
@@ -281,9 +281,9 @@
             linksAndRelatedPromises.push(
               $http.get(
                 apiPrefix +
-                  "/associated?type=" +
-                  associatedTypes.join(",") +
-                  (!isApproved ? "&approved=false" : ""),
+                "/associated?type=" +
+                associatedTypes.join(",") +
+                (!isApproved ? "&approved=false" : ""),
                 {
                   headers: {
                     Accept: "application/json"
@@ -610,8 +610,8 @@
               scopedName: params.remote
                 ? ""
                 : params.name === qParams.name
-                ? ""
-                : qParams.name,
+                  ? ""
+                  : qParams.name,
               uuidref: qParams.uuidDS,
               uuid: qParams.uuidSrv,
               url: qParams.remote ? qParams.url : "",
@@ -932,7 +932,13 @@
     function ($http) {
       return {
         search: function (url, prefix, query) {
-          return $http.get(url + "?prefix=" + prefix + "&query=" + query);
+          return $http.get(
+            url +
+            "?prefix=" +
+            prefix +
+            "&query=" +
+            query.replaceAll("https://doi.org/", "")
+          );
         }
       };
     }

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/doisearchpanel.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/doisearchpanel.html
@@ -17,6 +17,7 @@
           data-ng-model-options="{ debounce: 1000 }"
           data-ng-readonly="isSearching"
           type="text"
+          title="{{'selectDOIResource' | translate}} - {{doiQueryPattern}}"
           autocomplete="off"
           placeholder="{{'anyPlaceHolder' | translate}}"
           aria-label="{{'anyPlaceHolder' | translate}}"


### PR DESCRIPTION
* Add tooltip with API query to inform user which fields are used for the search.
* Ignore https://doi.org prefix as most of the time user search using the DOI URL but the API https://support.datacite.org/docs/api-queries search is only based on prefix/id

![image](https://github.com/user-attachments/assets/a23224d5-fbce-4cd4-b055-0125c2afc24e)


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->


Funded by Ifremer