### PR TITLE
ISO19139 / ISO19115.3 / Index resource date fields as defined in the metadata.

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
@@ -327,14 +327,16 @@
             </xsl:variable>
             <xsl:choose>
               <xsl:when test="$zuluDateTime != ''">
+                <!-- Store original date information for the resource, instead of $zuluDateTime,
+                     to avoid timezone shifts when used for facet filters -->
                 <xsl:element name="{$dateType}DateForResource">
-                  <xsl:value-of select="$zuluDateTime"/>
+                  <xsl:value-of select="$date"/>
                 </xsl:element>
                 <xsl:element name="{$dateType}YearForResource">
-                  <xsl:value-of select="substring($zuluDateTime, 0, 5)"/>
+                  <xsl:value-of select="substring($date, 0, 5)"/>
                 </xsl:element>
                 <xsl:element name="{$dateType}MonthForResource">
-                  <xsl:value-of select="substring($zuluDateTime, 0, 8)"/>
+                  <xsl:value-of select="substring($date, 0, 8)"/>
                 </xsl:element>
               </xsl:when>
               <xsl:otherwise>

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
@@ -287,14 +287,16 @@
 
             <xsl:choose>
               <xsl:when test="$zuluDateTime != ''">
+                <!-- Store original date information for the resource, instead of $zuluDateTime,
+                     to avoid timezone shifts when used for facet filters -->
                 <xsl:element name="{$dateType}DateForResource">
-                  <xsl:value-of select="$zuluDateTime"/>
+                  <xsl:value-of select="$date"/>
                 </xsl:element>
                 <xsl:element name="{$dateType}YearForResource">
-                  <xsl:value-of select="substring($zuluDateTime, 0, 5)"/>
+                  <xsl:value-of select="substring($date, 0, 5)"/>
                 </xsl:element>
                 <xsl:element name="{$dateType}MonthForResource">
-                  <xsl:value-of select="substring($zuluDateTime, 0, 8)"/>
+                  <xsl:value-of select="substring($date, 0, 8)"/>
                 </xsl:element>
               </xsl:when>
               <xsl:otherwise>


### PR DESCRIPTION
Previously the values were converted to UTC. If the timezone defined in the server is Europe/Madrid and the metadata has a creation date '2023-01-01T00:00:00', the index field creationYearForResource had the value 2022


Test case: 

1) Create an ISO19139 and add a creation date `2023-01-01T00:00:00`.

![creation-date](https://github.com/user-attachments/assets/3c3b4bad-f1e8-4a30-887b-29d2a3dafa62)

2) In the UI settings replace the Search application facet `creationYearForResource` with 

```
  "creationYearForResource": {
    "terms": {
      "field": "creationYearForResource",
      "order": {
        "_key": "desc"
      }
    },
    "meta": {
      "collapsed": true
    }
  },
```
![creation-date-facet](https://github.com/user-attachments/assets/b8d06cca-5cdd-44fe-a095-d88657f43c05)

3) Go to the search page:

  - Without the fix:

![facet-no-ok](https://github.com/user-attachments/assets/ea19476d-489b-4899-ad58-4e75444ee5e0)


  - With the fix:

![facet-ok](https://github.com/user-attachments/assets/4bd16187-be41-4c25-a47a-11ab5a747168)

---

@fxprunayre, instead of extracting the year from the XML content, should we convert the date for these fields, not to UTC, but to the server timezone configured? 

With the current change we are not dealing with metadata dates that have a timezone.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
