### PR TITLE
Metadata detail page - hide history types selector when tasks (DOI) and workflow are disabled

### DIFF
--- a/web-ui/src/main/resources/catalog/components/history/GnHistoryDirective.js
+++ b/web-ui/src/main/resources/catalog/components/history/GnHistoryDirective.js
@@ -58,7 +58,10 @@
             if (gnConfig["metadata.workflow.enable"]) {
               types.workflow = true;
             }
-            types.task = true;
+            // Currently the only task is DOI
+            if (gnConfig["system.publication.doi.doienabled"]) {
+              types.task = true;
+            }
             types.event = true;
 
             scope.filter = {
@@ -68,6 +71,10 @@
               size: recordByPage
             };
           });
+
+          scope.getNumberOfTypes = function () {
+            return Object.keys(scope.filter.types).length;
+          };
 
           // Wait for metatada to be available
           scope.$watch("md", function (n, o) {

--- a/web-ui/src/main/resources/catalog/components/history/partials/recordHistory.html
+++ b/web-ui/src/main/resources/catalog/components/history/partials/recordHistory.html
@@ -4,7 +4,7 @@
     <span data-translate="">recordHistory</span>
   </div>
   <div class="panel-body">
-    <div class="btn-group">
+    <div class="btn-group" data-ng-if="getNumberOfTypes() > 1">
       <label
         data-ng-repeat="(k, v) in filter.types"
         class="btn btn-default"


### PR DESCRIPTION
Previously the metadata page displayed the Tasks and Events selector, even if DOI (Task) was disabled in the settings.

![Screenshot 2024-09-16 at 13 32 58](https://github.com/user-attachments/assets/d20761c4-bd56-4f1f-9949-132501c8e433)

With the change:

![Screenshot 2024-09-16 at 13 32 34](https://github.com/user-attachments/assets/73803e25-03fe-4ed2-980d-d8b811108c1d)


With the change, if DOI is enabled, it works as previously displaying the selector.

Test case:

1) Login as administrator and enable the metadata history and disable the DOI publication in the system settings. 

2) Load ISO19139 templates and create a metadata.

3) Go to the metadata page:

  - Without the change: A selector for Tasks and Events is displayed
  - With the change: No selector is displayed.


3) Enable the DOI publication in the system settings and go to the metadata page:

  - With the change: Check that the selector for Tasks and Events is displayed.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
