### PR TITLE
Identifying (GetFeatureInfo) on a WMS layer in the map only shows data in columns with a lowercase title.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/viewer/gfi/FeaturesLoader.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/gfi/FeaturesLoader.js
@@ -247,8 +247,9 @@
                 obj[key] = $filter('linky')(obj[key], '_blank');
               }
               if (obj[key]) {
-                obj[key] = obj[key].replace(/>(.)*</, ' ' +
+                obj[key.toLowerCase()] = obj[key].replace(/>(.)*</, ' ' +
                     'target="_blank">' + linkTpl + '<');
+                delete obj[key];
               }
             } else {
               // Exclude objects which will not be displayed properly


### PR DESCRIPTION
 Fixes #8353.

Affects only 3.12.x branch. Follow up of #6802, that missed to lower the data row keys to unify the comparison with the column names from the GetFeaturesInfo response and the FeatureCatalogue metadata (when the dataset metadata has a FeatureCatalogue metadata associated).

See test case described in #8353.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

