### PR TITLE
Map viewer / WMS GetFeatureInfo support for application/json info format

### DIFF
--- a/web-ui/src/main/resources/catalog/components/viewer/gfi/FeaturesLoader.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/gfi/FeaturesLoader.js
@@ -151,7 +151,7 @@
       })
       .then(
         function (response) {
-          if (infoFormat && infoFormat.match(/application\/(geo|geo\+)json/i) != null) {
+          if (infoFormat && infoFormat.match(/application\/(geo|geo\+)?json/i) != null) {
             var jsonf = new ol.format.GeoJSON();
             var features = [];
             response.data.features.forEach(function (f) {


### PR DESCRIPTION
The addition of a WMS layer that returned `application/json` as a supported info format was not handled correctly (only `application/geojson` and  `application/geo+json` were supported.

This caused the response to be processed as GML, failing feature information:

```
TypeError: t.setAttribute is not a function
    at e.readFeatures_ (WMSGetFeatureInfo.js:87:14)
    at e.readFeaturesFromNode (WMSGetFeatureInfo.js:142:21)
```

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation


