### PR TITLE
Fix the schema artifact name in add schema script

### DIFF
--- a/add-schema.sh
+++ b/add-schema.sh
@@ -83,7 +83,7 @@ then
   ${insertLine} a\\
 \        <dependency>\\
 \          <groupId>org.geonetwork-opensource.schemas</groupId>\\
-\          <artifactId>schema-${schema}</artifactId>\\
+\          <artifactId>gn-schema-${schema}</artifactId>\\
 \          <version>${gnSchemasVersion}</version>\\
 \        </dependency>
 SED_SCRIPT
@@ -103,7 +103,7 @@ SED_SCRIPT
 \      <dependencies>\\
 \        <dependency>\\
 \          <groupId>org.geonetwork-opensource.schemas</groupId>\\
-\          <artifactId>schema-${schema}</artifactId>\\
+\          <artifactId>gn-schema-${schema}</artifactId>\\
 \          <version>${gnSchemasVersion}</version>\\
 \        </dependency>\\
 \      </dependencies>\\
@@ -121,7 +121,7 @@ SED_SCRIPT
 \                  <artifactItems>\\
 \                    <artifactItem>\\
 \                      <groupId>org.geonetwork-opensource.schemas</groupId>\\
-\                      <artifactId>schema-${schema}</artifactId>\\
+\                      <artifactId>gn-schema-${schema}</artifactId>\\
 \                      <type>zip</type>\\
 \                      <overWrite>false</overWrite>\\
 \                      <outputDirectory>\$\{schema-plugins.dir\}</outputDirectory>\\
@@ -138,7 +138,7 @@ SED_SCRIPT
 fi
 
 # Add schema resources in service/pom.xml with test scope for unit tests
-line=$(grep -n "<artifactId>schema-${schema}</artifactId>" services/pom.xml | cut -d: -f1)
+line=$(grep -n "<artifactId>gn-schema-${schema}</artifactId>" services/pom.xml | cut -d: -f1)
 
 if [ ! $line ]
 then
@@ -154,7 +154,7 @@ then
   ${finalLine} a\\
 \    <dependency>\\
 \      <groupId>${projectGroupId}</groupId>\\
-\      <artifactId>schema-${schema}</artifactId>\\
+\      <artifactId>gn-schema-${schema}</artifactId>\\
 \      <version>${gnSchemasVersion}</version>\\
 \      <scope>test</scope>\\
 \    </dependency>


### PR DESCRIPTION
Maven artifact identifiers were changed to include the `gn-` prefix, the script for adding metadata schemas to the development project was not updated.

This change requires revising the custom schemas at https://github.com/metadata101 to use the old convention if they are not already using it.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

