### PR TITLE
Indexing / DCAT multilingual support

### DIFF
--- a/web/src/main/webapp/xslt/common/index-utils.xsl
+++ b/web/src/main/webapp/xslt/common/index-utils.xsl
@@ -251,6 +251,7 @@
                   select="count($elements[not(@xml:lang)]) > 1"/>
 
 
+    <!-- Select the items to be processed depending on whether they are ISO multilingual or not ISO, but multilingual eg. DC or DCAT -->
     <xsl:for-each select="if($languages and count($elements//(*:CharacterString|*:Anchor|*:LocalisedCharacterString)) = 0 ) then $elements[1] else $elements">
       <xsl:variable name="element" select="."/>
       <xsl:variable name="textObject" as="node()*">

--- a/web/src/main/webapp/xslt/common/index-utils.xsl
+++ b/web/src/main/webapp/xslt/common/index-utils.xsl
@@ -244,24 +244,29 @@
 
     <!--<xsl:message>gn-fn-index:add-field <xsl:value-of select="$fieldName"/></xsl:message>
     <xsl:message>gn-fn-index:add-field elements <xsl:copy-of select="$elements"/></xsl:message>
-    <xsl:message>gn-fn-index:add-field languages <xsl:copy-of select="$languages"/></xsl:message>-->
+    <xsl:message>gn-fn-index:add-field languages <xsl:copy-of select="$languages"/></xsl:message>
+    <xsl:message>gn-fn-index:add-field mainLanguage <xsl:copy-of select="$mainLanguage"/></xsl:message>-->
 
     <xsl:variable name="isArray"
                   select="count($elements[not(@xml:lang)]) > 1"/>
-    <xsl:for-each select="$elements">
+
+
+    <xsl:for-each select="if($languages and count($elements//(*:CharacterString|*:Anchor|*:LocalisedCharacterString)) = 0 ) then $elements[1] else $elements">
       <xsl:variable name="element" select="."/>
       <xsl:variable name="textObject" as="node()*">
         <xsl:choose>
           <!-- Not ISO but multilingual eg. DC or DCAT -->
           <xsl:when test="$languages and count($element//(*:CharacterString|*:Anchor|*:LocalisedCharacterString)) = 0">
-            <xsl:if test="position() = 1">
               <value><xsl:value-of select="concat($doubleQuote, 'default', $doubleQuote, ':',
                                              $doubleQuote, util:escapeForJson(.), $doubleQuote)"/></value>
               <xsl:for-each select="$elements">
-                <value><xsl:value-of select="concat($doubleQuote, 'lang', @xml:lang, $doubleQuote, ':',
+                <xsl:variable name="elementLangAttribute"
+                              select="@xml:lang"/>
+                <xsl:variable name="elementLangCode"
+                              select="$languages/lang[@value = $elementLangAttribute]/@code"/>
+                <value><xsl:value-of select="concat($doubleQuote, 'lang', $elementLangCode, $doubleQuote, ':',
                                              $doubleQuote, util:escapeForJson(.), $doubleQuote)"/></value>
               </xsl:for-each>
-            </xsl:if>
           </xsl:when>
           <xsl:when test="$languages">
             <!-- The default language -->
@@ -707,10 +712,10 @@
   <xsl:function name="gn-fn-index:json-escape" as="xs:string?">
     <!-- This function is deprecated. Please update your code to define the following namespace:
             xmlns:util="java:org.fao.geonet.util.XslUtil"
-            
-            and use util:escapeForJson function 
+
+            and use util:escapeForJson function
     -->
-    
+
       <xsl:param name="v" as="xs:string?" />
       <xsl:choose>
         <xsl:when test="normalize-space($v) = ''"></xsl:when>


### PR DESCRIPTION
* Use 3 letter code for field ID like in ISO
* Fix position to properly index a set of multilingual elements 

```xml
<dct:title xml:lang="nl">NL</dct:title>
<dct:title xml:lang="en">EN</dct:title>
```


Related to https://github.com/metadata101/dcat-ap.vl/pull/5


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

Funded by Vlaanderen