### PR TITLE
[Backport 4.2.x] Upgrade springdocs to 1.8.0 and jackson to 2.16.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1584,7 +1584,7 @@
     <spring.security.version>5.7.12</spring.security.version>
     <spring.jpa.version>2.2.13.RELEASE</spring.jpa.version>
     <springboot.version>2.7.0</springboot.version>
-    <springdoc.version>1.7.0</springdoc.version>
+    <springdoc.version>1.8.0</springdoc.version>
 
     <metrics.version>2.2.0</metrics.version>
     <maven.build.timestamp.format>yyyy-MM-dd'T'HH'\:'mm'\:'ssZ</maven.build.timestamp.format>
@@ -1596,7 +1596,7 @@
     <node.version>v8.11.1</node.version>
     <npm.version>5.8.0</npm.version>
     <xmlunit.version>2.1.1</xmlunit.version>
-    <jackson.version>2.10.5</jackson.version>
+    <jackson.version>2.16.2</jackson.version>
     <flying-saucer>9.1.22</flying-saucer>
     <camel.version>2.25.1</camel.version>
     <log4j2.version>2.17.2</log4j2.version>

--- a/services/src/main/java/org/fao/geonet/api/tools/i18n/TranslationApi.java
+++ b/services/src/main/java/org/fao/geonet/api/tools/i18n/TranslationApi.java
@@ -275,7 +275,6 @@ public class TranslationApi {
         }
     }
 
-
     @io.swagger.v3.oas.annotations.Operation(
         summary = "List database translations (used to overrides client application translations).")
     @GetMapping(value = "/db/translations",
@@ -289,10 +288,11 @@ public class TranslationApi {
                 "{" +
                     "  \"translationKey1\": \"Translated Key One\",\n" +
                     "  \"translationKey2\": \"Translated Key Two\",\n" +
-                    "  \"translationKey3\": \"Translated Key Two\"\n" +
+                    "  \"translationKey3\": \"Translated Key Three\"\n" +
                     "}")
-        }, schema = @Schema(type = "{ < * >: string }"))
+        }, schema = @Schema(type = "object", additionalPropertiesSchema = String.class))
     )
+    @ResponseStatus(OK)
     @ResponseBody
     public Map<String, String> getDbTranslations(
         ServletRequest request

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/linkToMd.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/linkToMd.html
@@ -38,7 +38,8 @@
         ng-disabled="(selectRecords.length < 1)"
       >
         <i class="fa gn-icon-{{mode}}"></i>
-        <i class="icon-external-link"></i>&nbsp; {{btn.label || ('saveLinkToSibling' | translate)}}
+        <i class="icon-external-link"></i>&nbsp; {{btn.label || ('saveLinkToSibling' |
+        translate)}}
       </button>
       <div data-gn-need-help="linking-records" class="pull-right"></div>
     </div>


### PR DESCRIPTION
Update springdoc to 1.8.0 which required upgrade of jackson.version to version 2.16.2
Fix springdocs HashMap mapping in /db/translations using new additionalPropertiesSchema

Backport of https://github.com/geonetwork/core-geonetwork/pull/7905
