### PR TITLE
Aggregations / Temporal range / Avoid browser autocomplete on calendar

### DIFF
--- a/docs/manual/docs/customizing-application/configuring-faceted-search.md
+++ b/docs/manual/docs/customizing-application/configuring-faceted-search.md
@@ -467,7 +467,7 @@ A date range field:
 "resourceTemporalDateRange": {
    "gnBuildFilterForRange": {
       "field": "resourceTemporalDateRange",
-      "buckets": "2021 - 1970",
+      "buckets": 51, //"2021 - 1970",
       "dateFormat": "YYYY",
       "vegaDateFormat": "%Y",
       "from": "1970",

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facet-temporalrange.html
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facet-temporalrange.html
@@ -12,6 +12,7 @@
       class="input-sm form-control"
       data-ng-model="range.from"
       data-ng-model-options="{debounce: 500}"
+      autocomplete="off"
       name="start"
     />
     <span class="input-group-addon">
@@ -22,6 +23,7 @@
       class="input-sm form-control"
       data-ng-model="range.to"
       data-ng-model-options="{debounce: 500}"
+      autocomplete="off"
       name="end"
     />
     <span class="input-group-btn">


### PR DESCRIPTION


When using temporal range for aggregations

```
 resourceTemporalDateRange: {
                gnBuildFilterForRange: {
                  field: "resourceTemporalDateRange",
                  buckets: 2024 - 1970,
                  dateFormat: "YYYY",
                  dateSelectMode: "years",
                  vegaDateFormat: "%Y",
                  from: 1970,
                  to: 2024,
                  mark: "area"
                },
                meta: {
                  vega: "timeline",
                  collapsed: true
                }
              },
```

browser autocomplete may overlap with calendar

![image](https://github.com/user-attachments/assets/e0a2e444-759b-430f-8418-05a0e3d93492)



<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

Funded by Ifremer
