### PR TITLE
[Backport 4.2.x] Metadata detail page - hide history types selector when tasks (DOI) and workflow are disabled

### DIFF
--- a/web-ui/src/main/resources/catalog/components/history/GnHistoryDirective.js
+++ b/web-ui/src/main/resources/catalog/components/history/GnHistoryDirective.js
@@ -58,7 +58,10 @@
             if (gnConfig["metadata.workflow.enable"]) {
               types.workflow = true;
             }
-            types.task = true;
+            // Currently the only task is DOI
+            if (gnConfig["system.publication.doi.doienabled"]) {
+              types.task = true;
+            }
             types.event = true;
 
             scope.filter = {
@@ -68,6 +71,10 @@
               size: recordByPage
             };
           });
+
+          scope.getNumberOfTypes = function () {
+            return Object.keys(scope.filter.types).length;
+          };
 
           // Wait for metatada to be available
           scope.$watch("md", function (n, o) {

--- a/web-ui/src/main/resources/catalog/components/history/partials/recordHistory.html
+++ b/web-ui/src/main/resources/catalog/components/history/partials/recordHistory.html
@@ -4,7 +4,7 @@
     <span data-translate="">recordHistory</span>
   </div>
   <div class="panel-body">
-    <div class="btn-group">
+    <div class="btn-group" data-ng-if="getNumberOfTypes() > 1">
       <label
         data-ng-repeat="(k, v) in filter.types"
         class="btn btn-default"


### PR DESCRIPTION
Backport #8369
 **Authored by:** @josegar74