### PR TITLE
Fix harvester execution logs added to previous logs

### DIFF
--- a/core/src/main/java/org/fao/geonet/util/LogUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/LogUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2023 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2024 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -57,7 +57,7 @@ public class LogUtil {
         // Filename safe representation of harvester name (using '_' as needed).
         final String harvesterName = name.replaceAll("\\W+", "_");
         final String harvesterType = type.replaceAll("\\W+", "_");
-        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyyMMddHHmm");
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyyMMddHHmmss");
 
         String logfile = "harvester_"
             + harvesterType
@@ -71,7 +71,7 @@ public class LogUtil {
         }
 
         ThreadContext.put("harvest", harvesterName);
-        ThreadContext.putIfNull("logfile", logfile);
+        ThreadContext.put("logfile", logfile);
         ThreadContext.put("timeZone", timeZoneSetting);
 
         return logfile;


### PR DESCRIPTION
Test case:

1. Create a harvester.
2. Execute it and check the harvester history tab. The execution has a button to download the log file.
3. Execute it 2 or more times and check the harvester history tab. Most probably is that the latest executions don't have the button to download the log file. Checking the previous log files, you can find out that are stored there.

The problem seems related to https://github.com/geonetwork/core-geonetwork/blob/1a780ac0d09f1a1df0cdbe23e513e8440c994227/core/src/main/java/org/fao/geonet/util/LogUtil.java#L74, as Quartz probably reuses threads and `putIfNull` does not update the value if a thread that had a set value has been reused. The other properties added to the `ThreadContext` are added using `put` instead. It is not clear why the log file name is added using `putIfNull`.



# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
