### PR TITLE
GeoNetwork harvester - avoid double counting of updated metadata.

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Aligner.java
@@ -1,5 +1,5 @@
 //=============================================================================
-//===    Copyright (C) 2001-2023 Food and Agriculture Organization of the
+//===    Copyright (C) 2001-2024 Food and Agriculture Organization of the
 //===    United Nations (FAO-UN), United Nations World Food Programme (WFP)
 //===    and United Nations Environment Programme (UNEP)
 //===
@@ -216,7 +216,6 @@ public class Aligner extends BaseAligner<GeonetParams> {
                                     params.useChangeDateForUpdate(),
                                     localUuids.getChangeDate(ri.uuid), true);
                                 log.info("Overriding record with uuid " + ri.uuid);
-                                result.updatedMetadata++;
 
                                 if (params.isIfRecordExistAppendPrivileges()) {
                                     addPrivileges(id, params.getPrivileges(), localGroups, context);


### PR DESCRIPTION

The counter for updated metadata is updated in `updateMetadata` method:

https://github.com/geonetwork/core-geonetwork/blob/c932372349a6d918a5da2671630252f3dc66962a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Aligner.java#L802

But with existing metadata managed by another harvester if the uuid collision policy is set to override, it was updated again in https://github.com/geonetwork/core-geonetwork/blob/c932372349a6d918a5da2671630252f3dc66962a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Aligner.java#L219

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

