### PR TITLE
Thesaurus / Date improvements.

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/Thesaurus.java
+++ b/core/src/main/java/org/fao/geonet/kernel/Thesaurus.java
@@ -1064,12 +1064,11 @@ public class Thesaurus {
 
         StringBuffer errorMsg = new StringBuffer("Error parsing the thesaurus date value: ");
         errorMsg.append(dateVal);
-        boolean success = false;
 
         for (SimpleDateFormat df : dfList) {
             try {
                 thesaurusDate = df.parse(dateVal);
-                success = true;
+                return thesaurusDate;
             } catch (Exception ex) {
                 // Ignore the exception and try next format
                 errorMsg.append("\n  * with format: ");
@@ -1079,11 +1078,9 @@ public class Thesaurus {
             }
         }
         // Report error if no success
-        if (!success) {
-            errorMsg.append("\nCheck thesaurus date in ");
-            errorMsg.append(this.fname);
-            Log.error(Geonet.THESAURUS_MAN, errorMsg.toString());
-        }
+        errorMsg.append("\nCheck thesaurus date in ");
+        errorMsg.append(this.fname);
+        Log.error(Geonet.THESAURUS_MAN, errorMsg.toString());
         return thesaurusDate;
     }
 

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/thesaurus-transformation.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/thesaurus-transformation.xsl
@@ -82,6 +82,12 @@
     <xsl:param name="withThesaurusAnchor"/>
 
     <mri:descriptiveKeywords>
+      <xsl:namespace name="mri" select="'http://standards.iso.org/iso/19115/-3/mri/1.0'"/>
+      <xsl:namespace name="mcc" select="'http://standards.iso.org/iso/19115/-3/mcc/1.0'"/>
+      <xsl:namespace name="cit" select="'http://standards.iso.org/iso/19115/-3/cit/2.0'"/>
+      <xsl:namespace name="gco" select="'http://standards.iso.org/iso/19115/-3/gco/1.0'"/>
+      <xsl:namespace name="gcx" select="'http://standards.iso.org/iso/19115/-3/gcx/1.0'"/>
+      <xsl:namespace name="xlink" select="'http://www.w3.org/1999/xlink'"/>
       <xsl:choose>
         <xsl:when test="$withXlink">
           <xsl:variable name="multiple"
@@ -257,20 +263,22 @@
                               codeListValue="{$thesauri/thesaurus[key = $currentThesaurus]/dname}" />
     </mri:type>
     <xsl:if test="$thesaurusInfo">
+      <xsl:variable name="thesaurus"
+                    select="$thesauri/thesaurus[key = $currentThesaurus]"/>
+
       <xsl:variable name="thesaurusInMainLanguage"
-                    select="$thesauri/thesaurus[key = $currentThesaurus]
-                              /multilingualTitles/multilingualTitle[
+                    select="$thesaurus/multilingualTitles/multilingualTitle[
                                 lang = util:twoCharLangCode($mainLanguage, '')]/title"/>
       <xsl:variable name="thesaurusTitle"
                     select="if ($thesaurusInMainLanguage != '')
                             then $thesaurusInMainLanguage
-                            else $thesauri/thesaurus[key = $currentThesaurus]/title"/>
+                            else $thesaurus/title"/>
       <mri:thesaurusName>
         <cit:CI_Citation>
           <cit:title>
             <xsl:choose>
               <xsl:when test="$withThesaurusAnchor = true()">
-                <gcx:Anchor xlink:href="{$thesauri/thesaurus[key = $currentThesaurus]/defaultNamespace}">
+                <gcx:Anchor xlink:href="{$thesaurus/defaultNamespace}">
                   <xsl:value-of select="$thesaurusTitle"/>
                 </gcx:Anchor>
               </xsl:when>
@@ -282,121 +290,30 @@
             </xsl:choose>
           </cit:title>
 
-          <xsl:variable name="thesaurusDate"
-                        select="normalize-space($thesauri/thesaurus[key = $currentThesaurus]/date)" />
-          <xsl:variable name="thesaurusCreatedDate"
-                        select="normalize-space($thesauri/thesaurus[key = $currentThesaurus]/createdDate)"/>
-          <xsl:variable name="thesaurusIssuedDate"
-                        select="normalize-space($thesauri/thesaurus[key = $currentThesaurus]/issuedDate)"/>
-          <xsl:variable name="thesaurusModifiedDate"
-                        select="normalize-space($thesauri/thesaurus[key = $currentThesaurus]/modifiedDate)"/>
+          <xsl:variable name="thesaurusDates" as="node()*">
+            <publication date="{normalize-space($thesaurus/date)}"/>
+            <creation date="{normalize-space($thesaurus/createdDate)}"/>
+            <publication date="{normalize-space($thesaurus/issuedDate)}"/>
+            <publication date="{normalize-space($thesaurus/modifiedDate)}"/>
+          </xsl:variable>
 
-          <xsl:if test="$thesaurusDate != ''">
+          <xsl:for-each-group select="$thesaurusDates[@date != '']" group-by="@date">
+            <xsl:sort select="@date" order="descending"/>
             <cit:date>
               <cit:CI_Date>
                 <cit:date>
-                  <xsl:choose>
-                    <xsl:when test="contains($thesaurusDate, 'T')">
-                      <gco:DateTime>
-                        <xsl:value-of select="$thesaurusDate" />
-                      </gco:DateTime>
-                    </xsl:when>
-                    <xsl:otherwise>
-                      <gco:Date>
-                        <xsl:value-of select="$thesaurusDate" />
-                      </gco:Date>
-                    </xsl:otherwise>
-                  </xsl:choose>
+                  <xsl:element name="{if (contains(current-grouping-key(), 'T')) then 'gco:DateTime' else 'gco:Date'}">
+                    <xsl:value-of select="current-grouping-key()" />
+                  </xsl:element>
                 </cit:date>
                 <cit:dateType>
                   <cit:CI_DateTypeCode
-                          codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode"
-                          codeListValue="publication" />
+                    codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_DateTypeCode"
+                    codeListValue="{name(current-group()[1])}"/>
                 </cit:dateType>
               </cit:CI_Date>
             </cit:date>
-          </xsl:if>
-
-          <!-- Publication Date-->
-          <xsl:choose>
-            <xsl:when test="$thesaurusIssuedDate != ''">
-              <cit:date>
-                <cit:CI_Date>
-                  <cit:date>
-                    <xsl:choose>
-                      <xsl:when test="contains($thesaurusIssuedDate, 'T')">
-                        <gco:DateTime>
-                          <xsl:value-of select="$thesaurusIssuedDate" />
-                        </gco:DateTime>
-                      </xsl:when>
-                      <xsl:otherwise>
-                        <gco:Date>
-                          <xsl:value-of select="$thesaurusIssuedDate" />
-                        </gco:Date>
-                      </xsl:otherwise>
-                    </xsl:choose>
-                  </cit:date>
-                  <cit:dateType>
-                    <cit:CI_DateTypeCode
-                      codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode"
-                      codeListValue="publication" />
-                  </cit:dateType>
-                </cit:CI_Date>
-              </cit:date>
-            </xsl:when>
-            <xsl:otherwise>
-              <cit:date>
-                <cit:CI_Date>
-                  <cit:date>
-                    <xsl:choose>
-                      <xsl:when test="contains($thesaurusDate, 'T')">
-                        <gco:DateTime>
-                          <xsl:value-of select="$thesaurusDate" />
-                        </gco:DateTime>
-                      </xsl:when>
-                      <xsl:otherwise>
-                        <gco:Date>
-                          <xsl:value-of select="$thesaurusDate" />
-                        </gco:Date>
-                      </xsl:otherwise>
-                    </xsl:choose>
-                  </cit:date>
-                  <cit:dateType>
-                    <cit:CI_DateTypeCode
-                      codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode"
-                      codeListValue="publication" />
-                  </cit:dateType>
-                </cit:CI_Date>
-              </cit:date>
-            </xsl:otherwise>
-          </xsl:choose>
-
-          <!--Creation Date-->
-          <xsl:if test="$thesaurusCreatedDate != ''">
-            <cit:date>
-              <cit:CI_Date>
-                <cit:date>
-                  <xsl:choose>
-                    <xsl:when test="contains($thesaurusCreatedDate, 'T')">
-                      <gco:DateTime>
-                        <xsl:value-of select="$thesaurusCreatedDate" />
-                      </gco:DateTime>
-                    </xsl:when>
-                    <xsl:otherwise>
-                      <gco:Date>
-                        <xsl:value-of select="$thesaurusCreatedDate" />
-                      </gco:Date>
-                    </xsl:otherwise>
-                  </xsl:choose>
-                </cit:date>
-                <cit:dateType>
-                  <cit:CI_DateTypeCode
-                    codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode"
-                    codeListValue="creation" />
-                </cit:dateType>
-              </cit:CI_Date>
-            </cit:date>
-          </xsl:if>
+          </xsl:for-each-group>
 
           <xsl:if test="$withThesaurusAnchor">
             <cit:identifier>

--- a/web/src/main/webapp/xslt/services/thesaurus/ldregistry-to-skos.xsl
+++ b/web/src/main/webapp/xslt/services/thesaurus/ldregistry-to-skos.xsl
@@ -71,7 +71,6 @@
 
 
         <dcterms:issued><xsl:value-of select="if ($thesaurusDate != '') then $thesaurusDate else $now"/></dcterms:issued>
-        <dcterms:modified><xsl:value-of select="if ($thesaurusDate != '') then $thesaurusDate else $now"/></dcterms:modified>
 
         <xsl:for-each select="distinct-values($concepts/*[skos:narrower and not(skos:broader)]/@rdf:about)">
           <skos:hasTopConcept rdf:resource="{.}"/>

--- a/web/src/main/webapp/xslt/services/thesaurus/registry-to-skos.xsl
+++ b/web/src/main/webapp/xslt/services/thesaurus/registry-to-skos.xsl
@@ -126,7 +126,6 @@
 
 
         <dcterms:issued><xsl:value-of select="if ($thesaurusDate != '') then $thesaurusDate else $now"/></dcterms:issued>
-        <dcterms:modified><xsl:value-of select="if ($thesaurusDate != '') then $thesaurusDate else $now"/></dcterms:modified>
 
         <!-- Add top concepts for all items with no parent -->
         <xsl:if test="$hasBroaderNarrowerLinks">


### PR DESCRIPTION
https://github.com/geonetwork/core-geonetwork/pull/6972/files#diff-c7548d94bdb4268915f50f66df5a90f1f7868e4fb1de2f3d2938397e202aaf2fR1057 added month and year format support. This was resolving thesaurus date to the last matching format ie. 1st January for the default date.

This can be tested using regions thesaurus which will contains 2 dates for the thesaurus block.

https://github.com/geonetwork/core-geonetwork/pull/6972 adds retrieval of `dct:issued|modified|created` dates but multiple dates could be added more than one time with same date type code. Improve the mapping (and add more flexibility to customize date type code).

@wangf1122, @ianwallen  if you could review to check if the grouping of various dates match your requirements?

Misc:
* Cleanup namespace so that they are added to the top of the XML response.

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

Funded by Service Public de Wallonie
