### PR TITLE
Thesaurus / OWL format / Mobility theme hierarchy

### DIFF
--- a/services/src/test/java/org/fao/geonet/api/registries/vocabularies/KeywordsApiTest.java
+++ b/services/src/test/java/org/fao/geonet/api/registries/vocabularies/KeywordsApiTest.java
@@ -249,6 +249,6 @@ public class KeywordsApiTest extends AbstractServiceIntegrationTest {
             "Mobility Theme", scheme.getChildText("title", NAMESPACE_DCT));
 
         List concepts = thesaurus.getChildren("Concept", SKOS_NAMESPACE);
-        assertEquals(123, concepts.size());
+        assertEquals(121, concepts.size());
     }
 }

--- a/web/src/main/webapp/xslt/services/thesaurus/owl-to-skos.xsl
+++ b/web/src/main/webapp/xslt/services/thesaurus/owl-to-skos.xsl
@@ -24,9 +24,9 @@
 <xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
                 xmlns:owl="http://www.w3.org/2002/07/owl#"
                 xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-                xmlns:dc="http://purl.org/dc/elements/1.1/"
-                xmlns:dcterms="http://purl.org/dc/terms/"
+                xmlns:terms="http://purl.org/dc/terms/"
                 xmlns:skos="http://www.w3.org/2004/02/skos/core#"
+                xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 exclude-result-prefixes="#all"
                 version="2.0">
 
@@ -40,12 +40,38 @@
 
   <xsl:template mode="owl-to-skos"
                 match="owl:Ontology">
-    <rdf:RDF xmlns:skos="http://www.w3.org/2004/02/skos/core#"
-             xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-             xmlns:dc="http://purl.org/dc/elements/1.1/"
-             xmlns:dcterms="http://purl.org/dc/terms/">
+    <rdf:RDF>
+      <xsl:namespace name="skos" select="'http://www.w3.org/2004/02/skos/core#'"/>
+      <xsl:namespace name="rdf" select="'http://www.w3.org/1999/02/22-rdf-syntax-ns#'"/>
+      <xsl:namespace name="dc" select="'http://purl.org/dc/elements/1.1/'"/>
+      <xsl:namespace name="terms" select="'http://purl.org/dc/terms/'"/>
       <skos:ConceptScheme rdf:about="{@rdf:about}">
-        <xsl:copy-of select="dcterms:*|skos:*"/>
+        <xsl:copy-of select="terms:*|skos:*[local-name() != 'hasTopConcept']" copy-namespaces="no"/>
+
+        <!--
+        Custom case for Mobility DCAT theme vocabulary top concepts.
+        https://mobilitydcat-ap.github.io/controlled-vocabularies/mobility-theme/latest/index.html#/
+
+        The vocabulary contains 2 top concepts:
+        <skos:hasTopConcept rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category"/>
+        <skos:hasTopConcept rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
+        which are not really needed for browsing the main categories and sub categories.
+
+        Use the narrower terms of the "content category" top concept as the top concepts of the scheme
+        to facilitate keyword selection in editor and generate proper facet hierarchy in search.
+        -->
+        <xsl:variable name="mobilityThemeTopConcept"
+                      select="../owl:NamedIndividual[@rdf:about = 'https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category']"/>
+        <xsl:choose>
+          <xsl:when test="$mobilityThemeTopConcept">
+            <xsl:for-each select="$mobilityThemeTopConcept/skos:narrower">
+              <skos:hasTopConcept rdf:resource="{@rdf:resource}"/>
+            </xsl:for-each>
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:copy-of select="skos:hasTopConcept" copy-namespaces="no"/>
+          </xsl:otherwise>
+        </xsl:choose>
       </skos:ConceptScheme>
 
       <xsl:apply-templates mode="owl-to-skos"
@@ -53,10 +79,29 @@
     </rdf:RDF>
   </xsl:template>
 
+  <xsl:variable name="excludedConcepts"
+                select="(
+                'https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category',
+                'https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category'
+                )"
+                as="xs:string*"/>
+
+  <xsl:template mode="owl-to-skos"
+                match="owl:NamedIndividual[@rdf:about = $excludedConcepts]
+                            |skos:broader[@rdf:resource = $excludedConcepts]"/>
+
   <xsl:template mode="owl-to-skos"
                 match="owl:NamedIndividual">
     <skos:Concept rdf:about="{@rdf:about}">
-      <xsl:copy-of select="skos:*"/>
+      <xsl:apply-templates mode="owl-to-skos" select="skos:*"/>
     </skos:Concept>
   </xsl:template>
+
+  <xsl:template mode="owl-to-skos"
+                match="@*|node()">
+    <xsl:copy copy-namespaces="no">
+      <xsl:apply-templates select="@*|node()" mode="owl-to-skos"/>
+    </xsl:copy>
+  </xsl:template>
+
 </xsl:stylesheet>


### PR DESCRIPTION
Follow up of https://github.com/geonetwork/core-geonetwork/pull/7674


Mobility DCAT theme vocabulary top concepts is available at https://mobilitydcat-ap.github.io/controlled-vocabularies/mobility-theme/latest/index.html#/

The vocabulary contains 2 top concepts:

```xml
<skos:hasTopConcept rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-category"/>
<skos:hasTopConcept rdf:resource="https://w3id.org/mobilitydcat-ap/mobility-theme/data-content-sub-category"/>
```
which are not needed for browsing the main categories and sub categories.

Use the narrower terms of the "content category" top concept as the top concepts of the scheme to

* generate proper facet hierarchy in search (after/before).

![image](https://github.com/user-attachments/assets/ba766c6a-f7c3-406b-a5b1-68ff245f64ff)

* and facilitate keyword selection in editor 


![image](https://github.com/user-attachments/assets/67c724e2-584b-42c2-8075-3c307e2f3b4f)



<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

Funded by Service Public de Wallonie