### PR TITLE
Metadata editor / validation report improvements

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/validationreport/partials/validationreport.html
+++ b/web-ui/src/main/resources/catalog/components/edit/validationreport/partials/validationreport.html
@@ -23,26 +23,30 @@
           <button
             type="button"
             class="btn btn-default btn-xs"
-            data-ng-class="showSuccess ? 'active' : ''"
+            data-ng-class="showSuccess ? 'active' : 'inactive'"
             data-ng-click="toggleShowSuccess();$event.stopPropagation();"
             data-ng-show="hasSuccess"
             data-toggle="tooltip"
             data-placement="top"
             title="{{'showHideSuccess' | translate}}"
           >
-            <span class="fa fa-thumbs-up text-success" aria-hidden="true"></span>
+            <span class="text-success" aria-hidden="true"
+              >{{'validationSuccessLabel' | translate | capitalize}}</span
+            >
           </button>
           <button
             type="button"
             class="btn btn-default btn-xs"
-            data-ng-class="showErrors ? 'active' : ''"
+            data-ng-class="showErrors ? 'active' : 'inactive'"
             data-ng-click="toggleShowErrors();$event.stopPropagation();"
             data-ng-show="hasErrors"
             data-toggle="tooltip"
             data-placement="top"
             title="{{'showHideErrors' | translate}}"
           >
-            <span class="fa fa-thumbs-down text-danger" aria-hidden="true"></span>
+            <span class="text-danger" aria-hidden="true"
+              >{{'validationErrorLabel' | translate | capitalize}}</span
+            >
           </button>
         </div>
       </div>
@@ -54,6 +58,22 @@
         data-ng-repeat="type in ruleTypes"
         data-ng-class="'schematron-result-list-' + labelImportanceClass(type)"
       >
+        <!-- No success or failed validation rules to display -->
+        <div
+          data-ng-if="type.error == 0 && type.success = 0"
+          data-gn-slide-toggle="{{initialSectionsClosed}}"
+          class="panel-heading clearfix"
+        >
+          <div class="col-md-9">
+            <h2 class="gn-schematron-title">
+              <span data-ng-if="type.schematronVerificationError">
+                <i class="fa fa-exclamation-triangle fa-fw text-danger"></i>&nbsp;</span
+              >{{(type.label || type.id) | translate}}
+            </h2>
+          </div>
+        </div>
+
+        <!-- Success or failed validation rules to display -->
         <div
           data-gn-slide-toggle="{{initialSectionsClosed}}"
           class="panel-heading clearfix"
@@ -83,10 +103,15 @@
               </ng-pluralize>
             </span>
             <span
-              class="label pull-right"
+              class="label pull-right label-success gn-margin-bottom-sm"
+              data-ng-if="type.total !== '?'"
+              >{{type.success}} {{'validationSuccessLabel' | translate}}</span
+            >
+            <span
+              class="label pull-right gn-margin-bottom-sm"
               data-ng-class="labelImportanceClass(type)"
               data-ng-if="type.total !== '?'"
-              >{{type.success}} / {{type.total}}</span
+              >{{type.error}} {{'validationErrorLabel' | translate}}</span
             >
           </div>
           <div
@@ -107,7 +132,10 @@
           </ul>
         </div>
         <div class="panel-body" data-ng-if="!type.schematronVerificationError">
-          <ul class="list-group" data-ng-repeat="pattern in type.patterns.pattern">
+          <ul
+            class="list-group"
+            data-ng-repeat="pattern in type.patterns.pattern | orderBy: 'type'"
+          >
             <li
               class="list-group-item"
               data-ng-repeat="rule in pattern.rules.rule"

--- a/web-ui/src/main/resources/catalog/components/edit/validationreport/partials/validationreport.html
+++ b/web-ui/src/main/resources/catalog/components/edit/validationreport/partials/validationreport.html
@@ -28,10 +28,10 @@
             data-ng-show="hasSuccess"
             data-toggle="tooltip"
             data-placement="top"
-            title="{{'showHideSuccess' | translate}}"
+            data-ng-attr-title="{{showSuccess ? ('hideSuccess' | translate): ('showSuccess' | translate)}}"
           >
             <span class="text-success" aria-hidden="true"
-              >{{'validationSuccessLabel' | translate | capitalize}}</span
+              >{{'validationSuccessLabel' | translate}}</span
             >
           </button>
           <button
@@ -42,10 +42,10 @@
             data-ng-show="hasErrors"
             data-toggle="tooltip"
             data-placement="top"
-            title="{{'showHideErrors' | translate}}"
+            data-ng-attr-title="{{showErrors ? ('hideErrors' | translate): ('showErrors' | translate)}}"
           >
             <span class="text-danger" aria-hidden="true"
-              >{{'validationErrorLabel' | translate | capitalize}}</span
+              >{{'validationErrorLabel' | translate}}</span
             >
           </button>
         </div>
@@ -60,8 +60,7 @@
       >
         <!-- No success or failed validation rules to display -->
         <div
-          data-ng-if="type.error == 0 && type.success = 0"
-          data-gn-slide-toggle="{{initialSectionsClosed}}"
+          data-ng-if="(type.error == 0 || type.error === '?') && (type.success == 0 || type.success === '?')"
           class="panel-heading clearfix"
         >
           <div class="col-md-9">
@@ -71,10 +70,55 @@
               >{{(type.label || type.id) | translate}}
             </h2>
           </div>
+
+          <div
+            class="col-md-3 gn-nopadding-right"
+            data-ng-if="!type.schematronVerificationError"
+          >
+            <span
+              class="label pull-right col-md-12"
+              data-ng-class="labelImportanceClass(type)"
+              data-ng-if="type.total === '?'"
+            >
+              <ng-pluralize
+                count="type.error"
+                when="{'0': '0 ' + ('error' | translate),
+                            '1': '1 ' +  ('error' | translate),
+                            'other': '{} ' +  ('errors' | translate)}"
+              >
+              </ng-pluralize>
+            </span>
+            <span
+              class="label pull-right label-success gn-margin-bottom-sm col-md-12"
+              data-ng-if="type.total !== '?' && type.success !== '?'"
+            >
+              <ng-pluralize
+                count="type.success"
+                when="{'0': '0 ' + ('success' | translate),
+                            '1': '1 ' +  ('success' | translate),
+                            'other': '{} ' +  ('successes' | translate)}"
+              >
+              </ng-pluralize>
+            </span>
+            <span
+              class="label pull-right gn-margin-bottom-sm col-md-12"
+              data-ng-class="labelImportanceClass(type)"
+              data-ng-if="type.total !== '?' && type.error !== '?'"
+            >
+              <ng-pluralize
+                count="type.error"
+                when="{'0': '0 ' + ('error' | translate),
+                            '1': '1 ' +  ('error' | translate),
+                            'other': '{} ' +  ('errors' | translate)}"
+              >
+              </ng-pluralize>
+            </span>
+          </div>
         </div>
 
         <!-- Success or failed validation rules to display -->
         <div
+          data-ng-if="(type.error != 0 && type.error !== '?') || (type.success != 0 && type.success !== '?')"
           data-gn-slide-toggle="{{initialSectionsClosed}}"
           class="panel-heading clearfix"
         >
@@ -90,7 +134,7 @@
             data-ng-if="!type.schematronVerificationError"
           >
             <span
-              class="label pull-right"
+              class="label pull-right col-md-12"
               data-ng-class="labelImportanceClass(type)"
               data-ng-if="type.total === '?'"
             >
@@ -103,16 +147,30 @@
               </ng-pluralize>
             </span>
             <span
-              class="label pull-right label-success gn-margin-bottom-sm"
-              data-ng-if="type.total !== '?'"
-              >{{type.success}} {{'validationSuccessLabel' | translate}}</span
+              class="label pull-right label-success gn-margin-bottom-sm col-md-12"
+              data-ng-if="type.total !== '?' && type.success !== '?'"
             >
+              <ng-pluralize
+                count="type.success"
+                when="{'0': '0 ' + ('success' | translate),
+                            '1': '1 ' +  ('success' | translate),
+                            'other': '{} ' +  ('successes' | translate)}"
+              >
+              </ng-pluralize>
+            </span>
             <span
-              class="label pull-right gn-margin-bottom-sm"
+              class="label pull-right gn-margin-bottom-sm col-md-12"
               data-ng-class="labelImportanceClass(type)"
-              data-ng-if="type.total !== '?'"
-              >{{type.error}} {{'validationErrorLabel' | translate}}</span
+              data-ng-if="type.total !== '?' && type.error !== '?'"
             >
+              <ng-pluralize
+                count="type.error"
+                when="{'0': '0 ' + ('error' | translate),
+                            '1': '1 ' +  ('error' | translate),
+                            'other': '{} ' +  ('errors' | translate)}"
+              >
+              </ng-pluralize>
+            </span>
           </div>
           <div
             class="col-md-3 gn-nopadding-right"

--- a/web-ui/src/main/resources/catalog/locales/en-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/en-editor.json
@@ -454,5 +454,7 @@
     "associated-fcats": "Feature catalog",
     "associated-siblings": "Associated resources",
     "associated-hasfeaturecats": "Using this feature catalog",
-    "associatedResourcesPanel": "Associated resources"
+    "associatedResourcesPanel": "Associated resources",
+    "validationSuccessLabel": "success",
+    "validationErrorLabel": "errors"
 }

--- a/web-ui/src/main/resources/catalog/style/gn_editor.less
+++ b/web-ui/src/main/resources/catalog/style/gn_editor.less
@@ -1024,3 +1024,9 @@ gn-bounding-polygon {
     border-radius: 50% !important;
   }
 }
+
+#gn-editor-validation-panel {
+  button.inactive {
+    opacity: 0.65;
+  }
+}


### PR DESCRIPTION
- Update buttons to display success and errors to use text instead of an icon.
- Show separate messages for success and errors.

<img width="375" alt="validation-rules-panel-1" src="https://github.com/user-attachments/assets/ff2cd3bd-9e73-45c3-b76a-abb35cc5a40a">

- Add style to display the display buttons greyed when the related rules are not displayed.

<img width="377" alt="validation-rules-panel-3" src="https://github.com/user-attachments/assets/6d218478-ee94-4aad-a9e6-0a69e90e37fd">


- If not success or errors reported don't show the expander to display the results in the validation rules.

<img width="393" alt="validation-geo" src="https://github.com/user-attachments/assets/0591fde3-93d7-4d0d-95b3-98e1690b2b49">

- Group the success and error messages.

<img width="372" alt="validation-rules-panel-2" src="https://github.com/user-attachments/assets/9b14fa40-4b18-496f-bb37-d2069343b92e">


# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
