### PR TITLE
Fixed spurious whitespace for gn-comma-list

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/less/gn_result_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_result_default.less
@@ -258,14 +258,20 @@
       display: inline;
       line-break: auto;
       word-break: break-word;
+      letter-spacing: -1em;
+      * {
+        letter-spacing: normal;
+      }
       a {
         line-break: normal;
       }
       &:after {
         content: ", ";
+        letter-spacing: normal;
       }
       &:last-child:after {
         content: "";
+        letter-spacing: normal;
       }
     }
   }

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/metadata.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/metadata.html
@@ -20,7 +20,9 @@
   <div>
     <h3 data-translate="">metadataLanguage</h3>
     <ul class="gn-comma-list">
-      <li data-ng-repeat="l in mdLanguages">{{l | translate}}</li>
+      <li data-ng-repeat="l in mdLanguages">
+        <span> {{l | translate}} </span>
+      </li>
     </ul>
   </div>
 </div>

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/spatial.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/spatial.html
@@ -35,7 +35,7 @@
         data-ng-repeat="d in mdView.current.record.resolutionScaleDenominator"
         class="gn-scale"
       >
-        {{d}}
+        <span> {{d}} </span>
       </li>
     </ul>
   </div>
@@ -51,7 +51,9 @@
   <div>
     <h3 data-translate="">resolution</h3>
     <ul class="gn-comma-list">
-      <li data-ng-repeat="r in mdView.current.record.resolutionDistance">{{r}}</li>
+      <li data-ng-repeat="r in mdView.current.record.resolutionDistance">
+        <span>{{r}}</span>
+      </li>
     </ul>
   </div>
 </div>

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/technical.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/technical.html
@@ -124,7 +124,7 @@
           data-ng-repeat="l in mdView.current.record.resourceLanguage"
           data-translate=""
         >
-          {{l}}
+          <span> {{l}} </span>
         </li>
       </ul>
     </div>

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/technical.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/technical.html
@@ -120,11 +120,8 @@
     <div>
       <h3 data-translate="">language</h3>
       <ul class="gn-comma-list">
-        <li
-          data-ng-repeat="l in mdView.current.record.resourceLanguage"
-          data-translate=""
-        >
-          <span> {{l}} </span>
+        <li data-ng-repeat="l in mdView.current.record.resourceLanguage">
+          <span data-translate=""> {{l}} </span>
         </li>
       </ul>
     </div>


### PR DESCRIPTION
The listing of CRS values was showing a spurious space, originating in the use of inline list items. The solution we implemented makes use of CSS where the whitespace elements are given zero space, while not touching the other element within the list items. This also updates any occurrence of the css class where there's bare text nodes included in the list items.

**before**
![image](https://github.com/user-attachments/assets/277f56b4-b74b-4a18-b646-3f16a9e6a972)

**after**
![image](https://github.com/user-attachments/assets/fa0ea4c2-9841-4a51-b5d9-490530a3af1b)


# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

