### PR TITLE
Fix the width of the projection switcher

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/less/gn_map_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_map_default.less
@@ -97,7 +97,7 @@
       margin: 0;
       padding: 0;
       position: absolute;
-      width: 16.5em;
+      width: 24.5em; // 34em - 7em - 2.5em
       border-radius: 0;
       li {
         width: calc(~"100% -30px");


### PR DESCRIPTION
The map projection switcher on the map is too small. This change fixes it.

The change can be seen by adding a second projection for the map in the admin.

**Before**:

<img width="537" alt="gn-map-before" src="https://github.com/user-attachments/assets/5b96c72f-d83a-438a-9976-7d918a34ce42">

**After**:

<img width="535" alt="gn-map-after" src="https://github.com/user-attachments/assets/2fcf38bb-c221-4c15-bfde-e051a263cdaa">


# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

