### PR TITLE
Metadata editor / Add required indicator to keyword selector and fix the required indicator for the field duration directive

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/fieldduration/partials/fieldduration.html
+++ b/web-ui/src/main/resources/catalog/components/edit/fieldduration/partials/fieldduration.html
@@ -1,4 +1,4 @@
-<span data-ng-class="required ? 'gn-required' : ''">
+<span data-ng-class="required == 'true' ? 'gn-required' : ''">
   <div class="" data-ng-show="isDisabled">
     <span data-ng-show="sign">-&nbsp;</span>
     <span data-ng-show="years != 0">{{years}} {{'year(s)' | translate}}&nbsp;</span>

--- a/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
+++ b/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
@@ -256,7 +256,8 @@
           // on keyword.
           maxTags: "@",
           thesaurusTitle: "@",
-          browsable: "@"
+          browsable: "@",
+          required: "@"
         },
         templateUrl:
           "../../catalog/components/thesaurus/" + "partials/keywordselector.html",

--- a/web-ui/src/main/resources/catalog/components/thesaurus/partials/keywordselector.html
+++ b/web-ui/src/main/resources/catalog/components/thesaurus/partials/keywordselector.html
@@ -17,7 +17,7 @@
   </div>
 
   <span data-ng-show="!invalidKeywordMatch">
-    <div class="row">
+    <div class="row" data-ng-class="required == 'true' ? 'gn-required' : ''">
       <label class="col-sm-2 control-label"> {{thesaurusTitle}} </label>
       <div
         class="col-sm-9"


### PR DESCRIPTION
Keyword selector support for required indicator:

![keyword-selector](https://github.com/user-attachments/assets/5a9e3c10-de1a-4b94-9d1f-840522134ad3)

For the field duration directive, the required indicator was not displayed properly. After the fix:

![fieldduration-directive](https://github.com/user-attachments/assets/8341f17a-0264-46bb-ba46-17306b2192b7)



# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation