### PR TITLE
Add option to mock a dropdown for keywordPickers

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout.xsl
@@ -541,6 +541,9 @@
       <xsl:with-param name="cls" select="local-name()"/>
       <xsl:with-param name="xpath" select="$xpath"/>
       <xsl:with-param name="type" select="gn-fn-iso19139:getCodeListType(name())"/>
+      <xsl:with-param name="directiveAttributes">
+        <xsl:copy-of select="gn-fn-metadata:getFieldDirective($editorConfig, name(),name(*[@codeListValue]), $xpath)"/>
+      </xsl:with-param>
       <xsl:with-param name="name"
                       select="if ($isEditing) then concat(*/gn:element/@ref, '_codeListValue') else ''"/>
       <xsl:with-param name="editInfo" select="*/gn:element"/>

--- a/web-ui/src/main/resources/catalog/components/edit/multientrycombiner/partials/multientrycombiner.html
+++ b/web-ui/src/main/resources/catalog/components/edit/multientrycombiner/partials/multientrycombiner.html
@@ -24,6 +24,7 @@
           data-gn-keyword-picker=""
           data-thesaurus-key="{{c.thesaurus}}"
           data-number-of-suggestions="{{c.numberOfSuggestions || 20}}"
+          data-show-hints-on-focus="{{c.showHintsOnFocus || false}}"
           data-faux-multilingual="true"
           data-focus-to-input="false"
           lang="{{lang}}"

--- a/web-ui/src/main/resources/catalog/components/edit/multientrycombiner/partials/multientrycombiner_onlineresourcesdescription.html
+++ b/web-ui/src/main/resources/catalog/components/edit/multientrycombiner/partials/multientrycombiner_onlineresourcesdescription.html
@@ -19,6 +19,7 @@
               data-gn-keyword-picker=""
               data-thesaurus-key="{{c.thesaurus}}"
               data-number-of-suggestions="{{c.numberOfSuggestions || 20}}"
+              data-show-hints-on-focus="{{c.showHintsOnFocus || false}}"
               data-faux-multilingual="true"
               data-focus-to-input="false"
               lang="{{lang}}"

--- a/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
+++ b/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
@@ -662,6 +662,11 @@
           scope.max = gnThesaurusService.DEFAULT_NUMBER_OF_RESULTS;
           scope.fauxMultilingual = scope.fauxMultilingual === "true"; //default false
           scope.showHintsOnFocus = attrs.showHintsOnFocus === "true"; // displays all the values on focus, default shows only the selected value
+          scope.mockDropdown = attrs.mockDropdown === "true";
+          if (scope.mockDropdown) {
+             // Add a class to the element
+             element.addClass("mock-dropdown");
+          }
 
           // Configuration only required when using the directive in template fields.
           //

--- a/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
+++ b/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
@@ -662,9 +662,10 @@
           scope.max = gnThesaurusService.DEFAULT_NUMBER_OF_RESULTS;
           scope.fauxMultilingual = scope.fauxMultilingual === "true"; //default false
           scope.showHintsOnFocus = attrs.showHintsOnFocus === "true"; // displays all the values on focus, default shows only the selected value
-          scope.mockDropdown = attrs.mockDropdown === "true";
+          scope.mockDropdown = attrs.mockDropdown === "true"; // Adds a caret to the end of the field to mock a dropdown or HTML5 datalist
+
+          // Add the required mock dropdown class if the attribute is set
           if (scope.mockDropdown) {
-             // Add a class to the element
              element.addClass("mock-dropdown");
           }
 

--- a/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
+++ b/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
@@ -661,11 +661,10 @@
           scope.orderById = attrs.orderById || "false";
           scope.max = gnThesaurusService.DEFAULT_NUMBER_OF_RESULTS;
           scope.fauxMultilingual = scope.fauxMultilingual === "true"; //default false
-          scope.showHintsOnFocus = attrs.showHintsOnFocus === "true"; // displays all the values on focus, default shows only the selected value
-          scope.mockDropdown = attrs.mockDropdown === "true"; // Adds a caret to the end of the field to mock a dropdown or HTML5 datalist
+          scope.showHintsOnFocus = attrs.showHintsOnFocus === "true"; // displays all the values on focus and adds a dropdown caret icon, default shows only the selected value
 
-          // Add the required mock dropdown class if the attribute is set
-          if (scope.mockDropdown) {
+          // Add the required mock dropdown class if show hints on focus is enabled
+          if (scope.showHintsOnFocus) {
              element.addClass("mock-dropdown");
           }
 

--- a/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
+++ b/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
@@ -663,11 +663,6 @@
           scope.fauxMultilingual = scope.fauxMultilingual === "true"; //default false
           scope.showHintsOnFocus = attrs.showHintsOnFocus === "true"; // displays all the values on focus and adds a dropdown caret icon, default shows only the selected value
 
-          // Add the required mock dropdown class if show hints on focus is enabled
-          if (scope.showHintsOnFocus) {
-             element.addClass("mock-dropdown");
-          }
-
           // Configuration only required when using the directive in template fields.
           //
           // - data-template-field: true to indicate a template field

--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -901,6 +901,7 @@
         restrict: "A",
         link: function (scope, element, attrs) {
           scope.prefix = attrs["prefix"] || "";
+          scope.showHintsOnFocus = attrs.showHintsOnFocus === "true"; // displays all the values on focus, default shows only the selected value
           element.attr("placeholder", "...");
           element.on("focus", function () {
             $http
@@ -945,7 +946,8 @@
                 $(element).typeahead(
                   {
                     minLength: 0,
-                    highlight: true
+                    highlight: true,
+                    showHintsOnFocus: scope.showHintsOnFocus
                   },
                   {
                     name: "isoLanguages",
@@ -958,6 +960,10 @@
                     }
                   }
                 );
+                // Since the typeahead is initialized on focus the first focus will not trigger the hints
+                // So we blur then refocus to trigger the hints
+                $(element).blur();
+                $(element).focus();
               });
             element.unbind("focus");
           });

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
@@ -689,3 +689,20 @@ form.gn-editor.gn-indent-bluescale {
     content: "";
   }
 }
+
+// Mock dropdown for typeahead
+.tt-input.mock-dropdown {
+  background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAMCAYAAABSgIzaAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyJpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMC1jMDYwIDYxLjEzNDc3NywgMjAxMC8wMi8xMi0xNzozMjowMCAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNSBNYWNpbnRvc2giIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6NDZFNDEwNjlGNzFEMTFFMkJEQ0VDRTM1N0RCMzMyMkIiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6NDZFNDEwNkFGNzFEMTFFMkJEQ0VDRTM1N0RCMzMyMkIiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDo0NkU0MTA2N0Y3MUQxMUUyQkRDRUNFMzU3REIzMzIyQiIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDo0NkU0MTA2OEY3MUQxMUUyQkRDRUNFMzU3REIzMzIyQiIvPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/PuGsgwQAAAA5SURBVHjaYvz//z8DOYCJgUxAf42MQIzTk0D/M+KzkRGPoQSdykiKJrBGpOhgJFYTWNEIiEeAAAMAzNENEOH+do8AAAAASUVORK5CYII=);
+  background-repeat: no-repeat;
+  background-position: right;
+  padding-right: 1.5em;
+}
+
+// Move mock dropdown caret in multilingual mode
+.gn-multilingual-field {
+  div:not(:has(.tt-input.mock-dropdown.hidden)) {
+    .tt-input.mock-dropdown {
+      background-position-y: 90%;
+    }
+  }
+}

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_editor_default.less
@@ -691,7 +691,7 @@ form.gn-editor.gn-indent-bluescale {
 }
 
 // Mock dropdown for typeahead
-.tt-input.mock-dropdown {
+[data-show-hints-on-focus="true"]:not(.tt-hint) {
   background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAA4AAAAMCAYAAABSgIzaAAAAGXRFWHRTb2Z0d2FyZQBBZG9iZSBJbWFnZVJlYWR5ccllPAAAAyJpVFh0WE1MOmNvbS5hZG9iZS54bXAAAAAAADw/eHBhY2tldCBiZWdpbj0i77u/IiBpZD0iVzVNME1wQ2VoaUh6cmVTek5UY3prYzlkIj8+IDx4OnhtcG1ldGEgeG1sbnM6eD0iYWRvYmU6bnM6bWV0YS8iIHg6eG1wdGs9IkFkb2JlIFhNUCBDb3JlIDUuMC1jMDYwIDYxLjEzNDc3NywgMjAxMC8wMi8xMi0xNzozMjowMCAgICAgICAgIj4gPHJkZjpSREYgeG1sbnM6cmRmPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5LzAyLzIyLXJkZi1zeW50YXgtbnMjIj4gPHJkZjpEZXNjcmlwdGlvbiByZGY6YWJvdXQ9IiIgeG1sbnM6eG1wPSJodHRwOi8vbnMuYWRvYmUuY29tL3hhcC8xLjAvIiB4bWxuczp4bXBNTT0iaHR0cDovL25zLmFkb2JlLmNvbS94YXAvMS4wL21tLyIgeG1sbnM6c3RSZWY9Imh0dHA6Ly9ucy5hZG9iZS5jb20veGFwLzEuMC9zVHlwZS9SZXNvdXJjZVJlZiMiIHhtcDpDcmVhdG9yVG9vbD0iQWRvYmUgUGhvdG9zaG9wIENTNSBNYWNpbnRvc2giIHhtcE1NOkluc3RhbmNlSUQ9InhtcC5paWQ6NDZFNDEwNjlGNzFEMTFFMkJEQ0VDRTM1N0RCMzMyMkIiIHhtcE1NOkRvY3VtZW50SUQ9InhtcC5kaWQ6NDZFNDEwNkFGNzFEMTFFMkJEQ0VDRTM1N0RCMzMyMkIiPiA8eG1wTU06RGVyaXZlZEZyb20gc3RSZWY6aW5zdGFuY2VJRD0ieG1wLmlpZDo0NkU0MTA2N0Y3MUQxMUUyQkRDRUNFMzU3REIzMzIyQiIgc3RSZWY6ZG9jdW1lbnRJRD0ieG1wLmRpZDo0NkU0MTA2OEY3MUQxMUUyQkRDRUNFMzU3REIzMzIyQiIvPiA8L3JkZjpEZXNjcmlwdGlvbj4gPC9yZGY6UkRGPiA8L3g6eG1wbWV0YT4gPD94cGFja2V0IGVuZD0iciI/PuGsgwQAAAA5SURBVHjaYvz//z8DOYCJgUxAf42MQIzTk0D/M+KzkRGPoQSdykiKJrBGpOhgJFYTWNEIiEeAAAMAzNENEOH+do8AAAAASUVORK5CYII=);
   background-repeat: no-repeat;
   background-position: right;
@@ -700,8 +700,8 @@ form.gn-editor.gn-indent-bluescale {
 
 // Move mock dropdown caret in multilingual mode
 .gn-multilingual-field {
-  div:not(:has(.tt-input.mock-dropdown.hidden)) {
-    .tt-input.mock-dropdown {
+  div:not(:has(.tt-input[data-show-hints-on-focus="true"].hidden)) {
+    .tt-input[data-show-hints-on-focus="true"] {
       background-position-y: 90%;
     }
   }


### PR DESCRIPTION
Currently keywordPicker fields do not give any indication that the field has suggested values. This is an issue for new users as the field appears as a plain text field. When a keywordPicker field is validated against its suggested values it is unclear to the user how to see all the options.

This PR aims to fix this issue by introducing an optional attribute on the keywordPicker which will add styles to make the field appear like a dropdown list / HTML5 datalist by adding the caret icon.

![image](https://github.com/user-attachments/assets/edfe2314-905f-45b5-bcf0-4429e6cd386c)

Seeing the caret icon will prompt the user to click on the field to see the available options.

When combined with the `data-show-hints-on-focus="true"` attribute introduced in #7227 when the field is clicked the whole list of hints is shown regardless of the current input which makes it much more clear to the user what the accepted values are.

![image](https://github.com/user-attachments/assets/2dd4974a-47ec-4176-aaa6-0f98eec047ec)

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation


