### PR TITLE
Record view / Does not display thesaurus block if no keywords.

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/less/gn_result_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_result_default.less
@@ -325,6 +325,9 @@
       }
     }
     // keywords
+    .gn-thesaurus:not(:has(button)) {
+      display: none !important;
+    }
     [data-gn-keyword-badges] {
       .btn {
         word-break: break-word;

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/technical.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/technical.html
@@ -22,7 +22,9 @@
     </ul>
   </section>
 
-  <div ng-include="'../../catalog/views/default/templates/recordView/maintenance.html'"></div>
+  <div
+    ng-include="'../../catalog/views/default/templates/recordView/maintenance.html'"
+  ></div>
 
   <div data-ng-if="mdView.current.record.serviceType" class="gn-margin-bottom flex-row">
     <span class="badge badge-rounded" title="{{'serviceType' | translate}}">
@@ -60,7 +62,7 @@
                  && viewConfig.internalThesaurus
                  && viewConfig.internalThesaurus.indexOf(key) !== -1)
                 || highlightedThesaurus.indexOf(key) === -1"
-    class="gn-margin-bottom flex-row"
+    class="gn-margin-bottom flex-row gn-thesaurus"
   >
     <span class="badge badge-rounded">
       <i class="fa fa-fw fa-tags"></i>


### PR DESCRIPTION
Avoid empty blocks like

![Screenshot from 2024-10-07 10-59-18](https://github.com/user-attachments/assets/7144c2e1-8b7d-442f-b280-15c8d7d1a153)




<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

Funded by EEA