### PR TITLE
[Backport 4.2.x] Add support for external management named properties in JCloud

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -394,7 +394,7 @@
     <dependency>
       <groupId>org.apache.jclouds</groupId>
       <artifactId>jclouds-all</artifactId>
-      <version>2.3.0</version>
+      <version>2.5.0</version>
     </dependency>
 
     <dependency>

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
@@ -1,6 +1,6 @@
 /*
  * =============================================================================
- * ===	Copyright (C) 2019 Food and Agriculture Organization of the
+ * ===	Copyright (C) 2024 Food and Agriculture Organization of the
  * ===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * ===	and United Nations Environment Programme (UNEP)
  * ===
@@ -44,12 +44,16 @@ import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.List;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 public abstract class AbstractStore implements Store {
+    protected static final String RESOURCE_MANAGEMENT_EXTERNAL_PROPERTIES_SEPARATOR = ":";
+    protected static final String RESOURCE_MANAGEMENT_EXTERNAL_PROPERTIES_ESCAPED_SEPARATOR = "\\:";
+
     @Override
     public final List<MetadataResource> getResources(final ServiceContext context, final String metadataUuid, final Sort sort,
             final String filter) throws Exception {
@@ -278,5 +282,29 @@ public abstract class AbstractStore implements Store {
                 }
             }
         };
+    }
+
+    private String escapeResourceManagementExternalProperties(String value) {
+        return value.replace(RESOURCE_MANAGEMENT_EXTERNAL_PROPERTIES_SEPARATOR, RESOURCE_MANAGEMENT_EXTERNAL_PROPERTIES_ESCAPED_SEPARATOR);
+}
+
+    /**
+     * Create an encoded base 64 object id contains the following fields to uniquely identify the resource
+     * The fields are separated by a colon ":"
+     * @param type to identify type of storage - document/folder
+     * @param visibility of the resource public/private
+     * @param metadataId internal metadata id
+     * @param version identifier which can be used to directly get this version.
+     * @param resourceId or filename of the resource
+     * @return based 64 object id
+     */
+    protected String getResourceManagementExternalPropertiesObjectId(final String type, final MetadataResourceVisibility visibility, final Integer metadataId, final String version,
+                                                                     final String resourceId) {
+        return Base64.getEncoder().encodeToString(
+            ((type + RESOURCE_MANAGEMENT_EXTERNAL_PROPERTIES_SEPARATOR +
+                escapeResourceManagementExternalProperties(visibility == null ? "" : visibility.toString().toLowerCase()) + RESOURCE_MANAGEMENT_EXTERNAL_PROPERTIES_SEPARATOR +
+                metadataId + RESOURCE_MANAGEMENT_EXTERNAL_PROPERTIES_SEPARATOR +
+                escapeResourceManagementExternalProperties(version == null ? "" : version) + RESOURCE_MANAGEMENT_EXTERNAL_PROPERTIES_SEPARATOR +
+                escapeResourceManagementExternalProperties(resourceId)).getBytes()));
     }
 }

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
@@ -1,6 +1,6 @@
 /*
  * =============================================================================
- * ===	Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * ===	Copyright (C) 2001-2024 Food and Agriculture Organization of the
  * ===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * ===	and United Nations Environment Programme (UNEP)
  * ===
@@ -627,8 +627,10 @@ public class CMISStore extends AbstractStore {
     /**
      * get external resource management for the supplied resource.
      * Replace the following
+     * {objectId}  type:visibility:metadataId:version:resourceId in base64 encoding
      * {id}  resource id
-     * {type:folder:document} // If the type is folder then type "folder" will be displayed else if document then "document" will be displayed
+     * {type:folder:document} // Custom return type based on type. If the type is folder then type "folder" will be displayed else if document then "document" will be displayed
+     * {type} // If the type is folder then type "folder" will be displayed else if document then "document" will be displayed
      * {uuid}  metadatauuid
      * {metadataid}  metadataid
      * {visibility}  visibility
@@ -657,16 +659,27 @@ public class CMISStore extends AbstractStore {
     ) {
         String metadataResourceExternalManagementPropertiesUrl = cmisConfiguration.getExternalResourceManagementUrl();
         if (!StringUtils.isEmpty(metadataResourceExternalManagementPropertiesUrl)) {
+            // {objectid}  objectId // It will be the type:visibility:metadataId:version:resourceId in base64
+            // i.e. folder::100::100                     # Folder in resource 100
+            // i.e. document:public:100:v1:sample.jpg    # public document 100 version v1 name sample.jpg
+            if (metadataResourceExternalManagementPropertiesUrl.contains("{objectid}")) {
+                metadataResourceExternalManagementPropertiesUrl = metadataResourceExternalManagementPropertiesUrl.replaceAll("(\\{objectid\\})",
+                    getResourceManagementExternalPropertiesObjectId((type == null ? "document" : (type instanceof Folder ? "folder" : "document")), visibility, metadataId, version, resourceId));
+            }
             // {id}  id
             if (metadataResourceExternalManagementPropertiesUrl.contains("{id}")) {
                 metadataResourceExternalManagementPropertiesUrl = metadataResourceExternalManagementPropertiesUrl.replaceAll("(\\{id\\})", (resourceId==null?"":resourceId));
             }
-            // {type:folder:document} // If the type is folder then type "folder" will be displayed else if document then "document" will be displayed
+            // {type:folder:document} // Custom return type based on type. If the type is folder then type "folder" will be displayed else if document then "document" will be displayed
             if (metadataResourceExternalManagementPropertiesUrl.contains("{type:")) {
                 metadataResourceExternalManagementPropertiesUrl = metadataResourceExternalManagementPropertiesUrl.replaceAll("\\{type:([a-zA-Z0-9]*?):([a-zA-Z0-9]*?)\\}",
                     (type==null?"":(type instanceof Folder?"$1":"$2")));
             }
-
+            // {type} // If the type is folder then type "folder" will be displayed else if document then "document" will be displayed
+            if (metadataResourceExternalManagementPropertiesUrl.contains("{type}")) {
+                metadataResourceExternalManagementPropertiesUrl = metadataResourceExternalManagementPropertiesUrl.replaceAll("(\\{type\\})",
+                    (type == null ? "document" : (type instanceof Folder ? "folder" : "document")));
+            }
             // {uuid}  metadatauuid
             if (metadataResourceExternalManagementPropertiesUrl.contains("{uuid}")) {
                 metadataResourceExternalManagementPropertiesUrl = metadataResourceExternalManagementPropertiesUrl.replaceAll("(\\{uuid\\})", (metadataUuid==null?"":metadataUuid));

--- a/core/src/main/java/org/fao/geonet/resources/CMISConfiguration.java
+++ b/core/src/main/java/org/fao/geonet/resources/CMISConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2024 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -59,26 +59,28 @@ import java.util.regex.Pattern;
 public class CMISConfiguration {
     private Session client = null;
 
-    public final static Integer CMIS_MAX_ITEMS_PER_PAGE = 1000;
-    public final static String CMIS_FOLDER_DELIMITER = "/"; // Specs indicate that "/" is the folder delimiter/separator - not sure if other delimiter can be used?.
-    public final static String CMIS_SECONDARY_PROPERTY_SEPARATOR = "->";
-    private final String CMIS_DEFAULT_WEBSERVICES_ACL_SERVICE = "/services/ACLService?wsdl";
-    private final String CMIS_DEFAULT_WEBSERVICES_DISCOVERY_SERVICE = "/services/DiscoveryService?wsdl";
-    private final String CMIS_DEFAULT_WEBSERVICES_MULTIFILING_SERVICE = "/services/MultiFilingService?wsdl";
-    private final String CMIS_DEFAULT_WEBSERVICES_NAVIGATION_SERVICE = "/services/NavigationService?wsdl";
-    private final String CMIS_DEFAULT_WEBSERVICES_OBJECT_SERVICE = "/services/ObjectService?wsdl";
-    private final String CMIS_DEFAULT_WEBSERVICES_POLICY_SERVICE = "/services/PolicyService?wsdl";
-    private final String CMIS_DEFAULT_WEBSERVICES_RELATIONSHIP_SERVICE = "/services/RelationshipService?wsdl";
-    private final String CMIS_DEFAULT_WEBSERVICES_REPOSITORY_SERVICE = "/services/RepositoryService?wsdl";
-    private final String CMIS_DEFAULT_WEBSERVICES_VERSIONING_SERVICE = "/services/VersioningService?wsdl";
-    private final String CMIS_DEFAULT_WEBSERVICES_BASE_URL_SERVICE = "/cmis";
-    private final String CMIS_DEFAULT_BROWSER_URL_SERVICE = "/browser";
-    private final String CMIS_DEFAULT_ATOMPUB_URL_SERVICE = "/atom";
+    // DFO change to 100. Due to bug with open text cmis where if max is set to 1000, it will return 100 but if it is set to 100 it will return all records.
+    // https://dev.azure.com/foc-poc/EDH-CDE/_workitems/edit/95878
+    public static final Integer CMIS_MAX_ITEMS_PER_PAGE = 100;
+    public static final String CMIS_FOLDER_DELIMITER = "/"; // Specs indicate that "/" is the folder delimiter/separator - not sure if other delimiter can be used?.
+    public static final String CMIS_SECONDARY_PROPERTY_SEPARATOR = "->";
+    private static final String CMIS_DEFAULT_WEBSERVICES_ACL_SERVICE = "/services/ACLService?wsdl";
+    private static final String CMIS_DEFAULT_WEBSERVICES_DISCOVERY_SERVICE = "/services/DiscoveryService?wsdl";
+    private static final String CMIS_DEFAULT_WEBSERVICES_MULTIFILING_SERVICE = "/services/MultiFilingService?wsdl";
+    private static final String CMIS_DEFAULT_WEBSERVICES_NAVIGATION_SERVICE = "/services/NavigationService?wsdl";
+    private static final String CMIS_DEFAULT_WEBSERVICES_OBJECT_SERVICE = "/services/ObjectService?wsdl";
+    private static final String CMIS_DEFAULT_WEBSERVICES_POLICY_SERVICE = "/services/PolicyService?wsdl";
+    private static final String CMIS_DEFAULT_WEBSERVICES_RELATIONSHIP_SERVICE = "/services/RelationshipService?wsdl";
+    private static final String CMIS_DEFAULT_WEBSERVICES_REPOSITORY_SERVICE = "/services/RepositoryService?wsdl";
+    private static final String CMIS_DEFAULT_WEBSERVICES_VERSIONING_SERVICE = "/services/VersioningService?wsdl";
+    private static final String CMIS_DEFAULT_WEBSERVICES_BASE_URL_SERVICE = "/cmis";
+    private static final String CMIS_DEFAULT_BROWSER_URL_SERVICE = "/browser";
+    private static final String CMIS_DEFAULT_ATOMPUB_URL_SERVICE = "/atom";
 
-    private final String CMIS_DEFAULT_EXTERNAL_RESOURCE_MANAGEMENT_WINDOW_PARAMETERS = "toolbar=0,width=600,height=600";
-    private final Boolean CMIS_DEFAULT_EXTERNAL_RESOURCE_MANAGEMENT_MODAL_ENABLED = true;
-    private final Boolean CMIS_DEFAULT_EXTERNAL_RESOURCE_MANAGEMENT_FOLDER_ENABLED = true;
-    private final Boolean CMIS_DEFAULT_VERSIONING_ENABLED = false;
+    private static final String CMIS_DEFAULT_EXTERNAL_RESOURCE_MANAGEMENT_WINDOW_PARAMETERS = "toolbar=0,width=600,height=600";
+    private static final Boolean CMIS_DEFAULT_EXTERNAL_RESOURCE_MANAGEMENT_MODAL_ENABLED = true;
+    private static final Boolean CMIS_DEFAULT_EXTERNAL_RESOURCE_MANAGEMENT_FOLDER_ENABLED = true;
+    private static final Boolean CMIS_DEFAULT_VERSIONING_ENABLED = false;
 
     private String servicesBaseUrl;
     private String bindingType;
@@ -111,7 +113,6 @@ public class CMISConfiguration {
      * Property name for validation status that is expected to be an integer with values of null, 0, 1, 2
      * (See MetadataResourceExternalManagementProperties.ValidationStatus for code meaning)
      * Property name follows the same format as cmisMetadataUUIDPropertyName
-     *
      * If null then validation status will default to UNKNOWN.
      */
     private String externalResourceManagementValidationStatusPropertyName;
@@ -505,7 +506,6 @@ public class CMISConfiguration {
                     String.format("Invalid format for property name %s property will not be used", externalResourceManagementValidationStatusPropertyName));
                 this.externalResourceManagementValidationStatusPropertyName = null;
                 this.externalResourceManagementValidationStatusSecondaryProperty = false;
-                return;
             } else {
                 this.externalResourceManagementValidationStatusSecondaryProperty = true;
             }
@@ -514,7 +514,7 @@ public class CMISConfiguration {
 
     public MetadataResourceExternalManagementProperties.ValidationStatus getValidationStatusDefaultValue() {
         // We only need to set the default if there is a status property supplied, and it is not already set
-        if (this.defaultStatus == null &&  !org.springframework.util.StringUtils.isEmpty(getExternalResourceManagementValidationStatusPropertyName())) {
+        if (this.defaultStatus == null &&  org.springframework.util.StringUtils.hasLength(getExternalResourceManagementValidationStatusPropertyName())) {
             if (getExternalResourceManagementValidationStatusDefaultValue() != null) {
                 // If a default property name does exist then use it
                 this.defaultStatus = MetadataResourceExternalManagementProperties.ValidationStatus.valueOf(getExternalResourceManagementValidationStatusDefaultValue());
@@ -536,9 +536,8 @@ public class CMISConfiguration {
         }
 
         // default factory implementation
-        Map<String, String> parameters = new HashMap<String, String>();
+        Map<String, String> parameters = new HashMap<>();
 
-        this.baseRepositoryPath = baseRepositoryPath;
         if (this.baseRepositoryPath == null) {
             this.baseRepositoryPath = "";
         }
@@ -609,7 +608,7 @@ public class CMISConfiguration {
                 }
             }
         } else {
-            // Try to find the repository name for the id that we have specified..
+            // Try to find the repository name for the id that we have specified.
             try {
                 for (Repository repository : factory.getRepositories(parameters)) {
                     if (repository.getId().equalsIgnoreCase(this.repositoryId)) {
@@ -633,7 +632,7 @@ public class CMISConfiguration {
                     repositoryUrl + "' using product '" + client.getRepositoryInfo().getProductName() + "' version '" +
                     client.getRepositoryInfo().getProductVersion() + "'.");
 
-                // Check if we can parse the secondary parameters from human readable to secondary ids.
+                // Check if we can parse the secondary parameters from human-readable to secondary ids.
                 parsedCmisMetadataUUIDPropertyName = parseSecondaryProperty(client, cmisMetadataUUIDPropertyName);
                 parsedExternalResourceManagementValidationStatusPropertyName = parseSecondaryProperty(client, externalResourceManagementValidationStatusPropertyName);
 
@@ -743,7 +742,7 @@ public class CMISConfiguration {
     }
 
     /**
-     * Generte a full url based on the supplied entered serviceurl and the default.
+     * Generate a full url based on the supplied entered serviceUrl and the default.
      *
      * @param baseUrl                Base url
      * @param serviceUrl             Supplied service url (This could start with / or http. If it starts with http then ignore baseUrl)

--- a/core/src/main/java/org/fao/geonet/resources/JCloudConfiguration.java
+++ b/core/src/main/java/org/fao/geonet/resources/JCloudConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2024 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -24,22 +24,23 @@
 package org.fao.geonet.resources;
 
 import org.apache.commons.lang.BooleanUtils;
-import org.apache.commons.lang.StringUtils;
+import org.fao.geonet.domain.MetadataResourceExternalManagementProperties;
 import org.jclouds.ContextBuilder;
 import org.jclouds.blobstore.BlobStoreContext;
+import org.springframework.util.StringUtils;
 
 import javax.annotation.Nonnull;
 import javax.annotation.PostConstruct;
 
 public class JCloudConfiguration {
-    private BlobStoreContext client = null;
-    private ContextBuilder builder = null;
 
-    private String DEFAULT_CLOUD_FOLDER_SEPARATOR = "/"; // not sure if this is consistent for all clouds defaulting to "/" and make it a config
-    private final String DEFAULT_EXTERNAL_RESOURCE_MANAGEMENT_WINDOW_PARAMETERS = "toolbar=0,width=600,height=600";
-    private final Boolean DEFAULT_EXTERNAL_RESOURCE_MANAGEMENT_MODAL_ENABLED = true;
-    private final Boolean DEFAULT_EXTERNAL_RESOURCE_MANAGEMENT_FOLDER_ENABLED = true;
-    private final Boolean DEFAULT_VERSIONING_ENABLED = false;
+    private BlobStoreContext client = null;
+
+    private static final String DEFAULT_CLOUD_FOLDER_SEPARATOR = "/"; // not sure if this is consistent for all clouds defaulting to "/" and make it a config
+    private static final String DEFAULT_EXTERNAL_RESOURCE_MANAGEMENT_WINDOW_PARAMETERS = "toolbar=0,width=600,height=600";
+    private static final Boolean DEFAULT_EXTERNAL_RESOURCE_MANAGEMENT_MODAL_ENABLED = true;
+    private static final Boolean DEFAULT_EXTERNAL_RESOURCE_MANAGEMENT_FOLDER_ENABLED = true;
+    private static final Boolean DEFAULT_VERSIONING_ENABLED = false;
 
     private String provider;
     private String baseFolder;
@@ -50,6 +51,10 @@ public class JCloudConfiguration {
     private String folderDelimiter = null;
 
     /**
+     * Property name for storing the metadata uuid that is expected to be a String
+     */
+    private String metadataUUIDPropertyName;
+    /**
      * Url used for managing enhanced resource properties related to the metadata.
      */
     private String externalResourceManagementUrl;
@@ -57,6 +62,25 @@ public class JCloudConfiguration {
     private Boolean externalResourceManagementModalEnabled;
     private Boolean externalResourceManagementFolderEnabled;
     private String externalResourceManagementFolderRoot;
+
+    /**
+     * Property name for storing the changed date as JCloud does not allow changing the last modified date.
+     */
+    private String externalResourceManagementChangedDatePropertyName;
+
+    /**
+     * Property name for validation status that is expected to be an integer with values of null, 0, 1, 2
+     * (See MetadataResourceExternalManagementProperties.ValidationStatus for code meaning)
+     * If null then validation status will default to UNKNOWN.
+     */
+    private String externalResourceManagementValidationStatusPropertyName;
+    /**
+     * Default value to be used for the validation status.
+     * If null then it will use INCOMPLETE as the default.
+     * Note that if property name is not supplied then it will always default to UNKNOWN
+     */
+    private String externalResourceManagementValidationStatusDefaultValue;
+    private MetadataResourceExternalManagementProperties.ValidationStatus defaultStatus = null;
 
     /*
      * Enable option to add versioning in the link to the resource.
@@ -84,7 +108,7 @@ public class JCloudConfiguration {
         if (this.folderDelimiter == null) {
             this.folderDelimiter = DEFAULT_CLOUD_FOLDER_SEPARATOR;
         }
-        if (StringUtils.isEmpty(baseFolder)) {
+        if (!StringUtils.hasLength(baseFolder)) {
             this.baseFolder = this.folderDelimiter;
         } else {
             if (baseFolder.endsWith(this.folderDelimiter)) {
@@ -142,7 +166,7 @@ public class JCloudConfiguration {
     }
 
     public void setExternalResourceManagementModalEnabled(String externalResourceManagementModalEnabled) {
-        this.externalResourceManagementModalEnabled = BooleanUtils.toBooleanObject(externalResourceManagementModalEnabled);;
+        this.externalResourceManagementModalEnabled = BooleanUtils.toBooleanObject(externalResourceManagementModalEnabled);
     }
 
     public Boolean isExternalResourceManagementFolderEnabled() {
@@ -172,7 +196,15 @@ public class JCloudConfiguration {
             }
         }
 
-        this.externalResourceManagementFolderRoot=folderRoot;
+        this.externalResourceManagementFolderRoot = folderRoot;
+    }
+
+    public String getExternalResourceManagementValidationStatusDefaultValue() {
+        return externalResourceManagementValidationStatusDefaultValue;
+    }
+
+    public void setExternalResourceManagementValidationStatusDefaultValue(String externalResourceManagementValidationStatusDefaultValue) {
+        this.externalResourceManagementValidationStatusDefaultValue = externalResourceManagementValidationStatusDefaultValue;
     }
 
     @Nonnull
@@ -191,7 +223,45 @@ public class JCloudConfiguration {
 
     public void setVersioningEnabled(String versioningEnabled) {
         this.versioningEnabled = BooleanUtils.toBooleanObject(versioningEnabled);
-        ;
+    }
+
+    public String getMetadataUUIDPropertyName() {
+       return metadataUUIDPropertyName;
+    }
+
+    public void setMetadataUUIDPropertyName(String metadataUUIDPropertyName) {
+        this.metadataUUIDPropertyName = metadataUUIDPropertyName;
+    }
+
+    public String getExternalResourceManagementChangedDatePropertyName() {
+        return externalResourceManagementChangedDatePropertyName;
+    }
+
+    public void setExternalResourceManagementChangedDatePropertyName(String externalResourceManagementChangedDatePropertyName) {
+        this.externalResourceManagementChangedDatePropertyName = externalResourceManagementChangedDatePropertyName;
+    }
+    public String getExternalResourceManagementValidationStatusPropertyName() {
+        return externalResourceManagementValidationStatusPropertyName;
+    }
+
+    public void setExternalResourceManagementValidationStatusPropertyName(String externalResourceManagementValidationStatusPropertyName) {
+        this.externalResourceManagementValidationStatusPropertyName = externalResourceManagementValidationStatusPropertyName;
+    }
+
+    public MetadataResourceExternalManagementProperties.ValidationStatus getValidationStatusDefaultValue() {
+        // We only need to set the default if there is a status property supplied, and it is not already set
+        if (this.defaultStatus == null &&  StringUtils.hasLength(getExternalResourceManagementValidationStatusPropertyName())) {
+            if (getExternalResourceManagementValidationStatusDefaultValue() != null) {
+                // If a default property name does exist then use it
+                this.defaultStatus = MetadataResourceExternalManagementProperties.ValidationStatus.valueOf(getExternalResourceManagementValidationStatusDefaultValue());
+            } else {
+                // Otherwise let's default to incomplete.
+                // Reason - as the administrator decided to use the status, it most likely means that there are extra properties that need to be set after a file is uploaded so defaulting it to
+                // incomplete seems reasonable.
+                this.defaultStatus = MetadataResourceExternalManagementProperties.ValidationStatus.INCOMPLETE;
+            }
+        }
+        return this.defaultStatus;
     }
 
     @PostConstruct
@@ -203,11 +273,17 @@ public class JCloudConfiguration {
         // Run the setBaseFolder following to ensure the baseFolder is formatted correctly.
         setBaseFolder(baseFolder);
 
+        validateMetadataPropertyNames();
+
+        ContextBuilder builder;
         if (storageAccountName != null && provider != null) {
             builder = ContextBuilder.newBuilder(provider).credentials(storageAccountName, storageAccountKey);
             storageAccountName = null;
             storageAccountKey = null;
+        } else {
+            throw new RuntimeException("Need to supply storage account name and provider for JCloud configuration");
         }
+
 
         if (endpoint != null) {
             builder.endpoint(endpoint);
@@ -215,10 +291,30 @@ public class JCloudConfiguration {
 
         client = builder.buildView(BlobStoreContext.class);
 
-        builder = null;
         if (containerName == null) {
             throw new RuntimeException("Missing the container Name configuration");
         }
+    }
+
+    /**
+     * Checks if the metadata names that were supplied are correct.
+     *
+     * @throws IllegalArgumentException is any of the metadata property names are invalid.
+     */
+    private void validateMetadataPropertyNames() throws  IllegalArgumentException {
+
+        // If provider not supplied then nothing to check.
+        if (this.provider == null) {
+            return;
+        }
+
+        String[] names = {
+            getMetadataUUIDPropertyName(),
+            getExternalResourceManagementChangedDatePropertyName(),
+            getExternalResourceManagementValidationStatusPropertyName()
+        };
+
+        JCloudMetadataNameValidator.validateMetadataNamesForProvider(provider, names);
     }
 
     @Nonnull

--- a/core/src/main/java/org/fao/geonet/resources/JCloudMetadataNameValidator.java
+++ b/core/src/main/java/org/fao/geonet/resources/JCloudMetadataNameValidator.java
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2001-2024 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+package org.fao.geonet.resources;
+
+import java.util.Map;
+import java.util.HashMap;
+import java.util.regex.Pattern;
+
+import org.springframework.util.StringUtils;
+
+/**
+ * Each JCloud provider has different restrictions on the naming standard used for the metadata property names.
+ * This class is used to check the requirement of these headers so that we don't get obscure errors when attempting to set the metadata property names.
+ */
+public class JCloudMetadataNameValidator {
+
+    public static class ProviderMetadataNamingRules {
+        private final String maxLength;
+        private final Pattern regex;
+
+        public ProviderMetadataNamingRules(String maxLength, Pattern regex) {
+            this.maxLength = maxLength;
+            this.regex = regex;
+        }
+
+        public String getMaxLength() {
+            return maxLength;
+        }
+
+        public Pattern getRegex() {
+            return regex;
+        }
+    }
+
+    // Define metadata naming rules for each provider
+    private static final Map<String, ProviderMetadataNamingRules> providerMetadataNamingRules = new HashMap<>();
+    private static final ProviderMetadataNamingRules defaultRules = new ProviderMetadataNamingRules(
+        "255",
+        Pattern.compile("^[a-zA-Z0-9._-]{1,255}$")
+    );
+
+    // Note: All these patterns have not been tested with all providers and may need adjustments.
+    static {
+        providerMetadataNamingRules.put("aws-s3", new ProviderMetadataNamingRules(
+            "255",
+            Pattern.compile("^[a-zA-Z0-9._-]{1,255}$")
+        ));
+
+        providerMetadataNamingRules.put("b2", new ProviderMetadataNamingRules(
+            "255",
+            Pattern.compile("^[a-zA-Z0-9._-]{1,255}$")
+        ));
+
+        providerMetadataNamingRules.put("google-cloud-storage", new ProviderMetadataNamingRules(
+            "1024",
+            Pattern.compile("^[a-zA-Z0-9._-]{1,1024}$")
+        ));
+
+        /**
+         * Azure blob
+         * https://learn.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata#metadata-names
+         * Follows C# naming in lowercase only
+         */
+        providerMetadataNamingRules.put("azureblob", new ProviderMetadataNamingRules(
+            "255",
+            Pattern.compile("^[a-z_][a-z0-9_]{0,254}$")
+        ));
+
+        providerMetadataNamingRules.put("rackspace-cloudfiles-us", new ProviderMetadataNamingRules(
+            "255",
+            Pattern.compile("^[a-zA-Z0-9._-]{1,255}$")
+        ));
+
+        providerMetadataNamingRules.put("rackspace-cloudfiles-uk", new ProviderMetadataNamingRules(
+            "255",
+            Pattern.compile("^[a-zA-Z0-9._-]{1,255}$")
+        ));
+    }
+
+    /**
+     * Validates metadata names for each provider.
+     *
+     * @param provider The name of the provider.
+     * @param metadataNames Array of metadata names to validate.
+     * @throws IllegalArgumentException if any metadata name is invalid according to the provider's rules.
+     */
+    public static void validateMetadataNamesForProvider(String provider, String[] metadataNames) throws IllegalArgumentException {
+        ProviderMetadataNamingRules rules = providerMetadataNamingRules.getOrDefault(provider.toLowerCase(), defaultRules);
+
+        for (String name : metadataNames) {
+            if (StringUtils.hasLength(name) && !isValidMetadataName(name, rules)) {
+                throw new IllegalArgumentException(String.format("Invalid metadata name for provider %s: %s", provider, name));
+            }
+        }
+    }
+
+    /**
+     * Checks if a single metadata name is valid based on the provider's rules.
+     *
+     * @param name   The metadata name to check.
+     * @param rules  The metadata naming rules for the provider.
+     * @return True if the name is valid, false otherwise.
+     */
+    private static boolean isValidMetadataName(String name, ProviderMetadataNamingRules rules) {
+        // Null/Empty property names are allow as it means they will not be used.
+        if (!StringUtils.hasLength(name)) {
+            return false;
+        }
+
+        if (name.length() > Integer.parseInt(rules.getMaxLength())) {
+            return false;
+        }
+
+        return rules.getRegex().matcher(name).matches();
+    }
+}

--- a/core/src/main/resources/config-store/config-cmis-overrides.properties
+++ b/core/src/main/resources/config-store/config-cmis-overrides.properties
@@ -11,8 +11,8 @@ cmis.external.resource.management.window.parameters=${CMIS_EXTERNAL_RESOURCE_MAN
 cmis.external.resource.management.modal.enabled=${CMIS_EXTERNAL_RESOURCE_MANAGEMENT_MODAL_ENABLED:#{null}}
 cmis.external.resource.management.folder.enabled=${CMIS_EXTERNAL_RESOURCE_MANAGEMENT_FOLDER_ENABLED:#{null}}
 cmis.external.resource.management.folder.root=${CMIS_EXTERNAL_RESOURCE_MANAGEMENT_FOLDER_ROOT:#{null}}
-cmis.external.resource.status.property.name=${CMIS_EXTERNAL_RESOURCE_STATUS_PROPERTY_NAME:#{null}}
-cmis.external.resource.management.status.default.value=${CMIS_EXTERNAL_RESOURCE_MANAGEMENT_STATUS_DEFAULT_VALUE:#{null}}
+cmis.external.resource.management.validation.status.property.name=${CMIS_EXTERNAL_RESOURCE_MANAGEMENT_VALIDATION_STATUS_PROPERTY_NAME:#{null}}
+cmis.external.resource.management.validation.status.default.value=${CMIS_EXTERNAL_RESOURCE_MANAGEMENT_VALIDATION_STATUS_DEFAULT_VALUE:#{null}}
 
 cmis.versioning.enabled=${CMIS_VERSIONING_ENABLED:#{null}}
 cmis.versioning.state=#{'${CMIS_VERSIONING_STATE:MAJOR}'.toUpperCase()}

--- a/core/src/main/resources/config-store/config-cmis.xml
+++ b/core/src/main/resources/config-store/config-cmis.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
+  ~ Copyright (C) 2001-2024 Food and Agriculture Organization of the
   ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
   ~ and United Nations Environment Programme (UNEP)
   ~
@@ -99,8 +99,8 @@
         <property name="externalResourceManagementModalEnabled" value="${cmis.external.resource.management.modal.enabled}"/>
         <property name="externalResourceManagementFolderEnabled" value="${cmis.external.resource.management.folder.enabled}"/>
         <property name="externalResourceManagementFolderRoot" value="${cmis.external.resource.management.folder.root}"/>
-        <property name="externalResourceManagementValidationStatusPropertyName" value="${cmis.external.resource.status.property.name}"/>
-        <property name="externalResourceManagementValidationStatusDefaultValue" value="${cmis.external.resource.management.status.default.value}"/>
+        <property name="externalResourceManagementValidationStatusPropertyName" value="${cmis.external.resource.management.validation.status.property.name}"/>
+        <property name="externalResourceManagementValidationStatusDefaultValue" value="${cmis.external.resource.management.validation.status.default.value}"/>
 
         <property name="versioningEnabled" value="${cmis.versioning.enabled}"/>
         <property name="versioningState" value="${cmis.versioning.state}"/>

--- a/core/src/main/resources/config-store/config-jcloud-overrides.properties
+++ b/core/src/main/resources/config-store/config-jcloud-overrides.properties
@@ -12,5 +12,11 @@ jcloud.external.resource.management.window.parameters=${JCLOUD_EXTERNAL_RESOURCE
 jcloud.external.resource.management.modal.enabled=${JCLOUD_EXTERNAL_RESOURCE_MANAGEMENT_MODAL_ENABLED:#{null}}
 jcloud.external.resource.management.folder.enabled=${JCLOUD_EXTERNAL_RESOURCE_MANAGEMENT_FOLDER_ENABLED:#{null}}
 jcloud.external.resource.management.folder.root=${JCLOUD_EXTERNAL_RESOURCE_MANAGEMENT_FOLDER_ROOT:#{null}}
+jcloud.external.resource.management.validation.status.property.name=${JCLOUD_EXTERNAL_RESOURCE_MANAGEMENT_VALIDATION_STATUS_PROPERTY_NAME:#{null}}
+jcloud.external.resource.management.validation.status.default.value=${JCLOUD_EXTERNAL_RESOURCE_MANAGEMENT_VALIDATION_STATUS_DEFAULT_VALUE:#{null}}
+
+jcloud.external.resource.management.changed.date.property.name=${JCLOUD_EXTERNAL_RESOURCE_MANAGEMENT_CHANGE_DATE_PROPERTY_NAME:#{null}}
 
 jcloud.versioning.enabled=${JCLOUD_VERSIONING_ENABLED:#{null}}
+
+jcloud.metadata.uuid.property.name=${JCLOUD_METADATA_UUID_PROPERTY_NAME:#{null}}

--- a/core/src/main/resources/config-store/config-jcloud.xml
+++ b/core/src/main/resources/config-store/config-jcloud.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-  ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
+  ~ Copyright (C) 2001-2024 Food and Agriculture Organization of the
   ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
   ~ and United Nations Environment Programme (UNEP)
   ~
@@ -50,8 +50,13 @@
         <property name="externalResourceManagementModalEnabled" value="${jcloud.external.resource.management.modal.enabled}"/>
         <property name="externalResourceManagementFolderEnabled" value="${jcloud.external.resource.management.folder.enabled}"/>
         <property name="externalResourceManagementFolderRoot" value="${jcloud.external.resource.management.folder.root}"/>
+        <property name="externalResourceManagementValidationStatusPropertyName" value="${jcloud.external.resource.management.validation.status.property.name}"/>
+        <property name="externalResourceManagementValidationStatusDefaultValue" value="${jcloud.external.resource.management.validation.status.default.value}"/>
+        <property name="externalResourceManagementChangedDatePropertyName" value="${jcloud.external.resource.management.changed.date.property.name}"/>
 
         <property name="versioningEnabled" value="${jcloud.versioning.enabled}"/>
+
+        <property name="metadataUUIDPropertyName" value="${jcloud.metadata.uuid.property.name}"/>
     </bean>
     <bean id="filesystemStore" class="org.fao.geonet.api.records.attachments.JCloudStore" />
     <bean id="resourceStore"


### PR DESCRIPTION
Backport #8357
 **Authored by:** @ianwallen

   Add {objectId} property in external management url (base64 unique identifier for the record)
   Change external management type url property {type} so that it is fixed values so that same value can be used in {objectId}
CMIS
   Fixed property names used for validation fields to be consistent with other names.
Jcloud
   Updgade from jcloud 2.3.0 to jcloud 2.5.0
   Add support for external management named properties similar to cmis
   Fix bug with deleting all resources as it was failing to identify folders correctly for azure blob.
