### PR TITLE
Elasticsearch / API / Allow ndjson for _msearch endpoint

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/es/EsHTTPProxy.java
+++ b/services/src/main/java/org/fao/geonet/api/es/EsHTTPProxy.java
@@ -330,11 +330,15 @@ public class EsHTTPProxy {
         description = "The multi search API executes several searches from a single API request. See https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html for search parameters, and https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl.html Query DSL.")
     @RequestMapping(value = "/search/records/_msearch",
         method = RequestMethod.POST,
-        produces = MediaType.APPLICATION_JSON_VALUE,
-        consumes = MediaType.APPLICATION_JSON_VALUE)
+        produces = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_NDJSON_VALUE},
+        consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.APPLICATION_NDJSON_VALUE})
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Search results.",
-            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(type = "string")))
+            content = {
+                @Content(mediaType = MediaType.APPLICATION_JSON_VALUE, schema = @Schema(type = "string")),
+                @Content(mediaType = MediaType.APPLICATION_NDJSON_VALUE, schema = @Schema(type = "string"))
+            }
+        )
     })
     @ResponseStatus(value = HttpStatus.OK)
     @ResponseBody


### PR DESCRIPTION
Some libraries/apps are using `_msearch` endpoint which can allow both `application/json` or `application/x-ndjson` content type.


When ndjson is used, the API call is not forwarded to Elasticsearch
```
ERROR [geonetwork] - Content type 'application/x-ndjson' not supported
```

Cf. https://www.elastic.co/guide/en/elasticsearch/reference/current/search-multi-search.html

eg.
```
curl -L 'https://apps.titellus.net/geonetwork/mapstore/api/search/records/_msearch?' \
  -H 'accept: application/json' \
  -H 'content-type: application/x-ndjson' \
  --data-raw $'{"preference":"cardQuickFilter_2"}\n{"query":{"bool":{"must":[{"bool":{"must":[{"query_string":{"query":"+(resourceType:application) -(th_infraSIG.default:Reporting_INSPIRE) -(cl_status.key:obsolete)"}}]}}]}},"size":0,"_source":{"includes":["*"],"excludes":[]},"aggs":{"th_Themes_geoportail_wallon_hierarchy.default":{"terms":{"field":"th_Themes_geoportail_wallon_hierarchy.default","size":100,"order":{"_count":"desc"}}}}}\n'
  
```


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->


Funded by Service Public de Wallonie