### PR TITLE
Document WAR configuration option for maxUploadSize

### DIFF
--- a/docs/manual/docs/user-guide/associating-resources/using-filestore.md
+++ b/docs/manual/docs/user-guide/associating-resources/using-filestore.md
@@ -5,7 +5,7 @@
     3.2
 
 
-If documents are not available, editors can upload attachments to a metadata record. The document is added to the filestore. The filestore can contains any kind of files.
+If documents are not available, editors can upload attachments to a metadata record. The attachment is added to the filestore. The filestore can contain any kind of files.
 
 ![](img/filestore.png)
 
@@ -27,5 +27,12 @@ A file uploaded in this way will be exported in the metadata export file (MEF). 
 
 By default, the maximum file size is set to 100Mb. This limit is set in `/services/src/main/resources/config-spring-geonetwork.xml` with the parameter `maxUploadSize`.
 
+During startup of the application, this limit can be adjusted by adding the following option to **CATALINA_OPTS**. The value is to be specified in bytes, thus, the following example configures a max upload size of 1 GB:
+
+```
+-Dapi.params.maxUploadSize=1000000000
+```
+
 Types of attachments allowed to be uploaded can be configured in the system settings.  
 See [Metadata configuration](../../administrator-guide/configuring-the-catalog/system-configuration.md#metadata_configuration) for more details.
+


### PR DESCRIPTION
<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

In case you want to update `maxUploadSize` for an already deployed WAR or prior to deploying.

This is meant to replace the obsolete PR [Adds WAR configuration option for maxUploadSize](https://github.com/geonetwork/doc/pull/200) from the archived `geonetwork/doc` repository.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [x] ~~*API Changes* are identified in commit messages~~
- [x] ~~*Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)~~
- [x] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [x] ~~*Build documentation* provided for development instructions in `README.md` files~~
- [x] ~~*Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation~~

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

