### PR TITLE
Update home page "browse by" to display facet as label if there is only one

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/templates/home.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/home.html
@@ -121,9 +121,12 @@
     <div data-ng-show="homeFacet.list.length > 0">
       <div class="row" data-ng-show="homeFacet.list.length > 1">
         <h1 class="col-md-12">
-          <span data-translate="">browseBy</span>
+          <span data-translate="" data-ng-if="homeFacet.list.length > 2">browseBy</span>
+          <span data-ng-if="homeFacet.list.length === 2" data-translate="">
+            {{::('facet-' + homeFacet.list[0]) | facetKeyTranslator}}
+          </span>
         </h1>
-        <div class="gn-topic-select col-md-12">
+        <div class="gn-topic-select col-md-12" data-ng-if="homeFacet.list.length > 2">
           <label
             data-ng-repeat="facetKey in homeFacet.list"
             data-ng-init="agg = searchInfo.aggregations[facetKey]"

--- a/web-ui/src/main/resources/catalog/views/default/templates/home.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/home.html
@@ -122,7 +122,7 @@
       <div class="row" data-ng-show="homeFacet.list.length > 1">
         <h1 class="col-md-12">
           <span data-translate="" data-ng-if="homeFacet.list.length > 2">browseBy</span>
-          <span data-ng-if="homeFacet.list.length === 2" data-translate="">
+          <span data-ng-if="homeFacet.list.length < 3" data-translate="">
             {{::('facet-' + homeFacet.list[0]) | facetKeyTranslator}}
           </span>
         </h1>

--- a/web-ui/src/main/resources/catalog/views/default/templates/home.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/home.html
@@ -119,7 +119,7 @@
 >
   <div data-ng-class="fluidLayout ? 'container-fluid' : 'container'">
     <div data-ng-show="homeFacet.list.length > 0">
-      <div class="row" data-ng-show="homeFacet.list.length > 1">
+      <div class="row">
         <h1 class="col-md-12">
           <span data-translate="" data-ng-if="homeFacet.list.length > 2">browseBy</span>
           <span data-ng-if="homeFacet.list.length < 3" data-translate="">


### PR DESCRIPTION
When there are only two facets displayed on the home page the first facet appears as a button. This can be confusing to the users as it appears like there is some action to be taken on this button but clicking it results in no action.

### Before changes:
#### Two facets:
![image](https://github.com/user-attachments/assets/6526753e-9e8e-4390-b322-58ec70a2a6c6)
#### Three facets:
![image](https://github.com/user-attachments/assets/17b3c4b7-2830-4be2-a1c3-cfed84ab70d9)

This PR aims to fix this issue by displaying the facet in place of the "Browse by" label when there is only a single facet to be displayed. The logic checks for two facets however as the last facet is displayed separately.

### After changes:
#### Two facets:
![image](https://github.com/user-attachments/assets/09c124fd-980e-4355-9e9f-4bec4f549288)
#### Three facets:
![image](https://github.com/user-attachments/assets/8e278103-2b14-414e-92bd-97f593033c50)

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

