### PR TITLE
Add better logging when resources are deleted to make it clear what metadata record the resource was deleted from

### DIFF
--- a/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStore.java
@@ -234,20 +234,26 @@ public class FilesystemStore extends AbstractStore {
         try {
             Log.info(Geonet.RESOURCES, String.format("Deleting all files from metadataId '%d'", metadataId));
             IO.deleteFileOrDirectory(metadataDir, true);
-            return String.format("Metadata '%s' directory removed.", metadataId);
+            Log.info(Geonet.RESOURCES,
+                String.format("Metadata '%d' directory removed.", metadataId));
+            return String.format("Metadata '%d' directory removed.", metadataId);
         } catch (Exception e) {
-            return String.format("Unable to remove metadata '%s' directory.", metadataId);
+            return String.format("Unable to remove metadata '%d' directory.", metadataId);
         }
     }
 
     @Override
     public String delResource(ServiceContext context, String metadataUuid, String resourceId, Boolean approved) throws Exception {
-        canEdit(context, metadataUuid, approved);
+        int metadataId = canEdit(context, metadataUuid, approved);
 
         try (ResourceHolder filePath = getResource(context, metadataUuid, resourceId, approved)) {
             Files.deleteIfExists(filePath.getPath());
-            return String.format("MetadataResource '%s' removed.", resourceId);
+            Log.info(Geonet.RESOURCES,
+                String.format("Resource '%s' removed for metadata %d (%s).", resourceId, metadataId, metadataUuid));
+            return String.format("Metadata resource '%s' removed.", resourceId);
         } catch (IOException e) {
+            Log.warning(Geonet.RESOURCES,
+                String.format("Unable to remove resource '%s' for metadata %d (%s). %s", resourceId, metadataId, metadataUuid, e.getMessage()));
             return String.format("Unable to remove resource '%s'.", resourceId);
         }
     }
@@ -255,12 +261,16 @@ public class FilesystemStore extends AbstractStore {
     @Override
     public String delResource(final ServiceContext context, final String metadataUuid, final MetadataResourceVisibility visibility,
                               final String resourceId, Boolean approved) throws Exception {
-        canEdit(context, metadataUuid, approved);
+        int metadataId = canEdit(context, metadataUuid, approved);
 
         try (ResourceHolder filePath = getResource(context, metadataUuid, visibility, resourceId, approved)) {
             Files.deleteIfExists(filePath.getPath());
-            return String.format("MetadataResource '%s' removed.", resourceId);
+            Log.info(Geonet.RESOURCES,
+                String.format("Resource '%s' removed for metadata %d (%s).", resourceId, metadataId, metadataUuid));
+            return String.format("Metadata resource '%s' removed.", resourceId);
         } catch (IOException e) {
+            Log.warning(Geonet.RESOURCES,
+                String.format("Unable to remove resource '%s' for metadata %d (%s). %s", resourceId, metadataId, metadataUuid, e.getMessage()));
             return String.format("Unable to remove resource '%s'.", resourceId);
         }
     }

--- a/datastorages/cmis/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
+++ b/datastorages/cmis/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
@@ -424,13 +424,9 @@ public class CMISStore extends AbstractStore {
 
         for (MetadataResourceVisibility visibility : MetadataResourceVisibility.values()) {
             if (tryDelResource(context, metadataUuid, metadataId, visibility, resourceId)) {
-                Log.info(Geonet.RESOURCES,
-                        String.format("MetadataResource '%s' removed.", resourceId));
-                return String.format("MetadataResource '%s' removed.", resourceId);
+                return String.format("Metadata resource '%s' removed.", resourceId);
             }
         }
-        Log.info(Geonet.RESOURCES,
-                String.format("Unable to remove resource '%s'.", resourceId));
         return String.format("Unable to remove resource '%s'.", resourceId);
     }
 
@@ -439,12 +435,8 @@ public class CMISStore extends AbstractStore {
                               final String resourceId, Boolean approved) throws Exception {
         int metadataId = canEdit(context, metadataUuid, approved);
         if (tryDelResource(context, metadataUuid, metadataId, visibility, resourceId)) {
-            Log.info(Geonet.RESOURCES,
-                    String.format("MetadataResource '%s' removed.", resourceId));
-            return String.format("MetadataResource '%s' removed.", resourceId);
+            return String.format("Metadata resource '%s' removed.", resourceId);
         }
-        Log.info(Geonet.RESOURCES,
-                String.format("Unable to remove resource '%s'.", resourceId));
         return String.format("Unable to remove resource '%s'.", resourceId);
     }
 
@@ -459,6 +451,8 @@ public class CMISStore extends AbstractStore {
         try {
             final CmisObject object = cmisConfiguration.getClient().getObjectByPath(key, oc);
             object.delete();
+            Log.info(Geonet.RESOURCES,
+                String.format("Resource '%s' removed for metadata %d (%s).", resourceId, metadataId, metadataUuid));
             if (object instanceof Folder) {
                 cmisUtils.invalidateFolderCacheItem(key);
             }
@@ -467,6 +461,8 @@ public class CMISStore extends AbstractStore {
             //CmisPermissionDeniedException when user does not have permissions.
             //CmisConstraintException when there is a lock on the file from a checkout.
         } catch (CmisObjectNotFoundException | CmisPermissionDeniedException | CmisConstraintException e) {
+            Log.info(Geonet.RESOURCES,
+                String.format("Unable to remove resource '%s' for metadata %d (%s). %s", resourceId, metadataId, metadataUuid, e.getMessage()));
             return false;
         }
     }

--- a/datastorages/jcloud/src/main/java/org/fao/geonet/api/records/attachments/JCloudStore.java
+++ b/datastorages/jcloud/src/main/java/org/fao/geonet/api/records/attachments/JCloudStore.java
@@ -356,11 +356,13 @@ public class JCloudStore extends AbstractStore {
                 }
                 marker = page.getNextMarker();
             } while (marker != null);
-            return String.format("Metadata '%s' directory removed.", metadataId);
+            Log.info(Geonet.RESOURCES,
+                String.format("Metadata '%d' directory removed.", metadataId));
+            return String.format("Metadata '%d' directory removed.", metadataId);
         } catch (ContainerNotFoundException e) {
             Log.warning(Geonet.RESOURCES,
-                String.format("Unable to located metadata '%s' directory to be removed.", metadataId));
-            return String.format("Unable to located metadata '%s' directory to be removed.", metadataId);
+                String.format("Unable to located metadata '%d' directory to be removed.", metadataId));
+            return String.format("Unable to located metadata '%d' directory to be removed.", metadataId);
         }
     }
 
@@ -371,13 +373,9 @@ public class JCloudStore extends AbstractStore {
 
         for (MetadataResourceVisibility visibility : MetadataResourceVisibility.values()) {
             if (tryDelResource(context, metadataUuid, metadataId, visibility, resourceId)) {
-                Log.info(Geonet.RESOURCES,
-                        String.format("MetadataResource '%s' removed.", resourceId));
-                return String.format("MetadataResource '%s' removed.", resourceId);
+                return String.format("Metadata resource '%s' removed.", resourceId);
             }
         }
-        Log.info(Geonet.RESOURCES,
-                String.format("Unable to remove resource '%s'.", resourceId));
         return String.format("Unable to remove resource '%s'.", resourceId);
     }
 
@@ -386,12 +384,8 @@ public class JCloudStore extends AbstractStore {
                               final String resourceId, Boolean approved) throws Exception {
         int metadataId = canEdit(context, metadataUuid, approved);
         if (tryDelResource(context, metadataUuid, metadataId, visibility, resourceId)) {
-            Log.info(Geonet.RESOURCES,
-                    String.format("MetadataResource '%s' removed.", resourceId));
-            return String.format("MetadataResource '%s' removed.", resourceId);
+            return String.format("Metadata resource '%s' removed.", resourceId);
         }
-        Log.info(Geonet.RESOURCES,
-                String.format("Unable to remove resource '%s'.", resourceId));
         return String.format("Unable to remove resource '%s'.", resourceId);
     }
 
@@ -401,8 +395,12 @@ public class JCloudStore extends AbstractStore {
 
         if (jCloudConfiguration.getClient().getBlobStore().blobExists(jCloudConfiguration.getContainerName(), key)) {
             jCloudConfiguration.getClient().getBlobStore().removeBlob(jCloudConfiguration.getContainerName(), key);
+            Log.info(Geonet.RESOURCES,
+                String.format("Resource '%s' removed for metadata %d (%s).", resourceId, metadataId, metadataUuid));
             return true;
         }
+        Log.info(Geonet.RESOURCES,
+            String.format("Unable to remove resource '%s' for metadata %d (%s).", resourceId, metadataId, metadataUuid));
         return false;
     }
 

--- a/datastorages/s3/src/main/java/org/fao/geonet/api/records/attachments/S3Store.java
+++ b/datastorages/s3/src/main/java/org/fao/geonet/api/records/attachments/S3Store.java
@@ -193,9 +193,13 @@ public class S3Store extends AbstractStore {
             for (S3ObjectSummary object: objects.getObjectSummaries()) {
                 s3.getClient().deleteObject(s3.getBucket(), object.getKey());
             }
-            return String.format("Metadata '%s' directory removed.", metadataId);
+            Log.info(Geonet.RESOURCES,
+                String.format("Metadata '%d' directory removed.", metadataId));
+            return String.format("Metadata '%d' directory removed.", metadataId);
         } catch (AmazonServiceException e) {
-            return String.format("Unable to remove metadata '%s' directory.", metadataId);
+            Log.warning(Geonet.RESOURCES,
+                String.format("Unable to remove metadata '%d' directory. %s", metadataId, e.getMessage()));
+            return String.format("Unable to remove metadata '%d' directory.", metadataId);
         }
     }
 
@@ -206,7 +210,7 @@ public class S3Store extends AbstractStore {
 
         for (MetadataResourceVisibility visibility: MetadataResourceVisibility.values()) {
             if (tryDelResource(metadataUuid, metadataId, visibility, resourceId)) {
-                return String.format("MetadataResource '%s' removed.", resourceId);
+                return String.format("Metadata resource '%s' removed.", resourceId);
             }
         }
         return String.format("Unable to remove resource '%s'.", resourceId);
@@ -217,7 +221,7 @@ public class S3Store extends AbstractStore {
             final String resourceId, Boolean approved) throws Exception {
         int metadataId = canEdit(context, metadataUuid, approved);
         if (tryDelResource(metadataUuid, metadataId, visibility, resourceId)) {
-            return String.format("MetadataResource '%s' removed.", resourceId);
+            return String.format("Metadata resource '%s' removed.", resourceId);
         }
         return String.format("Unable to remove resource '%s'.", resourceId);
     }
@@ -227,8 +231,12 @@ public class S3Store extends AbstractStore {
         final String key = getKey(metadataUuid, metadataId, visibility, resourceId);
         if (s3.getClient().doesObjectExist(s3.getBucket(), key)) {
             s3.getClient().deleteObject(s3.getBucket(), key);
+            Log.info(Geonet.RESOURCES,
+                String.format("Resource '%s' removed for metadata %d (%s).", resourceId, metadataId, metadataUuid));
             return true;
         }
+        Log.info(Geonet.RESOURCES,
+            String.format("Unable to remove resource '%s' for metadata %d (%s).", resourceId, metadataId, metadataUuid));
         return false;
     }
 


### PR DESCRIPTION
Add better logging when resources are deleted to make it clear what metadata record the resource was deleted from

Also renamed "MetadataResource" in the message to be "Metadata resource"


# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

