### PR TITLE
Harvester / Remove records by harvester UUID

### DIFF
--- a/domain/src/main/java/org/fao/geonet/repository/MetadataRepository.java
+++ b/domain/src/main/java/org/fao/geonet/repository/MetadataRepository.java
@@ -24,20 +24,17 @@
 package org.fao.geonet.repository;
 
 import java.util.List;
-
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-
 import org.fao.geonet.domain.Metadata;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
-import org.springframework.transaction.annotation.Transactional;
 
 /**
  * Data Access object for the {@link Metadata} entities.
- *
+ * <p>
  * The use of this class is discouraged, you should use IMetadataUtils or IMetadataManager instead.
  *
  * @author Jesse
@@ -60,12 +57,12 @@ public interface MetadataRepository extends GeonetRepository<Metadata, Integer>,
 
     /**
      * Find all metadata by the metadata's uuid.
-    *
-    * @param uuid the uuid of the metadata to find
-    * @return a list of metadata.
-    */
-   @Nullable
-   List<Metadata> findAllByUuid(@Nonnull String uuid);
+     *
+     * @param uuid the uuid of the metadata to find
+     * @return a list of metadata.
+     */
+    @Nullable
+    List<Metadata> findAllByUuid(@Nonnull String uuid);
 
     /**
      * Find all metadata harvested by the identified harvester.
@@ -76,7 +73,76 @@ public interface MetadataRepository extends GeonetRepository<Metadata, Integer>,
     @Nonnull
     List<Metadata> findAllByHarvestInfo_Uuid(@Nonnull String uuid);
 
+    int countByHarvestInfo_Uuid(@Nonnull String uuid);
 
+    @Query(value = "SELECT distinct(source) FROM metadata WHERE harvestuuid = :harvesterUuid)",
+        nativeQuery = true)
+    List<String> findDistinctSourcesByHarvestInfo__uuid(@Param("harvesterUuid") String harvesterUuid);
+
+
+    @Query(value = "DELETE FROM operationallowed WHERE metadataid IN (SELECT id FROM metadata WHERE harvestuuid = :harvesterUuid)",
+        nativeQuery = true)
+    @Modifying
+    void deleteAllOperationAllowedByHarvesterUuid(@Param("harvesterUuid") String harvesterUuid);
+
+    @Query(value = "DELETE FROM metadatarating WHERE metadataid IN (SELECT id FROM metadata WHERE harvestuuid = :harvesterUuid)",
+        nativeQuery = true)
+    @Modifying
+    void deleteAllMetadataRatingByHarvesterUuid(@Param("harvesterUuid") String harvesterUuid);
+
+    @Query(value = "DELETE FROM validation WHERE metadataid IN (SELECT id FROM metadata WHERE harvestuuid = :harvesterUuid)",
+        nativeQuery = true)
+    @Modifying
+    void deleteAllValidationByHarvesterUuid(@Param("harvesterUuid") String harvesterUuid);
+
+    @Query(value = "DELETE FROM usersavedselections WHERE metadatauuid IN (SELECT uuid FROM metadata WHERE harvestuuid = :harvesterUuid)",
+        nativeQuery = true)
+    @Modifying
+    void deleteAllUsersavedselectionsByHarvesterUuid(@Param("harvesterUuid") String harvesterUuid);
+
+    @Query(value = "DELETE FROM metadatafiledownloads WHERE metadataid IN (SELECT id FROM metadata WHERE harvestuuid = :harvesterUuid)",
+        nativeQuery = true)
+    @Modifying
+    void deleteAllMetadatafiledownloadsByHarvesterUuid(@Param("harvesterUuid") String harvesterUuid);
+
+    @Query(value = "DELETE FROM metadatafileuploads WHERE metadataid IN (SELECT id FROM metadata WHERE harvestuuid = :harvesterUuid)",
+        nativeQuery = true)
+    @Modifying
+    void deleteAllMetadatafileuploadsByHarvesterUuid(@Param("harvesterUuid") String harvesterUuid);
+
+    @Query(value = "DELETE FROM metadatastatus WHERE metadataid IN (SELECT id FROM metadata WHERE harvestuuid = :harvesterUuid)",
+        nativeQuery = true)
+    @Modifying
+    void deleteAllMetadatastatusByHarvesterUuid(@Param("harvesterUuid") String harvesterUuid);
+
+    @Query(value = "DELETE FROM metadatalink WHERE metadataid IN (SELECT id FROM metadata WHERE harvestuuid = :harvesterUuid)",
+        nativeQuery = true)
+    @Modifying
+    void deleteAllMetadatalinkByHarvesterUuid(@Param("harvesterUuid") String harvesterUuid);
+
+    @Query(value = "DELETE FROM metadatacateg WHERE metadataid IN (SELECT id FROM metadata WHERE harvestuuid = :harvesterUuid)",
+        nativeQuery = true)
+    @Modifying
+    void deleteAllMetadatacategByHarvesterUuid(@Param("harvesterUuid") String harvesterUuid);
+
+    @Query(value = "DELETE FROM metadata WHERE harvestuuid = :harvesterUuid",
+        nativeQuery = true)
+    @Modifying
+    void deleteAllMetadataByHarvesterUuid(@Param("harvesterUuid") String harvesterUuid);
+
+    default void deleteAllByHarvesterUuid(String harvesterUuid) {
+        deleteAllOperationAllowedByHarvesterUuid(harvesterUuid);
+        deleteAllMetadataRatingByHarvesterUuid(harvesterUuid);
+        deleteAllValidationByHarvesterUuid(harvesterUuid);
+        deleteAllUsersavedselectionsByHarvesterUuid(harvesterUuid);
+        deleteAllMetadatafiledownloadsByHarvesterUuid(harvesterUuid);
+        deleteAllMetadatafiledownloadsByHarvesterUuid(harvesterUuid);
+        deleteAllMetadatafileuploadsByHarvesterUuid(harvesterUuid);
+        deleteAllMetadatastatusByHarvesterUuid(harvesterUuid);
+        deleteAllMetadatalinkByHarvesterUuid(harvesterUuid);
+        deleteAllMetadatacategByHarvesterUuid(harvesterUuid);
+        deleteAllMetadataByHarvesterUuid(harvesterUuid);
+    }
 
     @Query(value = "SELECT replace(data, :search, :replace) FROM metadata m " +
         "WHERE uuid = :uuid",


### PR DESCRIPTION
When harvester contains lot of records, remove records take a while or could even return heapspace errors.

Try to improve performances by using delete by query (instead of loop on each records) eg. 1500 records
* Select > Delete all = 2min
* Harvester > Remove records = 700ms

This will bypass events but maybe that is fine for harvested records?

Maybe there is better JPA alternative for this kind of query?


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

Funded by Ifremer
