### PR TITLE
Allow removal of empty graphic overviews

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/process/thumbnail-remove.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/process/thumbnail-remove.xsl
@@ -54,7 +54,6 @@
     <xsl:variable name="position" select="count(//gmd:graphicOverview[current() >> .]) + 1" />
 
     <xsl:if test="not(
-                      gmd:MD_BrowseGraphic[gmd:fileName/gco:CharacterString != ''] and
                       ($resourceIdx = '' or $position = xs:integer($resourceIdx)) and
                       ($resourceHash != '' or ($thumbnail_url != null and (normalize-space(gmd:MD_BrowseGraphic/gmd:fileName/gco:CharacterString) = normalize-space($thumbnail_url))))
                         and ($resourceHash = '' or digestUtils:md5Hex(normalize-space(.)) = $resourceHash)


### PR DESCRIPTION
Currently an empty graphic overview cannot be removed as the match condition checks for an empty file name. This PR aims to fix this issue by removing the check for an empty file name allowing empty graphic overviews to be removed.
  
![GIF 10-15-2024 1-57-09 PM](https://github.com/user-attachments/assets/6fcf64f8-9c3a-46db-8072-5fb289576616)

An example of an empty graphic overview looks like:

```
<gmd:graphicOverview>
    <gmd:MD_BrowseGraphic>
        <gmd:fileName gco:nilReason="missing">
            <gco:CharacterString/>
        </gmd:fileName>
    </gmd:MD_BrowseGraphic>
</gmd:graphicOverview>
```

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

