### PR TITLE
Fix saving UI settings without changes

### DIFF
--- a/web-ui/src/main/resources/catalog/js/admin/SystemSettingsController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/SystemSettingsController.js
@@ -410,7 +410,11 @@
               "../api/ui" + (isUpdate ? "/" + newid : ""),
               {
                 id: newid,
-                configuration: isUpdate ? $scope.uiConfiguration.configuration : null
+                configuration: isUpdate
+                  ? typeof $scope.uiConfiguration.configuration === "string"
+                    ? $scope.uiConfiguration.configuration
+                    : JSON.stringify($scope.uiConfiguration.configuration, null, 2)
+                  : null
               },
               { responseType: "text" }
             )


### PR DESCRIPTION
The UI settings form has always the `Save` button enabled and clicking it without changes, returns the following error:

```
JSON parse error: Cannot deserialize value of type `java.lang.String` from Object value (token 
`JsonToken.START_OBJECT`); nested exception is com.fasterxml.jackson.databind.exc.MismatchedInputException: 
Cannot deserialize value of type `java.lang.String` from Object value (token `JsonToken.START_OBJECT`) at [Source: 
REDACTED (`StreamReadFeature.INCLUDE_SOURCE_IN_LOCATION` disabled); line: 1, column: 29] (through reference 
chain: org.fao.geonet.domain.UiSetting["configuration"])
```

This pull request fix the issue.

A better solution would be to disable the button if there are no changes, but the current form is not ready for this and it will require to model the UI settings in javascript.


# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
