### PR TITLE
Unable to rename graphicOverview

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/process/thumbnail-add.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/process/thumbnail-add.xsl
@@ -95,19 +95,28 @@
   </xsl:template>
 
   <!-- Updating the gmd:graphicOverview based on update parameters -->
-  <!-- Note: first part of the match needs to match the xsl:for-each select from extract-relations.xsl in order to get the position() to match -->
-  <!-- The unique identifier is marked with resourceIdx which is the position index and resourceHash which is hash code of the current node (combination of url, resource name, and description) -->
-  <xsl:template
-    priority="2"
-    match="*//gmd:graphicOverview
-         [$resourceIdx = '' or position() = xs:integer($resourceIdx)]
-         [    ($resourceHash != '' or ($updateKey != '' and normalize-space($updateKey) = concat(
+  <!-- Template to match all gmd:graphicOverview elements -->
+  <xsl:template match="//gmd:graphicOverview" priority="2">
+    <!-- Calculate the global position of the current gmd:graphicOverview element -->
+    <xsl:variable name="position" select="count(//gmd:graphicOverview[current() >> .]) + 1" />
+
+    <xsl:choose>
+      <!-- The unique identifier is marked with resourceIdx which is the position index and resourceHash which is hash code of the current node (combination of url, resource name, and description) -->
+      <xsl:when test="($resourceIdx = '' or $position = xs:integer($resourceIdx)) and
+                        ($resourceHash != '' or ($updateKey != '' and normalize-space($updateKey) = concat(
                            */gmd:fileName/gco:CharacterString,
                            */gmd:fileName/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale = '#DE'],
                            */gmd:fileDescription/gmd:PT_FreeText/gmd:textGroup/gmd:LocalisedCharacterString[@locale = '#DE'],
                            */gmd:fileDescription/gco:CharacterString)))
-          and ($resourceHash = '' or digestUtils:md5Hex(normalize-space(.)) = $resourceHash)]">
-    <xsl:call-template name="fill"/>
+                        and ($resourceHash = '' or digestUtils:md5Hex(normalize-space(.)) = $resourceHash)">
+        <xsl:call-template name="fill"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:copy>
+          <xsl:apply-templates select="@*|node()"/>
+        </xsl:copy>
+      </xsl:otherwise>
+    </xsl:choose>
   </xsl:template>
 
   <!-- TMP TO REMOVE when gco:characterString is added in multilingual elements


### PR DESCRIPTION
This PR arose from the HNAP PR [403](https://github.com/metadata101/iso19139.ca.HNAP/pull/403) where the graphic overviews could not be updated with a new name. It was suggested that iso19139 could also use these changes. I am unable to test this however as there does not appear to be an edit option for graphic overviews on iso19139 like there is on HNAP.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

