### PR TITLE
Avoid duplicate validation message when trying to register a user with existing email

### DIFF
--- a/core/src/test/resources/org/fao/geonet/api/Messages.properties
+++ b/core/src/test/resources/org/fao/geonet/api/Messages.properties
@@ -54,8 +54,7 @@ user_password_changed='%s' password was updated.
 user_password_notchanged=A problem occurred trying to change '%s' password. Contact the helpdesk.
 user_password_invalid_changekey='%s' is an invalid change key for '%s'. Change keys are only valid for one day.
 user_registered=User '%s' registered.
-user_with_that_email_found=A user with this email or username already exists.
-user_with_that_username_found=A user with this email or username already exists.
+user_with_that_email_username_found=A user with this email or username already exists.
 register_email_admin_subject=%s / New account for %s as %s
 register_email_admin_message=Dear Admin,\n\
   Newly registered user %s has requested %s access for %s.\n\

--- a/core/src/test/resources/org/fao/geonet/api/Messages_fre.properties
+++ b/core/src/test/resources/org/fao/geonet/api/Messages_fre.properties
@@ -53,8 +53,7 @@ user_password_sent=Si l''utilisateur existe, vous recevrez un courriel contenant
 user_password_changed=Le mot de passe de %s a \u00E9t\u00E9 mis \u00E0 jour.
 user_password_notchanged=\u00C9chec lors du changement de mot de passe de %s. Contactez le support.
 user_password_invalid_changekey=%s est une cl\u00E9 invalide pour %s. Les cl\u00E9s ne sont valides que pendant une journ\u00E9e.
-user_with_that_email_found=Un utilisateur avec cette adresse email ou ce nom d''utilisateur existe d\u00E9j\u00E0.
-user_with_that_username_found=Un utilisateur avec cette adresse email ou ce nom d''utilisateur existe d\u00E9j\u00E0.
+user_with_that_email_username_found=Un utilisateur avec cette adresse email ou ce nom d''utilisateur existe d\u00E9j\u00E0.
 register_email_admin_subject=%s / Cr\u00E9ation de compte pour %s en tant que %s
 register_email_admin_message=Cher administrateur,\n\
   L'utilisateur %s vient de demander une cr\u00E9ation de compte pour %s.\n\

--- a/services/src/main/java/org/fao/geonet/api/users/validation/UserRegisterDtoValidator.java
+++ b/services/src/main/java/org/fao/geonet/api/users/validation/UserRegisterDtoValidator.java
@@ -60,12 +60,10 @@ public class UserRegisterDtoValidator implements Validator {
         }
 
         UserRepository userRepository = ApplicationContextHolder.get().getBean(UserRepository.class);
-        if (userRepository.findOneByEmail(userRegisterDto.getEmail()) != null) {
-            errors.rejectValue("", "user_with_that_email_found", "A user with this email or username already exists.");
+        if ((userRepository.findOneByEmail(userRegisterDto.getEmail()) != null) ||
+            (!userRepository.findByUsernameIgnoreCase(userRegisterDto.getEmail()).isEmpty())) {
+            errors.rejectValue("", "user_with_that_email_username_found", "A user with this email or username already exists.");
         }
 
-        if (userRepository.findByUsernameIgnoreCase(userRegisterDto.getEmail()).size() != 0) {
-            errors.rejectValue("", "user_with_that_username_found", "A user with this email or username already exists.");
-        }
     }
 }

--- a/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages.properties
+++ b/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages.properties
@@ -54,8 +54,7 @@ user_password_changed='%s' password was updated.
 user_password_notchanged=A problem occurred trying to change '%s' password. Contact the helpdesk.
 user_password_invalid_changekey='%s' is an invalid change key for '%s'. Change keys are only valid for one day.
 user_registered=User '%s' registered.
-user_with_that_email_found=A user with this email or username already exists.
-user_with_that_username_found=A user with this email or username already exists.
+user_with_that_email_username_found=A user with this email or username already exists.
 register_email_admin_subject=%s / New account for %s as %s
 register_email_admin_message=Dear Admin,\n\
   Newly registered user %s has requested %s access for %s.\n\

--- a/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages_fre.properties
+++ b/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages_fre.properties
@@ -53,8 +53,7 @@ user_password_sent=Si l''utilisateur existe, vous recevrez un courriel contenant
 user_password_changed=Le mot de passe de %s a \u00E9t\u00E9 mis \u00E0 jour.
 user_password_notchanged=\u00C9chec lors du changement de mot de passe de %s. Contactez le support.
 user_password_invalid_changekey=%s est une cl\u00E9 invalide pour %s. Les cl\u00E9s ne sont valides que pendant une journ\u00E9e.
-user_with_that_email_found=Un utilisateur avec cette adresse email ou ce nom d''utilisateur existe d\u00E9j\u00E0.
-user_with_that_username_found=Un utilisateur avec cette adresse email ou ce nom d''utilisateur existe d\u00E9j\u00E0.
+user_with_that_email_username_found=Un utilisateur avec cette adresse email ou ce nom d''utilisateur existe d\u00E9j\u00E0.
 register_email_admin_subject=%s / Cr\u00E9ation de compte pour %s en tant que %s
 register_email_admin_message=Cher administrateur,\n\
   L'utilisateur %s vient de demander une cr\u00E9ation de compte pour %s.\n\


### PR DESCRIPTION
In the register user form, register a new user with the email of an existing user.

Before:

![Screenshot 2024-10-17 at 10 10 57](https://github.com/user-attachments/assets/6557de56-5214-4d44-9036-cee9468968ca)

After:

![Screenshot 2024-10-17 at 10 11 42](https://github.com/user-attachments/assets/5e5cf27f-5c0c-4eb3-bd67-b8b1c4d14f65)


# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation