### PR TITLE
XSL utility / Add function to retrieve thesaurus URI

### DIFF
--- a/core/src/main/java/org/fao/geonet/util/XslUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/XslUtil.java
@@ -1440,7 +1440,7 @@ public final class XslUtil {
 
         return thesaurus == null ? "" : "geonetwork.thesaurus." + thesaurus.getKey();
     }
-    
+
     /**
      * Retrieve the thesaurus title using the thesaurus key.
      *
@@ -1453,6 +1453,15 @@ public final class XslUtil {
         Thesaurus thesaurus = thesaurusManager.getThesaurusByName(id);
         return thesaurus == null ? "" : thesaurus.getTitle();
     }
+
+
+    public static String getThesaurusUriByKey(String id) {
+        ApplicationContext applicationContext = ApplicationContextHolder.get();
+        ThesaurusManager thesaurusManager = applicationContext.getBean(ThesaurusManager.class);
+        Thesaurus thesaurus = thesaurusManager.getThesaurusByName(id);
+        return thesaurus == null ? "" : thesaurus.getDefaultNamespace();
+    }
+
 
 
     /**
@@ -1594,7 +1603,7 @@ public final class XslUtil {
     public static String escapeForJson(String value) {
         return StringEscapeUtils.escapeJson(value);
     }
-  
+
     public static String getWebAnalyticsService() {
         ApplicationContext applicationContext = ApplicationContextHolder.get();
         WebAnalyticsConfiguration webAnalyticsConfiguration = applicationContext.getBean(WebAnalyticsConfiguration.class);


### PR DESCRIPTION
RDF based schema plugins may need the URI of vocabularies in a number of places. This utility is used in the DCAT-AP plugin when building concept elements in thesaurus-transformation.xsl:

eg.
```
  <dct:accessRights xmlns:dct="http://purl.org/dc/terms/">
    <skos:Concept xmlns:skos="http://www.w3.org/2004/02/skos/core#" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" rdf:about="http://publications.europa.eu/resource/authority/access-right/PUBLIC">
      <skos:prefLabel xml:lang="en">public</skos:prefLabel>
      <skos:prefLabel xml:lang="es">public</skos:prefLabel>
      <skos:inScheme rdf:resource="http://publications.europa.eu/resource/authority/access-right" />
    </skos:Concept>
  </dct:accessRights>
```


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

Funded by https://metadata.vlaanderen.be/