### PR TITLE
Delete resources when a new working copy is cancelled

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/draft/DraftMetadataUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/draft/DraftMetadataUtils.java
@@ -27,6 +27,7 @@ import com.google.common.base.Optional;
 import com.google.common.collect.Sets;
 import jeeves.server.context.ServiceContext;
 import org.eclipse.jetty.io.RuntimeIOException;
+import org.fao.geonet.api.records.attachments.Store;
 import org.fao.geonet.api.records.attachments.StoreUtils;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.*;
@@ -648,6 +649,10 @@ public class DraftMetadataUtils extends BaseMetadataUtils {
                 metadataRatingByIpRepository.deleteAllById_MetadataId(intId);
                 metadataValidationRepository.deleteAllById_MetadataId(intId);
                 metadataStatusRepository.deleteAllById_MetadataId(intId);
+
+                // Delete resources
+                Store store = context.getBean("resourceStore", Store.class);
+                store.delResources(context, intId);
 
                 // --- remove metadata
                 xmlSerializer.delete(id, ServiceContext.get());


### PR DESCRIPTION
When a newly created working copy is cancelled the working copy is deleted. The associated resources however are not deleted resulting in orphaned files.

This PR aims to fix this issue by also deleting the associated resources when a new working copy is deleted using the "cancel" button in the editor. This functionality is already present when using the "cancel working copy" button on the record view.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
