### PR TITLE
getResourceInternal implementation for cmis and jcloud

### DIFF
--- a/core/src/main/java/org/fao/geonet/api/records/attachments/ResourceLoggerStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/ResourceLoggerStore.java
@@ -91,7 +91,12 @@ public class ResourceLoggerStore extends AbstractStore {
 
     @Override
     public ResourceHolder getResourceInternal(String metadataUuid, MetadataResourceVisibility visibility, String resourceId, Boolean approved) throws Exception {
-        throw new UnsupportedOperationException("ResourceLoggerStore does not support getResourceInternal.");
+        if (decoratedStore != null) {
+            final ResourceHolder resource = decoratedStore
+                .getResourceInternal(metadataUuid, visibility, resourceId, approved);
+            return resource;
+        }
+        return null;
     }
 
     @Override

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/ResourceLoggerStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/ResourceLoggerStore.java
@@ -91,12 +91,7 @@ public class ResourceLoggerStore extends AbstractStore {
 
     @Override
     public ResourceHolder getResourceInternal(String metadataUuid, MetadataResourceVisibility visibility, String resourceId, Boolean approved) throws Exception {
-        if (decoratedStore != null) {
-            final ResourceHolder resource = decoratedStore
-                .getResourceInternal(metadataUuid, visibility, resourceId, approved);
-            return resource;
-        }
-        return null;
+        throw new UnsupportedOperationException("ResourceLoggerStore does not support getResourceInternal.");
     }
 
     @Override

--- a/core/src/main/java/org/fao/geonet/util/XslUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/XslUtil.java
@@ -1246,7 +1246,7 @@ public final class XslUtil {
                 Matcher m = Pattern.compile(settingManager.getNodeURL() + "api/records/(.*)/attachments/(.*)$").matcher(url);
                 BufferedImage image;
                 if (m.find()) {
-                    Store store = ApplicationContextHolder.get().getBean("resourceStore", Store.class);
+                    Store store = ApplicationContextHolder.get().getBean("filesystemStore", Store.class);
                     try (Store.ResourceHolder file = store.getResourceInternal(
                         m.group(1),
                         MetadataResourceVisibility.PUBLIC,

--- a/core/src/main/java/org/fao/geonet/util/XslUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/XslUtil.java
@@ -1246,7 +1246,7 @@ public final class XslUtil {
                 Matcher m = Pattern.compile(settingManager.getNodeURL() + "api/records/(.*)/attachments/(.*)$").matcher(url);
                 BufferedImage image;
                 if (m.find()) {
-                    Store store = ApplicationContextHolder.get().getBean(FilesystemStore.class);
+                    Store store = ApplicationContextHolder.get().getBean("resourceStore", Store.class);
                     try (Store.ResourceHolder file = store.getResourceInternal(
                         m.group(1),
                         MetadataResourceVisibility.PUBLIC,
@@ -1581,7 +1581,7 @@ public final class XslUtil {
     public static String escapeForJson(String value) {
         return StringEscapeUtils.escapeJson(value);
     }
-  
+
     public static String getWebAnalyticsService() {
         ApplicationContext applicationContext = ApplicationContextHolder.get();
         WebAnalyticsConfiguration webAnalyticsConfiguration = applicationContext.getBean(WebAnalyticsConfiguration.class);

--- a/datastorages/cmis/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
+++ b/datastorages/cmis/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
@@ -190,7 +190,20 @@ public class CMISStore extends AbstractStore {
 
     @Override
     public ResourceHolder getResourceInternal(String metadataUuid, MetadataResourceVisibility visibility, String resourceId, Boolean approved) throws Exception {
-        throw new UnsupportedOperationException("CMISStore does not support getResourceInternal.");
+        int metadataId = getAndCheckMetadataId(metadataUuid, approved);
+        checkResourceId(resourceId);
+
+        try {
+            ServiceContext context = ServiceContext.get();
+            final CmisObject object = cmisConfiguration.getClient().getObjectByPath(getKey(context, metadataUuid, metadataId, visibility, resourceId));
+            return new ResourceHolderImpl(object, createResourceDescription(context, metadataUuid, visibility, resourceId,
+                (Document) object, metadataId, approved));
+        } catch (CmisObjectNotFoundException e) {
+            throw new ResourceNotFoundException(
+                String.format("Metadata resource '%s' not found for metadata '%s'", resourceId, metadataUuid))
+                .withMessageKey("exception.resourceNotFound.resource", new String[]{resourceId})
+                .withDescriptionKey("exception.resourceNotFound.resource.description", new String[]{resourceId, metadataUuid});
+        }
     }
 
     protected String getKey(final ServiceContext context, String metadataUuid, int metadataId, MetadataResourceVisibility visibility, String resourceId) {

--- a/datastorages/jcloud/src/main/java/org/fao/geonet/api/records/attachments/JCloudStore.java
+++ b/datastorages/jcloud/src/main/java/org/fao/geonet/api/records/attachments/JCloudStore.java
@@ -164,7 +164,22 @@ public class JCloudStore extends AbstractStore {
 
     @Override
     public ResourceHolder getResourceInternal(String metadataUuid, MetadataResourceVisibility visibility, String resourceId, Boolean approved) throws Exception {
-        throw new UnsupportedOperationException("JCloud does not support getResourceInternal.");
+        int metadataId = getAndCheckMetadataId(metadataUuid, approved);
+        checkResourceId(resourceId);
+
+        try {
+            ServiceContext context = ServiceContext.get();
+            final Blob object = jCloudConfiguration.getClient().getBlobStore().getBlob(
+                jCloudConfiguration.getContainerName(), getKey(context, metadataUuid, metadataId, visibility, resourceId));
+            return new ResourceHolderImpl(object, createResourceDescription(context, metadataUuid, visibility, resourceId,
+                object.getMetadata(), metadataId, approved));
+        } catch (ContainerNotFoundException e) {
+            throw new ResourceNotFoundException(
+                String.format("Metadata resource '%s' not found for metadata '%s'", resourceId, metadataUuid))
+                .withMessageKey("exception.resourceNotFound.resource", new String[]{resourceId})
+                .withDescriptionKey("exception.resourceNotFound.resource.description", new String[]{resourceId, metadataUuid});
+        }
+
     }
 
     private String getKey(final ServiceContext context, String metadataUuid, int metadataId, MetadataResourceVisibility visibility, String resourceId) {


### PR DESCRIPTION
This change implement  `getResourceInternal` (created in #5467) for CmisStore and JcloudStore.

It is used by `buildDataUrl`

https://github.com/geonetwork/core-geonetwork/blob/573d4be9c98e98f28246db6aaa9cdd33c3ad16bc/core/src/main/java/org/fao/geonet/util/XslUtil.java#L1236-L1250

and the function is used within individual shema's search engine indexing. for example:

https://github.com/geonetwork/core-geonetwork/blob/573d4be9c98e98f28246db6aaa9cdd33c3ad16bc/schemas/dublin-core/src/main/plugin/dublin-core/index-fields/index.xsl#L248-L251
 

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

