### PR TITLE
Attachments API use filename from Content-Disposition before url

### DIFF
--- a/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
@@ -158,8 +158,9 @@ public abstract class AbstractStore implements Store {
     }
 
     protected String getFilenameFromHeader(final URL fileUrl) throws IOException {
-        HttpURLConnection connection = (HttpURLConnection) fileUrl.openConnection();
+        HttpURLConnection connection = null;
         try {
+            connection = (HttpURLConnection) fileUrl.openConnection();
             connection.setRequestMethod("HEAD");
             connection.connect();
             String contentDisposition = connection.getHeaderField("Content-Disposition");
@@ -173,7 +174,9 @@ public abstract class AbstractStore implements Store {
             log.error("Error retrieving resource filename from header", e);
             return null;
         } finally {
-            connection.disconnect();
+            if (connection != null) {
+                connection.disconnect();
+            }
         }
     }
 

--- a/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsApi.java
@@ -229,7 +229,6 @@ public class AttachmentsApi {
     @io.swagger.v3.oas.annotations.Operation(summary = "Create a new resource from a URL for a given metadata")
     @PreAuthorize("hasAuthority('Editor')")
     @RequestMapping(method = RequestMethod.PUT,
-        consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(value = HttpStatus.CREATED)
     @ApiResponses(value = {@ApiResponse(responseCode = "201", description = "Attachment added."),

--- a/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsApi.java
@@ -200,7 +200,7 @@ public class AttachmentsApi {
     @io.swagger.v3.oas.annotations.Operation(summary = "Create a new resource for a given metadata")
     @PreAuthorize("hasAuthority('Editor')")
     @RequestMapping(method = RequestMethod.POST,
-        consumes = MediaType.ALL_VALUE,
+        consumes = MediaType.MULTIPART_FORM_DATA_VALUE,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(value = HttpStatus.CREATED)
     @ApiResponses(value = {@ApiResponse(responseCode = "201", description = "Attachment uploaded."),
@@ -228,7 +228,9 @@ public class AttachmentsApi {
 
     @io.swagger.v3.oas.annotations.Operation(summary = "Create a new resource from a URL for a given metadata")
     @PreAuthorize("hasAuthority('Editor')")
-    @RequestMapping(method = RequestMethod.PUT)
+    @RequestMapping(method = RequestMethod.PUT,
+        consumes = MediaType.APPLICATION_FORM_URLENCODED_VALUE,
+        produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(value = HttpStatus.CREATED)
     @ApiResponses(value = {@ApiResponse(responseCode = "201", description = "Attachment added."),
         @ApiResponse(responseCode = "403", description = ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_EDIT)})


### PR DESCRIPTION
Currently the attachments `putResourceFromURL` API uses the last node from the URL (excluding query parameters) to get the filename. This becomes an issue when providing URL's that do not contain the filename in the last node. Instead the content disposition header should have higher priority over the url for retrieving the filename.

For example when providing a URL for a file that is uploaded to a cloud provider like OneDrive the download URL looks like `.../.../download.aspx?...`. This means when putResourceFromUrl is called the extracted filename is always `download.aspx` rather than the actual file download's name. If content disposition is used instead the actual filename can be extracted from the header.

![image](https://github.com/user-attachments/assets/636ba0d3-1698-432d-a44f-8dcfc90841fb)

Additionally there are some issues with the "consumes" and "produces" spring docs for `putResource` and `putResourceFromURL` leading to an incorrect OpenAPI spec which causes the APIs to fail or return invalid responses. This also causes the swagger page to be incorrect and causes issues for codegen as the generated methods for putResource do not correctly provide the file as `multipart/form-data`.

This should show that only multipart is accepted:
![image](https://github.com/user-attachments/assets/b9a0209c-561e-47ce-8d18-3cb406b1a1e6)

Issues with response codes because JSON is not defined as the return type (This call was successful):
![image](https://github.com/user-attachments/assets/b2693339-de35-4c48-a460-82bae5efacb7)

This PR aims to fix these issues by first attempting to get the file name from the `Content-Disposition` header before falling back to the URL for the filename and by updating the spring docs.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [X] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

