### PR TITLE
Sort groups alphabetically on the new account and report pages

### DIFF
--- a/web-ui/src/main/resources/catalog/components/utility/UtilityService.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityService.js
@@ -436,6 +436,22 @@
         return defer.promise;
       };
 
+      /**
+       * Sort an array of elements with translations labels, using the provided language.
+       *
+       */
+      var sortByTranslation = function (values, sortByLanguage, defaultProperty) {
+        return Object.values(
+          // Don't mutate the original array
+          values.concat().sort(function (a, b) {
+            var aValue = a.label[sortByLanguage] || a[defaultProperty];
+            var bValue = b.label[sortByLanguage] || b[defaultProperty];
+
+            return aValue.localeCompare(bValue);
+          })
+        );
+      };
+
       return {
         scrollTo: scrollTo,
         isInView: isInView,
@@ -452,7 +468,8 @@
         randomUuid: randomUuid,
         displayPermalink: displayPermalink,
         openModal: openModal,
-        goBack: goBack
+        goBack: goBack,
+        sortByTranslation: sortByTranslation
       };
     }
   ]);

--- a/web-ui/src/main/resources/catalog/js/LoginController.js
+++ b/web-ui/src/main/resources/catalog/js/LoginController.js
@@ -155,7 +155,11 @@
       $scope.retrieveGroups = function () {
         $http.get("../api/groups").then(
           function (response) {
-            $scope.groups = response.data;
+            $scope.groups = gnUtilityService.sortByTranslation(
+              response.data,
+              $scope.lang,
+              "name"
+            );
           },
           function (response) {}
         );

--- a/web-ui/src/main/resources/catalog/js/admin/ReportController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/ReportController.js
@@ -36,7 +36,8 @@
     "$http",
     "$rootScope",
     "$translate",
-    function ($scope, $routeParams, $http, $rootScope, $translate) {
+    "gnUtilityService",
+    function ($scope, $routeParams, $http, $rootScope, $translate, gnUtilityService) {
       $scope.pageMenu = {
         folder: "report/",
         defaultTab: "report-updated-metadata",
@@ -150,7 +151,11 @@
         if ($scope.user.profile === "Administrator") {
           $http.get("../api/groups").then(
             function (response) {
-              $scope.groups = response.data;
+              $scope.groups = gnUtilityService.sortByTranslation(
+                response.data,
+                $scope.lang,
+                "name"
+              );
             },
             function (response) {
               // TODO
@@ -166,6 +171,12 @@
               $scope.groups = _.uniqBy(groups, function (e) {
                 return e.id;
               });
+
+              $scope.groups = gnUtilityService.sortByTranslation(
+                $scope.groups,
+                $scope.lang,
+                "name"
+              );
             },
             function (response) {
               // TODO


### PR DESCRIPTION
Display the group names alphabetically in new account and report pages.

Before:

![sort-1](https://github.com/user-attachments/assets/a72d08f9-ff1b-4f74-ba4f-b9854e8a6d6c)

After:

![sort-2](https://github.com/user-attachments/assets/9f903e6d-47d9-496b-b99d-72b0f5d1da9f)


# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
