### PR TITLE
Metadata editor / Fix display of multiple choice elements with custom label

### DIFF
--- a/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
@@ -567,7 +567,7 @@
                       <xsl:attribute name="aria-haspopup">true</xsl:attribute>
                       <xsl:attribute name="aria-expanded">false</xsl:attribute>
                     </xsl:if>
-                    <i class="{if ($btnClass != '') then $btnClass else 'fa fa-plus'}"/>
+                    <i class="{if ($btnClass != '') then $btnClass else 'fa fa-plus'}"></i>
                     <xsl:if test="$btnLabel != ''">&#160;
                       <span>
                         <xsl:value-of select="$btnLabel"/>
@@ -934,9 +934,9 @@
               <xsl:when test="$qualifiedName = 'gfc:code' and $schema='iso19110'">
 
                 <div class="btn-group">
-                  <button type="button" class="btn btn-default dropdown-toggle fa fa-plus gn-add" data-toggle="dropdown" title="{$i18n/addA} {$label}">
-                    <span/>
-                    <span class="caret"/>
+                  <button type="button" class="btn btn-default dropdown-toggle gn-add" data-toggle="dropdown" title="{$i18n/addA} {$label}">
+                    <i class="fa fa-plus"></i>
+                    <span class="caret"></span>
                   </button>
                   <ul class="dropdown-menu">
                     <xsl:variable name="name" select="'gco:CharacterString'"/>
@@ -982,10 +982,10 @@
               <xsl:when test="count($childEditInfo/gn:choose) > 1">
                 <div class="btn-group">
                   <button type="button"
-                          class="btn btn-default dropdown-toggle {if ($btnClass != '') then $btnClass else 'fa fa-plus'} gn-add"
+                          class="btn btn-default dropdown-toggle gn-add"
                           data-toggle="dropdown"
                           title="{$i18n/addA} {$label}">
-                    <span/>
+                    <i class="{if ($btnClass != '') then $btnClass else 'fa fa-plus'}"></i>
                     <xsl:if test="$btnLabel != ''">&#160;
                       <span>
                         <xsl:value-of select="$btnLabel"/>
@@ -1019,7 +1019,7 @@
                 <a class="btn btn-default"
                    title="{$i18n/addA} {$label}"
                    data-gn-click-and-spin="add({$parentEditInfo/@ref}, '{if ($name != '') then $name else concat(@prefix, ':', @name)}', '{$id}', 'before');">
-                  <i class="{if ($btnClass != '') then $btnClass else 'fa fa-plus'} gn-add"/>
+                  <i class="{if ($btnClass != '') then $btnClass else 'fa fa-plus'} gn-add"></i>
                   <xsl:if test="$btnLabel != ''">&#160;
                     <span>
                       <xsl:value-of select="$btnLabel"/>
@@ -1477,7 +1477,7 @@
       <a class="btn btn-default"
          title="{$i18n/addA} {$name}"
          data-gn-click-and-spin="add({$parentEditInfo/@parent}, '{$name}', {$editInfo/@ref})">
-        <i class="fa fa-plus gn-add"/>
+        <i class="fa fa-plus gn-add"></i>
       </a>
     </xsl:if>
   </xsl:template>
@@ -1640,7 +1640,7 @@
             id="gn-attr-add-button-{$fieldName}"
             data-gn-click-and-spin="add('{$ref}', '{@name}', '{$insertRef}', null, true)"
             title="{$attributeLabel/description}">
-      <i class="fa fa-plus fa-fw"/>
+      <i class="fa fa-plus fa-fw"></i>
       <xsl:value-of select="$attributeLabel/label"/>
     </button>
   </xsl:template>


### PR DESCRIPTION
Elements that define a `btnLabel` value and define multiple choices, like:

```xml
<element name="gmd:DQ_Result" id="128">
    <label>Ergebnis</label>
    <btnLabel>Ergebnis</btnLabel>
...
</element>
```

Are displayed with a wrong font due to FontAwesome styling applied wrongly to `button` elements:

![button-font-1](https://github.com/user-attachments/assets/9c362223-4b7a-4d82-b15a-c2966f76b611)

After the fix:

![button-font-2](https://github.com/user-attachments/assets/cd7703cf-08fc-4ff3-a286-27fe5bac6a9c)

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation