### PR TITLE
Directory entries / Fix parsing of sorting configuration

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/directoryentryselector/DirectoryEntrySelector.js
+++ b/web-ui/src/main/resources/catalog/components/edit/directoryentryselector/DirectoryEntrySelector.js
@@ -128,6 +128,10 @@
             pre: function preLink(scope) {
               var directorySearchSettings = gnGlobalSettings.gnCfg.mods.directory || {};
 
+              var sortConfig = (
+                directorySearchSettings.sortBy || gnSearchSettings.sortBy
+              ).split("#");
+
               scope.searchObj = {
                 any: "",
                 internal: true,
@@ -138,8 +142,8 @@
                   from: 1,
                   to: 20,
                   root: "gmd:CI_ResponsibleParty",
-                  sortBy: directorySearchSettings.sortBy || gnSearchSettings.sortBy,
-                  sortOrder: "",
+                  sortBy: sortConfig[0] || "relevance",
+                  sortOrder: sortConfig[1] || "",
                   resultType: "subtemplates",
                   queryBase:
                     directorySearchSettings.queryBase || gnSearchSettings.queryBase
@@ -639,6 +643,10 @@
             pre: function preLink(scope) {
               var directorySearchSettings = gnGlobalSettings.gnCfg.mods.directory || {};
 
+              var sortConfig = (
+                directorySearchSettings.sortBy || gnSearchSettings.sortBy
+              ).split("#");
+
               scope.searchObj = {
                 internal: true,
                 configId: "directoryInEditor",
@@ -648,7 +656,8 @@
                   from: 1,
                   to: 10,
                   root: "gmd:CI_ResponsibleParty",
-                  sortBy: directorySearchSettings.sortBy || gnSearchSettings.sortBy,
+                  sortBy: sortConfig[0] || "relevance",
+                  sortOrder: sortConfig[1] || "",
                   queryBase:
                     directorySearchSettings.queryBase || gnSearchSettings.queryBase
                 }

--- a/web-ui/src/main/resources/catalog/js/edit/DirectoryController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/DirectoryController.js
@@ -106,12 +106,17 @@
 
       $scope.facetConfig = directorySearchSettings.facetConfig;
 
+      var sortConfig = (directorySearchSettings.sortBy || gnSearchSettings.sortBy).split(
+        "#"
+      );
+
       $scope.defaultSearchObj = {
         selectionBucket: "d101",
         configId: "directory",
         any: "",
         params: {
-          sortBy: directorySearchSettings.sortBy || gnSearchSettings.sortBy,
+          sortBy: sortConfig[0] || "relevance",
+          sortOrder: sortConfig[1] || "",
           isTemplate: ["s"],
           from: 1,
           to: 20,


### PR DESCRIPTION
Configuring a the Manage directory sorting options with this format `changeDate#desc`, including the sort order: http://localhost:8080/geonetwork/srv/eng/admin.console#/settings/ui

![manage-directory-sort-default](https://github.com/user-attachments/assets/ef21bd0a-c5ce-4c2e-a751-35998f2b8b3a)


Causes the manage directory page to fail: http://localhost:8080/geonetwork/srv/eng/catalog.edit#/directory

![manage-directory-search-error](https://github.com/user-attachments/assets/606b288a-032c-4848-96f8-bb234ed0bf74)

This pull request fixes the parsing of the sort configuration for the Manage directory page and the entry selector component in the metadata editor.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
