### PR TITLE
Use filesystemStore bean instead of hardcoded class

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/ogcwxs/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/ogcwxs/Harvester.java
@@ -911,7 +911,7 @@ class Harvester extends BaseAligner<OgcWxSParams> implements IHarvester<HarvestR
             Path filename = getMapThumbnail(layer);
 
             // Add downloaded file to metadata store
-            Store store = context.getBean(FilesystemStore.class);
+            Store store = context.getBean("filesystemStore", Store.class);
             try {
                 store.delResource(context, layer.uuid, filename.getFileName().toString());
             } catch (Exception e) {}


### PR DESCRIPTION
The intention of this code change is to fix potential issue with harvesting file store. The current file store was hardcoded to FileSystemStore class instead of dynamic bean injection.

The similar fix was apply to this pull request which is already merged https://github.com/geonetwork/core-geonetwork/pull/8466/files

https://github.com/geonetwork/core-geonetwork/blob/cd50dedd9046ee3a676bf9e1af57c5b0767bad8f/core/src/main/java/org/fao/geonet/util/XslUtil.java#L1249


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

