### PR TITLE
[Backport 4.2.x] Enhance static page with group user accessibility

### DIFF
--- a/domain/src/main/java/org/fao/geonet/domain/page/Page.java
+++ b/domain/src/main/java/org/fao/geonet/domain/page/Page.java
@@ -23,10 +23,13 @@
 package org.fao.geonet.domain.page;
 
 import java.io.Serializable;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Set;
 
 import javax.annotation.Nullable;
 import javax.persistence.Basic;
+import javax.persistence.CascadeType;
 import javax.persistence.CollectionTable;
 import javax.persistence.Column;
 import javax.persistence.ElementCollection;
@@ -35,10 +38,14 @@ import javax.persistence.Entity;
 import javax.persistence.EnumType;
 import javax.persistence.Enumerated;
 import javax.persistence.FetchType;
+import javax.persistence.JoinColumn;
+import javax.persistence.JoinTable;
 import javax.persistence.Lob;
+import javax.persistence.ManyToMany;
 import javax.persistence.Table;
 
 import org.fao.geonet.domain.GeonetEntity;
+import org.fao.geonet.domain.Group;
 import org.hibernate.annotations.Type;
 
 /**
@@ -56,6 +63,7 @@ public class Page extends GeonetEntity implements Serializable {
     private PageFormat format;
     private List<PageSection> sections;
     private PageStatus status;
+    private Set<Group> groups = new LinkedHashSet<>();
 
     private String label;
 
@@ -63,7 +71,7 @@ public class Page extends GeonetEntity implements Serializable {
 
     }
 
-    public Page(PageIdentity pageIdentity, byte[] data, String link, PageFormat format, List<PageSection> sections, PageStatus status, String label) {
+    public Page(PageIdentity pageIdentity, byte[] data, String link, PageFormat format, List<PageSection> sections, PageStatus status, String label, Set<Group> groups) {
         super();
         this.pageIdentity = pageIdentity;
         this.data = data;
@@ -72,10 +80,11 @@ public class Page extends GeonetEntity implements Serializable {
         this.sections = sections;
         this.status = status;
         this.label = label;
+        this.groups = groups;
     }
 
     public enum PageStatus {
-        PUBLIC, PUBLIC_ONLY, PRIVATE, HIDDEN;
+        PUBLIC, PUBLIC_ONLY, GROUPS, PRIVATE, HIDDEN;
     }
 
     public enum PageFormat {
@@ -137,6 +146,29 @@ public class Page extends GeonetEntity implements Serializable {
     @Column(nullable = false)
     public String getLabel() {
         return label;
+    }
+
+
+    /**
+     * Get all the page's groups.
+     *
+     * @return all the page's groups.
+     */
+    @ManyToMany(fetch = FetchType.EAGER, cascade = {CascadeType.DETACH, CascadeType.PERSIST, CascadeType.REFRESH})
+    @JoinTable(name = "spg_page_group", joinColumns = {@JoinColumn(name = "language"), @JoinColumn(name = "linktext")},
+        inverseJoinColumns = {@JoinColumn(name = "groupid", referencedColumnName = "id", unique = false)})
+    public Set<Group> getGroups() {
+        return groups;
+    }
+
+    /**
+     * Set all the page's groups.
+     *
+     * @param groups all the page's groups.
+     * @return this group object
+     */
+    public void setGroups(Set<Group> groups) {
+        this.groups = groups;
     }
 
     public void setPageIdentity(PageIdentity pageIdentity) {

--- a/domain/src/main/java/org/fao/geonet/repository/page/PageRepository.java
+++ b/domain/src/main/java/org/fao/geonet/repository/page/PageRepository.java
@@ -29,7 +29,9 @@ import org.fao.geonet.domain.page.PageIdentity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface PageRepository extends JpaRepository<Page, PageIdentity> {
-    
+
     List<Page> findByPageIdentityLanguage(String language);
+
+    List<Page> findPageByStatus(Page.PageStatus status);
 
 }

--- a/services/src/main/java/org/fao/geonet/api/pages/PageProperties.java
+++ b/services/src/main/java/org/fao/geonet/api/pages/PageProperties.java
@@ -1,11 +1,14 @@
 package org.fao.geonet.api.pages;
 
+import org.apache.commons.collections4.CollectionUtils;
+import org.fao.geonet.domain.Group;
 import org.fao.geonet.domain.page.Page;
 import org.fao.geonet.domain.page.Page.PageFormat;
 import org.fao.geonet.domain.page.Page.PageSection;
 import org.fao.geonet.domain.page.Page.PageStatus;
 
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.List;
 
 public class PageProperties implements Serializable {
@@ -20,6 +23,7 @@ public class PageProperties implements Serializable {
     private String content;
     private String label;
     private Page.PageFormat format;
+    private List<String> groups;
     private Page page;
 
     public PageProperties() {
@@ -34,6 +38,12 @@ public class PageProperties implements Serializable {
         sections = p.getSections();
         status = p.getStatus();
         label = p.getLabel();
+        if (CollectionUtils.isNotEmpty(p.getGroups())) {
+            groups = new ArrayList<>();
+            for (Group g : p.getGroups()) {
+                groups.add(g.getName());
+            }
+        }
     }
 
     @Override
@@ -103,5 +113,13 @@ public class PageProperties implements Serializable {
 
     public void setLabel(String label) {
         this.label = label;
+    }
+
+    public List<String> getGroups() {
+        return groups;
+    }
+
+    public void setGroups(List<String> groups) {
+        this.groups = groups;
     }
 }

--- a/services/src/main/java/org/fao/geonet/api/pages/PagesAPI.java
+++ b/services/src/main/java/org/fao/geonet/api/pages/PagesAPI.java
@@ -27,6 +27,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jeeves.server.UserSession;
+import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.api.ApiParams;
@@ -35,10 +36,16 @@ import org.fao.geonet.api.exception.ResourceAlreadyExistException;
 import org.fao.geonet.api.exception.ResourceNotFoundException;
 import org.fao.geonet.api.exception.WebApplicationException;
 import org.fao.geonet.api.tools.i18n.LanguageUtils;
+import org.fao.geonet.domain.Group;
 import org.fao.geonet.domain.Profile;
+import org.fao.geonet.domain.UserGroup;
 import org.fao.geonet.domain.page.Page;
 import org.fao.geonet.domain.page.PageIdentity;
+import org.fao.geonet.repository.GroupRepository;
+import org.fao.geonet.repository.UserGroupRepository;
 import org.fao.geonet.repository.page.PageRepository;
+import org.fao.geonet.repository.specification.UserGroupSpecs;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -55,8 +62,10 @@ import javax.validation.constraints.NotNull;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.springframework.http.HttpHeaders.CONTENT_TYPE;
 
@@ -75,11 +84,16 @@ public class PagesAPI {
     private static final String ERROR_CREATE = "Wrong parameters are provided";
 
     private final PageRepository pageRepository;
+    private final GroupRepository groupRepository;
+
+    @Autowired
+    UserGroupRepository userGroupRepository;
 
     private final LanguageUtils languageUtils;
 
-    public PagesAPI(PageRepository pageRepository, LanguageUtils languageUtils) {
+    public PagesAPI(PageRepository pageRepository, GroupRepository groupRepository, LanguageUtils languageUtils) {
         this.pageRepository = pageRepository;
+        this.groupRepository = groupRepository;
         this.languageUtils = languageUtils;
     }
 
@@ -157,6 +171,7 @@ public class PagesAPI {
         String language = pageProperties.getLanguage();
         String pageId = pageProperties.getPageId();
         Page.PageFormat format = pageProperties.getFormat();
+        List<String> groups = pageProperties.getGroups();
 
         if (language != null) {
             checkValidLanguage(language);
@@ -182,6 +197,15 @@ public class PagesAPI {
 
             if (status != null) {
                 newPage.setStatus(status);
+
+                if (status == Page.PageStatus.GROUPS && CollectionUtils.isNotEmpty(groups)) {
+                    Set<Group> pageGroups = new LinkedHashSet<>();
+                    for (String groupName : groups) {
+                        Group group = groupRepository.findByName(groupName);
+                        pageGroups.add(group);
+                    }
+                    newPage.setGroups(pageGroups);
+                }
             }
 
             pageRepository.save(newPage);
@@ -201,6 +225,30 @@ public class PagesAPI {
         String newPageId = pageProperties.getPageId();
         Page.PageFormat format = pageProperties.getFormat();
         String newLabel = pageProperties.getLabel();
+
+        Set<Group> _groups = new LinkedHashSet<>();
+        if (CollectionUtils.isNotEmpty(pageProperties.getGroups())) {
+            for (String groupName : pageProperties.getGroups()) {
+                Group group = groupRepository.findByName(groupName);
+
+                Group groupToAdd= new Group();
+                groupToAdd.setId(group.getId());
+                groupToAdd.setAllowedCategories(group.getAllowedCategories());
+                groupToAdd.setDescription(group.getDescription());
+                groupToAdd.setEmail(group.getEmail());
+                groupToAdd.setLogo(group.getLogo());
+                groupToAdd.setEnableAllowedCategories(group.getEnableAllowedCategories());
+                groupToAdd.setDefaultCategory(group.getDefaultCategory());
+                groupToAdd.setName(group.getName());
+                groupToAdd.setReferrer(group.getReferrer());
+                groupToAdd.setWebsite(group.getWebsite());
+                groupToAdd.setLabelTranslations(group.getLabelTranslations());
+
+                _groups.add(groupToAdd);
+            }
+
+        }
+
 
         checkValidLanguage(language);
 
@@ -238,7 +286,8 @@ public class PagesAPI {
                 format != null ? format : pageToUpdate.getFormat(),
                 pageProperties.getSections() != null ? pageProperties.getSections() : pageToUpdate.getSections(),
                 pageProperties.getStatus() != null ? pageProperties.getStatus() : pageToUpdate.getStatus(),
-                newLabel != null ? newLabel : pageToUpdate.getLabel());
+                newLabel != null ? newLabel : pageToUpdate.getLabel(),
+                CollectionUtils.isNotEmpty(_groups)? _groups: null);
 
             pageRepository.save(pageCopy);
             pageRepository.delete(pageToUpdate);
@@ -249,6 +298,11 @@ public class PagesAPI {
             pageToUpdate.setStatus(pageProperties.getStatus() != null ? pageProperties.getStatus() : pageToUpdate.getStatus());
             pageToUpdate.setLabel(newLabel);
             pageRepository.save(pageToUpdate);
+            pageToUpdate.getGroups().clear();
+            if (pageToUpdate.getStatus() == Page.PageStatus.GROUPS) {
+                pageToUpdate.getGroups().addAll(_groups);
+            }
+
         }
 
         return ResponseEntity.noContent().build();
@@ -346,7 +400,7 @@ public class PagesAPI {
         final UserSession us = ApiUtils.getUserSession(session);
         if (page.get().getStatus().equals(Page.PageStatus.HIDDEN) && us.getProfile() != Profile.Administrator) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-        } else if (page.get().getStatus().equals(Page.PageStatus.PRIVATE) && (us.getProfile() == null || us.getProfile() == Profile.Guest)) {
+        } else if ((page.get().getStatus().equals(Page.PageStatus.PRIVATE) || page.get().getStatus().equals(Page.PageStatus.GROUPS)) && (us.getProfile() == null || us.getProfile() == Profile.Guest)) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         } else {
             String content;
@@ -380,6 +434,7 @@ public class PagesAPI {
         @Parameter(hidden = true) final HttpSession session) {
 
         final UserSession us = ApiUtils.getUserSession(session);
+
         List<Page> unfilteredResult;
 
         if (language == null) {
@@ -393,15 +448,16 @@ public class PagesAPI {
         for (final Page page : unfilteredResult) {
             if (page.getStatus().equals(Page.PageStatus.HIDDEN) && us.getProfile() == Profile.Administrator
                 || page.getStatus().equals(Page.PageStatus.PRIVATE) && us.getProfile() != null && us.getProfile() != Profile.Guest
+                || page.getStatus().equals(Page.PageStatus.GROUPS) && us.getProfile() != null && us.getProfile() != Profile.Guest && checkGroupPermission(us, page)
                 || page.getStatus().equals(Page.PageStatus.PUBLIC)
                 || page.getStatus().equals(Page.PageStatus.PUBLIC_ONLY) && !us.isAuthenticated()) {
                 if (section == null) {
-                    filteredResult.add(new org.fao.geonet.api.pages.PageProperties(page));
+                    filteredResult.add(new PageProperties(page));
                 } else {
                     final List<Page.PageSection> sections = page.getSections();
                     final boolean containsRequestedSection = sections.contains(section);
                     if (containsRequestedSection) {
-                        filteredResult.add(new org.fao.geonet.api.pages.PageProperties(page));
+                        filteredResult.add(new PageProperties(page));
                     }
                 }
             }
@@ -494,17 +550,17 @@ public class PagesAPI {
      * @param page    the page
      * @return the response entity
      */
-    private ResponseEntity<org.fao.geonet.api.pages.PageProperties> checkPermissionsOnSinglePageAndReturn(final HttpSession session, final Page page) {
+    private ResponseEntity<PageProperties> checkPermissionsOnSinglePageAndReturn(final HttpSession session, final Page page) {
         if (page == null) {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         } else {
             final UserSession us = ApiUtils.getUserSession(session);
             if (page.getStatus().equals(Page.PageStatus.HIDDEN) && us.getProfile() != Profile.Administrator) {
                 return new ResponseEntity<>(HttpStatus.FORBIDDEN);
-            } else if (page.getStatus().equals(Page.PageStatus.PRIVATE) && (us.getProfile() == null || us.getProfile() == Profile.Guest)) {
+            } else if ((page.getStatus().equals(Page.PageStatus.PRIVATE) || page.getStatus().equals(Page.PageStatus.GROUPS)) && (us.getProfile() == null || us.getProfile() == Profile.Guest)) {
                 return new ResponseEntity<>(HttpStatus.FORBIDDEN);
             } else {
-                return new ResponseEntity<>(new org.fao.geonet.api.pages.PageProperties(page), HttpStatus.OK);
+                return new ResponseEntity<>(new PageProperties(page), HttpStatus.OK);
             }
         }
     }
@@ -533,7 +589,7 @@ public class PagesAPI {
      */
     protected Page getEmptyHiddenDraftPage(final String language, final String pageId, final String label, final Page.PageFormat format) {
         final List<Page.PageSection> sections = new ArrayList<>();
-        return new Page(new PageIdentity(language, pageId), null, null, format, sections, Page.PageStatus.HIDDEN, label);
+        return new Page(new PageIdentity(language, pageId), null, null, format, sections, Page.PageStatus.HIDDEN, label, null);
     }
 
     /**
@@ -565,5 +621,37 @@ public class PagesAPI {
             }
         }
 
+    }
+
+    /**
+     * Check is the user is in designated group to access the static page when page permission level is set to GROUP
+     * @param us Current User Session
+     * @param page static page object
+     * @return permission granted
+     */
+    private boolean checkGroupPermission (UserSession us, Page page) {
+        boolean isGranted = false;
+        String currentUserId = us.getUserId();
+
+        if (us.getProfile() == Profile.Administrator) {
+            isGranted = true;
+        } else if (page.getStatus().equals(Page.PageStatus.GROUPS) && StringUtils.isNotEmpty(currentUserId)) {
+            List<UserGroup> userGroups = userGroupRepository.findAll(UserGroupSpecs.hasUserId(Integer.parseInt(currentUserId)));
+
+            Set<Group> accessingGroups = page.getGroups();
+
+            if (CollectionUtils.isNotEmpty(userGroups) && CollectionUtils.isNotEmpty(accessingGroups)) {
+                for (UserGroup userGroup : userGroups) {
+                    for (Group group : accessingGroups) {
+                        if (org.apache.commons.lang3.StringUtils.equals(userGroup.getGroup().getName(), group.getName())) {
+                            isGranted = true;
+                            break;
+                        }
+                    }
+                }
+            }
+        }
+
+        return isGranted;
     }
 }

--- a/web-ui/src/main/resources/catalog/js/admin/StaticPagesController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/StaticPagesController.js
@@ -41,6 +41,7 @@
       $scope.staticPageSelected = null;
       $scope.queue = [];
       $scope.uploadScope = angular.element("#gn-static-page-edit").scope();
+      $scope.groups = [];
 
       $scope.unsupportedFile = false;
       $scope.$watchCollection("queue", function (n, o) {
@@ -61,6 +62,12 @@
         });
         $http.get("../api/pages/config/sections").then(function (r) {
           $scope.sections = r.data;
+        });
+      }
+
+      function loadGroups() {
+        $http.get("../api/groups").then(function (r) {
+          $scope.groups = r.data;
         });
       }
 
@@ -144,6 +151,7 @@
 
       $scope.addStaticPage = function () {
         $scope.isUpdate = false;
+        $scope.isGroupEnabled = false;
         $scope.staticPageSelected = {
           language: "",
           pageId: "",
@@ -152,6 +160,7 @@
           data: "",
           content: "",
           status: "HIDDEN",
+          groups: "",
           label: "",
           sections: []
         };
@@ -164,6 +173,7 @@
       $scope.selectStaticPage = function (v) {
         $scope.isUpdate = true;
         $scope.staticPageSelected = v;
+        $scope.isGroupEnabled = $scope.staticPageSelected.status == "GROUPS";
 
         var link =
           "api/pages/" +
@@ -214,6 +224,12 @@
           $scope.uploadScope.submit();
         } else {
           delete sp.data;
+
+          // Reset empty string to null to avoid parsing error
+          if (sp.groups == "") {
+            sp.groups = null;
+          }
+
           return $http
             .put(action, sp, {
               headers: {
@@ -223,6 +239,13 @@
             .then(successHandler, function (r) {
               failureHandler(r.data);
             });
+        }
+      };
+      $scope.updateGroupSelection = function () {
+        if ($scope.staticPageSelected.status === "GROUPS") {
+          $scope.isGroupEnabled = true;
+        } else {
+          $scope.isGroupEnabled = false;
         }
       };
 
@@ -262,6 +285,7 @@
       loadFormats();
       loadDbLanguages();
       loadStaticPages();
+      loadGroups();
     }
   ]);
 })();

--- a/web-ui/src/main/resources/catalog/locales/en-v4.json
+++ b/web-ui/src/main/resources/catalog/locales/en-v4.json
@@ -393,6 +393,7 @@
   "staticPageFormat-TEXT": "Plain text content",
   "staticPageStatus-HIDDEN": "Visible only to the administrator",
   "staticPageStatus-PRIVATE": "Visible to logged users",
+  "staticPageStatus-GROUPS": "Visible to users belonging to the groups",
   "staticPageStatus-PUBLIC": "Visible to everyone",
   "pageLink": "Link",
   "pageSection-help": "Currently, the default UI view only supports TOP and FOOTER values. Custom UI views can make use of additional values.",

--- a/web-ui/src/main/resources/catalog/templates/admin/settings/static-pages.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/settings/static-pages.html
@@ -289,12 +289,33 @@
                 class="form-control"
                 required=""
                 data-ng-model="staticPageSelected.status"
+                data-ng-change="updateGroupSelection()"
               >
                 <option value="HIDDEN">{{'staticPageStatus-HIDDEN' | translate }}</option>
                 <option value="PRIVATE">
                   {{'staticPageStatus-PRIVATE' | translate }}
                 </option>
+                <option value="GROUPS">{{'staticPageStatus-GROUPS' | translate }}</option>
                 <option value="PUBLIC">{{'staticPageStatus-PUBLIC' | translate }}</option>
+              </select>
+            </div>
+          </div>
+
+          <div class="form-group">
+            <label class="control-label col-sm-3" data-translate="">groups</label>
+
+            <div class="col-sm-9">
+              <select
+                name="groups"
+                class="form-control"
+                data-ng-disabled="!isGroupEnabled"
+                data-ng-readonly="!isGroupEnabled"
+                data-ng-model="staticPageSelected.groups"
+                multiple
+              >
+                <option data-ng-repeat="g in groups" value="{{g.name}}">
+                  {{g.label[lang]|empty:g.name}}
+                </option>
               </select>
             </div>
           </div>


### PR DESCRIPTION
Backport conflict resolving for https://github.com/geonetwork/core-geonetwork/pull/7707

* Add group/accessExpression field to static page feature

* Filter none group member access to page belong to certain group

* code improvement

* multi selections for groups

* multi selections for groups.

* Refactoring group checking logic

* Update services/src/main/java/org/fao/geonet/api/pages/model/GroupAccessExpression.java



* ui change menu behavior

* Fixing ui issue

* pageGroup joint relation in page entity

* pageGroup joint relation in page entity (add SQL)

* remove page creation script

* Update domain/src/main/java/org/fao/geonet/domain/page/Page.java



* rename group

* prevent group remove if it has association with static pages

* JPA ManyToMany bug fix

---------


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

