### PR TITLE
Batch selection is not in sync between search results and record view.

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/SelectionManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/SelectionManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2024 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -51,9 +51,9 @@ import static org.fao.geonet.kernel.search.EsSearchManager.FIELDLIST_UUID;
  * Manage objects selection for a user session.
  */
 public class SelectionManager {
-
     public static final String SELECTION_METADATA = "metadata";
-    public static final String SELECTION_BUCKET = "bucket";
+    // Bucket name used in the search UI to store the selected the metadata
+    public static final String SELECTION_BUCKET = "s101";
     // used to limit select all if get system setting maxrecords fails or contains value we can't parse
     public static final int DEFAULT_MAXHITS = 1000;
     public static final String ADD_ALL_SELECTED = "add-all";
@@ -61,20 +61,20 @@ public class SelectionManager {
     public static final String ADD_SELECTED = "add";
     public static final String REMOVE_SELECTED = "remove";
     public static final String CLEAR_ADD_SELECTED = "clear-add";
-    private Hashtable<String, Set<String>> selections = null;
+    private Hashtable<String, Set<String>> selections;
 
     private SelectionManager() {
-        selections = new Hashtable<String, Set<String>>(0);
+        selections = new Hashtable<>(0);
 
         Set<String> MDSelection = Collections
-            .synchronizedSet(new HashSet<String>(0));
+            .synchronizedSet(new HashSet<>(0));
         selections.put(SELECTION_METADATA, MDSelection);
     }
 
 
     public Map<String, Integer> getSelectionsAndSize() {
         return selections.entrySet().stream().collect(Collectors.toMap(
-            e -> e.getKey(),
+            Map.Entry::getKey,
             e -> e.getValue().size()
         ));
     }
@@ -183,7 +183,7 @@ public class SelectionManager {
         // Get the selection manager or create it
         Set<String> selection = this.getSelection(type);
         if (selection == null) {
-            selection = Collections.synchronizedSet(new HashSet<String>());
+            selection = Collections.synchronizedSet(new HashSet<>());
             this.selections.put(type, selection);
         }
 
@@ -192,30 +192,21 @@ public class SelectionManager {
                 this.selectAll(type, context, session);
             else if (selected.equals(REMOVE_ALL_SELECTED))
                 this.close(type);
-            else if (selected.equals(ADD_SELECTED) && listOfIdentifiers.size() > 0) {
+            else if (selected.equals(ADD_SELECTED) && !listOfIdentifiers.isEmpty()) {
                 // TODO ? Should we check that the element exist first ?
-                for (String paramid : listOfIdentifiers) {
-                    selection.add(paramid);
-                }
-            } else if (selected.equals(REMOVE_SELECTED) && listOfIdentifiers.size() > 0) {
+                selection.addAll(listOfIdentifiers);
+            } else if (selected.equals(REMOVE_SELECTED) && !listOfIdentifiers.isEmpty()) {
                 for (String paramid : listOfIdentifiers) {
                     selection.remove(paramid);
                 }
-            } else if (selected.equals(CLEAR_ADD_SELECTED) && listOfIdentifiers.size() > 0) {
+            } else if (selected.equals(CLEAR_ADD_SELECTED) && !listOfIdentifiers.isEmpty()) {
                 this.close(type);
-                for (String paramid : listOfIdentifiers) {
-                    selection.add(paramid);
-                }
+                selection.addAll(listOfIdentifiers);
             }
         }
 
         // Remove empty/null element from the selection
-        Iterator<String> iter = selection.iterator();
-        while (iter.hasNext()) {
-            Object element = iter.next();
-            if (element == null)
-                iter.remove();
-        }
+        selection.removeIf(Objects::isNull);
 
         return selection.size();
     }
@@ -241,14 +232,12 @@ public class SelectionManager {
 
         if (StringUtils.isNotEmpty(type)) {
             JsonNode request = (JsonNode) session.getProperty(Geonet.Session.SEARCH_REQUEST + type);
-            if (request == null) {
-                return;
-            } else {
+            if (request != null) {
                 final SearchResponse searchResponse;
                 try {
                     EsSearchManager searchManager = context.getBean(EsSearchManager.class);
                     searchResponse = searchManager.query(request.get("query"), FIELDLIST_UUID, 0, maxhits);
-                    List<String> uuidList = new ArrayList();
+                    List<String> uuidList = new ArrayList<>();
                     ObjectMapper objectMapper = new ObjectMapper();
                     for (Hit h : (List<Hit>) searchResponse.hits().hits()) {
                         uuidList.add((String) objectMapper.convertValue(h.source(), Map.class).get(Geonet.IndexFieldNames.UUID));
@@ -293,7 +282,7 @@ public class SelectionManager {
         Set<String> sel = selections.get(type);
         if (sel == null) {
             Set<String> MDSelection = Collections
-                .synchronizedSet(new HashSet<String>(0));
+                .synchronizedSet(new HashSet<>(0));
             selections.put(type, MDSelection);
         }
         return selections.get(type);

--- a/services/src/main/java/org/fao/geonet/api/es/EsHTTPProxy.java
+++ b/services/src/main/java/org/fao/geonet/api/es/EsHTTPProxy.java
@@ -301,7 +301,7 @@ public class EsHTTPProxy {
     @ResponseStatus(value = HttpStatus.OK)
     @ResponseBody
     public void search(
-        @RequestParam(defaultValue = SelectionManager.SELECTION_METADATA)
+        @RequestParam(defaultValue = SelectionManager.SELECTION_BUCKET)
         String bucket,
         @Parameter(description = "Type of related resource. If none, no associated resource returned.",
             required = false
@@ -387,7 +387,7 @@ public class EsHTTPProxy {
     @PreAuthorize("hasAuthority('Administrator')")
     @ResponseBody
     public void call(
-        @RequestParam(defaultValue = SelectionManager.SELECTION_METADATA)
+        @RequestParam(defaultValue = SelectionManager.SELECTION_BUCKET)
         String bucket,
         @Parameter(description = "'_search' for search service.")
         @PathVariable String endPoint,


### PR DESCRIPTION
Fixes #8295

@fxprunayre the fix solves the issue, but there is another selection bucket (`SELECTION_METADATA`) that is used in 22 places:

https://github.com/geonetwork/core-geonetwork/blob/bedfe3da2b9461e5549f6c9935a5f9c73a9a4f97/core/src/main/java/org/fao/geonet/kernel/SelectionManager.java#L55

I have change `EsHTTPProxy` search methods to use `SELECTION_BUCKET` and update the value from `bucket` to `s101`. I haven't change `EsHTTPProxy.msearch` that still uses `SELECTION_METADATA` as I'm not sure if should be changed or not.

I would like to add some comment to `SELECTION_METADATA` describing it's usage.

---

Includes Sonarlint code improvements.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
