### PR TITLE
Change french stemmer in order to have better results

### DIFF
--- a/web/src/main/webResources/WEB-INF/data/config/index/records.json
+++ b/web/src/main/webResources/WEB-INF/data/config/index/records.json
@@ -130,7 +130,7 @@
           },
           "french_stemmer": {
             "type": "stemmer",
-            "language": "light_french"
+            "language": "minimal_french"
           },
           "english_stop": {
             "type": "stop",


### PR DESCRIPTION
<!--Include a few sentences describing the overall goals for this Pull Request-->
  
It solves issues with elasticsearch requests.

Stemmer (as I understand) is used to optimize word computation when requests are excuted. Words with the same roots are then reduced to their root "version". So, words like "continua", "continuait" are reduced to "continu".

The lightest the stemmer is, the closest it is to a dictionnary stemmer (all words, with all declinaisons...) but it's also slower.

For a record with French word "Etablissements", some requests didn't work. It works for all languagues and default but not French.

I've set record with the same translation "Etablissements de Cleaux" for different lang and tried those ES requests : 
```json
{
  "query": {
    "bool" : {
      "should": [
        { "prefix": { "resourceTitleObject.langfre": "etabliss"}}
      ]
    }
  },
  "_source": [
    "resourceTitleObject"
  ],
  "from": 0,
  "size": 20
}
```
OR
```json
{
  "query": {
    "match_phrase_prefix" : {
      "resourceTitleObject.langfre": {
         "query": "etabliss"
      }
    }
  },
  "_source": [
    "resourceTitleObject"
  ],
  "from": 0,
  "size": 20
}
```

<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged

