### PR TITLE
Webcomponent / Use relative path to load main template from cache.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -43,7 +43,7 @@
         getMapservices: function () {
           if (mapservicesCache === null) {
             var client = new XMLHttpRequest();
-            client.open("GET", "../api/mapservices", false);
+            client.open("GET", gnGlobalSettings.gnUrl + "api/mapservices", false);
             client.setRequestHeader("accept", "application/json");
             client.send();
             if (client.status === 200) {

--- a/web-ui/src/main/resources/catalog/components/utility/CORSInterceptor.js
+++ b/web-ui/src/main/resources/catalog/components/utility/CORSInterceptor.js
@@ -71,7 +71,7 @@
                 (config.url.indexOf("http") !== 0 && config.url.indexOf("//") !== 0);
 
               // If this is an authorized mapservice then we need to adjust the url or add auth headers
-              // Only check http url and exclude any urls like data: which should not be changed. Also, there is not need to check prox urls.
+              // Only check http url and exclude any urls like data: which should not be changed. Also, there is no need to check proxy urls.
               if (
                 config.url !== null &&
                 config.url.startsWith("http") &&

--- a/web-ui/src/main/resources/catalog/components/utility/SessionService.js
+++ b/web-ui/src/main/resources/catalog/components/utility/SessionService.js
@@ -42,9 +42,9 @@
   module.factory("gnSessionService", [
     "$rootScope",
     "$translate",
-    "$timeout",
     "$cookies",
-    function ($rootScope, $translate, $timeout, $cookies) {
+    "$interval",
+    function ($rootScope, $translate, $cookies, $interval) {
       var session = {
         remainingTime: null,
         start: null,
@@ -109,10 +109,22 @@
         }
       }
       function scheduleCheck(user, interval) {
-        $timeout(function () {
-          check(user);
-          scheduleCheck(user, interval);
-        }, interval || session.checkInterval);
+        // FIXME: When embedding the app using webcomponent mode,
+        // this interact with the location for unknown reason.
+        // This was observed when deploying an Angular app with the map as webcomponent
+        // on Apache or GN5 spring boot app embedded.
+        // Map actions are oddly redirecting to other route.
+        // The link between scheduleCheck and $locationChangeSuccess is not clear.
+        if (typeof gnShadowRoot === "undefined") {
+          $interval(
+            function () {
+              check(user);
+            },
+            interval || session.checkInterval,
+            0,
+            false
+          );
+        }
       }
       return {
         getSession: getSession,

--- a/web-ui/src/main/resources/catalog/components/viewer/ViewerDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/ViewerDirective.js
@@ -383,7 +383,14 @@
                 }
               });
 
-              scope.$on("$locationChangeSuccess", function (next, current) {
+              scope.$on("$locationChangeSuccess", function (evt, next, current, newState, oldState) {
+                // When using window.location.hash or replace to change the location
+                // $locationChangeSuccess is triggered 2 times.
+                // Second time on HashChangeEvent which can be ignored
+                // and the state contains a navigationId property.
+                if (oldState && oldState.navigationId) {
+                  return;
+                }
                 initFromLocation();
               });
 

--- a/web-ui/src/main/resources/catalog/views/default/module.js
+++ b/web-ui/src/main/resources/catalog/views/default/module.js
@@ -530,7 +530,10 @@
         );
       }
       var setActiveTab = function () {
-        $scope.activeTab = $location.path().match(/^(\/[a-zA-Z0-9]*)($|\/.*)/)[1];
+        let match = $location.path().match(/^(\/[a-zA-Z0-9]*)($|\/.*)/);
+        if (match) {
+          $scope.activeTab = match[1];
+        }
       };
 
       setActiveTab();

--- a/web-ui/src/main/resources/catalog/webcomponents/webcomponents.js
+++ b/web-ui/src/main/resources/catalog/webcomponents/webcomponents.js
@@ -40,7 +40,7 @@ customElements.define(
       var div = document.createElement("div");
       div.setAttribute(
         "data-ng-include",
-        "'" + baseUrl + "/catalog/views/default/templates/index.html'"
+        "'../../catalog/views/default/templates/index.html'"
       );
       div.setAttribute("class", "gn-full");
       app.appendChild(div);


### PR DESCRIPTION
* index.html default view template can be loaded from the Angular template cache directly. If not, webcomponent can failed to load the template due to gnMapServicesCache.getMapservice when base URL does not match GeoNetwork URL.

Avoid this unneeded API call in webcomponent mode:

![image](https://github.com/user-attachments/assets/f4fab810-003b-48d0-9ffd-c76c322d17e4)


* Tentative fix for locationChangeSuccess redirect related to session
* Avoid multiple locationChangeSuccess when changing hash in URL
* Avoid JS error when .path is null


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

Funded by Ifremer