### PR TITLE
Metadata editor / Regions picker display empty entry form the metadata regions dao

### DIFF
--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -504,7 +504,10 @@
            * Load list on init to fill the dropdown
            */
           gnRegionService.loadList().then(function (data) {
-            scope.regionTypes = angular.copy(data);
+            var dataFiltered = _.filter(data, function (o) {
+              return o.id !== "metadata";
+            });
+            scope.regionTypes = angular.copy(dataFiltered);
             if (addGeonames) {
               scope.regionTypes.unshift({
                 name: "Geonames",


### PR DESCRIPTION
Regions picker display empty entry form the metadata regions dao:

![regions-selector](https://github.com/user-attachments/assets/7e52040d-9c80-48d3-9fc3-b8e153bca565)

Metadata regions dao is used to generate the extent images for the metadata, but it's not intended to use it in the regions picker to search for regions. Updated the regions picker directive to don't display the related entry.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

