### PR TITLE
Update translations for Portuguese in codelists for schema 19139

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/loc/por/codelists.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/por/codelists.xml
@@ -47,7 +47,7 @@
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
   </codelist>
   <!-- ==================================================== -->
-  <codelist name="gmd:CI_OnLineFunctionCode">
+  <codelist name="gmd:CI_OnLineFunctionCode" alias="function">
     <entry>
       <code>download</code>
       <label>Download</label>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/por/codelists.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/por/codelists.xml
@@ -26,7 +26,7 @@
 
   <codelist name="gmd:CI_DateTypeCode">
     <entry>
-      <code>criation</code>
+      <code>creation</code>
       <label>Criação</label>
       <description>A data identifica quando o recurso foi criado</description>
     </entry>
@@ -86,7 +86,7 @@
     <entry>
       <code>documentDigital</code>
       <label>Documento digital</label>
-      <description>Visualização digital dum item principalmente escrito (também possa conter
+      <description>Visualização digital de um item principalmente escrito (também pode conter
         ilustrações)
       </description>
     </entry>
@@ -339,7 +339,7 @@
     <entry>
       <code>campaign</code>
       <label>Campanha</label>
-      <description>Série de acções organizadas e planeadas</description>
+      <description>Série de acções organizadas e planejadas</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
@@ -401,7 +401,7 @@
     <entry>
       <code>program</code>
       <label>Programa</label>
-      <description>Actividade específica e planeada</description>
+      <description>Actividade específica e planejada</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
@@ -1096,7 +1096,7 @@
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>notPlanned</code>
-      <label>Não planeado</label>
+      <label>Não planejado</label>
       <description>Não há planos para actualizar os dados</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
@@ -1349,7 +1349,7 @@
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>planned</code>
-      <label>Planeado</label>
+      <label>Planejado</label>
       <description>Data fixa estabelecida, a partir da qual, os dados foram ou serão criados ou
         actualizados
       </description>
@@ -1582,7 +1582,7 @@
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>stereoModel</code>
-      <label>Modelo estereofónico</label>
+      <label>Modelo estereofônico</label>
       <description>Vista tridimensional, que é formada pelos reios homólogos intersectandos
         dum par de imagens sobrepostos
       </description>
@@ -1608,7 +1608,7 @@
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>biota</code>
-      <label>Biotopos</label>
+      <label>Biota</label>
       <description>Fauna e flora em habitat natural. Exemplos: vida selvagem, vegetação, ciências
         biológicas, ecologia, desertos, vida marinha, zonas húmidas, habitat
       </description>
@@ -1624,7 +1624,7 @@
     <entry>
       <code>climatologyMeteorologyAtmosphere</code>
       <label>Climatologia, Atmosfera</label>
-      <description>Processos e fenómenos atmosféricos. Exemplos: nebulosidade, estado do tempo,
+      <description>Processos e fenômenos atmosféricos. Exemplos: nebulosidade, estado do tempo,
         clima, condições atmosféricas, alterações climáticas, precipitação
       </description>
     </entry>
@@ -1632,7 +1632,7 @@
     <entry>
       <code>economy</code>
       <label>Economia</label>
-      <description>Actividades económicas e emprego. Exemplos: produção, emprego, rendimentos,
+      <description>Actividades econômicas e emprego. Exemplos: produção, emprego, rendimentos,
         comércio, indústria, turismo e eco-turismo, florestas, pescas, caça para fins comerciais ou
         de subsistência, exploração e extracção de recursos minerais, petróleo e gás
       </description>
@@ -1650,7 +1650,7 @@
       <code>environment</code>
       <label>Ambiente</label>
       <description>Recursos ambientais, protecção e conservação da natureza. Exemplos: poluição,
-        armazenamento e tratamento de resíduos, avaliação de impactes ambientais, monitorização do
+        armazenamento e tratamento de resíduos, avaliação de impactos ambientais, monitoramento do
         risco ambiental, reservas naturais, paisagem
       </description>
     </entry>
@@ -1716,8 +1716,8 @@
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>planningCadastre</code>
-      <label>Planeamento e Cadastro</label>
-      <description>informação destinada ao planeamento do uso do território. Exemplos: mapas de uso
+      <label>Planejamento e Cadastro</label>
+      <description>informação destinada ao planejamento do uso do território. Exemplos: mapas de uso
         do solo, mapas de zonamento, levantamentos cadastrais, registo predial e rústico
       </description>
     </entry>
@@ -1734,7 +1734,7 @@
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>structure</code>
-      <label>Património Edificado</label>
+      <label>Patrimônio Edificado</label>
       <description>Construção desenvolvida pelo homem. Exemplos: edifícios, museus, igrejas,
         fábricas, habitação, monumentos, lojas
       </description>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/por/codelists.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/por/codelists.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="ISO-8859-1"?>
+<?xml version="1.0" encoding="UTF-8"?>
 <!--
   ~ Copyright (C) 2001-2016 Food and Agriculture Organization of the
   ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
@@ -27,19 +27,19 @@
   <codelist name="gmd:CI_DateTypeCode">
     <entry>
       <code>creation</code>
-      <label>Criação</label>
+      <label>CriaÃ§Ã£o</label>
       <description>A data identifica quando o recurso foi criado</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>publication</code>
-      <label>Publicação</label>
+      <label>PublicaÃ§Ã£o</label>
       <description>A data identifica quando o recurso foi emitido</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>revision</code>
-      <label>Revisão</label>
+      <label>RevisÃ£o</label>
       <description>A data identifica quando o recurso foi examinado ou re-examinado e melhorado ou
         retificado
       </description>
@@ -51,20 +51,20 @@
     <entry>
       <code>download</code>
       <label>Download</label>
-      <description>Instruções online para transferir dados duma memória ou sistema a uma outra
+      <description>InstruÃ§Ãµes online para transferir dados duma memÃ³ria ou sistema a uma outra
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>information</code>
-      <label>Informação</label>
-      <description>Informação online sobre o recurso</description>
+      <label>InformaÃ§Ã£o</label>
+      <description>InformaÃ§Ã£o online sobre o recurso</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>offlineAccess</code>
       <label>Acesso offline</label>
-      <description>Instruções online para solicitar o recurso do provider</description>
+      <description>InstruÃ§Ãµes online para solicitar o recurso do provider</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
@@ -76,7 +76,7 @@
     <entry>
       <code>search</code>
       <label>Pesquisa</label>
-      <description>Interface online de pesquisa para encontrar informação sobre o recurso
+      <description>Interface online de pesquisa para encontrar informaÃ§Ã£o sobre o recurso
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
@@ -86,41 +86,41 @@
     <entry>
       <code>documentDigital</code>
       <label>Documento digital</label>
-      <description>Visualização digital de um item principalmente escrito (também pode conter
-        ilustrações)
+      <description>VisualizaÃ§Ã£o digital de um item principalmente escrito (tambÃ©m pode conter
+        ilustraÃ§Ãµes)
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>imageDigital</code>
       <label>Imagem digital</label>
-      <description>Imagem de características, objectos e actividades naturais ou artificiais,
+      <description>Imagem de caracterÃ­sticas, objectos e actividades naturais ou artificiais,
         adquirido
-        pelo sensoriamento de espectro eletromagnético (tanto o segmento visível como os outros
+        pelo sensoriamento de espectro eletromagnÃ©tico (tanto o segmento visÃ­vel como os outros
         segmentos)
-        por sensores, tais como de infravermelho, e radar de alta resolução e afinal gravado num
+        por sensores, tais como de infravermelho, e radar de alta resoluÃ§Ã£o e afinal gravado num
         formato digital
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>documentHardcopy</code>
-      <label>Impressão de documento</label>
-      <description>Visualização dum item principalmente escrito (também possa conter ilustrações)
-        em papel, material fotográfico ou outras mídias
+      <label>ImpressÃ£o de documento</label>
+      <description>VisualizaÃ§Ã£o dum item principalmente escrito (tambÃ©m possa conter ilustraÃ§Ãµes)
+        em papel, material fotogrÃ¡fico ou outras mÃ­dias
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>imageHardcopy</code>
-      <label>Impressão de imagem</label>
-      <description>Imagem de características, objectos e actividades naturais ou artificiais,
+      <label>ImpressÃ£o de imagem</label>
+      <description>Imagem de caracterÃ­sticas, objectos e actividades naturais ou artificiais,
         adquirido
-        pelo sensoriamento de espectro eletromagnético (tanto o segmento visível como os outros
+        pelo sensoriamento de espectro eletromagnÃ©tico (tanto o segmento visÃ­vel como os outros
         segmentos)
-        por sensores, tais como de infravermelho, e radar de alta resolução e afinal reproduzido em
+        por sensores, tais como de infravermelho, e radar de alta resoluÃ§Ã£o e afinal reproduzido em
         papel,
-        material fotográfico ou outras mídias para o uso imediato pelo utilizador humano
+        material fotogrÃ¡fico ou outras mÃ­dias para o uso imediato pelo utilizador humano
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
@@ -132,8 +132,8 @@
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>mapHardcopy</code>
-      <label>Impressão de mapa</label>
-      <description>Mapa impresso em papel, material fotográfico ou outras mídias para
+      <label>ImpressÃ£o de mapa</label>
+      <description>Mapa impresso em papel, material fotogrÃ¡fico ou outras mÃ­dias para
         o uso imediato pelo utilizador humano
       </description>
     </entry>
@@ -141,54 +141,54 @@
     <entry>
       <code>modelDigital</code>
       <label>Modelo digital</label>
-      <description>Representação digital e multidimensional duma característica, dum processo,
+      <description>RepresentaÃ§Ã£o digital e multidimensional duma caracterÃ­stica, dum processo,
         etc.
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>modelHardcopy</code>
-      <label>Impressão de modelo</label>
-      <description>Modelo físico de três dimensões</description>
+      <label>ImpressÃ£o de modelo</label>
+      <description>Modelo fÃ­sico de trÃªs dimensÃµes</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>profileDigital</code>
       <label>Perfil digital</label>
-      <description>Secção plana em forma digital</description>
+      <description>SecÃ§Ã£o plana em forma digital</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>profileHardcopy</code>
-      <label>Impressão de perfil</label>
-      <description>Secção plana impressa em papel, etc.</description>
+      <label>ImpressÃ£o de perfil</label>
+      <description>SecÃ§Ã£o plana impressa em papel, etc.</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>tableDigital</code>
       <label>Tabela digital</label>
-      <description>Apresentação sistematica (em colunas) de factos ou números em forma digital
+      <description>ApresentaÃ§Ã£o sistematica (em colunas) de factos ou nÃºmeros em forma digital
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>tableHardcopy</code>
-      <label>Impressão de tabela</label>
-      <description>Apresentação sistematica (em colunas) de factos ou números
-        impressos em papel, material fotográfico ou outras mídias
+      <label>ImpressÃ£o de tabela</label>
+      <description>ApresentaÃ§Ã£o sistematica (em colunas) de factos ou nÃºmeros
+        impressos em papel, material fotogrÃ¡fico ou outras mÃ­dias
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>videoDigital</code>
-      <label>Vídeo digital</label>
-      <description>Gravação de vídeo digital</description>
+      <label>VÃ­deo digital</label>
+      <description>GravaÃ§Ã£o de vÃ­deo digital</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>videoHardcopy</code>
-      <label>Hardcopy de vídeo</label>
-      <description>Gravação de vídeo em filme</description>
+      <label>Hardcopy de vÃ­deo</label>
+      <description>GravaÃ§Ã£o de vÃ­deo em filme</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
   </codelist>
@@ -202,9 +202,9 @@
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>custodian</code>
-      <label>Depositário</label>
-      <description>Parte que assume a prestação de contas e a responsabilidade dos dados
-        e assegura o cuidado adequado, assim como a manutenção do recurso
+      <label>DepositÃ¡rio</label>
+      <description>Parte que assume a prestaÃ§Ã£o de contas e a responsabilidade dos dados
+        e assegura o cuidado adequado, assim como a manutenÃ§Ã£o do recurso
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
@@ -235,7 +235,7 @@
     <entry>
       <code>pointOfContact</code>
       <label>Ponto de contacto</label>
-      <description>Parte que pode ser contactado para obter conhecimento sobre (a aquisição) de
+      <description>Parte que pode ser contactado para obter conhecimento sobre (a aquisiÃ§Ã£o) de
         recurso
       </description>
     </entry>
@@ -243,7 +243,7 @@
     <entry>
       <code>principalInvestigator</code>
       <label>Investigador principal</label>
-      <description>Parte-chave que é responsável para colher informação e dirigir a pesquisa
+      <description>Parte-chave que Ã© responsÃ¡vel para colher informaÃ§Ã£o e dirigir a pesquisa
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
@@ -262,7 +262,7 @@
     <entry>
       <code>author</code>
       <label>Autor</label>
-      <description>Parte que é o autor do recurso</description>
+      <description>Parte que Ã© o autor do recurso</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
   </codelist>
@@ -270,28 +270,28 @@
   <codelist name="gmd:DQ_EvaluationMethodTypeCode">
     <entry>
       <code>directInternal</code>
-      <label>Avaliação directo interno</label>
-      <description>Método de avaliar a qualidade dum conjunto de dados, baseado em inspecções de
+      <label>AvaliaÃ§Ã£o directo interno</label>
+      <description>MÃ©todo de avaliar a qualidade dum conjunto de dados, baseado em inspecÃ§Ãµes de
         pormenores dentro
-        do conjunto de dados, de modo que não é necessário considerar dados de fora do conjunto
+        do conjunto de dados, de modo que nÃ£o Ã© necessÃ¡rio considerar dados de fora do conjunto
         avaliado
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>directExternal</code>
-      <label>Avaliação directo externo</label>
-      <description>Método de avaliar a qualidade dum conjunto de dados, baseado em inspecções de
+      <label>AvaliaÃ§Ã£o directo externo</label>
+      <description>MÃ©todo de avaliar a qualidade dum conjunto de dados, baseado em inspecÃ§Ãµes de
         pormenores dentro
-        do conjunto de dados, aqueles são avaliado através uma comparação com dados de referência
+        do conjunto de dados, aqueles sÃ£o avaliado atravÃ©s uma comparaÃ§Ã£o com dados de referÃªncia
         externos
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>indirect</code>
-      <label>Avaliação indirecto</label>
-      <description>Método de avaliação da qualidade dum conjunto de dados, baseado em conhecimento
+      <label>AvaliaÃ§Ã£o indirecto</label>
+      <description>MÃ©todo de avaliaÃ§Ã£o da qualidade dum conjunto de dados, baseado em conhecimento
         externo
       </description>
     </entry>
@@ -301,26 +301,26 @@
   <codelist name="gmd:DS_AssociationTypeCode" alias="associationType">
     <entry>
       <code>crossReference</code>
-      <label>Referência cruzada</label>
-      <description>Referência dum conjunto de dados a um outro</description>
+      <label>ReferÃªncia cruzada</label>
+      <description>ReferÃªncia dum conjunto de dados a um outro</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>largerWorkCitation</code>
-      <label>Citação dum trabalho maior</label>
-      <description>Referência a um conjunto de dados principal, naquele este faz parte</description>
+      <label>CitaÃ§Ã£o dum trabalho maior</label>
+      <description>ReferÃªncia a um conjunto de dados principal, naquele este faz parte</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>partOfSeamlessDatabase</code>
-      <label>Parte dum banco de dados inconsútil</label>
+      <label>Parte dum banco de dados inconsÃºtil</label>
       <description>Parte do mesmo banco de dados estruturado, mantido num computador</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>source</code>
       <label>Fonte</label>
-      <description>Informacões cartográficas e tabelares de quais o conteúdo de conjunto de dados
+      <description>InformacÃµes cartogrÃ¡ficas e tabelares de quais o conteÃºdo de conjunto de dados
         origina-se
       </description>
     </entry>
@@ -339,39 +339,39 @@
     <entry>
       <code>campaign</code>
       <label>Campanha</label>
-      <description>Série de acções organizadas e planejadas</description>
+      <description>SÃ©rie de acÃ§Ãµes organizadas e planejadas</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>collection</code>
-      <label>Colecção</label>
-      <description>Acumulação de conjuntos de dados, compostos para um propósito específico
+      <label>ColecÃ§Ã£o</label>
+      <description>AcumulaÃ§Ã£o de conjuntos de dados, compostos para um propÃ³sito especÃ­fico
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>exercise</code>
-      <label>Exercício</label>
-      <description>Performance específica duma função ou dum grupo de funções</description>
+      <label>ExercÃ­cio</label>
+      <description>Performance especÃ­fica duma funÃ§Ã£o ou dum grupo de funÃ§Ãµes</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>experiment</code>
       <label>Experimento</label>
-      <description>Processo desenhado para descobrir se alguma coisa é efectiva ou válida
+      <description>Processo desenhado para descobrir se alguma coisa Ã© efectiva ou vÃ¡lida
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>investigation</code>
-      <label>Investigação</label>
-      <description>Pesquisa ou inquérito sistemático</description>
+      <label>InvestigaÃ§Ã£o</label>
+      <description>Pesquisa ou inquÃ©rito sistemÃ¡tico</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>mission</code>
-      <label>Missão</label>
-      <description>Operação específica dum sistema de colecção dos dados</description>
+      <label>MissÃ£o</label>
+      <description>OperaÃ§Ã£o especÃ­fica dum sistema de colecÃ§Ã£o dos dados</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
@@ -382,49 +382,49 @@
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>operation</code>
-      <label>Operação</label>
-      <description>Acção que faz parte numa série das acções</description>
+      <label>OperaÃ§Ã£o</label>
+      <description>AcÃ§Ã£o que faz parte numa sÃ©rie das acÃ§Ãµes</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>platform</code>
       <label>Plataforma</label>
-      <description>Veículo ou outra base de apoio que dispõe dum sensor</description>
+      <description>VeÃ­culo ou outra base de apoio que dispÃµe dum sensor</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>process</code>
       <label>Processo</label>
-      <description>Método de fazer alguma coisa envolvendo uma série de passos</description>
+      <description>MÃ©todo de fazer alguma coisa envolvendo uma sÃ©rie de passos</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>program</code>
       <label>Programa</label>
-      <description>Actividade específica e planejada</description>
+      <description>Actividade especÃ­fica e planejada</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>project</code>
       <label>Projecto</label>
-      <description>Empreendimento, investigação ou desenvolvimento organizado/a</description>
+      <description>Empreendimento, investigaÃ§Ã£o ou desenvolvimento organizado/a</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>study</code>
       <label>Estudo</label>
-      <description>Examinação ou investigação</description>
+      <description>ExaminaÃ§Ã£o ou investigaÃ§Ã£o</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>task</code>
       <label>Tarefa</label>
-      <description>Peça de trabalho</description>
+      <description>PeÃ§a de trabalho</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>trial</code>
-      <label>Experiência</label>
+      <label>ExperiÃªncia</label>
       <description>Processo de teste para descobrir ou demonstrar alguma coisa</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
@@ -434,13 +434,13 @@
     <entry>
       <code>point</code>
       <label>Ponto</label>
-      <description>Cada célula representa um ponto</description>
+      <description>Cada cÃ©lula representa um ponto</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>area</code>
-      <label>Área</label>
-      <description>Cada célula representa uma área</description>
+      <label>Ãrea</label>
+      <description>Cada cÃ©lula representa uma Ã¡rea</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
   </codelist>
@@ -465,21 +465,21 @@
     <entry>
       <code>utf7</code>
       <label>UTF7</label>
-      <description>7-bit UCS Transfer Format de tamanho variável, baseado em ISO/IEC 10646
+      <description>7-bit UCS Transfer Format de tamanho variÃ¡vel, baseado em ISO/IEC 10646
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>utf8</code>
       <label>UTF8</label>
-      <description>8-bit UCS Transfer Format de tamanho variável, baseado em ISO/IEC 10646
+      <description>8-bit UCS Transfer Format de tamanho variÃ¡vel, baseado em ISO/IEC 10646
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>utf16</code>
       <label>UTF16</label>
-      <description>16-bit UCS Transfer Format de tamanho variável, baseado em ISO/IEC 10646
+      <description>16-bit UCS Transfer Format de tamanho variÃ¡vel, baseado em ISO/IEC 10646
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
@@ -658,34 +658,34 @@
   <codelist name="gmd:MD_ClassificationCode">
     <entry>
       <code>unclassified</code>
-      <label>Não classificado</label>
-      <description>Disponível para a divulgação geral</description>
+      <label>NÃ£o classificado</label>
+      <description>DisponÃ­vel para a divulgaÃ§Ã£o geral</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>restricted</code>
       <label>Restrito</label>
-      <description>Não para a divulgação geral</description>
+      <description>NÃ£o para a divulgaÃ§Ã£o geral</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>confidential</code>
       <label>Confidencial</label>
-      <description>Disponível para alguém, a quem informação pode ser confiada</description>
+      <description>DisponÃ­vel para alguÃ©m, a quem informaÃ§Ã£o pode ser confiada</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>secret</code>
       <label>Secreto</label>
       <description>Mantido ou destinado a ser mantido privado, desconhecido ou escondido de todos,
-        além dum grupo de pessoas seleccionadas
+        alÃ©m dum grupo de pessoas seleccionadas
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>topSecret</code>
       <label>Estritamente sigiloso</label>
-      <description>De altíssimo sigilo</description>
+      <description>De altÃ­ssimo sigilo</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
   </codelist>
@@ -694,23 +694,23 @@
     <entry>
       <code>image</code>
       <label>Imagem</label>
-      <description>Representação númerica elucidativa dum parâmetro físico,
-        que não é o valor actual do parâmetro físico
+      <description>RepresentaÃ§Ã£o nÃºmerica elucidativa dum parÃ¢metro fÃ­sico,
+        que nÃ£o Ã© o valor actual do parÃ¢metro fÃ­sico
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>thematicClassification</code>
-      <label>Classificação temática</label>
-      <description>Valor de código sem significado quantitativo, usado para representar uma
-        quantidade física
+      <label>ClassificaÃ§Ã£o temÃ¡tica</label>
+      <description>Valor de cÃ³digo sem significado quantitativo, usado para representar uma
+        quantidade fÃ­sica
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>physicalMeasurement</code>
-      <label>Medição física</label>
-      <description>Valor em unidades físicas da quantidade medida</description>
+      <label>MediÃ§Ã£o fÃ­sica</label>
+      <description>Valor em unidades fÃ­sicas da quantidade medida</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
   </codelist>
@@ -720,84 +720,84 @@
       <code>class</code>
       <label>Classe</label>
       <description>Descriptor dum conjunto de objctivos que partilham os mesmos
-        atributos, operações, métodos, relações e comportamento
+        atributos, operaÃ§Ãµes, mÃ©todos, relaÃ§Ãµes e comportamento
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>codelist</code>
-      <label>Lista de códigos</label>
+      <label>Lista de cÃ³digos</label>
       <description>Descriptor dum conjunto de objctivos que partilham os mesmos
-        atributos, operações, métodos, relações e comportamento
+        atributos, operaÃ§Ãµes, mÃ©todos, relaÃ§Ãµes e comportamento
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>enumeration</code>
-      <label>Numeração</label>
-      <description>Tipo de dados cujos casos formam uma lista de valores nomeados e literais, não
-        extensíveis
+      <label>NumeraÃ§Ã£o</label>
+      <description>Tipo de dados cujos casos formam uma lista de valores nomeados e literais, nÃ£o
+        extensÃ­veis
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>codelistElement</code>
-      <label>Elemento da lista de códigos</label>
-      <description>Valor permissível para uma lista de códigos ou uma numeração</description>
+      <label>Elemento da lista de cÃ³digos</label>
+      <description>Valor permissÃ­vel para uma lista de cÃ³digos ou uma numeraÃ§Ã£o</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>abstractClass</code>
       <label>Classe abstracta</label>
-      <description>Classe que não pode ser instanciado directamente</description>
+      <description>Classe que nÃ£o pode ser instanciado directamente</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>aggregateClass</code>
       <label>Classe agregada</label>
-      <description>Classe composta por classes, a quais é ligado por uma relação de agregação
+      <description>Classe composta por classes, a quais Ã© ligado por uma relaÃ§Ã£o de agregaÃ§Ã£o
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>specifiedClass</code>
-      <label>Classe específicada</label>
+      <label>Classe especÃ­ficada</label>
       <description>Subclasse que possa substituir a sua superclasse</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>datatypeClass</code>
       <label>Classe de tipo de dados</label>
-      <description>Classe com poucas ou sem operações, cujas função principal é manter o estado
+      <description>Classe com poucas ou sem operaÃ§Ãµes, cujas funÃ§Ã£o principal Ã© manter o estado
         abstracto
-        duma outra classe, para transmissão, armazenamento, codificação ou armazenamento persistente
+        duma outra classe, para transmissÃ£o, armazenamento, codificaÃ§Ã£o ou armazenamento persistente
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>interfaceClass</code>
       <label>Classe de interface</label>
-      <description>Conjunto nomeado de operações que caracterizam o comportamento dum elemento
+      <description>Conjunto nomeado de operaÃ§Ãµes que caracterizam o comportamento dum elemento
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>unionClass</code>
-      <label>Classe de união</label>
-      <description>Classe que descreve uma selecção de um dos tipos específicados</description>
+      <label>Classe de uniÃ£o</label>
+      <description>Classe que descreve uma selecÃ§Ã£o de um dos tipos especÃ­ficados</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>metaClass</code>
       <label>Meta-classe</label>
-      <description>Classe cujas casos são classes</description>
+      <description>Classe cujas casos sÃ£o classes</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>typeClass</code>
       <label>Classe de tipos</label>
-      <description>Classe usada para a específicação dum âmbito de casos (objectos), é aplicável aos
-        objectos em conjunto com as operações. Um tipo possa ter atributos e associacões
+      <description>Classe usada para a especÃ­ficaÃ§Ã£o dum Ã¢mbito de casos (objectos), Ã© aplicÃ¡vel aos
+        objectos em conjunto com as operaÃ§Ãµes. Um tipo possa ter atributos e associacÃµes
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
@@ -809,14 +809,14 @@
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>integer</code>
-      <label>Número inteiro</label>
-      <description>Campo númerico</description>
+      <label>NÃºmero inteiro</label>
+      <description>Campo nÃºmerico</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>association</code>
-      <label>Associação</label>
-      <description>Relação semântica entre duas classes, aquela envolve ligações entre seus casos
+      <label>AssociaÃ§Ã£o</label>
+      <description>RelaÃ§Ã£o semÃ¢ntica entre duas classes, aquela envolve ligaÃ§Ãµes entre seus casos
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
@@ -843,14 +843,14 @@
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>track</code>
-      <label>Traço</label>
-      <description>Ao longo da direcção de movimento do ponto de scan</description>
+      <label>TraÃ§o</label>
+      <description>Ao longo da direcÃ§Ã£o de movimento do ponto de scan</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>crossTrack</code>
-      <label>Traço cruzado</label>
-      <description>Perpendicular ao direcção de movimento do ponto de scan</description>
+      <label>TraÃ§o cruzado</label>
+      <description>Perpendicular ao direcÃ§Ã£o de movimento do ponto de scan</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
@@ -861,14 +861,14 @@
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>sample</code>
-      <label>Apalpação</label>
+      <label>ApalpaÃ§Ã£o</label>
       <description>Elemento ao longo duma linha de scan</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>time</code>
       <label>Tempo</label>
-      <description>Duração</description>
+      <description>DuraÃ§Ã£o</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
   </codelist>
@@ -877,47 +877,47 @@
     <entry>
       <code>complex</code>
       <label>Complexo</label>
-      <description>Conjunto de 'primitivos geométricos' (geometric primitives) tal que os limites
+      <description>Conjunto de 'primitivos geomÃ©tricos' (geometric primitives) tal que os limites
         deles podem ser
-        representado como uma união de outros 'primitivos'
+        representado como uma uniÃ£o de outros 'primitivos'
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>composite</code>
-      <label>Composição</label>
-      <description>Conjunto conectado de curvas, sólidos ou superfícies</description>
+      <label>ComposiÃ§Ã£o</label>
+      <description>Conjunto conectado de curvas, sÃ³lidos ou superfÃ­cies</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>curve</code>
       <label>Curva</label>
-      <description>'Primitivo geométrico' limitado e monodimensional, a representar a imagem
-        contínua duma linha
+      <description>'Primitivo geomÃ©trico' limitado e monodimensional, a representar a imagem
+        contÃ­nua duma linha
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>point</code>
       <label>Ponto</label>
-      <description>'Primitivo geométrico' sem dimensão, a representar uma posição, sem ter uma
-        expansão
+      <description>'Primitivo geomÃ©trico' sem dimensÃ£o, a representar uma posiÃ§Ã£o, sem ter uma
+        expansÃ£o
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>solid</code>
-      <label>Sólido</label>
-      <description>'Primitivo geométrico' limitado, conectado e tridimensional,
-        a representar a imagem contínua duma região de espaço
+      <label>SÃ³lido</label>
+      <description>'Primitivo geomÃ©trico' limitado, conectado e tridimensional,
+        a representar a imagem contÃ­nua duma regiÃ£o de espaÃ§o
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>surface</code>
-      <label>Superfície</label>
-      <description>'Primitivo geométrico' limitado, conectado e bidimensional,
-        a representar a imagem contínua duma região de plano
+      <label>SuperfÃ­cie</label>
+      <description>'Primitivo geomÃ©trico' limitado, conectado e bidimensional,
+        a representar a imagem contÃ­nua duma regiÃ£o de plano
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
@@ -927,19 +927,19 @@
     <entry>
       <code>blurredImage</code>
       <label>Imagem desfocada</label>
-      <description>Porcão da foto é desfocada</description>
+      <description>PorcÃ£o da foto Ã© desfocada</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>cloud</code>
       <label>Nuvem</label>
-      <description>A foto é parcialmente coberta por nuvens</description>
+      <description>A foto Ã© parcialmente coberta por nuvens</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>degradingObliquity</code>
       <label>Obliquidade degradando</label>
-      <description>Ângulo agudo entre o plano da eclíptica (plano da órbita da terra) e o plano do
+      <description>Ã‚ngulo agudo entre o plano da eclÃ­ptica (plano da Ã³rbita da terra) e o plano do
         equador celeste
       </description>
     </entry>
@@ -947,13 +947,13 @@
     <entry>
       <code>fog</code>
       <label>Nevoeiro</label>
-      <description>A foto é parcialmente coberta por nevoeiro</description>
+      <description>A foto Ã© parcialmente coberta por nevoeiro</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>heavySmokeOrDust</code>
-      <label>Fumaça ou pó</label>
-      <description>A foto é parcialmente coberta por fumaça ou pó</description>
+      <label>FumaÃ§a ou pÃ³</label>
+      <description>A foto Ã© parcialmente coberta por fumaÃ§a ou pÃ³</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
@@ -977,20 +977,20 @@
     <entry>
       <code>shadow</code>
       <label>Sombra</label>
-      <description>A foto é parcialmente coberta por sombra</description>
+      <description>A foto Ã© parcialmente coberta por sombra</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>snow</code>
       <label>Neve</label>
-      <description>A foto é parcialmente coberta por neve</description>
+      <description>A foto Ã© parcialmente coberta por neve</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>terrainMasking</code>
       <label>Cobertura de relevo</label>
-      <description>A ausência de dados coligidos dum ponto ou duma área dado, causado pela
-        localização relativa de características topográficas, quais obstruem
+      <description>A ausÃªncia de dados coligidos dum ponto ou duma Ã¡rea dado, causado pela
+        localizaÃ§Ã£o relativa de caracterÃ­sticas topogrÃ¡ficas, quais obstruem
         o atalho de recolha entre o(s) colector(es) e o(s) sujeito(s) de interesse
       </description>
     </entry>
@@ -1001,27 +1001,27 @@
     <entry>
       <code>discipline</code>
       <label>Disciplina</label>
-      <description>Palavra-chave identifica um ramo de instrução ou aprendizagem especilizada
+      <description>Palavra-chave identifica um ramo de instruÃ§Ã£o ou aprendizagem especilizada
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>place</code>
       <label>Lugar</label>
-      <description>Palavra-chave identifica uma localização</description>
+      <description>Palavra-chave identifica uma localizaÃ§Ã£o</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>stratum</code>
       <label>Estrato</label>
-      <description>Palavra-chave identifica a(s) camada(s) de qualquer substância depositada
+      <description>Palavra-chave identifica a(s) camada(s) de qualquer substÃ¢ncia depositada
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>temporal</code>
       <label>Temporal</label>
-      <description>Palavra-chave identifica um período relacionado ao conjunto de dados
+      <description>Palavra-chave identifica um perÃ­odo relacionado ao conjunto de dados
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
@@ -1036,74 +1036,74 @@
   <codelist name="gmd:MD_MaintenanceFrequencyCode">
     <entry>
       <code>continual</code>
-      <label>Contínuo</label>
-      <description>Os dados são actualizados repetidamente e frequentemente</description>
+      <label>ContÃ­nuo</label>
+      <description>Os dados sÃ£o actualizados repetidamente e frequentemente</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>daily</code>
-      <label>Diário</label>
-      <description>Os dados são actualizados todos os dias</description>
+      <label>DiÃ¡rio</label>
+      <description>Os dados sÃ£o actualizados todos os dias</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>weekly</code>
       <label>Semanal</label>
-      <description>Os dados são actualizados uma vez por semana</description>
+      <description>Os dados sÃ£o actualizados uma vez por semana</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>fortnightly</code>
       <label>Quinzenal</label>
-      <description>Os dados são actualizados de duas em duas semanas</description>
+      <description>Os dados sÃ£o actualizados de duas em duas semanas</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>monthly</code>
       <label>Mensal</label>
-      <description>Os dados são actualizados uma vez por mês</description>
+      <description>Os dados sÃ£o actualizados uma vez por mÃªs</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>quarterly</code>
       <label>Trimestral</label>
-      <description>Os dados são actualizados de três em três meses</description>
+      <description>Os dados sÃ£o actualizados de trÃªs em trÃªs meses</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>biannually</code>
       <label>Semestral</label>
-      <description>Os dados são actualizados duas vezes por ano</description>
+      <description>Os dados sÃ£o actualizados duas vezes por ano</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>annually</code>
       <label>Anual</label>
-      <description>Os dados são actualizados uma vez por ano</description>
+      <description>Os dados sÃ£o actualizados uma vez por ano</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>asNeeded</code>
-      <label>Quando necessário</label>
-      <description>Os dados são actualizados quando é considerado como necessário</description>
+      <label>Quando necessÃ¡rio</label>
+      <description>Os dados sÃ£o actualizados quando Ã© considerado como necessÃ¡rio</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>irregular</code>
       <label>Irregular</label>
-      <description>Os dados são actualizados em intervalos alternantes</description>
+      <description>Os dados sÃ£o actualizados em intervalos alternantes</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>notPlanned</code>
-      <label>Não planejado</label>
-      <description>Não há planos para actualizar os dados</description>
+      <label>NÃ£o planejado</label>
+      <description>NÃ£o hÃ¡ planos para actualizar os dados</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>unknown</code>
       <label>Desconhecido</label>
-      <description>A frequência da manutenção de dados é desconhecida</description>
+      <description>A frequÃªncia da manutenÃ§Ã£o de dados Ã© desconhecida</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
   </codelist>
@@ -1235,25 +1235,25 @@
     <entry>
       <code>onLine</code>
       <label>Online</label>
-      <description>Ligação directa de computador</description>
+      <description>LigaÃ§Ã£o directa de computador</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>satellite</code>
-      <label>Satélite</label>
-      <description>Ligação por uma sistema de comunicação de satélite</description>
+      <label>SatÃ©lite</label>
+      <description>LigaÃ§Ã£o por uma sistema de comunicaÃ§Ã£o de satÃ©lite</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>telephoneLink</code>
       <label>Telefone</label>
-      <description>Comunicação por uma rede de telefone</description>
+      <description>ComunicaÃ§Ã£o por uma rede de telefone</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>hardcopy</code>
-      <label>Cópia</label>
-      <description>Brochura ou folheto contém informação descritiva</description>
+      <label>CÃ³pia</label>
+      <description>Brochura ou folheto contÃ©m informaÃ§Ã£o descritiva</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
   </codelist>
@@ -1261,20 +1261,20 @@
   <codelist name="gmd:MD_ObligationCode">
     <entry>
       <code>mandatory</code>
-      <label>Obrigatório</label>
-      <description>O elemento é sempre necessário</description>
+      <label>ObrigatÃ³rio</label>
+      <description>O elemento Ã© sempre necessÃ¡rio</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>optional</code>
       <label>Opcional</label>
-      <description>O elemento não é obrigatório</description>
+      <description>O elemento nÃ£o Ã© obrigatÃ³rio</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>conditional</code>
       <label>Condicional</label>
-      <description>O elemento necessário quando uma condição específica ocorrer</description>
+      <description>O elemento necessÃ¡rio quando uma condiÃ§Ã£o especÃ­fica ocorrer</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
   </codelist>
@@ -1291,32 +1291,32 @@
     <entry>
       <code>lowerLeft</code>
       <label>Inferior esquerdo</label>
-      <description>O canto do pixel mais perto da origem de SRS; se há dois na
-        mesma distância da origem, seria aquele com o valor menor de x
+      <description>O canto do pixel mais perto da origem de SRS; se hÃ¡ dois na
+        mesma distÃ¢ncia da origem, seria aquele com o valor menor de x
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>lowerRight</code>
       <label>Inferior direito</label>
-      <description>O canto a seguir àquele inferior esquerdo no sentido contrário dos ponteiros do
-        relógio
+      <description>O canto a seguir Ã quele inferior esquerdo no sentido contrÃ¡rio dos ponteiros do
+        relÃ³gio
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>upperRight</code>
       <label>Superior direito</label>
-      <description>O canto a seguir àquele inferior direito no sentido contrário dos ponteiros do
-        relógio
+      <description>O canto a seguir Ã quele inferior direito no sentido contrÃ¡rio dos ponteiros do
+        relÃ³gio
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>upperLeft</code>
       <label>Superior esquerdo</label>
-      <description>O canto a seguir àquele superior direito no sentido contrário dos ponteiros do
-        relógio
+      <description>O canto a seguir Ã quele superior direito no sentido contrÃ¡rio dos ponteiros do
+        relÃ³gio
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
@@ -1325,46 +1325,46 @@
   <codelist name="gmd:MD_ProgressCode">
     <entry>
       <code>completed</code>
-      <label>Concluído</label>
-      <description>Produção dos dados concluída</description>
+      <label>ConcluÃ­do</label>
+      <description>ProduÃ§Ã£o dos dados concluÃ­da</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>historicalArchive</code>
       <label>Arquivo antigo</label>
-      <description>Os dados foram gravados numa instalação de armazenamento offline</description>
+      <description>Os dados foram gravados numa instalaÃ§Ã£o de armazenamento offline</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>obsolete</code>
       <label>Obsoleto</label>
-      <description>Os dados não são mais relevantes</description>
+      <description>Os dados nÃ£o sÃ£o mais relevantes</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>onGoing</code>
-      <label>Contínuo</label>
-      <description>Os dados são actualizados continuamente</description>
+      <label>ContÃ­nuo</label>
+      <description>Os dados sÃ£o actualizados continuamente</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>planned</code>
       <label>Planejado</label>
-      <description>Data fixa estabelecida, a partir da qual, os dados foram ou serão criados ou
+      <description>Data fixa estabelecida, a partir da qual, os dados foram ou serÃ£o criados ou
         actualizados
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>required</code>
-      <label>Necessário</label>
+      <label>NecessÃ¡rio</label>
       <description>Os dados precisam de ser gerado ou actualizado</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>underDevelopment</code>
       <label>Em desenvolvimento</label>
-      <description>Os dados estão no processo de criação</description>
+      <description>Os dados estÃ£o no processo de criaÃ§Ã£o</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
   </codelist>
@@ -1372,11 +1372,11 @@
   <codelist name="gmd:MD_RestrictionCode">
     <entry>
       <code>copyright</code>
-      <label>Direitos de reprodução</label>
-      <description>Direitos em exlusivo à publicação, produção ou venda dos direitos para uma
-        obra literária, dramática, musical ou artística, ou para o uso numa impressão comercial ou
-        num rótulo,
-        são concedido pela lei a um autor, compositor, artista ou distribuidor durante um período
+      <label>Direitos de reproduÃ§Ã£o</label>
+      <description>Direitos em exlusivo Ã  publicaÃ§Ã£o, produÃ§Ã£o ou venda dos direitos para uma
+        obra literÃ¡ria, dramÃ¡tica, musical ou artÃ­stica, ou para o uso numa impressÃ£o comercial ou
+        num rÃ³tulo,
+        sÃ£o concedido pela lei a um autor, compositor, artista ou distribuidor durante um perÃ­odo
         especificado
       </description>
     </entry>
@@ -1385,49 +1385,49 @@
       <code>patent</code>
       <label>Patente</label>
       <description>O governo concedeu o direito exclusivo para fazer, vender, usar
-        ou dar licenças (d)uma invenção ou descoberta
+        ou dar licenÃ§as (d)uma invenÃ§Ã£o ou descoberta
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>patentPending</code>
       <label>Patente pendente</label>
-      <description>Informação produzida ou vendida a espera duma patente</description>
+      <description>InformaÃ§Ã£o produzida ou vendida a espera duma patente</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>trademark</code>
       <label>Marca registada</label>
-      <description>Um nome, símbolo ou uma outra marca que identifica um produto; registado
+      <description>Um nome, sÃ­mbolo ou uma outra marca que identifica um produto; registado
         oficialmente
-        e restrito legalmente ao uso pelo proprietário ou fabricante
+        e restrito legalmente ao uso pelo proprietÃ¡rio ou fabricante
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>license</code>
-      <label>Licença</label>
-      <description>Permissão formal para fazer alguma coisa</description>
+      <label>LicenÃ§a</label>
+      <description>PermissÃ£o formal para fazer alguma coisa</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>intellectualPropertyRights</code>
       <label>Direitos de propriedade intelectual</label>
-      <description>Direitos de controlar a distribuição e lucrar financeiramente de
-        propriedade não-palpável que é um resultado de criatividade
+      <description>Direitos de controlar a distribuiÃ§Ã£o e lucrar financeiramente de
+        propriedade nÃ£o-palpÃ¡vel que Ã© um resultado de criatividade
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>restricted</code>
       <label>Restrito</label>
-      <description>Retido da circulação ou divulgação geral</description>
+      <description>Retido da circulaÃ§Ã£o ou divulgaÃ§Ã£o geral</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>otherRestrictions</code>
-      <label>Outras restrições</label>
-      <description>Limitação não listado</description>
+      <label>Outras restriÃ§Ãµes</label>
+      <description>LimitaÃ§Ã£o nÃ£o listado</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
   </codelist>
@@ -1436,85 +1436,85 @@
     <entry>
       <code>attribute</code>
       <label>Atributo</label>
-      <description>Informação aplica-se à classe de atributos</description>
+      <description>InformaÃ§Ã£o aplica-se Ã  classe de atributos</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>attributeType</code>
       <label>Tipo de atributo</label>
-      <description>Informação aplica-se à particularidade duma característica</description>
+      <description>InformaÃ§Ã£o aplica-se Ã  particularidade duma caracterÃ­stica</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>collectionHardware</code>
-      <label>Hardware de colecção</label>
-      <description>Informação aplica-se à classe de hardware de colecção</description>
+      <label>Hardware de colecÃ§Ã£o</label>
+      <description>InformaÃ§Ã£o aplica-se Ã  classe de hardware de colecÃ§Ã£o</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>collectionSession</code>
-      <label>Sessão de colecçõ</label>
-      <description>Informação aplica-se à sessão de colecçõ</description>
+      <label>SessÃ£o de colecÃ§Ãµ</label>
+      <description>InformaÃ§Ã£o aplica-se Ã  sessÃ£o de colecÃ§Ãµ</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>dataset</code>
       <label>Conjunto de dados</label>
-      <description>Informação aplica-se ao conjunto de dados</description>
+      <description>InformaÃ§Ã£o aplica-se ao conjunto de dados</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>series</code>
-      <label>Série</label>
-      <description>Informação aplica-se à série</description>
+      <label>SÃ©rie</label>
+      <description>InformaÃ§Ã£o aplica-se Ã  sÃ©rie</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>nonGeographicDataset</code>
-      <label>Conjunto de dados não-geográficos</label>
-      <description>Informação aplica-se a dados não-geográficos</description>
+      <label>Conjunto de dados nÃ£o-geogrÃ¡ficos</label>
+      <description>InformaÃ§Ã£o aplica-se a dados nÃ£o-geogrÃ¡ficos</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>dimensionGroup</code>
-      <label>Grupo de dimensão</label>
-      <description>Informação aplica-se a um grupo de dimensão</description>
+      <label>Grupo de dimensÃ£o</label>
+      <description>InformaÃ§Ã£o aplica-se a um grupo de dimensÃ£o</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>feature</code>
-      <label>Característica</label>
-      <description>Informação aplica-se a uma característica</description>
+      <label>CaracterÃ­stica</label>
+      <description>InformaÃ§Ã£o aplica-se a uma caracterÃ­stica</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>featureType</code>
-      <label>Tipo de característica</label>
-      <description>Informação aplica-se a feature type</description>
+      <label>Tipo de caracterÃ­stica</label>
+      <description>InformaÃ§Ã£o aplica-se a feature type</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>propertyType</code>
       <label>Tipo de propriedade</label>
-      <description>Informação aplica-se a um tipo de propriedade</description>
+      <description>InformaÃ§Ã£o aplica-se a um tipo de propriedade</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>fieldSession</code>
-      <label>Sessão de campo</label>
-      <description>Informação aplica-se a uma sessão de campo</description>
+      <label>SessÃ£o de campo</label>
+      <description>InformaÃ§Ã£o aplica-se a uma sessÃ£o de campo</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>software</code>
       <label>Software</label>
-      <description>Informação aplica-se a uma programa ou rotina de computador</description>
+      <description>InformaÃ§Ã£o aplica-se a uma programa ou rotina de computador</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>service</code>
-      <label>Serviço</label>
-      <description>Informação aplica-se a uma capacidade, qual um provedor de acesso à Internet
+      <label>ServiÃ§o</label>
+      <description>InformaÃ§Ã£o aplica-se a uma capacidade, qual um provedor de acesso Ã  Internet
         disponibiliza
         a um utilizador por um conjunto de interfaces, que define um comportamento, tal como um caso
         de uso
@@ -1524,14 +1524,14 @@
     <entry>
       <code>model</code>
       <label>Modelo</label>
-      <description>Informação aplica-se a uma cópia ou imitaçõ dum objecto existente ou hipotético
+      <description>InformaÃ§Ã£o aplica-se a uma cÃ³pia ou imitaÃ§Ãµ dum objecto existente ou hipotÃ©tico
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>tile</code>
       <label>Tile</label>
-      <description>Informação aplica-se a um 'tile', um subconjunto espacial de dados geográficos
+      <description>InformaÃ§Ã£o aplica-se a um 'tile', um subconjunto espacial de dados geogrÃ¡ficos
       </description>
     </entry>
 
@@ -1558,19 +1558,19 @@
     <entry>
       <code>vector</code>
       <label>Vector</label>
-      <description>Informação vectorial é usada para representar informação geográfica</description>
+      <description>InformaÃ§Ã£o vectorial Ã© usada para representar informaÃ§Ã£o geogrÃ¡fica</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>grid</code>
       <label>Grid</label>
-      <description>Informação matricial é usada para representar informação geográfica</description>
+      <description>InformaÃ§Ã£o matricial Ã© usada para representar informaÃ§Ã£o geogrÃ¡fica</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>textTable</code>
       <label>Tabela de texto</label>
-      <description>Dados textuais ou tabelares são usados para representar informação geográfica
+      <description>Dados textuais ou tabelares sÃ£o usados para representar informaÃ§Ã£o geogrÃ¡fica
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
@@ -1582,16 +1582,16 @@
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>stereoModel</code>
-      <label>Modelo estereofônico</label>
-      <description>Vista tridimensional, que é formada pelos reios homólogos intersectandos
+      <label>Modelo estereofÃ´nico</label>
+      <description>Vista tridimensional, que Ã© formada pelos reios homÃ³logos intersectandos
         dum par de imagens sobrepostos
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>video</code>
-      <label>Vídeo</label>
-      <description>Cena duma gravação de vídeo</description>
+      <label>VÃ­deo</label>
+      <description>Cena duma gravaÃ§Ã£o de vÃ­deo</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
   </codelist>
@@ -1599,9 +1599,9 @@
   <codelist name="gmd:MD_TopicCategoryCode" alias="topicCategory">
     <entry>
       <code>farming</code>
-      <label>Agricultura, Pesca, Pecuária</label>
-      <description>Criação de animais e/ou cultivo de espécies vegetais. Exemplos: agricultura,
-        irrigação, aquacultura, plantações, pecuária, pestes e doenças que afectam as colheitas e o
+      <label>Agricultura, Pesca, PecuÃ¡ria</label>
+      <description>CriaÃ§Ã£o de animais e/ou cultivo de espÃ©cies vegetais. Exemplos: agricultura,
+        irrigaÃ§Ã£o, aquacultura, plantaÃ§Ãµes, pecuÃ¡ria, pestes e doenÃ§as que afectam as colheitas e o
         gado
       </description>
     </entry>
@@ -1609,39 +1609,39 @@
     <entry>
       <code>biota</code>
       <label>Biota</label>
-      <description>Fauna e flora em habitat natural. Exemplos: vida selvagem, vegetação, ciências
-        biológicas, ecologia, desertos, vida marinha, zonas húmidas, habitat
+      <description>Fauna e flora em habitat natural. Exemplos: vida selvagem, vegetaÃ§Ã£o, ciÃªncias
+        biolÃ³gicas, ecologia, desertos, vida marinha, zonas hÃºmidas, habitat
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>boundaries</code>
       <label>Limites Administrativos</label>
-      <description>Limites legais do território. Exemplos: fronteiras administrativas e políticas
+      <description>Limites legais do territÃ³rio. Exemplos: fronteiras administrativas e polÃ­ticas
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>climatologyMeteorologyAtmosphere</code>
       <label>Climatologia, Atmosfera</label>
-      <description>Processos e fenômenos atmosféricos. Exemplos: nebulosidade, estado do tempo,
-        clima, condições atmosféricas, alterações climáticas, precipitação
+      <description>Processos e fenÃ´menos atmosfÃ©ricos. Exemplos: nebulosidade, estado do tempo,
+        clima, condiÃ§Ãµes atmosfÃ©ricas, alteraÃ§Ãµes climÃ¡ticas, precipitaÃ§Ã£o
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>economy</code>
       <label>Economia</label>
-      <description>Actividades econômicas e emprego. Exemplos: produção, emprego, rendimentos,
-        comércio, indústria, turismo e eco-turismo, florestas, pescas, caça para fins comerciais ou
-        de subsistência, exploração e extracção de recursos minerais, petróleo e gás
+      <description>Actividades econÃ´micas e emprego. Exemplos: produÃ§Ã£o, emprego, rendimentos,
+        comÃ©rcio, indÃºstria, turismo e eco-turismo, florestas, pescas, caÃ§a para fins comerciais ou
+        de subsistÃªncia, exploraÃ§Ã£o e extracÃ§Ã£o de recursos minerais, petrÃ³leo e gÃ¡s
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>elevation</code>
       <label>Altimetria, Batimetria</label>
-      <description>Elevação abaixo ou acima do nível do mar. Exemplos: altitude, batimetria, modelos
+      <description>ElevaÃ§Ã£o abaixo ou acima do nÃ­vel do mar. Exemplos: altitude, batimetria, modelos
         digitais do terreno, declives e produtos derivados
       </description>
     </entry>
@@ -1649,114 +1649,114 @@
     <entry>
       <code>environment</code>
       <label>Ambiente</label>
-      <description>Recursos ambientais, protecção e conservação da natureza. Exemplos: poluição,
-        armazenamento e tratamento de resíduos, avaliação de impactos ambientais, monitoramento do
+      <description>Recursos ambientais, protecÃ§Ã£o e conservaÃ§Ã£o da natureza. Exemplos: poluiÃ§Ã£o,
+        armazenamento e tratamento de resÃ­duos, avaliaÃ§Ã£o de impactos ambientais, monitoramento do
         risco ambiental, reservas naturais, paisagem
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>geoscientificInformation</code>
-      <label>Informação geocientífica</label>
-      <description>Informação relativa às ciências da terra. Exemplos: aspectos e processos
-        geofísicos, geologia, minerais, sismicidade, actividade vulcânica, derrocadas, informação
-        gravimétrica, solos, permafrost, hidrogeologia e erosão
+      <label>InformaÃ§Ã£o geocientÃ­fica</label>
+      <description>InformaÃ§Ã£o relativa Ã s ciÃªncias da terra. Exemplos: aspectos e processos
+        geofÃ­sicos, geologia, minerais, sismicidade, actividade vulcÃ¢nica, derrocadas, informaÃ§Ã£o
+        gravimÃ©trica, solos, permafrost, hidrogeologia e erosÃ£o
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>health</code>
-      <label>Saúde</label>
-      <description>Saúde, serviços de saúde, ecologia humana e segurança. Exemplos: doenças,
-        factores condicionantes da saúde, higiene, abuso de substâncias, saúde física e mental,
-        serviços de saúde
+      <label>SaÃºde</label>
+      <description>SaÃºde, serviÃ§os de saÃºde, ecologia humana e seguranÃ§a. Exemplos: doenÃ§as,
+        factores condicionantes da saÃºde, higiene, abuso de substÃ¢ncias, saÃºde fÃ­sica e mental,
+        serviÃ§os de saÃºde
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>imageryBaseMapsEarthCover</code>
-      <label>Mapas de base, Coberturas Aéreas, imagens de Satélite</label>
-      <description>cartografia de base. Exemplos: mapas topográficos, imagens de satélite,
-        coberturas aero-fotográficas
+      <label>Mapas de base, Coberturas AÃ©reas, imagens de SatÃ©lite</label>
+      <description>cartografia de base. Exemplos: mapas topogrÃ¡ficos, imagens de satÃ©lite,
+        coberturas aero-fotogrÃ¡ficas
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>intelligenceMilitary</code>
-      <label>Informação militar</label>
+      <label>InformaÃ§Ã£o militar</label>
       <description>Bases, estruturas e actividades militares. Exemplos: campos de treino,
-        transportes militares, quartéis, casernas
+        transportes militares, quartÃ©is, casernas
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>inlandWaters</code>
-      <label>Águas interiores</label>
-      <description>Entidades relativas a águas interiores, sistemas de drenagem e suas
-        características. Exemplos: rios, glaciares, lagos salgados, planos de gestão da água,
-        diques, correntes, cheias, qualidade da água, aspectos hidrográficos
+      <label>Ãguas interiores</label>
+      <description>Entidades relativas a Ã¡guas interiores, sistemas de drenagem e suas
+        caracterÃ­sticas. Exemplos: rios, glaciares, lagos salgados, planos de gestÃ£o da Ã¡gua,
+        diques, correntes, cheias, qualidade da Ã¡gua, aspectos hidrogrÃ¡ficos
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>location</code>
-      <label>Localização</label>
-      <description>Informação e serviços de localização. Exemplos: moradas, redes geodésicas, pontos
-        de controlo, zonas postais e serviços, designações de lugares
+      <label>LocalizaÃ§Ã£o</label>
+      <description>InformaÃ§Ã£o e serviÃ§os de localizaÃ§Ã£o. Exemplos: moradas, redes geodÃ©sicas, pontos
+        de controlo, zonas postais e serviÃ§os, designaÃ§Ãµes de lugares
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>oceans</code>
       <label>Oceanos</label>
-      <description>Entidades e características dos corpos de água salgada (excluindo águas
-        interiores). Exemplos: marés, ondulação e vagas, informação costeira, recifes e baixios
+      <description>Entidades e caracterÃ­sticas dos corpos de Ã¡gua salgada (excluindo Ã¡guas
+        interiores). Exemplos: marÃ©s, ondulaÃ§Ã£o e vagas, informaÃ§Ã£o costeira, recifes e baixios
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>planningCadastre</code>
       <label>Planejamento e Cadastro</label>
-      <description>informação destinada ao planejamento do uso do território. Exemplos: mapas de uso
-        do solo, mapas de zonamento, levantamentos cadastrais, registo predial e rústico
+      <description>informaÃ§Ã£o destinada ao planejamento do uso do territÃ³rio. Exemplos: mapas de uso
+        do solo, mapas de zonamento, levantamentos cadastrais, registo predial e rÃºstico
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>society</code>
       <label>Sociedade e Cultura</label>
-      <description>Características sociais e culturais. Exemplos: residências e estabelecimentos,
-        antropologia, arqueologia, educação, crenças tradicionais, hábitos e costumes, dados
-        demográficos, áreas e actividades recreacionais, avaliação de impactos sociais, crime e
-        justiça, informação dos censos
+      <description>CaracterÃ­sticas sociais e culturais. Exemplos: residÃªncias e estabelecimentos,
+        antropologia, arqueologia, educaÃ§Ã£o, crenÃ§as tradicionais, hÃ¡bitos e costumes, dados
+        demogrÃ¡ficos, Ã¡reas e actividades recreacionais, avaliaÃ§Ã£o de impactos sociais, crime e
+        justiÃ§a, informaÃ§Ã£o dos censos
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>structure</code>
-      <label>Patrimônio Edificado</label>
-      <description>Construção desenvolvida pelo homem. Exemplos: edifícios, museus, igrejas,
-        fábricas, habitação, monumentos, lojas
+      <label>PatrimÃ´nio Edificado</label>
+      <description>ConstruÃ§Ã£o desenvolvida pelo homem. Exemplos: edifÃ­cios, museus, igrejas,
+        fÃ¡bricas, habitaÃ§Ã£o, monumentos, lojas
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>transportation</code>
       <label>Transporte</label>
-      <description>Meios e formas de deslocação de pessoas e/ou mercadorias. Exemplos: estradas,
-        aeroportos, rotas de navegação, túneis, cartas náuticas e aeronáuticas, localização de
+      <description>Meios e formas de deslocaÃ§Ã£o de pessoas e/ou mercadorias. Exemplos: estradas,
+        aeroportos, rotas de navegaÃ§Ã£o, tÃºneis, cartas nÃ¡uticas e aeronÃ¡uticas, localizaÃ§Ã£o de
         frotas de transporte, caminhos de ferro
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>utilitiesCommunication</code>
-      <label>Infraestruturas e comunicação</label>
-      <description>Energia, sistemas de água e esgoto e infra-estrutura e serviços de comunicação.
-        Exemplos: hidroeléctricidade, fontes da energia geotérmica, solar e nuclear, purificação
-        e distribuição da água, colecção e disposição final de esgotos, distribuição de
+      <label>Infraestruturas e comunicaÃ§Ã£o</label>
+      <description>Energia, sistemas de Ã¡gua e esgoto e infra-estrutura e serviÃ§os de comunicaÃ§Ã£o.
+        Exemplos: hidroelÃ©ctricidade, fontes da energia geotÃ©rmica, solar e nuclear, purificaÃ§Ã£o
+        e distribuiÃ§Ã£o da Ã¡gua, colecÃ§Ã£o e disposiÃ§Ã£o final de esgotos, distribuiÃ§Ã£o de
         electricidade
-        e gás, tráfego e transmissão de dados, telecomunicação, rádio, redes de comunicação
+        e gÃ¡s, trÃ¡fego e transmissÃ£o de dados, telecomunicaÃ§Ã£o, rÃ¡dio, redes de comunicaÃ§Ã£o
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
@@ -1774,66 +1774,66 @@
     <entry>
       <code>topology1D</code>
       <label>Topologia 1D</label>
-      <description>Complexo topológico monodimensional - comummente chamado topologia de
+      <description>Complexo topolÃ³gico monodimensional - comummente chamado topologia de
         'chain-node'
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>planarGraph</code>
-      <label>Gráfico plano</label>
-      <description>Complexo topológico monodimensional que é plano. (Um gráfico plano pode ser
+      <label>GrÃ¡fico plano</label>
+      <description>Complexo topolÃ³gico monodimensional que Ã© plano. (Um grÃ¡fico plano pode ser
         desenhado
-        numa planície numa maneira que duas arestas não se cruzam, excepto num vértice.)
+        numa planÃ­cie numa maneira que duas arestas nÃ£o se cruzam, excepto num vÃ©rtice.)
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>fullPlanarGraph</code>
-      <label>Gráfico plano completo</label>
-      <description>Complexo topológico bidimensional que é plano. (Um complexo topológico
+      <label>GrÃ¡fico plano completo</label>
+      <description>Complexo topolÃ³gico bidimensional que Ã© plano. (Um complexo topolÃ³gico
         bidimensional
-        é comummente chamado 'topologia completa' num ambiente cartográfico bidimensional.)
+        Ã© comummente chamado 'topologia completa' num ambiente cartogrÃ¡fico bidimensional.)
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>surfaceGraph</code>
-      <label>Gráfico de superfície</label>
-      <description>Complexo topológico monodimensional que é isomórfico a um subconjunto duma
-        superfície.
-        (Um complexo geométrico é isomórfico a um complexo topológico se os elementos deles seriam
+      <label>GrÃ¡fico de superfÃ­cie</label>
+      <description>Complexo topolÃ³gico monodimensional que Ã© isomÃ³rfico a um subconjunto duma
+        superfÃ­cie.
+        (Um complexo geomÃ©trico Ã© isomÃ³rfico a um complexo topolÃ³gico se os elementos deles seriam
         uns aos
-        outros numa correspondência um-para-um e conversando dimensões e fronteiras.)
+        outros numa correspondÃªncia um-para-um e conversando dimensÃµes e fronteiras.)
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>fullSurfaceGraph</code>
-      <label>Gráfico de superfície completo</label>
-      <description>Complexo topológico bidimensional que é isomórfico a um subconjunto duma
-        superfície.
+      <label>GrÃ¡fico de superfÃ­cie completo</label>
+      <description>Complexo topolÃ³gico bidimensional que Ã© isomÃ³rfico a um subconjunto duma
+        superfÃ­cie.
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>topology3D</code>
       <label>Topologia 3D</label>
-      <description>Complexo topológico tridimensional. (Um complexo topológico é uma colecção de
-        'primitivos topológicos' que são fechados em baixa de operacões de fronteira.)
+      <description>Complexo topolÃ³gico tridimensional. (Um complexo topolÃ³gico Ã© uma colecÃ§Ã£o de
+        'primitivos topolÃ³gicos' que sÃ£o fechados em baixa de operacÃµes de fronteira.)
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>fullTopology3D</code>
       <label>Topologia 3D completa</label>
-      <description>Cobertura completa dum espaço coordenado euclidiano tridimensional</description>
+      <description>Cobertura completa dum espaÃ§o coordenado euclidiano tridimensional</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>abstract</code>
       <label>Resumo</label>
-      <description>Complexo topológico sem qualquer realização geométrica específicada</description>
+      <description>Complexo topolÃ³gico sem qualquer realizaÃ§Ã£o geomÃ©trica especÃ­ficada</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
   </codelist>
@@ -1842,85 +1842,85 @@
     <entry>
       <code>attribute</code>
       <label>Atributo</label>
-      <description>Informação aplica-se à classe de atributos</description>
+      <description>InformaÃ§Ã£o aplica-se Ã  classe de atributos</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>attributeType</code>
       <label>Tipo de atributo</label>
-      <description>Informação aplica-se à particularidade duma característica</description>
+      <description>InformaÃ§Ã£o aplica-se Ã  particularidade duma caracterÃ­stica</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>collectionHardware</code>
-      <label>Hardware de colecção</label>
-      <description>Informação aplica-se à classe de hardware de colecção</description>
+      <label>Hardware de colecÃ§Ã£o</label>
+      <description>InformaÃ§Ã£o aplica-se Ã  classe de hardware de colecÃ§Ã£o</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>collectionSession</code>
-      <label>Sessão de colecçõ</label>
-      <description>Informação aplica-se à sessão de colecçõ</description>
+      <label>SessÃ£o de colecÃ§Ãµ</label>
+      <description>InformaÃ§Ã£o aplica-se Ã  sessÃ£o de colecÃ§Ãµ</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>dataset</code>
       <label>Conjunto de dados</label>
-      <description>Informação aplica-se ao conjunto de dados</description>
+      <description>InformaÃ§Ã£o aplica-se ao conjunto de dados</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>series</code>
-      <label>Série</label>
-      <description>Informação aplica-se à série</description>
+      <label>SÃ©rie</label>
+      <description>InformaÃ§Ã£o aplica-se Ã  sÃ©rie</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>nonGeographicDataset</code>
-      <label>Conjunto de dados não-geográficos</label>
-      <description>Informação aplica-se a dados não-geográficos</description>
+      <label>Conjunto de dados nÃ£o-geogrÃ¡ficos</label>
+      <description>InformaÃ§Ã£o aplica-se a dados nÃ£o-geogrÃ¡ficos</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>dimensionGroup</code>
-      <label>Grupo de dimensão</label>
-      <description>Informação aplica-se a um grupo de dimensão</description>
+      <label>Grupo de dimensÃ£o</label>
+      <description>InformaÃ§Ã£o aplica-se a um grupo de dimensÃ£o</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>feature</code>
-      <label>Característica</label>
-      <description>Informação aplica-se a uma característica</description>
+      <label>CaracterÃ­stica</label>
+      <description>InformaÃ§Ã£o aplica-se a uma caracterÃ­stica</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>featureType</code>
-      <label>Tipo de característica</label>
-      <description>Informação aplica-se a feature type</description>
+      <label>Tipo de caracterÃ­stica</label>
+      <description>InformaÃ§Ã£o aplica-se a feature type</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>propertyType</code>
       <label>Tipo de propriedade</label>
-      <description>Informação aplica-se a um tipo de propriedade</description>
+      <description>InformaÃ§Ã£o aplica-se a um tipo de propriedade</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>fieldSession</code>
-      <label>Sessão de campo</label>
-      <description>Informação aplica-se a uma sessão de campo</description>
+      <label>SessÃ£o de campo</label>
+      <description>InformaÃ§Ã£o aplica-se a uma sessÃ£o de campo</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>software</code>
       <label>Software</label>
-      <description>Informação aplica-se a uma programa ou rotina de computador</description>
+      <description>InformaÃ§Ã£o aplica-se a uma programa ou rotina de computador</description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>service</code>
-      <label>Serviço</label>
-      <description>Informação aplica-se a uma capacidade, que um provedor de acesso à Internet
+      <label>ServiÃ§o</label>
+      <description>InformaÃ§Ã£o aplica-se a uma capacidade, que um provedor de acesso Ã  Internet
         disponibiliza
         a um utilizador por um conjunto de interfaces, qual define um comportamento, tal como um
         caso de uso
@@ -1930,21 +1930,21 @@
     <entry>
       <code>model</code>
       <label>Modelo</label>
-      <description>Informação aplica-se a uma cópia ou imitaçõ dum objecto existente ou hipotético
+      <description>InformaÃ§Ã£o aplica-se a uma cÃ³pia ou imitaÃ§Ãµ dum objecto existente ou hipotÃ©tico
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>tile</code>
       <label>Tile</label>
-      <description>Informação aplica-se a um 'tile', um subconjunto espacial de dados geográficos
+      <description>InformaÃ§Ã£o aplica-se a um 'tile', um subconjunto espacial de dados geogrÃ¡ficos
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>initiative</code>
       <label>Iniciativa</label>
-      <description>A entidade referenciando aplica-se a um agregado de transferência que foi
+      <description>A entidade referenciando aplica-se a um agregado de transferÃªncia que foi
         identificado originalmente como uma iniciativa (DS_Initiative)
       </description>
     </entry>
@@ -1952,7 +1952,7 @@
     <entry>
       <code>stereomate</code>
       <label>Stereo mate</label>
-      <description>A entidade referenciando aplica-se a um agregado de transferência que foi
+      <description>A entidade referenciando aplica-se a um agregado de transferÃªncia que foi
         identificado originalmente como um 'stereo mate' (DS_StereoMate)
       </description>
     </entry>
@@ -1960,48 +1960,48 @@
     <entry>
       <code>sensor</code>
       <label>Sensor</label>
-      <description>A entidade referenciando aplica-se a um agregado de transferência que foi
+      <description>A entidade referenciando aplica-se a um agregado de transferÃªncia que foi
         identificado originalmente como um sensor (DS_Sensor)
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>platformSeries</code>
-      <label>Série de plataforma</label>
-      <description>A entidade referenciando aplica-se a um agregado de transferência que foi
-        identificado originalmente como uma série de plataforma (DS_PlatformSeries)
+      <label>SÃ©rie de plataforma</label>
+      <description>A entidade referenciando aplica-se a um agregado de transferÃªncia que foi
+        identificado originalmente como uma sÃ©rie de plataforma (DS_PlatformSeries)
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>sensorSeries</code>
-      <label>Série de sensor</label>
-      <description>A entidade referenciando aplica-se a um agregado de transferência que foi
-        identificado originalmente como uma série de sensor (DS_SensorSeries)
+      <label>SÃ©rie de sensor</label>
+      <description>A entidade referenciando aplica-se a um agregado de transferÃªncia que foi
+        identificado originalmente como uma sÃ©rie de sensor (DS_SensorSeries)
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>productionSeries</code>
-      <label>Série de produção</label>
-      <description>A entidade referenciando aplica-se a um agregado de transferência que foi
-        identificado originalmente como uma série de produção (DS_ProductionSeries)
+      <label>SÃ©rie de produÃ§Ã£o</label>
+      <description>A entidade referenciando aplica-se a um agregado de transferÃªncia que foi
+        identificado originalmente como uma sÃ©rie de produÃ§Ã£o (DS_ProductionSeries)
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>transferAggregate</code>
-      <label>Agregado de transferência</label>
-      <description>A entidade referenciando aplica-se a um agregado de transferência
-        que não existe fora de contexto da transferência
+      <label>Agregado de transferÃªncia</label>
+      <description>A entidade referenciando aplica-se a um agregado de transferÃªncia
+        que nÃ£o existe fora de contexto da transferÃªncia
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
     <entry>
       <code>otherAggregate</code>
       <label>Outro agregado</label>
-      <description>A entidade referenciando aplica-se a um agregado de transferência que existe
-        fora de contexto da transferência, mas não pertence a um tipo de agregado específico.
+      <description>A entidade referenciando aplica-se a um agregado de transferÃªncia que existe
+        fora de contexto da transferÃªncia, mas nÃ£o pertence a um tipo de agregado especÃ­fico.
       </description>
     </entry>
     <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
@@ -2044,19 +2044,19 @@
     <entry>
       <code>tight</code>
       <label>Apertado</label>
-      <description>Enlaçado apertadamente: dados associados</description>
+      <description>EnlaÃ§ado apertadamente: dados associados</description>
     </entry>
     <entry>
       <code>mixed</code>
       <label>Misto</label>
-      <description>Enlaçado misto: dados associados; dados externos podem ser processados
+      <description>EnlaÃ§ado misto: dados associados; dados externos podem ser processados
         adicionalmente
       </description>
     </entry>
     <entry>
       <code>loose</code>
       <label>Frouxo</label>
-      <description>Enlaçado frouxamente: não hão dados associados</description>
+      <description>EnlaÃ§ado frouxamente: nÃ£o hÃ£o dados associados</description>
     </entry>
   </codelist>
   <codelist name="srv:SV_ParameterDirection">


### PR DESCRIPTION
In the Portuguese codelist for the schema 19139, few words had typos and others were in Spanish.
  
# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation