### PR TITLE
Change ESAPI logger to SLF4J using log4j2

### DIFF
--- a/web/src/main/webapp/WEB-INF/classes/ESAPI.properties
+++ b/web/src/main/webapp/WEB-INF/classes/ESAPI.properties
@@ -68,11 +68,12 @@ ESAPI.HTTPUtilities=org.owasp.esapi.reference.DefaultHTTPUtilities
 ESAPI.IntrusionDetector=org.owasp.esapi.reference.DefaultIntrusionDetector
 # Log4JFactory Requires log4j.xml or log4j.properties in classpath - http://www.laliluna.de/log4j-tutorial.html
 # Note that this is now considered deprecated!
-ESAPI.Logger=org.owasp.esapi.logging.log4j.Log4JLogFactory
+#ESAPI.Logger=org.owasp.esapi.logging.log4j.Log4JLogFactory
 #ESAPI.Logger=org.owasp.esapi.logging.java.JavaLogFactory
 # To use the new SLF4J logger in ESAPI (see GitHub issue #129), set
 #    ESAPI.Logger=org.owasp.esapi.logging.slf4j.Slf4JLogFactory
 # and do whatever other normal SLF4J configuration that you normally would do for your application.
+ESAPI.Logger=org.owasp.esapi.logging.slf4j.Slf4JLogFactory
 ESAPI.Randomizer=org.owasp.esapi.reference.DefaultRandomizer
 ESAPI.Validator=org.owasp.esapi.reference.DefaultValidator
 


### PR DESCRIPTION
ESAPI logger was using log4j logger (we use log4j2 in GeoNetwork) and locally when trying to reset the user password an exception is launched:

```
ESAPI: DefaultSecurityConfiguration: The code to print all the properties is currently commented out
2024-11-28T13:43:19,906 ERROR [geonetwork] - java.lang.ClassNotFoundException: org.owasp.esapi.logging.log4j.Log4JLogFactory LogFactory class (org.owasp.esapi.logging.log4j.Log4JLogFactory) must be in class path.
org.owasp.esapi.errors.ConfigurationException: java.lang.ClassNotFoundException: org.owasp.esapi.logging.log4j.Log4JLogFactory LogFactory class (org.owasp.esapi.logging.log4j.Log4JLogFactory) must be in class path.
    at org.owasp.esapi.util.ObjFactory.make(ObjFactory.java:108) ~[esapi-2.5.4.0.jar:2.5.4.0]
    at org.owasp.esapi.ESAPI.logFactory(ESAPI.java:139) ~[esapi-2.5.4.0.jar:2.5.4.0]
    at org.owasp.esapi.ESAPI.getLogger(ESAPI.java:155) ~[esapi-2.5.4.0.jar:2.5.4.0]
    at org.owasp.esapi.reference.DefaultEncoder.<init>(DefaultEncoder.java:85) ~[esapi-2.5.4.0.jar:2.5.4.0]
    at org.owasp.esapi.reference.DefaultEncoder.<init>(DefaultEncoder.java:109) ~[esapi-2.5.4.0.jar:2.5.4.0]
    at org.owasp.esapi.reference.DefaultEncoder.getInstance(DefaultEncoder.java:68) ~[esapi-2.5.4.0.jar:2.5.4.0]
    at org.fao.geonet.util.XslUtil.encodeForJavaScript(XslUtil.java:1297) ~[gn-core-4.4.7-SNAPSHOT.jar:?]
    at org.fao.geonet.api.users.PasswordApi.sendPasswordByEmail(PasswordApi.java:236) ~[gn-services-4.4.7-SNAPSHOT.jar:?]
```

Updated to use SLF4J logger using log4j2, as described in https://github.com/ESAPI/esapi-java-legacy/wiki/Using-ESAPI-with-SLF4J#slf4j-using-log4j-2x

Test case:

1) Configure the mail settings.
2) In the login page try to reset the password for a user. 

  - Without the fix: the previous error occurs.
  - With the fix: no error occurs and the mail to reset the password is sent if the user exists.

---

It is not entirely clear why in a deployed version it seems to work, it seems to be something to do with running the application under development. In any case the change to use logger SLF4J using log4j2 seems good as we don't use log4j anymore.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation



