### PR TITLE
Formatter / DCAT / Service

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/dcat/dcat-core-access-and-use.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/dcat/dcat-core-access-and-use.xsl
@@ -19,7 +19,7 @@
                 xmlns:msr="http://standards.iso.org/iso/19115/-3/msr/2.0"
                 xmlns:mrd="http://standards.iso.org/iso/19115/-3/mrd/1.0"
                 xmlns:mdq="http://standards.iso.org/iso/19157/-2/mdq/1.0"
-                xmlns:srv="http://standards.iso.org/iso/19115/-3/srv/2.1"
+                xmlns:srv="http://standards.iso.org/iso/19115/-3/srv/2.0"
                 xmlns:gcx="http://standards.iso.org/iso/19115/-3/gcx/1.0"
                 xmlns:gex="http://standards.iso.org/iso/19115/-3/gex/1.0"
                 xmlns:gml="http://www.opengis.net/gml/3.2"

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/dcat/dcat-core-catalog.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/dcat/dcat-core-catalog.xsl
@@ -19,7 +19,7 @@
                 xmlns:msr="http://standards.iso.org/iso/19115/-3/msr/2.0"
                 xmlns:mrd="http://standards.iso.org/iso/19115/-3/mrd/1.0"
                 xmlns:mdq="http://standards.iso.org/iso/19157/-2/mdq/1.0"
-                xmlns:srv="http://standards.iso.org/iso/19115/-3/srv/2.1"
+                xmlns:srv="http://standards.iso.org/iso/19115/-3/srv/2.0"
                 xmlns:gcx="http://standards.iso.org/iso/19115/-3/gcx/1.0"
                 xmlns:gex="http://standards.iso.org/iso/19115/-3/gex/1.0"
                 xmlns:gml="http://www.opengis.net/gml/3.2"

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/dcat/dcat-core-dataservice.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/dcat/dcat-core-dataservice.xsl
@@ -15,7 +15,7 @@
   Filter to define which service operation has to be considered
   as an endpoint URL or description depending on linkage and protocol.
   -->
-  <xsl:param name="endpointDescriptionUrllExpression"
+  <xsl:param name="endpointDescriptionUrlExpression"
                 as="xs:string"
                 select="'GetCapabilities|WSDL'"/>
   <xsl:param name="endpointDescriptionProtocolsExpression"
@@ -31,7 +31,7 @@
   <xsl:template mode="iso19115-3-to-dcat"
                 match="srv:containsOperations/*/srv:connectPoint/*[not(
                                 matches(cit:protocol/(gco:CharacterString|gcx:Anchor)/text(), $endpointDescriptionProtocolsExpression, 'i')
-                                or matches(cit:linkage/(gco:CharacterString|gcx:Anchor)/text(), $endpointDescriptionUrllExpression, 'i'))]/cit:linkage">
+                                or matches(cit:linkage/(gco:CharacterString|gcx:Anchor)/text(), $endpointDescriptionUrlExpression, 'i'))]/cit:linkage">
 
     <dcat:endpointURL rdf:resource="{normalize-space((gco:CharacterString|gcx:Anchor)/text())}"/>
   </xsl:template>
@@ -54,7 +54,7 @@
   <xsl:template mode="iso19115-3-to-dcat"
                 match="srv:containsOperations/*/srv:connectPoint/*[
                                 matches(cit:protocol/(gco:CharacterString|gcx:Anchor)/text(), $endpointDescriptionProtocolsExpression, 'i')
-                                or matches(cit:linkage/(gco:CharacterString|gcx:Anchor)/text(), $endpointDescriptionUrllExpression, 'i')]/cit:linkage">
+                                or matches(cit:linkage/(gco:CharacterString|gcx:Anchor)/text(), $endpointDescriptionUrlExpression, 'i')]/cit:linkage">
     <dcat:endpointDescription rdf:resource="{normalize-space((gco:CharacterString|gcx:Anchor)/text())}"/>
   </xsl:template>
 

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/dcat/dcat-core-dataservice.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/dcat/dcat-core-dataservice.xsl
@@ -4,15 +4,24 @@
                 xmlns:xs="http://www.w3.org/2001/XMLSchema"
                 xmlns:xlink="http://www.w3.org/1999/xlink"
                 xmlns:cit="http://standards.iso.org/iso/19115/-3/cit/2.0"
-                xmlns:srv="http://standards.iso.org/iso/19115/-3/srv/2.1"
+                xmlns:srv="http://standards.iso.org/iso/19115/-3/srv/2.0"
                 xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0"
+                xmlns:gcx="http://standards.iso.org/iso/19115/-3/gcx/1.0"
                 xmlns:dcat="http://www.w3.org/ns/dcat#"
                 xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
                 exclude-result-prefixes="#all">
 
-  <xsl:variable name="endpointDescriptionProtocols"
-                as="xs:string*"
-                select="('OpenAPI', 'GetCapabilities')"/>
+  <!--
+  Filter to define which service operation has to be considered
+  as an endpoint URL or description depending on linkage and protocol.
+  -->
+  <xsl:param name="endpointDescriptionUrllExpression"
+                as="xs:string"
+                select="'GetCapabilities|WSDL'"/>
+  <xsl:param name="endpointDescriptionProtocolsExpression"
+                as="xs:string"
+                select="'OpenAPI|Swagger|GetCapabilities|WSDL|Description'"/>
+
   <!--
   RDF Property:	dcat:endpointURL
   Definition:	The root location or primary endpoint of the service (a Web-resolvable IRI).
@@ -20,8 +29,11 @@
   Range:	rdfs:Resource
   -->
   <xsl:template mode="iso19115-3-to-dcat"
-                match="srv:containsOperations/*/srv:connectPoint/*[not(cit:protocol/*/text() = $endpointDescriptionProtocols)]/cit:linkage">
-    <dcat:endpointURL rdf:resource="{normalize-space(gco:CharacterString/text())}"/>
+                match="srv:containsOperations/*/srv:connectPoint/*[not(
+                                matches(cit:protocol/(gco:CharacterString|gcx:Anchor)/text(), $endpointDescriptionProtocolsExpression, 'i')
+                                or matches(cit:linkage/(gco:CharacterString|gcx:Anchor)/text(), $endpointDescriptionUrllExpression, 'i'))]/cit:linkage">
+
+    <dcat:endpointURL rdf:resource="{normalize-space((gco:CharacterString|gcx:Anchor)/text())}"/>
   </xsl:template>
 
 
@@ -31,11 +43,19 @@
   Domain:	dcat:DataService
   Range:	rdfs:Resource
   Usage note:	The endpoint description gives specific details of the actual endpoint instances, while dcterms:conformsTo is used to indicate the general standard or specification that the endpoints implement.
-  Usage note:	An endpoint description may be expressed in a machine-readable form, such as an OpenAPI (Swagger) description [OpenAPI], an OGC GetCapabilities response [WFS], [ISO-19142], [WMS], [ISO-19128], a SPARQL Service Description [SPARQL11-SERVICE-DESCRIPTION], an [OpenSearch] or [WSDL20] document, a Hydra API description [HYDRA], else in text or some other informal mode if a formal representation is not possible.
+  Usage note:	An endpoint description may be expressed in a machine-readable form, such as an OpenAPI (Swagger) description [OpenAPI],
+  an OGC GetCapabilities response [WFS], [ISO-19142], [WMS], [ISO-19128],
+  a SPARQL Service Description [SPARQL11-SERVICE-DESCRIPTION],
+  an [OpenSearch]
+  or [WSDL20] document,
+  a Hydra API description [HYDRA],
+   else in text or some other informal mode if a formal representation is not possible.
   -->
   <xsl:template mode="iso19115-3-to-dcat"
-                match="srv:containsOperations/*/srv:connectPoint/*[cit:protocol/*/text() = $endpointDescriptionProtocols]/cit:linkage">
-    <dcat:endpointDescription rdf:resource="{normalize-space(gco:CharacterString/text())}"/>
+                match="srv:containsOperations/*/srv:connectPoint/*[
+                                matches(cit:protocol/(gco:CharacterString|gcx:Anchor)/text(), $endpointDescriptionProtocolsExpression, 'i')
+                                or matches(cit:linkage/(gco:CharacterString|gcx:Anchor)/text(), $endpointDescriptionUrllExpression, 'i')]/cit:linkage">
+    <dcat:endpointDescription rdf:resource="{normalize-space((gco:CharacterString|gcx:Anchor)/text())}"/>
   </xsl:template>
 
   <!--
@@ -46,7 +66,7 @@
   <xsl:template mode="iso19115-3-to-dcat"
                 match="srv:operatesOn">
     <dcat:servesDataset>
-      <dcat:Dataset rdf:about="{if (@xlink:href) then @xlink:href else @uriref}"/>
+      <dcat:Dataset rdf:about="{if (@xlink:href) then @xlink:href else @uuidref}"/>
     </dcat:servesDataset>
   </xsl:template>
 </xsl:stylesheet>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/dcat/dcat-core.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/dcat/dcat-core.xsl
@@ -21,7 +21,7 @@
                 xmlns:mmi="http://standards.iso.org/iso/19115/-3/mmi/1.0"
                 xmlns:mrd="http://standards.iso.org/iso/19115/-3/mrd/1.0"
                 xmlns:mdq="http://standards.iso.org/iso/19157/-2/mdq/1.0"
-                xmlns:srv="http://standards.iso.org/iso/19115/-3/srv/2.1"
+                xmlns:srv="http://standards.iso.org/iso/19115/-3/srv/2.0"
                 xmlns:gex="http://standards.iso.org/iso/19115/-3/gex/1.0"
                 xmlns:gml="http://www.opengis.net/gml/3.2"
                 xmlns:gmd="http://www.isotc211.org/2005/gmd"

--- a/services/src/test/resources/org/fao/geonet/api/records/formatters/iso19115-3.2018-dcat-service-core.rdf
+++ b/services/src/test/resources/org/fao/geonet/api/records/formatters/iso19115-3.2018-dcat-service-core.rdf
@@ -360,7 +360,8 @@
       </dcat:distribution>
       <dcat:endpointURL rdf:resource="https://geoservices.wallonie.be/inspire/atom/PS_Opensearch.xml"/>
       <dcat:endpointURL rdf:resource="https://geoservices.wallonie.be/inspire/atom/PS_Service.xml"/>
-      <dcat:endpointDescription rdf:resource="https://geoservices.wallonie.be/wms/PS_Service"/>
+      <dcat:endpointDescription rdf:resource="https://geoservices.wallonie.be/wms/PS_Service?ProtocolIsGetCapabilities"/>
+      <dcat:endpointURL rdf:resource="https://geoservices.wallonie.be/wms/PS_Service"/>
       <dcat:servesDataset>
          <dcat:Dataset rdf:about="https://metawal.wallonie.be/geonetwork/srv/api/records/c2526c30-ee7e-4c0b-b866-599e9aba3665"/>
       </dcat:servesDataset>

--- a/services/src/test/resources/org/fao/geonet/api/records/formatters/iso19115-3.2018-dcat-service.xml
+++ b/services/src/test/resources/org/fao/geonet/api/records/formatters/iso19115-3.2018-dcat-service.xml
@@ -7,7 +7,7 @@
                  xmlns:gcx="http://standards.iso.org/iso/19115/-3/gcx/1.0"
                  xmlns:gex="http://standards.iso.org/iso/19115/-3/gex/1.0"
                  xmlns:lan="http://standards.iso.org/iso/19115/-3/lan/1.0"
-                 xmlns:srv="http://standards.iso.org/iso/19115/-3/srv/2.1"
+                 xmlns:srv="http://standards.iso.org/iso/19115/-3/srv/2.0"
                  xmlns:mas="http://standards.iso.org/iso/19115/-3/mas/1.0"
                  xmlns:mcc="http://standards.iso.org/iso/19115/-3/mcc/1.0"
                  xmlns:mco="http://standards.iso.org/iso/19115/-3/mco/1.0"
@@ -1447,7 +1447,7 @@
           <srv:connectPoint>
             <cit:CI_OnlineResource>
               <cit:linkage xsi:type="lan:PT_FreeText_PropertyType">
-                <gco:CharacterString>https://geoservices.wallonie.be/wms/PS_Service</gco:CharacterString>
+                <gco:CharacterString>https://geoservices.wallonie.be/wms/PS_Service?ProtocolIsGetCapabilities</gco:CharacterString>
                 <lan:PT_FreeText>
                   <lan:textGroup>
                     <lan:LocalisedCharacterString locale="#FR">https://geoservices.wallonie.be/wms/PS_Service
@@ -1457,6 +1457,33 @@
               </cit:linkage>
               <cit:protocol>
                 <gco:CharacterString>GetCapabilities</gco:CharacterString>
+              </cit:protocol>
+            </cit:CI_OnlineResource>
+          </srv:connectPoint>
+        </srv:SV_OperationMetadata>
+      </srv:containsOperations>
+      <srv:containsOperations>
+        <srv:SV_OperationMetadata>
+          <srv:operationName>
+            <gco:CharacterString>GetCapabilities</gco:CharacterString>
+          </srv:operationName>
+          <srv:distributedComputingPlatform>
+            <srv:DCPList codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#DCPList"
+                         codeListValue="WebServices"/>
+          </srv:distributedComputingPlatform>
+          <srv:connectPoint>
+            <cit:CI_OnlineResource>
+              <cit:linkage xsi:type="lan:PT_FreeText_PropertyType">
+                <gco:CharacterString>https://geoservices.wallonie.be/wms/PS_Service</gco:CharacterString>
+                <lan:PT_FreeText>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#FR">https://geoservices.wallonie.be/wms/PS_Service?protocolIsWms
+                    </lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                </lan:PT_FreeText>
+              </cit:linkage>
+              <cit:protocol>
+                <gco:CharacterString>OGC:WMS</gco:CharacterString>
               </cit:protocol>
             </cit:CI_OnlineResource>
           </srv:connectPoint>


### PR DESCRIPTION
* Fix service mapping for DCAT due to the change in namespace for SRV (https://github.com/geonetwork/core-geonetwork/pull/7806) which happened in between PRs.
* Add more flexible parameters to make distinction between endpoint URLs and endpoint description
* Fix `uuidref` attribute typo.

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

Funded by Service Public de Wallonie
