### PR TITLE
Use the copyBlob to copy the resource with updated metadata

### DIFF
--- a/datastorages/jcloud/src/main/java/org/fao/geonet/api/records/attachments/JCloudStore.java
+++ b/datastorages/jcloud/src/main/java/org/fao/geonet/api/records/attachments/JCloudStore.java
@@ -610,10 +610,10 @@ public class JCloudStore extends AbstractStore {
                         String sourceBlobName = sourceStorageMetadata.getName();
                         String targetBlobName = targetResourceTypeDir + sourceBlobName.substring(sourceResourceTypeDir.length());
 
-                        Blob sourceBlob = jCloudConfiguration.getClient().getBlobStore().getBlob(jCloudConfiguration.getContainerName(), sourceBlobName);
+                        BlobMetadata blobMetadata = jCloudConfiguration.getClient().getBlobStore().blobMetadata(jCloudConfiguration.getContainerName(), sourceBlobName);
 
                         // Copy existing properties.
-                        Map<String, String> targetProperties = new HashMap<>(sourceBlob.getMetadata().getUserMetadata());
+                        Map<String, String> targetProperties = new HashMap<>(blobMetadata.getUserMetadata());
 
                         // Check if target exists.
                         StorageMetadata targetStorageMetadata = null;
@@ -670,14 +670,14 @@ public class JCloudStore extends AbstractStore {
                                     targetProperties.get(versionPropertyName)));
                             }
                         }
-                        Blob targetblob = jCloudConfiguration.getClient().getBlobStore().blobBuilder(targetBlobName)
-                            .payload(sourceBlob.getPayload())
-                            .contentLength(sourceBlob.getMetadata().getContentMetadata().getContentLength())
-                            .userMetadata(targetProperties)
-                            .build();
 
-                        // Upload the Blob in multiple chunks to supports large files.
-                        jCloudConfiguration.getClient().getBlobStore().putBlob(jCloudConfiguration.getContainerName(), targetblob, multipart());
+                        // Use the copyBlob to copy the resource with updated metadata.
+                        jCloudConfiguration.getClient().getBlobStore().copyBlob(
+                            jCloudConfiguration.getContainerName(),
+                            sourceBlobName,
+                            jCloudConfiguration.getContainerName(),
+                            targetBlobName,
+                            CopyOptions.builder().userMetadata(targetProperties).build());
                     }
                 }
                 marker = page.getNextMarker();


### PR DESCRIPTION
Use the copyBlob to copy the resource with updated metadata

Prior it was trying to copy the payload which was buggy on large files and could produce the following error
    "`Failed copy of resources: Incomplete output stream connecting to PUT`"

Also increase performance as the copyBlob is more efficient.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

