### PR TITLE
Facet / Add meta property to customize label.

### DIFF
--- a/docs/manual/docs/customizing-application/configuring-faceted-search.md
+++ b/docs/manual/docs/customizing-application/configuring-faceted-search.md
@@ -338,6 +338,23 @@ When using a generic field like `tag.default` and including only a subset of key
 },
 ```
 
+To translate the label `IDP_TOPICS`, 2 options:
+
+* Use the translation API to add your custom translation in the database for the facet key `facet-IDP_TOPICS` (see the Admin console --> Settings --> Languages).
+* Or declare a meta property `labels` in the facet configuration:
+
+``` js
+"IDP_TOPICS": {
+  "terms": {
+    ...
+  "meta": {
+      "labels": {
+        "eng": "IDP topics",
+        "fre": "Thèmes IDP"
+      },
+```
+
+
 ## Decorate aggregations {#configuring-facet-decorator}
 
 All aggregations can be decorated by an icon or an image in the home page or in other pages. The decorator is configured in the `meta` properties of the facet:

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/FacetDirective.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/FacetDirective.js
@@ -187,6 +187,19 @@
     }
   ]);
 
+  module.service("gnFacetMetaLabel", [
+    "$translate",
+    function ($translate) {
+      this.getFacetLabel = function (facet) {
+        if (!facet || !facet.meta || !facet.meta.labels) {
+          return null;
+        }
+        var currentLang = $translate.use();
+        return facet.meta.labels[currentLang] || null;
+      };
+    }
+  ]);
+
   module.filter("facetTooltip", [
     "$translate",
     "$filter",
@@ -266,7 +279,8 @@
   module.directive("esFacets", [
     "gnFacetSorter",
     "gnSearchSettings",
-    function (gnFacetSorter, gnSearchSettings) {
+    "gnFacetMetaLabel",
+    function (gnFacetSorter, gnSearchSettings, gnFacetMetaLabel) {
       return {
         restrict: "A",
         controllerAs: "ctrl",
@@ -291,6 +305,7 @@
           // Directive tab field property
           scope.isTabMode = scope.ctrl.tabField !== undefined;
           scope.facetSorter = gnFacetSorter.sortByTranslation;
+          scope.getFacetLabel = gnFacetMetaLabel.getFacetLabel;
         }
       };
     }

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/FacetDirective.js
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/FacetDirective.js
@@ -189,13 +189,49 @@
 
   module.service("gnFacetMetaLabel", [
     "$translate",
-    function ($translate) {
-      this.getFacetLabel = function (facet) {
+    "$filter",
+    function ($translate, $filter) {
+      var translateKey = function (key) {
+        try {
+          var facetKeyTranslatorFilter = $filter("facetKeyTranslator");
+          var t = facetKeyTranslatorFilter(key);
+          return t;
+        } catch (e) {
+          return key;
+        }
+      };
+
+      /**
+       * Retrieves the facet label.
+       *
+       * If the facet has a meta-property label defined with the current UI language, retrieves the translation
+       * from the facet configuration; otherwise it uses the provided translation key to retrieve the translation
+       * from the application translation files.
+       *
+       * {
+       *   "facetConfig": {
+       *     "resourceType": {
+       *       "terms": {
+       *         "field": "resourceType"
+       *       },
+       *       "meta": {
+       *         "labels": {
+       *           "eng": "Hierarchy level",
+       *           "spa": "Nivel jerárquico",
+       *           ...
+       *         },
+       *         ...
+       *
+       * @param facet facet configuration.
+       * @param key   translation key.
+       * @returns {*|null}
+       */
+      this.getFacetLabel = function (facet, key) {
         if (!facet || !facet.meta || !facet.meta.labels) {
-          return null;
+          return translateKey(key);
         }
         var currentLang = $translate.use();
-        return facet.meta.labels[currentLang] || null;
+        return facet.meta.labels[currentLang] || translateKey(key);
       };
     }
   ]);

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facets.html
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facets.html
@@ -54,7 +54,7 @@
         gn-collapsible="::ctrl.fLvlCollapse[facet.key]"
       >
         <span class="flex-shrink text-ellipsis"
-          >{{('facet-' + facet.key) | facetKeyTranslator}}</span
+          >{{getFacetLabel(facet) || (('facet-' + facet.key) | facetKeyTranslator)}}</span
         >
         <span
           class="fa fa-fw"

--- a/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facets.html
+++ b/web-ui/src/main/resources/catalog/components/elasticsearch/directives/partials/facets.html
@@ -54,7 +54,7 @@
         gn-collapsible="::ctrl.fLvlCollapse[facet.key]"
       >
         <span class="flex-shrink text-ellipsis"
-          >{{getFacetLabel(facet) || (('facet-' + facet.key) | facetKeyTranslator)}}</span
+          >{{getFacetLabel(facet, 'facet-' + facet.key)}}</span
         >
         <span
           class="fa fa-fw"

--- a/web-ui/src/main/resources/catalog/components/metadataactions/RelatedDirective.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/RelatedDirective.js
@@ -889,7 +889,8 @@
   module.directive("gnRecordsFilters", [
     "$rootScope",
     "gnGlobalSettings",
-    function ($rootScope, gnGlobalSettings) {
+    "gnFacetMetaLabel",
+    function ($rootScope, gnGlobalSettings, gnFacetMetaLabel) {
       return {
         restrict: "A",
         templateUrl: function (elem, attrs) {
@@ -911,6 +912,7 @@
           scope.criteria = { p: {} };
           scope.relatedFacetConfig =
             gnGlobalSettings.gnCfg.mods.recordview.relatedFacetConfig;
+          scope.getFacetLabel = gnFacetMetaLabel.getFacetLabel;
 
           function removeEmptyFilters(filters, agg) {
             var cleanFilterPos = [];

--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/recordsFilters.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/recordsFilters.html
@@ -2,9 +2,7 @@
   <h2>{{title}}</h2>
   <p class="text-muted" translate="">filterHelp</p>
   <div data-ng-repeat="filter in filtersToProcess">
-    <label
-      >{{getFacetLabel(agg[filter]) || ('facet-' + filter) | facetKeyTranslator}}</label
-    >
+    <label>{{getFacetLabel(agg[filter], 'facet-' + filter)}}</label>
     <div>
       <button
         data-ng-repeat="(key, b) in agg[filter].buckets"

--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/recordsFilters.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/recordsFilters.html
@@ -2,7 +2,9 @@
   <h2>{{title}}</h2>
   <p class="text-muted" translate="">filterHelp</p>
   <div data-ng-repeat="filter in filtersToProcess">
-    <label>{{('facet-' + filter) | facetKeyTranslator}}</label>
+    <label
+      >{{getFacetLabel(agg[filter]) || ('facet-' + filter) | facetKeyTranslator}}</label
+    >
     <div>
       <button
         data-ng-repeat="(key, b) in agg[filter].buckets"

--- a/web-ui/src/main/resources/catalog/components/search/searchfiltertag/SearchFilterTagsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/searchfiltertag/SearchFilterTagsDirective.js
@@ -45,7 +45,8 @@
 
   module.directive("searchFilterTags", [
     "$location",
-    function ($location) {
+    "gnFacetMetaLabel",
+    function ($location, gnFacetMetaLabel) {
       return {
         restrict: "EA",
         require: "^ngSearchForm",
@@ -61,6 +62,12 @@
 
           // key is the raw facet path, value is a valid filter object
           scope.facetFilterCache = {};
+          scope.getFacetLabel = gnFacetMetaLabel.getFacetLabel;
+          scope.dimensionList = {};
+          for (var i = 0; i < scope.dimensions.length; i++) {
+            var dimension = scope.dimensions[i];
+            scope.dimensionList[dimension.key] = dimension;
+          }
 
           function getSearchParams() {
             if (scope.useLocationParameters) {

--- a/web-ui/src/main/resources/catalog/components/search/searchfiltertag/partials/searchFilterTagsTemplate.html
+++ b/web-ui/src/main/resources/catalog/components/search/searchfiltertag/partials/searchFilterTagsTemplate.html
@@ -21,7 +21,10 @@
       ng-click="removeFilter(filter)"
     >
       <strong class="text-no-wrap">
-        <span ng-if="::!specific">{{('facet-' + filter.key) | facetKeyTranslator}}</span>
+        <span ng-if="::!specific"
+          >{{getFacetLabel(dimensionList[filter.key]) || ('facet-' + filter.key) |
+          facetKeyTranslator}}</span
+        >
         <span ng-if="::specific">{{filter.key}}</span>
       </strong>
       <div class="flex-spacer"></div>

--- a/web-ui/src/main/resources/catalog/components/search/searchfiltertag/partials/searchFilterTagsTemplate.html
+++ b/web-ui/src/main/resources/catalog/components/search/searchfiltertag/partials/searchFilterTagsTemplate.html
@@ -22,8 +22,7 @@
     >
       <strong class="text-no-wrap">
         <span ng-if="::!specific"
-          >{{getFacetLabel(dimensionList[filter.key]) || ('facet-' + filter.key) |
-          facetKeyTranslator}}</span
+          >{{getFacetLabel(dimensionList[filter.key], 'facet-' + filter.key)}}</span
         >
         <span ng-if="::specific">{{filter.key}}</span>
       </strong>

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -1608,6 +1608,7 @@
     "gnExternalViewer",
     "gnAlertService",
     "gnESFacet",
+    "gnFacetMetaLabel",
     function (
       $scope,
       $http,
@@ -1628,7 +1629,8 @@
       $cookies,
       gnExternalViewer,
       gnAlertService,
-      gnESFacet
+      gnESFacet,
+      gnFacetMetaLabel
     ) {
       $scope.version = "0.0.1";
       var defaultNode = "srv";
@@ -1753,6 +1755,8 @@
       $scope.isExternalViewerEnabled = gnExternalViewer.isEnabled();
       $scope.externalViewerUrl = gnExternalViewer.getBaseUrl();
       $scope.publicationOptions = [];
+      $scope.getFacetLabel = gnFacetMetaLabel.getFacetLabel;
+
 
       $http.get("../api/records/sharing/options").then(function (response) {
         $scope.publicationOptions = response.data;

--- a/web-ui/src/main/resources/catalog/views/default/templates/home.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/home.html
@@ -123,8 +123,8 @@
         <h1 class="col-md-12">
           <span data-translate="" data-ng-if="homeFacet.list.length > 2">browseBy</span>
           <span data-ng-if="homeFacet.list.length < 3" data-translate="">
-            {{::getFacetLabel(searchInfo.aggregations[homeFacet.list[0]]) || ('facet-' +
-            homeFacet.list[0]) | facetKeyTranslator}}
+            {{::getFacetLabel(searchInfo.aggregations[homeFacet.list[0]], 'facet-' +
+            homeFacet.list[0])}}
           </span>
         </h1>
         <div class="gn-topic-select col-md-12" data-ng-if="homeFacet.list.length > 2">
@@ -140,9 +140,7 @@
               data-ng-model="homeFacet.key"
               data-ng-value="facetKey"
             />
-            <span data-translate=""
-              >{{::getFacetLabel(agg) || (('facet-' + facetKey) |
-              facetKeyTranslator)}}</span
+            <span data-translate="">{{::getFacetLabel(agg, 'facet-' + facetKey)}}</span
             >&nbsp;
           </label>
         </div>
@@ -160,8 +158,8 @@
     <div data-ng-show="searchInfo.aggregations[homeFacet.lastKey].buckets.length > 0">
       <div class="row">
         <h1 class="col-md-12" data-translate="">
-          {{getFacetLabel(searchInfo.aggregations[homeFacet.lastKey]) || (('facet-' +
-          homeFacet.lastKey) | facetKeyTranslator)}}
+          {{getFacetLabel(searchInfo.aggregations[homeFacet.lastKey], 'facet-' +
+          homeFacet.lastKey)}}
         </h1>
       </div>
       <div class="row">

--- a/web-ui/src/main/resources/catalog/views/default/templates/home.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/home.html
@@ -139,7 +139,7 @@
               data-ng-model="homeFacet.key"
               data-ng-value="facetKey"
             />
-            <span data-translate="">{{::('facet-' + facetKey) | facetKeyTranslator}}</span
+            <span data-translate="">{{::getFacetLabel(agg) ||  (('facet-' + facetKey) | facetKeyTranslator)}}</span
             >&nbsp;
           </label>
         </div>
@@ -157,7 +157,7 @@
     <div data-ng-show="searchInfo.aggregations[homeFacet.lastKey].buckets.length > 0">
       <div class="row">
         <h1 class="col-md-12" data-translate="">
-          {{('facet-' + homeFacet.lastKey) | facetKeyTranslator}}
+          {{getFacetLabel(searchInfo.aggregations[homeFacet.lastKey]) ||  (('facet-' + homeFacet.lastKey) | facetKeyTranslator)}}
         </h1>
       </div>
       <div class="row">

--- a/web-ui/src/main/resources/catalog/views/default/templates/home.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/home.html
@@ -123,7 +123,8 @@
         <h1 class="col-md-12">
           <span data-translate="" data-ng-if="homeFacet.list.length > 2">browseBy</span>
           <span data-ng-if="homeFacet.list.length < 3" data-translate="">
-            {{::('facet-' + homeFacet.list[0]) | facetKeyTranslator}}
+            {{::getFacetLabel(searchInfo.aggregations[homeFacet.list[0]]) || ('facet-' +
+            homeFacet.list[0]) | facetKeyTranslator}}
           </span>
         </h1>
         <div class="gn-topic-select col-md-12" data-ng-if="homeFacet.list.length > 2">
@@ -139,7 +140,9 @@
               data-ng-model="homeFacet.key"
               data-ng-value="facetKey"
             />
-            <span data-translate="">{{::getFacetLabel(agg) ||  (('facet-' + facetKey) | facetKeyTranslator)}}</span
+            <span data-translate=""
+              >{{::getFacetLabel(agg) || (('facet-' + facetKey) |
+              facetKeyTranslator)}}</span
             >&nbsp;
           </label>
         </div>
@@ -157,7 +160,8 @@
     <div data-ng-show="searchInfo.aggregations[homeFacet.lastKey].buckets.length > 0">
       <div class="row">
         <h1 class="col-md-12" data-translate="">
-          {{getFacetLabel(searchInfo.aggregations[homeFacet.lastKey]) ||  (('facet-' + homeFacet.lastKey) | facetKeyTranslator)}}
+          {{getFacetLabel(searchInfo.aggregations[homeFacet.lastKey]) || (('facet-' +
+          homeFacet.lastKey) | facetKeyTranslator)}}
         </h1>
       </div>
       <div class="row">


### PR DESCRIPTION
To facilitate facet configuration when using the application using webcomponent mode. All users may not have access to the admin UI to add or customize labels using database translations.

Add also documentation on how to configure labels when the key used for the facet is not known.

eg. 

```js
facetConfig: {
              resourceType: {
                terms: {
                  field: "resourceType"
                },
                meta: {
                  labels: {
                    eng: "Hierarchy level"
                  },
```

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

Funded by Ifremer
