### PR TITLE
ISO19115.3-2008 / Fix typo in facsimile codelist value

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/loc/eng/codelists.xml
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/loc/eng/codelists.xml
@@ -63,7 +63,7 @@
       <description>Telephone provides voice service</description>
     </entry>
     <entry>
-      <code>facsimilie</code>
+      <code>facsimile</code>
       <label>Facsimile</label>
       <description>Telephone provides facsimile service</description>
     </entry>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/loc/fre/codelists.xml
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/loc/fre/codelists.xml
@@ -38,7 +38,7 @@
       <description>Le téléphone offre un service voacal</description>
     </entry>
     <entry>
-      <code>facsimilie</code>
+      <code>facsimile</code>
       <label>Fax</label>
       <description>Le téléphone offre un service de fax</description>
     </entry>


### PR DESCRIPTION
The codelist value had a typo `facsimilie` instead of the correct value `facsimile`.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation


