### PR TITLE
Editor / Improve support of schema having sibling elements for translation

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/EditLib.java
+++ b/core/src/main/java/org/fao/geonet/kernel/EditLib.java
@@ -243,21 +243,23 @@ public class EditLib {
 
         List<Element> result = new ArrayList<>();
 
-        MultilingualSchemaPlugin multilingualSchemaPlugin = (MultilingualSchemaPlugin) mdSchema.getSchemaPlugin();
+        if (mdSchema.getSchemaPlugin() instanceof MultilingualSchemaPlugin) {
+            MultilingualSchemaPlugin multilingualSchemaPlugin = (MultilingualSchemaPlugin) mdSchema.getSchemaPlugin();
 
-        if (!languages.isEmpty() &&
-            multilingualSchemaPlugin.duplicateElementsForMultilingual() &&
-            multilingualSchemaPlugin.isMultilingualElementType(mdSchema.getElementType(qname, el.getName()))) {
-            for(String language : languages) {
-                Element child = addElement(mdSchema, el, qname);
-                ((MultilingualSchemaPlugin) mdSchema.getSchemaPlugin()).addTranslationToElement(child, language, "");
-                result.add(child);
+            if (!languages.isEmpty() &&
+                multilingualSchemaPlugin.duplicateElementsForMultilingual() &&
+                multilingualSchemaPlugin.isMultilingualElementType(mdSchema.getElementType(qname, el.getName()))) {
+                for(String language : languages) {
+                    Element child = addElement(mdSchema, el, qname);
+                    ((MultilingualSchemaPlugin) mdSchema.getSchemaPlugin()).addTranslationToElement(child, language, "");
+                    result.add(child);
+                }
+                return result;
             }
-            return result;
-        } else {
-            // If no multilingual management is required, process the single element.
-            result.add(addElement(mdSchema, el, qname));
         }
+
+        // If no multilingual management is required, process the single element.
+        result.add(addElement(mdSchema, el, qname));
 
         return result;
     }

--- a/core/src/main/java/org/fao/geonet/kernel/EditLib.java
+++ b/core/src/main/java/org/fao/geonet/kernel/EditLib.java
@@ -3,7 +3,7 @@
 //=== EditLib
 //===
 //=============================================================================
-//===	Copyright (C) 2001-2007 Food and Agriculture Organization of the
+//===	Copyright (C) 2001-2024 Food and Agriculture Organization of the
 //===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
 //===	and United Nations Environment Programme (UNEP)
 //===
@@ -35,7 +35,6 @@ import java.io.IOException;
 import java.io.StringReader;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import org.apache.commons.collections.CollectionUtils;
@@ -50,6 +49,7 @@ import org.fao.geonet.kernel.schema.ISOPlugin;
 import org.fao.geonet.kernel.schema.MetadataAttribute;
 import org.fao.geonet.kernel.schema.MetadataSchema;
 import org.fao.geonet.kernel.schema.MetadataType;
+import org.fao.geonet.kernel.schema.MultilingualSchemaPlugin;
 import org.fao.geonet.kernel.schema.SchemaPlugin;
 import org.fao.geonet.utils.Xml;
 import org.jaxen.JaxenException;
@@ -221,6 +221,45 @@ public class EditLib {
         fillElement(mdSchema, mdSugg, el, child);
 
         return child;
+    }
+
+    /**
+     * Creates an element with a name (qname) as child of an element (el).
+     *
+     * If the element to create is multilingual and the related metadata schemas requires to duplicate it,
+     * one child per metadata language is added.
+     *
+     * See {@link org.fao.geonet.kernel.schema.MultilingualSchemaPlugin#duplicateElementsForMultilingual()}
+     *
+     * @param mdSchema  Metadata schema
+     * @param el        Parent element to add the new element.
+     * @param qname     Name of the new element to add.
+     * @param languages Languages to add to the new elements.
+     * @return          List of child elements added. For non-multilingual, contains 1 element.
+     * @throws Exception
+     */
+    public List<Element> addElements(MetadataSchema mdSchema, Element el,
+                                     String qname, List<String> languages) throws Exception {
+
+        List<Element> result = new ArrayList<>();
+
+        MultilingualSchemaPlugin multilingualSchemaPlugin = (MultilingualSchemaPlugin) mdSchema.getSchemaPlugin();
+
+        if (!languages.isEmpty() &&
+            multilingualSchemaPlugin.duplicateElementsForMultilingual() &&
+            multilingualSchemaPlugin.isMultilingualElementType(mdSchema.getElementType(qname, el.getName()))) {
+            for(String language : languages) {
+                Element child = addElement(mdSchema, el, qname);
+                ((MultilingualSchemaPlugin) mdSchema.getSchemaPlugin()).addTranslationToElement(child, language, "");
+                result.add(child);
+            }
+            return result;
+        } else {
+            // If no multilingual management is required, process the single element.
+            result.add(addElement(mdSchema, el, qname));
+        }
+
+        return result;
     }
 
     /**
@@ -968,7 +1007,7 @@ public class EditLib {
     //--------------------------------------------------------------------------
 
     private List<Element> filterOnQname(List<Element> children, String qname) {
-        Vector<Element> result = new Vector<Element>();
+        Vector<Element> result = new Vector<>();
         for (Element child : children) {
             if (child.getQualifiedName().equals(qname)) {
                 result.add(child);
@@ -1166,7 +1205,7 @@ public class EditLib {
         //
 
         boolean hasContent = false;
-        Vector<Element> holder = new Vector<Element>();
+        Vector<Element> holder = new Vector<>();
 
         MetadataSchema mdSchema = scm.getSchema(schema);
         String chUQname = getUnqualifiedName(chName);
@@ -1222,12 +1261,12 @@ public class EditLib {
         MetadataType thisType = mdSchema.getTypeInfo(typeName);
 
         if (thisType.hasContainers) {
-            Vector<Content> holder = new Vector<Content>();
+            Vector<Content> holder = new Vector<>();
 
             for (String chName: thisType.getAlElements()) {
                 if (edit_CHOICE_GROUP_SEQUENCE_in(chName)) {
                     List<Element> elems = searchChildren(chName, md, schema);
-                    if (elems.size() > 0) {
+                    if (!elems.isEmpty()) {
                         holder.addAll(elems);
                     }
                 } else {
@@ -1246,7 +1285,7 @@ public class EditLib {
      * For each container element - descend and collect children.
      */
     private Vector<Object> getContainerChildren(Element md) {
-        Vector<Object> result = new Vector<Object>();
+        Vector<Object> result = new Vector<>();
 
         @SuppressWarnings("unchecked")
         List<Element> chChilds = md.getChildren();
@@ -1268,7 +1307,7 @@ public class EditLib {
     public void contractElements(Element md) {
         //--- contract container children at each level in the XML tree
 
-        Vector<Object> children = new Vector<Object>();
+        Vector<Object> children = new Vector<>();
         @SuppressWarnings("unchecked")
         List<Content> childs = md.getContent();
         for (Content obj : childs) {
@@ -1276,9 +1315,9 @@ public class EditLib {
                 Element mdCh = (Element) obj;
                 String mdName = mdCh.getName();
                 if (edit_CHOICE_GROUP_SEQUENCE_in(mdName)) {
-                    if (mdCh.getChildren().size() > 0) {
+                    if (!mdCh.getChildren().isEmpty()) {
                         Vector<Object> chChilds = getContainerChildren(mdCh);
-                        if (chChilds.size() > 0) {
+                        if (!chChilds.isEmpty()) {
                             children.addAll(chChilds);
                         }
                     }
@@ -1525,7 +1564,7 @@ public class EditLib {
         @SuppressWarnings("unchecked")
         List<Element> list = md.getChildren();
 
-        List<Element> v = new ArrayList<Element>();
+        List<Element> v = new ArrayList<>();
 
         for (int i = 0; i < list.size(); i++) {
             Element el = list.get(i);
@@ -1606,7 +1645,8 @@ public class EditLib {
         MetadataSchema mds = scm.getSchema(schema);
         MetadataType mdt = getType(mds, parent);
 
-        int min = -1, max = -1;
+        int min = -1;
+        int max = -1;
 
         for (int i = 0; i < mdt.getElementCount(); i++) {
             if (childQName.equals(mdt.getElementAt(i))) {

--- a/schemas/iso19115-3.2018/src/main/java/org/fao/geonet/schema/iso19115_3_2018/ISO19115_3_2018SchemaPlugin.java
+++ b/schemas/iso19115-3.2018/src/main/java/org/fao/geonet/schema/iso19115_3_2018/ISO19115_3_2018SchemaPlugin.java
@@ -588,23 +588,13 @@ public class ISO19115_3_2018SchemaPlugin
     @Override
     public List<String> getMetadataLanguages(Element metadata) {
         try {
-             Xml.selectNodes(metadata, ".//mdb:defaultLocale/lan:PT_Locale/@id", allNamespaces.asList())
+             return Xml.selectNodes(metadata, ".//*[name() = 'mdb:defaultLocale' or name() = 'mdb:otherLocale']/lan:PT_Locale/@id", allNamespaces.asList())
                 .stream()
-                .filter(node -> node instanceof Attribute)
+                .filter(Attribute.class::isInstance)
                 .map(node -> ((Attribute)node).getValue())
                 .filter(s -> s != null && !s.isBlank())
-                .filter(Objects::nonNull)
-                .collect(Collectors.toList()).addAll(
-                     Xml.selectNodes(metadata, ".//mdb:otherLocale/lan:PT_Locale/@id", allNamespaces.asList())
-                         .stream()
-                         .filter(node -> node instanceof Attribute)
-                         .map(node -> ((Attribute)node).getValue())
-                         .filter(s -> s != null && !s.isBlank())
-                         .filter(Objects::nonNull)
-                         .collect(Collectors.toList())
-                 );
-        } catch (JDOMException e) {
-            e.printStackTrace();
+                .collect(Collectors.toList());
+        } catch (JDOMException ignored) {
         }
         return Collections.emptyList();
     }

--- a/schemas/iso19115-3.2018/src/main/java/org/fao/geonet/schema/iso19115_3_2018/ISO19115_3_2018SchemaPlugin.java
+++ b/schemas/iso19115-3.2018/src/main/java/org/fao/geonet/schema/iso19115_3_2018/ISO19115_3_2018SchemaPlugin.java
@@ -30,6 +30,7 @@ import org.fao.geonet.kernel.schema.LinkPatternStreamer.ILinkBuilder;
 import org.fao.geonet.kernel.schema.LinkPatternStreamer.RawLinkPatternStreamer;
 import org.fao.geonet.utils.Log;
 import org.fao.geonet.utils.Xml;
+import org.jdom.Attribute;
 import org.jdom.Element;
 import org.jdom.JDOMException;
 import org.jdom.Namespace;
@@ -577,6 +578,41 @@ public class ISO19115_3_2018SchemaPlugin
             return super.processElement(el, attributeRef, parsedAttributeName, attributeValue);
         }
 
+    }
+
+    @Override
+    public boolean duplicateElementsForMultilingual() {
+        return false;
+    }
+
+    @Override
+    public List<String> getMetadataLanguages(Element metadata) {
+        try {
+             Xml.selectNodes(metadata, ".//mdb:defaultLocale/lan:PT_Locale/@id", allNamespaces.asList())
+                .stream()
+                .filter(node -> node instanceof Attribute)
+                .map(node -> ((Attribute)node).getValue())
+                .filter(s -> s != null && !s.isBlank())
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList()).addAll(
+                     Xml.selectNodes(metadata, ".//mdb:otherLocale/lan:PT_Locale/@id", allNamespaces.asList())
+                         .stream()
+                         .filter(node -> node instanceof Attribute)
+                         .map(node -> ((Attribute)node).getValue())
+                         .filter(s -> s != null && !s.isBlank())
+                         .filter(Objects::nonNull)
+                         .collect(Collectors.toList())
+                 );
+        } catch (JDOMException e) {
+            e.printStackTrace();
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
+    public boolean isMultilingualElementType(String elementType) {
+        // Not required in ISO schemas, only required for schemas where duplicateElementsForMultilingual returns true.
+        return false;
     }
 
     /**

--- a/schemas/iso19139/src/main/java/org/fao/geonet/schema/iso19139/ISO19139SchemaPlugin.java
+++ b/schemas/iso19139/src/main/java/org/fao/geonet/schema/iso19139/ISO19139SchemaPlugin.java
@@ -617,13 +617,11 @@ public class ISO19139SchemaPlugin
         try {
             return Xml.selectNodes(metadata, ".//gmd:locale/gmd:PT_Locale/@id", allNamespaces.asList())
                 .stream()
-                .filter(node -> node instanceof Attribute)
+                .filter(Attribute.class::isInstance)
                 .map(node -> ((Attribute)node).getValue())
                 .filter(s -> s != null && !s.isBlank())
-                .filter(Objects::nonNull)
                 .collect(Collectors.toList());
-        } catch (JDOMException e) {
-            e.printStackTrace();
+        } catch (JDOMException ignored) {
         }
         return Collections.emptyList();
     }

--- a/schemas/iso19139/src/main/java/org/fao/geonet/schema/iso19139/ISO19139SchemaPlugin.java
+++ b/schemas/iso19139/src/main/java/org/fao/geonet/schema/iso19139/ISO19139SchemaPlugin.java
@@ -607,6 +607,33 @@ public class ISO19139SchemaPlugin
 
     }
 
+    @Override
+    public boolean duplicateElementsForMultilingual() {
+        return false;
+    }
+
+    @Override
+    public List<String> getMetadataLanguages(Element metadata) {
+        try {
+            return Xml.selectNodes(metadata, ".//gmd:locale/gmd:PT_Locale/@id", allNamespaces.asList())
+                .stream()
+                .filter(node -> node instanceof Attribute)
+                .map(node -> ((Attribute)node).getValue())
+                .filter(s -> s != null && !s.isBlank())
+                .filter(Objects::nonNull)
+                .collect(Collectors.toList());
+        } catch (JDOMException e) {
+            e.printStackTrace();
+        }
+        return Collections.emptyList();
+    }
+
+    @Override
+    public boolean isMultilingualElementType(String elementType) {
+        // Not required in ISO schemas, only required for schemas where duplicateElementsForMultilingual returns true.
+        return false;
+    }
+
     /**
      * Checks if an element requires processing in {@link #processElement(Element, String, String, String)}.
      *

--- a/schemas/schema-core/src/main/java/org/fao/geonet/kernel/schema/MultilingualSchemaPlugin.java
+++ b/schemas/schema-core/src/main/java/org/fao/geonet/kernel/schema/MultilingualSchemaPlugin.java
@@ -26,6 +26,7 @@ package org.fao.geonet.kernel.schema;
 import org.jdom.Element;
 import org.jdom.JDOMException;
 
+import java.util.ArrayList;
 import java.util.List;
 
 /**
@@ -40,8 +41,66 @@ public interface MultilingualSchemaPlugin {
      */
     public abstract List<Element> getTranslationForElement(Element element, String languageIdentifier);
 
+    /**
+     * Updates an element with the related multilingual information using the language and value provided.
+     *
+     * @param element               XML element to update.
+     * @param languageIdentifier    Language identifier.
+     * @param value                 Value for the element.
+     */
     public abstract void addTranslationToElement(Element element, String languageIdentifier, String value);
 
+    /**
+     * Remove all multilingual aspect of an element.
+     *
+     * @param element               XML element to update.
+     * @param mdLang                Metadata languages.
+     * @return
+     * @throws JDOMException
+     */
     public abstract  Element removeTranslationFromElement(Element element, List<String> mdLang) throws JDOMException;
 
+    /**
+     * Retrieves the list of metadata languages used in the metadata.
+     * @param metadata
+     * @return
+     */
+    public abstract List<String> getMetadataLanguages(Element metadata);
+
+    /**
+     * Checks if an element type is multilingual. For example, in DCAT schema, rdf:PlainLiteral type.
+     *
+     * @param elementType   Element type to check.
+     * @return              true if the element type is multilingual, otherwise false.
+     */
+    public abstract boolean isMultilingualElementType(String elementType);
+
+
+    /**
+     * Flag to indicate when adding an element to the metadata editor, if should be duplicated for each metadata language.
+     * For example, in DCAT schema adding vcard:organization-name in a metadata that has English and French languages
+     * (similar case for Dublin Core), should duplicate the element for each language:
+     *
+     *    <vcard:organization-name xml:lang="en"/>
+     *    <vcard:organization-name xml:lang="fr"/>
+     *
+     * For ISO profiles should be set to false, as the multilingual elements are not duplicated. Multilingual values
+     * are added as children elements, requiring a different processing. Adding gmd:organisationName in a metadata
+     * that has English and French languages:
+     *
+     * <gmd:organisationName xsi:type="gmd:PT_FreeText_PropertyType">
+     *     <gco:CharacterString></gco:CharacterString>
+     *     <gmd:PT_FreeText>
+     *         <gmd:textGroup>
+     *             <gmd:LocalisedCharacterString locale="#EN"></gmd:LocalisedCharacterString>
+     *         </gmd:textGroup>
+     *         <gmd:textGroup>
+     *             <gmd:LocalisedCharacterString locale="#FR"></gmd:LocalisedCharacterString>
+     *         </gmd:textGroup>
+     *     </gmd:PT_FreeText>
+     * </gmd:organisationName>
+     *
+     * @return
+     */
+    public abstract boolean duplicateElementsForMultilingual();
 }

--- a/services/src/main/java/org/fao/geonet/api/records/editing/AjaxEditUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/records/editing/AjaxEditUtils.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2024 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -36,6 +36,7 @@ import org.fao.geonet.kernel.EditLib;
 import org.fao.geonet.kernel.SchemaManager;
 import org.fao.geonet.kernel.UpdateDatestamp;
 import org.fao.geonet.kernel.schema.MetadataSchema;
+import org.fao.geonet.kernel.schema.MultilingualSchemaPlugin;
 import org.fao.geonet.kernel.schema.SchemaPlugin;
 import org.fao.geonet.lib.Lib;
 import org.fao.geonet.schema.iso19139.ISO19139Namespaces;
@@ -340,8 +341,16 @@ public class AjaxEditUtils extends EditUtils {
 
     /**
      * For Ajax Editing : adds an element or an attribute to a metadata element ([add] link).
+     *
+     * @param session       User session.
+     * @param id            Metadata identifier.
+     * @param ref           Reference of the parent element to add the element.
+     * @param name          Name of the element or attribute to add, with the namespace
+     * @param childName     Empty for inserting element, `geonet:attribute` for attributes.
+     * @return
+     * @throws Exception
      */
-    public synchronized Element addElementEmbedded(UserSession session, String id, String ref, String name, String childName) throws Exception {
+    public synchronized List<Element> addElementEmbedded(UserSession session, String id, String ref, String name, String childName) throws Exception {
         Lib.resource.checkEditPrivilege(context, id);
         String schema = dataManager.getMetadataSchema(id);
         //--- get metadata from session
@@ -362,10 +371,13 @@ public class AjaxEditUtils extends EditUtils {
             md.removeChild(Edit.RootChild.INFO, Edit.NAMESPACE);
         }
 
-        Element child = null;
+        List<Element> children = new ArrayList<>();
         MetadataSchema mds = dataManager.getSchema(schema);
+
         if (childName != null) {
             if (childName.equals("geonet:attribute")) {
+                Element child = null;
+
                 String defaultValue = "";
                 @SuppressWarnings("unchecked")
                 List<Element> attributeDefs = el.getChildren(Edit.RootChild.ATTRIBUTE, Edit.NAMESPACE);
@@ -385,9 +397,11 @@ public class AjaxEditUtils extends EditUtils {
                 el.setAttribute(new Attribute(attInfo.two(), defaultValue, attInfo.one()));
 
                 child = el;
+                children.add(child);
+
             } else {
                 //--- normal element
-                child = editLib.addElement(mds, el, name);
+                Element child = editLib.addElement(mds, el, name);
                 if (!childName.equals("")) {
                     //--- or element
                     String uChildName = editLib.getUnqualifiedName(childName);
@@ -403,20 +417,35 @@ public class AjaxEditUtils extends EditUtils {
                     //--- add mandatory sub-tags
                     editLib.fillElement(schema, child, orChild);
                 }
+
+                children.add(child);
             }
         } else {
-            child = editLib.addElement(mds, el, name);
+            List<String> metadataLanguages = new ArrayList<>();
+            if (mds.getSchemaPlugin() instanceof MultilingualSchemaPlugin) {
+                // Metadata languages are only required if the schema plugin requires to duplicate the added
+                // element for each language and the element to add is multilingual.
+                // See {@link org.fao.geonet.kernel.schema.MultilingualSchemaPlugin#duplicateElementsForMultilingual()}
+                metadataLanguages = ((MultilingualSchemaPlugin) mds.getSchemaPlugin()).getMetadataLanguages(md);
+            }
+
+            children = editLib.addElements(mds, el, name, metadataLanguages);
         }
+
         //--- now enumerate the new child (if not a simple attribute)
-        if (childName == null || !childName.equals("geonet:attribute")) {
-            int iRef = editLib.findMaximumRef(md);
-            editLib.enumerateTreeStartingAt(child, iRef + 1, Integer.parseInt(ref));
-            editLib.expandTree(mds, child);
+        if ((childName == null || !childName.equals("geonet:attribute")) && (children != null)) {
+            for (Element c: children) {
+                int iRef = editLib.findMaximumRef(md);
+                editLib.enumerateTreeStartingAt(c, iRef + 1, Integer.parseInt(ref));
+                editLib.expandTree(mds, c);
+            }
         }
-        if (info != null) {
-            //--- remove and re-attach the info element to the child
-            child.removeChild(Edit.RootChild.INFO, Edit.NAMESPACE);
-            child.addContent(info);
+        if ((info != null) && (children != null)) {
+            for (Element c: children) {
+                //--- remove and re-attach the info element to the child
+                c.removeChild(Edit.RootChild.INFO, Edit.NAMESPACE);
+                c.addContent((Element) info.clone());
+            }
         }
 
           /* When adding an gmx:Anchor to an element, due to the following code gets also a gco:CharacterString in EditLib.
@@ -436,9 +465,11 @@ public class AjaxEditUtils extends EditUtils {
             Element child = isoPlugin.createBasicTypeCharacterString();
             element.addContent(child);
         */
-        if (childName != null && childName.equals("gmx:Anchor")) {
-            if (child.getChild("CharacterString", ISO19139Namespaces.GCO) != null) {
-                child.removeChild("CharacterString", ISO19139Namespaces.GCO);
+        if (childName != null && childName.equals("gmx:Anchor") && (children != null)) {
+            for (Element c: children) {
+                if (c.getChild("CharacterString", ISO19139Namespaces.GCO) != null) {
+                    c.removeChild("CharacterString", ISO19139Namespaces.GCO);
+                }
             }
         }
 
@@ -451,8 +482,7 @@ public class AjaxEditUtils extends EditUtils {
         setMetadataIntoSession(session, (Element) md.clone(), id);
 
         // Return element added
-        return child;
-
+        return children;
     }
 
     /**


### PR DESCRIPTION
Dublin core or DCAT use `xml:lang` attribute added to sibling elements for translations (compared to ISO which always have a container element with translations in it).

This change add support for:
* adding such element in embedded mode (ie. not while saving the full document but only requesting expansion of a particular element) 
* and ordering  multilingual elements.




<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

Funded by https://metadata.vlaanderen.be/