### PR TITLE
ISO19110 / Fix indexing of multiple feature type aliases

### DIFF
--- a/schemas/iso19110/src/main/plugin/iso19110/index-fields/index.xsl
+++ b/schemas/iso19110/src/main/plugin/iso19110/index-fields/index.xsl
@@ -101,7 +101,11 @@
           "definition" :"<xsl:value-of select="util:escapeForJson(gfc:FC_FeatureType/gfc:definition/*/text())"/>",
           "code" :"<xsl:value-of select="util:escapeForJson(gfc:FC_FeatureType/gfc:code/*/text())"/>",
           "isAbstract" :"<xsl:value-of select="gfc:FC_FeatureType/gfc:isAbstract/*/text()"/>",
-          "aliases" : "<xsl:value-of select="util:escapeForJson(gfc:FC_FeatureType/gfc:aliases/*/text())"/>"
+          "aliases" : [
+          <xsl:for-each select="gfc:FC_FeatureType/gfc:aliases[string(*/text())]">
+            "<xsl:value-of select="util:escapeForJson(*/text())"/>"<xsl:if test="position() != last()">,</xsl:if>
+          </xsl:for-each>
+          ]
           <!--"inheritsFrom" : "<xsl:value-of select="gfc:FC_FeatureType/gfc:inheritsFrom/*/text()"/>",
           "inheritsTo" : "<xsl:value-of select="gfc:FC_FeatureType/gfc:inheritsTo/*/text()"/>",
           "constrainedBy" : "<xsl:value-of select="gfc:FC_FeatureType/gfc:constrainedBy/*/text()"/>",

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/featurecatalogue.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/featurecatalogue.html
@@ -49,7 +49,7 @@
       </tr>
       <tr data-ng-if="featureType.aliases">
         <th data-translate="">featureAliases</th>
-        <td>{{featureType.aliases}}</td>
+        <td>{{featureType.aliases.join(", ")}}</td>
       </tr>
       <tr data-ng-if="featureType.attributeTable">
         <td


### PR DESCRIPTION
Test case:

1) Create an ISO19110 metadata and assign 2 FeatureType aliases.

![featuretype-aliases](https://github.com/user-attachments/assets/7d7dc7a5-40a5-451b-81e7-50a5863cf6ea)


2) Without the fix the following indexing error occurs:

```
Error on line 104 of index.xsl:
  XPTY0004: A sequence of more than one item is not allowed as the first argument of
  util:escapeForJson() ("Variable Name", "Variable Info") 
```

---

The UI is updated to concatenate the values, requiring to reindex the ISO19110 to process the aliases as an array.

![featuretype-aliases-2](https://github.com/user-attachments/assets/30675d1e-073f-4b77-9afe-e6a73bf67498)



# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
