### PR TITLE
Editor / Add support for conditional default view

### DIFF
--- a/web/src/main/webapp/xslt/common/base-variables-metadata.xsl
+++ b/web/src/main/webapp/xslt/common/base-variables-metadata.xsl
@@ -106,10 +106,11 @@
                         then /root/request/currTab
                         else if (/root/gui/currTab != '')
                         then /root/gui/currTab
-                        else $editorConfig/editor/views/view[@default]/tab[
+                        else ($editorConfig/editor/views/view[@default and
+                          gn-fn-metadata:check-elementandsession-visibility($schema, $metadata, $serviceInfo, @displayIfRecord, @displayIfServiceInfo)]/tab[
                           @default and
                           gn-fn-metadata:check-elementandsession-visibility($schema, $metadata, $serviceInfo, @displayIfRecord, @displayIfServiceInfo)
-                        ]/@id"/>
+                        ]/@id)[1]"/>
 
   <xsl:variable name="viewConfig"
                 select="$editorConfig/editor/views/view[tab/@id = $tab]"/>


### PR DESCRIPTION
When creating an editor configuration with more than one default view an exception is returned.

```
Error on line 82 of edit.xsl:
  XPTY0004: A sequence of more than one item is not allowed as the second argument of concat()
```

Instead, select the first default view defined.

Also add support for conditionally defined default views:

```xml
    <view name="default-for-dataset"
          default="true"
          displayIfRecord="count(//dcat:Catalog/dcat:dataset) > 0">
      <tab id="Dataset" default="true">
        <section name="Dataset info"/>
      </tab>
    </view>
    <view name="default-for-service"
          default="true"
          displayIfRecord="count(//dcat:Catalog/dcat:service) > 0">
      <tab id="Service" default="true">
        <section name="Service info"/>
      </tab>
    </view>
```


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

