### PR TITLE
[Backport 4.2.x] Attachments API / Set content-length and close input stream when retrieving a metadata resource

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsApi.java
@@ -1,6 +1,6 @@
 /*
  * =============================================================================
- * ===	Copyright (C) 2001-2023 Food and Agriculture Organization of the
+ * ===	Copyright (C) 2001-2024 Food and Agriculture Organization of the
  * ===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * ===	and United Nations Environment Programme (UNEP)
  * ===
@@ -68,6 +68,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.awt.image.BufferedImage;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URL;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -171,8 +172,7 @@ public class AttachmentsApi {
         @RequestParam(required = false, defaultValue = FilesystemStore.DEFAULT_FILTER) String filter,
         @Parameter(hidden = true) HttpServletRequest request) throws Exception {
         ServiceContext context = ApiUtils.createServiceContext(request);
-        List<MetadataResource> list = store.getResources(context, metadataUuid, sort, filter, approved);
-        return list;
+        return store.getResources(context, metadataUuid, sort, filter, approved);
     }
 
     @io.swagger.v3.oas.annotations.Operation(summary = "Delete all uploaded metadata resources")
@@ -291,7 +291,11 @@ public class AttachmentsApi {
                         MIN_IMAGE_SIZE, MAX_IMAGE_SIZE, size));
                 }
             } else {
-                StreamUtils.copy(Files.newInputStream(file.getPath()), response.getOutputStream());
+                response.setContentLengthLong(Files.size(file.getPath()));
+
+                try (InputStream inputStream = Files.newInputStream(file.getPath())) {
+                    StreamUtils.copy(inputStream, response.getOutputStream());
+                }
             }
         }
     }


### PR DESCRIPTION
Backport #8556
 **Authored by:** @josegar74