### PR TITLE
GN5 / Security configuration

### DIFF
--- a/web/src/main/webapp/WEB-INF/config-security/config-security-gn5-overrides.properties
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-gn5-overrides.properties
@@ -1,0 +1,51 @@
+# Copyright (C) 2024 Food and Agriculture Organization of the
+# United Nations (FAO-UN), United Nations World Food Programme (WFP)
+# and United Nations Environment Programme (UNEP)
+#
+# This program is free software; you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation; either version 2 of the License, or (at
+# your option) any later version.
+#
+# This program is distributed in the hope that it will be useful, but
+# WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+# General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+#
+# Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+# Rome - Italy. email: geonetwork@osgeo.org
+jwtheadersConfiguration.JwtConfiguration.userNameHeaderAttributeName=${JWTHEADERS_UserNameHeaderName:gn5.to.gn4.trusted.json.auth}
+jwtheadersConfiguration.JwtConfiguration.userNameFormatChoice=${JWTHEADERS_UserNameFormat:JSON}
+
+jwtheadersConfiguration.JwtConfiguration.UserNameJsonPath=${JWTHEADERS_UserNameJsonPath:username}
+
+
+jwtheadersConfiguration.JwtConfiguration.rolesJsonPath=${JWTHEADERS_RolesJsonPath:resource_access.live-key2.roles}
+jwtheadersConfiguration.JwtConfiguration.rolesHeaderName=${JWTHEADERS_RolesHeaderName:OIDC_id_token_payload}
+jwtheadersConfiguration.JwtConfiguration.jwtHeaderRoleSource=${JWTHEADERS_JwtHeaderRoleSource:DB}
+
+jwtheadersConfiguration.JwtConfiguration.roleConverterString=${JWTHEADERS_RoleConverterString:"GeonetworkAdministrator=ADMINISTRATOR"}
+jwtheadersConfiguration.JwtConfiguration.onlyExternalListedRoles=${JWTHEADERS_OnlyExternalListedRoles:false}
+
+jwtheadersConfiguration.JwtConfiguration.validateToken=${JWTHEADERS_ValidateToken:false}
+
+jwtheadersConfiguration.JwtConfiguration.validateTokenExpiry=${JWTHEADERS_ValidateTokenExpiry:false}
+
+
+jwtheadersConfiguration.JwtConfiguration.validateTokenAgainstURL=${JWTHEADERS_ValidateTokenAgainstURL:true}
+jwtheadersConfiguration.JwtConfiguration.validateTokenAgainstURLEndpoint=${JWTHEADERS_ValidateTokenAgainstURLEndpoint:}
+jwtheadersConfiguration.JwtConfiguration.validateSubjectWithEndpoint=${JWTHEADERS_ValidateSubjectWithEndpoint:true}
+
+jwtheadersConfiguration.JwtConfiguration.validateTokenAudience=${JWTHEADERS_ValidateTokenAudience:true}
+jwtheadersConfiguration.JwtConfiguration.validateTokenAudienceClaimName=${JWTHEADERS_ValidateTokenAudienceClaimName:""}
+jwtheadersConfiguration.JwtConfiguration.validateTokenAudienceClaimValue=${JWTHEADERS_ValidateTokenAudienceClaimValue:""}
+
+jwtheadersConfiguration.JwtConfiguration.validateTokenSignature=${JWTHEADERS_ValidateTokenSignature:true}
+jwtheadersConfiguration.JwtConfiguration.validateTokenSignatureURL=${JWTHEADERS_ValidateTokenSignatureURL:""}
+
+jwtHeadersSecurityConfig.UpdateProfile=${JWTHEADERS_UpdateProfile:false}
+jwtHeadersSecurityConfig.UpdateGroup=${JWTHEADERS_UpdateGroup:false}

--- a/web/src/main/webapp/WEB-INF/config-security/config-security-gn5.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-gn5.xml
@@ -29,7 +29,7 @@
           http://www.springframework.org/schema/context/spring-context-3.0.xsd">
 
   <context:property-override
-    location="WEB-INF/config-security/config-security-jwt-headers-overrides.properties"
+    location="WEB-INF/config-security/config-security-gn5-overrides.properties"
     ignore-resource-not-found="true"/>
 
   <import resource="config-security-jwt-headers-base.xml"/>

--- a/web/src/main/webapp/WEB-INF/config-security/config-security-jwt-headers-base.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-jwt-headers-base.xml
@@ -1,0 +1,73 @@
+<!--
+  ~ Copyright (C) 2024 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+<beans xmlns="http://www.springframework.org/schema/beans"
+       xmlns:context="http://www.springframework.org/schema/context"
+       xmlns:security="http://www.springframework.org/schema/security"
+       xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+       xmlns:util="http://www.springframework.org/schema/util"
+       xsi:schemaLocation="
+          http://www.springframework.org/schema/beans
+          http://www.springframework.org/schema/beans/spring-beans-3.0.xsd
+          http://www.springframework.org/schema/context
+          http://www.springframework.org/schema/context/spring-context-3.0.xsd
+          http://www.springframework.org/schema/util
+          http://www.springframework.org/schema/util/spring-util.xsd">
+
+  <bean id ="jwtHeadersSecurityConfig" class="org.fao.geonet.kernel.security.jwtheaders.JwtHeadersSecurityConfig"/>
+
+  <bean id ="jwtheadersConfiguration" class="org.fao.geonet.kernel.security.jwtheaders.JwtHeadersConfiguration">
+    <constructor-arg ref ="jwtHeadersSecurityConfig" />
+  </bean>
+  <bean id ="jwtHeadersUserUtil" class="org.fao.geonet.kernel.security.jwtheaders.JwtHeadersUserUtil"/>
+
+  <bean id="jwtHeadersAuthFilter" class="org.fao.geonet.kernel.security.jwtheaders.JwtHeadersAuthFilter">
+    <constructor-arg ref ="jwtheadersConfiguration" />
+  </bean>
+
+
+
+
+  <bean id="filterChainFilters" class="java.util.ArrayList">
+    <constructor-arg>
+      <list>
+        <ref bean="securityContextPersistenceFilter"/>
+        <!-- To disable csrf security (not recommended) comment the following line -->
+        <ref bean="csrfFilter" />
+        <!-- To disable csrf security (not recommended) comment the upper line -->
+
+
+        <ref bean="logoutFilter"/>
+        <ref bean="jwtHeadersAuthFilter"/>
+
+
+        <ref bean="requestCacheFilter"/>
+        <ref bean="anonymousFilter"/>
+        <ref bean="sessionMgmtFilter"/>
+        <ref bean="exceptionTranslationFilter"/>
+        <ref bean="filterSecurityInterceptor"/>
+      </list>
+    </constructor-arg>
+  </bean>
+
+
+</beans>

--- a/web/src/main/webapp/WEB-INF/config-security/config-security.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security.xml
@@ -59,6 +59,7 @@
      jwt-headers-multi - This adds two configurable jwt-headers filters.  This is useful for BOTH OIDC and OAUTH2 (access token)
                          at the same time.
                            + (see config-security-jwt-headers-multi.xml and -overrides.properties for details)
+     gn5             - GeoNetwork 5 security based on jwt-headers
      ldap            - ldap security (see config-security-ldap.xml for more details)
      ldap-recursive  - ldap-recursive security (see config-security-ldap-recursive.xml for more details)
      ecas            - ecas security (see config-security-ecas.xml for more details)


### PR DESCRIPTION
Security configuration for GeoNetwork 4 deployed behing GeoNetwork 5 prototype using simple mode (ie. GN4 MUST not be exposed to intranet and internet).

Authentication is managed by version 5 which check user credentials and create user in the database if needed. Then a JWT token is added to a header that version 4 checks.

Related to:
* JWT headers support https://github.com/geonetwork/core-geonetwork/pull/7899
* GeoNetwork 5 auth https://github.com/geonetwork/geonetwork/pull/77

To enable the configuration, use:

```sh
mvn jetty:run -Dgeonetwork.security.type=gn5
```


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

