### PR TITLE
Enforce upload size limit on putResourceFromUrl api

### DIFF
--- a/core/src/main/java/org/fao/geonet/api/exception/InputStreamLimitExceededException.java
+++ b/core/src/main/java/org/fao/geonet/api/exception/InputStreamLimitExceededException.java
@@ -1,3 +1,26 @@
+//=============================================================================
+//===	Copyright (C) 2001-2025 Food and Agriculture Organization of the
+//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
+//===	and United Nations Environment Programme (UNEP)
+//===
+//===	This library is free software; you can redistribute it and/or
+//===	modify it under the terms of the GNU Lesser General Public
+//===	License as published by the Free Software Foundation; either
+//===	version 2.1 of the License, or (at your option) any later version.
+//===
+//===	This library is distributed in the hope that it will be useful,
+//===	but WITHOUT ANY WARRANTY; without even the implied warranty of
+//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//===	Lesser General Public License for more details.
+//===
+//===	You should have received a copy of the GNU Lesser General Public
+//===	License along with this library; if not, write to the Free Software
+//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+//===
+//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+//===	Rome - Italy. email: geonetwork@osgeo.org
+//==============================================================================
+
 package org.fao.geonet.api.exception;
 
 import org.springframework.web.multipart.MaxUploadSizeExceededException;

--- a/core/src/main/java/org/fao/geonet/api/exception/InputStreamLimitExceededException.java
+++ b/core/src/main/java/org/fao/geonet/api/exception/InputStreamLimitExceededException.java
@@ -1,12 +1,11 @@
 package org.fao.geonet.api.exception;
 
-import java.io.IOException;
+import org.springframework.web.multipart.MaxUploadSizeExceededException;
 
 /**
  * Custom exception to be thrown when the size of a remote file to be uploaded to the store exceeds the maximum upload size.
  */
-public class InputStreamLimitExceededException extends IOException {
-    private final long maxUploadSize;
+public class InputStreamLimitExceededException extends MaxUploadSizeExceededException {
     private final long remoteFileSize;
 
     /**
@@ -25,18 +24,8 @@ public class InputStreamLimitExceededException extends IOException {
      * @param remoteFileSize the size of the remote file
      */
     public InputStreamLimitExceededException(long maxUploadSize, long remoteFileSize) {
-        super("Remote file size " + (remoteFileSize >= 0L ? "of " + remoteFileSize + " bytes " : "") + "exceeds the maximum upload size" + (maxUploadSize >= 0L ? " of " + maxUploadSize + " bytes" : ""));
-        this.maxUploadSize = maxUploadSize;
+        super(maxUploadSize);
         this.remoteFileSize = remoteFileSize;
-    }
-
-    /**
-     * Get the maximum upload size allowed.
-     *
-     * @return the maximum upload size allowed
-     */
-    public long getMaxUploadSize() {
-        return this.maxUploadSize;
     }
 
     /**

--- a/core/src/main/java/org/fao/geonet/api/exception/InputStreamLimitExceededException.java
+++ b/core/src/main/java/org/fao/geonet/api/exception/InputStreamLimitExceededException.java
@@ -5,7 +5,7 @@ import java.io.IOException;
 /**
  * Custom exception to be thrown when the size of a remote file to be uploaded to the store exceeds the maximum upload size.
  */
-public class RemoteFileTooLargeException extends IOException {
+public class InputStreamLimitExceededException extends IOException {
     private final long maxUploadSize;
     private final long remoteFileSize;
 
@@ -14,7 +14,7 @@ public class RemoteFileTooLargeException extends IOException {
      *
      * @param maxUploadSize the maximum upload size allowed
      */
-    public RemoteFileTooLargeException(long maxUploadSize) {
+    public InputStreamLimitExceededException(long maxUploadSize) {
         this(maxUploadSize, -1L);
     }
 
@@ -24,7 +24,7 @@ public class RemoteFileTooLargeException extends IOException {
      * @param maxUploadSize the maximum upload size allowed
      * @param remoteFileSize the size of the remote file
      */
-    public RemoteFileTooLargeException(long maxUploadSize, long remoteFileSize) {
+    public InputStreamLimitExceededException(long maxUploadSize, long remoteFileSize) {
         super("Remote file size " + (remoteFileSize >= 0L ? "of " + remoteFileSize + " bytes " : "") + "exceeds the maximum upload size" + (maxUploadSize >= 0L ? " of " + maxUploadSize + " bytes" : ""));
         this.maxUploadSize = maxUploadSize;
         this.remoteFileSize = remoteFileSize;

--- a/core/src/main/java/org/fao/geonet/api/exception/InputStreamLimitExceededException.java
+++ b/core/src/main/java/org/fao/geonet/api/exception/InputStreamLimitExceededException.java
@@ -10,7 +10,7 @@ public class InputStreamLimitExceededException extends IOException {
     private final long remoteFileSize;
 
     /**
-     * Create a new RemoteFileTooLargeException with an unknown remote file size.
+     * Create a new InputStreamLimitExceededException with an unknown remote file size.
      *
      * @param maxUploadSize the maximum upload size allowed
      */
@@ -19,7 +19,7 @@ public class InputStreamLimitExceededException extends IOException {
     }
 
     /**
-     * Create a new RemoteFileTooLargeException with a known remote file size.
+     * Create a new InputStreamLimitExceededException with a known remote file size.
      *
      * @param maxUploadSize the maximum upload size allowed
      * @param remoteFileSize the size of the remote file

--- a/core/src/main/java/org/fao/geonet/api/exception/RemoteFileTooLargeException.java
+++ b/core/src/main/java/org/fao/geonet/api/exception/RemoteFileTooLargeException.java
@@ -1,9 +1,11 @@
 package org.fao.geonet.api.exception;
 
+import java.io.IOException;
+
 /**
  * Custom exception to be thrown when the size of a remote file to be uploaded to the store exceeds the maximum upload size.
  */
-public class RemoteFileTooLargeException extends RuntimeException {
+public class RemoteFileTooLargeException extends IOException {
     private final long maxUploadSize;
     private final long remoteFileSize;
 

--- a/core/src/main/java/org/fao/geonet/api/exception/RemoteFileTooLargeException.java
+++ b/core/src/main/java/org/fao/geonet/api/exception/RemoteFileTooLargeException.java
@@ -1,0 +1,48 @@
+package org.fao.geonet.api.exception;
+
+/**
+ * Custom exception to be thrown when the size of a remote file to be uploaded to the store exceeds the maximum upload size.
+ */
+public class RemoteFileTooLargeException extends RuntimeException {
+    private final long maxUploadSize;
+    private final long remoteFileSize;
+
+    /**
+     * Create a new RemoteFileTooLargeException with an unknown remote file size.
+     *
+     * @param maxUploadSize the maximum upload size allowed
+     */
+    public RemoteFileTooLargeException(long maxUploadSize) {
+        this(maxUploadSize, -1L);
+    }
+
+    /**
+     * Create a new RemoteFileTooLargeException with a known remote file size.
+     *
+     * @param maxUploadSize the maximum upload size allowed
+     * @param remoteFileSize the size of the remote file
+     */
+    public RemoteFileTooLargeException(long maxUploadSize, long remoteFileSize) {
+        super("Remote file size " + (remoteFileSize >= 0L ? "of " + remoteFileSize + " bytes " : "") + "exceeds the maximum upload size" + (maxUploadSize >= 0L ? " of " + maxUploadSize + " bytes" : ""));
+        this.maxUploadSize = maxUploadSize;
+        this.remoteFileSize = remoteFileSize;
+    }
+
+    /**
+     * Get the maximum upload size allowed.
+     *
+     * @return the maximum upload size allowed
+     */
+    public long getMaxUploadSize() {
+        return this.maxUploadSize;
+    }
+
+    /**
+     * Get the size of the remote file.
+     *
+     * @return the size of the remote file or -1 if the size is unknown
+     */
+    public long getRemoteFileSize() {
+        return this.remoteFileSize;
+    }
+}

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
@@ -28,7 +28,7 @@ import jeeves.server.context.ServiceContext;
 import org.apache.commons.io.FilenameUtils;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.api.exception.NotAllowedException;
-import org.fao.geonet.api.exception.RemoteFileTooLargeException;
+import org.fao.geonet.api.exception.InputStreamLimitExceededException;
 import org.fao.geonet.api.exception.ResourceNotFoundException;
 import org.fao.geonet.domain.AbstractMetadata;
 import org.fao.geonet.domain.MetadataResource;
@@ -236,7 +236,7 @@ public abstract class AbstractStore implements Store {
         // Check if the content length is within the allowed limit
         long contentLength = connection.getContentLengthLong();
         if (contentLength > maxUploadSize) {
-            throw new RemoteFileTooLargeException(maxUploadSize, contentLength);
+            throw new InputStreamLimitExceededException(maxUploadSize, contentLength);
         }
 
         // Put the resource but limit the input stream to the max upload size plus one byte

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
@@ -249,7 +249,7 @@ public abstract class AbstractStore implements Store {
         // Extract filename from Content-Disposition header if present otherwise use the filename from the URL
         String contentDisposition = connection.getHeaderField("Content-Disposition");
         String filename = extractFilenameFromContentDisposition(contentDisposition);
-        if (filename.isEmpty()) {
+        if (filename == null || filename.isEmpty()) {
             filename = getFilenameFromUrl(fileUrl);
         }
 

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
@@ -61,8 +61,8 @@ public abstract class AbstractStore implements Store {
     protected static final String RESOURCE_MANAGEMENT_EXTERNAL_PROPERTIES_ESCAPED_SEPARATOR = "\\:";
     private static final Logger log = LoggerFactory.getLogger(AbstractStore.class);
 
-    @Value("${api.params.maxUploadSize:100000000}")
-    private long maxUploadSize;
+    @Value("${api.params.maxUploadSize}")
+    private int maxUploadSize;
 
     @Override
     public final List<MetadataResource> getResources(final ServiceContext context, final String metadataUuid, final Sort sort,

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
@@ -61,8 +61,8 @@ public abstract class AbstractStore implements Store {
     protected static final String RESOURCE_MANAGEMENT_EXTERNAL_PROPERTIES_ESCAPED_SEPARATOR = "\\:";
     private static final Logger log = LoggerFactory.getLogger(AbstractStore.class);
 
-    @Value("${api.params.maxUploadSize}")
-    private int maxUploadSize;
+    @Value("${api.params.maxUploadSize:100000000}")
+    private long maxUploadSize;
 
     @Override
     public final List<MetadataResource> getResources(final ServiceContext context, final String metadataUuid, final Sort sort,

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
@@ -239,8 +239,7 @@ public abstract class AbstractStore implements Store {
             throw new InputStreamLimitExceededException(maxUploadSize, contentLength);
         }
 
-        // Put the resource but limit the input stream to the max upload size plus one byte
-        // so we can check if the file is larger than the allowed size
+        // Upload the resource while ensuring the input stream does not exceed the maximum allowed size.
         try (LimitedInputStream is = new LimitedInputStream(connection.getInputStream(), maxUploadSize)) {
             return putResource(context, metadataUuid, filename, is, null, visibility, approved);
         }

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
@@ -44,7 +44,6 @@ import org.springframework.context.ApplicationContext;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.BufferedInputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.URL;
@@ -163,7 +162,7 @@ public abstract class AbstractStore implements Store {
         return metadataId;
     }
 
-    protected String getFilenameFromHeader(final URL fileUrl) throws IOException {
+    protected String getFilenameFromHeader(final URL fileUrl) {
         HttpURLConnection connection = null;
         try {
             connection = (HttpURLConnection) fileUrl.openConnection();

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStore.java
@@ -26,7 +26,7 @@
 package org.fao.geonet.api.records.attachments;
 
 import jeeves.server.context.ServiceContext;
-import org.fao.geonet.api.exception.RemoteFileTooLargeException;
+import org.fao.geonet.api.exception.InputStreamLimitExceededException;
 import org.fao.geonet.api.exception.ResourceAlreadyExistException;
 import org.fao.geonet.api.exception.ResourceNotFoundException;
 import org.fao.geonet.constants.Geonet;
@@ -205,7 +205,7 @@ public class FilesystemStore extends AbstractStore {
         Path filePath = getPath(context, metadataId, visibility, filename, approved);
         try {
             Files.copy(is, filePath, StandardCopyOption.REPLACE_EXISTING);
-        } catch (RemoteFileTooLargeException e) {
+        } catch (InputStreamLimitExceededException e) {
                 Files.deleteIfExists(filePath);
                 throw e;
         }

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStore.java
@@ -205,13 +205,9 @@ public class FilesystemStore extends AbstractStore {
         Path filePath = getPath(context, metadataId, visibility, filename, approved);
         try {
             Files.copy(is, filePath, StandardCopyOption.REPLACE_EXISTING);
-        } catch (Exception e) {
-            if (e.getMessage().contains("Exceeded configured input limit of")) {
+        } catch (RemoteFileTooLargeException e) {
                 Files.deleteIfExists(filePath);
-                throw new RemoteFileTooLargeException(this.maxUploadSize);
-            } else {
                 throw e;
-            }
         }
         if (changeDate != null) {
             IO.touch(filePath, FileTime.from(changeDate.getTime(), TimeUnit.MILLISECONDS));

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStore.java
@@ -206,8 +206,8 @@ public class FilesystemStore extends AbstractStore {
         try {
             Files.copy(is, filePath, StandardCopyOption.REPLACE_EXISTING);
         } catch (InputStreamLimitExceededException e) {
-                Files.deleteIfExists(filePath);
-                throw e;
+            Files.deleteIfExists(filePath);
+            throw e;
         }
         if (changeDate != null) {
             IO.touch(filePath, FileTime.from(changeDate.getTime(), TimeUnit.MILLISECONDS));

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStore.java
@@ -26,7 +26,7 @@
 package org.fao.geonet.api.records.attachments;
 
 import jeeves.server.context.ServiceContext;
-import org.fao.geonet.api.exception.GeonetMaxUploadSizeExceededException;
+import org.fao.geonet.api.exception.RemoteFileTooLargeException;
 import org.fao.geonet.api.exception.ResourceAlreadyExistException;
 import org.fao.geonet.api.exception.ResourceNotFoundException;
 import org.fao.geonet.constants.Geonet;
@@ -36,8 +36,6 @@ import org.fao.geonet.domain.MetadataResourceVisibility;
 import org.fao.geonet.kernel.GeonetworkDataDirectory;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.lib.Lib;
-import org.fao.geonet.util.FileUtil;
-import org.fao.geonet.util.LimitedInputStream;
 import org.fao.geonet.utils.IO;
 import org.fao.geonet.utils.Log;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -205,14 +203,15 @@ public class FilesystemStore extends AbstractStore {
         int metadataId = canEdit(context, metadataUuid, approved);
         checkResourceId(filename);
         Path filePath = getPath(context, metadataId, visibility, filename, approved);
-        Files.copy(is, filePath, StandardCopyOption.REPLACE_EXISTING);
-        if (is instanceof LimitedInputStream && ((LimitedInputStream) is).isLimitReached()) {
-            Files.deleteIfExists(filePath);
-            throw new GeonetMaxUploadSizeExceededException("uploadedResourceSizeExceededException")
-                .withMessageKey("exception.maxUploadSizeExceeded",
-                    new String[]{FileUtil.humanizeFileSize(maxUploadSize)})
-                .withDescriptionKey("exception.maxUploadSizeExceededUnknownSize.description",
-                    new String[]{FileUtil.humanizeFileSize(maxUploadSize)});
+        try {
+            Files.copy(is, filePath, StandardCopyOption.REPLACE_EXISTING);
+        } catch (Exception e) {
+            if (e.getMessage().contains("Exceeded configured input limit of")) {
+                Files.deleteIfExists(filePath);
+                throw new RemoteFileTooLargeException(this.maxUploadSize);
+            } else {
+                throw e;
+            }
         }
         if (changeDate != null) {
             IO.touch(filePath, FileTime.from(changeDate.getTime(), TimeUnit.MILLISECONDS));

--- a/core/src/main/java/org/fao/geonet/util/LimitedInputStream.java
+++ b/core/src/main/java/org/fao/geonet/util/LimitedInputStream.java
@@ -1,6 +1,5 @@
 package org.fao.geonet.util;
 
-import java.io.FilterInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 

--- a/core/src/main/java/org/fao/geonet/util/LimitedInputStream.java
+++ b/core/src/main/java/org/fao/geonet/util/LimitedInputStream.java
@@ -1,13 +1,13 @@
 package org.fao.geonet.util;
 
-import org.fao.geonet.api.exception.RemoteFileTooLargeException;
+import org.fao.geonet.api.exception.InputStreamLimitExceededException;
 
 import java.io.IOException;
 import java.io.InputStream;
 
 /**
  * Implementation of {@link org.apache.commons.fileupload.util.LimitedInputStream} that throws a
- * {@link RemoteFileTooLargeException} when the configured limit is exceeded.
+ * {@link InputStreamLimitExceededException} when the configured limit is exceeded.
  */
 public class LimitedInputStream extends org.apache.commons.fileupload.util.LimitedInputStream {
 
@@ -25,6 +25,6 @@ public class LimitedInputStream extends org.apache.commons.fileupload.util.Limit
 
     @Override
     protected void raiseError(long pSizeMax, long pCount) throws IOException {
-        throw new RemoteFileTooLargeException(pSizeMax);
+        throw new InputStreamLimitExceededException(pSizeMax);
     }
 }

--- a/core/src/main/java/org/fao/geonet/util/LimitedInputStream.java
+++ b/core/src/main/java/org/fao/geonet/util/LimitedInputStream.java
@@ -3,13 +3,23 @@ package org.fao.geonet.util;
 import java.io.IOException;
 import java.io.InputStream;
 
+/**
+ * Like a {@link org.apache.commons.io.input.BoundedInputStream} but includes a method to check if the limit has been reached.
+ */
 public class LimitedInputStream extends InputStream {
     private final InputStream in;
     private final long max;
     private long pos;
     private long mark;
     private boolean propagateClose;
+    private boolean limitReached;
 
+    /**
+     * Creates a new instance.
+     *
+     * @param in   the input stream
+     * @param size the maximum number of bytes to read
+     */
     public LimitedInputStream(InputStream in, long size) {
         this.pos = 0L;
         this.mark = -1L;
@@ -18,12 +28,24 @@ public class LimitedInputStream extends InputStream {
         this.in = in;
     }
 
+    /**
+     * Creates a new instance.
+     *
+     * @param in the input stream
+     */
     public LimitedInputStream(InputStream in) {
         this(in, -1L);
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>In this implementation if the limit has been reached, returns -1.</p>
+     */
+    @Override
     public int read() throws IOException {
         if (this.max >= 0L && this.pos >= this.max) {
+            this.limitReached = true;
             return -1;
         } else {
             int result = this.in.read();
@@ -32,12 +54,25 @@ public class LimitedInputStream extends InputStream {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>In this implementation if the limit has been reached, returns -1.</p>
+     */
+    @Override
     public int read(byte[] b) throws IOException {
         return this.read(b, 0, b.length);
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>In this implementation if the limit has been reached, returns -1.</p>
+     */
+    @Override
     public int read(byte[] b, int off, int len) throws IOException {
         if (this.max >= 0L && this.pos >= this.max) {
+            this.limitReached = true;
             return -1;
         } else {
             long maxRead = this.max >= 0L ? Math.min((long)len, this.max - this.pos) : (long)len;
@@ -51,6 +86,12 @@ public class LimitedInputStream extends InputStream {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>In this implementation the number of bytes skipped is limited by the maximum number of bytes to read.</p>
+     */
+    @Override
     public long skip(long n) throws IOException {
         long toSkip = this.max >= 0L ? Math.min(n, this.max - this.pos) : n;
         long skippedBytes = this.in.skip(toSkip);
@@ -58,18 +99,37 @@ public class LimitedInputStream extends InputStream {
         return skippedBytes;
     }
 
+    /**
+     * {@inheritDoc}
+     *
+     * <p>In this implementation the number of bytes available is limited by the maximum number of bytes to read.</p>
+     */
+    @Override
     public int available() throws IOException {
         return this.max >= 0L && this.pos >= this.max ? 0 : this.in.available();
     }
 
+    /**
+     * Returns whether the limit has been reached.
+     *
+     * @return {@code true} if the limit has been reached, {@code false} otherwise
+     */
     public boolean isLimitReached() {
-        return this.pos >= this.max;
+        return this.limitReached;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public String toString() {
         return this.in.toString();
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public void close() throws IOException {
         if (this.propagateClose) {
             this.in.close();
@@ -77,25 +137,29 @@ public class LimitedInputStream extends InputStream {
 
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public synchronized void reset() throws IOException {
         this.in.reset();
         this.pos = this.mark;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public synchronized void mark(int readlimit) {
         this.in.mark(readlimit);
         this.mark = this.pos;
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public boolean markSupported() {
         return this.in.markSupported();
-    }
-
-    public boolean isPropagateClose() {
-        return this.propagateClose;
-    }
-
-    public void setPropagateClose(boolean propagateClose) {
-        this.propagateClose = propagateClose;
     }
 }

--- a/core/src/main/java/org/fao/geonet/util/LimitedInputStream.java
+++ b/core/src/main/java/org/fao/geonet/util/LimitedInputStream.java
@@ -1,3 +1,26 @@
+//=============================================================================
+//===	Copyright (C) 2001-2025 Food and Agriculture Organization of the
+//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
+//===	and United Nations Environment Programme (UNEP)
+//===
+//===	This library is free software; you can redistribute it and/or
+//===	modify it under the terms of the GNU Lesser General Public
+//===	License as published by the Free Software Foundation; either
+//===	version 2.1 of the License, or (at your option) any later version.
+//===
+//===	This library is distributed in the hope that it will be useful,
+//===	but WITHOUT ANY WARRANTY; without even the implied warranty of
+//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//===	Lesser General Public License for more details.
+//===
+//===	You should have received a copy of the GNU Lesser General Public
+//===	License along with this library; if not, write to the Free Software
+//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+//===
+//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+//===	Rome - Italy. email: geonetwork@osgeo.org
+//==============================================================================
+
 package org.fao.geonet.util;
 
 import org.fao.geonet.api.exception.InputStreamLimitExceededException;

--- a/core/src/main/java/org/fao/geonet/util/LimitedInputStream.java
+++ b/core/src/main/java/org/fao/geonet/util/LimitedInputStream.java
@@ -1,0 +1,102 @@
+package org.fao.geonet.util;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+
+public class LimitedInputStream extends InputStream {
+    private final InputStream in;
+    private final long max;
+    private long pos;
+    private long mark;
+    private boolean propagateClose;
+
+    public LimitedInputStream(InputStream in, long size) {
+        this.pos = 0L;
+        this.mark = -1L;
+        this.propagateClose = true;
+        this.max = size;
+        this.in = in;
+    }
+
+    public LimitedInputStream(InputStream in) {
+        this(in, -1L);
+    }
+
+    public int read() throws IOException {
+        if (this.max >= 0L && this.pos >= this.max) {
+            return -1;
+        } else {
+            int result = this.in.read();
+            ++this.pos;
+            return result;
+        }
+    }
+
+    public int read(byte[] b) throws IOException {
+        return this.read(b, 0, b.length);
+    }
+
+    public int read(byte[] b, int off, int len) throws IOException {
+        if (this.max >= 0L && this.pos >= this.max) {
+            return -1;
+        } else {
+            long maxRead = this.max >= 0L ? Math.min((long)len, this.max - this.pos) : (long)len;
+            int bytesRead = this.in.read(b, off, (int)maxRead);
+            if (bytesRead == -1) {
+                return -1;
+            } else {
+                this.pos += (long)bytesRead;
+                return bytesRead;
+            }
+        }
+    }
+
+    public long skip(long n) throws IOException {
+        long toSkip = this.max >= 0L ? Math.min(n, this.max - this.pos) : n;
+        long skippedBytes = this.in.skip(toSkip);
+        this.pos += skippedBytes;
+        return skippedBytes;
+    }
+
+    public int available() throws IOException {
+        return this.max >= 0L && this.pos >= this.max ? 0 : this.in.available();
+    }
+
+    public boolean isLimitReached() {
+        return this.pos >= this.max;
+    }
+
+    public String toString() {
+        return this.in.toString();
+    }
+
+    public void close() throws IOException {
+        if (this.propagateClose) {
+            this.in.close();
+        }
+
+    }
+
+    public synchronized void reset() throws IOException {
+        this.in.reset();
+        this.pos = this.mark;
+    }
+
+    public synchronized void mark(int readlimit) {
+        this.in.mark(readlimit);
+        this.mark = this.pos;
+    }
+
+    public boolean markSupported() {
+        return this.in.markSupported();
+    }
+
+    public boolean isPropagateClose() {
+        return this.propagateClose;
+    }
+
+    public void setPropagateClose(boolean propagateClose) {
+        this.propagateClose = propagateClose;
+    }
+}

--- a/core/src/main/java/org/fao/geonet/util/LimitedInputStream.java
+++ b/core/src/main/java/org/fao/geonet/util/LimitedInputStream.java
@@ -6,7 +6,8 @@ import java.io.IOException;
 import java.io.InputStream;
 
 /**
- *
+ * Implementation of {@link org.apache.commons.fileupload.util.LimitedInputStream} that throws a
+ * {@link RemoteFileTooLargeException} when the configured limit is exceeded.
  */
 public class LimitedInputStream extends org.apache.commons.fileupload.util.LimitedInputStream {
 

--- a/core/src/main/java/org/fao/geonet/util/LimitedInputStream.java
+++ b/core/src/main/java/org/fao/geonet/util/LimitedInputStream.java
@@ -1,165 +1,29 @@
 package org.fao.geonet.util;
 
+import org.fao.geonet.api.exception.RemoteFileTooLargeException;
+
 import java.io.IOException;
 import java.io.InputStream;
 
 /**
- * Like a {@link org.apache.commons.io.input.BoundedInputStream} but includes a method to check if the limit has been reached.
+ *
  */
-public class LimitedInputStream extends InputStream {
-    private final InputStream in;
-    private final long max;
-    private long pos;
-    private long mark;
-    private boolean propagateClose;
-    private boolean limitReached;
+public class LimitedInputStream extends org.apache.commons.fileupload.util.LimitedInputStream {
+
 
     /**
      * Creates a new instance.
      *
-     * @param in   the input stream
-     * @param size the maximum number of bytes to read
+     * @param inputStream The input stream, which shall be limited.
+     * @param pSizeMax    The limit; no more than this number of bytes
+     *                    shall be returned by the source stream.
      */
-    public LimitedInputStream(InputStream in, long size) {
-        this.pos = 0L;
-        this.mark = -1L;
-        this.propagateClose = true;
-        this.max = size;
-        this.in = in;
+    public LimitedInputStream(InputStream inputStream, long pSizeMax) {
+        super(inputStream, pSizeMax);
     }
 
-    /**
-     * Creates a new instance.
-     *
-     * @param in the input stream
-     */
-    public LimitedInputStream(InputStream in) {
-        this(in, -1L);
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * <p>In this implementation if the limit has been reached, returns -1.</p>
-     */
     @Override
-    public int read() throws IOException {
-        if (this.max >= 0L && this.pos >= this.max) {
-            this.limitReached = true;
-            return -1;
-        } else {
-            int result = this.in.read();
-            ++this.pos;
-            return result;
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * <p>In this implementation if the limit has been reached, returns -1.</p>
-     */
-    @Override
-    public int read(byte[] b) throws IOException {
-        return this.read(b, 0, b.length);
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * <p>In this implementation if the limit has been reached, returns -1.</p>
-     */
-    @Override
-    public int read(byte[] b, int off, int len) throws IOException {
-        if (this.max >= 0L && this.pos >= this.max) {
-            this.limitReached = true;
-            return -1;
-        } else {
-            long maxRead = this.max >= 0L ? Math.min((long)len, this.max - this.pos) : (long)len;
-            int bytesRead = this.in.read(b, off, (int)maxRead);
-            if (bytesRead == -1) {
-                return -1;
-            } else {
-                this.pos += (long)bytesRead;
-                return bytesRead;
-            }
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * <p>In this implementation the number of bytes skipped is limited by the maximum number of bytes to read.</p>
-     */
-    @Override
-    public long skip(long n) throws IOException {
-        long toSkip = this.max >= 0L ? Math.min(n, this.max - this.pos) : n;
-        long skippedBytes = this.in.skip(toSkip);
-        this.pos += skippedBytes;
-        return skippedBytes;
-    }
-
-    /**
-     * {@inheritDoc}
-     *
-     * <p>In this implementation the number of bytes available is limited by the maximum number of bytes to read.</p>
-     */
-    @Override
-    public int available() throws IOException {
-        return this.max >= 0L && this.pos >= this.max ? 0 : this.in.available();
-    }
-
-    /**
-     * Returns whether the limit has been reached.
-     *
-     * @return {@code true} if the limit has been reached, {@code false} otherwise
-     */
-    public boolean isLimitReached() {
-        return this.limitReached;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public String toString() {
-        return this.in.toString();
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void close() throws IOException {
-        if (this.propagateClose) {
-            this.in.close();
-        }
-
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public synchronized void reset() throws IOException {
-        this.in.reset();
-        this.pos = this.mark;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public synchronized void mark(int readlimit) {
-        this.in.mark(readlimit);
-        this.mark = this.pos;
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public boolean markSupported() {
-        return this.in.markSupported();
+    protected void raiseError(long pSizeMax, long pCount) throws IOException {
+        throw new RemoteFileTooLargeException(pSizeMax);
     }
 }

--- a/core/src/test/resources/WEB-INF/config.properties
+++ b/core/src/test/resources/WEB-INF/config.properties
@@ -20,5 +20,7 @@ es.index.checker.interval=0/5 * * * * ?
 
 thesaurus.cache.maxsize=400000
 
+api.params.maxUploadSize=100000000
+
 language.default=eng
 language.forceDefault=false

--- a/core/src/test/resources/org/fao/geonet/api/Messages.properties
+++ b/core/src/test/resources/org/fao/geonet/api/Messages.properties
@@ -178,6 +178,7 @@ api.exception.unsatisfiedRequestParameter=Unsatisfied request parameter
 api.exception.unsatisfiedRequestParameter.description=Unsatisfied request parameter.
 exception.maxUploadSizeExceeded=Maximum upload size of {0} exceeded.
 exception.maxUploadSizeExceeded.description=The request was rejected because its size ({0}) exceeds the configured maximum ({1}).
+exception.maxUploadSizeExceededUnknownSize.description=The request was rejected because its size exceeds the configured maximum ({0}).
 exception.resourceNotFound.metadata=Metadata not found
 exception.resourceNotFound.metadata.description=Metadata with UUID ''{0}'' not found.
 exception.resourceNotFound.resource=Metadata resource ''{0}'' not found

--- a/core/src/test/resources/org/fao/geonet/api/Messages_fre.properties
+++ b/core/src/test/resources/org/fao/geonet/api/Messages_fre.properties
@@ -172,6 +172,7 @@ api.exception.unsatisfiedRequestParameter=Param\u00E8tre de demande non satisfai
 api.exception.unsatisfiedRequestParameter.description=Param\u00E8tre de demande non satisfait.
 exception.maxUploadSizeExceeded=La taille maximale du t\u00E9l\u00E9chargement de {0} a \u00E9t\u00E9 exc\u00E9d\u00E9e.
 exception.maxUploadSizeExceeded.description=La demande a \u00E9t\u00E9 refus\u00E9e car sa taille ({0}) exc\u00E8de le maximum configur\u00E9 ({1}).
+exception.maxUploadSizeExceededUnknownSize.description=La demande a \u00E9t\u00E9 refus\u00E9e car sa taille exc\u00E8de le maximum configur\u00E9 ({0}).
 exception.resourceNotFound.metadata=Fiches introuvables
 exception.resourceNotFound.metadata.description=La fiche ''{0}'' est introuvable.
 exception.resourceNotFound.resource=Ressource ''{0}'' introuvable

--- a/datastorages/jcloud/src/main/java/org/fao/geonet/api/records/attachments/JCloudStore.java
+++ b/datastorages/jcloud/src/main/java/org/fao/geonet/api/records/attachments/JCloudStore.java
@@ -310,12 +310,13 @@ public class JCloudStore extends AbstractStore {
                 Log.info(Geonet.RESOURCES,
                     String.format("Put(2) blob '%s' with version label '%s'.", key, properties.get(jCloudConfiguration.getExternalResourceManagementVersionPropertyName())));
 
-                // Upload the Blob in multiple chunks to supports large files.
                 try {
+                    // Upload the Blob in multiple chunks to supports large files.
                     jCloudConfiguration.getClient().getBlobStore().putBlob(jCloudConfiguration.getContainerName(), blob, multipart());
                 } catch (HttpResponseException e) {
+                    // This is special logic for the jcloud store as the InputStreamLimitExceededException gets wrapped in a HttpResponseException
                     Throwable cause = e.getCause();
-                    if (cause != null && cause instanceof InputStreamLimitExceededException) {
+                    if (cause instanceof InputStreamLimitExceededException) {
                         throw (InputStreamLimitExceededException) cause;
                     }
                     throw e;

--- a/datastorages/jcloud/src/main/java/org/fao/geonet/api/records/attachments/JCloudStore.java
+++ b/datastorages/jcloud/src/main/java/org/fao/geonet/api/records/attachments/JCloudStore.java
@@ -30,7 +30,6 @@ import jeeves.server.context.ServiceContext;
 
 import org.apache.commons.collections.MapUtils;
 import org.fao.geonet.ApplicationContextHolder;
-import org.fao.geonet.api.exception.RemoteFileTooLargeException;
 import org.fao.geonet.api.exception.ResourceNotFoundException;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.MetadataResource;
@@ -42,8 +41,6 @@ import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.languages.IsoLanguagesMapper;
 import org.fao.geonet.lib.Lib;
 import org.fao.geonet.resources.JCloudConfiguration;
-import org.fao.geonet.util.FileUtil;
-import org.fao.geonet.util.LimitedInputStream;
 import org.fao.geonet.utils.IO;
 import org.fao.geonet.utils.Log;
 import org.jclouds.blobstore.ContainerNotFoundException;

--- a/datastorages/jcloud/src/main/java/org/fao/geonet/api/records/attachments/JCloudStore.java
+++ b/datastorages/jcloud/src/main/java/org/fao/geonet/api/records/attachments/JCloudStore.java
@@ -43,7 +43,7 @@ import org.fao.geonet.languages.IsoLanguagesMapper;
 import org.fao.geonet.lib.Lib;
 import org.fao.geonet.resources.JCloudConfiguration;
 import org.fao.geonet.util.FileUtil;
-import org.fao.geonet.util.LimitedIntputStream;
+import org.fao.geonet.util.LimitedInputStream;
 import org.fao.geonet.utils.IO;
 import org.fao.geonet.utils.Log;
 import org.jclouds.blobstore.ContainerNotFoundException;

--- a/datastorages/jcloud/src/main/java/org/fao/geonet/api/records/attachments/JCloudStore.java
+++ b/datastorages/jcloud/src/main/java/org/fao/geonet/api/records/attachments/JCloudStore.java
@@ -29,7 +29,6 @@ import static org.jclouds.blobstore.options.PutOptions.Builder.multipart;
 import jeeves.server.context.ServiceContext;
 
 import org.apache.commons.collections.MapUtils;
-import org.apache.commons.io.input.CountingInputStream;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.api.exception.GeonetMaxUploadSizeExceededException;
 import org.fao.geonet.api.exception.ResourceNotFoundException;
@@ -44,6 +43,7 @@ import org.fao.geonet.languages.IsoLanguagesMapper;
 import org.fao.geonet.lib.Lib;
 import org.fao.geonet.resources.JCloudConfiguration;
 import org.fao.geonet.util.FileUtil;
+import org.fao.geonet.util.LimitedInputStream;
 import org.fao.geonet.utils.IO;
 import org.fao.geonet.utils.Log;
 import org.jclouds.blobstore.ContainerNotFoundException;

--- a/services/src/main/java/org/fao/geonet/api/GlobalExceptionController.java
+++ b/services/src/main/java/org/fao/geonet/api/GlobalExceptionController.java
@@ -153,7 +153,7 @@ public class GlobalExceptionController {
     @ApiResponse(content = {@Content(mediaType = APPLICATION_JSON_VALUE)})
     @ExceptionHandler({
         MaxUploadSizeExceededException.class,
-        RemoteFileTooLargeException.class
+        InputStreamLimitExceededException.class
     })
     public ApiError maxFileExceededHandler(final Exception exception, final HttpServletRequest request) {
         Exception ex;
@@ -166,9 +166,9 @@ public class GlobalExceptionController {
                 .withDescriptionKey("exception.maxUploadSizeExceeded.description",
                     new String[]{FileUtil.humanizeFileSize(contentLength),
                         FileUtil.humanizeFileSize(((MaxUploadSizeExceededException) exception).getMaxUploadSize())});
-        } else if (exception instanceof RemoteFileTooLargeException) {
-            long maxUploadSize = ((RemoteFileTooLargeException) exception).getMaxUploadSize();
-            long remoteFileSize = ((RemoteFileTooLargeException) exception).getRemoteFileSize();
+        } else if (exception instanceof InputStreamLimitExceededException) {
+            long maxUploadSize = ((InputStreamLimitExceededException) exception).getMaxUploadSize();
+            long remoteFileSize = ((InputStreamLimitExceededException) exception).getRemoteFileSize();
             if (remoteFileSize == -1) {
                 ex = new GeonetMaxUploadSizeExceededException("uploadedResourceSizeExceededException", exception)
                     .withMessageKey("exception.maxUploadSizeExceeded",

--- a/services/src/main/java/org/fao/geonet/api/GlobalExceptionController.java
+++ b/services/src/main/java/org/fao/geonet/api/GlobalExceptionController.java
@@ -163,6 +163,8 @@ public class GlobalExceptionController {
                 ((InputStreamLimitExceededException) exception).getRemoteFileSize() :
                 request.getContentLengthLong();
 
+            // This can occur if the content length header is present on a resource but does not reflect the actual file size.
+            // This could indicate an attempt to bypass the maximum upload size.
             if (contentLength > 0 && contentLength < maxUploadSize) {
                 Log.warning(Geonet.RESOURCES, "Request content length is less than the maximum upload size but still caused an exception.");
             }

--- a/services/src/main/java/org/fao/geonet/api/GlobalExceptionController.java
+++ b/services/src/main/java/org/fao/geonet/api/GlobalExceptionController.java
@@ -153,20 +153,19 @@ public class GlobalExceptionController {
     @ApiResponse(content = {@Content(mediaType = APPLICATION_JSON_VALUE)})
     @ExceptionHandler({
         MaxUploadSizeExceededException.class,
-        RemoteFileTooLargeException.class,
+        RemoteFileTooLargeException.class
     })
     public ApiError maxFileExceededHandler(final Exception exception, final HttpServletRequest request) {
         Exception ex;
         long contentLength = request.getContentLengthLong();
         // As MaxUploadSizeExceededException is a spring exception, we need to convert it to a localized exception so that it can be translated.
         if (exception instanceof MaxUploadSizeExceededException) {
-            long maxUploadSize = ((MaxUploadSizeExceededException) exception).getMaxUploadSize();
-                ex = new GeonetMaxUploadSizeExceededException("uploadedResourceSizeExceededException", exception)
-                    .withMessageKey("exception.maxUploadSizeExceeded",
-                        new String[]{FileUtil.humanizeFileSize(maxUploadSize)})
-                    .withDescriptionKey("exception.maxUploadSizeExceeded.description",
-                        new String[]{FileUtil.humanizeFileSize(contentLength),
-                            FileUtil.humanizeFileSize(maxUploadSize)});
+            ex = new GeonetMaxUploadSizeExceededException("uploadedResourceSizeExceededException", exception)
+                .withMessageKey("exception.maxUploadSizeExceeded",
+                    new String[]{FileUtil.humanizeFileSize(((MaxUploadSizeExceededException) exception).getMaxUploadSize())})
+                .withDescriptionKey("exception.maxUploadSizeExceeded.description",
+                    new String[]{FileUtil.humanizeFileSize(contentLength),
+                        FileUtil.humanizeFileSize(((MaxUploadSizeExceededException) exception).getMaxUploadSize())});
         } else if (exception instanceof RemoteFileTooLargeException) {
             long maxUploadSize = ((RemoteFileTooLargeException) exception).getMaxUploadSize();
             long remoteFileSize = ((RemoteFileTooLargeException) exception).getRemoteFileSize();

--- a/services/src/test/java/org/fao/geonet/api/records/attachments/AbstractStoreTest.java
+++ b/services/src/test/java/org/fao/geonet/api/records/attachments/AbstractStoreTest.java
@@ -39,8 +39,8 @@ import org.springframework.mock.web.MockMultipartFile;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.net.HttpURLConnection;
 import java.net.URL;
-import java.net.URLConnection;
 import java.net.URLStreamHandler;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -69,7 +69,7 @@ public abstract class AbstractStoreTest extends AbstractServiceIntegrationTest {
         final Path file = Paths.get(resources, filename);
 
         assertTrue("Mock file " + filename + " not found", Files.exists(file));
-        final URLConnection mockConnection = Mockito.mock(URLConnection.class);
+        final HttpURLConnection mockConnection = Mockito.mock(HttpURLConnection.class);
 
         Mockito.when(mockConnection.getInputStream()).thenReturn(
             Files.newInputStream(file)
@@ -77,7 +77,7 @@ public abstract class AbstractStoreTest extends AbstractServiceIntegrationTest {
 
         final URLStreamHandler handler = new URLStreamHandler() {
             @Override
-            protected URLConnection openConnection(final URL arg0) {
+            protected HttpURLConnection openConnection(final URL arg0) {
                 return mockConnection;
             }
         };

--- a/services/src/test/java/org/fao/geonet/api/records/attachments/AbstractStoreTest.java
+++ b/services/src/test/java/org/fao/geonet/api/records/attachments/AbstractStoreTest.java
@@ -77,6 +77,8 @@ public abstract class AbstractStoreTest extends AbstractServiceIntegrationTest {
 
         Mockito.when(mockConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
 
+        Mockito.when(mockConnection.getContentLengthLong()).thenReturn(-1L);
+
         final URLStreamHandler handler = new URLStreamHandler() {
             @Override
             protected HttpURLConnection openConnection(final URL arg0) {

--- a/services/src/test/java/org/fao/geonet/api/records/attachments/AbstractStoreTest.java
+++ b/services/src/test/java/org/fao/geonet/api/records/attachments/AbstractStoreTest.java
@@ -75,6 +75,8 @@ public abstract class AbstractStoreTest extends AbstractServiceIntegrationTest {
             Files.newInputStream(file)
         );
 
+        Mockito.when(mockConnection.getResponseCode()).thenReturn(HttpURLConnection.HTTP_OK);
+
         final URLStreamHandler handler = new URLStreamHandler() {
             @Override
             protected HttpURLConnection openConnection(final URL arg0) {

--- a/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages.properties
+++ b/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages.properties
@@ -183,6 +183,7 @@ api.exception.unsatisfiedRequestParameter=Unsatisfied request parameter
 api.exception.unsatisfiedRequestParameter.description=Unsatisfied request parameter.
 exception.maxUploadSizeExceeded=Maximum upload size of {0} exceeded.
 exception.maxUploadSizeExceeded.description=The request was rejected because its size ({0}) exceeds the configured maximum ({1}).
+exception.maxUploadSizeExceededUnknownSize.description=The request was rejected because its size exceeds the configured maximum ({0}).
 exception.resourceNotFound.metadata=Metadata not found
 exception.resourceNotFound.metadata.description=Metadata with UUID ''{0}'' not found.
 exception.resourceNotFound.resource=Metadata resource ''{0}'' not found

--- a/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages_fre.properties
+++ b/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages_fre.properties
@@ -177,6 +177,7 @@ api.exception.unsatisfiedRequestParameter=Param\u00E8tre de demande non satisfai
 api.exception.unsatisfiedRequestParameter.description=Param\u00E8tre de demande non satisfait.
 exception.maxUploadSizeExceeded=La taille maximale du t\u00E9l\u00E9chargement de {0} a \u00E9t\u00E9 exc\u00E9d\u00E9e.
 exception.maxUploadSizeExceeded.description=La demande a \u00E9t\u00E9 refus\u00E9e car sa taille ({0}) exc\u00E8de le maximum configur\u00E9 ({1}).
+exception.maxUploadSizeExceededUnknownSize.description=La demande a \u00E9t\u00E9 refus\u00E9e car sa taille exc\u00E8de le maximum configur\u00E9 ({0}).
 exception.resourceNotFound.metadata=Fiches introuvables
 exception.resourceNotFound.metadata.description=La fiche ''{0}'' est introuvable.
 exception.resourceNotFound.resource=Ressource ''{0}'' introuvable


### PR DESCRIPTION
Currently the `putResourceFromURL` api does not enforce the maximum upload size limit. This means that you can upload files larger than the limit if you provide a URL to that resource rather than uploading the file directly.

This PR aims to fix this issue by checking the InputStream's available bytes against the configured `maxUploadSize`.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [X] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

