### PR TITLE
API / Extents / Scale factor / Add option to generate square image

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/extent/ExpandFactor.java
+++ b/services/src/main/java/org/fao/geonet/api/records/extent/ExpandFactor.java
@@ -38,6 +38,12 @@ public final class ExpandFactor implements Comparable<ExpandFactor> {
     double proportion;
     double factor;
 
+    /**
+     * If true, the image will be square.  If false, the image will be proportional to the geometry.
+     * Usually, use square image when factor is high (geometry will be small).
+     */
+    boolean squareImage = false;
+
     public double getProportion() {
         return proportion;
     }
@@ -52,6 +58,14 @@ public final class ExpandFactor implements Comparable<ExpandFactor> {
 
     public void setFactor(double factor) {
         this.factor = factor;
+    }
+
+    public boolean isSquareImage() {
+        return squareImage;
+    }
+
+    public void setSquareImage(boolean squareImage) {
+        this.squareImage = squareImage;
     }
 
     @Override

--- a/services/src/main/java/org/fao/geonet/api/regions/RegionsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/regions/RegionsApi.java
@@ -203,7 +203,19 @@ public class RegionsApi {
 
     @io.swagger.v3.oas.annotations.Operation(
         summary = "Get geometry as image",
-        description = "A rendering of the geometry as a png.")
+        description = "A rendering of the geometry as a `png`.\n " +
+            "\n " +
+            "The coverage of the image is computed from the geometry envelope and size using scale factor configuration " +
+            "(See `regionGetMapExpandFactors` bean in `config-spring-geonetwork.xml`) " +
+            "to give enough context on where the geometry is. The smaller the geometry, the bigger the expand factor.\n" +
+            "\n " +
+            "If needed, when the factor is high, square image mode can be enabled (instead of proportional geometry size):\n" +
+            "\n " +
+            "```xml\n" +
+            " <util:set id=\"regionGetMapExpandFactors\" set-class=\"java.util.TreeSet\">\n" +
+            "    <bean class=\"org.fao.geonet.api.records.extent.ExpandFactor\"\n" +
+            "          p:proportion=\".00005\" p:factor=\"256\" p:squareImage=\"true\"/>\n" +
+            "```\n")
     @RequestMapping(
         value = "/geom.png",
         produces = {


### PR DESCRIPTION
When scale factor is big, image generated always follows geom proportions. It may not be relevant as the geom is small on the image and a square image may be preferred.


![image](https://github.com/user-attachments/assets/d7a11a76-e131-45d8-9c6c-e290837185a5)

Add an option to render square image depending on the scale factor.

![image](https://github.com/user-attachments/assets/10bca8aa-a983-4ad5-b23b-f9d6726869a8)


Sample configuration (with large scale factor for small geometry - this catalogue contains quite some point extent in the middle of the sea):

```xml

  <util:set id="regionGetMapExpandFactors" set-class="java.util.TreeSet">
    <bean class="org.fao.geonet.api.records.extent.ExpandFactor"
          p:proportion=".00005" p:factor="256" p:squareImage="true"/>


```

Added more detailed API doc:

![image](https://github.com/user-attachments/assets/18105a7a-348e-456d-8945-2771b5d38fe4)



<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

Funded by Ifremer

