### PR TITLE
support section variable in manual url (#8494)

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/needhelp/NeedHelpDirective.js
+++ b/web-ui/src/main/resources/catalog/components/common/needhelp/NeedHelpDirective.js
@@ -141,6 +141,18 @@
           };
 
           /**
+           * Processes an URL removing // characters in the URL path.
+           *
+           * @param url
+           * @returns {string}
+           */
+          var processUrl = function(url) {
+            var urlToProcess = new URL(url);
+            urlToProcess.pathname = urlToProcess.pathname.replace(/\/\//g, "/");
+            return urlToProcess.toString();
+          }
+
+          /**
            * Get the URL of the corresponding help page and open it in a new tab
            * @returns {boolean}
            */
@@ -152,18 +164,25 @@
             if (gnGlobalSettings.lang !== "en") {
               baseUrl = scope.helpBaseUrl.replace("{{lang}}", gnGlobalSettings.lang);
             } else {
-              baseUrl = scope.helpBaseUrl.replace("/{{lang}}", "");
+              baseUrl = scope.helpBaseUrl.replace("{{lang}}", "");
             }
 
             baseUrl = baseUrl.replace("{{version}}", scope.applicationVersion);
 
-            var helpPageUrl = baseUrl + "/" + page;
+            var helpPageUrl;
+            if (baseUrl.includes("{{section}}")) {
+              helpPageUrl = baseUrl.replace("{{section}}", page);
+            } else {
+              helpPageUrl = baseUrl + "/" + page;
+            }
+
+            helpPageUrl = processUrl(helpPageUrl);
 
             testAndOpen(helpPageUrl).then(
               function () {},
               function () {
                 var baseUrl = scope.helpBaseUrl
-                  .replace("/{{lang}}", "")
+                  .replace("{{lang}}", "")
                   .replace("{{version}}", scope.applicationVersion);
                 var helpPageUrl = baseUrl + "/" + page;
 


### PR DESCRIPTION
Manuals backport for https://github.com/geonetwork/core-geonetwork/pull/8494

* support section variable in manual url

* isoLang variable, help wording

* Revert "isoLang variable, help wording"

This reverts commit 0b000ce2

* ignore path "/" for default language replacement

* Update web-ui/src/main/resources/catalog/locales/en-admin.json



* remove double slash

* remove double slash in error handler

---------


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

