### PR TITLE
remove outgoing headers for the proxy

### DIFF
--- a/web/src/main/java/org/fao/geonet/proxy/URITemplateProxyServlet.java
+++ b/web/src/main/java/org/fao/geonet/proxy/URITemplateProxyServlet.java
@@ -72,6 +72,8 @@ import java.util.regex.Pattern;
 import java.util.regex.PatternSyntaxException;
 import java.util.stream.Collectors;
 
+import static org.apache.commons.lang3.StringUtils.isBlank;
+
 /**
  * This is a class extending the real proxy to make sure we can tweak specifics like removing the CSRF token on requests
  *
@@ -95,11 +97,15 @@ public class URITemplateProxyServlet extends ProxyServlet {
     private static final long serialVersionUID = 4847856943273604410L;
     private static final String P_SECURITY_MODE = "securityMode";
     private static final String P_IS_SECURED = "isSecured";
+    private static final String P_DISALLOW_HEADERS = "disallowHeaders";
+
     private static final String TARGET_URI_NAME = "targetUri";
     private static final String P_EXCLUDE_HOSTS = "excludeHosts";
     private static final String P_ALLOW_PORTS = "allowPorts";
     private static final String ATTR_QUERY_STRING =
         URITemplateProxyServlet.class.getSimpleName() + ".queryString";
+
+    protected List<String> disallowHeaders = new ArrayList<>();
 
     /*
      * These are the "hop-by-hop" headers that should not be copied.
@@ -133,6 +139,15 @@ public class URITemplateProxyServlet extends ProxyServlet {
     // Allowed ports allowed to access through the proxy
     private Set<Integer> allowPorts = new HashSet<>(Arrays.asList(80, 443));
 
+    @Override
+    protected void copyRequestHeader(HttpServletRequest servletRequest, HttpRequest proxyRequest,
+                                     String headerName) {
+        if (disallowHeaders.contains(headerName)) {
+            return; // dont copy
+        }
+        super.copyRequestHeader(servletRequest,proxyRequest,headerName);
+    }
+
     /**
      * Init some properties from the servlet's init parameters. They try to be resolved the same way other GeoNetwork
      * configuration properties are resolved. If after checking externally no configuration can be found it relies into
@@ -159,6 +174,11 @@ public class URITemplateProxyServlet extends ProxyServlet {
      */
     @Override
     protected void initTarget() throws ServletException {
+        //parse the disallowHeaders
+        if (!isBlank(getConfigParam(P_DISALLOW_HEADERS))) {
+            disallowHeaders =  Arrays.asList(getConfigParam(P_DISALLOW_HEADERS).split(","));
+        }
+
         securityMode = SECURITY_MODE.parse(getConfigParam(P_SECURITY_MODE));
         String doForwardHostString = getConfigParam(P_FORWARDEDHOST);
         if (doForwardHostString != null) {
@@ -173,7 +193,7 @@ public class URITemplateProxyServlet extends ProxyServlet {
         targetUriTemplate = getConfigValue(TARGET_URI_NAME);
 
         // If not set externally try to use the value from web.xml
-        if (StringUtils.isBlank(targetUriTemplate)) {
+        if (isBlank(targetUriTemplate)) {
             targetUriTemplate = getConfigParam(P_TARGET_URI);
             if (targetUriTemplate == null) {
                 throw new ServletException(P_TARGET_URI + "  is required in web.xml or set externally");
@@ -185,7 +205,7 @@ public class URITemplateProxyServlet extends ProxyServlet {
 
         this.username = getConfigValue("username");
         this.password = getConfigValue("password");
-        if (StringUtils.isBlank(this.username)) {
+        if (isBlank(this.username)) {
             this.username = getConfigParam("username");
             this.password = getConfigParam("password");
         }
@@ -196,7 +216,7 @@ public class URITemplateProxyServlet extends ProxyServlet {
         }
 
         String excludeHosts = getConfigValue(P_EXCLUDE_HOSTS);
-        if (StringUtils.isBlank(excludeHosts)) {
+        if (isBlank(excludeHosts)) {
             excludeHosts = getConfigParam(P_EXCLUDE_HOSTS);
         }
 
@@ -209,7 +229,7 @@ public class URITemplateProxyServlet extends ProxyServlet {
         }
 
         String additionalAllowPorts = getConfigValue(P_ALLOW_PORTS);
-        if (StringUtils.isBlank(additionalAllowPorts)) {
+        if (isBlank(additionalAllowPorts)) {
             additionalAllowPorts = getConfigParam(P_ALLOW_PORTS);
         }
 
@@ -236,7 +256,7 @@ public class URITemplateProxyServlet extends ProxyServlet {
         result = resolveConfigValue(webappName + "." + getServletName() + "." + suffix);
 
 
-        if (StringUtils.isBlank(result)) {
+        if (isBlank(result)) {
             // GEONETWORK is the default prefix
 
             LOGGER.info(
@@ -464,7 +484,7 @@ public class URITemplateProxyServlet extends ProxyServlet {
 
     private boolean isUrlAllowed(HttpServletRequest servletRequest) {
         String url = servletRequest.getParameter("url");
-        if (StringUtils.isBlank(url)) {
+        if (isBlank(url)) {
             return true;
         }
 

--- a/web/src/main/webResources/WEB-INF/web.xml
+++ b/web/src/main/webResources/WEB-INF/web.xml
@@ -405,6 +405,15 @@
       <param-value>false</param-value>
     </init-param>
     <init-param>
+      <param-name>disallowHeaders</param-name>
+      <!-- comma separated list of header to NOT send to the remote proxy-ed server -->
+      <!--
+           This is the standard gn5->gn4 security header name. It should not be sent to
+           external services!
+       -->
+      <param-value>gn5.to.gn4.trusted.json.auth</param-value>
+    </init-param>
+    <init-param>
       <param-name>http.protocol.handle-redirects</param-name>
       <param-value>true</param-value>
     </init-param>


### PR DESCRIPTION
<!--Include a few sentences describing the overall goals for this Pull Request-->
  
When doing the GN5 -> GN4 proxy, I added authentication headers.  See https://github.com/geonetwork/geonetwork/pull/77

However, under some configurations, this could leak authentication tokens via the GN4 proxy. 

I've added the ability to disallow some headers to be attached to the GN4 proxy requests.  I've set it up so it, by default, will block the "standard" GN5->GN4 authentication header ("`gn5.to.gn4.trusted.json.auth`").

However, there are (potentially) other headers that should be removed.  For example, OAUTH Bearer tokens (and other security system's tokens or identification information).


<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [x] *API Changes* are identified in commit messages
- [x] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [x] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [x] *Build documentation* provided for development instructions in `README.md` files
- [x] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

