### PR TITLE
[Backport 4.2.x] Update index to use a key with translations defined for map resource types

### DIFF
--- a/docs/manual/docs/annexes/standards/iso19115-3.2018.md
+++ b/docs/manual/docs/annexes/standards/iso19115-3.2018.md
@@ -6887,7 +6887,7 @@ Those values are defined in the standard but hidden when editing.
 
 | code                         | label                          | description |
 |------------------------------|--------------------------------|-------------|
-| map staticMap interactiveMap | Map Static map Interactive map |             |
+| map map-static map-interactive | Map Static map Interactive map |             |
 
 ### Scope description {#iso19115-3.2018-elem-mcc-MD_ScopeDescription-7995800501eaf72f941d8e81542f8e98}
 
@@ -19811,7 +19811,7 @@ Those values are defined in the standard but hidden when editing.
 
 | code                         | label                          | description |
 |------------------------------|--------------------------------|-------------|
-| map staticMap interactiveMap | Map Static map Interactive map |             |
+| map map-static map-interactive | Map Static map Interactive map |             |
 
 ### Standard codelists Spatial Representation Type (mcc:MD_SpatialRepresentationTypeCode) {#iso19115-3.2018-cl-mcc-MD_SpatialRepresentationTypeCode}
 

--- a/docs/manual/docs/annexes/standards/iso19139.md
+++ b/docs/manual/docs/annexes/standards/iso19139.md
@@ -11963,7 +11963,7 @@ Those values are defined in the standard but hidden when editing.
 
 | code                                        | label                                          | description |
 |---------------------------------------------|------------------------------------------------|-------------|
-| map staticMap interactiveMap featureCatalog | Map Static map Interactive map Feature catalog |             |
+| map map-static map-interactive featureCatalog | Map Static map Interactive map Feature catalog |             |
 
 Displayed only if
 
@@ -17436,7 +17436,7 @@ Those values are defined in the standard but hidden when editing.
 
 | code                                        | label                                          | description |
 |---------------------------------------------|------------------------------------------------|-------------|
-| map staticMap interactiveMap featureCatalog | Map Static map Interactive map Feature catalog |             |
+| map map-static map-interactive featureCatalog | Map Static map Interactive map Feature catalog |             |
 
 Displayed only if
 

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/loc/eng/codelists.xml
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/loc/eng/codelists.xml
@@ -1694,12 +1694,12 @@
       <description></description>
     </entry>
     <entry hideInEditMode="true">
-      <code>staticMap</code>
+      <code>map-static</code>
       <label>Static map</label>
       <description></description>
     </entry>
     <entry hideInEditMode="true">
-      <code>interactiveMap</code>
+      <code>map-interactive</code>
       <label>Interactive map</label>
       <description></description>
     </entry>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/loc/fre/codelists.xml
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/loc/fre/codelists.xml
@@ -1726,12 +1726,12 @@
       <description></description>
     </entry>
     <entry hideInEditMode="true">
-      <code>staticMap</code>
+      <code>map-static</code>
       <label>Carte statique</label>
       <description></description>
     </entry>
     <entry hideInEditMode="true">
-      <code>interactiveMap</code>
+      <code>map-interactive</code>
       <label>Carte interactive</label>
       <description></description>
     </entry>

--- a/schemas/iso19115-3.2018/src/test/resources/metadata-for-editing-light.xml
+++ b/schemas/iso19115-3.2018/src/test/resources/metadata-for-editing-light.xml
@@ -1813,12 +1813,12 @@ Acteur qui a assuré la réalisation de la ressource,éventuellement en faisant 
               <description />
             </entry>
             <entry hideInEditMode="true">
-              <code>staticMap</code>
+              <code>map-static</code>
               <label>Carte statique</label>
               <description />
             </entry>
             <entry hideInEditMode="true">
-              <code>interactiveMap</code>
+              <code>map-interactive</code>
               <label>Carte interactive</label>
               <description />
             </entry>
@@ -8929,12 +8929,12 @@ Acteur qui a assuré la réalisation de la ressource,éventuellement en faisant 
               <description />
             </entry>
             <entry hideInEditMode="true">
-              <code>staticMap</code>
+              <code>map-static</code>
               <label>Carte statique</label>
               <description />
             </entry>
             <entry hideInEditMode="true">
-              <code>interactiveMap</code>
+              <code>map-interactive</code>
               <label>Carte interactive</label>
               <description />
             </entry>

--- a/schemas/iso19115-3.2018/src/test/resources/metadata-for-editing.xml
+++ b/schemas/iso19115-3.2018/src/test/resources/metadata-for-editing.xml
@@ -584,7 +584,7 @@ La liste des changements d'état sont accessibles ici :
       <insertFileMode js="true">Import de fichiers</insertFileMode>
       <insertMode>Mode d'insertion :</insertMode>
       <insertPasteMode>Copier/Coller</insertPasteMode>
-      <interactiveMap>Carte interactive</interactiveMap>
+      <map-interactive>Carte interactive</map-interactive>
       <interMapInfo>
         <h1>Information et cartes interactives</h1>
         <p>Vous pouvez trouver des cartes interactives en cherchant dans Geonetwork pour des jeux de données numérique avec une carte interactive, ou bien en vous connectant directement à un serveur cartographique existant</p>
@@ -20334,12 +20334,12 @@ Acteur qui a assuré la réalisation de la ressource,éventuellement en faisant 
               <description />
             </entry>
             <entry hideInEditMode="true">
-              <code>staticMap</code>
+              <code>map-static</code>
               <label>Carte statique</label>
               <description />
             </entry>
             <entry hideInEditMode="true">
-              <code>interactiveMap</code>
+              <code>map-interactive</code>
               <label>Carte interactive</label>
               <description />
             </entry>
@@ -27450,12 +27450,12 @@ Acteur qui a assuré la réalisation de la ressource,éventuellement en faisant 
               <description />
             </entry>
             <entry hideInEditMode="true">
-              <code>staticMap</code>
+              <code>map-static</code>
               <label>Carte statique</label>
               <description />
             </entry>
             <entry hideInEditMode="true">
-              <code>interactiveMap</code>
+              <code>map-interactive</code>
               <label>Carte interactive</label>
               <description />
             </entry>

--- a/schemas/iso19115-3.2018/src/test/resources/metadata-iso19139-for-editing.xml
+++ b/schemas/iso19115-3.2018/src/test/resources/metadata-iso19139-for-editing.xml
@@ -584,7 +584,7 @@ La liste des changements d'état sont accessibles ici :
       <insertFileMode js="true">Import de fichiers</insertFileMode>
       <insertMode>Mode d'insertion :</insertMode>
       <insertPasteMode>Copier/Coller</insertPasteMode>
-      <interactiveMap>Carte interactive</interactiveMap>
+      <map-interactive>Carte interactive</map-interactive>
       <interMapInfo>
         <h1>Information et cartes interactives</h1>
         <p>Vous pouvez trouver des cartes interactives en cherchant dans Geonetwork pour des jeux de données numérique avec une carte interactive, ou bien en vous connectant directement à un serveur cartographique existant</p>
@@ -20334,12 +20334,12 @@ Acteur qui a assuré la réalisation de la ressource,éventuellement en faisant 
               <description />
             </entry>
             <entry hideInEditMode="true">
-              <code>staticMap</code>
+              <code>map-static</code>
               <label>Carte statique</label>
               <description />
             </entry>
             <entry hideInEditMode="true">
-              <code>interactiveMap</code>
+              <code>map-interactive</code>
               <label>Carte interactive</label>
               <description />
             </entry>
@@ -27450,12 +27450,12 @@ Acteur qui a assuré la réalisation de la ressource,éventuellement en faisant 
               <description />
             </entry>
             <entry hideInEditMode="true">
-              <code>staticMap</code>
+              <code>map-static</code>
               <label>Carte statique</label>
               <description />
             </entry>
             <entry hideInEditMode="true">
-              <code>interactiveMap</code>
+              <code>map-interactive</code>
               <label>Carte interactive</label>
               <description />
             </entry>

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
@@ -220,10 +220,10 @@
           <resourceType>map</resourceType>
           <xsl:choose>
             <xsl:when test="$isStatic">
-              <resourceType>map/static</resourceType>
+              <resourceType>map-static</resourceType>
             </xsl:when>
             <xsl:when test="$isInteractive or $isPublishedWithWMCProtocol">
-              <resourceType>map/interactive</resourceType>
+              <resourceType>map-interactive</resourceType>
             </xsl:when>
           </xsl:choose>
         </xsl:when>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/ara/codelists.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/ara/codelists.xml
@@ -1539,12 +1539,12 @@
       <description></description>
     </entry>
     <entry hideInEditMode="true">
-      <code>staticMap</code>
+      <code>map-static</code>
       <label>Static map</label>
       <description></description>
     </entry>
     <entry hideInEditMode="true">
-      <code>interactiveMap</code>
+      <code>map-interactive</code>
       <label>Interactive map</label>
       <description></description>
     </entry>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/cat/codelists.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/cat/codelists.xml
@@ -1536,12 +1536,12 @@
       <description />
     </entry>
     <entry hideInEditMode="true">
-      <code>staticMap</code>
+      <code>map-static</code>
       <label>Mapa estàtic</label>
       <description />
     </entry>
     <entry hideInEditMode="true">
-      <code>interactiveMap</code>
+      <code>map-interactive</code>
       <label>Mapa interactiu</label>
       <description />
     </entry>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/chi/codelists.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/chi/codelists.xml
@@ -1538,12 +1538,12 @@
       <description></description>
     </entry>
     <entry hideInEditMode="true">
-      <code>staticMap</code>
+      <code>map-static</code>
       <label>Static map</label>
       <description></description>
     </entry>
     <entry hideInEditMode="true">
-      <code>interactiveMap</code>
+      <code>map-interactive</code>
       <label>Interactive map</label>
       <description></description>
     </entry>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/dut/codelists.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/dut/codelists.xml
@@ -1615,12 +1615,12 @@
       <description></description>
     </entry>
     <entry hideInEditMode="true">
-      <code>staticMap</code>
+      <code>map-static</code>
       <label>Static map</label>
       <description></description>
     </entry>
     <entry hideInEditMode="true">
-      <code>interactiveMap</code>
+      <code>map-interactive</code>
       <label>Interactive map</label>
       <description></description>
     </entry>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/eng/codelists.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/eng/codelists.xml
@@ -1626,12 +1626,12 @@
       <description></description>
     </entry>
     <entry hideInEditMode="true">
-      <code>staticMap</code>
+      <code>map-static</code>
       <label>Static map</label>
       <description></description>
     </entry>
     <entry hideInEditMode="true">
-      <code>interactiveMap</code>
+      <code>map-interactive</code>
       <label>Interactive map</label>
       <description></description>
     </entry>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/fin/codelists.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/fin/codelists.xml
@@ -1518,12 +1518,12 @@
       <description></description>
     </entry>
     <entry hideInEditMode="true">
-      <code>staticMap</code>
+      <code>map-static</code>
       <label>Static map</label>
       <description></description>
     </entry>
     <entry hideInEditMode="true">
-      <code>interactiveMap</code>
+      <code>map-interactive</code>
       <label>Interactive map</label>
       <description></description>
     </entry>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/fre/codelists.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/fre/codelists.xml
@@ -1558,12 +1558,12 @@
       <description></description>
     </entry>
     <entry>
-      <code>staticMap</code>
+      <code>map-static</code>
       <label>Carte statique</label>
       <description></description>
     </entry>
     <entry>
-      <code>interactiveMap</code>
+      <code>map-interactive</code>
       <label>Carte interactive</label>
       <description></description>
     </entry>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/ger/codelists.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/ger/codelists.xml
@@ -1585,12 +1585,12 @@
       <description></description>
     </entry>
     <entry hideInEditMode="true">
-      <code>staticMap</code>
+      <code>map-static</code>
       <label>Statische Karte</label>
       <description></description>
     </entry>
     <entry hideInEditMode="true">
-      <code>interactiveMap</code>
+      <code>map-interactive</code>
       <label>Interaktive Karte</label>
       <description></description>
     </entry>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/ita/codelists.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/ita/codelists.xml
@@ -1607,12 +1607,12 @@
       <description></description>
     </entry>
     <entry hideInEditMode="true">
-      <code>staticMap</code>
+      <code>map-static</code>
       <label>Static map</label>
       <description></description>
     </entry>
     <entry hideInEditMode="true">
-      <code>interactiveMap</code>
+      <code>map-interactive</code>
       <label>Interactive map</label>
       <description></description>
     </entry>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/nor/codelists.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/nor/codelists.xml
@@ -1604,12 +1604,12 @@
       <description></description>
     </entry>
     <entry hideInEditMode="true">
-      <code>staticMap</code>
+      <code>map-static</code>
       <label>Static map</label>
       <description></description>
     </entry>
     <entry hideInEditMode="true">
-      <code>interactiveMap</code>
+      <code>map-interactive</code>
       <label>Interactive map</label>
       <description></description>
     </entry>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/pol/codelists.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/pol/codelists.xml
@@ -1526,12 +1526,12 @@
       <description></description>
     </entry>
     <entry hideInEditMode="true">
-      <code>staticMap</code>
+      <code>map-static</code>
       <label>Static map</label>
       <description></description>
     </entry>
     <entry hideInEditMode="true">
-      <code>interactiveMap</code>
+      <code>map-interactive</code>
       <label>Interactive map</label>
       <description></description>
     </entry>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/por/codelists.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/por/codelists.xml
@@ -1542,12 +1542,12 @@
       <description></description>
     </entry>
     <entry hideInEditMode="true">
-      <code>staticMap</code>
+      <code>map-static</code>
       <label>Static map</label>
       <description></description>
     </entry>
     <entry hideInEditMode="true">
-      <code>interactiveMap</code>
+      <code>map-interactive</code>
       <label>Interactive map</label>
       <description></description>
     </entry>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/rus/codelists.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/rus/codelists.xml
@@ -1537,12 +1537,12 @@
       <description></description>
     </entry>
     <entry hideInEditMode="true">
-      <code>staticMap</code>
+      <code>map-static</code>
       <label>Статическая карта</label>
       <description></description>
     </entry>
     <entry hideInEditMode="true">
-      <code>interactiveMap</code>
+      <code>map-interactive</code>
       <label>Интерактивная карта</label>
       <description></description>
     </entry>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/slo/codelists.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/slo/codelists.xml
@@ -1448,12 +1448,12 @@ Informácie o mapách a grafoch, z ktorých dátová sada pochádza </descriptio
       <description/>
     </entry>
     <entry hideineditmode="true">
-      <code>staticMap</code>
+      <code>map-static</code>
       <label>Statická mapa</label>
       <description/>
     </entry>
     <entry hideineditmode="true">
-      <code>interactiveMap</code>
+      <code>map-interactive</code>
       <label>Interaktívna mapa</label>
       <description/>
     </entry>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/spa/codelists.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/spa/codelists.xml
@@ -1543,12 +1543,12 @@
       <description />
     </entry>
     <entry hideInEditMode="true">
-      <code>staticMap</code>
+      <code>map-static</code>
       <label>Mapa estático</label>
       <description />
     </entry>
     <entry hideInEditMode="true">
-      <code>interactiveMap</code>
+      <code>map-interactive</code>
       <label>Mapa interactivo</label>
       <description />
     </entry>

--- a/schemas/iso19139/src/main/plugin/iso19139/loc/tur/codelists.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/loc/tur/codelists.xml
@@ -1579,12 +1579,12 @@
       <description></description>
     </entry>
     <entry hideInEditMode="true">
-      <code>staticMap</code>
+      <code>map-static</code>
       <label>Static map</label>
       <description></description>
     </entry>
     <entry hideInEditMode="true">
-      <code>interactiveMap</code>
+      <code>map-interactive</code>
       <label>Interactive map</label>
       <description></description>
     </entry>

--- a/web-ui/src/main/resources/catalog/components/viewer/ViewerDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/ViewerDirective.js
@@ -393,7 +393,7 @@
                         filters: {
                           filters: {
                             maps: {
-                              query_string: { query: '+resourceType:"map/interactive"' }
+                              query_string: { query: '+resourceType:"map-interactive"' }
                             }
                           }
                         }

--- a/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/owscontext/OwsContextDirective.js
@@ -45,7 +45,7 @@
         filters: [
           {
             query_string: {
-              query: '+resourceType:"map/interactive"'
+              query: '+resourceType:"map-interactive"'
             }
           }
         ],

--- a/web-ui/src/main/resources/catalog/components/viewer/searchlayerformap/SearchLayerForMapDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/searchlayerformap/SearchLayerForMapDirective.js
@@ -75,7 +75,7 @@
               }
             };
             if ($scope.mode === "map") {
-              $scope.searchObj.params.type = "map/interactive";
+              $scope.searchObj.params.type = "map-interactive";
             } else {
               $scope.searchObj.params.linkProtocol = "OGC:WMS*";
             }

--- a/web-ui/src/main/resources/catalog/js/edit/NewMetadataController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/NewMetadataController.js
@@ -79,7 +79,7 @@
         featureCatalog: "fa-table",
         service: "fa-cog",
         map: "fa-map",
-        staticMap: "fa-map",
+        "map-static": "fa-map",
         dataset: "fa-file"
       };
 
@@ -116,7 +116,7 @@
             resourceType: {
               terms: {
                 field: "resourceType",
-                exclude: ["map/static", "theme", "place"],
+                exclude: ["map-static", "theme", "place"],
                 missing: "other"
               }
             }

--- a/web-ui/src/main/resources/catalog/locales/ca-core.json
+++ b/web-ui/src/main/resources/catalog/locales/ca-core.json
@@ -263,7 +263,7 @@
     "spatialRepresentationType": "Tipus de representació",
     "cl_spatialRepresentationType": "Tipus de representació",
     "state": "Estat",
-    "staticMap": "Mapa estàtic",
+    "map-static": "Mapa estàtic",
     "surname": "Cognom",
     "title": "Títol",
     "to": "A",

--- a/web-ui/src/main/resources/catalog/locales/cs-core.json
+++ b/web-ui/src/main/resources/catalog/locales/cs-core.json
@@ -263,7 +263,7 @@
     "spatialRepresentationType": "Prostorové typy",
     "cl_spatialRepresentationType": "Prostorový typ",
     "state": "Stát",
-    "staticMap": "Statická mapa",
+    "map-static": "Statická mapa",
     "surname": "Příjmení",
     "title": "Název",
     "to": "Komu",

--- a/web-ui/src/main/resources/catalog/locales/da-core.json
+++ b/web-ui/src/main/resources/catalog/locales/da-core.json
@@ -263,7 +263,7 @@
     "spatialRepresentationType": "Repræsentationstype",
     "cl_spatialRepresentationType": "Repræsentationstype",
     "state": "Stat",
-    "staticMap": "Statisk kort",
+    "map-static": "Statisk kort",
     "surname": "Efternavn",
     "title": "Titel",
     "to": "Til",

--- a/web-ui/src/main/resources/catalog/locales/de-core.json
+++ b/web-ui/src/main/resources/catalog/locales/de-core.json
@@ -263,7 +263,7 @@
     "spatialRepresentationType": "Darstellungsart",
     "cl_spatialRepresentationType": "Darstellungsart",
     "state": "Bundesland / Kanton",
-    "staticMap": "Statische Karte",
+    "map-static": "Statische Karte",
     "surname": "Nachname",
     "title": "Titel",
     "to": "Bis",

--- a/web-ui/src/main/resources/catalog/locales/en-core.json
+++ b/web-ui/src/main/resources/catalog/locales/en-core.json
@@ -265,7 +265,7 @@
     "spatialRepresentationType": "Representation type",
     "cl_spatialRepresentationType": "Representation type",
     "state": "State",
-    "staticMap": "Static map",
+    "map-static": "Static map",
     "surname": "Surname",
     "title": "Title",
     "to": "To",

--- a/web-ui/src/main/resources/catalog/locales/es-core.json
+++ b/web-ui/src/main/resources/catalog/locales/es-core.json
@@ -263,7 +263,7 @@
     "spatialRepresentationType": "Tipo de Representación",
     "cl_spatialRepresentationType": "Tipo de Representación",
     "state": "Estado",
-    "staticMap": "Mapa estático",
+    "map-static": "Mapa estático",
     "surname": "Apellido",
     "title": "Título",
     "to": "A",

--- a/web-ui/src/main/resources/catalog/locales/fi-core.json
+++ b/web-ui/src/main/resources/catalog/locales/fi-core.json
@@ -263,7 +263,7 @@
     "spatialRepresentationType": "Esitysmuoto",
     "cl_spatialRepresentationType": "Esitysmuoto",
     "state": "Tila",
-    "staticMap": "Staattinen kartta",
+    "map-static": "Staattinen kartta",
     "surname": "Sukunimi",
     "title": "Titteli",
     "to": "Vastaanottaja",

--- a/web-ui/src/main/resources/catalog/locales/fr-core.json
+++ b/web-ui/src/main/resources/catalog/locales/fr-core.json
@@ -263,7 +263,7 @@
     "spatialRepresentationType": "Type de représentation",
     "cl_spatialRepresentationType": "Type de représentation",
     "state": "Région",
-    "staticMap": "Carte statique",
+    "map-static": "Carte statique",
     "surname": "Nom",
     "title": "Titre",
     "to": "à",

--- a/web-ui/src/main/resources/catalog/locales/is-core.json
+++ b/web-ui/src/main/resources/catalog/locales/is-core.json
@@ -263,7 +263,7 @@
     "spatialRepresentationType": "Framsetning tegund",
     "cl_spatialRepresentationType": "Framsetning tegund",
     "state": "Ástand",
-    "staticMap": "Kyrrstætt kort",
+    "map-static": "Kyrrstætt kort",
     "surname": "Eftirnafn",
     "title": "Titill",
     "to": "Til",

--- a/web-ui/src/main/resources/catalog/locales/it-core.json
+++ b/web-ui/src/main/resources/catalog/locales/it-core.json
@@ -263,7 +263,7 @@
     "spatialRepresentationType": "Tipo di rappresentazione",
     "cl_spatialRepresentationType": "Tipo di rappresentazione",
     "state": "Stato",
-    "staticMap": "Mappa statica",
+    "map-static": "Mappa statica",
     "surname": "Cognome",
     "title": "Titolo",
     "to": "A",

--- a/web-ui/src/main/resources/catalog/locales/ko-core.json
+++ b/web-ui/src/main/resources/catalog/locales/ko-core.json
@@ -263,7 +263,7 @@
     "spatialRepresentationType": "표현 형태",
     "cl_spatialRepresentationType": "표현 형태",
     "state": "주",
-    "staticMap": "정적 지도",
+    "map-static": "정적 지도",
     "surname": "성",
     "title": "제목",
     "to": "종료",

--- a/web-ui/src/main/resources/catalog/locales/nl-core.json
+++ b/web-ui/src/main/resources/catalog/locales/nl-core.json
@@ -263,7 +263,7 @@
     "spatialRepresentationType": "Representatie type",
     "cl_spatialRepresentationType": "Representatie type",
     "state": "Staat",
-    "staticMap": "Vaste kaart",
+    "map-static": "Vaste kaart",
     "surname": "Achternaam",
     "title": "Titel",
     "to": "Tot",

--- a/web-ui/src/main/resources/catalog/locales/pt-core.json
+++ b/web-ui/src/main/resources/catalog/locales/pt-core.json
@@ -263,7 +263,7 @@
     "spatialRepresentationType": "Tipo de representação",
     "cl_spatialRepresentationType": "Tipo de representação",
     "state": "Estado",
-    "staticMap": "Mapa estático",
+    "map-static": "Mapa estático",
     "surname": "Sobrenome",
     "title": "Título",
     "to": "Até",

--- a/web-ui/src/main/resources/catalog/locales/ru-core.json
+++ b/web-ui/src/main/resources/catalog/locales/ru-core.json
@@ -263,7 +263,7 @@
     "spatialRepresentationType": "Типы представлений",
     "cl_spatialRepresentationType": "Типы представлений",
     "state": "Государство",
-    "staticMap": "Статическая карта",
+    "map-static": "Статическая карта",
     "surname": "Фамилия",
     "title": "Титул",
     "to": "К",

--- a/web-ui/src/main/resources/catalog/locales/sk-core.json
+++ b/web-ui/src/main/resources/catalog/locales/sk-core.json
@@ -263,7 +263,7 @@
     "spatialRepresentationType": "Priestorové typy",
     "cl_spatialRepresentationType": "Priestorový typ",
     "state": "Štát",
-    "staticMap": "Statická mapa",
+    "map-static": "Statická mapa",
     "surname": "Priezvisko",
     "title": "Názov",
     "to": "Komu",

--- a/web-ui/src/main/resources/catalog/locales/sv-core.json
+++ b/web-ui/src/main/resources/catalog/locales/sv-core.json
@@ -263,7 +263,7 @@
     "spatialRepresentationType": "Representationstyp",
     "cl_spatialRepresentationType": "Representationstyp",
     "state": "Län",
-    "staticMap": "Statisk karta",
+    "map-static": "Statisk karta",
     "surname": "Efternamn",
     "title": "Titel",
     "to": "Till",

--- a/web-ui/src/main/resources/catalog/locales/zh-core.json
+++ b/web-ui/src/main/resources/catalog/locales/zh-core.json
@@ -263,7 +263,7 @@
     "spatialRepresentationType": "表示类型",
     "cl_spatialRepresentationType": "表示类型",
     "state": "州",
-    "staticMap": "静态地图",
+    "map-static": "静态地图",
     "surname": "姓",
     "title": "标题",
     "to": "至",

--- a/web-ui/src/main/resources/catalog/style/gn_icons.less
+++ b/web-ui/src/main/resources/catalog/style/gn_icons.less
@@ -12,11 +12,11 @@
   content: @fa-var-cog;
 }
 .gn-icon-map:before,
-.gn-icon-staticMap:before,
+.gn-icon-map-static:before,
 .gn-icon-maps:before {
   content: @fa-var-map;
 }
-.gn-icon-interactiveMap:before {
+.gn-icon-map-interactive:before {
   content: @fa-var-globe;
 }
 .gn-icon-featureCatalog:before {

--- a/web-ui/src/main/resources/catalog/views/default/module.js
+++ b/web-ui/src/main/resources/catalog/views/default/module.js
@@ -121,7 +121,7 @@
         filters: [
           {
             query_string: {
-              query: '+resourceType:"map/interactive"'
+              query: '+resourceType:"map-interactive"'
             }
           }
         ],


### PR DESCRIPTION
Backport #8529

Customized to avoid the need to backport 8155 first. All keys are changed to `map-static` and `map-interactive`.