### PR TITLE
Record view / contact focus on feature: allow to customise the contact field name to filter

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/mdview/mdviewDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/mdviewDirective.js
@@ -437,11 +437,22 @@
           // Group by 'default', 'role', 'org-role'
           mode: "@gnMode",
           // 'icon' or 'list' (default)
-          layout: "@layout"
+          layout: "@layout",
+          type: "@type"
         },
         link: function (scope, element, attrs, controller) {
           if (["default", "role", "org-role"].indexOf(scope.mode) == -1) {
             scope.mode = "default";
+          }
+
+          if (scope.type === "metadata") {
+            scope.focusOnFilterFieldName = "OrgObject.default";
+          } else if (scope.type === "distribution") {
+            scope.focusOnFilterFieldName = "OrgForDistributionObject.default";
+          } else if (scope.type === "processing") {
+            scope.focusOnFilterFieldName = "OrgForProcessingObject.default";
+          } else {
+            scope.focusOnFilterFieldName = "OrgForResourceObject.default";
           }
 
           scope.calculateContacts = function () {

--- a/web-ui/src/main/resources/catalog/components/search/mdview/partials/contact.html
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/partials/contact.html
@@ -41,7 +41,7 @@
         </address>
 
         <div
-          data-gn-search-filter-link="OrgForResourceObject.default"
+          data-gn-search-filter-link="{{focusOnFilterFieldName}}"
           data-filter="c.organisation"
           data-label="focusOnFrom"
         >
@@ -99,7 +99,7 @@
           </address>
 
           <div
-            data-gn-search-filter-link="OrgForResourceObject.default"
+            data-gn-search-filter-link="{{focusOnFilterFieldName}}"
             data-filter="c.organisation"
             data-label="focusOnFrom"
           >
@@ -157,7 +157,7 @@
           </address>
 
           <div
-            data-gn-search-filter-link="OrgForResourceObject.default"
+            data-gn-search-filter-link="{{focusOnFilterFieldName}}"
             data-filter="c.organisation"
             data-label="focusOnFrom"
           >

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -1757,7 +1757,6 @@
       $scope.publicationOptions = [];
       $scope.getFacetLabel = gnFacetMetaLabel.getFacetLabel;
 
-
       $http.get("../api/records/sharing/options").then(function (response) {
         $scope.publicationOptions = response.data;
       });

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/contact.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/contact.html
@@ -5,6 +5,7 @@
     data-gn-metadata-contacts="mdView.current.record.contactForResource"
     data-gn-mode="role"
     data-layout="icon"
+    data-focus-on-field-name="resource"
   ></div>
 </div>
 

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/metadatacontact.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/metadatacontact.html
@@ -3,6 +3,7 @@
     data-gn-metadata-contacts="mdView.current.record.contact"
     data-gn-mode="role"
     data-layout="icon"
+    data-type="metadata"
   ></div>
 </div>
 <div data-ng-if="showCitation" data-gn-metadata-citation="mdView.current.record"></div>

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/processsteps.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/processsteps.html
@@ -43,6 +43,7 @@
       data-ng-if="mdView.current.record.contactForProcessing"
       data-gn-metadata-contacts="mdView.current.record.contactForProcessing"
       data-gn-mode="default"
+      data-type="processing"
       data-layout="icon"
     ></div>
   </div>

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/type-dataset.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/type-dataset.html
@@ -102,6 +102,7 @@
       data-ng-if="mdView.current.record.contactForDistribution"
       data-gn-metadata-contacts="mdView.current.record.contactForDistribution"
       data-gn-mode="default"
+      data-type="distribution"
       data-layout="icon"
     ></div>
 

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/type-series.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/type-series.html
@@ -85,6 +85,7 @@
       data-ng-if="mdView.current.record.contactForDistribution"
       data-gn-metadata-contacts="mdView.current.record.contactForDistribution"
       data-gn-mode="default"
+      data-type="distribution"
       data-layout="icon"
     ></div>
 


### PR DESCRIPTION
In the metadata page, clicking on a contact shows an option to filter by the organisation name: 

![Screenshot 2024-12-23 at 13 49 25](https://github.com/user-attachments/assets/db2c5f3b-caba-4151-81c3-24580f4004ba)

The filter was hardcoded to use the field `OrgForResourceObject.default`, to filter by the resource contact. Updated the code to configure the field name depending on the type of contact displayed. 

In the previous example, for a metadata contact, the query was not showing any result: 

http://localhost:8080/geonetwork/srv/eng/catalog.search?debug#/search?query_string=%7B%22OrgForResourceObject.default%22:%7B%22FAO%20-%20NRCW%22:true%7D%7D

![Screenshot 2024-12-23 at 14 13 41](https://github.com/user-attachments/assets/49582de3-f01f-488c-a372-7692130dbb04)


With the change, the query shows the results properly:

http://localhost:8080/geonetwork/srv/eng/catalog.search?debug#/search?query_string=%7B%22OrgObject.default%22:%7B%22FAO%20-%20NRCW%22:true%7D%7D

![Screenshot 2024-12-23 at 14 13 50](https://github.com/user-attachments/assets/c29dfaf4-23b0-4c71-b000-3a5fb081b2aa)


# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
