### PR TITLE
Return xml inside JSON status

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java
@@ -68,6 +68,8 @@ import org.fao.geonet.utils.Xml;
 import org.jdom.Element;
 import org.jdom.input.JDOMParseException;
 import org.jdom.output.XMLOutputter;
+import org.json.JSONException;
+import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.data.domain.PageRequest;
@@ -1261,7 +1263,27 @@ public class MetadataWorkflowApi {
             checkCanViewStatus(stateText, httpSession);
         }
 
+        if (isValidJSON(stateText)) {
+            JSONObject json = new JSONObject(stateText);
+            String xmlRecord = json.getString("xmlRecord");
+            return xmlRecord;
+        }
+
         return stateText;
+    }
+
+    /**
+     * Check if the input string is valid JSON format string
+     * @param json input string
+     * @return boolean if string is JSON format
+     */
+    private boolean isValidJSON(String json) {
+        try {
+            new JSONObject(json);
+        } catch (JSONException e) {
+            return false;
+        }
+        return true;
     }
 
     /**


### PR DESCRIPTION
After batch editing several records, the history is the status in the database is stored as JSON and XML embedded.

![image](https://github.com/user-attachments/assets/bda19a52-cc1f-4642-847f-206699ae38fd)

When trying to view the previous and current version from UI:

![image](https://github.com/user-attachments/assets/020fb5f8-745b-4cb7-94aa-e2e5e2d34991)


The API specify the format as  XML

https://github.com/geonetwork/core-geonetwork/blob/da294f7466fb9832edf9f1493d58de8bbd8f9e72/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java#L814

https://github.com/geonetwork/core-geonetwork/blob/da294f7466fb9832edf9f1493d58de8bbd8f9e72/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java#L844

So the browser cannot render the text:
![image](https://github.com/user-attachments/assets/ca52531f-de75-4fe7-aa98-7947512b2db7)


The JSON format is not very compactible to the API. I am adding a JSON conversion to XML to render the API properly.



<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

