### PR TITLE
Fix set site settings in swagger_ui so it function correctly.

### DIFF
--- a/services/src/test/java/org/fao/geonet/api/site/SiteApiTest.java
+++ b/services/src/test/java/org/fao/geonet/api/site/SiteApiTest.java
@@ -62,7 +62,7 @@ public class SiteApiTest extends AbstractServiceIntegrationTest {
 
 
     @Test
-    public void updateSettings() throws Exception {
+    public void updateSettingsFormUrlEncoded() throws Exception {
         this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
 
         this.mockHttpSession = loginAsAdmin();
@@ -78,10 +78,42 @@ public class SiteApiTest extends AbstractServiceIntegrationTest {
 
         String newName = "DataHub";
         this.mockMvc.perform(post("/srv/api/site/settings")
+                .contentType(MediaType.APPLICATION_FORM_URLENCODED_VALUE)
                 .param("system/site/name", newName)
+                .session(this.mockHttpSession))
+            .andExpect(status().is(204))
+            .andExpect(content().string("")); // No content should be returned.
+
+        this.mockMvc.perform(get("/srv/api/site/settings")
                 .session(this.mockHttpSession)
                 .accept(MediaType.parseMediaType("application/json")))
-            .andExpect(status().is(204));
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(API_JSON_EXPECTED_ENCODING))
+            .andExpect(jsonPath("$['system/site/name']", is(newName)));
+    }
+
+    @Test
+    public void updateSettingsJson() throws Exception {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
+
+        this.mockHttpSession = loginAsAdmin();
+
+        encryptor.initialize();
+
+        this.mockMvc.perform(get("/srv/api/site/settings")
+                .session(this.mockHttpSession)
+                .accept(MediaType.parseMediaType("application/json")))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(API_JSON_EXPECTED_ENCODING))
+            .andExpect(jsonPath("$['system/site/name']", is("My GeoNetwork catalogue")));
+
+        String newName = "JsonDataHub";
+        this.mockMvc.perform(post("/srv/api/site/settings")
+                .contentType(MediaType.APPLICATION_JSON_VALUE)
+                .content("{\"system/site/name\": \"" + newName + "\"}")
+                .session(this.mockHttpSession))
+            .andExpect(status().is(204))
+            .andExpect(content().string("")); // No content should be returned.
 
         this.mockMvc.perform(get("/srv/api/site/settings")
                 .session(this.mockHttpSession)


### PR DESCRIPTION
Prior to this fix, the swagger ui for applying site settings was not working.

Before the swagger ui would look like the following 

![image](https://github.com/user-attachments/assets/623b4ff1-abe8-45a7-bc30-3c2b349a08a6)

And generate the following error 

![image](https://github.com/user-attachments/assets/ae2d5c81-9c8d-4b10-b2e3-efd68953a1b7)

After, it will look like the following (with some examples.)

![image](https://github.com/user-attachments/assets/3af1b258-4a30-4fac-95c7-510096117105)

And when valid values are supplied, it will generate the following results

![image](https://github.com/user-attachments/assets/e7c09212-2173-4ee3-b4ee-f90d1114d67e)


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [x] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

