### PR TITLE
Move StatusValue.Events to an enum class

### DIFF
--- a/listeners/src/main/java/org/fao/geonet/listener/history/AttachmentAddedListener.java
+++ b/listeners/src/main/java/org/fao/geonet/listener/history/AttachmentAddedListener.java
@@ -31,7 +31,7 @@ import org.springframework.stereotype.Component;
 public class AttachmentAddedListener extends GenericMetadataEventListener implements ApplicationListener<AttachmentAddedEvent> {
 
     private String changeMessage = "";
-    private String eventType = StatusValue.Events.ATTACHMENTADDED;
+    private final StatusValue.Events eventType = StatusValue.Events.ATTACHMENTADDED;
 
     @Override
     public String getChangeMessage() {
@@ -40,7 +40,7 @@ public class AttachmentAddedListener extends GenericMetadataEventListener implem
 
     @Override
     public String getEventType() {
-        return eventType;
+        return eventType.getCode();
     }
 
     @Override

--- a/listeners/src/main/java/org/fao/geonet/listener/history/AttachmentDeletedListener.java
+++ b/listeners/src/main/java/org/fao/geonet/listener/history/AttachmentDeletedListener.java
@@ -31,7 +31,7 @@ import org.springframework.stereotype.Component;
 public class AttachmentDeletedListener extends GenericMetadataEventListener implements ApplicationListener<AttachmentDeletedEvent> {
 
     private String changeMessage = "";
-    private String eventType = StatusValue.Events.ATTACHMENTDELETED;
+    private final StatusValue.Events eventType = StatusValue.Events.ATTACHMENTDELETED;
 
     @Override
     public String getChangeMessage() {
@@ -40,7 +40,7 @@ public class AttachmentDeletedListener extends GenericMetadataEventListener impl
 
     @Override
     public String getEventType() {
-        return eventType;
+        return eventType.getCode();
     }
 
     @Override

--- a/listeners/src/main/java/org/fao/geonet/listener/history/RecordCategoryChangeListener.java
+++ b/listeners/src/main/java/org/fao/geonet/listener/history/RecordCategoryChangeListener.java
@@ -31,7 +31,7 @@ import org.springframework.stereotype.Component;
 public class RecordCategoryChangeListener extends GenericMetadataEventListener implements ApplicationListener<RecordCategoryChangeEvent> {
 
     private String changeMessage = "";
-    private String eventType = StatusValue.Events.RECORDCATEGORYCHANGE;
+    private final StatusValue.Events eventType = StatusValue.Events.RECORDCATEGORYCHANGE;
 
     @Override
     public String getChangeMessage() {
@@ -40,7 +40,7 @@ public class RecordCategoryChangeListener extends GenericMetadataEventListener i
 
     @Override
     public String getEventType() {
-        return eventType;
+        return eventType.getCode();
     }
 
     @Override

--- a/listeners/src/main/java/org/fao/geonet/listener/history/RecordCreatedListener.java
+++ b/listeners/src/main/java/org/fao/geonet/listener/history/RecordCreatedListener.java
@@ -31,7 +31,7 @@ import org.springframework.stereotype.Component;
 public class RecordCreatedListener extends GenericMetadataEventListener implements ApplicationListener<RecordCreateEvent> {
 
     private String changeMessage = "";
-    private String eventType = StatusValue.Events.RECORDCREATED;
+    private final StatusValue.Events eventType = StatusValue.Events.RECORDCREATED;
 
     @Override
     public String getChangeMessage() {
@@ -40,7 +40,7 @@ public class RecordCreatedListener extends GenericMetadataEventListener implemen
 
     @Override
     public String getEventType() {
-        return eventType;
+        return eventType.getCode();
     }
 
     @Override

--- a/listeners/src/main/java/org/fao/geonet/listener/history/RecordDeletedListener.java
+++ b/listeners/src/main/java/org/fao/geonet/listener/history/RecordDeletedListener.java
@@ -31,7 +31,7 @@ import org.springframework.stereotype.Component;
 public class RecordDeletedListener extends GenericMetadataEventListener implements ApplicationListener<RecordDeletedEvent> {
 
     private String changeMessage = "";
-    private String eventType = StatusValue.Events.RECORDDELETED;
+    private final StatusValue.Events eventType = StatusValue.Events.RECORDDELETED;
 
     @Override
     public String getChangeMessage() {
@@ -40,7 +40,7 @@ public class RecordDeletedListener extends GenericMetadataEventListener implemen
 
     @Override
     public String getEventType() {
-        return eventType;
+        return eventType.getCode();
     }
 
     @Override

--- a/listeners/src/main/java/org/fao/geonet/listener/history/RecordGroupOwnerChangeListener.java
+++ b/listeners/src/main/java/org/fao/geonet/listener/history/RecordGroupOwnerChangeListener.java
@@ -32,7 +32,7 @@ public class RecordGroupOwnerChangeListener extends GenericMetadataEventListener
         implements ApplicationListener<RecordGroupOwnerChangeEvent> {
 
     private String changeMessage = "";
-    private String eventType = StatusValue.Events.RECORDGROUPOWNERCHANGE;
+    private final StatusValue.Events eventType = StatusValue.Events.RECORDGROUPOWNERCHANGE;
 
     @Override
     public String getChangeMessage() {
@@ -41,7 +41,7 @@ public class RecordGroupOwnerChangeListener extends GenericMetadataEventListener
 
     @Override
     public String getEventType() {
-        return eventType;
+        return eventType.getCode();
     }
 
     @Override

--- a/listeners/src/main/java/org/fao/geonet/listener/history/RecordImportedListener.java
+++ b/listeners/src/main/java/org/fao/geonet/listener/history/RecordImportedListener.java
@@ -31,7 +31,7 @@ import org.springframework.stereotype.Component;
 public class RecordImportedListener extends GenericMetadataEventListener implements ApplicationListener<RecordImportedEvent> {
 
     private String changeMessage = "";
-    private String eventType = StatusValue.Events.RECORDIMPORTED;
+    private final StatusValue.Events eventType = StatusValue.Events.RECORDIMPORTED;
 
     @Override
     public String getChangeMessage() {
@@ -40,7 +40,7 @@ public class RecordImportedListener extends GenericMetadataEventListener impleme
 
     @Override
     public String getEventType() {
-        return eventType;
+        return eventType.getCode();
     }
 
     @Override

--- a/listeners/src/main/java/org/fao/geonet/listener/history/RecordOwnerChangeListener.java
+++ b/listeners/src/main/java/org/fao/geonet/listener/history/RecordOwnerChangeListener.java
@@ -31,7 +31,7 @@ import org.springframework.stereotype.Component;
 public class RecordOwnerChangeListener extends GenericMetadataEventListener implements ApplicationListener<RecordOwnerChangeEvent> {
 
     private String changeMessage = "";
-    private String eventType = StatusValue.Events.RECORDOWNERCHANGE;
+    private final StatusValue.Events eventType = StatusValue.Events.RECORDOWNERCHANGE;
 
     @Override
     public String getChangeMessage() {
@@ -40,7 +40,7 @@ public class RecordOwnerChangeListener extends GenericMetadataEventListener impl
 
     @Override
     public String getEventType() {
-        return eventType;
+        return eventType.getCode();
     }
 
     @Override

--- a/listeners/src/main/java/org/fao/geonet/listener/history/RecordPrivilegesChangeListener.java
+++ b/listeners/src/main/java/org/fao/geonet/listener/history/RecordPrivilegesChangeListener.java
@@ -32,7 +32,7 @@ public class RecordPrivilegesChangeListener extends GenericMetadataEventListener
         implements ApplicationListener<RecordPrivilegesChangeEvent> {
 
     private String changeMessage = "";
-    private String eventType = StatusValue.Events.RECORDPRIVILEGESCHANGE;
+    private final StatusValue.Events eventType = StatusValue.Events.RECORDPRIVILEGESCHANGE;
 
     @Override
     public String getChangeMessage() {
@@ -41,7 +41,7 @@ public class RecordPrivilegesChangeListener extends GenericMetadataEventListener
 
     @Override
     public String getEventType() {
-        return eventType;
+        return eventType.getCode();
     }
 
     @Override

--- a/listeners/src/main/java/org/fao/geonet/listener/history/RecordProcessingChangeListener.java
+++ b/listeners/src/main/java/org/fao/geonet/listener/history/RecordProcessingChangeListener.java
@@ -32,7 +32,7 @@ public class RecordProcessingChangeListener extends GenericMetadataEventListener
         implements ApplicationListener<RecordProcessingChangeEvent> {
 
     private String changeMessage = "";
-    private String eventType = StatusValue.Events.RECORDPROCESSINGCHANGE;
+    private final StatusValue.Events eventType = StatusValue.Events.RECORDPROCESSINGCHANGE;
 
     @Override
     public String getChangeMessage() {
@@ -41,7 +41,7 @@ public class RecordProcessingChangeListener extends GenericMetadataEventListener
 
     @Override
     public String getEventType() {
-        return eventType;
+        return eventType.getCode();
     }
 
     @Override

--- a/listeners/src/main/java/org/fao/geonet/listener/history/RecordRestoredListener.java
+++ b/listeners/src/main/java/org/fao/geonet/listener/history/RecordRestoredListener.java
@@ -31,7 +31,7 @@ import org.springframework.stereotype.Component;
 public class RecordRestoredListener extends GenericMetadataEventListener implements ApplicationListener<RecordRestoredEvent> {
 
     private String changeMessage = "";
-    private String eventType = StatusValue.Events.RECORDRESTORED;
+    private final StatusValue.Events eventType = StatusValue.Events.RECORDRESTORED;
 
     @Override
     public String getChangeMessage() {
@@ -40,7 +40,7 @@ public class RecordRestoredListener extends GenericMetadataEventListener impleme
 
     @Override
     public String getEventType() {
-        return eventType;
+        return eventType.getCode();
     }
 
     @Override

--- a/listeners/src/main/java/org/fao/geonet/listener/history/RecordUpdatedListener.java
+++ b/listeners/src/main/java/org/fao/geonet/listener/history/RecordUpdatedListener.java
@@ -31,7 +31,7 @@ import org.springframework.stereotype.Component;
 public class RecordUpdatedListener extends GenericMetadataEventListener implements ApplicationListener<RecordUpdatedEvent> {
 
     private String changeMessage = "";
-    private String eventType = StatusValue.Events.RECORDUPDATED;
+    private final StatusValue.Events eventType = StatusValue.Events.RECORDUPDATED;
 
     @Override
     public String getChangeMessage() {
@@ -40,7 +40,7 @@ public class RecordUpdatedListener extends GenericMetadataEventListener implemen
 
     @Override
     public String getEventType() {
-        return eventType;
+        return eventType.getCode();
     }
 
     @Override

--- a/listeners/src/main/java/org/fao/geonet/listener/history/RecordValidationTriggeredListener.java
+++ b/listeners/src/main/java/org/fao/geonet/listener/history/RecordValidationTriggeredListener.java
@@ -32,7 +32,7 @@ public class RecordValidationTriggeredListener extends GenericMetadataEventListe
         implements ApplicationListener<RecordValidationTriggeredEvent> {
 
     private String changeMessage = "";
-    private String eventType = StatusValue.Events.RECORDVALIDATIONTRIGGERED;
+    private final StatusValue.Events eventType = StatusValue.Events.RECORDVALIDATIONTRIGGERED;
 
     @Override
     public String getChangeMessage() {
@@ -41,7 +41,7 @@ public class RecordValidationTriggeredListener extends GenericMetadataEventListe
 
     @Override
     public String getEventType() {
-        return eventType;
+        return eventType.getCode();
     }
 
     @Override

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java
@@ -68,8 +68,6 @@ import org.fao.geonet.utils.Xml;
 import org.jdom.Element;
 import org.jdom.input.JDOMParseException;
 import org.jdom.output.XMLOutputter;
-import org.json.JSONException;
-import org.json.JSONObject;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.data.domain.PageRequest;
@@ -85,6 +83,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static org.fao.geonet.api.ApiParams.*;
 import static org.fao.geonet.kernel.setting.Settings.SYSTEM_METADATAPRIVS_PUBLICATION_NOTIFICATIONLEVEL;
@@ -162,11 +161,7 @@ public class MetadataWorkflowApi {
     RoleHierarchy roleHierarchy;
 
     // The restore function currently supports these states
-    static final Integer[] supportedRestoreStatuses = {
-        Integer.parseInt(StatusValue.Events.RECORDUPDATED),
-        Integer.parseInt(StatusValue.Events.RECORDPROCESSINGCHANGE),
-        Integer.parseInt(StatusValue.Events.RECORDDELETED),
-        Integer.parseInt(StatusValue.Events.RECORDRESTORED)};
+    static final StatusValue.Events[] supportedRestoreStatuses = StatusValue.Events.getSupportedRestoreStatuses();
 
     private enum State {
         BEFORE, AFTER
@@ -1051,15 +1046,15 @@ public class MetadataWorkflowApi {
     }
 
     private String extractCurrentStatus(MetadataStatus s) {
-        switch (Integer.toString(s.getStatusValue().getId())) {
-            case StatusValue.Events.ATTACHMENTADDED:
+        switch (StatusValue.Events.fromId(s.getStatusValue().getId())) {
+            case ATTACHMENTADDED:
                 return s.getCurrentState();
-            case StatusValue.Events.RECORDOWNERCHANGE:
-            case StatusValue.Events.RECORDGROUPOWNERCHANGE:
+            case RECORDOWNERCHANGE:
+            case RECORDGROUPOWNERCHANGE:
                 return ObjectJSONUtils.extractFieldFromJSONString(s.getCurrentState(), "owner", "name");
-            case StatusValue.Events.RECORDPROCESSINGCHANGE:
+            case RECORDPROCESSINGCHANGE:
                 return ObjectJSONUtils.extractFieldFromJSONString(s.getCurrentState(), "process");
-            case StatusValue.Events.RECORDCATEGORYCHANGE:
+            case RECORDCATEGORYCHANGE:
                 List<String> categories = ObjectJSONUtils.extractListOfFieldFromJSONString(s.getCurrentState(), "category",
                     "name");
                 StringBuilder categoriesAsString = new StringBuilder("[ ");
@@ -1068,7 +1063,7 @@ public class MetadataWorkflowApi {
                 }
                 categoriesAsString.append("]");
                 return categoriesAsString.toString();
-            case StatusValue.Events.RECORDVALIDATIONTRIGGERED:
+            case RECORDVALIDATIONTRIGGERED:
                 if (s.getCurrentState() == null) {
                     return "UNKNOWN";
                 } else if (s.getCurrentState().equals("1")) {
@@ -1082,11 +1077,11 @@ public class MetadataWorkflowApi {
     }
 
     private String extractPreviousStatus(MetadataStatus s) {
-        switch (Integer.toString(s.getStatusValue().getId())) {
-            case StatusValue.Events.ATTACHMENTDELETED:
+        switch (StatusValue.Events.fromId(s.getStatusValue().getId())) {
+            case ATTACHMENTDELETED:
                 return s.getPreviousState();
-            case StatusValue.Events.RECORDOWNERCHANGE:
-            case StatusValue.Events.RECORDGROUPOWNERCHANGE:
+            case RECORDOWNERCHANGE:
+            case RECORDGROUPOWNERCHANGE:
                 return ObjectJSONUtils.extractFieldFromJSONString(s.getPreviousState(), "owner", "name");
             default:
                 return "";
@@ -1232,20 +1227,31 @@ public class MetadataWorkflowApi {
     private String getValidatedStateText(MetadataStatus metadataStatus, State state, HttpServletRequest request, HttpSession httpSession) throws Exception {
 
         if (!StatusValueType.event.equals(metadataStatus.getStatusValue().getType())
-            || !ArrayUtils.contains(supportedRestoreStatuses, metadataStatus.getStatusValue().getId())) {
+            || !ArrayUtils.contains(supportedRestoreStatuses, StatusValue.Events.fromId(metadataStatus.getStatusValue().getId()))) {
             throw new NotAllowedException("Unsupported action on status type '" + metadataStatus.getStatusValue().getType()
                 + "' for metadata '" + metadataStatus.getUuid() + "'. Supports status type '"
-                + StatusValueType.event + "' with the status id '" + Arrays.toString(supportedRestoreStatuses) + "'.");
+                + StatusValueType.event + "' with the status id '" + Arrays.stream(supportedRestoreStatuses).map(StatusValue.Events::getId).collect(Collectors.toList()) + "'.");
         }
 
         String stateText;
+        MediaType stateFormat;
         if (state.equals(State.AFTER)) {
             stateText = metadataStatus.getCurrentState();
+            stateFormat = StatusValue.Events.fromId(metadataStatus.getStatusValue().getId()).getCurrentStateFormat();
         } else {
             stateText = metadataStatus.getPreviousState();
+            stateFormat = StatusValue.Events.fromId(metadataStatus.getStatusValue().getId()).getPreviousStateFormat();
         }
 
-        if (stateText == null) {
+        String xmlStateText;
+        if (stateFormat.equals(MediaType.APPLICATION_JSON)) {
+            // Any status with JSON format will have the XML stored in the field 'xmlRecord'
+            xmlStateText = ObjectJSONUtils.extractFieldFromJSONString(stateText, "xmlRecord");
+        } else {
+            xmlStateText = stateText;
+        }
+
+        if (xmlStateText == null) {
             throw new ResourceNotFoundException(
                 String.format("No data exists for previous state on metadata record '%s', user '%d' at date '%s'",
                     metadataStatus.getUuid(), metadataStatus.getUserId(), metadataStatus.getChangeDate()));
@@ -1260,30 +1266,10 @@ public class MetadataWorkflowApi {
         } catch (ResourceNotFoundException e) {
             // If metadata record does not exists then it was deleted so
             // we will only allow the administrator, owner to view the contents
-            checkCanViewStatus(stateText, httpSession);
+            checkCanViewStatus(xmlStateText, httpSession);
         }
 
-        if (isValidJSON(stateText)) {
-            JSONObject json = new JSONObject(stateText);
-            String xmlRecord = json.getString("xmlRecord");
-            return xmlRecord;
-        }
-
-        return stateText;
-    }
-
-    /**
-     * Check if the input string is valid JSON format string
-     * @param json input string
-     * @return boolean if string is JSON format
-     */
-    private boolean isValidJSON(String json) {
-        try {
-            new JSONObject(json);
-        } catch (JSONException e) {
-            return false;
-        }
-        return true;
+        return xmlStateText;
     }
 
     /**


### PR DESCRIPTION
Move StatusValue.Events to an enum class
Identified the media type that is being stored in the database. 
Instead of detecting if data is json or xml, instead base it on the media type for the event.

This is mostly a refactoring the code.

This is an enhancement on the changes from #8579

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

