### PR TITLE
[Backport 4.2.x] Url decode the resourceId supplied to store.getResourceInternal to fix filenames containing spaces.

### DIFF
--- a/core/src/main/java/org/fao/geonet/util/XslUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/XslUtil.java
@@ -55,8 +55,8 @@ import org.elasticsearch.index.query.QueryBuilders;
 import org.elasticsearch.search.SearchHits;
 import org.elasticsearch.search.builder.SearchSourceBuilder;
 import org.fao.geonet.ApplicationContextHolder;
+import org.fao.geonet.Constants;
 import org.fao.geonet.SystemInfo;
-import org.fao.geonet.api.records.attachments.FilesystemStore;
 import org.fao.geonet.api.records.attachments.FilesystemStoreResourceContainer;
 import org.fao.geonet.api.records.attachments.Store;
 import org.fao.geonet.constants.Geonet;
@@ -122,6 +122,7 @@ import java.io.InputStream;
 import java.io.StringReader;
 import java.net.URL;
 import java.net.URLConnection;
+import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.util.*;
@@ -1257,9 +1258,9 @@ public final class XslUtil {
                 if (m.find()) {
                     Store store = ApplicationContextHolder.get().getBean("filesystemStore", Store.class);
                     try (Store.ResourceHolder file = store.getResourceInternal(
-                        m.group(1),
+                        URLDecoder.decode(m.group(1), Constants.ENCODING),
                         MetadataResourceVisibility.PUBLIC,
-                        m.group(2), true)) {
+                        URLDecoder.decode(m.group(2), Constants.ENCODING), true)) {
                         image = ImageIO.read(file.getPath().toFile());
                     }
                 } else {


### PR DESCRIPTION
Backport #8581
 **Authored by:** @ianwallen

