### PR TITLE
Record view / fix javascript error when a metadata has multiple lineage source descriptions

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/search/EsSearchManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/EsSearchManager.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2023 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2025 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -587,7 +587,7 @@ public class EsSearchManager implements ISearchManager {
             .add("MD_SecurityConstraintsUseLimitation")
             .add("MD_SecurityConstraintsUseLimitationObject")
             .add("overview")
-            .add("sourceDescription")
+            .add("sourceDescriptionObject")
             .add("MD_ConstraintsUseLimitation")
             .add("MD_ConstraintsUseLimitationObject")
             .add("resourceType")

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -1757,7 +1757,6 @@
       $scope.publicationOptions = [];
       $scope.getFacetLabel = gnFacetMetaLabel.getFacetLabel;
 
-
       $http.get("../api/records/sharing/options").then(function (response) {
         $scope.publicationOptions = response.data;
       });

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/lineage.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/lineage.html
@@ -3,9 +3,15 @@
   <p data-ng-bind-html="mdView.current.record.lineage | linky | newlines"></p>
 </div>
 
-<div data-ng-if="mdView.current.record.sourceDescription">
+<div
+  data-ng-if="mdView.current.record.sourceDescription && mdView.current.record.sourceDescription.length > 0"
+>
   <h2 data-translate="">sourceDescription</h2>
-  <p data-ng-bind-html="mdView.current.record.sourceDescription | linky | newlines"></p>
+
+  <p
+    data-ng-repeat="d in mdView.current.record.sourceDescription track by $index"
+    data-ng-bind-html="d | linky | newlines"
+  ></p>
 </div>
 
 <div data-ng-if="mdView.current.record.supplementalInformation">


### PR DESCRIPTION
When a metadata has multiple resource lineage source descriptions the following javascript error occurs:

```
angular.js?v=2e31720b368df88f570059d390b081d82fe9cf75:15697 Error: [linky:notstring] Expected string but received: 
[...
```

A metadata can have multiple lineage sources, updated the code to process the array of lineage sources. After the change:

![image](https://github.com/user-attachments/assets/ba1832d9-c6a0-4eae-9abb-f400edd42c18)


# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

