### PR TITLE
Metadata indexing / parse process steps and measure dates to check that are valid.

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
@@ -1180,10 +1180,13 @@
         <xsl:variable name="processSteps"
                       select="mrl:processStep/*[mrl:description/gco:CharacterString != '']"/>
         <xsl:for-each select="$processSteps">
+          <xsl:variable name="stepDateTimeZulu"
+                        select="date-util:convertToISOZuluDateTime(normalize-space(mrl:stepDateTime))"/>
+
           <processSteps type="object">{
             "descriptionObject": <xsl:value-of select="gn-fn-index:add-multilingual-field(
                                 'description', mrl:description, $allLanguages, true())"/>
-            <xsl:if test="normalize-space(mrl:stepDateTime) != ''">
+            <xsl:if test="$stepDateTimeZulu != ''">
               ,"date": "<xsl:value-of select="mrl:stepDateTime//gml:timePosition/text()"/>"
             </xsl:if>
             <xsl:if test="normalize-space(mrl:source) != ''">
@@ -1247,16 +1250,16 @@
                         select="mdq:valueUnit//gml:identifier"/>
           <xsl:variable name="description"
                         select="(../../mdq:measure/*/mdq:measureDescription/gco:CharacterString)[1]"/>
-
           <xsl:variable name="measureDate"
-                        select="mdq:dateTime/gco:DateTime"/>
-
+                        select="normalize-space(mdq:dateTime/gco:DateTime)"/>
+          <xsl:variable name="measureDateZulu"
+                        select="date-util:convertToISOZuluDateTime($measureDate)"/>
           <measure type="object">{
             "name": "<xsl:value-of select="util:escapeForJson($name)"/>",
             <xsl:if test="$description != ''">
               "description": "<xsl:value-of select="util:escapeForJson($description)"/>",
             </xsl:if>
-            <xsl:if test="$measureDate != ''">
+            <xsl:if test="$measureDateZulu != ''">
               "date": "<xsl:value-of select="util:escapeForJson($measureDate)"/>",
             </xsl:if>
             <!-- First value only. -->

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
@@ -1033,12 +1033,14 @@
                         select="(../../gmd:measureDescription/gco:CharacterString)[1]"/>
           <xsl:variable name="measureDate"
                         select="(../../gmd:dateTime/gco:DateTime)[1]"/>
+          <xsl:variable name="measureDateZulu"
+                        select="date-util:convertToISOZuluDateTime($measureDate)"/>
           <measure type="object">{
             "name": "<xsl:value-of select="util:escapeForJson($name)"/>",
             <xsl:if test="$description != ''">
               "description": "<xsl:value-of select="util:escapeForJson($description)"/>",
             </xsl:if>
-            <xsl:if test="$measureDate != ''">
+            <xsl:if test="$measureDateZulu != ''">
               "date": "<xsl:value-of select="util:escapeForJson($measureDate)"/>",
             </xsl:if>
             <!-- First value only. -->
@@ -1060,10 +1062,13 @@
         <xsl:variable name="processSteps"
                       select="gmd:lineage/*/gmd:processStep/*[gmd:description/gco:CharacterString != '']"/>
         <xsl:for-each select="$processSteps">
+          <xsl:variable name="stepDateTimeZulu"
+                        select="date-util:convertToISOZuluDateTime(normalize-space(gmd:dateTime))"/>
+
           <processSteps type="object">{
             "descriptionObject": <xsl:value-of select="gn-fn-index:add-multilingual-field(
                                 'description', gmd:description, $allLanguages, true())"/>
-            <xsl:if test="normalize-space(gmd:dateTime) != ''">
+            <xsl:if test="$stepDateTimeZulu != ''">
               ,"date": "<xsl:value-of select="gmd:dateTime/gco:*/text()"/>"
             </xsl:if>
             <xsl:if test="normalize-space(gmd:source) != ''">


### PR DESCRIPTION
If the dates are not valid there was an error in the metadata document index, failing the search when the metadata is returned:

```
java.lang.NullPointerException
	at org.fao.geonet.api.es.EsHTTPProxy.lambda$processResponse$0(EsHTTPProxy.java:700)
	at org.fao.geonet.api.es.JsonStreamUtils.filterTree(JsonStreamUtils.java:147)
	at org.fao.geonet.api.es.JsonStreamUtils.lambda$null$1(JsonStreamUtils.java:109)
	at org.fao.geonet.api.es.JsonStreamUtils.filterArrayElements(JsonStreamUtils.java:50)
	at org.fao.geonet.api.es.JsonStreamUtils.lambda$addInfoToDocs$2(JsonStreamUtils.java:108)
	at org.fao.geonet.api.es.JsonStreamUtils.filterObjectInPath(JsonStreamUtils.java:74)
	at org.fao.geonet.api.es.JsonStreamUtils.filterObjectInPath(JsonStreamUtils.java:77)
	at org.fao.geonet.api.es.JsonStreamUtils.addInfoToDocs(JsonStreamUtils.java:106)
	at org.fao.geonet.api.es.EsHTTPProxy.processResponse(EsHTTPProxy.java:687)
	at org.fao.geonet.api.es.EsHTTPProxy.handleRequest(EsHTTPProxy.java:651)
```

Index error of a metadata with invalid date for the process step with an invalid date value `%PUBDATE_CIT%`:

```
2025-01-14T04:37:53,803 ERROR [geonetwork.index] - Document with error #e6885605-e1f3-4921-942c-46cd3ee73180: ElasticsearchException[Elasticsearch exception 
[type=mapper_parsing_exception, reason=failed to parse field [processSteps.date] of type [date] in document with id 'e6885605-e1f3-4921-942c-46cd3ee73180'. 
Preview of field's value: '%PUBDATE_CIT%T00:00:00']]; nested: 
ElasticsearchException[Elasticsearch exception [type=illegal_argument_exception, reason=failed to parse date field [%PUBDATE_CIT%T00:00:00] with format [strict_date_optional_time||epoch_millis]]]; nested: 
ElasticsearchException[Elasticsearch exception [type=date_time_parse_exception, reason=Failed to parse with all enclosed parsers]];.
```

This pull request analyses the date, to check if it is valid for indexing.

Related to #7180

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
