### PR TITLE
French translation for user registered message

### DIFF
--- a/core/src/test/resources/org/fao/geonet/api/Messages_fre.properties
+++ b/core/src/test/resources/org/fao/geonet/api/Messages_fre.properties
@@ -53,6 +53,7 @@ user_password_sent=Si l''utilisateur existe, vous recevrez un courriel contenant
 user_password_changed=Le mot de passe de %s a \u00E9t\u00E9 mis \u00E0 jour.
 user_password_notchanged=\u00C9chec lors du changement de mot de passe de %s. Contactez le support.
 user_password_invalid_changekey=%s est une cl\u00E9 invalide pour %s. Les cl\u00E9s ne sont valides que pendant une journ\u00E9e.
+user_registered=Utilisateur '%s' enregistr\u00E9.
 user_with_that_email_username_found=Un utilisateur avec cette adresse email ou ce nom d''utilisateur existe d\u00E9j\u00E0.
 register_email_admin_subject=%s / Cr\u00E9ation de compte pour %s en tant que %s
 register_email_admin_message=Cher administrateur,\n\

--- a/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages_fre.properties
+++ b/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages_fre.properties
@@ -53,6 +53,7 @@ user_password_sent=Si l''utilisateur existe, vous recevrez un courriel contenant
 user_password_changed=Le mot de passe de %s a \u00E9t\u00E9 mis \u00E0 jour.
 user_password_notchanged=\u00C9chec lors du changement de mot de passe de %s. Contactez le support.
 user_password_invalid_changekey=%s est une cl\u00E9 invalide pour %s. Les cl\u00E9s ne sont valides que pendant une journ\u00E9e.
+user_registered=Utilisateur '%s' enregistr\u00E9.
 user_with_that_email_username_found=Un utilisateur avec cette adresse email ou ce nom d''utilisateur existe d\u00E9j\u00E0.
 register_email_admin_subject=%s / Cr\u00E9ation de compte pour %s en tant que %s
 register_email_admin_message=Cher administrateur,\n\


### PR DESCRIPTION
Test case:

Steps to recreate:
- use the french interface
- click sign in / s'identifier
- click create an account / créer un compte
- fill in the registration form and click register / créer un compte
- a blue message box pops up in the top, left corner with the message in English: "User '[email address]' registered."

With the pull request in the French user interface, it is displayed the message: "Utilisateur '[email address]' enregistré."


# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
