### PR TITLE
API / Improve OpenAPI spec schema.

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/OpenApiConfig.java
+++ b/services/src/main/java/org/fao/geonet/api/OpenApiConfig.java
@@ -26,11 +26,13 @@
 package org.fao.geonet.api;
 
 import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.ExternalDocumentation;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.info.Contact;
 import io.swagger.v3.oas.models.info.Info;
 import io.swagger.v3.oas.models.info.License;
+import io.swagger.v3.oas.models.media.Schema;
 import io.swagger.v3.oas.models.servers.Server;
 import io.swagger.v3.oas.models.servers.ServerVariable;
 import io.swagger.v3.oas.models.servers.ServerVariables;

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataProcessApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataProcessApi.java
@@ -24,6 +24,10 @@
 package org.fao.geonet.api.records;
 
 import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.enums.Explode;
+import io.swagger.v3.oas.annotations.enums.ParameterIn;
+import io.swagger.v3.oas.annotations.enums.ParameterStyle;
+import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -167,7 +171,15 @@ public class MetadataProcessApi {
     public @ResponseBody
     ResponseEntity processRecord(
         @Parameter(description = API_PARAM_RECORD_UUID, required = true) @PathVariable String metadataUuid,
-        @Parameter(description = ApiParams.API_PARAM_PROCESS_ID) @PathVariable String process, HttpServletRequest request)
+        @Parameter(description = ApiParams.API_PARAM_PROCESS_ID, example = "thumbnail-add") @PathVariable String process,
+        @Parameter(name = "processParams", description = "Parameters to pass to the process",
+            in = ParameterIn.QUERY,
+            required = false,
+            schema = @Schema(type = "object", additionalProperties = Schema.AdditionalPropertiesValue.TRUE, example = "{\"thumbnail_url\":\"http://\",\"thumbnail_desc\":\"Dataset overview\"}"),
+            style = ParameterStyle.FORM,
+            explode = Explode.TRUE)
+        @RequestParam(required = false) Map<String,String> processParams,
+        HttpServletRequest request)
         throws Exception {
         AbstractMetadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
         boolean save = true;

--- a/services/src/main/java/org/fao/geonet/api/site/SiteApi.java
+++ b/services/src/main/java/org/fao/geonet/api/site/SiteApi.java
@@ -179,11 +179,29 @@ public class SiteApi {
         summary = "Get site (or portal) description",
         description = "")
     @RequestMapping(
+        consumes = {MediaType.APPLICATION_JSON_VALUE, MediaType.ALL_VALUE},
         produces = MediaType.APPLICATION_JSON_VALUE,
         method = RequestMethod.GET)
     @ResponseStatus(HttpStatus.OK)
     @ApiResponses(value = {
-        @ApiResponse(responseCode = "200", description = "Site description.")
+        @ApiResponse(responseCode = "200", description = "Site description.",
+        content = {
+            @Content(schema = @Schema(
+                type = "object",
+                additionalPropertiesSchema = String.class
+            ),
+                examples = @ExampleObject(value = "{\n" +
+                "  \"system/site/name\": \"My GeoNetwork catalogue\",\n" +
+                "  \"system/site/organization\": \"My organization\",\n" +
+                "  \"system/site/siteId\": \"33bc8c82-7ac2-49b6-a22b-af7376dbcf10\",\n" +
+                "  \"system/platform/version\": \"4.4.7\",\n" +
+                "  \"system/platform/subVersion\": \"SNAPSHOT\",\n" +
+                "  \"node/default\": \"true\",\n" +
+                "  \"node/id\": \"33bc8c82-7ac2-49b6-a22b-af7376dbcf10\",\n" +
+                "  \"node/name\": \"My GeoNetwork catalogue\",\n" +
+                "  \"microservices/enabled\": false\n" +
+                "}"))
+        })
     })
     @ResponseBody
     public SettingsListResponse getSiteOrPortalDescription(


### PR DESCRIPTION
* `/site` response is using `SettingsListToObjectSerializer` which returns a simple object

![image](https://github.com/user-attachments/assets/672aee27-cfbb-462d-8c81-60e8cf4a2f0c)

* `/records/{metadataUuid}/processes/{process}` can receive additional parameters forwarded to process. This will also improve OpenAPI generator outputs.

![image](https://github.com/user-attachments/assets/c7d061b8-34c4-4210-ab08-04a1da77d6db)


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

