### PR TITLE
Add byte data to metadata summary page for its children thumbnails

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/search/EsSearchManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/EsSearchManager.java
@@ -142,6 +142,7 @@ public class EsSearchManager implements ISearchManager {
         FIELDLIST_RELATED_SCRIPTED = ImmutableMap.<String, String>builder()
             // Elasticsearch scripted field to get the first overview url. Scripted fields must return single values.
             .put("overview", "return params['_source'].overview == null ? [] : params['_source'].overview.stream().map(f -> f.url).findFirst().orElse('');")
+            .put("overview_data", "return params['_source'].overview == null ? [] : params['_source'].overview.stream().map(f -> f.data).findFirst().orElse('');")
             .build();
     }
 

--- a/web-ui/src/main/resources/catalog/components/metadataactions/RelatedDirective.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/RelatedDirective.js
@@ -1075,6 +1075,8 @@
             if (md.overview && md.overview.length > 0) {
               return md.overview[0].url;
               // Related records contain the first overview in the properties.overview property
+            } else if (md.properties && md.properties.overview_data) {
+              return md.properties.overview_data;
             } else if (md.properties && md.properties.overview) {
               return md.properties.overview;
             }


### PR DESCRIPTION

The parent metadata can contain large amounts of children record and on its summary page, it displays their thumbnails.
![image](https://github.com/user-attachments/assets/90213bc8-6dd2-4191-a83b-a50b83b5509d)

The issue was it was url for each of the thumbnail which invokes its resource API and with large volumes of HTTP traffic it will crash the application if the backend database pool is relative small.

This pull request will alter the search service to have the data as part of the children in related records.

![image](https://github.com/user-attachments/assets/d506f2bc-efbd-4332-b925-cc4f3088876f)

and these byte data from the search engine can be used to the HTML/Javascript 

![image](https://github.com/user-attachments/assets/484a635d-75ce-41eb-a782-4888ea779ded)



# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

