### PR TITLE
Fix privileges cannot be unset

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataOperations.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataOperations.java
@@ -119,13 +119,18 @@ public class BaseMetadataOperations implements IMetadataOperations, ApplicationE
     /**
      * Removes all operations stored for a metadata except for the operations of the groups in the exclude list.
      * Used for preventing deletion of operations for reserved and restricted groups.
+     * If groupIdsToExclude is null or empty, all operations are deleted.
      *
      * @param metadataId        Metadata identifier
      * @param groupIdsToExclude List of group ids to exclude from deletion
      */
     @Override
     public void deleteMetadataOper(String metadataId, List<Integer> groupIdsToExclude) {
-        opAllowedRepo.deleteAllByMetadataIdExceptGroupId(Integer.parseInt(metadataId), groupIdsToExclude);
+        if (groupIdsToExclude == null || groupIdsToExclude.isEmpty()) {
+            opAllowedRepo.deleteAllByMetadataId(Integer.parseInt(metadataId));
+        } else {
+            opAllowedRepo.deleteAllByMetadataIdExceptGroupId(Integer.parseInt(metadataId), groupIdsToExclude);
+        }
     }
 
     /**


### PR DESCRIPTION
Currently privileges cannot be unset from the `Manage Record > Privileges` UI.

The issue occurs when list of operations to exclude from deletion is empty. Passing an empty list seems to cause no operations to be deleted instead of all operations for certain database types. H2 does not have this issue however PostgreSQL does.

This PR aims to fix this issue by deleting all operations when the excludes list is empty instead of passing the empty list.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
