### PR TITLE
Update GeoTools 28.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1619,8 +1619,8 @@
 
     <!-- NOTE: When updating GeoTools, check which version
     of Postgres is used and update pg.version if needed. -->
-    <geotools.version>28.2</geotools.version>
-    <jts.version>1.18.2</jts.version>
+    <geotools.version>31.5</geotools.version>
+    <jts.version>1.19.0</jts.version>
     <pg.version>42.3.10</pg.version>
 
     <spring.version>5.3.39</spring.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1619,7 +1619,7 @@
 
     <!-- NOTE: When updating GeoTools, check which version
     of Postgres is used and update pg.version if needed. -->
-    <geotools.version>31.5</geotools.version>
+    <geotools.version>28.6</geotools.version>
     <jts.version>1.19.0</jts.version>
     <pg.version>42.3.10</pg.version>
 


### PR DESCRIPTION
I have released an unsupported version of [GeoTools 28.6](https://github.com/geotools/geotools/releases/tag/28.6) that contains the patch for CVE-2024-36404.

This is not intended to be a functional change, only to prevent security scans for being upset. 

For *main* branch see https://github.com/geonetwork/core-geonetwork/pull/8613 

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

