### PR TITLE
Update backport bot action image to Ubuntu 24.04

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -14,7 +14,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     name: Backport
     steps:
       - name: Backport Bot


### PR DESCRIPTION
Ubuntu 20.04 is going to reach end of support soon in Github actions. Change it by 24.04.

