### PR TITLE
Fix jcloud content length is inaccurate

### DIFF
--- a/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
@@ -240,7 +240,7 @@ public abstract class AbstractStore implements Store {
         }
 
         // Upload the resource while ensuring the input stream does not exceed the maximum allowed size.
-        try (LimitedInputStream is = new LimitedInputStream(connection.getInputStream(), maxUploadSize)) {
+        try (LimitedInputStream is = new LimitedInputStream(connection.getInputStream(), maxUploadSize, contentLength)) {
             return putResource(context, metadataUuid, filename, is, null, visibility, approved);
         }
     }

--- a/core/src/main/java/org/fao/geonet/util/LimitedInputStream.java
+++ b/core/src/main/java/org/fao/geonet/util/LimitedInputStream.java
@@ -34,6 +34,11 @@ import java.io.InputStream;
  */
 public class LimitedInputStream extends org.apache.commons.fileupload.util.LimitedInputStream {
 
+    /**
+     * The size of the file being uploaded if known.
+     */
+    long fileSize = -1;
+
 
     /**
      * Creates a new instance.
@@ -46,8 +51,25 @@ public class LimitedInputStream extends org.apache.commons.fileupload.util.Limit
         super(inputStream, pSizeMax);
     }
 
+    /**
+     * Creates a new instance.
+     *
+     * @param inputStream The input stream, which shall be limited.
+     * @param pSizeMax    The limit; no more than this number of bytes
+     *                    shall be returned by the source stream.
+     * @param fileSize    The size of the file being uploaded.
+     */
+    public LimitedInputStream(InputStream inputStream, long pSizeMax, long fileSize) {
+        super(inputStream, pSizeMax);
+        this.fileSize = fileSize;
+    }
+
     @Override
     protected void raiseError(long pSizeMax, long pCount) throws IOException {
         throw new InputStreamLimitExceededException(pSizeMax);
+    }
+
+    public long getFileSize() {
+        return fileSize;
     }
 }

--- a/core/src/main/java/org/fao/geonet/util/LimitedInputStream.java
+++ b/core/src/main/java/org/fao/geonet/util/LimitedInputStream.java
@@ -39,7 +39,6 @@ public class LimitedInputStream extends org.apache.commons.fileupload.util.Limit
      */
     long fileSize = -1;
 
-
     /**
      * Creates a new instance.
      *

--- a/datastorages/jcloud/src/main/java/org/fao/geonet/api/records/attachments/JCloudStore.java
+++ b/datastorages/jcloud/src/main/java/org/fao/geonet/api/records/attachments/JCloudStore.java
@@ -42,6 +42,7 @@ import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.languages.IsoLanguagesMapper;
 import org.fao.geonet.lib.Lib;
 import org.fao.geonet.resources.JCloudConfiguration;
+import org.fao.geonet.util.LimitedInputStream;
 import org.fao.geonet.utils.IO;
 import org.fao.geonet.utils.Log;
 import org.jclouds.blobstore.ContainerNotFoundException;
@@ -301,9 +302,17 @@ public class JCloudStore extends AbstractStore {
                 // Update/set version
                 setPropertiesVersion(context, properties, isNewResource, metadataUuid, metadataId, visibility, approved, filename);
 
+                long contentLength;
+                // If the input stream is a LimitedInputStream and the file size is known then use that value otherwise use the available value.
+                if (is instanceof LimitedInputStream && ((LimitedInputStream) is).getFileSize() > 0) {
+                    contentLength = ((LimitedInputStream) is).getFileSize();
+                } else {
+                    contentLength = is.available();
+                }
+
                 Blob blob = jCloudConfiguration.getClient().getBlobStore().blobBuilder(key)
                     .payload(is)
-                    .contentLength(is.available())
+                    .contentLength(contentLength)
                     .userMetadata(properties)
                     .build();
 


### PR DESCRIPTION
Currently the content length for uploading resources to jcloud is set using the InputStream.available function which is unreliable. This results in uploads ending pre-maturely.

This PR aims to fix this issue by passing the content length to the input stream so the jcloud store can use that value if it is known.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
