### PR TITLE
Set related children's thumbnail to default 4

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/type-dataset.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/type-dataset.html
@@ -214,7 +214,7 @@
       data-user="user"
       data-layout="card"
       data-types="children"
-      data-size="4"
+      data-size="20"
       data-title="{{'seriesComposedOf' | translate}}"
     ></div>
 

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/type-dataset.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/type-dataset.html
@@ -214,6 +214,7 @@
       data-user="user"
       data-layout="card"
       data-types="children"
+      data-size="4"
       data-title="{{'seriesComposedOf' | translate}}"
     ></div>
 


### PR DESCRIPTION
Set a limit to rendering the number of children thumbnail. Similar to the card view 

https://github.com/geonetwork/core-geonetwork/blob/ed27371b6fae65cb451ab5b8b28c19cd972cab8d/web-ui/src/main/resources/catalog/views/default/templates/recordView/type-dataset.html#L121

![image](https://github.com/user-attachments/assets/f1714859-3b8b-4ff1-b882-8a98cff8fb77)


In some extreme case, the user can set hundreds of children to a parent record and causing some mess to the parent record view page. This issue is discussed in pull request of https://github.com/geonetwork/core-geonetwork/pull/8608

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

