### PR TITLE
Changes for integration tests

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -684,7 +684,7 @@
                 <include>**/*.java</include>
               </includes>
               <runOrder>alphabetical</runOrder>
-              <forkCount>1</forkCount>
+              <forkCount>${system.numCores}</forkCount>
             </configuration>
             <executions>
               <execution>
@@ -713,6 +713,12 @@
               <transportPort>9300</transportPort>
               <httpPort>9200</httpPort>
               <environmentVariables><ES_JAVA_OPTS>-Xmx2g</ES_JAVA_OPTS></environmentVariables>
+              <instanceSettings>
+                <properties>
+                  <!-- Problem with elastic - if you don't have enough disk space (90+% full), it will NOT start. -->
+                  <cluster.routing.allocation.disk.threshold_enabled>false</cluster.routing.allocation.disk.threshold_enabled>
+                </properties>
+              </instanceSettings>
             </configuration>
             <executions>
               <execution>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -684,7 +684,7 @@
                 <include>**/*.java</include>
               </includes>
               <runOrder>alphabetical</runOrder>
-              <forkCount>${system.numCores}</forkCount>
+              <forkCount>1</forkCount>
             </configuration>
             <executions>
               <execution>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -363,7 +363,7 @@
                 <include>**/*.java</include>
               </includes>
               <runOrder>alphabetical</runOrder>
-              <forkCount>${system.numCores}</forkCount>
+              <forkCount>1</forkCount>
             </configuration>
             <executions>
               <execution>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -392,6 +392,12 @@
               <transportPort>9300</transportPort>
               <httpPort>9200</httpPort>
               <environmentVariables><ES_JAVA_OPTS>-Xmx2g</ES_JAVA_OPTS></environmentVariables>
+              <instanceSettings>
+                <properties>
+                  <!-- Problem with elastic - if you don't have enough disk space (90+% full), it will NOT start. -->
+                  <cluster.routing.allocation.disk.threshold_enabled>false</cluster.routing.allocation.disk.threshold_enabled>
+                </properties>
+              </instanceSettings>
             </configuration>
             <executions>
               <execution>

--- a/services/src/test/java/org/fao/geonet/api/registries/vocabularies/KeywordsApiTest.java
+++ b/services/src/test/java/org/fao/geonet/api/registries/vocabularies/KeywordsApiTest.java
@@ -210,6 +210,11 @@ public class KeywordsApiTest extends AbstractServiceIntegrationTest {
             "taxref.csv", scheme.getChildText("title", NAMESPACE_DC));
     }
 
+    // see finally block in #testImportOntologyToSkos
+    // this is required to locate the file to be deleted.
+    @Autowired
+    GeonetworkDataDirectory geonetworkDataDirectory;
+
 
     @Test
     public void testImportOntologyToSkos() throws Exception {

--- a/services/src/test/java/org/fao/geonet/api/registries/vocabularies/KeywordsApiTest.java
+++ b/services/src/test/java/org/fao/geonet/api/registries/vocabularies/KeywordsApiTest.java
@@ -26,6 +26,7 @@ package org.fao.geonet.api.registries.vocabularies;
 import java.nio.file.Files;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.User;
+import org.fao.geonet.kernel.GeonetworkDataDirectory;
 import org.fao.geonet.kernel.SpringLocalServiceInvoker;
 import org.fao.geonet.services.AbstractServiceIntegrationTest;
 import org.fao.geonet.utils.Xml;

--- a/services/src/test/java/org/fao/geonet/api/registries/vocabularies/KeywordsApiTest.java
+++ b/services/src/test/java/org/fao/geonet/api/registries/vocabularies/KeywordsApiTest.java
@@ -43,6 +43,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
 import javax.servlet.http.HttpSession;
+import java.nio.file.Path;
 import java.util.List;
 
 import static org.fao.geonet.csw.common.Csw.NAMESPACE_DC;
@@ -266,7 +267,7 @@ public class KeywordsApiTest extends AbstractServiceIntegrationTest {
             // the thesaurus already exists.  This will clean up and there will not be a problem on the next run.
             // This is typically only an issue if you are running the test locally - on the build server it gets a
             // new, clean, filesystem so there isn't a problem.
-            var uploadedThesauras = geonetworkDataDirectory.resolveWebResource(
+            Path uploadedThesauras = geonetworkDataDirectory.resolveWebResource(
                 "WEB-INF/data/config/codelist/external/thesauri/theme/mobility-theme.rdf");
             Files.deleteIfExists(uploadedThesauras);
         }

--- a/services/src/test/java/org/fao/geonet/api/registries/vocabularies/KeywordsApiTest.java
+++ b/services/src/test/java/org/fao/geonet/api/registries/vocabularies/KeywordsApiTest.java
@@ -213,42 +213,55 @@ public class KeywordsApiTest extends AbstractServiceIntegrationTest {
 
     @Test
     public void testImportOntologyToSkos() throws Exception {
-        createServiceContext();
-        User user = new User().setId(USER_ID);
-        HttpSession session = loginAs(user);
-        MockHttpSession mockHttpSession = loginAsAdmin();
+        try {
+            createServiceContext();
+            User user = new User().setId(USER_ID);
+            HttpSession session = loginAs(user);
+            MockHttpSession mockHttpSession = loginAsAdmin();
 
-        MockMultipartHttpServletRequest request = new MockMultipartHttpServletRequest(session.getServletContext());
-        request.setRequestURI("/srv/api/registries/vocabularies");
-        MockMultipartFile file = new MockMultipartFile(
-            "file",
-            "mobility-theme.owl",
-            null,
-            getClass().getClassLoader().getResourceAsStream("mobility-theme.owl"));
-        request.addFile(file);
-        request.setSession(session);
-        request.setParameter("type", "external");
-        request.setParameter("dir", "theme");
-        MockHttpServletResponse response = new MockHttpServletResponse();
-        invoker.invoke(request, response);
-        assertEquals(200, response.getStatus());
+            MockMultipartHttpServletRequest request = new MockMultipartHttpServletRequest(session.getServletContext());
+            request.setRequestURI("/srv/api/registries/vocabularies");
+            MockMultipartFile file = new MockMultipartFile(
+                "file",
+                "mobility-theme.owl",
+                null,
+                getClass().getClassLoader().getResourceAsStream("mobility-theme.owl"));
+            request.addFile(file);
+            request.setSession(session);
+            request.setParameter("type", "external");
+            request.setParameter("dir", "theme");
+            MockHttpServletResponse response = new MockHttpServletResponse();
+            invoker.invoke(request, response);
+            assertEquals(200, response.getStatus());
 
 
-        MockMvc mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
-        MvcResult result = mockMvc.perform(get("/srv/api/registries/vocabularies/external.theme.mobility-theme")
-                .accept("application/xml")
-                .session(mockHttpSession))
-            .andExpect(status().isOk())
-            .andReturn();
+            MockMvc mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
+            MvcResult result = mockMvc.perform(get("/srv/api/registries/vocabularies/external.theme.mobility-theme")
+                    .accept("application/xml")
+                    .session(mockHttpSession))
+                .andExpect(status().isOk())
+                .andReturn();
 
-        Element thesaurus = Xml.loadString(result.getResponse().getContentAsString(), false);
-        Element scheme = (Element) thesaurus.getChildren("ConceptScheme", SKOS_NAMESPACE).get(0);
-        assertEquals(
-            "https://w3id.org/mobilitydcat-ap/mobility-theme", scheme.getAttributeValue("about", RDF_NAMESPACE));
-        assertEquals(
-            "Mobility Theme", scheme.getChildText("title", NAMESPACE_DCT));
+            Element thesaurus = Xml.loadString(result.getResponse().getContentAsString(), false);
+            Element scheme = (Element) thesaurus.getChildren("ConceptScheme", SKOS_NAMESPACE).get(0);
+            assertEquals(
+                "https://w3id.org/mobilitydcat-ap/mobility-theme", scheme.getAttributeValue("about", RDF_NAMESPACE));
+            assertEquals(
+                "Mobility Theme", scheme.getChildText("title", NAMESPACE_DCT));
 
-        List concepts = thesaurus.getChildren("Concept", SKOS_NAMESPACE);
-        assertEquals(121, concepts.size());
+            List concepts = thesaurus.getChildren("Concept", SKOS_NAMESPACE);
+            assertEquals(121, concepts.size());
+        }
+        finally {
+            //clean up
+            // this test case uploads a thesaurus.
+            // if you don't delete it, then, on the next run, it will be picked up and you'll get an error because
+            // the thesaurus already exists.  This will clean up and there will not be a problem on the next run.
+            // This is typically only an issue if you are running the test locally - on the build server it gets a
+            // new, clean, filesystem so there isn't a problem.
+            var uploadedThesauras = geonetworkDataDirectory.resolveWebResource(
+                "WEB-INF/data/config/codelist/external/thesauri/theme/mobility-theme.rdf");
+            Files.deleteIfExists(uploadedThesauras);
+        }
     }
 }

--- a/services/src/test/java/org/fao/geonet/api/registries/vocabularies/KeywordsApiTest.java
+++ b/services/src/test/java/org/fao/geonet/api/registries/vocabularies/KeywordsApiTest.java
@@ -23,6 +23,7 @@
 
 package org.fao.geonet.api.registries.vocabularies;
 
+import java.nio.file.Files;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.User;
 import org.fao.geonet.kernel.SpringLocalServiceInvoker;


### PR DESCRIPTION
<!--Include a few sentences describing the overall goals for this Pull Request-->

This does the following:

1) Set the integration test's elastic so it will **NOT** give  `low disk watermark` error messages and refuse to start if your disk is >90% full.
    * for `core/`
    * for `services/`
  
2) Set `services` so that it runs on a single JVM. This was because elastic is shared between all the different test cases - some tests were modifying the data at the same time (cf https://github.com/geonetwork/core-geonetwork/pull/8263), causing inconsistencies as to the uuid of metadata record `id=100`. 
* this could cause some slow downs during the integration tests for `services/`.  However, the slowdown was very small on my local computer.  This is something to keep an eye on.

3) One of the integration tests `KeywordsApiTest#testImportOntologyToSkos` uploaded a  file - this would be written (by the ThesaurusManager) to the file system (WEB-INF). On the next run, the test would give an error saying the thesaurus already exisits
* I've added some cleanup code to this test case.

This is problematic on development machines with low disk available (>90% full), and quite difficult to remedy.


I suspect that this hasn't been noticed because the build server;
1. has enough disk space (<90% full)
2. only runs the integration tests once (the added thesaurus isn't visible on the first run because WEB-INF is clean)
3.  https://github.com/geonetwork/core-geonetwork/pull/8263 hasn't been merged yet.

<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [x] *API Changes* are identified in commit messages
- [x] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [x] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [x] *Build documentation* provided for development instructions in `README.md` files
- [x] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

