### PR TITLE
URL Decode filename for resources uploaded by url

### DIFF
--- a/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
@@ -48,8 +48,11 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.URL;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -170,6 +173,7 @@ public abstract class AbstractStore implements Store {
         if (fileName.contains("?")) {
             fileName = fileName.substring(0, fileName.indexOf("?"));
         }
+        fileName = URLDecoder.decode(fileName, StandardCharsets.UTF_8);
         return fileName;
     }
 

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
@@ -48,7 +48,6 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.UnsupportedEncodingException;
 import java.net.HttpURLConnection;
 import java.net.URL;
 import java.net.URLDecoder;

--- a/core/src/test/java/org/fao/geonet/api/records/attachments/FilesystemStoreTest.java
+++ b/core/src/test/java/org/fao/geonet/api/records/attachments/FilesystemStoreTest.java
@@ -37,6 +37,7 @@ import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.io.InputStream;
+import java.net.URL;
 import java.util.Date;
 
 import static org.junit.Assert.*;
@@ -99,5 +100,22 @@ public class FilesystemStoreTest extends AbstractCoreIntegrationTest {
         // context, metadataUuid, visibility, path, approved)
         filesystemStore.getResourceDescription(context, "nonExistingUuid",
             MetadataResourceVisibility.PUBLIC, "existingResource.jpg", true);
+    }
+
+    @Test
+    public void testGetFilenameFromUrl() throws Exception {
+        FilesystemStore filesystemStore = new FilesystemStore();
+
+        String fileName = filesystemStore.getFilenameFromUrl(new URL("http://mydomain.com/filename.txt"));
+        assertEquals("filename.txt", fileName);
+
+        fileName = filesystemStore.getFilenameFromUrl(new URL("http://mydomain.com/filename%20with%20spaces.txt"));
+        assertEquals("filename with spaces.txt", fileName);
+
+        fileName = filesystemStore.getFilenameFromUrl(new URL("http://mydomain.com/filename.txt?param=value"));
+        assertEquals("filename.txt", fileName);
+
+        fileName = filesystemStore.getFilenameFromUrl(new URL("http://mydomain.com/filename%20with%20spaces.txt?param=value"));
+        assertEquals("filename with spaces.txt", fileName);
     }
 }


### PR DESCRIPTION
Currently the putResourceFromUrl API gets the file name from the URL itself but does not consider URL encoded characters. This means if a URL like `http://domain.com/dictionnaire%20de%20donn%C3%A9es.pdf` is provided the uploaded file's name will be `dictionnaire%20de%20donn%C3%A9es.pdf`.

This PR aims to fix this issue by URL decoding the filename. With this fix the filename would be `dictionnaire de données.pdf` as intended.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

