### PR TITLE
Setting to configure whether editor users who are metadata owners can edit their metadata when they do not have editing privileges for the metadata.

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/AccessManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/AccessManager.java
@@ -1,5 +1,5 @@
 //=============================================================================
-//===	Copyright (C) 2001-2007 Food and Agriculture Organization of the
+//===	Copyright (C) 2001-2026 Food and Agriculture Organization of the
 //===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
 //===	and United Nations Environment Programme (UNEP)
 //===
@@ -49,6 +49,7 @@ import java.util.stream.Stream;
 
 import static org.fao.geonet.kernel.setting.Settings.SYSTEM_INTRANET_IP_SEPARATOR;
 import static org.fao.geonet.kernel.setting.Settings.SYSTEM_METADATAPRIVS_PUBLICATIONBYGROUPOWNERONLY;
+import static org.fao.geonet.kernel.setting.Settings.SYSTEM_METADATAPRIVS_USER_ALWAYS_CAN_EDIT_OWNED_METADATA;
 import static org.fao.geonet.repository.specification.OperationAllowedSpecs.hasMetadataId;
 import static org.fao.geonet.repository.specification.OperationAllowedSpecs.hasOperation;
 import static org.springframework.data.jpa.domain.Specification.where;
@@ -126,7 +127,7 @@ public class AccessManager {
     }
 
     public Set<String> getOperationNames(ServiceContext context, String mdId, String ip, Collection<Operation> operations) throws Exception {
-        Set<String> names = new HashSet<String>();
+        Set<String> names = new HashSet<>();
 
         for (Operation op : getOperations(context, mdId, ip, operations)) {
             names.add(op.getName());
@@ -139,7 +140,7 @@ public class AccessManager {
      * Returns all operations permitted by the user on a particular metadata.
      */
     public Set<Operation> getAllOperations(ServiceContext context, String mdId, String ip) throws Exception {
-        HashSet<Operation> operations = new HashSet<Operation>();
+        HashSet<Operation> operations = new HashSet<>();
         Set<Integer> groups = getUserGroups(context.getUserSession(),
             ip, false);
         for (OperationAllowed opAllow : operationAllowedRepository.findByMetadataId(mdId)) {
@@ -158,7 +159,7 @@ public class AccessManager {
     public Set<Integer> getUserGroups(UserSession usrSess, String ip, boolean editingGroupsOnly) throws Exception {
         final ConfigurableApplicationContext applicationContext = ApplicationContextHolder.get();
 
-        Set<Integer> hs = new HashSet<Integer>();
+        Set<Integer> hs = new HashSet<>();
 
         // add All (1) network group
         hs.add(ReservedGroup.all.getId());
@@ -205,7 +206,7 @@ public class AccessManager {
     }
 
     public Set<Integer> getReviewerGroups(UserSession usrSess) throws Exception {
-        Set<Integer> hs = new HashSet<Integer>();
+        Set<Integer> hs = new HashSet<>();
 
         // get other groups
         if ((usrSess != null) && usrSess.isAuthenticated()) {
@@ -226,7 +227,7 @@ public class AccessManager {
      * @param userId the id of the user
      */
     public Set<Integer> getVisibleGroups(final int userId) throws Exception {
-        Set<Integer> hs = new HashSet<Integer>();
+        Set<Integer> hs = new HashSet<>();
 
         Optional<User> user = userRepository.findById(userId);
 
@@ -255,10 +256,22 @@ public class AccessManager {
      *     <li>the user has edit rights over the metadata</li>
      * </ul>
      *
+     * If the setting to allow edit always to the metadata the owner (independently of the edit privilege in
+     * the group owner of the metadata) is disabled, only the edit privileges are checked, except for Administrators.
+     *
      * @param id The metadata internal identifier
      */
     public boolean canEdit(final ServiceContext context, final String id) throws Exception {
-        return isOwner(context, id) || hasEditPermission(context, id);
+        UserSession us = context.getUserSession();
+        final Profile profile = us.getProfile();
+
+        if ((profile == Profile.Administrator) || settingManager.getValueAsBool(SYSTEM_METADATAPRIVS_USER_ALWAYS_CAN_EDIT_OWNED_METADATA, true)) {
+            return isOwner(context, id) || hasEditPermission(context, id);
+        } else {
+            // Ownership is not checked.. If the user is Editor and is the metadata owner,
+            // can only edit the metadata if has edit privileges for the metadata.
+            return hasEditPermission(context, id);
+        }
     }
 
     /**
@@ -441,9 +454,9 @@ public class AccessManager {
         return hasReviewPermission(context, info);
     }
 
-    private String GROUPOWNERONLY_STRATEGY =
+    private static final String GROUPOWNERONLY_STRATEGY =
         "api.metadata.share.strategy.groupOwnerOnly";
-    private String REVIEWERINGROUP_STRATEGY =
+    private static final String REVIEWERINGROUP_STRATEGY =
         "api.metadata.share.strategy.reviewerInGroup";
 
     public String getReviewerRule() {
@@ -509,9 +522,9 @@ public class AccessManager {
             return false;
         }
 
-        Specification spec = where(UserGroupSpecs.hasProfile(profile)).and(UserGroupSpecs.hasUserId(us.getUserIdAsInt()));
+        Specification<UserGroup> spec = where(UserGroupSpecs.hasProfile(profile)).and(UserGroupSpecs.hasUserId(us.getUserIdAsInt()));
 
-        List<Integer> opAlloweds = new ArrayList<Integer>();
+        List<Integer> opAlloweds = new ArrayList<>();
         for (OperationAllowed opAllowed : allOpAlloweds) {
             opAlloweds.add(opAllowed.getId().getGroupId());
         }

--- a/core/src/main/java/org/fao/geonet/kernel/setting/Settings.java
+++ b/core/src/main/java/org/fao/geonet/kernel/setting/Settings.java
@@ -110,6 +110,7 @@ public class Settings {
     public static final String SYSTEM_METADATAPRIVS_PUBLICATIONNOTIFICATION_EMAILS = "system/metadataprivs/publication/notificationEmails";
     public static final String SYSTEM_METADATAPRIVS_PUBLICATION_NOTIFICATIONLEVEL = "system/metadataprivs/publication/notificationLevel";
     public static final String SYSTEM_METADATAPRIVS_PUBLICATION_NOTIFICATIONGROUPS = "system/metadataprivs/publication/notificationGroups";
+    public static final String SYSTEM_METADATAPRIVS_USER_ALWAYS_CAN_EDIT_OWNED_METADATA = "system/metadataprivs/userAlwaysCanEditOwnedMetadata";
     public static final String SYSTEM_INSPIRE_ATOM_PROTOCOL = "system/inspire/atomProtocol";
     public static final String SYSTEM_HARVESTING_MAIL_RECIPIENT = "system/harvesting/mail/recipient";
     public static final String SYSTEM_HARVESTING_MAIL_LEVEL3 = "system/harvesting/mail/level3";

--- a/docs/manual/docs/administrator-guide/configuring-the-catalog/system-configuration.md
+++ b/docs/manual/docs/administrator-guide/configuring-the-catalog/system-configuration.md
@@ -232,6 +232,8 @@ Note: this option is only available for databases that have been tested. Those d
 
 *Only set privileges to user's groups*: If enabled then only the groups that the user belongs to will be displayed in the metadata privileges page (unless the user is an Administrator). At the moment this option cannot be disabled and is likely to be deprecated in the next version of GeoNetwork.
 
+*Users can always edit their own metadata*: If enabled (default), users with the Editor or Reviewer profile who own a metadata record can always edit it, regardless of whether they have been granted the editing privilege for that record through their group. When disabled, ownership alone does not grant editing rights — users can only edit metadata if they have explicit editing privileges in the groups where they hold the Editor role. Administrators can always edit any record regardless of this setting.
+
 ## Metadata create
 
 ### Generate UUID

--- a/docs/manual/docs/user-guide/publishing/managing-privileges.md
+++ b/docs/manual/docs/user-guide/publishing/managing-privileges.md
@@ -67,7 +67,9 @@ A *reviewer* / *editor* can edit a metadata if:
 
 * The metadata has editing privilege in the group(s) where the user is a *reviewer* / *editor*.
 
+!!! note
 
+    The default behavior allows editors who own a metadata record to always edit it. An administrator can change this by disabling the *Users can always edit their own metadata* setting in [System Configuration](../../administrator-guide/configuring-the-catalog/system-configuration.md#metadata-privileges). When disabled, ownership alone does not grant editing rights — editors must have explicit editing privileges through their group membership.
 
 # Setting Privileges
 

--- a/services/src/main/java/org/fao/geonet/api/es/EsHTTPProxy.java
+++ b/services/src/main/java/org/fao/geonet/api/es/EsHTTPProxy.java
@@ -65,6 +65,7 @@ import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.kernel.schema.MetadataSchema;
 import org.fao.geonet.kernel.schema.MetadataSchemaOperationFilter;
 import org.fao.geonet.kernel.search.EsFilterBuilder;
+import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.repository.SourceRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -91,6 +92,8 @@ import java.util.zip.DeflaterOutputStream;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
 
+import static org.fao.geonet.kernel.setting.Settings.SYSTEM_METADATAPRIVS_USER_ALWAYS_CAN_EDIT_OWNED_METADATA;
+
 
 @RequestMapping(value = {
     "/{portal}/api"
@@ -104,7 +107,7 @@ import java.util.zip.GZIPOutputStream;
  * The portal and privileges are included the search provided by the user.
  */
 public class EsHTTPProxy {
-    public static final String[] _validContentTypes = {
+    protected static final String[] validContentTypes = {
         "application/json", "text/plain"
     };
     private static final Logger LOGGER = LoggerFactory.getLogger(Geonet.INDEX_ENGINE);
@@ -112,7 +115,7 @@ public class EsHTTPProxy {
      * Privileges filter only allows
      * * op0 (ie. view operation) contains one of the ids of your groups
      */
-    private static final String filterTemplate = " {\n" +
+    private static final String FILTER_TEMPLATE = " {\n" +
         "       \t\"query_string\": {\n" +
         "       \t\t\"query\": \"%s\"\n" +
         "       \t}\n" +
@@ -145,7 +148,7 @@ public class EsHTTPProxy {
     /**
      * Ignore list of headers handled by proxy implementation directly.
      */
-    private String[] proxyHeadersIgnoreList =  {"Content-Length"};
+    private String[] proxyHeadersIgnoreList = {"Content-Length"};
 
     @Autowired
     private EsRestClient client;
@@ -215,7 +218,7 @@ public class EsHTTPProxy {
         final AccessManager accessManager = context.getBean(AccessManager.class);
         final boolean isOwner = accessManager.isOwner(context, sourceInfo);
         final HashSet<ReservedOperation> operations;
-        boolean canEdit = false;
+        boolean canEdit = id != null && accessManager.canEdit(context, id);
         if (isOwner) {
             operations = Sets.newHashSet(Arrays.asList(ReservedOperation.values()));
             if (owner != null) {
@@ -224,8 +227,6 @@ public class EsHTTPProxy {
         } else {
             final Collection<Integer> groups =
                 accessManager.getUserGroups(context.getUserSession(), context.getIpAddress(), false);
-            final Collection<Integer> editingGroups =
-                accessManager.getUserGroups(context.getUserSession(), context.getIpAddress(), true);
             operations = Sets.newHashSet();
             for (ReservedOperation operation : ReservedOperation.values()) {
                 final JsonNode operationNodes = doc.get("_source").get(Geonet.IndexFieldNames.OP_PREFIX + operation.getId());
@@ -234,11 +235,6 @@ public class EsHTTPProxy {
                     if (opFields != null) {
                         for (JsonNode field : opFields) {
                             final int groupId = field.asInt();
-                            if (operation == ReservedOperation.editing
-                                && !canEdit
-                                && editingGroups.contains(groupId)) {
-                                canEdit = true;
-                            }
 
                             if (groups.contains(groupId)) {
                                 operations.add(operation);
@@ -248,9 +244,15 @@ public class EsHTTPProxy {
                 }
             }
         }
-        doc.put(Edit.Info.Elem.EDIT, isOwner || canEdit);
+
+        final SettingManager settingManager = context.getBean(SettingManager.class);
+        if (settingManager.getValueAsBool(SYSTEM_METADATAPRIVS_USER_ALWAYS_CAN_EDIT_OWNED_METADATA, true)) {
+            doc.put(Edit.Info.Elem.EDIT, isOwner || canEdit);
+        } else {
+            doc.put(Edit.Info.Elem.EDIT, canEdit);
+        }
         doc.put(Edit.Info.Elem.REVIEW,
-            id != null ? accessManager.hasReviewPermission(context, id) : false);
+            id != null && accessManager.hasReviewPermission(context, id));
         doc.put(Edit.Info.Elem.OWNER, isOwner);
         doc.put(Edit.Info.Elem.IS_PUBLISHED_TO_ALL, hasOperation(doc, ReservedGroup.all, ReservedOperation.view));
         addReservedOperation(doc, operations, ReservedOperation.view);
@@ -359,8 +361,8 @@ public class EsHTTPProxy {
         @RequestBody
         @io.swagger.v3.oas.annotations.parameters.RequestBody(description = "JSON request based on Elasticsearch API.",
             content = @Content(examples = {
-            @ExampleObject(value = "{\"query\":{\"match\":{\"_id\":\"catalogue_uuid\"}}}")
-        }))
+                @ExampleObject(value = "{\"query\":{\"match\":{\"_id\":\"catalogue_uuid\"}}}")
+            }))
         String body) throws Exception {
         ServiceContext context = ApiUtils.createServiceContext(request);
         call(context, httpSession, request, response, MULTISEARCH_ENDPOINT, body, bucket, relatedTypes);
@@ -409,10 +411,10 @@ public class EsHTTPProxy {
     }
 
     private void call(ServiceContext context, HttpSession httpSession, HttpServletRequest request,
-                     HttpServletResponse response,
-                     String endPoint, String body,
-                     String selectionBucket,
-                     RelatedItemType[] relatedTypes) throws Exception {
+                      HttpServletResponse response,
+                      String endPoint, String body,
+                      String selectionBucket,
+                      RelatedItemType[] relatedTypes) throws Exception {
         final String url = client.getServerUrl() + "/" + defaultIndex + "/" + endPoint + "?";
         // Make query on multiple indices
 //        final String url = client.getServerUrl() + "/" + defaultIndex + ",gn-features/" + endPoint + "?";
@@ -423,7 +425,7 @@ public class EsHTTPProxy {
 
             // multisearch support
             final MappingIterator<Object> mappingIterator = objectMapper.readerFor(JsonNode.class).readValues(body);
-            StringBuffer requestBody = new StringBuffer();
+            StringBuilder requestBody = new StringBuilder();
             while (mappingIterator.hasNextValue()) {
                 JsonNode node = (JsonNode) mappingIterator.nextValue();
                 final JsonNode indexNode = node.get("index");
@@ -527,7 +529,7 @@ public class EsHTTPProxy {
      * Add search privilege criteria to a query.
      */
     private String buildQueryFilter(ServiceContext context, String type, boolean isSearchingForDraft) throws Exception {
-        return String.format(filterTemplate,
+        return String.format(FILTER_TEMPLATE,
             EsFilterBuilder.build(context, type, isSearchingForDraft, node));
 
     }
@@ -586,7 +588,7 @@ public class EsHTTPProxy {
                             "Error is: %s.\nRequest:\n%s.\nError:\n%s.",
                             connectionWithFinalHost.getResponseMessage(),
                             requestBody,
-                            IOUtils.toString(errorDetails)
+                            IOUtils.toString(errorDetails, StandardCharsets.UTF_8)
                         ));
                     return;
                 }
@@ -601,13 +603,12 @@ public class EsHTTPProxy {
 
                 // content type has to be valid
                 if (!isContentTypeValid(contentType)) {
-                    if (connectionWithFinalHost.getResponseMessage() != null) {
-                        if (connectionWithFinalHost.getResponseMessage().equalsIgnoreCase("Not Found")) {
-                            // content type was not valid because it was a not found page (text/html)
-                            response.sendError(HttpServletResponse.SC_NOT_FOUND, "Remote host not found");
-                            return;
-                        }
+                    if (connectionWithFinalHost.getResponseMessage() != null && connectionWithFinalHost.getResponseMessage().equalsIgnoreCase("Not Found")) {
+                        // content type was not valid because it was a not found page (text/html)
+                        response.sendError(HttpServletResponse.SC_NOT_FOUND, "Remote host not found");
+                        return;
                     }
+
 
                     response.sendError(HttpServletResponse.SC_FORBIDDEN,
                         "The content type of the remote host's response \"" + contentType
@@ -686,7 +687,7 @@ public class EsHTTPProxy {
                     addSelectionInfo(doc, selections);
                 }
 
-                if ((relatedTypes != null ) && (relatedTypes.length > 0)) {
+                if ((relatedTypes != null) && (relatedTypes.length > 0)) {
                     addRelatedTypes(doc, relatedTypes, context);
                 }
 
@@ -722,7 +723,7 @@ public class EsHTTPProxy {
                     addSelectionInfo(doc, selections);
                 }
 
-                if ((relatedTypes != null ) && (relatedTypes.length > 0)) {
+                if ((relatedTypes != null) && (relatedTypes.length > 0)) {
                     addRelatedTypes(doc, relatedTypes, context);
                 }
 
@@ -750,13 +751,11 @@ public class EsHTTPProxy {
      */
     private String getContentEncoding(Map<String, List<String>> headerFields) {
         for (String headerName : headerFields.keySet()) {
-            if (headerName != null) {
-                if ("Content-Encoding".equalsIgnoreCase(headerName)) {
-                    List<String> valuesList = headerFields.get(headerName);
-                    StringBuilder sBuilder = new StringBuilder();
-                    valuesList.forEach(sBuilder::append);
-                    return sBuilder.toString().toLowerCase();
-                }
+            if (headerName != null && "Content-Encoding".equalsIgnoreCase(headerName)) {
+                List<String> valuesList = headerFields.get(headerName);
+                StringBuilder sBuilder = new StringBuilder();
+                valuesList.forEach(sBuilder::append);
+                return sBuilder.toString().toLowerCase();
             }
         }
         return null;
@@ -828,7 +827,7 @@ public class EsHTTPProxy {
 
         // focus only on type, not on the text encoding
         String type = contentType.split(";")[0];
-        for (String validTypeContent : EsHTTPProxy._validContentTypes) {
+        for (String validTypeContent : EsHTTPProxy.validContentTypes) {
             if (validTypeContent.equals(type)) {
                 return true;
             }
@@ -840,29 +839,29 @@ public class EsHTTPProxy {
     /**
      * Process the metadata schema filters to filter out from the Elasticsearch response
      * the elements defined in the metadata schema filters.
-     *
+     * <p>
      * It uses a jsonpath to filter the elements, typically is configured with the following jsonpath, to
      * filter the ES object elements with an attribute nilReason = 'withheld'.
-     *
-     *  $.*[?(@.nilReason == 'withheld')]
-     *
+     * <p>
+     * $.*[?(@.nilReason == 'withheld')]
+     * <p>
      * The metadata index process, has to define this attribute. Any element that requires to be filtered, should be
      * defined as an object in Elasticsearch.
-     *
+     * <p>
      * Example for contacts:
-     *
-     *  <xsl:template mode="index-contact" match="*[cit:CI_Responsibility]">
-     *      ...
-     *      <!-- Check if the contact has an attribute @gco:nilReason = 'withheld', added by update-fixed-info.xsl process -->
-     *      <xsl:variable name="hasWithheld" select="@gco:nilReason = 'withheld'" as="xs:boolean" />
-     *
-     *      <xsl:element name="contact{$fieldSuffix}">
-     *        <xsl:attribute name="type" select="'object'"/>{
-     *        ...
-     *        "address":"<xsl:value-of select="util:escapeForJson($address)"/>"
-     *        <xsl:if test="$hasWithheld">
-     *         ,"nilReason": "withheld"
-     *        </xsl:if>
+     * <p>
+     * <xsl:template mode="index-contact" match="*[cit:CI_Responsibility]">
+     * ...
+     * <!-- Check if the contact has an attribute @gco:nilReason = 'withheld', added by update-fixed-info.xsl process -->
+     * <xsl:variable name="hasWithheld" select="@gco:nilReason = 'withheld'" as="xs:boolean" />
+     * <p>
+     * <xsl:element name="contact{$fieldSuffix}">
+     * <xsl:attribute name="type" select="'object'"/>{
+     * ...
+     * "address":"<xsl:value-of select="util:escapeForJson($address)"/>"
+     * <xsl:if test="$hasWithheld">
+     * ,"nilReason": "withheld"
+     * </xsl:if>
      *
      * @param mds
      * @param doc
@@ -917,10 +916,11 @@ public class EsHTTPProxy {
             doc.set("_source", actualObj);
         }
     }
+
     private JsonNode filterResponseElements(ObjectMapper mapper, ObjectNode sourceNode, List<String> jsonPathFilters) throws JsonProcessingException {
         DocumentContext jsonContext = JsonPath.parse(sourceNode.toPrettyString());
 
-        for(String jsonPath : jsonPathFilters) {
+        for (String jsonPath : jsonPathFilters) {
             if (StringUtils.isNotBlank(jsonPath)) {
                 try {
                     jsonContext = jsonContext.delete(jsonPath);

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -796,6 +796,8 @@
     "system/metadataprivs/publication/notificationLevel-help": "Define which users to alert when a metadata is published / unpublished",
     "system/metadataprivs/publication/notificationGroups": "Groups to notify when a metadata is published / unpublished",
     "system/metadataprivs/publication/notificationGroups-help": "List of groups, separated by the char |, to notify when a metadata is published / unpublished (for 'Notify the group(s) emails' notification level)",
+    "system/metadataprivs/userAlwaysCanEditOwnedMetadata": "Users can always edit their own metadata",
+    "system/metadataprivs/userAlwaysCanEditOwnedMetadata-help": "If enabled (default) a user can always edit the metadata records he owns. Otherwise, a user can only edit metadata if they have edit permissions for the metadata in the groups in which the user has the Editor role.",
     "system/metadatacreate" : "Metadata create",
     "system/metadatacreate/generateUuid" : "Generate UUID",
     "system/metadatacreate/generateUuid-help" : "GeoNetwork assigns a random metadata UUID to the metadata created by a user (default). To assign the metadata UUID manually disable this option and fill the metadata UUID prefix.",

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/data/data-db-default.sql
@@ -668,6 +668,7 @@ INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/metadataprivs/publicationbyrevieweringroupowneronly', 'true', 2, 9181, 'n');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/metadataprivs/publication/notificationLevel', '', 0, 9182, 'n');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/metadataprivs/publication/notificationGroups', '', 0, 9183, 'n');
+INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/metadataprivs/userAlwaysCanEditOwnedMetadata', 'true', 2, 9184, 'n');
 
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/threadedindexing/maxthreads', '1', 1, 9210, 'y');
 INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/inspire/remotevalidation/url', '', 0, 7211, 'n');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v4410/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v4410/migrate-default.sql
@@ -9,5 +9,7 @@ INSERT INTO Settings (name, value, datatype, position, internal) SELECT distinct
 UPDATE groups SET type='RecordPrivilege' WHERE id<2 AND type IS NULL;
 UPDATE groups SET type='Workspace' WHERE id>=2 AND type IS NULL;
 
+INSERT INTO Settings (name, value, datatype, position, internal) SELECT distinct 'system/metadataprivs/userAlwaysCanEditOwnedMetadata', 'true', 2, 9184, 'n' from settings WHERE NOT EXISTS (SELECT name FROM Settings WHERE name = 'system/metadataprivs/userAlwaysCanEditOwnedMetadata');
+
 UPDATE Settings SET value='4.4.10' WHERE name='system/platform/version';
 UPDATE Settings SET value='SNAPSHOT' WHERE name='system/platform/subVersion';


### PR DESCRIPTION
This change adds a new setting to configure whether editor users who are metadata owners can edit their metadata when they do not have editing privileges for the metadata.

By default, the setting is enabled to preserve the original behavior in GeoNetwork: editor users can edit a metadata if they are the owner of the metadata or have editing privileges in any of the groups where they have the editor profile. For most users it is not necessary to change this setting.

![edit-owner-setting](https://github.com/user-attachments/assets/bd79f55e-ef7f-4c8b-bc2f-8aad20c45845)

When the setting is disabled a user with editor profile can only edit a metadata if has edit privileges in any of the groups where has the Editor role.

The setting doesn't affect Administrator users, that can always edit the metadata.

---

The pull request contains Sonarlint code improvements.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

- Funded by IFremer