### PR TITLE
Search result record abstract parsing improvement

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/resultsview/ResultsviewDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/ResultsviewDirective.js
@@ -192,7 +192,7 @@
             if (resourceAbstract) {
               var abstractParagraphs = resourceAbstract.split('\n');
               var abstractBrief="";
-              for (let index=0; index < abstractParagraphs.length; index++) {
+              for (var index=0; index < abstractParagraphs.length; index++) {
                 var abstractBrief=abstractBrief+abstractParagraphs[index]+"\n";
                 if (abstractBrief.length>50) {
                   break;

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/ResultsviewDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/ResultsviewDirective.js
@@ -190,17 +190,17 @@
 
           scope.abstractBriefMaker = function (resourceAbstract) {
             if (resourceAbstract) {
-              var abstractParagraphs = resourceAbstract.split('\n');
-              var abstractBrief="";
-              for (var index=0; index < abstractParagraphs.length; index++) {
-                var abstractBrief=abstractBrief+abstractParagraphs[index]+"\n";
-                if (abstractBrief.length>50) {
+              var abstractParagraphs = resourceAbstract.split("\n");
+              var abstractBrief = "";
+              for (var index = 0; index < abstractParagraphs.length; index++) {
+                var abstractBrief = abstractBrief + abstractParagraphs[index] + "\n";
+                if (abstractBrief.length > 50) {
                   break;
                 }
               }
 
               //remove the last line break character
-              return abstractBrief.substring(0, abstractBrief.length-1);;
+              return abstractBrief.substring(0, abstractBrief.length - 1);
             }
           };
 

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/ResultsviewDirective.js
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/ResultsviewDirective.js
@@ -188,6 +188,22 @@
             }
           };
 
+          scope.abstractBriefMaker = function (resourceAbstract) {
+            if (resourceAbstract) {
+              var abstractParagraphs = resourceAbstract.split('\n');
+              var abstractBrief="";
+              for (let index=0; index < abstractParagraphs.length; index++) {
+                var abstractBrief=abstractBrief+abstractParagraphs[index]+"\n";
+                if (abstractBrief.length>50) {
+                  break;
+                }
+              }
+
+              //remove the last line break character
+              return abstractBrief.substring(0, abstractBrief.length-1);;
+            }
+          };
+
           if (scope.map) {
             scope.hoverOL.setMap(scope.map);
           }

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid.html
@@ -67,7 +67,7 @@
         <div class="gn-md-details">
           <div class="gn-md-abstract text-muted">
             <div class="ellipsis">
-              <p>{{md.resourceAbstract.split('\n')[0] | striptags}}</p>
+              <p>{{abstractBriefMaker(md.resourceAbstract) | striptags}}</p>
             </div>
           </div>
         </div>

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/grid.html
@@ -67,7 +67,7 @@
         <div class="gn-md-details">
           <div class="gn-md-abstract text-muted">
             <div class="ellipsis">
-              <p>{{abstractBriefMaker(md.resourceAbstract) | striptags}}</p>
+              <p>{{::abstractBriefMaker(md.resourceAbstract) | striptags}}</p>
             </div>
           </div>
         </div>

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/list.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/list.html
@@ -58,7 +58,7 @@
         <div class="col-lg-6 col-md-6 col-sm-6">
           <div class="gn-md-abstract text-muted">
             <p title="{{md.resourceAbstract}}">
-              {{md.resourceAbstract.split('\n')[0] | striptags}}
+              {{abstractBriefMaker(md.resourceAbstract) | striptags}}
             </p>
 
             <div

--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/list.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/viewtemplates/list.html
@@ -58,7 +58,7 @@
         <div class="col-lg-6 col-md-6 col-sm-6">
           <div class="gn-md-abstract text-muted">
             <p title="{{md.resourceAbstract}}">
-              {{abstractBriefMaker(md.resourceAbstract) | striptags}}
+              {{::abstractBriefMaker(md.resourceAbstract) | striptags}}
             </p>
 
             <div


### PR DESCRIPTION
The Search Page break down the abstract brief by line break as paragraphs. However, there is some special case some user write the format as 

Description:
This is some abstract etc.

By the existing logic, search result will show very little abstract which is not clear to the user

![image](https://github.com/user-attachments/assets/fb4f45d3-e450-49ca-8e32-9f56221b6edc)


The improved logic will make sure the abstract brief is at least 50 characters or it will keep appending the next paragraph together.

As result, the user will have more content to read.

![image](https://github.com/user-attachments/assets/462bd105-427f-498e-9b70-ff6e352ca998)


# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

