### PR TITLE
Restore link to sibling translations.

### DIFF
--- a/web-ui/src/main/resources/catalog/locales/ca-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/ca-editor.json
@@ -165,7 +165,7 @@
     "linkToParentTitle": "Enllaça una metadada pare a l'actual metadada",
     "linkToService": "Enllaça a un servei",
     "linkToServiceTitle": "Enllaça un servei a l'actual metadada",
-    "linkToSibling": "Link to records",
+    "linkToSibling": "Enllaça a altres recursos",
     "linkToSiblingTitle": "Enllaça un altre recurs a l'actual metadada",
     "linkToSource": "Enllaça a un conjunt de dades font",
     "linkToSourceTitle": "Enllaça un conjunt de dades font a l'actual metadada",

--- a/web-ui/src/main/resources/catalog/locales/cs-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/cs-editor.json
@@ -165,7 +165,7 @@
     "linkToParentTitle": "Propojit nadřazený metadatový záznam s aktuálními metadaty",
     "linkToService": "Propojit se službou",
     "linkToServiceTitle": "Propojit službu s aktuálními metadaty",
-    "linkToSibling": "Link to records",
+    "linkToSibling": "Propojit s dalšími zdroji",
     "linkToSiblingTitle": "Propojit zdroj s aktuálními metadaty",
     "linkToSource": "Propojit se zdrojovou datovou sadou",
     "linkToSourceTitle": "Propojit zdrojovou datovou sadu s aktuálními metadaty",

--- a/web-ui/src/main/resources/catalog/locales/da-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/da-editor.json
@@ -165,7 +165,7 @@
     "linkToParentTitle": "Link en parent metadata-post til de aktuelle metadata",
     "linkToService": "Link til en service",
     "linkToServiceTitle": "Link en tjeneste til de nuværende metadata",
-    "linkToSibling": "Link to records",
+    "linkToSibling": "Link til andre ressourcer",
     "linkToSiblingTitle": "Link en ressource til de aktuelle metadata",
     "linkToSource": "Link til et kildedatasæt",
     "linkToSourceTitle": "Link til et kildedatasæt",

--- a/web-ui/src/main/resources/catalog/locales/de-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/de-editor.json
@@ -165,7 +165,7 @@
     "linkToParentTitle": "Verbinde einen Eltern-Metadatensatz mit dem aktuellen Metadatensatz",
     "linkToService": "Mit einem Service verlinken",
     "linkToServiceTitle": "Verbinde einen Dienst mit dem aktuellen Metadatensatz",
-    "linkToSibling": "Link to records",
+    "linkToSibling": "Link zu übergeordnetem Datensatz erstellen",
     "linkToSiblingTitle": "Verlinke eine Resource mit dem aktuellen Metadatensatz",
     "linkToSource": "Mit dem Herkunfts-Datensatz verlinken",
     "linkToSourceTitle": "Verlinke einen Ursprungsdatensatz mit dem aktuellen Metadatensatz",

--- a/web-ui/src/main/resources/catalog/locales/es-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/es-editor.json
@@ -165,7 +165,7 @@
     "linkToParentTitle": "Enlazar un metadato padre al actual metadato",
     "linkToService": "Enlazar a un servicio",
     "linkToServiceTitle": "Enlazar un servicio al actual metadato",
-    "linkToSibling": "Link to records",
+    "linkToSibling": "Enlazar a otros recursos",
     "linkToSiblingTitle": "Enlazar otro recurso al actual metadato",
     "linkToSource": "Enlazar a un conjunto de datos fuente",
     "linkToSourceTitle": "Enlazar un conjunto de datos fuente al actual metadato",

--- a/web-ui/src/main/resources/catalog/locales/fi-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/fi-editor.json
@@ -165,7 +165,7 @@
     "linkToParentTitle": "Linkitä ylämetatietodokumentti tähän metatietoon",
     "linkToService": "Linkki palveluun",
     "linkToServiceTitle": "Linkitä palvelu tähän metatietoon",
-    "linkToSibling": "Link to records",
+    "linkToSibling": "Linkki muihin resursseihin",
     "linkToSiblingTitle": "Linkitä resurssi tähän metatietoon",
     "linkToSource": "Linkki lähdeaineistoon",
     "linkToSourceTitle": "Linkitä lähdeaineisto tähän metatietoon",

--- a/web-ui/src/main/resources/catalog/locales/fr-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/fr-editor.json
@@ -165,7 +165,7 @@
     "linkToParentTitle": "Associer une fiche parent",
     "linkToService": "Associer un service",
     "linkToServiceTitle": "Associer un service",
-    "linkToSibling": "Associer",
+    "linkToSibling": "Autres liens (eg. études, capteurs)",
     "linkToSiblingTitle": "Associer une ressource (eg. études, capteurs)",
     "linkToSource": "Associer à une donnée source",
     "linkToSourceTitle": "Associer une donnée source utilisée pour créer ce jeu de données",

--- a/web-ui/src/main/resources/catalog/locales/is-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/is-editor.json
@@ -165,7 +165,7 @@
     "linkToParentTitle": "Tengja foreldra lýsigagna færslu við núgildandi lýsigögn",
     "linkToService": "Tengja við þjónustu",
     "linkToServiceTitle": "Tengja þjónustu við núgildandi lýsigögn",
-    "linkToSibling": "Link to records",
+    "linkToSibling": "Tengja við önnur gögn",
     "linkToSiblingTitle": "Tengja aðföng við núgildandi lýsigögn",
     "linkToSource": "Tengja við uppruna gagnasett",
     "linkToSourceTitle": "Tengja uppruna gagnasett við núgildandi lýsigögn",

--- a/web-ui/src/main/resources/catalog/locales/it-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/it-editor.json
@@ -165,7 +165,7 @@
     "linkToParentTitle": "Collega un record di metadati \"genitore\" ai metadati correnti",
     "linkToService": "Collegamento a un servizio",
     "linkToServiceTitle": "Collega un servizio ai metadati correnti",
-    "linkToSibling": "Link to records",
+    "linkToSibling": "Collegamento ad altre risorse",
     "linkToSiblingTitle": "Collega una risorsa ai metadati correnti",
     "linkToSource": "Collegamento a un dataset di origine",
     "linkToSourceTitle": "Collega un set di dati di origine ai metadati correnti",

--- a/web-ui/src/main/resources/catalog/locales/ko-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/ko-editor.json
@@ -165,7 +165,7 @@
     "linkToParentTitle": "부모 메타데이터 레코드를 현재 메타데이터에 링크",
     "linkToService": "서비스에 링크",
     "linkToServiceTitle": "서비스를 현재 메타데이터에 링크",
-    "linkToSibling": "Link to records",
+    "linkToSibling": "다른 자원에 링크",
     "linkToSiblingTitle": "자원을 현재 메타데이터에 링크",
     "linkToSource": "원본 데이터셋에 링크",
     "linkToSourceTitle": "원본 데이터셋을 현재 메타데이터에 링크",

--- a/web-ui/src/main/resources/catalog/locales/nl-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/nl-editor.json
@@ -165,7 +165,7 @@
     "linkToParentTitle": "Link een parent metadata record aan de huidige metadata",
     "linkToService": "Link naar een service",
     "linkToServiceTitle": "Link een service aan de huidige metadata",
-    "linkToSibling": "Link to records",
+    "linkToSibling": "Link naar andere bronnen",
     "linkToSiblingTitle": "Link een bron aan de huidige metadata",
     "linkToSource": "Link naar een bron dataset",
     "linkToSourceTitle": "Link een bron dataset aan de huidige metadata",

--- a/web-ui/src/main/resources/catalog/locales/pt-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/pt-editor.json
@@ -165,7 +165,7 @@
     "linkToParentTitle": "Vincular um registro de metadado pai ao metadado atual",
     "linkToService": "Link para um serviço",
     "linkToServiceTitle": "Vincular um serviço ao metadado atual",
-    "linkToSibling": "Link to records",
+    "linkToSibling": "Link para outros recursos",
     "linkToSiblingTitle": "Vincular um recurso ao metadado atual",
     "linkToSource": "Link para um conjunto de dados fonte",
     "linkToSourceTitle": "Vincular um conjunto de dados fonte ao metadado atual",

--- a/web-ui/src/main/resources/catalog/locales/ru-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/ru-editor.json
@@ -165,7 +165,7 @@
     "linkToParentTitle": "Link a parent metadata record to the current metadata",
     "linkToService": "Link to a service",
     "linkToServiceTitle": "Link a service to the current metadata",
-    "linkToSibling": "Link to records",
+    "linkToSibling": "Link to other resources",
     "linkToSiblingTitle": "Link a resource to the current metadata",
     "linkToSource": "Link to a source dataset",
     "linkToSourceTitle": "Link a source dataset to the current metadata",

--- a/web-ui/src/main/resources/catalog/locales/sk-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/sk-editor.json
@@ -165,7 +165,7 @@
     "linkToParentTitle": "Prepojiť materský metaúdajový záznam s aktuálnymi metaúdajmi",
     "linkToService": "Prepojiť so službou",
     "linkToServiceTitle": "Prepojiť službu s aktuálnymi metaúdajmi",
-    "linkToSibling": "Link to records",
+    "linkToSibling": "Prepojiť s ďalšími zdrojmi",
     "linkToSiblingTitle": "Prepojiť zdroj s aktuálnymi metaúdajmi",
     "linkToSource": "Prepojiť so zdrojovou údajovou sadou",
     "linkToSourceTitle": "Prepojiť zdrojovú údajovú sadu s aktuálnymi metaúdajmi",

--- a/web-ui/src/main/resources/catalog/locales/sv-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/sv-editor.json
@@ -165,7 +165,7 @@
     "linkToParentTitle": "Länka ett överordnat metadata till aktuellt metadata",
     "linkToService": "Länk till en tjänst",
     "linkToServiceTitle": "Koppla en tjänst till aktivt metadata",
-    "linkToSibling": "Link to records",
+    "linkToSibling": "Länk till andra resurser",
     "linkToSiblingTitle": "Koppla en resurs till aktuellt metadata",
     "linkToSource": "Länk till en källdatamängd",
     "linkToSourceTitle": "Koppla en källdatamängd till aktuellt metadata",

--- a/web-ui/src/main/resources/catalog/locales/zh-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/zh-editor.json
@@ -165,7 +165,7 @@
     "linkToParentTitle": "链接父元数据记录到当前的元数据",
     "linkToService": "链接至服务",
     "linkToServiceTitle": "链接服务至当前的元数据",
-    "linkToSibling": "Link to records",
+    "linkToSibling": "链接到其他资源",
     "linkToSiblingTitle": "链接资源至当前元数据",
     "linkToSource": "链接到源数据集",
     "linkToSourceTitle": "链接源数据集到当前的元数据",


### PR DESCRIPTION
This pull request is for `4.2.x` where backporting the Transifex translations to this branch in #8166 the translations for link to sibling were changed accidentally to English.

Thanks @ianwallen for reporting the issue.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
