### PR TITLE
API / Keyword search by id / Do not decode URI parameter

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
@@ -491,8 +491,6 @@ public class KeywordsApi {
         Element descKeys;
         Map<String, Map<String, String>> jsonResponse = new HashMap<>();
 
-        uri = URLDecoder.decode(uri, StandardCharsets.UTF_8);
-
         if (uri == null) {
             descKeys = new Element("descKeys");
         } else {

--- a/web-ui/src/main/resources/catalog/components/utility/UtilityService.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityService.js
@@ -728,7 +728,7 @@
               "../api/registries/vocabularies/keyword",
               gnUrlUtils.toKeyValue({
                 thesaurus: thesaurus || fieldId.replace(/th_(.*)_tree.key/, "$1"),
-                id: encodeURIComponent(uris.join(",")),
+                id: uris.join(","),
                 lang: gnLangs.getCurrent() + "," + Object.keys(gnLangs.langs).join(",")
               }),
               {


### PR DESCRIPTION
Searching keyword having + in URI was returning nothing eg. https://www.iana.org/assignments/media-types/application/geopackage+sqlite3 (and the editor was not adding the selected keywords).

API call properly encode parameters cf. https://github.com/geonetwork/core-geonetwork/blob/main/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusService.js#L364-L366

Spring is decoding URL parameters.

Can be tested with https://github.com/metadata101/dcat-ap/blob/main/resources/thesauri/theme/media-types.rdf

Was added in https://github.com/geonetwork/core-geonetwork/pull/2113/commits/0423a22b0884b019ad8c097e53a18507ccee82d8


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

