### PR TITLE
Add Dutch translations of the iso19115-3.2018 metadata schema

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/loc/dut/codelists.xml
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/loc/dut/codelists.xml
@@ -1,0 +1,2918 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+ * Hide in edit mode : If some codelist needs to be hidden
+ in edit mode, the hideInEditMode attribute could be added
+ to any entries.
+
+ eg.
+	<entry hideInEditMode="true">
+
+ This will restrict the number of available entries for end
+ user editors and keep all records ISO compatible when using
+ codelist (eg. harvested records could use codelist hidden
+ in local node and needs to be displayed in view mode).
+
+ By default, this attribute is not used.
+
+ * editorMode attribute allows to configure the editor form field.
+
+ * - not set -: simple combo box
+ * radio : radio button in one line
+ * radio_linebreak : radio button with line break
+ * radio_withdesc : radion button with line break and codelist entry description
+ * select : select box with size set to the number of items if lower than 7 entries.
+
+-->
+<codelists xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+           xmlns:cat="http://standards.iso.org/iso/19115/-3/cat/1.0"
+           xmlns:cit="http://standards.iso.org/iso/19115/-3/cit/2.0"
+           xmlns:gcx="http://standards.iso.org/iso/19115/-3/gcx/1.0"
+           xmlns:gex="http://standards.iso.org/iso/19115/-3/gex/1.0"
+           xmlns:lan="http://standards.iso.org/iso/19115/-3/lan/1.0"
+           xmlns:srv="http://standards.iso.org/iso/19115/-3/srv/2.0"
+           xmlns:mas="http://standards.iso.org/iso/19115/-3/mas/1.0"
+           xmlns:mcc="http://standards.iso.org/iso/19115/-3/mcc/1.0"
+           xmlns:mco="http://standards.iso.org/iso/19115/-3/mco/1.0"
+           xmlns:mda="http://standards.iso.org/iso/19115/-3/mda/1.0"
+           xmlns:mdb="http://standards.iso.org/iso/19115/-3/mdb/2.0"
+           xmlns:mds="http://standards.iso.org/iso/19115/-3/mds/2.0"
+           xmlns:reg="http://standards.iso.org/iso/19135/-2/reg/1.0"
+           xmlns:mdt="http://standards.iso.org/iso/19115/-3/mdt/2.0"
+           xmlns:mex="http://standards.iso.org/iso/19115/-3/mex/1.0"
+           xmlns:mmi="http://standards.iso.org/iso/19115/-3/mmi/1.0"
+           xmlns:mpc="http://standards.iso.org/iso/19115/-3/mpc/1.0"
+           xmlns:mrc="http://standards.iso.org/iso/19115/-3/mrc/2.0"
+           xmlns:mrd="http://standards.iso.org/iso/19115/-3/mrd/1.0"
+           xmlns:mri="http://standards.iso.org/iso/19115/-3/mri/1.0"
+           xmlns:mrl="http://standards.iso.org/iso/19115/-3/mrl/2.0"
+           xmlns:mrs="http://standards.iso.org/iso/19115/-3/mrs/1.0"
+           xmlns:msr="http://standards.iso.org/iso/19115/-3/msr/2.0"
+           xmlns:mdq="http://standards.iso.org/iso/19157/-2/mdq/1.0"
+           xmlns:mac="http://standards.iso.org/iso/19115/-3/mac/2.0"
+           xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0"
+           xmlns:gml="http://www.opengis.net/gml/3.2"
+           xmlns:xlink="http://www.w3.org/1999/xlink"
+           xsi:noNamespaceSchemaLocation="../../../../../../../schema-labels.xsd">
+
+
+  <codelist name="cit:CI_TelephoneTypeCode">
+    <entry>
+      <code>voice</code>
+      <label>Voice</label>
+      <description>Telephone provides voice service</description>
+    </entry>
+    <entry>
+      <code>facsimile</code>
+      <label>Facsimile</label>
+      <description>Telephone provides facsimile service</description>
+    </entry>
+    <entry>
+      <code>sms</code>
+      <label>SMS</label>
+      <description>Telephone provides sms service</description>
+    </entry>
+  </codelist>
+  <codelist name="cit:CI_DateTypeCode">
+    <entry>
+      <code>creation</code>
+      <label>creatie</label>
+      <description>Datum waarop de dataset of dataset serie is gecre&#236;erd.</description>
+    </entry>
+    <entry>
+      <code>publication</code>
+      <label>publicatie</label>
+      <description>Publicatie datum waarop de dataset of dataset serie is gepubliceerd.
+      </description>
+    </entry>
+    <entry>
+      <code>revision</code>
+      <label>revisie</label>
+      <description>Datum waarop de dataset of dataset serie is gecontroleerd, verbeterd of
+        gewijzigd.
+      </description>
+    </entry>
+    <entry>
+      <code>expiry</code>
+      <label>Expiry</label>
+      <description>Date identifies when the resource expires</description>
+    </entry>
+    <entry>
+      <code>lastUpdate</code>
+      <label>Last Update</label>
+      <description>Date identifies when the resource was last updated
+      </description>
+    </entry>
+    <entry>
+      <code>lastRevision</code>
+      <label>Last Revision</label>
+      <description>Date identifies when the resource was last reviewed
+      </description>
+    </entry>
+    <entry>
+      <code>nextUpdate</code>
+      <label>Next Update</label>
+      <description>Date identifies when the resource will be next updated
+      </description>
+    </entry>
+    <entry>
+      <code>unavailable</code>
+      <label>Unavailable</label>
+      <description>Date identifies when the resource became not available or
+        obtainable
+      </description>
+    </entry>
+    <entry>
+      <code>inForce</code>
+      <label>In Force</label>
+      <description>Date identifies when the resource became in force
+      </description>
+    </entry>
+    <entry>
+      <code>adopted</code>
+      <label>Adopted</label>
+      <description>Date identifies when the resource was adopted</description>
+    </entry>
+    <entry>
+      <code>deprecated</code>
+      <label>Deprecated</label>
+      <description>Date identifies when the resource was deprecated
+      </description>
+    </entry>
+    <entry>
+      <code>superseded</code>
+      <label>Superseded</label>
+      <description>Date identifies when the resource was superseded or replaced
+        by another resource
+      </description>
+    </entry>
+    <entry>
+      <code>validityBegins</code>
+      <label>Validity Begins</label>
+      <description>Date identifies when the resource is considered to be valid
+      </description>
+    </entry>
+    <entry>
+      <code>validityExpires</code>
+      <label>Validity Expires</label>
+      <description>Date identifies when the resource is no longer considered to
+        be valid
+      </description>
+    </entry>
+    <entry>
+      <code>released</code>
+      <label>Released</label>
+      <description>Date identifies when the resource shall be released for
+        public access
+      </description>
+    </entry>
+    <entry>
+      <code>distribution</code>
+      <label>Distribution</label>
+      <description>Date identifies when an instance of the resource was
+        distributed
+      </description>
+    </entry>
+  </codelist>
+  <codelist name="cit:CI_OnLineFunctionCode" alias="function">
+    <entry>
+      <code>download</code>
+      <label>download</label>
+      <description>online instructions for transferring data from one storage device or system to
+        another
+      </description>
+    </entry>
+    <entry>
+      <code>information</code>
+      <label>information</label>
+      <description>online information about the resource</description>
+    </entry>
+    <entry>
+      <code>offlineAccess</code>
+      <label>offlineAccess</label>
+      <description>online instructions for requesting the resource from the
+        provider
+      </description>
+    </entry>
+    <entry>
+      <code>order</code>
+      <label>order</label>
+      <description>online order process for obtening the resource</description>
+    </entry>
+    <entry>
+      <code>search</code>
+      <label>search</label>
+      <description>online search interface for seeking out information about the
+        resource
+      </description>
+    </entry>
+    <entry>
+      <code>completeMetadata</code>
+      <label>Complete Metadata</label>
+      <description>Complete metadata provided</description>
+    </entry>
+    <entry>
+      <code>doi</code>
+      <label>Digital Object Identifier (DOI)</label>
+      <description></description>
+    </entry>
+    <entry>
+      <code>browseGraphic</code>
+      <label>Browse Graphic</label>
+      <description>Browse Graphic provided</description>
+    </entry>
+    <entry>
+      <code>upload</code>
+      <label>Upload</label>
+      <description>Upload service provided</description>
+    </entry>
+    <entry>
+      <code>emailService</code>
+      <label>Email Service</label>
+      <description>Email service provided</description>
+    </entry>
+    <entry>
+      <code>browsing</code>
+      <label>Browsing</label>
+      <description>Online browsing provided</description>
+    </entry>
+    <entry>
+      <code>fileAccess</code>
+      <label>Access File</label>
+      <description>Online file access provided</description>
+    </entry>
+  </codelist>
+  <codelist name="cit:CI_PresentationFormCode">
+    <entry>
+      <code>documentDigital</code>
+      <label>documentDigital</label>
+      <description>digital representation of a primarily textual item (can contain illustrations
+        also)
+      </description>
+    </entry>
+    <entry>
+      <code>imageDigital</code>
+      <label>imageDigital</label>
+      <description>likeness of natural or man-made features, objects, and activities acquired
+        through the sensing of visual or any other segment of the electromagnetic spectrum by
+        sensors, such as thermal infrared, and high resolution radar and stored in digital
+        format
+      </description>
+    </entry>
+    <entry>
+      <code>documentHardcopy</code>
+      <label>documentHardcopy</label>
+      <description>representation of a primarily textual item (can contain illustrations also) on
+        paper, photographic material, or other media
+      </description>
+    </entry>
+    <entry>
+      <code>imageHardcopy</code>
+      <label>imageHardcopy</label>
+      <description>likeness of natural or man-made features, objects, and activities acquired
+        through the sensing of visual or any other segment of the electromagnetic spectrum by
+        sensors, such as thermal infrared, and high resolution radar and reproduced on paper,
+        photographic material, or other media for use directly by the human user
+      </description>
+    </entry>
+    <entry>
+      <code>mapDigital</code>
+      <label>mapDigital</label>
+      <description>map represented in raster or vector form</description>
+    </entry>
+    <entry>
+      <code>mapHardcopy</code>
+      <label>mapHardcopy</label>
+      <description>map printed on paper, photographic material, or other media for use directly
+        by the human user
+      </description>
+    </entry>
+    <entry>
+      <code>modelDigital</code>
+      <label>modelDigital</label>
+      <description>multi-dimensional digital representation of a feature, process,
+        etc.
+      </description>
+    </entry>
+    <entry>
+      <code>modelHardcopy</code>
+      <label>modelHardcopy</label>
+      <description>3-dimensional, physical model</description>
+    </entry>
+    <entry>
+      <code>profileDigital</code>
+      <label>profileDigital</label>
+      <description>vertical cross-section in digital form</description>
+    </entry>
+    <entry>
+      <code>profileHardcopy</code>
+      <label>profileHardcopy</label>
+      <description>vertical cross-section printed on paper, etc.</description>
+    </entry>
+    <entry>
+      <code>tableDigital</code>
+      <label>tableDigital</label>
+      <description>digital representation of facts or figures systematically displayed,
+        especially in columns
+      </description>
+    </entry>
+    <entry>
+      <code>tableHardcopy</code>
+      <label>tableHardcopy</label>
+      <description>representation of facts or figures systematically displayed, especially in
+        columns, printed onpapers, photographic material, or other media
+      </description>
+    </entry>
+    <entry>
+      <code>videoDigital</code>
+      <label>videoDigital</label>
+      <description>digital video recording</description>
+    </entry>
+    <entry>
+      <code>videoHardcopy</code>
+      <label>videoHardcopy</label>
+      <description>video recording on film</description>
+    </entry>
+    <entry>
+      <code>audioDigital</code>
+      <label>Digital audio</label>
+      <description>Digital audio recording</description>
+    </entry>
+    <entry>
+      <code>audioHardcopy</code>
+      <label>Hardcopy audio</label>
+      <description>Audio recording delivered by analog media, such as magnetic
+        tape
+      </description>
+    </entry>
+    <entry>
+      <code>multimediaDigital</code>
+      <label>Multimedia digital</label>
+      <description>Information representation using simultaneously various
+        digital modes for text, sound and image
+      </description>
+    </entry>
+    <entry>
+      <code>multimediaHardcopy</code>
+      <label>Multimedia hardcopy</label>
+      <description>Information representation using simultaneously various
+        analog modes for text, sound and image
+      </description>
+    </entry>
+    <entry>
+      <code>physicalObject</code>
+      <label>Physical object</label>
+      <description>A physical object eg. rock or mineral sample, microscope
+        slide
+      </description>
+    </entry>
+    <entry>
+      <code>diagramDigital</code>
+      <label>Digital diagram</label>
+      <description>Information represented graphically by charts such as pie
+        chart, bar chart and other type of diagrams and recorded in digital
+        format
+      </description>
+    </entry>
+    <entry>
+      <code>diagramHardcopy</code>
+      <label>Hardcopy diagram</label>
+      <description>Information represented graphically by charts such as pie
+        chart, bar chart and other type of diagrams and printed on paper,
+        photographic material, or other media
+      </description>
+    </entry>
+  </codelist>
+  <codelist name="cit:CI_RoleCode" alias="roleCode">
+    <entry>
+      <code>resourceProvider</code>
+      <label>verstrekker</label>
+      <description>Organisatie die de data verstrekt.</description>
+    </entry>
+    <entry>
+      <code>custodian</code>
+      <label>beheerder</label>
+      <description>Partij die verantwoordelijkheid heeft geaccepteerd en zorg draagt voor het beheer
+        van de data.
+      </description>
+    </entry>
+    <entry>
+      <code>owner</code>
+      <label>eigenaar</label>
+      <description>Partij die eigenaar is van de data.</description>
+    </entry>
+    <entry>
+      <code>user</code>
+      <label>gebruiker</label>
+      <description>Partij die de data gebruikt.</description>
+    </entry>
+    <entry>
+      <code>distributor</code>
+      <label>distributeur</label>
+      <description>Partij die de data verstrekt.</description>
+    </entry>
+    <entry>
+      <code>originator</code>
+      <label>maker</label>
+      <description>Partij die de data heeft gecre&#236;erd</description>
+    </entry>
+    <entry>
+      <code>pointOfContact</code>
+      <label>contactpunt</label>
+      <description>Partij waarmee contact kan worden opgenomen voor het vergaren van kennis of
+        verstrekking van de data.
+      </description>
+    </entry>
+    <entry>
+      <code>principalInvestigator</code>
+      <label>inwinner</label>
+      <description>Sleutelpartij verantwoordelijk voor verzamelen van data en de uitvoering van
+        onderzoek.
+      </description>
+    </entry>
+    <entry>
+      <code>processor</code>
+      <label>bewerker</label>
+      <description>Partij die de data heeft bewerkt, zodanig dat de data is gewijzigd.</description>
+    </entry>
+    <entry>
+      <code>publisher</code>
+      <label>uitgever</label>
+      <description>Partij die de data publiceert.</description>
+    </entry>
+    <entry>
+      <code>author</code>
+      <label>auteur</label>
+      <description>Partij die auteur is van de data.</description>
+    </entry>
+    <entry>
+      <code>sponsor</code>
+      <label>Sponsor</label>
+      <description>Party who speaks for the resource</description>
+    </entry>
+    <entry>
+      <code>coAuthor</code>
+      <label>Co-author</label>
+      <description>Party who jointly authors the resource</description>
+    </entry>
+    <entry>
+      <code>collaborator</code>
+      <label>Collaborator</label>
+      <description>Party who assists with the generation of the resource other
+        than the principal investigator
+      </description>
+    </entry>
+    <entry>
+      <code>editor</code>
+      <label>Editor</label>
+      <description>Party who reviewed or modified the resource to improve the
+        content
+      </description>
+    </entry>
+    <entry>
+      <code>mediator</code>
+      <label>Mediator</label>
+      <description>A class of entity that mediates access to the resource and
+        for whom the resource is intended or useful
+      </description>
+    </entry>
+    <entry>
+      <code>rightsHolder</code>
+      <label>Rights holder</label>
+      <description>Party owning or managing rights over the resource
+      </description>
+    </entry>
+    <entry>
+      <code>contributor</code>
+      <label>Contributor</label>
+      <description>Party contributing to the resource</description>
+    </entry>
+    <entry>
+      <code>funder</code>
+      <label>Funder</label>
+      <description>Party providing monetary support for the resource
+      </description>
+    </entry>
+    <entry>
+      <code>stakeholder</code>
+      <label>Stakeholder</label>
+      <description>Party who has an interest in the resource or the use of the
+        resource
+      </description>
+    </entry>
+  </codelist>
+  <codelist name="mdq:DQ_EvaluationMethodTypeCode">
+    <entry>
+      <code>directInternal</code>
+      <label>directInternal</label>
+      <description>method of evaluating the quality of a dataset based on inspection of items
+        within the dataset, where all data required is internal to the dataset being
+        evaluated
+      </description>
+    </entry>
+    <entry>
+      <code>directExternal</code>
+      <label>directExternal</label>
+      <description>method of evaluating the quality of a dataset based on inspection of items
+        within the dataset, where reference data external to the dataset being evaluated is
+        required
+      </description>
+    </entry>
+    <entry>
+      <code>indirect</code>
+      <label>indirect</label>
+      <description>method of evaluating the quality of a dataset based on external
+        knowledge
+      </description>
+    </entry>
+  </codelist>
+  <codelist name="mri:DS_AssociationTypeCode" alias="associationType">
+    <entry>
+      <code>crossReference</code>
+      <label>Kruis verwijzing</label>
+      <description>Referentie van een dataset naar een andere</description>
+    </entry>
+    <entry>
+      <code>largerWorkCitation</code>
+      <label>Citatie uit een groter werk</label>
+      <description></description>
+    </entry>
+    <entry>
+      <code>partOfSeamlessDatabase</code>
+      <label>Deel van een naadloze database</label>
+      <description></description>
+    </entry>
+    <entry>
+      <code>stereoMate</code>
+      <label>Stereo mate</label>
+      <description>Deel van een set afbeeldingen die samen een 3D beeld vormen
+      </description>
+    </entry>
+    <entry>
+      <code>isComposedOf</code>
+      <label>Is composed of</label>
+      <description>Reference to resources that are parts of this resource
+      </description>
+    </entry>
+    <entry>
+      <code>collectiveTitle</code>
+      <label>Collective Title</label>
+      <description>Common title for a collection of resources. NOTE Title
+        identifies elements of a series collectively, combined with information
+        about what volumes are available at the source cite
+      </description>
+    </entry>
+    <entry>
+      <code>series</code>
+      <label>Series</label>
+      <description>Associated through a common heritage such as produced to a
+        common product specification
+      </description>
+    </entry>
+    <entry>
+      <code>dependency</code>
+      <label>Dependency</label>
+      <description>Associated through a dependency</description>
+    </entry>
+    <entry>
+      <code>revisionOf</code>
+      <label>Revision Of</label>
+      <description>Resource is a revision of associated resource</description>
+    </entry>
+  </codelist>
+
+  <codelist name="mri:DS_InitiativeTypeCode" alias="initiativeType">
+    <entry>
+      <code>campaign</code>
+      <label>Campagne</label>
+      <description></description>
+    </entry>
+    <entry>
+      <code>collection</code>
+      <label>Collectie</label>
+      <description>accumulation of datasets assembled for a specific purpose</description>
+    </entry>
+    <entry>
+      <code>exercise</code>
+      <label>Opdracht</label>
+      <description></description>
+    </entry>
+    <entry>
+      <code>experiment</code>
+      <label>Experiment</label>
+      <description></description>
+    </entry>
+    <entry>
+      <code>investigation</code>
+      <label>Onderzoek</label>
+      <description></description>
+    </entry>
+    <entry>
+      <code>mission</code>
+      <label>Missie</label>
+      <description></description>
+    </entry>
+    <entry>
+      <code>sensor</code>
+      <label>Sensor</label>
+      <description></description>
+    </entry>
+    <entry>
+      <code>operation</code>
+      <label>Operatie</label>
+      <description></description>
+    </entry>
+    <entry>
+      <code>platform</code>
+      <label>Platform</label>
+      <description></description>
+    </entry>
+    <entry>
+      <code>process</code>
+      <label>Proces</label>
+      <description></description>
+    </entry>
+    <entry>
+      <code>program</code>
+      <label>Programma</label>
+      <description></description>
+    </entry>
+    <entry>
+      <code>project</code>
+      <label>Project</label>
+      <description></description>
+    </entry>
+    <entry>
+      <code>study</code>
+      <label>Studie</label>
+      <description></description>
+    </entry>
+    <entry>
+      <code>task</code>
+      <label>Taak</label>
+      <description></description>
+    </entry>
+    <entry>
+      <code>trial</code>
+      <label>Experiment</label>
+      <description></description>
+    </entry>
+  </codelist>
+  <codelist name="gfc:FC_RoleType">
+    <entry>
+      <code>ordinary</code>
+      <label>Ordinary</label>
+      <description>Indicates an ordinary association.</description>
+    </entry>
+    <entry>
+      <code>aggregation</code>
+      <label>Aggregation</label>
+      <description>Indicates a UML aggregation (part role).</description>
+    </entry>
+    <entry>
+      <code>composition</code>
+      <label>Composition</label>
+      <description>Indicates a UML composition (part role).</description>
+    </entry>
+  </codelist>
+  <codelist name="mco:MD_ClassificationCode">
+    <entry>
+      <code>unclassified</code>
+      <label>vrij toegankelijk</label>
+      <description>Beschikbaar voor algemene ontsluiting.</description>
+    </entry>
+    <entry>
+      <code>restricted</code>
+      <label>niet toegankelijk</label>
+      <description>Niet geschikt voor algemene ontsluiting.</description>
+    </entry>
+    <entry>
+      <code>confidential</code>
+      <label>vertrouwelijk</label>
+      <description>Beschikbaar voor personen die vertrouwd kan omgaan met de informatie.
+      </description>
+    </entry>
+    <entry>
+      <code>secret</code>
+      <label>geheim</label>
+      <description>Dient geheim en verborgen te worden gehouden voor iedereen behalve een
+        geselecteerde groep personen.
+      </description>
+    </entry>
+    <entry>
+      <code>topSecret</code>
+      <label>zeer geheim</label>
+      <description>Hoogste geheimhouding verplicht.</description>
+    </entry>
+    <entry>
+      <code>forOfficialUseOnly</code>
+      <label>For Official Use Only</label>
+      <description>Unclassified information that is to be used only for official
+        purposes determined by the designating body
+      </description>
+    </entry>
+    <entry>
+      <code>protected</code>
+      <label>Protected</label>
+      <description>Compromise of the information could cause damage
+      </description>
+    </entry>
+    <entry>
+      <code>limitedDistribution</code>
+      <label>Limited Distribution</label>
+      <description>Dissemination limited by designating body</description>
+    </entry>
+  </codelist>
+  <codelist name="mrc:MD_CoverageContentTypeCode">
+    <entry>
+      <code>image</code>
+      <label>image</label>
+      <description>meaningful numerical representation of a physical parameter that is not the
+        actual value of the physical parameter
+      </description>
+    </entry>
+    <entry>
+      <code>thematicClassification</code>
+      <label>thematicClassification</label>
+      <description>code value with no quantitative meaning, used to represent a physical
+        quantity
+      </description>
+    </entry>
+    <entry>
+      <code>physicalMeasurement</code>
+      <label>physicalMeasurement</label>
+      <description>value in physical units of the quantity being measured</description>
+    </entry>
+    <entry>
+      <code>auxillaryInformation</code>
+      <label>Auxillary Information</label>
+      <description>Data, usually a physical measurement, used to support the
+        calculation of the primary physicalMeasurement coverages in the dataset.
+        EXAMPLE: Grid of aerosol optical thickness used in the calculation of a
+        sea surface temperature product
+      </description>
+    </entry>
+    <entry>
+      <code>qualityInformation</code>
+      <label>Quality Information</label>
+      <description>Data used to characterize the quality of the
+        physicalMeasurement coverages in the dataset. NOTE: Typically included
+        in a gmi:QE_CoverageResult
+      </description>
+    </entry>
+    <entry>
+      <code>referenceInformation</code>
+      <label>Reference Information</label>
+      <description>Data used to characterize the quality of the
+        physicalMeasurement coverages in the dataset. NOTE: Typically included
+        in a gmi:QE_CoverageResult
+      </description>
+    </entry>
+    <entry>
+      <code>modelResult</code>
+      <label>Model Result</label>
+      <description>Resources with values that are calculated using a model
+        rather than being observed or calculated from observations
+      </description>
+    </entry>
+    <entry>
+      <code>coordinate</code>
+      <label>Coordinate</label>
+      <description>Data used to provide coordinate axis values</description>
+    </entry>
+  </codelist>
+  <codelist name="mex:MD_DatatypeCode">
+    <entry>
+      <code>class</code>
+      <label>class</label>
+      <description>descriptor of a set of objects that share the same attributes, operations,
+        methods, relationships, and behavior
+      </description>
+    </entry>
+    <entry>
+      <code>codelist</code>
+      <label>codelist</label>
+      <description>descriptor of a set of objects that share the same attributes, operations,
+        methods, relationships, and behavior
+      </description>
+    </entry>
+    <entry>
+      <code>enumeration</code>
+      <label>enumeration</label>
+      <description>data type whose instances form a list of named literal values, not
+        extendable
+      </description>
+    </entry>
+    <entry>
+      <code>codelistElement</code>
+      <label>codelistElement</label>
+      <description>permissible value for a codelist or enumeration</description>
+    </entry>
+    <entry>
+      <code>abstractClass</code>
+      <label>abstractClass</label>
+      <description>class that cannot be directly instantiated</description>
+    </entry>
+    <entry>
+      <code>aggregateClass</code>
+      <label>aggregateClass</label>
+      <description>class that is composed of classes it is connected to by an aggregate
+        relationship
+      </description>
+    </entry>
+    <entry>
+      <code>specifiedClass</code>
+      <label>specifiedClass</label>
+      <description>subclass that may be substituted for its superclass</description>
+    </entry>
+    <entry>
+      <code>datatypeClass</code>
+      <label>datatypeClass</label>
+      <description>class with few or no operations whose primary purpose is to hold the abstract
+        state of another class for transmittal, storage, encoding or persistent
+        storage
+      </description>
+    </entry>
+    <entry>
+      <code>interfaceClass</code>
+      <label>interfaceClass</label>
+      <description>named set of operations that characterize the behavior of an
+        element
+      </description>
+    </entry>
+    <entry>
+      <code>unionClass</code>
+      <label>unionClass</label>
+      <description>class describing a selection of one of the specified types</description>
+    </entry>
+    <entry>
+      <code>metaClass</code>
+      <label>metaClass</label>
+      <description>class whose instances are classes</description>
+    </entry>
+    <entry>
+      <code>typeClass</code>
+      <label>typeClass</label>
+      <description>class used for specification of a domain of instances (objects), together with
+        the operations applicable to the objects. A type may have attributes and
+        associations
+      </description>
+    </entry>
+    <entry>
+      <code>characterString</code>
+      <label>characterString</label>
+      <description>free text field</description>
+    </entry>
+    <entry>
+      <code>integer</code>
+      <label>integer</label>
+      <description>numerical field</description>
+    </entry>
+    <entry>
+      <code>association</code>
+      <label>association</label>
+      <description>semantic relationship between two classes that involves connections among
+        their instances
+      </description>
+    </entry>
+  </codelist>
+  <codelist name="msr:MD_DimensionNameTypeCode">
+    <entry>
+      <code>row</code>
+      <label>row</label>
+      <description>ordinate (y) axis</description>
+    </entry>
+    <entry>
+      <code>column</code>
+      <label>column</label>
+      <description>abscissa (x) axis</description>
+    </entry>
+    <entry>
+      <code>vertical</code>
+      <label>vertical</label>
+      <description>vertical (z) axis</description>
+    </entry>
+    <entry>
+      <code>track</code>
+      <label>track</label>
+      <description>along the direction of motion of the scan point</description>
+    </entry>
+    <entry>
+      <code>crossTrack</code>
+      <label>crossTrack</label>
+      <description>perpendicular to the direction of motion of the scan point</description>
+    </entry>
+    <entry>
+      <code>line</code>
+      <label>line</label>
+      <description>scan line of a sensor</description>
+    </entry>
+    <entry>
+      <code>sample</code>
+      <label>sample</label>
+      <description>element along a scan line</description>
+    </entry>
+    <entry>
+      <code>time</code>
+      <label>time</label>
+      <description>duration</description>
+    </entry>
+  </codelist>
+  <codelist name="msr:MD_GeometricObjectTypeCode">
+    <entry>
+      <code>complex</code>
+      <label>complex</label>
+      <description>set of geometric primitives such that their boundaries can be represented as a
+        union of other primitives
+      </description>
+    </entry>
+    <entry>
+      <code>composite</code>
+      <label>composite</label>
+      <description>connected set of curves, solids or surfaces</description>
+    </entry>
+    <entry>
+      <code>curve</code>
+      <label>curve</label>
+      <description>bounded, 1-dimensional geometric primitive, representing the continuous image
+        of a line
+      </description>
+    </entry>
+    <entry>
+      <code>point</code>
+      <label>point</label>
+      <description>zero-dimensional geometric primitive, representing a position but not having
+        an extent
+      </description>
+    </entry>
+    <entry>
+      <code>solid</code>
+      <label>solid</label>
+      <description>bounded, connected 3-dimensional geometric primitive, representing the
+        continuous image of a region of space
+      </description>
+    </entry>
+    <entry>
+      <code>surface</code>
+      <label>surface</label>
+      <description>bounded, connected 2-dimensional geometric primitive, representing the
+        continuous image of a region of a plane
+      </description>
+    </entry>
+  </codelist>
+  <codelist name="mrc:MD_ImagingConditionCode">
+    <entry>
+      <code>blurredImage</code>
+      <label>blurredImage</label>
+      <description>portion of the image is blurred</description>
+    </entry>
+    <entry>
+      <code>cloud</code>
+      <label>cloud</label>
+      <description>portion of the image is partially obscured by cloud cover</description>
+    </entry>
+    <entry>
+      <code>degradingObliquity</code>
+      <label>degradingObliquity</label>
+      <description>acute angle between the plane of the ecliptic (the plane of the Earth s orbit)
+        and the plane of the celestial equator
+      </description>
+    </entry>
+    <entry>
+      <code>fog</code>
+      <label>fog</label>
+      <description>portion of the image is partially obscured by fog</description>
+    </entry>
+    <entry>
+      <code>heavySmokeOrDust</code>
+      <label>heavySmokeOrDust</label>
+      <description>portion of the image is partially obscured by heavy smoke or
+        dust
+      </description>
+    </entry>
+    <entry>
+      <code>night</code>
+      <label>night</label>
+      <description>image was taken at night</description>
+    </entry>
+    <entry>
+      <code>rain</code>
+      <label>rain</label>
+      <description>image was taken during rainfall</description>
+    </entry>
+    <entry>
+      <code>semiDarkness</code>
+      <label>semiDarkness</label>
+      <description>image was taken during semi-dark conditions -- twilight
+        conditions
+      </description>
+    </entry>
+    <entry>
+      <code>shadow</code>
+      <label>shadow</label>
+      <description>portion of the image is obscured by shadow</description>
+    </entry>
+    <entry>
+      <code>snow</code>
+      <label>snow</label>
+      <description>portion of the image is obscured by snow</description>
+    </entry>
+    <entry>
+      <code>terrainMasking</code>
+      <label>terrainMasking</label>
+      <description>the absence of collection data of a given point or area caused by the relative
+        location of topographic features which obstruct the collection path between the
+        collector(s) and the subject(s) of interest
+      </description>
+    </entry>
+  </codelist>
+  <codelist name="mri:MD_KeywordTypeCode">
+    <entry>
+      <code>discipline</code>
+      <label>discipline</label>
+      <description>keyword identifies a branch of instruction or specialized
+        learning
+      </description>
+    </entry>
+    <entry>
+      <code>place</code>
+      <label>place</label>
+      <description>keyword identifies a location</description>
+    </entry>
+    <entry>
+      <code>stratum</code>
+      <label>stratum</label>
+      <description>keyword identifies the layer(s) of any deposited substance</description>
+    </entry>
+    <entry>
+      <code>temporal</code>
+      <label>temporal</label>
+      <description>keyword identifies a time period related to the dataset</description>
+    </entry>
+    <entry>
+      <code>theme</code>
+      <label>theme</label>
+      <description>keyword identifies a particular subject or topic</description>
+    </entry>
+    <entry>
+      <code>dataCentre</code>
+      <label>Data centre</label>
+      <description>Keyword identifies a repository or archive that manages and
+        distributes data
+      </description>
+    </entry>
+    <entry>
+      <code>featureType</code>
+      <label>Feature type</label>
+      <description>Keyword identifies a resource containing or about a
+        collection of feature instances with common characteristics
+      </description>
+    </entry>
+    <entry>
+      <code>instrument</code>
+      <label>Instrument</label>
+      <description>Keyword identifies a device used to measure or compare
+        physical properties
+      </description>
+    </entry>
+    <entry>
+      <code>platform</code>
+      <label>Platform</label>
+      <description>Keyword identifies a structure upon which an instrument is
+        mounted
+      </description>
+    </entry>
+    <entry>
+      <code>process</code>
+      <label>Process</label>
+      <description>Keyword identifies a series of actions or natural
+        occurrences
+      </description>
+    </entry>
+    <entry>
+      <code>project</code>
+      <label>Project</label>
+      <description>Keyword identifies an endeavour undertaken to create or
+        modify a product or service
+      </description>
+    </entry>
+    <entry>
+      <code>service</code>
+      <label>Service</label>
+      <description>Keyword identifies an activity carried out by one party for
+        the benefit of another
+      </description>
+    </entry>
+    <entry>
+      <code>product</code>
+      <label>Product</label>
+      <description>Keyword identifies a type of product</description>
+    </entry>
+    <entry>
+      <code>subTopicCategory</code>
+      <label>Sub-Topic Category</label>
+      <description>Refinement of a topic category for the purpose of geographic
+        data classification
+      </description>
+    </entry>
+    <entry>
+      <code>taxon</code>
+      <label>Taxon</label>
+      <description>Keyword identifies a taxonomy of the resource</description>
+    </entry>
+  </codelist>
+  <codelist name="mmi:MD_MaintenanceFrequencyCode">
+    <entry>
+      <code>continual</code>
+      <label>continu</label>
+      <description>Data wordt herhaaldelijk en vaak geactualiseerd.</description>
+    </entry>
+    <entry>
+      <code>daily</code>
+      <label>dagelijks</label>
+      <description>Data wordt elke dag geactualiseerd.</description>
+    </entry>
+    <entry>
+      <code>weekly</code>
+      <label>wekelijks</label>
+      <description>Data wordt wekelijks geactualiseerd.</description>
+    </entry>
+    <entry>
+      <code>fortnightly</code>
+      <label>2-wekelijks</label>
+      <description>Data wordt 2-wekelijks geactualiseerd.</description>
+    </entry>
+    <entry>
+      <code>monthly</code>
+      <label>maandelijks</label>
+      <description>Data wordt maandelijks geactualiseerd.</description>
+    </entry>
+    <entry>
+      <code>quarterly</code>
+      <label>1 x per kwartaal</label>
+      <description>Data wordt elke kwartaal geactualiseerd.</description>
+    </entry>
+    <entry>
+      <code>biannually</code>
+      <label>1 x per half jaar</label>
+      <description>Data wordt half jaarlijks geactualiseerd.</description>
+    </entry>
+    <entry>
+      <code>annually</code>
+      <label>jaarlijks</label>
+      <description>Data wordt jaarlijks geactualiseerd.</description>
+    </entry>
+    <entry>
+      <code>asNeeded</code>
+      <label>indien nodig</label>
+      <description>Data wordt geactualiseerd indien nodig.</description>
+    </entry>
+    <entry>
+      <code>irregular</code>
+      <label>onregelmatig</label>
+      <description>Data wordt geactualiseerd in intervallen die niet even lang duren.</description>
+    </entry>
+    <entry>
+      <code>notPlanned</code>
+      <label>niet gepland</label>
+      <description>Er zijn geen plannen om de data te actualiseren.</description>
+    </entry>
+    <entry>
+      <code>unknown</code>
+      <label>onbekend</label>
+      <description>Herzieningsfrequentie is niet bekend.</description>
+    </entry>
+    <entry>
+      <code>periodic</code>
+      <label>Periodic</label>
+      <description>Resource is updated at regular intervals</description>
+    </entry>
+    <entry>
+      <code>semimonthly</code>
+      <label>Semi-monthly</label>
+      <description>Resource updated twice monthly</description>
+    </entry>
+    <entry>
+      <code>biennially</code>
+      <label>Biennially</label>
+      <description>Resource is updated every 2 years</description>
+    </entry>
+  </codelist>
+  <codelist name="mrd:MD_MediumFormatCode">
+    <entry>
+      <code>cpio</code>
+      <label>cpio</label>
+      <description>CoPy In / Out (UNIX file format and command)</description>
+    </entry>
+    <entry>
+      <code>tar</code>
+      <label>tar</label>
+      <description>Tape ARchive</description>
+    </entry>
+    <entry>
+      <code>highSierra</code>
+      <label>highSierra</label>
+      <description>high sierra file system</description>
+    </entry>
+    <entry>
+      <code>iso9660</code>
+      <label>iso9660</label>
+      <description>information processing volume and file structure of CD-ROM</description>
+    </entry>
+    <entry>
+      <code>iso9660RockRidge</code>
+      <label>iso9660RockRidge</label>
+      <description>rock ridge interchange protocol (UNIX)</description>
+    </entry>
+    <entry>
+      <code>iso9660AppleHFS</code>
+      <label>iso9660AppleHFS</label>
+      <description>hierarchical file system (Macintosh)</description>
+    </entry>
+    <entry>
+      <code>udf</code>
+      <label>UDF</label>
+      <description>Universal Disk Format</description>
+    </entry>
+  </codelist>
+  <codelist name="mex:MD_ObligationCode">
+    <entry>
+      <code>mandatory</code>
+      <label>mandatory</label>
+      <description>element is always required</description>
+    </entry>
+    <entry>
+      <code>optional</code>
+      <label>optional</label>
+      <description>element is not required</description>
+    </entry>
+    <entry>
+      <code>conditional</code>
+      <label>conditional</label>
+      <description>element is required when a specific condition is met</description>
+    </entry>
+  </codelist>
+  <codelist name="msr:MD_PixelOrientationCode">
+    <entry>
+      <code>center</code>
+      <label>center</label>
+      <description>point halfway between the lower left and the upper right of the
+        pixel
+      </description>
+    </entry>
+    <entry>
+      <code>lowerLeft</code>
+      <label>lowerLeft</label>
+      <description>the corner in the pixel closest to the origin of the SRS; if two are at the
+        same distance from the origin, the one with the smallest x-value
+      </description>
+    </entry>
+    <entry>
+      <code>lowerRight</code>
+      <label>lowerRight</label>
+      <description>next corner counterclockwise from the lower left</description>
+    </entry>
+    <entry>
+      <code>upperRight</code>
+      <label>upperRight</label>
+      <description>next corner counterclockwise from the lower right</description>
+    </entry>
+    <entry>
+      <code>upperLeft</code>
+      <label>upperLeft</label>
+      <description>next corner counterclockwise from the upper right</description>
+    </entry>
+  </codelist>
+  <codelist name="mcc:MD_ProgressCode">
+    <entry>
+      <code>completed</code>
+      <label>compleet</label>
+      <description>Productie van de data is compleet / afgerond.</description>
+    </entry>
+    <entry>
+      <code>historicalArchive</code>
+      <label>historisch archief</label>
+      <description>De data is opgeslagen in een offline opslagmedium.</description>
+    </entry>
+    <entry>
+      <code>obsolete</code>
+      <label>niet relevant</label>
+      <description>Data is niet langer relevant.</description>
+    </entry>
+    <entry>
+      <code>onGoing</code>
+      <label>continu geactualiseerd</label>
+      <description>Data wordt continu geactualiseerd.</description>
+    </entry>
+    <entry>
+      <code>planned</code>
+      <label>gepland</label>
+      <description>Datum is al bekend wanneer de data gecre&#233;erd of geactualiseerd moet zijn.
+      </description>
+    </entry>
+    <entry>
+      <code>required</code>
+      <label>actualisatie vereist</label>
+      <description>Data moet nog gegenereerd of geactualiseerd worden.</description>
+    </entry>
+    <entry>
+      <code>underDevelopment</code>
+      <label>in ontwikkeling</label>
+      <description>Data wordt momenteel gecre&#233;erd.</description>
+    </entry>
+    <entry>
+      <code>final</code>
+      <label>Final</label>
+      <description>Progress concluded and no changes will be accepted
+      </description>
+    </entry>
+    <entry>
+      <code>pending</code>
+      <label>Pending</label>
+      <description>Committed to, but not yet addressed</description>
+    </entry>
+    <entry>
+      <code>retired</code>
+      <label>Retired</label>
+      <description>Item is no longer recommended for use. It has not been
+        superseded by another item
+      </description>
+    </entry>
+    <entry>
+      <code>superseded</code>
+      <label>Superseded</label>
+      <description>Replaced by new item</description>
+    </entry>
+    <entry>
+      <code>tentative</code>
+      <label>Tentative</label>
+      <description>Provisional changes likely before resource becomes final or
+        complete
+      </description>
+    </entry>
+    <entry>
+      <code>valid</code>
+      <label>Valid</label>
+      <description>Acceptable under specific conditions</description>
+    </entry>
+    <entry>
+      <code>accepted</code>
+      <label>Accepted</label>
+      <description>Agreed to by sponsor</description>
+    </entry>
+    <entry>
+      <code>notAccepted</code>
+      <label>Not Accepted</label>
+      <description>Rejected by sponsor</description>
+    </entry>
+    <entry>
+      <code>withdrawn</code>
+      <label>Withdrawn</label>
+      <description>Withdrawn</description>
+    </entry>
+    <entry>
+      <code>proposed</code>
+      <label>Proposed</label>
+      <description>Suggested that development needs to be undertaken
+      </description>
+    </entry>
+    <entry>
+      <code>deprecated</code>
+      <label>Deprecated</label>
+      <description>Resource superseded and will become obsolete, use only for
+        historical purposes
+      </description>
+    </entry>
+    <entry hideInEditMode="true">
+      <code>notobsolete</code>
+      <label>Not obsolete</label>
+      <description></description>
+    </entry>
+  </codelist>
+  <codelist name="mco:MD_RestrictionCode">
+    <entry>
+      <code>copyright</code>
+      <label>copyright</label>
+      <description>Exclusief recht voor publicatie, productie,
+        of verkoop van rechten op een literair,
+        theater, muzikaal of artistiek werk, of op
+        het gebruik van een commerci&#233;le druk of
+        label, toegekend bij wet voor een
+        specifieke periode of tijd aan een auteur,
+        componist, artiest of distributeur.
+      </description>
+    </entry>
+    <entry>
+      <code>patent</code>
+      <label>patent</label>
+      <description>Overheid heeft een exclusief recht
+        toegekend om een uitvinding te maken,
+        verkopen, gebruiken of in licentie uit te
+        geven.
+      </description>
+    </entry>
+    <entry>
+      <code>patentPending</code>
+      <label>patent in
+        wording
+      </label>
+      <description>Geproduceerde of verkochte informatie
+        wachtend op een patent.
+      </description>
+    </entry>
+    <entry>
+      <code>trademark</code>
+      <label>merknaam</label>
+      <description>Een naam, symbool of ander object om
+        een product te identificeren, wat officieel
+        geregistreerd is en gebruik wettelijk
+        voorbehouden is aan de eigenaar of
+        fabrikant.
+      </description>
+    </entry>
+    <entry>
+      <code>license</code>
+      <label>licentie</label>
+      <description>Formele toestemming of iets te doen.</description>
+    </entry>
+    <entry>
+      <code>intellectualPropertyRights</code>
+      <label>intellectueel
+        eigendom
+      </label>
+      <description>Recht op een financieel voordeel van en
+        controle hebben op de distributie een niet
+        tastbaar eigendom wat het resultaat is
+        van creativiteit.
+      </description>
+    </entry>
+    <entry>
+      <code>restricted</code>
+      <label>niet
+        toegankelijk
+      </label>
+      <description>Verbod op distributie en gebruik.</description>
+    </entry>
+    <entry>
+      <code>otherRestrictions</code>
+      <label>anders</label>
+      <description>Restrictie niet opgenomen in lijst.</description>
+    </entry>
+    <entry>
+      <code>unrestricted</code>
+      <label>Unrestricted</label>
+      <description>No constraints exist</description>
+    </entry>
+    <entry>
+      <code>licenceUnrestricted</code>
+      <label>Licence Unrestricted</label>
+      <description>formal permission not required to use the resource
+      </description>
+    </entry>
+    <entry>
+      <code>licenceEndUser</code>
+      <label>Licence End User</label>
+      <description>Formal permission required for a person or an entity to use
+        the resource and that may differ from the person that orders or
+        purchases it
+      </description>
+    </entry>
+    <entry>
+      <code>licenceDistributor</code>
+      <label>Licence Distributor</label>
+      <description>Formal permission required for a person or an entity to
+        commercialize or distribute the resource
+      </description>
+    </entry>
+    <entry>
+      <code>private</code>
+      <label>Private</label>
+      <description>Protects rights of individual or organisations from
+        observation, intrusion, or attention of others
+      </description>
+    </entry>
+    <entry>
+      <code>statutory</code>
+      <label>Statutory</label>
+      <description>Prescribed by law</description>
+    </entry>
+    <entry>
+      <code>confidential</code>
+      <label>Confidential</label>
+      <description>Not available to the public. NOTE: Contains information that
+        could be prejudicial to a commercial, industrial, or national interest
+      </description>
+    </entry>
+    <entry>
+      <code>SBU</code>
+      <label>Sensitive But Unclassified</label>
+      <description>Although unclassified, requires strict controls over its
+        distribution
+      </description>
+    </entry>
+    <entry>
+      <code>in-confidence</code>
+      <label>In-Confidence</label>
+      <description>With trust</description>
+    </entry>
+  </codelist>
+
+  <codelist name="mcc:MD_ScopeCode">
+    <entry>
+      <code>attribute</code>
+      <label>attribute</label>
+      <description>information applies to the attribute class</description>
+    </entry>
+    <entry>
+      <code>attributeType</code>
+      <label>attributeType</label>
+      <description>information applies to the characteristic of a feature</description>
+    </entry>
+    <entry>
+      <code>collectionHardware</code>
+      <label>collectionHardware</label>
+      <description>information applies to the collection hardware class</description>
+    </entry>
+    <entry>
+      <code>collectionSession</code>
+      <label>collectionSession</label>
+      <description>information applies to the collection session</description>
+    </entry>
+    <entry>
+      <code>dataset</code>
+      <label>dataset</label>
+      <description>Informatie heeft betrekking op de
+        dataset.
+      </description>
+    </entry>
+    <entry>
+      <code>series</code>
+      <label>series</label>
+      <description>Informatie heeft betrekking op de serie.</description>
+    </entry>
+    <entry>
+      <code>nonGeographicDataset</code>
+      <label>nonGeographicDataset</label>
+      <description>information applies to non-geographic data</description>
+    </entry>
+    <entry>
+      <code>dimensionGroup</code>
+      <label>dimensionGroup</label>
+      <description>information applies to a dimension group</description>
+    </entry>
+    <entry>
+      <code>feature</code>
+      <label>feature</label>
+      <description>information applies to a feature</description>
+    </entry>
+    <entry>
+      <code>featureType</code>
+      <label>featureType</label>
+      <description>information applies to a feature type</description>
+    </entry>
+    <entry>
+      <code>propertyType</code>
+      <label>propertyType</label>
+      <description>information applies to a property type</description>
+    </entry>
+    <entry>
+      <code>fieldSession</code>
+      <label>fieldSession</label>
+      <description>information applies to a field session</description>
+    </entry>
+    <entry>
+      <code>software</code>
+      <label>software</label>
+      <description>information applies to a computer program or routine</description>
+    </entry>
+    <entry>
+      <code>service</code>
+      <label>service</label>
+      <description>information applies to a capability which a service provider entity makes
+        available to a service user entity through a set of interfaces that define a behaviour,
+        such as a use case
+      </description>
+    </entry>
+    <entry>
+      <code>model</code>
+      <label>model</label>
+      <description>information applies to a copy or imitation of an existing or hypothetical
+        object
+      </description>
+    </entry>
+    <entry>
+      <code>tile</code>
+      <label>tile</label>
+      <description>information applies to a tile, a spatial subset of geographic
+        data
+      </description>
+    </entry>
+    <entry>
+      <code>metadata</code>
+      <label>Metadata</label>
+      <description>Information applies to metadata</description>
+    </entry>
+    <entry>
+      <code>initiative</code>
+      <label>Initiative</label>
+      <description>Information applies to an initiative</description>
+    </entry>
+    <entry>
+      <code>sample</code>
+      <label>Sample</label>
+      <description>Information applies to a sample</description>
+    </entry>
+    <entry>
+      <code>document</code>
+      <label>Document</label>
+      <description>Information applies to a document</description>
+    </entry>
+    <entry>
+      <code>repository</code>
+      <label>Repository</label>
+      <description>Information applies to a repository</description>
+    </entry>
+    <entry>
+      <code>aggregate</code>
+      <label>Aggregate</label>
+      <description>Information applies to an aggregate resource</description>
+    </entry>
+    <entry>
+      <code>product</code>
+      <label>Product</label>
+      <description>Metadata describing an ISO 19131 data product specification
+      </description>
+    </entry>
+    <entry>
+      <code>collection</code>
+      <label>Collection</label>
+      <description>Information applies to an unstructured set</description>
+    </entry>
+    <entry>
+      <code>coverage</code>
+      <label>Coverage</label>
+      <description>Information applies to a coverage</description>
+    </entry>
+    <entry>
+      <code>application</code>
+      <label>Application</label>
+      <description>Information resource hosted on a specific set of hardware and
+        accessible over a network
+      </description>
+    </entry>
+
+    <entry hideInEditMode="true">
+      <code>map</code>
+      <label>Map</label>
+      <description></description>
+    </entry>
+    <entry hideInEditMode="true">
+      <code>map-static</code>
+      <label>Static map</label>
+      <description></description>
+    </entry>
+    <entry hideInEditMode="true">
+      <code>map-interactive</code>
+      <label>Interactive map</label>
+      <description></description>
+    </entry>
+  </codelist>
+  <codelist name="mcc:MD_SpatialRepresentationTypeCode">
+    <entry>
+      <code>vector</code>
+      <label>vector</label>
+      <description>Vector data wordt gebruikt om
+        geografische data te representeren.
+      </description>
+    </entry>
+    <entry>
+      <code>grid</code>
+      <label>grid</label>
+      <description>Grid data wordt gebruikt om geografische
+        data te representeren.
+      </description>
+    </entry>
+    <entry>
+      <code>textTable</code>
+      <label>tekstTabel</label>
+      <description>Tekstuele of tabel data wordt gebruikt
+        om geografische data te representeren.
+      </description>
+    </entry>
+    <entry>
+      <code>tin</code>
+      <label>tin</label>
+      <description>Triangulated irregular network.</description>
+    </entry>
+    <entry>
+      <code>stereoModel</code>
+      <label>stereoModel</label>
+      <description>3D overzicht wordt gevormd door
+        intersectie van twee kernstralen van twee
+        overlappende beelden.
+      </description>
+    </entry>
+    <entry>
+      <code>video</code>
+      <label>video</label>
+      <description>Sc&#232;ne uit een video opname.</description>
+    </entry>
+  </codelist>
+  <codelist name="mri:MD_TopicCategoryCode" alias="topicCategory">
+    <entry>
+      <code>farming</code>
+      <label>landbouw en veeteelt</label>
+      <description>Houden van dieren en/of verbouwen van
+        planten. Vb: landbouw, irrigatie, ziekten die
+        gewassen aantasten.
+      </description>
+    </entry>
+    <entry>
+      <code>biota</code>
+      <label>biota</label>
+      <description>Flora en fauna in natuurlijke omgeving.
+        Vb: habitats, ecologie.
+      </description>
+    </entry>
+    <entry>
+      <code>boundaries</code>
+      <label>grenzen</label>
+      <description>Wettelijke gebiedsbeschrijvingen.
+        Vb: politieke en administratieve grenzen.
+      </description>
+    </entry>
+    <entry>
+      <code>climatologyMeteorologyAtmosphere</code>
+      <label>klimatologie,
+        meteorologie
+        atmosfeer
+      </label>
+      <description>Processen en fenomenen in de
+        atmosfeer.
+        Vb: wolkbedekking, weer, klimaat
+        verandering.
+      </description>
+    </entry>
+    <entry>
+      <code>economy</code>
+      <label>economie</label>
+      <description>Economische activiteiten, condities en
+        werkgelegenheid.
+        Vb: Werkgelegenheid, industrie,
+        toerisme, olie- en gasvelden, bosbouw,
+        visserij.
+      </description>
+    </entry>
+    <entry>
+      <code>elevation</code>
+      <label>hoogte</label>
+      <description>Hoogte boven of onder zeeniveau.
+        Vb: hoogtekaart, DEM, hellingen.
+      </description>
+    </entry>
+    <entry>
+      <code>environment</code>
+      <label>natuur en
+        milieu
+      </label>
+      <description>Natuurlijke bronnen, bescherming en beheer.
+        Vb: milieuverontreiniging, landschap,
+        natuurlijke reserves, vuilopslag.
+      </description>
+    </entry>
+    <entry>
+      <code>geoscientificInformation</code>
+      <label>Geo wetenschappelijke data</label>
+      <description>Data die behoort tot een
+        aardwetenschap. Vb: geologie, mineralen, structuur van
+        de aarde, zwaartekrachtskaart,
+        grondstoffen, erosie.
+      </description>
+    </entry>
+    <entry>
+      <code>health</code>
+      <label>gezondheid</label>
+      <description>Gezondheid(szorg), menselijke ecologie
+        en veiligheid.
+        Vb: ziekten, hygi&#233;ne, gezondheidszorg.
+      </description>
+    </entry>
+    <entry>
+      <code>imageryBaseMapsEarthCover</code>
+      <label>referentie
+        materiaal
+        aardbedekking
+      </label>
+      <description>Basiskaarten.
+        Vb: landbedekking, topografische
+        kaarten, foto's, ongeclassificeerde
+        kaarten.
+      </description>
+    </entry>
+    <entry>
+      <code>intelligenceMilitary</code>
+      <label>militair</label>
+      <description>Militaire basissen, structuren en
+        activiteiten.
+        Vb: barakken, oefenterreinen, militaire
+        transporten.
+      </description>
+    </entry>
+    <entry>
+      <code>inlandWaters</code>
+      <label>binnenwater</label>
+      <description>Binnenwater, drainagesystemen en hun
+        karakteristieken.
+        Vb: Rivieren en gletsjers, dijken,
+        stromen, waterzuiveringsinstallaties,
+        overloopgebieden.
+      </description>
+    </entry>
+    <entry>
+      <code>location</code>
+      <label>locatie</label>
+      <description>Positionele informatie en services.
+        Vb: adressen, geodetisch netwerk,
+        postcode gebieden, plaatsnamen,
+        controlepunten.
+      </description>
+    </entry>
+    <entry>
+      <code>oceans</code>
+      <label>oceanen</label>
+      <description>Gebieden met zoutwaterlichamen (niet
+        binnenlands). Vb: Getijden, tsunami's, kustinformatie,
+        riffen.
+      </description>
+    </entry>
+    <entry>
+      <code>planningCadastre</code>
+      <label>planning
+        kadaster
+      </label>
+      <description>Informatie die gebruikt wordt voor
+        nodige planmatige activiteiten.
+        Vb: Landgebruik, kadastrale informatie.
+      </description>
+    </entry>
+    <entry>
+      <code>society</code>
+      <label>maatschappij</label>
+      <description>Kenmerken van maatschappij en
+        culturen.
+        Vb: antropologie, archeologie,
+        criminaliteit, gewoonten, nederzettingen,
+        onderwijs.
+      </description>
+    </entry>
+    <entry>
+      <code>structure</code>
+      <label>(civiele)
+        structuren
+      </label>
+      <description>Civiele werken (door mensen gemaakte
+        structuren).
+        Gebouwen, musea, kerken, winkels,
+        torens.
+      </description>
+    </entry>
+    <entry>
+      <code>transportation</code>
+      <label>transport</label>
+      <description>Middelen voor vervoer van goederen
+        en/of personen.
+        Vb: Wegen, Vliegvelden, tunnels,
+        spoorwegen.
+      </description>
+    </entry>
+    <entry>
+      <code>utilitiesCommunication</code>
+      <label>nutsbedrijven
+        communicatie
+      </label>
+      <description>Energie, waterleidingen en riolering en
+        communicatie infrastructuren en
+        services.
+        Vb: elektriciteit- en gasdistributie,
+        waterzuivering en verstrekking,
+        telecommunicatie, radio.
+      </description>
+    </entry>
+    <entry>
+      <code>extraTerrestrial</code>
+      <label>Extra Terrestrial</label>
+      <description>Region more than 100 km above the surface of the Earth
+      </description>
+    </entry>
+    <entry>
+      <code>disaster</code>
+      <label>Disaster</label>
+      <description>Information related to disasters EXAMPLES: Site of the
+        disaster, evacuation zone, disaster-prevention facility, disaster relief
+        activities
+      </description>
+    </entry>
+  </codelist>
+  <codelist name="msr:MD_TopologyLevelCode">
+    <entry>
+      <code>geometryOnly</code>
+      <label>Alleen geometrie</label>
+      <description>geometry objects without any additional structure which describes
+        topology
+      </description>
+    </entry>
+    <entry>
+      <code>topology1D</code>
+      <label>1D topologie</label>
+      <description>1-dimensional topological complex -- commonly called chain-node
+        topology
+      </description>
+    </entry>
+    <entry>
+      <code>planarGraph</code>
+      <label>Planar Graph</label>
+      <description>1-dimensional topological complex that is planar. (A planar graph is a graph
+        that can be drawn in a plane in such a way that no two edges intersect except at a
+        vertex.)
+      </description>
+    </entry>
+    <entry>
+      <code>fullPlanarGraph</code>
+      <label>Full Planar Graph</label>
+      <description>2-dimensional topological complex that is planar. (A 2-dimensional topological
+        complex is commonly called full topology in a cartographic 2D
+        environment.)
+      </description>
+    </entry>
+    <entry>
+      <code>surfaceGraph</code>
+      <label>Surface Graph</label>
+      <description>1-dimensional topological complex that is isomorphic to a subset of a surface.
+        (A geometric complex is isomorphic to a topological complex if their elements are in a
+        one-to-one, dimensional-and boundry-preserving correspondence to one
+        another.)
+      </description>
+    </entry>
+    <entry>
+      <code>fullSurfaceGraph</code>
+      <label>Full Surface Graph</label>
+      <description>2-dimensional topological complex that is isomorphic to a subset of a
+        surface
+      </description>
+    </entry>
+    <entry>
+      <code>topology3D</code>
+      <label>3D Topologie</label>
+      <description>3-dimensional topological complex. (A topological complex is a collection of
+        topological primitives that are closed under the boundary operations.)
+      </description>
+    </entry>
+    <entry>
+      <code>fullTopology3D</code>
+      <label>Full 3D Topologie</label>
+      <description>complete coverage of a 3D Euclidean coordinate space</description>
+    </entry>
+    <entry>
+      <code>abstract</code>
+      <label>abstract</label>
+      <description>topological complex without any specified geometric realisation</description>
+    </entry>
+  </codelist>
+  <codelist name="mrc:MI_BandDefinition">
+    <entry>
+      <code>3db</code>
+      <label>3db</label>
+      <description>TBD</description>
+    </entry>
+    <entry>
+      <code>halfMaximum</code>
+      <label>Half Maximum</label>
+      <description>Description: width of a distribution equal to the distance
+        between the outer two points on the distribution having power level half
+        of that at the peak
+      </description>
+    </entry>
+    <entry>
+      <code>fiftyPercent</code>
+      <label>Fifty Percent</label>
+      <description>Description: wavelength difference between the upper and
+        lower bounds at the 50% (-3db) points of the sensor spectral response
+      </description>
+    </entry>
+    <entry>
+      <code>oneOverE</code>
+      <label>One Over E</label>
+      <description>TBD</description>
+    </entry>
+    <entry>
+      <code>equivalentWidth</code>
+      <label>Equivalent Width</label>
+      <description>TBD</description>
+    </entry>
+  </codelist>
+  <codelist name="mac:MI_ContextCode">
+    <entry>
+      <code>acquisition</code>
+      <label>Acquisition</label>
+      <description>Event related to a specific collection</description>
+    </entry>
+    <entry>
+      <code>pass</code>
+      <label>Pass</label>
+      <description>Event related to general collection</description>
+    </entry>
+    <entry>
+      <code>wayPoint</code>
+      <label>Way Point</label>
+      <description>Event related to general collection</description>
+    </entry>
+  </codelist>
+  <codelist name="mac:MI_GeometryTypeCode">
+    <entry>
+      <code>areal</code>
+      <label>Areal</label>
+      <description>Collection of a geographic area defined by a polygon
+        (coverage)
+      </description>
+    </entry>
+    <entry>
+      <code>strip</code>
+      <label>Strip</label>
+      <description>Series of linear collections grouped by way points
+      </description>
+    </entry>
+    <entry>
+      <code>linear</code>
+      <label>Linear</label>
+      <description></description>
+    </entry>
+    <entry>
+      <code>point</code>
+      <label>Point</label>
+      <description></description>
+    </entry>
+  </codelist>
+  <codelist name="mac:MI_ObjectiveTypeCode">
+    <entry>
+      <code>instantaneousCollection</code>
+      <label>Instantaneous Collection</label>
+      <description>Single instance of collection</description>
+    </entry>
+    <entry>
+      <code>persistentView</code>
+      <label>Persistent View</label>
+      <description>Multiple instances of collection</description>
+    </entry>
+    <entry>
+      <code>survey</code>
+      <label>Survey</label>
+      <description>Comparative collection</description>
+    </entry>
+  </codelist>
+  <codelist name="mac:MI_OperationTypeCode">
+    <entry>
+      <code>real</code>
+      <label>Real</label>
+      <description></description>
+    </entry>
+    <entry>
+      <code>simulated</code>
+      <label>Simulated</label>
+      <description></description>
+    </entry>
+    <entry>
+      <code>synthetic</code>
+      <label>Synthetic</label>
+      <description></description>
+    </entry>
+  </codelist>
+  <codelist name="mrc:MI_PolarisationOrientationCode">
+    <entry>
+      <code>horizontal</code>
+      <label>Horizontal</label>
+      <description></description>
+    </entry>
+    <entry>
+      <code>vertical</code>
+      <label>Vertical</label>
+      <description></description>
+    </entry>
+    <entry>
+      <code>leftCircular</code>
+      <label>Left Circular</label>
+      <description></description>
+    </entry>
+    <entry>
+      <code>rightCircular</code>
+      <label>Right Circular</label>
+      <description></description>
+    </entry>
+    <entry>
+      <code>theta</code>
+      <label>Theta</label>
+      <description></description>
+    </entry>
+    <entry>
+      <code>phi</code>
+      <label>Phi</label>
+      <description></description>
+    </entry>
+  </codelist>
+  <codelist name="mac:MI_PriorityCode">
+    <entry>
+      <code>critical</code>
+      <label>Critical</label>
+      <description>Decisive importance</description>
+    </entry>
+    <entry>
+      <code>highImportance</code>
+      <label>High Importance</label>
+      <description>Requires resources to be made available</description>
+    </entry>
+    <entry>
+      <code>mediumImportance</code>
+      <label>Medium Importance</label>
+      <description>Normal operation priority</description>
+    </entry>
+    <entry>
+      <code>lowImportance</code>
+      <label>Low Importance</label>
+      <description>To be completed when resources are available</description>
+    </entry>
+    <entry>
+      <code>theta</code>
+      <label>theta</label>
+      <description></description>
+    </entry>
+    <entry>
+      <code>phi</code>
+      <label>phi</label>
+      <description></description>
+    </entry>
+  </codelist>
+  <codelist name="mac:MI_SequenceCode">
+    <entry>
+      <code>start</code>
+      <label>Start</label>
+      <description>Beginning of a collection</description>
+    </entry>
+    <entry>
+      <code>end</code>
+      <label>End</label>
+      <description>End of a collection</description>
+    </entry>
+    <entry>
+      <code>instantaneous</code>
+      <label>Instantaneous</label>
+      <description>Collection without a significant duration</description>
+    </entry>
+  </codelist>
+  <codelist name="mrc:MI_TransferFunctionTypeCode">
+    <entry>
+      <code>linear</code>
+      <label>Linear</label>
+      <description></description>
+    </entry>
+    <entry>
+      <code>logarithmic</code>
+      <label>Logarithmic</label>
+      <description></description>
+    </entry>
+    <entry>
+      <code>exponential</code>
+      <label>Exponential</label>
+      <description></description>
+    </entry>
+  </codelist>
+  <codelist name="mac:MI_TriggerCode">
+    <entry>
+      <code>automatic</code>
+      <label>Automatic</label>
+      <description>Event due to external stimuli</description>
+    </entry>
+    <entry>
+      <code>manual</code>
+      <label>Manual</label>
+      <description>Event manually instigated</description>
+    </entry>
+    <entry>
+      <code>preProgrammed</code>
+      <label>PreProgrammed</label>
+      <description>Event instigated by planned stimuli</description>
+    </entry>
+  </codelist>
+  <codelist name="reg:RE_AmendmentType">
+    <entry>
+      <code>supersession</code>
+      <label>Supersession</label>
+      <description></description>
+    </entry>
+    <entry>
+      <code>retirement</code>
+      <label>Retirement</label>
+      <description></description>
+    </entry>
+  </codelist>
+  <codelist name="reg:RE_DecisionStatus">
+    <entry>
+      <code>pending</code>
+      <label>Pending</label>
+      <description></description>
+    </entry>
+    <entry>
+      <code>tentative</code>
+      <label>Tentative</label>
+      <description></description>
+    </entry>
+    <entry>
+      <code>final</code>
+      <label>Final</label>
+      <description></description>
+    </entry>
+  </codelist>
+  <codelist name="reg:RE_Disposition">
+    <entry>
+      <code>withdrawn</code>
+      <label>Withdrawn</label>
+      <description></description>
+    </entry>
+    <entry>
+      <code>accepted</code>
+      <label>Accepted</label>
+      <description></description>
+    </entry>
+    <entry>
+      <code>notAccepted</code>
+      <label>Not Accepted</label>
+      <description></description>
+    </entry>
+  </codelist>
+  <codelist name="reg:RE_ItemStatus">
+    <entry>
+      <code>notValid</code>
+      <label>Not Valid</label>
+      <description></description>
+    </entry>
+    <entry>
+      <code>valid</code>
+      <label>Valid</label>
+      <description></description>
+    </entry>
+    <entry>
+      <code>superseded</code>
+      <label>Superseded</label>
+      <description></description>
+    </entry>
+    <entry>
+      <code>retired</code>
+      <label>Retired</label>
+      <description></description>
+    </entry>
+  </codelist>
+  <codelist name="srv:SV_ParameterDirection">
+    <entry>
+      <code>in</code>
+      <label>Input</label>
+      <description>The parameter is an input parameter to the service instance
+      </description>
+    </entry>
+    <entry>
+      <code>out</code>
+      <label>Output</label>
+      <description>The parameter is an output parameter to the service
+        instance
+      </description>
+    </entry>
+    <entry>
+      <code>in/out</code>
+      <label>Input/output</label>
+      <description>The parameter is both an input and output parameter to the
+        service instance
+      </description>
+    </entry>
+  </codelist>
+  <codelist name="mrs:MD_ReferenceSystemTypeCode">
+    <entry>
+      <code>compoundEngineeringParametric</code>
+      <label>Compound Engineering Parametric</label>
+      <description>Compound spatio-parametric coordinate reference system
+        containing an engineering coordinate reference system and a parametric
+        reference system EXAMPLE: [local] x, y, pressure
+      </description>
+    </entry>
+    <entry>
+      <code>compoundEngineeringParametricTemporal</code>
+      <label>Compound Engineering Parametric Temporal</label>
+      <description>Compound spatio-parametric-temporal coordinate reference
+        system containing an engineering, a parametric, and a temporal
+        coordinate reference system EXAMPLE: [local] x, y, pressure, time
+      </description>
+    </entry>
+    <entry>
+      <code>compoundEngineeringTemporal</code>
+      <label>Compound Engineering Temporal</label>
+      <description>Compound spatio-temporal coordinate reference system
+        containing an engineering and a temporal coordinate reference system
+        EXAMPLE: [local] x, y, time
+      </description>
+    </entry>
+    <entry>
+      <code>compoundEngineeringVertical</code>
+      <label>Compound Engineering Vertical</label>
+      <description>Compound spatial reference system containing a horizontal
+        engineering coordinate reference system and a vertical coordinate
+        reference system EXAMPLE: [local] x, y, height
+      </description>
+    </entry>
+    <entry>
+      <code>compoundEngineeringVerticalTemporal</code>
+      <label>Compound Engineering Vertical Temporal</label>
+      <description>Compound spatio-temporal coordinate reference system
+        containing an engineering, a vertical, and a temporal coordinate
+        reference system EXAMPLE: [local] x, y, height, time
+      </description>
+    </entry>
+    <entry>
+      <code>compoundGeographic2DParametric</code>
+      <label>Compound Geographic 2D Parametric</label>
+      <description>Compound spatio-parametric coordinate reference system
+        containing a 2 dimensional geographic horizontal coordinate reference
+        system and a parametric reference system EXAMPLE: latitude, longitude,
+        pressure
+      </description>
+    </entry>
+    <entry>
+      <code>compoundGeographic2DParametricTemporal</code>
+      <label>Compound Geographic 2D Parametric Temporal</label>
+      <description>Compound spatio-parametric-temporal coordinate reference
+        system containing a 2 dimensional geographic horizontal, a parametric
+        and a temporal coordinate reference system EXAMPLE: latitude, longitude,
+        pressure, time
+      </description>
+    </entry>
+    <entry>
+      <code>compoundGeographic2DTemporal</code>
+      <label>Compound Geographic 2D Temporal</label>
+      <description>Compound spatio-temporal coordinate reference system
+        containing a 2 dimensional geographic horizontal coordinate reference
+        system and a temporal reference system EXAMPLE: latitude, longitude,
+        time
+      </description>
+    </entry>
+    <entry>
+      <code>compoundGeographic2DVertical</code>
+      <label>Compound Geographic 2D Vertical</label>
+      <description>Compound coordinate reference system in which one constituent
+        coordinate reference system is a horizontal geodetic coordinate
+        reference system and one is a vertical coordinate reference system
+        EXAMPLE: latitude, longitude, [gravity-related] height or depth
+      </description>
+    </entry>
+    <entry>
+      <code>compoundGeographic2DVerticalTemporal</code>
+      <label>Compound Geographic 2D Vertical Temporal</label>
+      <description>Compound spatio-temporal coordinate reference system
+        containing a 2 dimensional geographic horizontal, a vertical, and a
+        temporal coordinate reference system EXAMPLE: latitude, longitude,
+        height, time
+      </description>
+    </entry>
+    <entry>
+      <code>compoundGeographic3DTemporal</code>
+      <label>Compound Geographic 3D Temporal</label>
+      <description>Compound spatio-temporal coordinate reference system
+        containing a 3 dimensional geographic and a temporal coordinate
+        reference system EXAMPLE latitude, longitude, ellipsoidal height, time
+      </description>
+    </entry>
+    <entry>
+      <code>compoundProjected2DParametric</code>
+      <label>Compound Projected 2D Parametric</label>
+      <description>Compound spatio-parametric coordinate reference system
+        containing a projected horizontal coordinate reference system and a
+        parametric reference system EXAMPLE: easting, northing, density
+      </description>
+    </entry>
+    <entry>
+      <code>compoundProjected2DParametricTemporal</code>
+      <label>Compound Projected 2D Parametric Temporal</label>
+      <description>Compound spatio-parametric-temporal coordinate reference
+        system containing a projected horizontal, a parametric, and a temporal
+        coordinate reference system EXAMPLE: easting, northing, density, time
+      </description>
+    </entry>
+    <entry>
+      <code>compoundProjectedTemporal</code>
+      <label>Compound Projected Temporal</label>
+      <description>Compound spatio-temporal coordinate reference system
+        containing a projected horizontal and a temporal coordinate reference
+        system EXAMPLE: easting, northing, time
+      </description>
+    </entry>
+    <entry>
+      <code>compoundProjectedVertical</code>
+      <label>Compound Projected Vertical</label>
+      <description>Compound spatial reference system containing a horizontal
+        projected coordinate reference system and a vertical coordinate
+        reference system EXAMPLE easting, northing, [gravity-related] height or
+        depth
+      </description>
+    </entry>
+    <entry>
+      <code>compoundProjectedVerticalTemporal</code>
+      <label>Compound Projected Vertical Temporal</label>
+      <description>Compound spatio-temporal coordinate reference system
+        containing a projected horizontal, a vertical, and a temporal coordinate
+        reference system EXAMPLE: easting, northing, height, time
+      </description>
+    </entry>
+    <entry>
+      <code>engineering</code>
+      <label>Engineering</label>
+      <description>Coordinate reference system based on an engineering datum
+        (datum describing the relationship of a coordinate system to a local
+        reference) EXAMPLE: [local] x,y
+      </description>
+    </entry>
+    <entry>
+      <code>engineeringDesign</code>
+      <label>Engineering Design</label>
+      <description>Engineering coordinate reference system in which the base
+        representation of a moving object is specified EXAMPLE: [local] x,y
+      </description>
+    </entry>
+    <entry>
+      <code>engineeringImage</code>
+      <label>Engineering Image</label>
+      <description>Coordinate reference system based on an image datum
+        (engineering datum which defines the relationship of a coordinate system
+        to an image) EXAMPLE: row, column
+      </description>
+    </entry>
+    <entry>
+      <code>geodeticGeocentric</code>
+      <label>Geodetic Geocentric</label>
+      <description>Geodetic CRS having a Cartesian 3D coordinate system EXAMPLE:
+        [geocentric] X,Y,Z
+      </description>
+    </entry>
+    <entry>
+      <code>geodeticGeographic2D</code>
+      <label>Geodetic Geographic 2D</label>
+      <description>Geodetic CRS having an ellipsoidal 2D coordinate system
+        EXAMPLE: latitude, longitude
+      </description>
+    </entry>
+    <entry>
+      <code>geodeticGeographic3D</code>
+      <label>Geodetic Geographic 3D</label>
+      <description>Geodetic CRS having an ellipsoidal 3D coordinate system
+        EXAMPLE: latitude, longitude, ellipsoidal height
+      </description>
+    </entry>
+    <entry>
+      <code>geographicIdentifier</code>
+      <label>Geographic Identifier</label>
+      <description>Spatial reference in the form of a label or code that
+        identifies a location EXAMPLE: post code
+      </description>
+    </entry>
+    <entry>
+      <code>linear</code>
+      <label>Linear</label>
+      <description>Reference system that identifies a location by reference to a
+        segment of a linear geographic feature and distance along that segment
+        from a given point EXAMPLE: x km along road
+      </description>
+    </entry>
+    <entry>
+      <code>parametric</code>
+      <label>Parametric</label>
+      <description>Coordinate reference system based on a parametric datum
+        (datum describing the relationship of a parametric coordinate system to
+        an object) EXAMPLE: pressure
+      </description>
+    </entry>
+    <entry>
+      <code>projected</code>
+      <label>Projected</label>
+      <description>Coordinate reference system derived from a two-dimensional
+        geodetic coordinate reference system by applying a map projection
+        EXAMPLE: easting, northing
+      </description>
+    </entry>
+    <entry>
+      <code>temporal</code>
+      <label>Temporal</label>
+      <description>Reference system against which time is measured EXAMPLE:
+        time
+      </description>
+    </entry>
+    <entry>
+      <code>vertical</code>
+      <label>Vertical</label>
+      <description>One-dimensional coordinate reference system based on a
+        vertical datum (datum describing the relation of gravity-related heights
+        or depths to the Earth) EXAMPLE: [gravity-related] height or depth
+      </description>
+    </entry>
+  </codelist>
+  <codelist name="msr:MD_CellGeometryCode">
+    <entry>
+      <code>point</code>
+      <label>point</label>
+      <description>each cell represents a point</description>
+    </entry>
+    <!-- - - - - - - - - - - - - - - - - - - - - - - - - -->
+    <entry>
+      <code>area</code>
+      <label>area</label>
+      <description>each cell represents an area</description>
+    </entry>
+    <entry>
+      <code>voxel</code>
+      <label>Voxel</label>
+      <description>Each cell represents a volumetric measurement on a regular
+        grid in three dimensional space
+      </description>
+    </entry>
+    <entry>
+      <code>stratum</code>
+      <label>Stratum</label>
+      <description>Height range for a single point vertical profile
+      </description>
+    </entry>
+  </codelist>
+  <codelist name="mrd:MD_MediumNameCode">
+    <entry>
+      <code>cdRom</code>
+      <label>cdRom</label>
+      <description>read-only optical disk</description>
+    </entry>
+    <entry>
+      <code>dvd</code>
+      <label>dvd</label>
+      <description>digital versatile disk</description>
+    </entry>
+    <entry>
+      <code>dvdRom</code>
+      <label>dvdRom</label>
+      <description>digital versatile disk, read only</description>
+    </entry>
+    <entry>
+      <code>3halfInchFloppy</code>
+      <label>3halfInchFloppy</label>
+      <description>3,5 inch magnetic disk</description>
+    </entry>
+    <entry>
+      <code>5quarterInchFloppy</code>
+      <label>5quarterInchFloppy</label>
+      <description>5,25 inch magnetic disk</description>
+    </entry>
+    <entry>
+      <code>7trackTape</code>
+      <label>7trackTape</label>
+      <description>7 track magnetic tape</description>
+    </entry>
+    <entry>
+      <code>9trackType</code>
+      <label>9trackType</label>
+      <description>9 track magnetic tape</description>
+    </entry>
+    <entry>
+      <code>3480Cartridge</code>
+      <label>3480Cartridge</label>
+      <description>3480 cartridge tape drive</description>
+    </entry>
+    <entry>
+      <code>3490Cartridge</code>
+      <label>3490Cartridge</label>
+      <description>3490 cartridge tape drive</description>
+    </entry>
+    <entry>
+      <code>3580Cartridge</code>
+      <label>3580Cartridge</label>
+      <description>3580 cartridge tape drive</description>
+    </entry>
+    <entry>
+      <code>4mmCartridgeTape</code>
+      <label>4mmCartridgeTape</label>
+      <description>4 millimetre magnetic tape</description>
+    </entry>
+    <entry>
+      <code>8mmCartridgeTape</code>
+      <label>8mmCartridgeTape</label>
+      <description>8 millimetre magnetic tape</description>
+    </entry>
+    <entry>
+      <code>1quarterInchCartridgeTape</code>
+      <label>1quarterInchCartridgeTape</label>
+      <description>0,25 inch magnetic tape</description>
+    </entry>
+    <entry>
+      <code>digitalLinearTap</code>
+      <label>digitalLinearTap</label>
+      <description>half inch cartridge streaming tape drive</description>
+    </entry>
+    <entry>
+      <code>onLine</code>
+      <label>onLine</label>
+      <description>direct computer linkage</description>
+    </entry>
+    <entry>
+      <code>satellite</code>
+      <label>satellite</label>
+      <description>linkage through a satellite communication system</description>
+    </entry>
+    <entry>
+      <code>telephoneLink</code>
+      <label>telephoneLink</label>
+      <description>communication through a telephone network</description>
+    </entry>
+    <entry>
+      <code>hardcopy</code>
+      <label>hardcopy</label>
+      <description>pamphlet or leaflet giving descriptive information</description>
+    </entry>
+  </codelist>
+
+  <codelist name="lan:MD_CharacterSetCode">
+    <entry>
+      <code>ucs2</code>
+      <label>ucs2</label>
+      <description>16-bit fixed size Universal Character Set, based on ISO/IEC
+        10646
+      </description>
+    </entry>
+    <entry>
+      <code>ucs4</code>
+      <label>ucs4</label>
+      <description>32-bit fixed size Universal Character Set, based on ISO/IEC
+        10646
+      </description>
+    </entry>
+    <entry>
+      <code>utf7</code>
+      <label>utf7</label>
+      <description>7-bit variable size UCS Transfer Format, based on ISO/IEC 10646</description>
+    </entry>
+    <entry>
+      <code>utf8</code>
+      <label>utf8</label>
+      <description>8-bit variable size UCS Transfer Format, based on ISO/IEC 10646</description>
+    </entry>
+    <entry>
+      <code>utf16</code>
+      <label>utf16</label>
+      <description>16-bit variable size UCS Transfer Format, based on ISO/IEC 10646</description>
+    </entry>
+    <entry>
+      <code>8859part1</code>
+      <label>8859part1</label>
+      <description>ISO/IEC 8859-1, Information technology - 8-bit single byte coded graphic
+        character sets - Part 1 : Latin alphabet No.1
+      </description>
+    </entry>
+    <entry>
+      <code>8859part2</code>
+      <label>8859part2</label>
+      <description>ISO/IEC 8859-2, Information technology - 8-bit single byte coded graphic
+        character sets - Part 2 : Latin alphabet No.2
+      </description>
+    </entry>
+    <entry>
+      <code>8859part3</code>
+      <label>8859part3</label>
+      <description>ISO/IEC 8859-3, Information technology - 8-bit single byte coded graphic
+        character sets - Part 3 : Latin alphabet No.3
+      </description>
+    </entry>
+    <entry>
+      <code>8859part4</code>
+      <label>8859part4</label>
+      <description>ISO/IEC 8859-4, Information technology - 8-bit single byte coded graphic
+        character sets - Part 4 : Latin alphabet No.4
+      </description>
+    </entry>
+    <entry>
+      <code>8859part5</code>
+      <label>8859part5</label>
+      <description>ISO/IEC 8859-5, Information technology - 8-bit single byte coded graphic
+        character sets - Part 5 : Latin/Cyrillic alphabet
+      </description>
+    </entry>
+    <entry>
+      <code>8859part6</code>
+      <label>8859part6</label>
+      <description>ISO/IEC 8859-6, Information technology - 8-bit single byte coded graphic
+        character sets - Part 6 : Latin/Arabic alphabet
+      </description>
+    </entry>
+    <entry>
+      <code>8859part7</code>
+      <label>8859part7</label>
+      <description>ISO/IEC 8859-7, Information technology - 8-bit single byte coded graphic
+        character sets - Part 7 : Latin/Greek alphabet
+      </description>
+    </entry>
+    <entry>
+      <code>8859part8</code>
+      <label>8859part8</label>
+      <description>ISO/IEC 8859-8, Information technology - 8-bit single byte coded graphic
+        character sets - Part 8 : Latin/Hebrew alphabet
+      </description>
+    </entry>
+    <entry>
+      <code>8859part9</code>
+      <label>8859part9</label>
+      <description>ISO/IEC 8859-9, Information technology - 8-bit single byte coded graphic
+        character sets - Part 9 : Latin alphabet No.5
+      </description>
+    </entry>
+    <entry>
+      <code>8859part10</code>
+      <label>8859part10</label>
+      <description>ISO/IEC 8859-10, Information technology - 8-bit single byte coded graphic
+        character sets - Part 10 : Latin alphabet No.6
+      </description>
+    </entry>
+    <entry>
+      <code>8859part11</code>
+      <label>8859part11</label>
+      <description>ISO/IEC 8859-11, Information technology - 8-bit single byte coded graphic
+        character sets - Part 11 : Latin/Thai alphabet
+      </description>
+    </entry>
+    <entry>
+      <code>8859part13</code>
+      <label>8859part13</label>
+      <description>ISO/IEC 8859-13, Information technology - 8-bit single byte coded graphic
+        character sets - Part 13 : Latin alphabet No.7
+      </description>
+    </entry>
+    <entry>
+      <code>8859part14</code>
+      <label>8859part14</label>
+      <description>ISO/IEC 8859-14, Information technology - 8-bit single byte coded graphic
+        character sets - Part 14 : Latin alphabet No.8 (Celtic)
+      </description>
+    </entry>
+    <entry>
+      <code>8859part15</code>
+      <label>8859part15</label>
+      <description>ISO/IEC 8859-15, Information technology - 8-bit single byte coded graphic
+        character sets - Part 15 : Latin alphabet No.9
+      </description>
+    </entry>
+    <entry>
+      <code>8859part16</code>
+      <label>8859part16</label>
+      <description>ISO/IEC 8859-16, Information technology - 8-bit single byte coded graphic
+        character sets - Part 16 : Latin alphabet No.10
+      </description>
+    </entry>
+    <entry>
+      <code>jis</code>
+      <label>jis</label>
+      <description>japanese code set used for electronic transmission</description>
+    </entry>
+    <entry>
+      <code>shiftJIS</code>
+      <label>shiftJIS</label>
+      <description>japanese code set used on MS-DOS machines</description>
+    </entry>
+    <entry>
+      <code>eucJP</code>
+      <label>eucJP</label>
+      <description>japanese code set used on UNIX based machines</description>
+    </entry>
+    <entry>
+      <code>usAscii</code>
+      <label>usAscii</label>
+      <description>United States ASCII code set (ISO 646 US)</description>
+    </entry>
+    <entry>
+      <code>ebcdic</code>
+      <label>ebcdic</label>
+      <description>IBM mainframe code set</description>
+    </entry>
+    <entry>
+      <code>eucKR</code>
+      <label>eucKR</label>
+      <description>Korean code set</description>
+    </entry>
+    <entry>
+      <code>big5</code>
+      <label>big5</label>
+      <description>traditional Chinese code set used in Taiwan, Hong Kong of China and other
+        areas
+      </description>
+    </entry>
+    <entry>
+      <code>GB2312</code>
+      <label>GB2312</label>
+      <description>simplified Chinese code set</description>
+    </entry>
+  </codelist>
+  <codelist name="srv:DCPList">
+    <entry>
+      <code>XML</code>
+      <label>XML</label>
+      <description>DCP is XML</description>
+    </entry>
+    <entry>
+      <code>CORBA</code>
+      <label>CORBA</label>
+      <description>DCP is CORBA</description>
+    </entry>
+    <entry>
+      <code>JAVA</code>
+      <label>JAVA</label>
+      <description>DCP is JAVA</description>
+    </entry>
+    <entry>
+      <code>COM</code>
+      <label>COM</label>
+      <description>DCP is COM</description>
+    </entry>
+    <entry>
+      <code>SQL</code>
+      <description>DCP is SQL</description>
+      <label>SQL</label>
+    </entry>
+    <entry>
+      <code>SOAP</code>
+      <label>SOAP</label>
+      <description>DCP is SOAP</description>
+    </entry>
+    <entry>
+      <code>Z3950</code>
+      <label>Z3950</label>
+      <description>DCP is Z3950</description>
+    </entry>
+    <entry>
+      <code>HTTP</code>
+      <label>HTTP</label>
+      <description>DCP is HTTP</description>
+    </entry>
+    <entry>
+      <code>FTP</code>
+      <label>FTP</label>
+      <description>DCP is FTP</description>
+    </entry>
+    <entry>
+      <code>WebServices</code>
+      <label>WebServices</label>
+      <description>DCP is WebServices</description>
+    </entry>
+  </codelist>
+  <codelist name="srv:SV_CouplingType">
+    <entry>
+      <code>loose</code>
+      <label>loose</label>
+      <description>Een service instance die niet gekoppeld is met een specifieke dataset of dataset
+        serie.
+        Looselycoupled services zouden een associatie kunnen hebben met een datatype door de
+        serviceType definitie. Metadata voor data wordt niet geleverd in de service metadata.
+      </description>
+    </entry>
+    <entry>
+      <code>mixed</code>
+      <label>mixed</label>
+      <description>Een service instance die gekoppeld is met een specifieke dataset of dataset
+        serie. Service metadata dienen zowel de service als geografische dataset te beschrijven
+        (door middel van ISO
+        19115). Daarnaast kan deze service instance ook gebruikt worden met externe data (data die
+        niet wordt beschreven door de operatesOn klasse).
+      </description>
+    </entry>
+    <entry>
+      <code>tight</code>
+      <label>tight</label>
+      <description>Een service instance die gekoppeld is met een specifieke dataset of dataset
+        serie. Service metadata dienen zowel de service als geografische dataset te beschrijven
+        (door middel van ISO
+        19115).
+      </description>
+    </entry>
+  </codelist>
+
+  <codelist name="indeterminatePosition">
+    <entry>
+      <code>after</code>
+      <label>Na</label>
+    </entry>
+    <entry>
+      <code>before</code>
+      <label>Eerder</label>
+    </entry>
+    <entry>
+      <code>now</code>
+      <label>Nu</label>
+    </entry>
+    <entry>
+      <code>unknown</code>
+      <label>Onbekend</label>
+    </entry>
+  </codelist>
+</codelists>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/loc/dut/labels.xml
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/loc/dut/labels.xml
@@ -1,0 +1,5905 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<labels xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xmlns:cat="http://standards.iso.org/iso/19115/-3/cat/1.0"
+        xmlns:cit="http://standards.iso.org/iso/19115/-3/cit/2.0"
+        xmlns:gcx="http://standards.iso.org/iso/19115/-3/gcx/1.0"
+        xmlns:gex="http://standards.iso.org/iso/19115/-3/gex/1.0"
+        xmlns:lan="http://standards.iso.org/iso/19115/-3/lan/1.0"
+        xmlns:srv="http://standards.iso.org/iso/19115/-3/srv/2.0"
+        xmlns:mas="http://standards.iso.org/iso/19115/-3/mas/1.0"
+        xmlns:mcc="http://standards.iso.org/iso/19115/-3/mcc/1.0"
+        xmlns:mco="http://standards.iso.org/iso/19115/-3/mco/1.0"
+        xmlns:mda="http://standards.iso.org/iso/19115/-3/mda/1.0"
+        xmlns:mdb="http://standards.iso.org/iso/19115/-3/mdb/2.0"
+        xmlns:mds="http://standards.iso.org/iso/19115/-3/mds/2.0"
+        xmlns:reg="http://standards.iso.org/iso/19135/-2/reg/1.0"
+        xmlns:mdt="http://standards.iso.org/iso/19115/-3/mdt/2.0"
+        xmlns:mex="http://standards.iso.org/iso/19115/-3/mex/1.0"
+        xmlns:mmi="http://standards.iso.org/iso/19115/-3/mmi/1.0"
+        xmlns:mpc="http://standards.iso.org/iso/19115/-3/mpc/1.0"
+        xmlns:mrc="http://standards.iso.org/iso/19115/-3/mrc/2.0"
+        xmlns:mrd="http://standards.iso.org/iso/19115/-3/mrd/1.0"
+        xmlns:mri="http://standards.iso.org/iso/19115/-3/mri/1.0"
+        xmlns:mrl="http://standards.iso.org/iso/19115/-3/mrl/2.0"
+        xmlns:mrs="http://standards.iso.org/iso/19115/-3/mrs/1.0"
+        xmlns:msr="http://standards.iso.org/iso/19115/-3/msr/2.0"
+        xmlns:mdq="http://standards.iso.org/iso/19157/-2/mdq/1.0"
+        xmlns:mac="http://standards.iso.org/iso/19115/-3/mac/2.0"
+        xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0"
+        xmlns:gml="http://www.opengis.net/gml/3.2"
+        xmlns:xlink="http://www.w3.org/1999/xlink"
+        xsi:noNamespaceSchemaLocation="../../../../../../../schema-labels.xsd">
+  <element name="gco:Distance">
+    <label>Afstand</label>
+    <description>Afstand</description>
+    <condition></condition>
+  </element>
+  <element name="gco:Length">
+    <label>Lengte</label>
+    <description>Lengte</description>
+    <condition></condition>
+  </element>
+  <element name="gco:Angle">
+    <label>Hoek</label>
+    <description>Hoek</description>
+    <condition></condition>
+  </element>
+  <element name="gco:Measure">
+    <label>Measure</label>
+    <description>Measure</description>
+    <condition></condition>
+  </element>
+  <element name="gml:PointType">
+    <label>Point type</label>
+    <description></description>
+    <condition></condition>
+  </element>
+  <element name="gml:pos">
+    <label>Pos</label>
+    <description></description>
+    <condition></condition>
+  </element>
+  <element name="msr:MD_PixelOrientationCode">
+    <label>Pixel orientatie code</label>
+    <description>Point in a pixel corresponding to the Earth location of the
+      pixel
+    </description>
+    <condition></condition>
+  </element>
+  <element name="lan:MD_CharacterSetCode">
+    <label>Karaktersetcode</label>
+    <description>Use IANA Character Set register:
+      http://www.iana.org/assignments/character-sets. These are the official
+      names for character sets that may be used in the Internet and may be
+      referred to in Internet documentation. These names are expressed in
+      ANSI_X3.4-1968 which is commonly called US-ASCII or simply ASCII.
+    </description>
+    <condition></condition>
+  </element>
+  <element name="mdb:acquisitionInformation">
+    <label>Acquisition information</label>
+    <description></description>
+    <condition></condition>
+  </element>
+  <element name="mac:MI_AcquisitionInformation">
+    <label>Acquisition information</label>
+    <description></description>
+    <condition></condition>
+  </element>
+  <element name="mac:instrument">
+    <label>Instrument</label>
+    <description></description>
+    <condition></condition>
+  </element>
+  <element name="mac:operation">
+    <label>Operation</label>
+    <description></description>
+    <condition></condition>
+  </element>
+  <element name="mac:platform">
+    <label>Platform</label>
+    <description></description>
+    <condition></condition>
+  </element>
+  <element name="mac:acquisitionPlan">
+    <label>Acquisition plan</label>
+    <description></description>
+    <condition></condition>
+  </element>
+  <element name="mac:objective">
+    <label>Objective</label>
+    <description></description>
+    <condition></condition>
+  </element>
+  <element name="mac:acquisitionRequirement">
+    <label>Acquisition requirement</label>
+    <description></description>
+    <condition></condition>
+  </element>
+  <element name="mac:environmentalConditions">
+    <label>Environmental conditions</label>
+    <description></description>
+    <condition></condition>
+  </element>
+  <element name="mac:averageAirTemperature">
+    <label>Air temperature average</label>
+    <description>Average air temperature along the flight pass during the photo flight.</description>
+    <condition></condition>
+  </element>
+  <element name="mac:maxRelativeHumidity">
+    <label>Maximum of relative humidity</label>
+    <description>Maximum relative humidity along the flight pass during the photo flight.</description>
+    <condition></condition>
+  </element>
+  <element name="mac:maxAltitude">
+    <label>Maximum altitude</label>
+    <description>Maximum altitude during the photo flight.</description>
+    <condition></condition>
+  </element>
+  <element name="mac:meterologicalConditions">
+    <label>Meterological conditions</label>
+    <description>Meteorological conditions in the photo flight area, in particular clouds, snow and wind.</description>
+    <condition></condition>
+  </element>
+  <element name="mac:MI_Instrument">
+    <label>Instrument</label>
+    <description>Characteristics of the measuring instrument</description>
+    <condition></condition>
+  </element>
+  <element name="mac:MI_Operation">
+    <label>Operation</label>
+    <description>Designations for the operation used to acquire the dataset
+    </description>
+    <condition></condition>
+  </element>
+  <element name="mac:status">
+    <label>Status</label>
+    <description></description>
+    <condition></condition>
+  </element>
+  <element name="mac:childOperation">
+    <label>Child operation</label>
+    <description></description>
+    <condition></condition>
+  </element>
+  <element name="mac:parentOperation">
+    <label>Parent operation</label>
+    <description></description>
+    <condition></condition>
+  </element>
+  <element name="mac:plan">
+    <label>Plan</label>
+    <description></description>
+    <condition></condition>
+  </element>
+  <element name="mac:significantEvent">
+    <label>Significant event</label>
+    <description></description>
+    <condition></condition>
+  </element>
+  <element name="mac:satisfiedRequirement">
+    <label>Satisfied requirement</label>
+    <description></description>
+    <condition></condition>
+  </element>
+  <element name="mac:citation">
+    <label>Citation</label>
+    <description></description>
+    <condition></condition>
+  </element>
+  <element name="mac:identifier">
+    <label>Identifier</label>
+    <description></description>
+    <condition></condition>
+  </element>
+  <element name="mac:type">
+    <label>Type</label>
+    <description></description>
+    <condition></condition>
+  </element>
+  <element name="mac:description">
+    <label>Description</label>
+    <description></description>
+    <condition></condition>
+  </element>
+  <element name="mac:mountedOn">
+    <label>Mounted on</label>
+    <description></description>
+    <condition></condition>
+  </element>
+  <element name="mac:MI_Requirement">
+    <label>Requirement</label>
+    <description>Requirement to be satisfied by the planned data acquisition
+    </description>
+    <condition></condition>
+  </element>
+  <element name="mac:recipient">
+    <label>Recipient</label>
+    <description></description>
+    <condition></condition>
+  </element>
+  <element name="mac:requestor">
+    <label>Requestor</label>
+    <description></description>
+    <condition></condition>
+  </element>
+  <element name="mac:requestedDate">
+    <label>Requested date</label>
+    <description>Range of date validity</description>
+    <condition></condition>
+  </element>
+  <element name="mac:MI_RequestedDate">
+    <label>Requested date</label>
+    <description></description>
+    <condition></condition>
+  </element>
+  <element name="mac:requestedDateOfCollection">
+    <label>Requested date of collection</label>
+    <description></description>
+    <condition></condition>
+  </element>
+  <element name="mac:latestAcceptableDate">
+    <label>Latest acceptable date</label>
+    <description></description>
+    <condition></condition>
+  </element>
+  <element name="mac:expiryDate">
+    <label>Expiry date</label>
+    <description></description>
+    <condition></condition>
+  </element>
+  <element name="mac:satisifiedPlan">
+    <label>Satisfied plan</label>
+    <description></description>
+    <condition></condition>
+  </element>
+  <element name="gml:BaseUnit">
+    <label>Basis eenheid</label>
+    <description></description>
+  </element>
+  <element name="gml:quantityType">
+    <label>Type waarde</label>
+    <description></description>
+  </element>
+  <element name="gml:quantityTypeReference">
+    <label>Referentie naar type waarde</label>
+    <description></description>
+  </element>
+  <element name="gml:catalogSymbol">
+    <label>Catalogue symbool</label>
+    <description></description>
+  </element>
+  <element name="gml:unitsSystem">
+    <label>Eenheidssysteem</label>
+    <description></description>
+  </element>
+  <element name="gml:TimeEdgeType">
+    <label>Time edge type</label>
+    <description></description>
+    <condition></condition>
+  </element>
+  <element name="gml:TimePeriodType">
+    <label>Time period type</label>
+    <description></description>
+    <condition></condition>
+  </element>
+  <element name="gml:TimeNodeType">
+    <label>Time node type</label>
+    <description></description>
+    <condition></condition>
+  </element>
+  <element name="gml:TimeInstantType">
+    <label>Time instant type</label>
+    <description></description>
+    <condition></condition>
+  </element>
+  <element name="dqc:dateTime">
+    <label>Date et heure</label>
+    <description></description>
+  </element>
+  <element name="dqc:relatedElement">
+    <label>Related element</label>
+    <description></description>
+  </element>
+  <element name="mrl:LI_ProcessStep">
+    <label>Process step (imagery)</label>
+    <description></description>
+    <condition></condition>
+  </element>
+  <element name="mrl:LE_ProcessStep">
+    <label>Process step</label>
+    <description></description>
+    <condition></condition>
+  </element>
+  <element name="mrl:LE_Source">
+    <label>Source (imagery)</label>
+    <description></description>
+    <condition></condition>
+  </element>
+  <element name="mrl:LE_ProcessStepReport">
+    <label>Process step report</label>
+    <description></description>
+    <condition></condition>
+  </element>
+  <element name="mrl:name">
+    <label>Name</label>
+    <description></description>
+    <condition></condition>
+  </element>
+  <element name="mrl:fileType">
+    <label>File type</label>
+    <description></description>
+    <condition></condition>
+  </element>
+  <element name="mrl:description">
+    <label>Omschrijving</label>
+    <description></description>
+    <condition></condition>
+  </element>
+  <element name="mrl:stepDateTime">
+    <label>Step date time</label>
+    <description></description>
+    <condition></condition>
+  </element>
+  <element name="mrl:report">
+    <label>Report</label>
+    <description></description>
+    <condition></condition>
+  </element>
+  <element name="mrl:output">
+    <label>Output</label>
+    <description></description>
+    <condition></condition>
+  </element>
+  <element name="mrl:reference">
+    <label>Reference</label>
+    <description></description>
+    <condition></condition>
+  </element>
+  <element name="mrl:processingInformation">
+    <label>Information sur le processus</label>
+    <description></description>
+    <condition></condition>
+  </element>
+  <element name="mdq:QE_CoverageResult">
+    <label>Coverage result</label>
+    <description>Result of a data quality measure organising the measured values
+      as a coverage
+    </description>
+    <condition></condition>
+  </element>
+  <element name="mdq:DQ_QuantitativeResult" id="133.0">
+    <label>Quantitative result</label>
+    <description>The values or information about the value(s) (or set of values)
+      obtained from
+      applying a data quality measure
+    </description>
+  </element>
+  <element name="mdq:deductiveSource">
+    <label>Deductive source</label>
+    <description>Information on which data are used as
+      sources in deductive evaluation method
+    </description>
+    <example>Positional accuracy of the rivers
+      nearby the archaeological camp
+    </example>
+  </element>
+  <element name="mrl:processedLevel">
+    <label>Processed level</label>
+    <description></description>
+    <condition></condition>
+  </element>
+
+
+  <element name="mdb:metadataStandard" id="21.0">
+    <label>Metadata standaard</label>
+    <description iso="true">Citation for the standard to which the metadata
+      conforms. NOTE Metadata standard citations should include an identifier.
+    </description>
+    <condition></condition>
+  </element>
+  <element name="mdb:resourceScope" id="40.0">
+    <label>Resource type</label>
+    <description iso="true">Code for the scope.</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mdb:name" id="41.0">
+    <label>Name</label>
+    <description iso="true">Description of the scope.</description>
+    <condition>optional</condition>
+  </element>
+  <element name="msr:MD_GridSpatialRepresentation" id="148.0">
+    <label>Grid spatial representation</label>
+    <description iso="true">Information about grid spatial objects in the
+      resource
+    </description>
+    <condition></condition>
+  </element>
+  <element name="msr:numberOfDimensions" id="149.0">
+    <label>Aantal dimensies</label>
+    <description iso="true">Number of independent spatial-temporal axes
+    </description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="msr:axisDimensionProperties" id="150.0">
+    <label>Axis dimension properties</label>
+    <description iso="true">Information about spatial-temporal axis properties
+    </description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="msr:cellGeometry" id="151.0">
+    <label>Cell geometry</label>
+    <description iso="true">Identification of grid data as point or cell
+    </description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="msr:transformationParameterAvailability" id="152.0">
+    <label>Transformation parameter availability</label>
+    <description iso="true">Indication of whether or not parameters for
+      transformation between image coordinates and geographic or map coordinates
+      exist (are available)
+    </description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="msr:MD_Georectified" id="153.0">
+    <label>Georectified</label>
+    <description iso="true">Grid whose cells are regularly spaced in a
+      geographic (i.e., lat / long) or map coordinate system defined in the
+      Spatial Referencing System (SRS) so that any cell in the grid can be
+      geolocated given its grid coordinate and the grid origin, cell spacing,
+      and orientation
+    </description>
+    <condition></condition>
+  </element>
+  <element name="msr:checkPointAvailability" id="154.0">
+    <label>Check point availability</label>
+    <description iso="true">Indication of whether or not geographic position
+      points are available to test the accuracy of the georeferenced grid data
+    </description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="msr:checkPointDescription" id="155.0">
+    <label>beschrijving controle punten</label>
+    <description iso="true">beschrijving van de geometrische posities waarmee de
+      gridgegevens gecontroleerd kunnen worden
+    </description>
+    <condition></condition>
+  </element>
+  <element name="msr:cornerPoints" id="156.0">
+    <label>Corner points</label>
+    <description iso="true">Earth location in the coordinate system defined by
+      the Spatial Reference System and the grid coordinate of the cells at
+      opposite ends of grid coverage along two diagonals in the grid spatial
+      dimensions NOTE There are four corner points in a georectified grid; at
+      least two corner points along one diagonal are required. The first corner
+      point corresponds to the origin of the grid..
+    </description>
+    <condition>optional</condition>
+  </element>
+  <element name="msr:centrePoint" id="157.0">
+    <label>Point central</label>
+    <description iso="true">Position terrestre dans le système de coordonnées
+      définie par le système de références spatiales et la coordonnée dans la
+      grille de la cellule située à mi-chemin entre les extrémités opposées de
+      la grille selon les dimensions spatiales.
+    </description>
+    <condition>optional</condition>
+  </element>
+  <element name="msr:pointInPixel" id="158.0">
+    <label>Point in pixel</label>
+    <description iso="true">earth location in the coordinate system defined by
+      the Spatial Reference System and the grid coordinate of the cell halfway
+      between opposite ends of the grid in the spatial dimensions
+    </description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="msr:transformationDimensionDescription" id="159.0">
+    <label>Transformation dimension description</label>
+    <description iso="true">General description of the transformation
+    </description>
+    <condition>optional</condition>
+  </element>
+  <element name="msr:transformationDimensionMapping" id="160.0">
+    <label>Transformation dimension mapping</label>
+    <description iso="true">information about which grid axes are the spatial
+      (map) axes
+    </description>
+    <condition>optional</condition>
+  </element>
+  <element name="msr:MD_Georeferenceable" id="161.0">
+    <label>Georeferenceable</label>
+    <description iso="true">Grid with cells irregularly spaced in any given
+      geographic/map projection coordinate system, whose individual cells can be
+      eolocated using geolocation information supplied with the data but cannot
+      be geolocated from the grid properties alone
+    </description>
+    <condition></condition>
+  </element>
+  <element name="msr:controlPointAvailability" id="162.0">
+    <label>Control point availability</label>
+    <description iso="true">Indication of whether or not control point(s)
+      existse existent
+    </description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="msr:orientationParameterAvailability" id="163.0">
+    <label>Orientation parameter availability</label>
+    <description iso="true">Indication of whether or not orientation parameters
+      are available
+    </description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="msr:orientationParameterDescription" id="164.0">
+    <label>Orientation parameter description</label>
+    <description iso="true">Description of parameters used to describe sensor
+      orientation
+    </description>
+    <condition>optional</condition>
+  </element>
+  <element name="msr:georeferencedParameters" id="165.0">
+    <label>Gegeorefereerde Parameters</label>
+    <description iso="true">Terms which support grid data georeferencing
+    </description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="msr:parameterCitation" id="166.0">
+    <label>Parameter citatie</label>
+    <description iso="true">reference providing description of the parameters
+    </description>
+    <condition>optional</condition>
+  </element>
+  <element name="msr:MD_VectorSpatialRepresentation" id="167.0">
+    <label>Vector ruimtelijke representatie</label>
+    <description iso="true">Information about the vector spatial objects in the
+      resource
+    </description>
+    <condition></condition>
+  </element>
+  <element name="msr:topologyLevel" id="168.0">
+    <label>Topology level</label>
+    <description iso="true">Code which identifies the degree of complexity of
+      the spatial relationships
+    </description>
+    <condition>optional</condition>
+  </element>
+  <element name="msr:geometricObjects" id="169.0">
+    <label>Geometric objects</label>
+    <description iso="true">Information about the geometric objects used in the
+      resource
+    </description>
+    <condition>optional</condition>
+  </element>
+  <element name="msr:MD_Dimension" id="170.0">
+    <label>Dimensies</label>
+    <description iso="true">Axis properties</description>
+    <condition></condition>
+  </element>
+  <element name="msr:dimensionName" id="171.0">
+    <label>Dimensie naam</label>
+    <description iso="true">Naam van de as</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="msr:dimensionSize" id="172.0">
+    <label>Dimensie omvang</label>
+    <description iso="true">Aantal elementen op de as</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="msr:resolution" id="173.0">
+    <label>Resolutie</label>
+    <description iso="true">Degree of detail in the grid dataset</description>
+    <condition>optional</condition>
+  </element>
+  <element name="msr:dimensionTitle" id="174.0">
+    <label>Dimension title</label>
+    <description iso="true">enhancement/modifier of the dimension name. EXAMPLE
+      dimensionName = “column” dimensionTitle = “Longitude”
+    </description>
+    <condition>optional</condition>
+  </element>
+  <element name="msr:dimensionDescription" id="175.0">
+    <label>Dimension description</label>
+    <description iso="true">Description of the axis</description>
+    <condition>optional</condition>
+  </element>
+  <element name="msr:MD_GeometricObjects" id="176.0">
+    <label>Geometrische objecten</label>
+    <description iso="true">Number of objects, listed by geometric object type,
+      used in the resource
+    </description>
+    <condition></condition>
+  </element>
+  <element name="msr:geometricObjectType" id="177.0">
+    <label>Geometric object type</label>
+    <description iso="true">Name of point or vector objects used to locate
+      zero-, one-, two-, or three-dimensional spatial locations in the resource
+    </description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="msr:geometricObjectCount" id="178.0">
+    <label>Geometric object count</label>
+    <description iso="true">Total number of the point or vector object type
+      occurring in the dataset
+    </description>
+    <condition>optional</condition>
+  </element>
+  <element name="msr:MD_ReferenceSystem" id="179.0">
+    <label>Referentiesysteem</label>
+    <description iso="true">Information about the reference system</description>
+    <condition></condition>
+  </element>
+  <element name="msr:referenceSystemIdentifier" id="180.0">
+    <label>Reference system identifier</label>
+    <description iso="true">identifier and codespace for reference system.: NOTE
+      Refer to SC_CRS in ISO 19111 and ISO 19111-2 when coordinate reference
+      system information is not given through reference system identifier.
+      EXAMPLE EPSG::4326
+    </description>
+    <condition>optional</condition>
+  </element>
+  <element name="msr:referenceSystemType" id="181.0">
+    <label>Reference system type</label>
+    <description iso="true">Type of reference system used. EXAMPLE
+      compoundGeographic2DParametric
+    </description>
+    <condition>optional</condition>
+  </element>
+  <element name="msr:MD_ContentInformation" id="182.0">
+    <label>ContentInformation</label>
+    <description iso="true">description of the content of a resource
+    </description>
+    <condition></condition>
+  </element>
+  <element name="msr:MD_FeatureCatalogueDescription" id="183.0">
+    <label>Feature catalogue description</label>
+    <description iso="true">Information identifying the feature catalogue or the
+      conceptual schema
+    </description>
+    <condition></condition>
+  </element>
+  <element name="msr:complianceCode" id="184.0">
+    <label>Compliance code</label>
+    <description iso="true">Indication of whether or not the cited feature
+      catalogue complies with ISO 191109110
+    </description>
+    <condition>optional</condition>
+  </element>
+  <element name="msr:locale" id="185.0">
+    <label>Locale</label>
+    <description iso="true">Language(s) and character set(s) used within the
+      catalogue
+    </description>
+    <condition>optional</condition>
+  </element>
+  <element name="msr:includedWithDataset" id="186.0">
+    <label>Included with dataset</label>
+    <description iso="true">Indication of whether or not the feature catalogue
+      is included with the resource
+    </description>
+    <condition>optional</condition>
+  </element>
+  <element name="msr:featureTypes" id="187.0">
+    <label>Feature types</label>
+    <description iso="true">Subset of feature types from cited feature catalogue
+      occurring in resource and count of feature instances
+    </description>
+    <condition>optional</condition>
+  </element>
+  <element name="msr:featureCatalogueCitation" id="188.0">
+    <label>Feature catalogue citation</label>
+    <description iso="true">complete bibliographic reference to one or more
+      external feature catalogues
+    </description>
+    <condition></condition>
+  </element>
+
+
+  <element name="mrc:MD_FeatureCatalogue" id="189.0">
+    <label>Feature catalogue</label>
+    <description iso="true">A catalogue of feature types</description>
+    <condition></condition>
+  </element>
+  <element name="mrc:featureCatalogue" id="190.0">
+    <label>Feature catalogue</label>
+    <description iso="true">The catalogue of feature types, attribution,
+      operations, and relationships used by the resource
+    </description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mrc:MD_FeatureTypeInfo" id="232.0">
+    <label>Feature type info</label>
+    <description iso="true">Information about the occurring feature type
+    </description>
+    <condition></condition>
+  </element>
+  <element name="mrc:featureTypeName" id="233.0">
+    <label>Feature type name</label>
+    <description iso="true">name of the feature type</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mrc:featureInstanceCount" id="234.0">
+    <label>Feature instance count</label>
+    <description iso="true">Number of occurrence of feature instances for this
+      feature type
+    </description>
+    <condition>optional</condition>
+  </element>
+  <element name="xsi:nil">
+    <label>Nil</label>
+    <description>Indicates that a certain element does not have a value or that the value is unknown.</description>
+  </element>
+  <element name="isInfinite">
+    <label>Is infinite</label>
+  </element>
+  <element name="gco:Multiplicity">
+    <label>Multiplicity</label>
+  </element>
+  <element name="gco:range">
+    <label>Range</label>
+  </element>
+  <element name="gco:MultiplicityRange">
+    <label>Multiplicity range</label>
+  </element>
+  <element name="gfc:FC_Binding">
+    <label>Binding</label>
+  </element>
+  <element name="gfc:FC_BoundAssociationRole">
+    <label>Bound association role</label>
+  </element>
+  <element name="gfc:FC_BoundFeatureAttribute">
+    <label>Bound feature attribute</label>
+  </element>
+  <element name="gfc:identifier">
+    <label>Identifier</label>
+  </element>
+  <element name="gfc:inheritanceRelation">
+    <label>Inheritance relation</label>
+    <description></description>
+  </element>
+  <element name="gfc:globalProperty">
+    <label>Global property</label>
+    <description></description>
+  </element>
+  <element name="gfc:designation">
+    <label>Designation</label>
+    <description></description>
+  </element>
+  <element name="gfc:subtype">
+    <label>Subtype</label>
+    <description></description>
+  </element>
+  <element name="gfc:supertype">
+    <label>Supertype</label>
+    <description></description>
+  </element>
+  <element name="gfc:FC_DefinitionSource">
+    <label>Definition source</label>
+    <description></description>
+  </element>
+  <element name="gfc:source">
+    <label>Source</label>
+    <description></description>
+  </element>
+
+  <element name="mdq:standaloneQualityReport">
+    <label>Standalone quality report</label>
+    <description></description>
+  </element>
+  <element name="mdq:DQ_StandaloneQualityReportInformation">
+    <label>Standalone quality report information</label>
+    <description></description>
+  </element>
+  <element name="mdq:reportReference">
+    <label>Report reference</label>
+    <description></description>
+  </element>
+  <element name="mdq:abstract">
+    <label>Samenvatting</label>
+    <description></description>
+  </element>
+  <element name="mdq:elementReport">
+    <label>Element report</label>
+    <description></description>
+  </element>
+  <element name="mdq:standaloneQualityReportDetails">
+    <label>Standalone quality report details</label>
+    <description></description>
+  </element>
+  <element name="mdq:measure">
+    <label>Measure</label>
+    <description></description>
+  </element>
+  <element name="mdq:evaluationMethod">
+    <label>Evaluation method</label>
+    <description></description>
+  </element>
+  <element name="mdq:result">
+    <label>Result</label>
+    <description></description>
+  </element>
+  <element name="mdq:derivedElement">
+    <label>Derived element</label>
+    <description></description>
+  </element>
+  <element name="mdq:DQ_MeasureReference">
+    <label>Measure reference</label>
+    <description></description>
+  </element>
+  <element name="mdq:measureIdentification">
+    <label>Measure identification</label>
+    <description></description>
+  </element>
+  <element name="mdq:nameOfMeasure">
+    <label>Name of measure</label>
+    <description></description>
+  </element>
+  <element name="mdq:measureDescription">
+    <label>Measure description</label>
+    <description></description>
+  </element>
+
+
+  <element name="mdq:DQ_DataInspection">
+    <label>Data inspection</label>
+    <description></description>
+  </element>
+  <element name="mdq:DQ_AggregationDerivation">
+    <label>Aggregation derivation</label>
+    <description></description>
+  </element>
+  <element name="mdq:DQ_FullInspection">
+    <label>Full inspection</label>
+    <description></description>
+  </element>
+  <element name="mdq:DQ_IndirectEvaluation">
+    <label>Indirect evaluation</label>
+    <description></description>
+  </element>
+  <element name="mdq:DQ_SampleBasedInspection">
+    <label>Sample based inspection</label>
+    <description></description>
+  </element>
+  <element name="mdq:DQ_EvaluationMethod">
+    <label>Evaluation method</label>
+    <description></description>
+  </element>
+  <element name="mdq:dateTime">
+    <label>Date time</label>
+    <description></description>
+  </element>
+  <element name="mdq:evaluationMethodDescription">
+    <label>Evaluation method description</label>
+    <description></description>
+  </element>
+  <element name="mdq:evaluationProcedure">
+    <label>Evaluation procedure</label>
+    <description></description>
+  </element>
+  <element name="mdq:referenceDoc">
+    <label>Reference doc</label>
+    <description></description>
+  </element>
+  <element name="mdq:evaluationMethodType">
+    <label>Evaluation method type</label>
+    <description></description>
+  </element>
+  <element name="mdq:DQ_ConformanceResult">
+    <label>Conformance result</label>
+    <description>Information about the outcome of evaluating
+      the obtained value (or set of values) against a
+      specified acceptable conformance quality
+      level
+    </description>
+  </element>
+  <element name="mdq:DQ_DescriptiveResult">
+    <label>Descriptive result</label>
+    <description>Data quality descriptive result</description>
+  </element>
+  <element name="mdq:resultScope">
+    <label>Result scope</label>
+    <description></description>
+  </element>
+  <element name="mdq:statement">
+    <label>Statement</label>
+    <description></description>
+  </element>
+  <element name="mdq:DQ_NonQuantitativeAttributeCorrectness">
+    <label>Non quantitative attribute correctness</label>
+    <description></description>
+  </element>
+  <element name="mdq:DQ_UsabilityElement">
+    <label>Usability element</label>
+    <description></description>
+  </element>
+  <element name="mdq:DQ_Confidence">
+    <label>Metaquality / Confidence</label>
+    <description>Trustworthiness of a data quality result.</description>
+  </element>
+  <element name="mdq:DQ_Homogeneity">
+    <label>Metaquality / Homogeneity</label>
+    <description>Expected or tested uniformity of the results obtained for a
+      data quality evaluation.
+    </description>
+  </element>
+  <element name="mdq:DQ_Representativity">
+    <label>Metaquality / Representativity</label>
+    <description>Degree to which the sample used has produced a result which is
+      representative of the
+      data within the data quality scope
+    </description>
+  </element>
+  <element name="mdq:explanation">
+    <label>Explanation</label>
+    <description></description>
+  </element>
+  <element name="mdq:pass">
+    <label>Pass</label>
+    <description></description>
+  </element>
+  <element name="mdq:specification">
+    <label>Specification</label>
+    <description></description>
+  </element>
+  <element name="mdq:relatedElement">
+    <label>Related quality element</label>
+    <description></description>
+  </element>
+
+
+  <element name="cit:CI_Individual" id="383.0">
+    <label>Individual</label>
+    <description iso="true">Class of information about the party if the party is
+      an individual
+    </description>
+  </element>
+  <element name="mdb:defaultLocale" id="17.0">
+    <label>Default locale</label>
+    <description iso="true">Language and character set used for documenting
+      metadata
+    </description>
+    <_condition>C / not defined by encoding and UTF-8 not used?</_condition>
+  </element>
+  <element name="mdb:parentMetadata" id="18.0">
+    <label>Parent metadata</label>
+    <description iso="true">Identification of the parent metadata record
+    </description>
+    <_condition>conditional / if If there is an upper level object</_condition>
+  </element>
+  <element name="mdb:dateInfo" id="20.0">
+    <label>Date info</label>
+    <description iso="true">Date(s) associated with the metadata. NOTE Creation”
+      date must be provided, others can also be provided
+    </description>
+    <_condition>mandatory</_condition>
+  </element>
+  <element name="mdb:alternativeMetadataReference" id="23.0">
+    <label>Alternative metadata reference</label>
+    <description iso="true">Reference to alternative metadata, e.g Dublin Core,
+      FGDC, or metadata in a non-ISO standard for the same resource
+    </description>
+    <_condition>optional</_condition>
+  </element>
+  <element name="mdb:metadataLinkage" id="25.0">
+    <label>Metadata linkage</label>
+    <description iso="true">Online location where the metadata is available
+    </description>
+    <_condition>optional</_condition>
+  </element>
+  <element name="mdb:otherLocale" id="24.0">
+    <label>Other locale</label>
+    <description iso="true">Provides information about alternatively used
+      localised character strings
+    </description>
+    <_condition>optional</_condition>
+  </element>
+  <element name="mdb:resourceLineage" id="37.0">
+    <label>Resource lineage</label>
+    <description iso="true">Information about the provenance, source(s), and/or
+      the production process(es) applied to the resource
+    </description>
+    <_condition>optional</_condition>
+  </element>
+  <element name="mdb:metadataScope" id="38.0">
+    <label>Type of resource</label>
+    <description iso="true">Type of resource for which metadata is provided
+    </description>
+  </element>
+
+  <element name="mdb:MD_MetadataScope" id="6.0">
+    <label>Hierarchy level</label>
+    <description>Scope to which the metadata applies (see annex H for more
+      information about
+      metadata hierarchy levels)
+    </description>
+  </element>
+  <element name="mri:temporalResolution" id="51.0">
+    <label>Temporal resolution</label>
+    <description iso="true">Smallest resolvable temporal period in a resource
+    </description>
+    <_condition>optional</_condition>
+  </element>
+  <element name="mrl:additionalDocumentation">
+    <label>Additional doc.</label>
+    <description/>
+  </element>
+  <element name="mrl:LI_Source">
+    <label>Bron</label>
+    <description/>
+  </element>
+  <element name="mri:associatedResource" id="62.0">
+    <label>Associated resource</label>
+    <description iso="true">Associated resource information</description>
+    <_condition>optional</_condition>
+  </element>
+  <element name="mri:MD_AssociatedResource" id="62.0">
+    <label>Associated resource</label>
+    <description iso="true">Associated resource information</description>
+    <_condition>optional</_condition>
+  </element>
+  <element name="mri:defaultLocale" id="64.0">
+    <label>Default locale</label>
+    <description iso="true">Language and character set used within the
+      resource
+    </description>
+    <_condition>C / language used in resource?</_condition>
+  </element>
+  <element name="mri:otherLocale" id="64.0">
+    <label>Other locale</label>
+    <description iso="true">Alternate localised language(s) and character set
+      (s) used within the resource
+    </description>
+    <_condition>optional</_condition>
+  </element>
+  <element name="mri:MD_KeywordClass" id="73.0">
+    <label>Keyword class</label>
+    <description iso="true">Specification of a class to categorize keywords in a
+      domain-specific vocabulary that has a binding to a formal ontology
+    </description>
+    <_condition>Use obligation from referencing object</_condition>
+  </element>
+  <element name="mri:conceptIdentifier" id="75.0">
+    <label>Concept Identifier</label>
+    <description iso="true">URI of concept in the ontology specified by the next
+      element (ontology) and labelled by the previous element (className)
+    </description>
+    <_condition>optional</_condition>
+  </element>
+  <element name="mri:className">
+    <label>Class name</label>
+    <description>Character string to label the keyword category in natural
+      language
+    </description>
+  </element>
+  <element name="mri:ontology" id="76.0">
+    <label>Ontology</label>
+    <description iso="true">Reference that binds the keyword class to a formal
+      conceptualization of a knowledge domain for use in semantic processing
+      NOTE Keywords in the associated MD_Keywords keyword list must be within
+      the scope of this ontology.
+    </description>
+    <_condition>mandatory</_condition>
+  </element>
+  <element name="mri:keywordClass" id="72.0">
+    <label>Keyword class</label>
+    <description iso="true">association of a MD_Keywords instance with a
+      MD_KeywordClass to provide user-defined categorization of groups of
+      keywords that extend or are orthogonal to the standardized
+      KeywordTypeCodes and are associated with an ontology that allows
+      additional semantic query processing NOTE The thesaurus citation specifies
+      a collection of instances from some ontology, but is not an ontology. It
+      might be a list of places that include rivers, mountains, counties and
+      cities. There might be a Laconte county, the city of Laconte, the Laconte
+      River, and Mt. Laconte; when searching it is useful for the user to be
+      able to restrict the search to only rivers.
+    </description>
+    <_condition>optional</_condition>
+  </element>
+  <element name="mri:processingLevel" id="55.0">
+    <label>Processing level</label>
+    <description iso="true">Code that identifies the level of processing in the
+      producers coding system of a resource. Example NOAA level 1B.
+    </description>
+    <_condition>optional</_condition>
+  </element>
+  <element name="mrl:scope" id="120.0">
+    <label>Scope</label>
+    <description iso="true">Type of resource and/or extent to which the lineage
+      information applies
+    </description>
+    <_condition>optional</_condition>
+  </element>
+  <element name="mmi:maintenanceDate" id="142.0"
+           context="mmi:MD_MaintenanceInformation">
+    <label>Maintenance date</label>
+    <description iso="true">Date information associated with maintenance of
+      resource
+    </description>
+    <_condition>optional</_condition>
+  </element>
+  <element name="mmi:maintenanceScope" id="144.0"
+           context="mmi:MD_MaintenanceInformation">
+    <label>Maintenance scopes</label>
+    <description iso="true">Type of resource and/or extent to which the
+      maintenance information applies
+    </description>
+    <_condition>optional</_condition>
+  </element>
+  <element name="mrs:referenceSystemType" id="181.0">
+    <label>Reference system type</label>
+    <description iso="true">Type of reference system used Example
+      compoundGeographic2DParametric
+    </description>
+    <_condition>optional</_condition>
+  </element>
+  <element name="mrc:includedWithDataset" id="186.0">
+    <label>Included with dataset</label>
+    <description iso="true">Indication of whether or not the feature catalogue
+      is included with the resource
+    </description>
+    <_condition>optional</_condition>
+  </element>
+  <element name="mrc:attributeGroup" id="194.0">
+    <label>Attribute group</label>
+    <description iso="true">Information on groups(s) of related attributes of
+      the resource with the same type
+    </description>
+    <_condition>optional</_condition>
+  </element>
+  <element name="mrc:MD_AttributeGroup" id="207.0">
+    <label>Attribute group</label>
+    <description iso="true">Class of information about contentType for groups of
+      attributes for a specific MD_RangeDimension
+    </description>
+  </element>
+  <element name="mrc:attribute" id="209.0">
+    <label>Attribute</label>
+    <description iso="true">Information on an attribute of the resource
+    </description>
+    <condition>optional</condition>
+  </element>
+  <element name="mrc:MD_SampleDimension" id="214.0">
+    <label>Sample dimension</label>
+    <description iso="true">Class of information about characteristics of each
+      dimension (layer) included in the resource
+    </description>
+    <condition></condition>
+  </element>
+  <element name="mrc:meanValue" id="220.0">
+    <label>Mean value</label>
+    <description iso="true">Mean value of data values in each dimension included
+      in the resource
+    </description>
+    <condition>optional</condition>
+  </element>
+  <element name="mrc:numberOfValues" id="221.0">
+    <label>Number of values</label>
+    <description iso="true">The number of values used in a
+      thematic-Classification resource. Example The number of classes in a Land
+      Cover Type coverage or the number of cells with data in other types of
+      coverages.
+    </description>
+    <condition>optional</condition>
+  </element>
+  <element name="mrc:standardDeviation" id="222.0">
+    <label>Standard deviation</label>
+    <description iso="true">Standard deviation of data values in each dimension
+      included in the resource
+    </description>
+    <condition>optional</condition>
+  </element>
+  <element name="mrc:otherPropertyType" id="223.0">
+    <label>Other property type</label>
+    <description iso="true">Type of other attribute description (i.e.
+      netcdf/variable in ncml.xsd)
+    </description>
+    <condition>optional</condition>
+  </element>
+  <element name="mrc:otherProperty" id="224.0">
+    <label>Other property</label>
+    <description iso="true">Instance of otherAttributeType that defines
+      attributes not explicitly included in MD_CoverageType
+    </description>
+    <condition>optional</condition>
+  </element>
+  <element name="mrc:boundMax" id="227.0">
+    <label>Bound max</label>
+    <description iso="true">Longest wavelength that the sensor is capable of
+      collecting within a designated band
+    </description>
+    <condition>optional</condition>
+  </element>
+  <element name="mrc:boundMin" id="228.0">
+    <label>Bound min</label>
+    <description iso="true">Shortest wavelength that the sensor is capable of
+      collecting within a designated band
+    </description>
+    <condition>optional</condition>
+  </element>
+  <element name="mrc:boundUnits" id="229.0">
+    <label>Bound unit</label>
+    <description iso="true">Units in which sensor wavelengths are expressed
+    </description>
+    <condition>optional</condition>
+  </element>
+  <element name="mrd:formatSpecificationCitation" id="255.0">
+    <label>Format specification citation</label>
+    <description iso="true">citation/URL of the specification for the format
+    </description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="lan:locale" id="453.0" context="lan:PT_LocaleContainer">
+    <label>Locale</label>
+    <description iso="true">Locale in which the localised strings of the
+      container are expressed
+    </description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mri:response" id="90.0">
+    <label>Response</label>
+    <description iso="true">Response to the user-determined limitations. Example
+      “This has been fixed in version x.”
+    </description>
+    <_condition>optional</_condition>
+  </element>
+  <element name="mrd:transferFrequency" id="247.0">
+    <label>Transfer frequency</label>
+    <description iso="true">Rate of occurrence of distribution</description>
+    <_condition>optional</_condition>
+  </element>
+  <element name="mrd:medium" id="258.0">
+    <label>Medium</label>
+    <description iso="true">Medium used by the format</description>
+    <_condition>optional</_condition>
+  </element>
+  <element name="mri:additionalDocumentation" id="91.0">
+    <label>Additional documentation</label>
+    <description iso="true">Publications that describe usage of data
+    </description>
+    <_condition>optional</_condition>
+  </element>
+  <element name="mri:identifiedIssues" id="92.0">
+    <label>Identified issues</label>
+    <description iso="true">Citation of a description of known issues associated
+      with the resource along with proposed solutions if available
+    </description>
+    <_condition>optional</_condition>
+  </element>
+  <element name="mri:metadataReference" id="97.0">
+    <label>Metadata Reference</label>
+    <description iso="true">Reference to the metadata of the associated
+      resource
+    </description>
+    <_condition>conditional / if name not documented?</_condition>
+  </element>
+  <element name="gex:verticalExtent" id="354.0">
+    <label>Vertical extent</label>
+    <description iso="true">Vertical extent component</description>
+  </element>
+  <element name="cit:individual" id="387.0">
+    <label>Individual</label>
+    <description>An individual in the named organization</description>
+    <_condition></_condition>
+  </element>
+  <element name="cit:CI_Organisation" id="385.0">
+    <label>Organisatie</label>
+    <description iso="true">Class of information about the party if the party is
+      an organization
+    </description>
+  </element>
+  <element name="cit:CI_Responsibility" id="376.0">
+    <label>Responsibility</label>
+    <description iso="true">Class of information about the party and their
+      role
+    </description>
+  </element>
+  <element name="cit:partyIdentifier">
+    <label>Identifier for the party</label>
+    <description/>
+  </element>
+  <element name="cit:role" id="377.0">
+    <label>Rol</label>
+  </element>
+  <element name="cit:role" id="377.0" context="cit:CI_Responsibility">
+    <label>Rol</label>
+    <description>Function performed by the responsible party</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="cit:party" id="379.0" context="cit:CI_Responsibility">
+    <label>Party</label>
+    <description iso="true">Information about the party</description>
+  </element>
+  <element name="cit:extent" id="378.0" context="cit:CI_Responsibility">
+    <label>Extent</label>
+    <description iso="true">Spatial or temporal extent of the role</description>
+  </element>
+  <element name="lan:language" id="448.0" context="/mdb:MD_Metadata/mdb:defaultLocale/lan:PT_Locale/lan:language">
+    <label>Metadata taal</label>
+    <description iso="true">Designation of the locale language</description>
+  </element>
+  <element name="lan:language" id="448.0" context="/mdb:MD_Metadata/mdb:identificationInfo/mri:MD_DataIdentification/mri:defaultLocale/lan:PT_Locale/lan:language">
+    <label>Taal van de bron</label>
+    <description iso="true">ISO 3 letters code.</description>
+  </element>
+  <element name="lan:language" id="448.0" context="/mdb:MD_Metadata/mdb:otherLocale/lan:PT_Locale/lan:language">
+    <label>Other language</label>
+    <description iso="true">Additional metadata language</description>
+  </element>
+  <element name="lan:language" id="448.0">
+    <label>Taal</label>
+    <description iso="true">Designation of the locale language</description>
+  </element>
+  <element name="cit:presentationForm" id="369.0">
+    <label>Wijze van presentatie</label>
+    <description iso="true">Mode in which the resource is represented
+    </description>
+    <help></help>
+    <condition/>
+  </element>
+  <element name="cit:series" id="370.0">
+    <label>Series</label>
+    <description iso="true">Information about the series, or aggregate resource,
+      of which the resource is a part
+    </description>
+    <help/>
+    <condition/>
+  </element>
+  <element name="cit:CI_Series" id="413.0">
+    <label>Séries</label>
+    <description iso="true">Class of information about the series, or aggregate
+      resource, to which a resource belongs
+    </description>
+    <help/>
+    <condition/>
+  </element>
+  <element name="mcc:MD_Scope" id="420.0">
+    <label>Scope</label>
+    <description iso="true">Class of information about the target resource and
+      physical extent for which information is reported
+    </description>
+    <help/>
+    <condition/>
+  </element>
+  <element name="cit:onlineResource" id="398.0" context="cit:CI_Contact">
+    <label>Online resource</label>
+    <description iso="true">On-line information that can be used to contact the
+      individual or organisation
+    </description>
+    <help/>
+    <condition/>
+  </element>
+  <element name="cit:phone" id="396.0">
+    <label>Telephone</label>
+    <description iso="true">Telephone numbers at which the organisation or
+      individual may be contacted
+    </description>
+    <help/>
+    <condition/>
+  </element>
+  <element name="cit:number" id="418.0">
+    <label>Number</label>
+    <description iso="true">Telephone number by which individuals can contact
+      responsible organisation or individual
+    </description>
+    <help/>
+    <condition/>
+  </element>
+  <element name="cit:contactType" id="401.0">
+    <label>Contact type</label>
+    <description iso="true">Type of the contact</description>
+    <help/>
+    <condition/>
+  </element>
+  <element name="cit:logo" id="386.0">
+    <label>Logo</label>
+    <description iso="true">Graphic identifying the organization</description>
+    <help/>
+    <condition/>
+  </element>
+  <element name="cit:numberType" id="419.0">
+    <label>Number type</label>
+    <description iso="true">Type of telephone number</description>
+    <help/>
+    <condition/>
+  </element>
+  <element name="mri:MD_ScopeCode">
+    <label>Scope code</label>
+    <description>Class of information to which the referencing entity applies
+    </description>
+  </element>
+  <element name="mcc:MD_ScopeCode">
+    <label>Scope code</label>
+    <description>Class of information to which the referencing entity applies
+    </description>
+  </element>
+  <element name="code" id="207.0" context="mri:MD_Identifier">
+    <label>Code</label>
+    <description>Alphanumeric value identifying an instance in the namespace
+    </description>
+    <help>alphanumeric value identifying an instance in the namespace</help>
+  </element>
+  <element name="code">
+    <label>System code</label>
+    <description>Code. i.e. EPSG code.</description>
+  </element>
+  <element name="code" id="547.0" context="mri:MD_CodeValue">
+    <label>Code</label>
+    <description>Value code</description>
+    <help>Value code (i.e. numeric)</help>
+  </element>
+  <element name="codeSpace" id="208.1">
+    <label>Reference Authority</label>
+    <description>Authority responsible for codification. i.e. EPSG</description>
+  </element>
+  <element name="cit:date" id="393.0">
+    <label>Datum</label>
+    <description>Formatted as 2007-09-12 (YYYY-MM-DD)</description>
+    <help>reference date and event used to describe it</help>
+    <_condition>Use obligation/condition from referencing object</_condition>
+  </element>
+  <element name="gco:DateTime" id="64.0" context="mri:MD_Usage">
+    <description>Formatted as 2007-09-12T15:00:00 (YYYY-MM-DDTHH:mm:ss)
+    </description>
+    <label>Usage Date / Time</label>
+    <help>date and time of the first use or range of uses of the resource and/or
+      resource
+      series
+    </help>
+  </element>
+  <element name="gco:DateTime" id="300.0" context="mrd:MD_StandardOrderProcess">
+    <description>Formatted as 2007-09-12T15:00:00 (YYYY-MM-DDTHH:mm:ss)
+    </description>
+    <label>Planned Available Date / Time</label>
+    <help>date and time when theresource will be available</help>
+  </element>
+  <element name="gco:DateTime">
+    <label>Date and time</label>
+    <description>Date and time or range of date and time on or over which the
+      process step occurred
+      (YYYY-MM-DDThh:mm:ss)
+    </description>
+  </element>
+  <element name="gco:Measure" id="100.0" context="mri:DQ_Element">
+    <label>Name of Measure</label>
+    <description>Name of the test applied to the data</description>
+  </element>
+  <element name="gco:Measure" id="357.0" context="mri:EX_VerticalExtent">
+    <label>Unit of Measure</label>
+    <description>Vertical units used for vertical extent information Examples:
+      metres, feet,
+      millimetres, hectopascals
+    </description>
+    <_condition>M</_condition>
+  </element>
+  <element name="cit:CI_Address" id="380.0">
+    <label>Adres</label>
+    <description>adres van de verantwoordelijke persoon of organisatie.</description>
+    <_condition>Use obligation/condition from referencing object</_condition>
+  </element>
+  <element name="cit:CI_Citation" id="361.0">
+    <label>Citation</label>
+    <description>Standardised resource reference</description>
+    <_condition>Use obligation/condition from referencing object</_condition>
+  </element>
+  <element name="cit:CI_Contact" id="387.0">
+    <label>Contact</label>
+    <description>Informatie die nodig is om contact op te nemen met de
+      verantwoordelijke persoon of organisatie.
+    </description>
+    <_condition>Use obligation/condition from referencing object</_condition>
+  </element>
+  <element name="cit:CI_Date" id="402.0">
+    <label>Datum</label>
+    <description>Referentie datum en gebeurtenis waarmee deze wordt
+      omschreven (YYYY-MM-DD).
+    </description>
+    <_condition>Use obligation/condition from referencing object</_condition>
+  </element>
+  <element name="cit:CI_OnlineResource" id="405.0">
+    <label>Online bronnen</label>
+    <description>Informatie over online bronnen waarmee de gegevens kunnen
+      worden verkregen.
+    </description>
+    <_condition>Use obligation/condition from referencing object</_condition>
+  </element>
+  <element name="mri:CI_ResponsibleParty" id="374.0">
+    <label>Verantwoordelijke partij</label>
+    <description>Identificatie en wijze van communicatie met personen of
+      organisaties die geassocieerd zijn met de dataset.
+    </description>
+    <_condition>Use obligation/condition from referencing object</_condition>
+  </element>
+  <element name="mri:CI_Series" id="403.0">
+    <label>Series</label>
+    <description>Information about the series, or aggregate dataset, to which a
+      dataset
+      belongs
+    </description>
+    <_condition>Use obligation/condition from referencing object</_condition>
+  </element>
+  <element name="cit:CI_Telephone" id="417.0">
+    <label>Telefoon</label>
+    <description>Telefoonnummer van de persoon of organisatie.</description>
+    <_condition>Use obligation/condition from referencing object</_condition>
+  </element>
+  <element name="mdq:DQ_AbsoluteExternalPositionalAccuracy" id="117.0">
+    <label>Absolute external positional accuracy</label>
+    <description>Closeness of reported coordinate values to values accepted as
+      or being
+      true
+    </description>
+  </element>
+  <element name="mdq:DQ_AccuracyOfATimeMeasurement" id="121.0">
+    <label>Accuracy of time measurement</label>
+    <description>Correctness of the temporal references of an item (reporting of
+      error in time
+      measurement)
+    </description>
+  </element>
+  <element name="mdq:DQ_CompletenessCommission" id="109.0">
+    <label>Completeness commission</label>
+    <description>Excess data present in the dataset, as described by the scope
+    </description>
+  </element>
+  <element name="mdq:DQ_CompletenessOmission" id="110.0">
+    <label>Completeness omission</label>
+    <description>Data absent from the dataset, as described by the scope
+    </description>
+  </element>
+  <element name="mdq:DQ_ConceptualConsistency" id="112.0">
+    <label>Conceptual consistency</label>
+    <description>Adherence to rules of the conceptual schema</description>
+  </element>
+  <element name="mri:DQ_ConformanceResult" id="129.0">
+    <label>Conformance result</label>
+    <description>Information about the outcome of evaluating the obtained value
+      (or set of
+      values) against a specified acceptable conformance quality level
+    </description>
+  </element>
+  <element name="mdq:DQ_DataQuality" id="78.0">
+    <label>Data quality</label>
+    <description>Quality information for the data specified by a data quality
+      scope
+    </description>
+  </element>
+  <element name="mdq:DQ_DomainConsistency" id="113.0">
+    <label>Domain consistency</label>
+    <description>Adherence of values to the value domains</description>
+  </element>
+  <element name="mdq:DQ_FormatConsistency" id="114.0">
+    <label>Format consistency</label>
+    <description>Degree to which data is stored in accordance with the physical
+      structure of the
+      dataset, as described by the scope
+    </description>
+  </element>
+  <element name="mdq:DQ_GriddedDataPositionalAccuracy" id="118.0">
+    <label>Gridded data positional accuracy</label>
+    <description>Closeness of gridded data position values to values accepted as
+      or being
+      true
+    </description>
+  </element>
+  <element name="mdq:DQ_NonQuantitativeAttributeAccuracy" id="126.0">
+    <label>Non quantitative attribute accuracy</label>
+    <description>Correctness of non-quantitative attributes</description>
+  </element>
+  <element name="mdq:DQ_QuantitativeAttributeAccuracy" id="127.0">
+    <label>Quantitative attribute accuracy</label>
+    <description>Accuracy of quantitative attributes</description>
+  </element>
+  <element name="mdq:DQ_RelativeInternalPositionalAccuracy" id="119.0">
+    <label>Relative internal positional accuracy</label>
+    <description>Closeness of the relative positions of features in the scope to
+      their
+      respective relative positions accepted as or being true
+    </description>
+  </element>
+  <element name="mri:DQ_Scope" id="138.0">
+    <label>Scope</label>
+    <description>Description of the data specified by the scope</description>
+    <help>extent of characteristic(s) of the data for which quality information
+      is
+      reported
+    </help>
+  </element>
+  <element name="mdq:DQ_TemporalConsistency" id="122.0">
+    <label>Temporal consistency</label>
+    <description>Correctness of ordered events or sequences, if reported
+    </description>
+  </element>
+  <element name="mdq:DQ_TemporalValidity" id="123.0">
+    <label>Temporal validity</label>
+    <description>Validity of data specified by the scope with respect to time
+    </description>
+  </element>
+  <element name="mdq:DQ_ThematicClassificationCorrectness" id="125.0">
+    <label>Thematic classification correctness</label>
+    <description>Comparison of the classes assigned to features or their
+      attributes to a
+      universe of discourse
+    </description>
+  </element>
+  <element name="mdq:DQ_TopologicalConsistency" id="115.0">
+    <label>Topological consistency</label>
+    <description>Correctness of the explicitly encoded topological
+      characteristics of the
+      dataset as described by the scope
+    </description>
+  </element>
+  <element name="gex:EX_BoundingPolygon" id="341.0">
+    <label>Bounding Polygon</label>
+    <description>Boundary enclosing the dataset, expressed as the closed set of
+      (x,y)
+      coordinates of the polygon (last point replicates first point)
+    </description>
+  </element>
+  <element name="gex:EX_Extent" id="334.0">
+    <label>Dekking Bereik</label>
+    <description>informatie over de ruimtelijke, verticale of temporele
+      dekking.
+    </description>
+  </element>
+  <element name="gex:EX_GeographicBoundingBox" id="343.0">
+    <label>Ruimtelijke dekking</label>
+    <description>Meest westelijke, oostelijke, zuidelijke en noordelijke
+      coordinaat uit de horizontale dekking van de dataset weergegeven in
+      longitude en lattitude en decimale graden (noord en oost als
+      positieve waarden). Gebruik WGS84 als refsysteem.
+    </description>
+  </element>
+  <element name="gex:EX_GeographicDescription" id="348.0">
+    <label>Geographic description</label>
+    <description>Description of the geographic area using identifiers
+    </description>
+  </element>
+  <element name="gex:EX_SpatialTemporalExtent" id="352.0">
+    <label>Spatial temporal extent</label>
+    <description>Extent with respect to date/time and spatial boundaries
+    </description>
+  </element>
+  <element name="gex:EX_TemporalExtent" id="350.0">
+    <label>Temporele dekking</label>
+    <description>Periode die van toepassing is op de gegevens in de
+      dataset
+    </description>
+  </element>
+  <element name="gex:EX_VerticalExtent" id="354.0">
+    <label>Vertical extent</label>
+    <description>Vertical domain of dataset</description>
+  </element>
+  <element name="cit:ISBN" id="372.0">
+    <label>ISBN</label>
+    <description>International Standard Book Number</description>
+  </element>
+  <element name="cit:ISSN" id="373.0">
+    <label>ISSN</label>
+    <description>International Standard Serial Number</description>
+  </element>
+  <element name="mrl:LI_Lineage" id="82.0">
+    <label>Lineage</label>
+    <description>Information about the events or source data used in
+      constructing the data
+      specified by the scope or lack of knowledge about lineage
+    </description>
+  </element>
+  <element name="mri:LI_ProcessStep" id="86.0">
+    <label>Processtap</label>
+    <description>Information about an event in the creation process for the data
+      specified by
+      the scope
+    </description>
+    <help>information about an event or transformation in the life of a dataset
+      including the
+      process used to maintain the dataset
+    </help>
+  </element>
+  <element name="mri:LI_Source" id="92.0">
+    <label>Bron</label>
+    <description>Information about the source data used in creating the data
+      specified by the
+      scope
+    </description>
+  </element>
+  <element name="mri:MD_AggregateInformation" id="66.1">
+    <label>Aggregate Information</label>
+    <description>Aggregate dataset information</description>
+  </element>
+  <element name="mas:MD_ApplicationSchemaInformation" id="320.0">
+    <description>Information about the application schema used to build the
+      dataset
+    </description>
+    <label>Applicatie schema info</label>
+  </element>
+  <element name="mrc:MD_Band" id="259.0">
+    <label>Band</label>
+    <description>Range of wavelengths in the electromagnetic spectrum
+    </description>
+    <help>range of wavelengths in the electromagnetic spectrum</help>
+  </element>
+  <element name="mcc:MD_BrowseGraphic" id="437.0">
+    <label>Browse Graphic</label>
+    <description>Graphic that provides an illustration of the dataset (should
+      include a legend for the graphic)
+    </description>
+    <description iso="true">Graphic that provides an illustration of a resource
+      NOTE Should include a legend for the graphic, if applicable. EXAMPLE A
+      dataset, an organisation logo, security constraint or citation graphic.
+    </description>
+  </element>
+  <element name="mco:MD_Constraints" id="98.0">
+    <label>Beperkingen</label>
+    <description>beperkingen die van toepassing zijn op de wijze van
+      toegang of het gebruik van een databron of metadata
+    </description>
+  </element>
+  <element name="mrc:MD_CoverageDescription" id="239.0">
+    <label>Beschrijving dekking</label>
+    <description>Information about the content of a grid data cell</description>
+  </element>
+  <element name="mri:MD_DataIdentification" id="36.0">
+    <label>Data identificatie</label>
+    <description>Informatie die nodig is om een dataset te identificeren.</description>
+  </element>
+  <element name="mrd:MD_DigitalTransferOptions" id="274.0">
+    <label>Digitale leverings opties</label>
+    <description>Technical means and media by which a resource is obtained from
+      the
+      distributor
+    </description>
+  </element>
+  <element name="mri:MD_Dimension" id="179.0">
+    <label>Dimension</label>
+    <description>Axis properties</description>
+  </element>
+  <element name="mrd:MD_Distribution" id="270.0">
+    <label>Distributie</label>
+    <description>Information about the distributor of and options for obtaining
+      the
+      resource
+    </description>
+  </element>
+  <element name="mrd:MD_Distributor" id="279.0">
+    <label>Distributeur</label>
+    <description>Information about the distributor</description>
+  </element>
+  <element name="mri:MD_ExtendedElementInformation" id="306.0">
+    <description>New metadata element, not found in ISO 19115, which is required
+      to describe
+      geographic data
+    </description>
+    <label>Aanvullend element informatie</label>
+  </element>
+  <element name="mrc:MD_FeatureCatalogueDescription" id="233.0">
+    <label>Featurecatalogus beschrijving</label>
+    <description>Information identifying the feature catalogue or the conceptual
+      schema
+    </description>
+  </element>
+  <element name="mrd:MD_Format" id="284.0">
+    <label>Formaat</label>
+    <description>Beschrijving van de wijze waarop de informatie wordt
+      opgeslagen in een record, bestand, bericht, opslagmedium of anders.
+    </description>
+  </element>
+  <element name="mri:MD_GeometricObjects" id="183.0">
+    <label>Geometric objects</label>
+    <description>Number of objects, listed by geometric object type, used in the
+      dataset
+    </description>
+  </element>
+  <element name="mri:MD_Georectified" id="162.0">
+    <label>Georectified</label>
+    <description>Grid whose cells are regularly spaced in a geographic (i.e.,
+      lat / long) or map
+      coordinate system defined in the Spatial Referencing System (SRS) so that
+      any cell in
+      the grid can be geolocated given its grid coordinate and the grid origin,
+      cell spacing,
+      and orientation
+    </description>
+  </element>
+  <element name="mri:MD_Georeferenceable" id="170.0">
+    <label>Georeferenceable</label>
+    <description>Grid with cells irregularly spaced in any given geographic/map
+      projection
+      coordinate system, whose individual cells can be geolocated using
+      geolocation
+      information supplied with the data but cannot be geolocated from the grid
+      properties
+      alone
+    </description>
+  </element>
+  <element name="mri:MD_GridSpatialRepresentation" id="157.0">
+    <label>Grid ruimtelijke representatie</label>
+    <description>Information about grid spatial objects in the dataset
+    </description>
+  </element>
+  <element name="mcc:MD_Identifier" id="431.0">
+    <label>Identifier</label>
+    <description>Value uniquely identifying an object within a namespace
+    </description>
+  </element>
+  <element name="mrc:MD_ImageDescription" id="243.0">
+    <label>Omschrijving afbeelding</label>
+    <description>Information about an image's suitability for use</description>
+  </element>
+  <element name="mri:MD_Keywords" id="52.0">
+    <label>Trefwoorden</label>
+    <description>informatie over de trefwoorden</description>
+  </element>
+  <element name="mco:MD_LegalConstraints" id="69.0">
+    <label>Legale beperkingen</label>
+    <description>Restrictions and legal prerequisites for accessing and using
+      the resource or
+      metadata
+    </description>
+  </element>
+  <element name="mmi:MD_MaintenanceInformation" id="142.0">
+    <label>Beheer informatie</label>
+    <description>Informatie over het bereik en de frequentie van updates.</description>
+  </element>
+  <element name="mrd:MD_Medium" id="291.0">
+    <label>Medium</label>
+    <description>Information about the media on which the resource can be
+      distributed
+    </description>
+  </element>
+  <element name="mdb:MD_Metadata" id="1.0">
+    <label>Metadata</label>
+    <description>Root entity which defines metadata about a resource or
+      resources
+    </description>
+  </element>
+  <element name="mri:MD_MetadataExtensionInformation" id="303.0">
+    <description>Information describing metadata extensions</description>
+    <label>Metadata extensie info</label>
+  </element>
+  <element name="mpc:MD_PortrayalCatalogueReference" id="268.0">
+    <label>Portrayal catalogus referentie</label>
+    <description>Information identifying the portrayal catalogue used
+    </description>
+  </element>
+  <element name="mrc:MD_RangeDimension" id="256.0">
+    <label>Range dimension</label>
+    <description>Information on the range of each dimension of a cell
+      measurement
+      value
+    </description>
+  </element>
+  <element name="mrs:MD_ReferenceSystem" id="186.0">
+    <label>Referentiesysteem</label>
+    <description>Information about the reference system.</description>
+    <help>information about the reference system</help>
+  </element>
+  <element name="mri:MD_RepresentativeFraction" id="56.0">
+    <label>Representative fraction</label>
+    <description>Derived from Scale where MD_RepresentativeFraction.denominator
+      = 1 /
+      Scale.measure And Scale.targetUnits = Scale.sourceUnits
+    </description>
+  </element>
+  <element name="mri:MD_Resolution" id="59.0">
+    <label>Resolution</label>
+    <description>Level of detail expressed as a scale factor or a ground
+      distance
+    </description>
+  </element>
+  <element name="mcc:MD_ScopeDescription" id="149.0">
+    <label>Scope description</label>
+    <description>Description of the class of information covered by the
+      information
+    </description>
+    <condition>Either attributes, features, featureInstances,
+      attributeInstnaces, dataset or other must be provided
+    </condition>
+  </element>
+  <element name="mcc:MD_ScopeDescription_Type" id="149.0">
+    <label>Scope description</label>
+    <description>Description of the class of information covered by the
+      information
+    </description>
+    <condition>Either attributes, features, featureInstances,
+      attributeInstnaces, dataset or other must be provided
+    </condition>
+  </element>
+  <element name="mco:MD_SecurityConstraints" id="73.0">
+    <label>Security constraints</label>
+    <description>Handling restrictions imposed on the resource or metadata for
+      national security
+      or similar security concerns
+    </description>
+  </element>
+  <element name="mri:MD_ServiceIdentification" id="47.0">
+    <label>Service Identification</label>
+    <description>Identification of capabilities which a service provider makes
+      available to a
+      service user through a set of interfaces that define a behaviour - See ISO
+      19119 -
+      Services for further information
+    </description>
+  </element>
+  <element name="mrd:MD_StandardOrderProcess" id="298.0">
+    <label>Standard order process</label>
+    <description>Common ways in which the resource may be obtained or received,
+      and related
+      instructions and fee information
+    </description>
+  </element>
+  <element name="mri:MD_Usage" id="62.0">
+    <label>Gebruik/Toepassing</label>
+    <description>Korte omschrijving van het gebruik van de dataset of
+      toepassingen waarbij de dataset wordt gebruikt.
+    </description>
+  </element>
+  <element name="mri:MD_VectorSpatialRepresentation" id="176.0">
+    <label>Vector spatial representation</label>
+    <description>Information about the vector spatial objects in the dataset
+    </description>
+  </element>
+  <element name="mri:PT_FreeText" id="601.0">
+    <label>Vrije tekst</label>
+    <description>Description of a multi-language free text metadata element
+    </description>
+  </element>
+  <element name="mri:RS_Identifier" id="208.0">
+    <description>Identifier used for reference systems</description>
+    <label>Identifier</label>
+  </element>
+  <element name="mri:URL" id="608.0">
+    <label>URL</label>
+    <description>URL</description>
+  </element>
+  <element name="mri:abstract" id="25.0">
+    <label>Samenvatting</label>
+    <description>Korte beschrijving van de inhoud van de dataset.</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mco:accessConstraints" id="70.0">
+    <label>(Juridische) toegangsrestrictie</label>
+    <description>Toegangseisen die er zorg voor dragen dat privacy of
+      intellectueel eigendom gewaarborgd zijn en elke andere speciale
+      beperkingen voor het verkrijgen van de metadata of data.
+    </description>
+  </element>
+  <element name="mri:address" id="525.0" context="mri:CI_ResponsibleParty">
+    <label>Adres</label>
+    <description>Address of the responsible party</description>
+  </element>
+  <element name="cit:address" id="389.0" context="CI_Contact">
+    <label>Adres</label>
+    <description>Physical and email address at which the organization or
+      individual may be
+      contacted
+    </description>
+  </element>
+  <element name="cit:address" id="397.0">
+    <label>Adresse</label>
+    <description>Adresse physique et électronique à laquelle la personne ou
+      l'organisation responsable peut être contactée
+    </description>
+    <help>Adresse postale ou électronique d'un premier niveau de contact (par
+      exemple un secrétariat). Ces informations sont du type CI_Address et sont
+      gérées dans la classe du même nom.
+    </help>
+    <condition/>
+
+  </element>
+  <element name="cit:administrativeArea" id="391.0">
+    <label>Provincie</label>
+    <description>Naam van de provincie</description>
+  </element>
+  <element name="mri:aggregateDataSetIdentifier" id="66.3">
+    <label>Gerelateerde dataset ID</label>
+    <description>Gerelateerde dataset ID van samenhangende datasets niet
+      zijnde een dataset serie.
+    </description>
+  </element>
+  <element name="mri:aggregateDataSetName" id="66.2">
+    <label>Naam gerelateerde dataset</label>
+    <description>Gerelateerde dataset naam van samenhangende datasets niet
+      zijnde een dataset serie.
+    </description>
+    <_condition>C / if aggregateDataSetIdentifier not documented?</_condition>
+  </element>
+  <element name="mri:aggregationInfo" id="35.1">
+    <label>Informatie over de relatie</label>
+    <description>Informatie over de relatie</description>
+  </element>
+  <element name="cit:alternateTitle" id="363.0">
+    <label>Alternatieve titel</label>
+    <description>Korte titel, afkorting of titel in een andere taal.</description>
+  </element>
+  <element name="mrd:amendmentNumber" id="287.0">
+    <label>Ammandement nummer</label>
+    <description>Ammandement nummer van de versie van het formaat</description>
+  </element>
+  <element name="cit:applicationProfile" id="408.0">
+    <label>Applicatie profiel</label>
+    <description>Naam van het applicatieprofiel dat kan worden gebruikt
+      met de bron.
+    </description>
+  </element>
+  <element name="mdb:applicationSchemaInfo" id="21.0">
+    <label>Applicatie schema info</label>
+    <description>geeft informatie over het conceptuele schema van de
+      dataset
+    </description>
+  </element>
+  <element name="mri:associationType" id="66.4">
+    <label>Type relatie</label>
+    <description>Type relatie</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mrc:attributeDescription" id="240.0">
+    <label>Attribuut beschrijving</label>
+    <description>beschrijving van het attribuut dat wordt beschreven door
+      de meetwaarde
+    </description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mcc:attributeInstances" id="153.0">
+    <label>Attribuut instanties</label>
+    <description>attribuut instanties waarop de informatie van toepassing
+      is
+    </description>
+    <condition/>
+  </element>
+  <element name="mcc:attributes" id="150.0">
+    <label>Attributen</label>
+    <description>attributen waarop de informatie van toepassing is</description>
+    <condition/>
+  </element>
+  <element name="mcc:authority" id="432.0">
+    <label>Autoriteit</label>
+    <description>persoon of organisatie die verantwoordelijk is voor het
+      beheer van een namespace.
+    </description>
+  </element>
+  <element name="mri:axisDimensionProperties" id="159.0">
+    <label>Tekencodering</label>
+    <description>Tekencodering</description>
+    <_condition>M</_condition>
+  </element>
+  <element name="mrc:bitsPerValue" id="264.0">
+    <label>Bits per waarde</label>
+    <description>Maximum aantal significante bits in de ongecompresseerde
+      weergave van de waarde van alle banden van iedere pixel.
+    </description>
+  </element>
+  <element name="mrc:cameraCalibrationInformationAvailability"
+           id="253.0">
+    <label>Camera calibratie informatie aanwezigheid</label>
+    <description>indicatie of er informatie aanwezig is waarmee de camera
+      gecalibreerd kan worden.
+    </description>
+  </element>
+  <element name="mri:cellGeometry" id="160.0">
+    <label>Cell geometrie</label>
+    <description>indentificatie van grid data als punt of cel.</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mri:centerPoint" id="166.0">
+    <label>Middelpunt</label>
+    <description>Earth location in the coordinate system defined by the Spatial
+      Reference System
+      and the grid coordinate of the cell halfway between opposite ends of the
+      grid in the
+      spatial dimensions
+    </description>
+  </element>
+  <element name="mri:characterSet" id="4.0" context="mri:MD_Metadata">
+    <label>Karakterset</label>
+    <description>Volledige naam van de karakterset die is gebruikt voor de
+      opslag van de (meta)data. Voor de meeste data is dat utf8
+    </description>
+    <condition>conditional</condition>
+    <_condition>conditional / ISO/IEC 10646-1 not used and not defined by
+      encoding?
+    </_condition>
+  </element>
+  <element name="mri:characterSet" id="40.0"
+           context="mri:MD_DataIdentification">
+    <label>Character set</label>
+    <description>Full name of the character coding standard used for the
+      dataset
+    </description>
+    <_condition>Conditional / ISO 10646-1 not used?</_condition>
+  </element>
+  <element name="mri:characterSet" id="4.0">
+    <label>Karakterset</label>
+    <description>Volledige naam van de karakterset die is gebruikt voor de
+      opslag van de (meta)data. Voor de meeste data is dat utf8
+    </description>
+    <condition>conditional</condition>
+  </element>
+  <element name="mri:checkPointAvailability" id="163.0">
+    <label>beschikbaarheid controle punten</label>
+    <description>indicatie of er al dan niet geometrische posities
+      beschikbaar zijn om de nauwkeurigheid van het gegeorefereerde grid te
+      testen.
+    </description>
+    <condition>mandatory</condition>
+    <label>Checkpoint Availability</label>
+  </element>
+  <element name="mri:checkPointDescription" id="164.0">
+    <description>Description of geographic position points used to test the
+      accuracy of the
+      georeferenced grid data
+    </description>
+    <condition>conditional</condition>
+    <label>Checkpoint Description</label>
+  </element>
+  <element name="mri:citation" id="24.0" context="mri:MD_Identification">
+    <label>Citatie</label>
+    <description>Citatie gegevens voor de data</description>
+  </element>
+  <element name="mri:citation" id="576.0" context="mri:MD_Authority">
+    <label>Citation</label>
+    <description>Citation which belongs to the authority</description>
+  </element>
+  <element name="mri:citation" id="581.0" context="mri:MD_Thesaurus">
+    <label>Citation</label>
+    <description>Citation of the thesaurus</description>
+  </element>
+  <element name="mri:citation" id="581.0">
+    <label>Citation</label>
+    <description>Citation data for the resource(s)</description>
+  </element>
+  <element name="cit:citedResponsibleParty" id="367.0">
+    <label>Geciteerde verantwoordelijke partij</label>
+    <description>naam en positie van de persoon of organisatie die
+      verantwoordelijk is voor de bron.
+    </description>
+  </element>
+  <element name="cit:city" id="390.0">
+    <label>Plaats</label>
+    <description>Plaatsnaam behorende bij het contactadres van de
+      organisatie.
+    </description>
+  </element>
+  <element name="mco:classification" id="74.0">
+    <condition>mandatory</condition>
+    <label>Classification</label>
+    <description>Name of the handling restrictions on the resource or metadata
+    </description>
+  </element>
+  <element name="mco:classificationSystem" id="76.0">
+    <label>Classificatiesysteem</label>
+    <description>naam van het Classificatiesysteem</description>
+  </element>
+  <element name="mrc:cloudCoverPercentage" id="248.0">
+    <label>bedekkingsgraad bewolking</label>
+    <description>percentage van de oppervlakte van het gebied dat wordt
+      bedekt door bewolking.
+    </description>
+  </element>
+  <element name="mri:code" id="207.0" context="mri:RS_Identifier">
+    <label>Unique resource identifier</label>
+    <description>Alphanumeric value identifying an instance in the namespace
+    </description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mcc:code" id="433.0">
+    <label>Code</label>
+    <description>Alfanumerieke waarde die een instance binnen een
+      namespace uniek identificeerd.
+    </description>
+    <description iso="true">Alphanumeric value identifying an instance in the
+      namespace. NOTE Avoid characters that are not legal in URLs. EXAMPLE
+      EPSG::4326
+    </description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mri:code" id="547.0" context="mri:MD_CodeValue">
+    <label>Code</label>
+    <description>Value code</description>
+    <help>Value code (i.e. numeric)</help>
+  </element>
+  <element name="mcc:codeSpace" id="434.0">
+    <label>Codespace</label>
+    <description>Name or identifier of the person or organization responsible
+      for
+      namespace
+    </description>
+    <description iso="true">Identifier or namespace in which the code is valid
+    </description>
+    <helper>
+      <option value="EPSG">EPSG</option>
+    </helper>
+  </element>
+  <element name="mri:collectiveTitle" id="371.0">
+    <label>Collectieve titel</label>
+    <description>Common title with holdings note. NOTE title identifies elements
+      of a series
+      collectively, combined with information about what volumes are available
+      at the source
+      cited
+    </description>
+    <help>This field is used to name the Basic Geodata as defined in the GeoIV
+      Annex I, as it is possible that there are more than 1 "physical" datasets
+      assigned to 1 legal entry. E.g.: Entry no. 47 "Geophysikalisches
+      Kartenwerk" consists of 3 datasets "Geophysikalische Karten 1:500000",
+      "Geophysikalische Spezialkarten" and "Gravimetrischer Atlas 1:100000"
+    </help>
+  </element>
+  <element name="mrc:complianceCode" id="234.0">
+    <label>Compliance code</label>
+    <description>Indication of whether or not the cited feature catalogue
+      complies with ISO
+      19110
+    </description>
+  </element>
+  <element name="mri:compressionGenerationQuantity" id="250.0">
+    <label>Compression generation quantity</label>
+    <description>Count of the number of lossy compression cycles
+      performed on the
+      image
+    </description>
+  </element>
+  <element name="mri:condition" id="312.0">
+    <label>Voorwaarde(n)</label>
+    <description>Voorwaarden waaronder het element verplicht is.</description>
+  </element>
+  <element name="mas:constraintLanguage" id="323.0">
+    <label>Constraintlanguage van applicatieschema</label>
+    <description>Formele taal welke wordt gebruikt in het applicatieschema</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mdb:contact" id="19.0">
+    <condition>mandatory</condition>
+    <label>Contact</label>
+    <description>Party responsible for the metadata information</description>
+  </element>
+  <element name="mmi:contact" id="148.1"
+           context="mmi:MD_MaintenanceInformation">
+    <label>Contact</label>
+    <description>Identification of, and means of communication with, person(s)
+      and
+      organization(s) with responsibility for maintaining the metadata
+    </description>
+  </element>
+  <element name="mri:contact" id="8.0">
+    <label>Metadata auteur</label>
+    <description>Organisatie die verantwoordelijk is voor de metadata.</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="cit:contactInfo" id="378.0">
+    <description>Adres van de verantwoordelijke partij.</description>
+    <label>Contact info</label>
+  </element>
+  <element name="cit:contactInstructions" id="392.0">
+    <label>Contact instructies</label>
+    <description>Aanvullende informatie over de wijze of tijdstip waarmee
+      contact kan worden opgenomen met de organisatie of persoon.
+    </description>
+  </element>
+  <element name="mdb:contentInfo" id="16.0">
+    <description>Geeft informatie over de featurecatalogus en beschrijft
+      de dekking en eigenschappen van afbeeldingsgegevens.
+    </description>
+    <label>Object catalogus</label>
+  </element>
+  <element name="mrc:contentType" id="241.0">
+    <label>Inhoud type</label>
+    <description>Soort informatie welke wordt weergegeven in de waarde van
+      de cellen
+    </description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mri:controlPointAvailability" id="171.0">
+    <description>indicatie of er al dan niet controlepunten bestaan.</description>
+    <condition>mandatory</condition>
+    <label>beschikbaarheid controle punten</label>
+  </element>
+  <element name="mri:cornerPoints" id="165.0">
+    <label>Hoekpunten</label>
+    <description>earth location in the coordinate system defined by the
+      Spatial Reference System and the grid coordinate of the cells at
+      opposite ends of grid coverage along two diagonals in the grid
+      spatial dimensions. There are four corner points in a georectified
+      grid; at least two corner points along one diagonal are required
+    </description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="cit:country" id="393.0">
+    <label>Land</label>
+    <description>Country of the physical address</description>
+  </element>
+  <element name="mri:country" id="508.0" context="mri:MD_Legislation">
+    <label>Land</label>
+    <description>Country in which the law was issued</description>
+  </element>
+  <element name="mri:country" id="605.0" context="PT_Group">
+    <label>Land</label>
+    <description>Country of language used for documenting a plain text
+    </description>
+  </element>
+  <element name="lan:country" id="449.0">
+    <label>Land</label>
+    <description>Designation of the specific country of the locale language
+    </description>
+    <condition>optional</condition>
+  </element>
+  <element name="lan:country" id="449.0" context="lan:PT_Locale">
+    <label>Land</label>
+    <description>Designation of the specific country of the locale language
+    </description>
+    <condition>optional</condition>
+  </element>
+  <element name="cit:country" id="393.0" context="cit:CI_Address">
+    <label>Land</label>
+    <description>Country of the address</description>
+    <condition>optional</condition>
+  </element>
+  <element name="mri:credit" id="46.0">
+    <label>Krediet</label>
+    <description>Erkenning van degene die bijgedragen hebben aan de bron.</description>
+  </element>
+  <element name="mdb:dataQualityInfo" id="18.0">
+    <label>Data kwaliteitsbeschrijving</label>
+    <description>Geeft de kwaliteit aan van de dataset.</description>
+  </element>
+  <element name="mcc:URI">
+    <label>URI</label>
+    <description></description>
+  </element>
+  <element name="mri:dataSetURI" id="11.1">
+    <label>Dataset URI</label>
+    <description>Uniformed Resource Identifier (URI) of the dataset to which the
+      metadata
+      applies
+    </description>
+    <help>Uniformed Resource Identifier (URI) of the dataset to which the
+      metadata applies. This
+      link refers direct to the machine-readable dataset.
+    </help>
+  </element>
+  <element name="mri:dataType" id="313.0">
+    <label>Data type</label>
+    <description>Code which identifies the kind of valueprovidedeprovided in the
+      extended
+      element
+    </description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mcc:dataset" id="154.0">
+    <description>Dataset to which the information applies</description>
+    <condition/>
+    <label>Dataset</label>
+  </element>
+  <element name="mri:date" id="570.0">
+    <label>Datum</label>
+    <description>Reference date for the cited resource (YYYY-MM-DD)
+    </description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mri:date" id="570.0" context="mri:MD_Revision">
+    <label>Date of last update</label>
+    <description>Date of last update</description>
+  </element>
+  <element name="mri:date" id="144.0" context="mri:MD_MaintenanceInformation">
+    <label>Date of next update</label>
+    <description>Scheduled revision date for resource</description>
+  </element>
+  <element name="cit:date" id="364.0" context="cit:CI_Citation">
+    <condition>mandatory</condition>
+    <label>Datum</label>
+    <description>Reference date for the cited resource</description>
+    <_condition>M</_condition>
+  </element>
+  <element name="cit:date" id="403.0" context="cit:CI_Date">
+    <condition>mandatory</condition>
+    <label>Datum</label>
+    <description>Reference date for the cited resource</description>
+    <_condition>M</_condition>
+  </element>
+  <element name="mri:dateOfNextUpdate" id="144.0">
+    <label>Datum volgende update</label>
+    <description>Geplande datum van volgende update (YYYY-MM-DD)</description>
+  </element>
+  <element name="mri:dateStamp" id="9.0">
+    <label>Metadata datum</label>
+    <description>Datum waarop de metadata is gecreeerd (YYYY-MM-DDThh:mm:ss)
+    </description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mri:dateTime" id="89.0">
+    <label>Date / Time</label>
+    <description>Date and time or range of date and time on or over which the
+      process step
+      occurred (YYYY-MM-DDThh:mm:ss)
+    </description>
+  </element>
+  <element name="mri:dateTime" id="89.0" context="LI_ProcessStep">
+    <description>Date and time or range of date and time on or over which the
+      process step
+      occurred (YYYY-MM-DDThh:mm:ss)
+    </description>
+    <label>Date / Time</label>
+  </element>
+  <element name="mri:dateTime" id="106.0" context="mri:DQ_Element">
+    <label>Date / Time</label>
+    <description>Date or range of dates on which a data quality measure was
+      applied
+    </description>
+  </element>
+  <element name="cit:dateType" id="404.0">
+    <label>Datum type</label>
+    <description>Gebeurtenis waar de datum betrekking op heeft.</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mri:definition" id="310.0">
+    <label>Definitie</label>
+    <description>Definitie van het uitgebreide element</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="cit:deliveryPoint" id="389.0">
+    <label>Adres</label>
+    <description>Address line for the location (as described in ISO 11180, annex
+      A)
+    </description>
+    <description iso="true">Address line for the location. Example Street number
+      and name, Suite number, etc.
+    </description>
+  </element>
+  <element name="mri:denominator" id="57.0">
+    <label>Toepassingsschaal</label>
+    <description>De beoogde schaal waarop het bestand waarheidsgetrouw
+      gebruikt mag worden. Dit moet een positief numeriek getal (dus u moet
+      hier 10000 invoeren als de schaal 1 10000 betreft).
+    </description>
+    <condition>add either a denominator or a distance</condition>
+    <helper>
+      <option value="5000">1:5´000</option>
+      <option value="10000">1:10´000</option>
+      <option value="25000">1:25´000</option>
+      <option value="50000">1:50´000</option>
+      <option value="100000">1:100´000</option>
+      <option value="200000">1:200´000</option>
+      <option value="300000">1:300´000</option>
+      <option value="500000">1:500´000</option>
+      <option value="1000000">1:1´000´000</option>
+    </helper>
+
+  </element>
+  <element name="mrd:density" id="293.0">
+    <label>Dichtheid</label>
+    <description>Dichtheid waarmee de gegevens zijn vastgelegd</description>
+  </element>
+  <element name="mrd:densityUnits" id="294.0">
+    <label>Eenheden dichtheid</label>
+    <description>Eenheid waarmee de dichtheid is vastgelegd</description>
+    <condition>conditional</condition>
+  </element>
+  <element name="mrc:description">
+    <label>Omschrijving</label>
+    <description>Description of the attribute</description>
+    <help></help>
+    <condition>optional</condition>
+  </element>
+  <element name="mrd:description" id="238.0" context="mrd:MD_Distribution">
+    <label>Omschrijving</label>
+    <description>Brief description of a set of distribution options
+    </description>
+    <help></help>
+    <condition>optional</condition>
+  </element>
+  <element name="mri:description" id="561.0">
+    <label>Omschrijving</label>
+    <description>Description of the event, including related parameters or
+      tolerances
+    </description>
+  </element>
+  <element name="mcc:description" id="436.0">
+    <label>Omschrijving</label>
+    <description iso="true">natural language description of the meaning of the
+      code value. EXAMPLE For codeSpace = EPSG, code= 4326, description =
+      WGS-84.
+    </description>
+  </element>
+  <element name="mri:description" id="561.0" context="mri:MD_AbstractClass">
+    <label>Description</label>
+    <description>Description</description>
+  </element>
+  <element name="mri:description" id="87.0" context="LI_ProcessStep">
+    <condition>mandatory</condition>
+    <label>Omschrijving</label>
+    <description>Description of the event, including related parameters or
+      tolerances
+    </description>
+  </element>
+  <element name="mrl:description" id="93.0" context="mrl:LI_Source">
+    <label>Omschrijving</label>
+    <description>Detailed description of the level of the source data
+    </description>
+    <_condition>Conditional / sourceExtent not provided?</_condition>
+  </element>
+  <element name="mrl:sourceMetadata" id="133.0">
+    <label>Source Metadata</label>
+    <description>Reference to metadata for the source</description>
+    <help></help>
+    <condition>optional</condition>
+  </element>
+  <element name="mrl:sourceSpatialResolution" id="133.0">
+    <label>Source spatial resolution</label>
+    <description>spatial resolution expressed as a scale factor, a distance, an
+      angle or a level of detail
+    </description>
+    <help></help>
+    <condition>optional</condition>
+  </element>
+  <element name="mrl:sourceStep" id="133.0" context="mrl:LI_Source">
+    <label>Source step</label>
+    <description>Information about a process step in which this source was
+      used
+    </description>
+    <help></help>
+    <condition>optional</condition>
+  </element>
+  <element name="gex:description" id="335.0" context="gex:EX_Extent">
+    <label>Omschrijving</label>
+    <description>Spatial and temporal extent for the referring object
+    </description>
+    <_condition>Conditional / geographicElement and temporalElement and
+      verticalElement not
+      documented?
+    </_condition>
+  </element>
+  <element name="cit:description" id="410.0" context="cit:CI_OnlineResource">
+    <label>Omschrijving</label>
+    <description>Detailed text description of what the online resource is/does
+    </description>
+  </element>
+  <element name="mri:description" id="541.0" context="mri:MD_CodeDomain">
+    <label>Omschrijving</label>
+    <description>Description of the code domain</description>
+  </element>
+  <element name="mri:description" id="549.0" context="mri:MD_CodeValue">
+    <label>Value description</label>
+    <description>Description of the value</description>
+  </element>
+  <element name="mri:description" id="552.0" context="mri:MD_Attribute">
+    <label>Omschrijving</label>
+    <description>Attribute description</description>
+  </element>
+  <element name="lan:localisedString" id="456.0"
+           context="lan:PT_LocaleContainer">
+    <label>Localised string</label>
+    <description iso="true">Provides the list of localised character string
+      expressing the linguistic translation of a set of textual information in a
+      given locale
+    </description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="lan:LocalisedCharacterString" id="445.0">
+    <label>Localised character string</label>
+    <description iso="true">Expression of a free text in a given locale
+    </description>
+    <condition></condition>
+  </element>
+  <element name="lan:locale" context="lan:LocalisedCharacterString" id="446.0">
+    <label>Locale</label>
+    <description iso="true">defines the locale in which the value (sequence of
+      characters) of the localised character string is expressed
+    </description>
+    <condition>mandatory</condition>
+  </element>
+
+
+  <element name="lan:date" id="454.0" context="lan:PT_LocaleContainer">
+    <label>Date</label>
+    <description iso="true">Date of creation or revision of the locale
+      container
+    </description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mri:description" id="557.0" context="mri:MD_Role">
+    <label>Omschrijving</label>
+    <description>Role description</description>
+  </element>
+  <element name="lan:description" id="238.0" context="lan:PT_LocaleContainer">
+    <label>Omschrijving</label>
+    <description>Designation of the locale language</description>
+    <help></help>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mri:descriptiveKeywords" id="33.0">
+    <label>Trefwoorden</label>
+    <description>In het algemeen gebruikte woorden of geformaliseerde
+      zinnen om een onderwerp te beschrijven.
+    </description>
+  </element>
+  <element name="mri:descriptor" id="258.0">
+    <label>Beschrijvende waarde</label>
+    <description>Beschrijving van de range waarmee de celwaarde is
+      beschreven
+    </description>
+  </element>
+  <element name="mri:dimension" id="242.0">
+    <label>Dimensie</label>
+    <description>informatie over de dimensie van de eenheid waarmee de
+      cellwaarde is beschreven
+    </description>
+  </element>
+  <element name="mri:dimensionName" id="180.0">
+    <label>Dimensie naam</label>
+    <description>Naam van de as</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mri:dimensionSize" id="181.0">
+    <label>Dimensie omvang</label>
+    <description>Aantal elementen op de as</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mri:distance" id="61.0">
+    <label>Spatial resolution</label>
+    <description>Ground sample distance</description>
+    <condition>Provide a distance if no equivalent Scale is documented</condition>
+  </element>
+  <element name="mrd:distributionFormat" id="271.0">
+    <label>Distributie formaat</label>
+    <condition>mandatory</condition>
+    <description>Provides a description of the format of the data to be
+      distributed
+    </description>
+  </element>
+  <element name="mdb:distributionInfo" id="17.0">
+    <description>Geeft informatie over de distributeur van de informatie
+      of de wijze waarop dit wordt gerealiseerd.
+    </description>
+    <label>Distributie info</label>
+  </element>
+  <element name="mrd:distributionOrderProcess" id="281.0">
+    <label>distributie bestelproces</label>
+    <description>Provides information about how the resource may be obtained,
+      and related
+      instructions and fee information
+    </description>
+  </element>
+  <element name="mrd:distributor" id="272.0">
+    <label>Distributeur</label>
+    <description>geeft informatie over de distributeur</description>
+  </element>
+  <element name="mrd:distributorContact" id="280.0">
+    <label>Distributeur contact</label>
+    <description>Partij die men kan benaderen om de databron te
+      verkrijgen.
+    </description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mrd:distributorFormat" id="282.0">
+    <label>Distributeur formaat</label>
+    <description>geeft informatie over de formaten die verkrijgbaar zijn
+      bij de distributeur
+    </description>
+    <condition>conditional</condition>
+  </element>
+  <element name="mrd:distributorTransferOptions" id="283.0">
+    <label>Distributeur methode overdracht</label>
+    <description>Geeft informatie over de wijze waarop de distributeur de
+      gegevens kan overdragen.
+    </description>
+  </element>
+  <element name="mri:domainCode" id="309.0">
+    <label>Domein code</label>
+    <description>Code van drie tekens toegewezen aan het uitgebreide
+      element
+    </description>
+    <_condition>Conditional / is dataType ?codelistElement??</_condition>
+  </element>
+  <element name="mri:domainOfValidity" id="197.0">
+    <label>Domein van geldigheid</label>
+    <description>Reeks die geldig is voor het referentiesysteem</description>
+  </element>
+  <element name="mri:domainValue" id="315.0">
+    <label>Domein waarde</label>
+    <description>geldige waarden die kunnen worden toegewezen aan het
+      uitgebreide element
+    </description>
+    <_condition>Conditonal / dataType not 'codelist', 'enumeration' or
+      'codelistElement'
+    </_condition>
+  </element>
+  <element name="mri:eastBoundLongitude" id="345.0">
+    <label>East bound</label>
+    <description>Eastern-most coordinate of the limit of the dataset extent,
+      expressed in
+      longitude in decimal degrees (positive east)
+    </description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="cit:edition" id="365.0">
+    <label>Versie</label>
+    <description>Version of the cited resource</description>
+  </element>
+  <element name="cit:editionDate" id="366.0">
+    <label>Versie editie datum</label>
+    <description>Datum versie editie (YYYY-MM-DD)</description>
+  </element>
+  <element name="cit:electronicMailAddress" id="394.0">
+    <label>Email</label>
+    <description>Email adres van de verantwoordelijke organisatie of
+      persoon.
+    </description>
+  </element>
+  <element name="mri:environmentDescription" id="44.0">
+    <label>Environment description</label>
+    <description>Description of the dataset in the producer_s processing
+      environment, including
+      items such as the software, the computer operating system, file name, and
+      the dataset
+      size
+    </description>
+  </element>
+  <element name="mri:equivalentScale" id="60.0">
+    <label>Toepassingsschaal</label>
+    <description>Level of detail expressed as the scale of a comparable hardcopy
+      map or
+      chart
+    </description>
+    <_condition>Conditional / distance not documented?</_condition>
+  </element>
+  <element name="mri:errorStatistic" id="136.0">
+    <label>Error statistic</label>
+    <description>Statistical method used to determine the value</description>
+  </element>
+  <element name="mri:evaluationMethodDescription" id="104.0">
+    <label>Evaluation method description</label>
+    <description>Description of the evaluation method</description>
+  </element>
+  <element name="mri:evaluationMethodType" id="103.0">
+    <label>Evaluation Method</label>
+    <description>Type of method used to evaluate quality of the dataset
+    </description>
+  </element>
+  <element name="mri:evaluationProcedure" id="105.0">
+    <label>Evaluation procedure</label>
+    <description>Reference to the procedure information</description>
+  </element>
+  <element name="mri:explanation" id="131.0">
+    <label>Uitleg</label>
+    <description>explanation of the meaning of conformance for this result</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mri:extendedElementInformation" id="305.0">
+    <label>Extended element information</label>
+    <description>Provides information about a new metadata element, not found in
+      ISO 19115, which is required to describe geographic data
+    </description>
+  </element>
+  <element name="mri:extensionOnLineResource" id="304.0">
+    <label>Extension Online resource</label>
+    <description>Information about on-line sources containing the community
+      profile name and the extended metadata elements. Information for all new metadata elements
+    </description>
+  </element>
+  <element name="mri:extent" id="45.0">
+    <label>Extent</label>
+    <description>Extent information including the bounding polygon, vertical,
+      and temporal extent of the dataset
+    </description>
+    <_condition>Conditional / if hierarchyLevel equals "dataset"? Either
+      extent.geographicElement.EX_GeographicBoundingBox or
+      extent.geographicElement.EX_GeographicDescription is required
+    </_condition>
+  </element>
+  <element name="mcc:extent" id="140.0" context="mcc:MD_Scope">
+    <label>Extent</label>
+    <description>Information about the horizontal, vertical and temporal extent
+      of the data specified by the scope
+    </description>
+  </element>
+  <element name="gex:extent" id="351.0" context="gex:EX_TemporalExtent">
+    <label>Extent</label>
+    <description>Date and time for the content of the dataset</description>
+    <_condition>mandatory</_condition>
+  </element>
+  <element name="gex:extentTypeCode" id="340.0">
+    <label>Dekking type code</label>
+    <description>Indication of whether the bounding polygon encompasses an area
+      covered by the data or an area where data is not present. Possible values: '1' for
+      inclusion or '0' for exclusion
+    </description>
+  </element>
+  <element name="mri:facsimile" id="409.0">
+    <label>Fax</label>
+    <description>Faxnummer van de verantwoordelijke persoon of
+      organisatie.
+    </description>
+  </element>
+  <element name="mrc:featureCatalogueCitation" id="238.0">
+    <label>Feature catalogus citatie</label>
+    <description>Complete bibliographic reference to one or more external feature catalogues
+    </description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mcc:featureInstances" id="152.0">
+    <label>Feature instances</label>
+    <description>Feature instances to which the information applies
+    </description>
+    <condition/>
+  </element>
+  <element name="mrc:featureTypes" id="237.0">
+    <label>Feature types</label>
+    <description>Subset of feature types from cited feature catalogue occurring
+      in
+      data
+    </description>
+  </element>
+  <element name="mcc:features" id="151.0">
+    <label>Features</label>
+    <description>Features to which the information applies</description>
+    <condition/>
+  </element>
+  <element name="mrd:fees" id="299.0">
+    <label>Prijsinformatie</label>
+    <description>Prijsinformatie voor het verkrijgen van de data inclusief
+      munteenheid (zoals beschreven in ISO 4217)
+    </description>
+  </element>
+  <element name="mrd:fileDecompressionTechnique" id="289.0">
+    <label>Wijze van bestandsdecompressie</label>
+    <description>Wijze waarop de gegevens kunnen worden uitgepakt indien
+      deze voorzien zijn van compressie-algoritmes.
+    </description>
+  </element>
+  <element name="mcc:fileDescription" id="439.0">
+    <label>File description</label>
+    <description>Text description of the illustration</description>
+  </element>
+  <element name="mdb:metadataIdentifier" id="2.0">
+    <label>Metadata identifier</label>
+    <description>Unique identifier for this metadata file</description>
+  </element>
+  <element name="mcc:fileName" id="438.0">
+    <label>File name</label>
+    <description>Name of the file that contains a graphic that provides an
+      illustration of the
+      dataset. It could be a public image document URL.
+    </description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mcc:fileType" id="440.0">
+    <label>File type</label>
+    <description>Format in which the illustration is encoded</description>
+    <help>Format in which the illustration is encoded Examples: EPS, GIF, JPEG,
+      PBM, PS,
+      TIFF, PDF
+    </help>
+    <helper>
+      <option value="EPS">EPS</option>
+      <option value="GIF">GIF</option>
+      <option value="JPEG">JPEG</option>
+      <option value="PNG">PNG</option>
+      <option value="PBM">PBM</option>
+      <option value="PS">PS</option>
+      <option value="TIFF">TIFF</option>
+      <option value="PDF">PDF</option>
+    </helper>
+  </element>
+  <element name="mcc:imageConstraints" id="441.0">
+    <label>Image constraints</label>
+    <description iso="true">restriction on access and/or use of browse graphic
+    </description>
+    <help></help>
+    <condition/>
+
+  </element>
+  <element name="mrc:filmDistortionInformationAvailability" id="254.0">
+    <label>Film distortion information availability</label>
+    <description>Indication of whether or not Calibration Reseau information is
+      available
+    </description>
+  </element>
+  <element name="cit:protocolRequest" id="412.0">
+    <label>Protocol request</label>
+    <description>Request used to access the resource depending on the protocol
+      (to be used mainly for POST requests)
+    </description>
+    <help></help>
+    <condition/>
+  </element>
+  <element name="mrd:formatDistributor" id="290.0">
+    <label>Formaat distributeur</label>
+    <description>Geeft informatie over de distributeur van het formaat</description>
+  </element>
+  <element name="cit:function" id="411.0">
+    <label>Functie</label>
+    <description>Code for function performed by the online resource
+    </description>
+  </element>
+  <element name="gex:geographicElement" id="336.0">
+    <label>Geografisch object</label>
+    <description>geeft het geografisch component van de dekking van het
+      beschreven object
+    </description>
+    <_condition>Conditional / description and temporalElement and
+      verticalElement not
+      documented?
+    </_condition>
+  </element>
+  <element name="gex:geographicIdentifier" id="349.0">
+    <label>Geographic identifier</label>
+    <description>Identifier used to represent a geographic area</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mri:geometricObjectCount" id="185.0">
+    <label>Geometric object count</label>
+    <description>Total number of the point or vector object type occurring in
+      the
+      dataset
+    </description>
+  </element>
+  <element name="mri:geometricObjectType" id="184.0">
+    <label>Geometric object type</label>
+    <description>Name of point and vector spatial objects used to locate zero-,
+      one-, and
+      two-dimensional spatial locations in the dataset
+    </description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mri:geometricObjects" id="178.0">
+    <label>Geometric objects</label>
+    <description>Information about the geometric objects used in the dataset
+    </description>
+  </element>
+  <element name="mri:georeferencedParameters" id="174.0">
+    <label>GeoreferencedParameters</label>
+    <description>GeoreferencedParameters</description>
+  </element>
+  <element name="mri:graphicOverview" id="31.0">
+    <label>Graphic overview</label>
+    <description>Provides a graphic that illustrates the resource(s) (should
+      include a legend
+      for the graphic)
+    </description>
+  </element>
+  <element name="mco:graphic" id="101.0">
+    <label>Graphic</label>
+    <description>Graphic /symbol indicating the constraint</description>
+  </element>
+  <element name="cit:graphic" id="375.0" context="cit:CI_Citation">
+    <label>Graphic</label>
+    <description>Citation graphic or logo for the cited resource</description>
+    <condition>optional</condition>
+  </element>
+  <element name="mas:graphicsFile" id="325.0">
+    <label>Graphics file</label>
+    <description>Full application schema given as a graphics file</description>
+  </element>
+  <element name="mco:handlingDescription" id="77.0">
+    <label>Handling description</label>
+    <description>Additional information about the restrictions on handling the
+      resource
+    </description>
+  </element>
+  <element name="mri:hierarchyLevel" id="6.0">
+    <label>Hierarchisch niveau</label>
+    <description>Hierarchisch niveau waar de metadata betrekking op heeft.</description>
+  </element>
+  <element name="mri:hierarchyLevelName" id="7.0">
+    <label>Beschrijving hierarchisch niveau</label>
+    <description>Naam van de hierarchieniveaus waarop de metadata
+      betrekking heeft.
+    </description>
+    <_condition>Conditional / hierarchyLevel is not equal to "dataset"?
+    </_condition>
+  </element>
+  <element name="cit:hoursOfService" id="391.0">
+    <label>Contacturen</label>
+    <description>Periode (tijd incl. tijdzone) waarbinnen contact
+      opgenomen kan worden met de organisatie of persoon.
+    </description>
+  </element>
+  <element name="mdb:identificationInfo" id="29.0">
+    <label>Identification info</label>
+    <description>Basic information about the resource(s) to which the metadata
+      applies
+    </description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mri:identifier" id="573.0">
+    <label>Identifier</label>
+    <description>Unique identifier for the resource. EXAMPLE: Universal Product
+      Code (UPC),
+      National Stock Number (NSN)
+    </description>
+  </element>
+  <element name="cit:identifier" id="573.0" context="cit:CI_Citation">
+    <label>Citation identifier</label>
+    <description>Identifier of the citation</description>
+  </element>
+  <element name="mri:identifier" id="575.0" context="mri:MD_Authority">
+    <label>Identifier</label>
+    <description>Identifier which belongs to the authority</description>
+  </element>
+  <element name="mrc:illuminationAzimuthAngle" id="245.0">
+    <label>Illumination azimuth angle</label>
+    <description>Illumination azimuth measured in degrees clockwise from true
+      north at the time
+      the image is taken. For images from a scanning device, refer to the centre
+      pixel of the
+      image
+    </description>
+  </element>
+  <element name="mrc:illuminationElevationAngle" id="244.0">
+    <label>Illumination elevation angle</label>
+    <description>Illumination elevation measured in degrees clockwise from the
+      target plane at
+      intersection of the optical line of sight with the Earth_s surface. For
+      images from a
+      scanning device, refer to the centre pixel of the image
+    </description>
+  </element>
+  <element name="mrc:imageQualityCode" id="247.0">
+    <label>Image quality code</label>
+    <description>Specifies the image quality</description>
+    <help>specifies the image quality</help>
+  </element>
+  <element name="mrc:imagingCondition" id="246.0">
+    <label>Imaging condition</label>
+    <description>Conditions affected the image</description>
+  </element>
+  <element name="mri:includedWithDataset" id="236.0">
+    <label>Included with dataset</label>
+    <description>Indication of whether or not the feature catalogue is included
+      with the
+      dataset
+    </description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mri:initiativeType" id="66.5">
+    <label>initiatief type</label>
+    <description>Type of initiative under which the aggregate dataset was
+      produced
+    </description>
+  </element>
+  <element name="cit:issueIdentification" id="405.0">
+    <label>Issue identification</label>
+    <description>Information identifying the issue of the series</description>
+  </element>
+  <element name="mri:keyword" id="53.0">
+    <label>Trefwoord</label>
+    <description>In het algemeen gebruikte woorden of geformaliseerde
+      zinnen om een onderwerp te beschrijven.
+    </description>
+  </element>
+  <element name="mri:language" context="mri:MD_Metadata" id="3.0">
+    <label>Metadata taal</label>
+    <description>Language used for documenting metadata</description>
+    <condition>conditional</condition>
+  </element>
+  <element name="mri:language" context="mri:MD_DataIdentification"
+           id="39.0">
+    <label>Taal van de bron</label>
+    <description>Language(s) used within the dataset</description>
+    <help>language(s) used within the dataset</help>
+    <_condition>Mandatory</_condition>
+  </element>
+  <element name="mrc:language" context="mrc:MD_FeatureCatalogueDescription"
+           id="235.0">
+    <label>Taal</label>
+    <description>Language(s) used within the catalogue</description>
+  </element>
+  <element name="mrc:lensDistortionInformationAvailability" id="255.0">
+    <label>Lens distortion information availability</label>
+    <description>Indication of whether or not lens aberration correction
+      information is
+      available
+    </description>
+  </element>
+  <element name="mcc:level" id="139.0">
+    <label>Niveau kwaliteitsbeschrijving</label>
+    <description>Niveau (dataset of serie) waar de kwaliteitsbeschrijving
+      betrekking op heeft.
+    </description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mcc:levelDescription" id="141.0">
+    <label>Beschrijving niveau kwaliteitsbeschrijving</label>
+    <description>Beschrijving van het niveau (dataset of serie) waar de
+      kwaliteitsbeschrijving betrekking op heeft
+    </description>
+    <_condition>Conditional / level not equal 'dataset' or 'series'?
+    </_condition>
+  </element>
+  <element name="mri:lineage" id="81.0">
+    <label>Lineage</label>
+    <description>Non-quantitative quality information about the lineage of the
+      data specified by
+      the scope
+    </description>
+    <_condition>Conditional / report not provided?</_condition>
+  </element>
+  <element name="cit:linkage" id="406.0">
+    <label>URL</label>
+    <description>Locatie voor online toegang bij gebruik van een Uniform
+      Resource Locator adres of een vergelijkbaar schema.
+    </description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mcc:linkage" id="442.0" context="mcc:MD_BrowseGraphic">
+    <label>Linkage</label>
+    <description>link to browse graphic</description>
+    <condition></condition>
+  </element>
+  <element name="mmi:maintenanceAndUpdateFrequency" id="143.0">
+    <label>Herzieningsfrequentie</label>
+    <description>Frequentie waarmee de data herzien wordt.</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mmi:maintenanceNote" id="148.0">
+    <label>Opmerking t.a.v. beheer</label>
+    <description>Informatie over zaken die nodig zijn om de bron te
+      beheren.
+    </description>
+  </element>
+  <element name="mrc:maxValue" id="260.0">
+    <label>Maximale waarde</label>
+    <description>Longest wavelength that the sensor is capable of collecting
+      within a designated
+      band
+    </description>
+  </element>
+  <element name="gex:maximumValue" id="356.0">
+    <label>Maximum waarde</label>
+    <description>Highest vertical extent contained in the dataset</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mri:measureDescription" id="102.0">
+    <label>Measure description</label>
+    <description>Description of the measure being determined</description>
+  </element>
+  <element name="mri:measureIdentification" id="101.0">
+    <label>Measure identification</label>
+    <description>Code identifying a registered standard procedure</description>
+  </element>
+  <element name="mrd:mediumFormat" id="296.0">
+    <label>Medium formaat</label>
+    <description>Method used to write to the medium</description>
+  </element>
+  <element name="mrd:mediumNote" id="297.0">
+    <label>Medium opmerkingen</label>
+    <description>Description of other limitations or requirements for using the
+      medium
+    </description>
+  </element>
+  <element name="mdb:metadataConstraints" id="34.0">
+    <label>Metadata beperkingen</label>
+    <description>Provides restrictions on the access and use of metadata
+    </description>
+  </element>
+  <element name="mdb:metadataExtensionInfo" id="14.0">
+    <description>Information describing metadata extensions</description>
+    <label>Metadata extensie info</label>
+  </element>
+  <element name="mdb:metadataMaintenance" id="22.0">
+    <label>Metadata beheer</label>
+    <description>Provides information about the frequency of metadata updates,
+      and the scope of
+      those updates
+    </description>
+  </element>
+  <element name="mri:metadataStandardName" id="10.0">
+    <label>Metadata standaard naam.</label>
+    <description>Naam van de gebruikte metadata-standaard.
+    </description>
+  </element>
+  <element name="mri:metadataStandardVersion" id="11.0">
+    <label>Metadata standaard versie</label>
+    <description>Versie (profiel) van de metadata-standaard die wordt
+      gebruikt.</description>
+  </element>
+  <element name="mrc:minValue" id="261.0">
+    <label>Minimale waarde</label>
+    <description>Shortest wavelength that the sensor is capable of collecting
+      within a
+      designated band
+    </description>
+  </element>
+  <element name="gex:minimumValue" id="355.0">
+    <label>Minimum waarde</label>
+    <description>Lowest vertical extent contained in the dataset</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mrc:name">
+    <label>Name</label>
+    <description>Identifiers for each attribute included in the resource. NOTE
+      These identifiers can be used to provide names for the attribute from a
+      standard set of names.
+    </description>
+  </element>
+  <element name="mri:name" context="mri:MD_AbstractClass" id="560.0">
+    <label>Name</label>
+    <description>Name</description>
+  </element>
+  <element name="mrd:name" context="mrd:MD_Medium" id="261.0">
+    <label>Name</label>
+    <description>Name of the medium on which the resource can be received
+    </description>
+    <condition>optional</condition>
+  </element>
+  <element name="mrd:identifier" context="mrd:MD_Medium" id="267.0">
+    <label>Identifier</label>
+    <description>Unique identifier for an instance of the MD_Medium
+    </description>
+    <condition>optional</condition>
+  </element>
+  <element name="mri:name" context="mri:RS_ReferenceSystem" id="196.0">
+    <label>Name</label>
+    <description>Name of reference system used</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mri:name" context="mri:MD_Format" id="285.0">
+    <label>Name</label>
+    <description>Name of the data transfer format(s)</description>
+    <help>name of the data transfer format(s)</help>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mri:name" context="mri:MD_ExtendedElementInformation"
+           id="307.0">
+    <label>Name</label>
+    <description>Name of the extended metadata element</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mri:name" context="mri:MD_AssociatedResource">
+    <label>Name</label>
+    <description>To be provided if no metadata reference provided</description>
+  </element>
+  <element name="mri:name">
+    <label>Name</label>
+    <description></description>
+  </element>
+  <element name="mas:name" context="mas:MD_ApplicationSchemaInformation"
+           id="321.0">
+    <label>Name</label>
+    <description>Name of the application schema used</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="cit:name" context="cit:CI_OnlineResource" id="409.0">
+    <label>Name of the resource</label>
+    <description>Name of the online resource</description>
+  </element>
+  <element name="cit:name" context="cit:CI_Series" id="414.0">
+    <label>Name</label>
+    <description>Name of the series, or aggregate dataset, of which the dataset
+      is a
+      part
+    </description>
+  </element>
+  <element name="mri:name" context="mri:MD_CodeDomain" id="537.0">
+    <label>Name</label>
+    <description>Name of the code domain</description>
+  </element>
+  <element name="mri:name" context="mri:MD_CodeValue" id="546.0">
+    <label>Name</label>
+    <description>Value name</description>
+  </element>
+  <element name="mri:name" context="mri:MD_Attribute" id="551.0">
+    <label>Name</label>
+    <description>Attribute name</description>
+  </element>
+  <element name="mri:name" context="mri:MD_Role" id="556.0">
+    <label>Name</label>
+    <description>Role name</description>
+  </element>
+  <element name="cit:name" context="cit:CI_Organisation" id="376.0">
+    <label>Organisatie naam</label>
+    <description>Name of the responsible organization</description>
+    <condition>conditional</condition>
+  </element>
+  <element name="cit:name" context="cit:CI_Individual" id="375.0">
+    <label>Naam Contactpersoon</label>
+    <description>Volledige naam van de contactpersoon</description>
+  </element>
+  <element name="cit:name">
+    <label>Name</label>
+    <description/>
+  </element>
+  <element name="mri:nameOfMeasure" id="100.0">
+    <label>Name of measure</label>
+    <description>Name of the test applied to the data</description>
+    <!-- ISO19138 Data quality basic measures Annex C - under revision ISO
+      19157 http://www.iso.org/iso/fr/catalogue_detail.htm?csnumber=32575 -->
+    <helper rel="mri:measureDescription">
+      <option value="">-- Completeness --</option>
+      <option value="Excess item"
+              title="Indication that an item is incorrectly present in the data"
+              id="ISO19138:2006:measure:1">Excess item
+      </option>
+      <option value="Number of excess items"
+              title="Number of items within the dataset, that should not have been in the dataset"
+              id="ISO19138:2006:measure:2">Number of excess items
+      </option>
+      <option value="Rate of excess items"
+              title="Number of excess items in the dataset in relation to the number of items that should have been present"
+              id="ISO19138:2006:measure:3">Rate of excess items
+      </option>
+      <option value="Number of duplicate feature instances"
+              title="Total number of exact duplications of feature instances within the data. Count of all items in the data that are incorrectly extracted with duplicate geometrie"
+              id="ISO19138:2006:measure:4">Number of duplicate feature instances
+      </option>
+      <option value="Missing item"
+              title="Indicator that shows that a specific item is missing in the data"
+              id="ISO19138:2006:measure:5">Missing item
+      </option>
+      <option value="Number of missing items"
+              title="Count of all items that should have been in the dataset and are missing"
+              id="ISO19138:2006:measure:6">Number of missing items
+      </option>
+      <option value="Rate of missing items"
+              title="Number of missing items in the dataset in relation to the number of items that should have been present"
+              id="ISO19138:2006:measure:7">Rate of missing items
+      </option>
+      <option value="">-- Logical consistency / Conceptual consistency
+        --
+      </option>
+      <option value="Conceptual schema noncompliance"
+              title="Indication that an item is not compliant to the rules of the relevant conceptual schema"
+              id="ISO19138:2006:measure:8">Conceptual schema noncompliance
+      </option>
+      <option value="Conceptual schema compliance"
+              title="Indication that an item complies with the rules of the relevant conceptual schema"
+              id="ISO19138:2006:measure:9">Conceptual schema compliance
+      </option>
+      <option
+              value="Number of items noncompliant to the rules of the conceptual schema"
+              title="Count of all items in the dataset that are noncompliant to the rules of the conceptual schema. If the conceptual schema explicitly or implicitly describes rules, these rules have to be followed. Violations against such rules can e.g. be invalid placement of features within a defined tolerance, duplication of features and invalid overlap of features."
+              id="ISO19138:2006:measure:10">Number of items noncompliant to the
+        rules of the conceptual
+        schema
+      </option>
+      <option value="Number of invalid overlaps of surfaces"
+              title="Total number of erroneous overlaps within the data Which surfaces may overlap and which must not is application dependent. Not all overlapping surfaces are necessarily erroneous. When reporting this data quality measure the types of feature classes corresponding to the illegal overlapping surfaces have to be reported as well."
+              id="ISO19138:2006:measure:11">Number of invalid overlaps of
+        surfaces
+      </option>
+      <option
+              value="Non-compliance rate with respect to the rules of the conceptual schema"
+              title="Number of items in the dataset that are noncompliant to the rules of the conceptual schema in relation to the total number of these items supposed to be in the dataset"
+              id="ISO19138:2006:measure:12">Non-compliance rate with respect to
+        the rules of the conceptual
+        schema
+      </option>
+      <option value=" Compliance rate with the rules of the conceptual schema"
+              title="number of items in the dataset in compliance with the rules of the conceptual schema in relation to the total number of items"
+              id="ISO19138:2006:measure:13">Compliance rate with the rules of
+        the conceptual schema
+      </option>
+      <option value="">-- Logical consistency / Domain consistency --
+      </option>
+      <option value="Value domain non-conformance"
+              title="Indication of if an item is not in conformance with its value domain"
+              id="ISO19138:2006:measure:14">Value domain non-conformance
+      </option>
+      <option value="Value domain conformance"
+              title="Indication of if an item is conforming to its value domain"
+              id="ISO19138:2006:measure:15">Value domain conformance
+      </option>
+      <option value="Number of items not in conformance with their value domain"
+              title="Count of all items in the dataset that are not in conformance with their value domain."
+              id="ISO19138:2006:measure:16">Number of items not in conformance
+        with their value domain
+      </option>
+      <option value="Value domain conformance rate"
+              title="Number of items in the dataset that are in conformance with their value domain in relation to the total number of items in the dataset"
+              id="ISO19138:2006:measure:17">Value domain conformance rate
+      </option>
+      <option value="Value domain non-conformance rate"
+              title="the number of items in the dataset that are not in conformance with their value domain in relation to the total number of items"
+              id="ISO19138:2006:measure:18">Value domain non-conformance rate
+      </option>
+      <option value="Physical structure conflicts"
+              title="Count of all items in the dataset that are stored in conflict with the physical structure of the dataset"
+              id="ISO19138:2006:measure:19">Physical structure conflicts
+      </option>
+      <option value="Physical structure conflict rate"
+              title="Number of items in the dataset that are stored in conflict with the physical structure of the dataset divided by the total number of items"
+              id="ISO19138:2006:measure:20">Physical structure conflict rate
+      </option>
+      <option value="">-- Logical consistency / Topological consistency
+        --
+      </option>
+      <option value="Number of faulty point-curve connections"
+              title="Number of faulty point-curve connections in the dataset. A point-curve connection exists where different curves touch. These curves have an intrinsic topological relationship that has to reflect the true constellation. If the point-curve connection contradicts the universe of discourse, the point-curve connection is faulty with respect to this data quality measure. The data quality measure counts the number of errors of this kind."
+              id="ISO19138:2006:measure:21">Number of faulty point-curve
+        connections
+      </option>
+      <option value="Rate of faulty point-curve connections"
+              title="Number of faulty link node connections in relation to the number of supposed link node connections"
+              id="ISO19138:2006:measure:22">Rate of faulty point-curve
+        connections
+      </option>
+      <option value="Number of missing connection due to undershoots"
+              title="Count of items in the dataset, within the parameter tolerance, that are mismatched due to undershoots"
+              id="ISO19138:2006:measure:23">Number of missing connection due to
+        undershoots
+      </option>
+      <option value="Number of missing connections due to overshoots"
+              title="Count of items in the dataset, within the parameter tolerance, that are mismatched due to overshoots"
+              id="ISO19138:2006:measure:24">Number of missing connections due to
+        overshoots
+      </option>
+      <option value="Number of invalid slivers"
+              title="Count of all items in the dataset that are invalid sliver surfaces. A sliver is an unintended area that occurs when adjacent surfaces are not digitized properly. The borders of the adjacent surfaces may unintentionally gap or overlap by small amounts to cause a topological error."
+              id="ISO19138:2006:measure:25">Number of invalid slivers
+      </option>
+      <option value="Number of invalid self intersect errors"
+              title="Count of all items in the data that illegally intersect with themselves"
+              id="ISO19138:2006:measure:26">Number of invalid self intersect
+        errors
+      </option>
+      <option value="Number of invalid self overlap errors"
+              title="Count of all items in the data that illegally self overlap"
+              id="ISO19138:2006:measure:27">Number of invalid self overlap
+        errors
+      </option>
+      <option value="">-- Positional accuracy / Absolute or external
+        accuracy / General measures --
+      </option>
+      <option value="Mean value of positional uncertainties"
+              title="Mean value of the positional uncertainties for a set of positions where the positional uncertainties are defined as the distance between a measured position and what is considered as the corresponding true position"
+              id="ISO19138:2006:measure:28">Mean value of positional
+        uncertainties
+      </option>
+      <option value="Mean value of positional uncertainties excluding outliers"
+              title="For a set of points where the distance does not exceed a defined threshold the arithmetical average of distances between their measured positions and what is considered as the corresponding true positions"
+              id="ISO19138:2006:measure:29">Mean value of positional
+        uncertainties excluding outliers
+      </option>
+      <option value="Number of positional uncertainties above a given threshold"
+              title="Number of positional uncertainties above a given threshold for a set of positions. The errors are defined as the distance between a measured position and what is considered as the corresponding true position"
+              id="ISO19138:2006:measure:30">Number of positional uncertainties
+        above a given threshold
+      </option>
+      <option value="Rate of positional errors above a given threshold"
+              title="Number of positional uncertainties above a given threshold for a set of positions in relation to the total number of measured positions. The errors are defined as the distance between a measured position and what is considered as the corresponding true position."
+              id="ISO19138:2006:measure:31">Rate of positional errors above a
+        given threshold
+      </option>
+      <option value="Covariance matrix"
+              title="A symmetrical square matrix with variances of point coordinates on the main diagonal and covariances between these coordinates as off-diagonal elements."
+              id="ISO19138:2006:measure:32">Covariance matrix
+      </option>
+      <option value="">-- Positional accuracy / Absolute or external
+        accuracy / Vertical --
+      </option>
+      <option value="Linear error probable"
+              title="Half length of the interval defined by an upper and a lower limit, in which the true value lies with probability 50%."
+              id="ISO19138:2006:measure:33">Linear error probable
+      </option>
+      <option value="Standard linear error"
+              title="Half length of the interval defined by an upper and a lower limit, in which the true value lies with probability 68.3%."
+              id="ISO19138:2006:measure:34">Standard linear error
+      </option>
+      <option value="Linear map accuracy at 90% significance level"
+              title="Half length of the interval defined by an upper and a lower limit, in which the true value lies with probability 90%."
+              id="ISO19138:2006:measure:35">Linear map accuracy at 90%
+        significance level
+      </option>
+      <option value="Linear map accuracy at 95% significance level"
+              title="Half length of the interval defined by an upper and a lower limit, in which the true value lies with probability 95%."
+              id="ISO19138:2006:measure:36">Linear map accuracy at 95%
+        significance level
+      </option>
+      <option value="Linear map accuracy at 99% significance level"
+              title="Half length of the interval defined by an upper and a lower limit, in which the true value lies with probability 99%."
+              id="ISO19138:2006:measure:37">Linear map accuracy at 99%
+        significance level
+      </option>
+      <option value="Near certainty linear error"
+              title="Half length of the interval defined by an upper and a lower limit, in which the true value lies with probability 99.8%."
+              id="ISO19138:2006:measure:38">Near certainty linear error
+      </option>
+      <option value="Root mean square error"
+              title="Standard deviation, where the true value is not estimated from the observations but known a priori."
+              id="ISO19138:2006:measure:39">Root mean square error
+      </option>
+      <option
+              value="Absolute linear error at 90% significance level of biased vertical data (Alternative 1)"
+              title="The absolute vertical accuracy of the data’s coordinates, expressed in terms of linear error at 90% probability given that a bias is present."
+              id="ISO19138:2006:measure:40">Absolute linear error at 90%
+        significance level of biased
+        vertical data (Alternative 1)
+      </option>
+      <option
+              value="Absolute linear error at 90% significance level of biased vertical data"
+              title="The absolute vertical accuracy of the data’s coordinates, expressed in terms of linear error at 90% probability given that a bias is present."
+              id="ISO19138:2006:measure:41">Absolute linear error at 90%
+        significance level of biased
+        vertical data
+      </option>
+      <option value="">-- Positional accuracy / Absolute or external
+        accuracy / Horizontal --
+      </option>
+      <option value="Circular standard deviation"
+              title="Radius describing a circle, in which the true point location lies with the probability of 39.4%."
+              id="ISO19138:2006:measure:42">Circular standard deviation
+      </option>
+      <option value="Circular error probable"
+              title="Radius describing a circle, in which the true point location lies with the probability of 50%."
+              id="ISO19138:2006:measure:43">Circular error probable
+      </option>
+      <option value=" Circular map accuracy standard"
+              title="Radius describing a circle, in which the true point location lies with the probability of 90%."
+              id="ISO19138:2006:measure:44">Circular map accuracy standard
+      </option>
+      <option value="Circular error at 95% significance level"
+              title="Radius describing a circle, in which the true point location lies with the probability of 95%."
+              id="ISO19138:2006:measure:45">Circular error at 95% significance
+        level
+      </option>
+      <option value="Circular near certainty error"
+              title="Radius describing a circle, in which the true point location lies with the probability of 99.8%."
+              id="ISO19138:2006:measure:46">Circular near certainty error
+      </option>
+      <option value="Root mean square error of planimetry"
+              title="Radius of a circle around the given point, in which the true value lies with probability P."
+              id="ISO19138:2006:measure:47">Root mean square error of planimetry
+      </option>
+      <option
+              value="Absolute circular error at 90% significance level of biased data (Alternative 2)"
+              title="The absolute horizontal accuracy of the data’s coordinates, expressed in terms of circular error at 90% probability given that a bias is present."
+              id="ISO19138:2006:measure:48">Absolute circular error at 90%
+        significance level of biased data
+        (Alternative 2)
+      </option>
+      <option
+              value="Absolute circular error at 90% significance level of biased data"
+              title="The absolute horizontal accuracy of the data’s coordinates, expressed in terms of circular error at 90% probability given that a bias is present."
+              id="ISO19138:2006:measure:49">Absolute circular error at 90%
+        significance level of biased data
+      </option>
+      <option value="Uncertainty ellipse"
+              title="2D ellipse with the two main axes indicating the direction and magnitude of the highest and the lowest uncertainty of a 2D point"
+              id="ISO19138:2006:measure:50">Uncertainty ellipse
+      </option>
+      <option value="Confidence ellipse"
+              title="2D ellipse with the two main axes indicating the direction and magnitude of the highest and the lowest uncertainty of a 2D point"
+              id="ISO19138:2006:measure:51">Confidence ellipse
+      </option>
+      <option value="">-- Positional accuracy / Relative or internal
+        accuracy --
+      </option>
+      <option value="Relative vertical error"
+              title="Evaluation of the random errors of one relief feature to another in the same dataset or on the same map/chart. It is a function of the random errors in the two elevations with respect to a common vertical datum."
+              id="ISO19138:2006:measure:52">Relative vertical error
+      </option>
+      <option value="Relative horizontal error"
+              title="Evaluation of the random errors in the horizontal position of one feature to another in the same dataset or on the same map/chart."
+              id="ISO19138:2006:measure:53">Relative horizontal error
+      </option>
+      <option value="">-- Temporal accuracy / Accuracy of a time
+        measurement --
+      </option>
+      <option value="Time accuracy at 68.3% significance level"
+              title="Half length of the interval defined by an upper and a lower limit, in which the true value for the time instance lies with probability 68.3%."
+              id="ISO19138:2006:measure:54">Time accuracy at 68.3% significance
+        level
+      </option>
+      <option value="Time accuracy at 50% significance level"
+              title="Half length of the interval defined by an upper and a lower limit, in which the true value for the time instance lies with probability 50%."
+              id="ISO19138:2006:measure:55">Time accuracy at 50% significance
+        level
+      </option>
+      <option value="Time accuracy at 90% significance level"
+              title="Half length of the interval defined by an upper and a lower limit, in which the true value for the time instance lies with probability 90%."
+              id="ISO19138:2006:measure:56">Time accuracy at 90% significance
+        level
+      </option>
+      <option value="Time accuracy at 95% significance level"
+              title="Half length of the interval defined by an upper and a lower limit, in which the true value for the time instance lies with probability 95%."
+              id="ISO19138:2006:measure:57">Time accuracy at 95% significance
+        level
+      </option>
+      <option value="Time accuracy at 99% significance level"
+              title="Half length of the interval defined by an upper and a lower limit, in which the true value for the time instance lies with probability 99%."
+              id="ISO19138:2006:measure:58">Time accuracy at 99% significance
+        level
+      </option>
+      <option value="Time accuracy at 99.8% significance level"
+              title="Half length of the interval defined by an upper and a lower limit, in which the true value for the time instance lies with probability 99.8%."
+              id="ISO19138:2006:measure:59">Time accuracy at 99.8% significance
+        level
+      </option>
+      <option value="">-- Thematic accuracy / Classification
+        correctness --
+      </option>
+      <option value="Number of incorrectly classified features"
+              title="Number of incorrectly classified features"
+              id="ISO19138:2006:measure:60">Number of
+        incorrectly classified features
+      </option>
+      <option value="Misclassification rate"
+              title="number of incorrectly classified features in relation to the number of features that are supposed to be there"
+              id="ISO19138:2006:measure:61">Misclassification rate
+      </option>
+      <option value="Misclassification matrix"
+              title="matrix that indicates the number of items of class (i) classified as class (j)."
+              id="ISO19138:2006:measure:62">Misclassification matrix
+      </option>
+      <option value="Relative misclassification matrix"
+              title="matrix that indicates the number of items of class (i) classified as class (i) divided by the number of items of class (i)"
+              id="ISO19138:2006:measure:63">Relative misclassification matrix
+      </option>
+      <option value="Kappa coefficient"
+              title="Coefficient to quantify the proportion of agreement of assignments to classes by removing misclassifications"
+              id="ISO19138:2006:measure:64">Kappa coefficient
+      </option>
+      <option value="">-- Thematic accuracy / Non-quantitative
+        attribute correctness --
+      </option>
+      <option value="Number of incorrect attribute values"
+              title="Total number of erroneous attribute values within the relevant part of the dataset"
+              id="ISO19138:2006:measure:65">Number of incorrect attribute values
+      </option>
+      <option value="Rate of correct attribute values"
+              title="Number of correct attribute values in relation to the total number of attribute values"
+              id="ISO19138:2006:measure:66">Rate of correct attribute values
+      </option>
+      <option value="Rate of incorrect attribute values"
+              title="Number of attribute values where incorrect values are assigned in relation to the total number of attribute values"
+              id="ISO19138:2006:measure:67">Rate of incorrect attribute values
+      </option>
+      <option value="">-- Thematic accuracy / Quantitative attribute
+        accuracy --
+      </option>
+      <option value="Attribute value uncertainty at 68.3% significance level"
+              title="Half length of the interval defined by an upper and a lower limit, in which the true value for the quantitative attribute lies with probability 68.3%."
+              id="ISO19138:2006:measure:68">Attribute value uncertainty at 68.3%
+        significance level
+      </option>
+      <option value="Attribute value uncertainty at 50% significance level"
+              title="Half length of the interval defined by an upper and a lower limit, in which the true value for the quantitative attribute lies with probability 50%."
+              id="ISO19138:2006:measure:69">Attribute value uncertainty at 50%
+        significance level
+      </option>
+      <option value="Attribute value uncertainty at 90% significance level"
+              title="Half length of the interval defined by an upper and a lower limit, in which the true value for the quantitative attribute lies with probability 90%."
+              id="ISO19138:2006:measure:70">Attribute value uncertainty at 90%
+        significance level
+      </option>
+      <option value="Attribute value uncertainty at 95% significance level"
+              title="Half length of the interval defined by an upper and a lower limit, in which the true value for the quantitative attribute lies with probability 95%."
+              id="ISO19138:2006:measure:71">Attribute value uncertainty at 95%
+        significance level
+      </option>
+      <option value="Attribute value uncertainty at 99% significance level"
+              title="Half length of the interval defined by an upper and a lower limit, in which the true value for the quantitative attribute lies with probability 99%."
+              id="ISO19138:2006:measure:72">Attribute value uncertainty at 99%
+        significance level
+      </option>
+      <option value="Attribute value uncertainty at 99.8% significance level"
+              title="Half length of the interval defined by an upper and a lower limit, in which the true value for the quantitative attribute lies with probability 99.8%."
+              id="ISO19138:2006:measure:73">Attribute value uncertainty at 99.8%
+        significance level
+      </option>
+    </helper>
+  </element>
+  <element name="mri:northBoundLatitude" id="347.0">
+    <label>North bound</label>
+    <description>Northern-most, coordinate of the limit of the dataset extent
+      expressed in
+      latitude in decimal degrees (positive north)
+    </description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mri:numberOfDimensions" id="158.0">
+    <label>Number of dimensions</label>
+    <description>Number of independent spatial-temporal axes</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mri:obligation" id="311.0">
+    <label>Verplichting</label>
+    <description>Obligation of the extended element</description>
+  </element>
+  <element name="mrd:offLine" id="278.0">
+    <label>Offline</label>
+    <description>Information about offline media on which the resource can be
+      obtained
+    </description>
+  </element>
+  <element name="mrc:offset" id="267.0">
+    <label>Verschuiving (Offset)</label>
+    <description>The physical value corresponding to a cell value of zero
+    </description>
+  </element>
+  <element name="mrd:onLine" id="277.0">
+    <label>OnLine bronnen</label>
+    <description>Information about online sources from which the resource can be
+      obtained
+    </description>
+  </element>
+  <element name="cit:onlineResource" id="390.0">
+    <help>Define URL to access the website</help>
+    <label>Website</label>
+    <description>On-line information that can be used to contact the individual
+      or
+      organisation
+    </description>
+  </element>
+  <element name="mrd:orderingInstructions" id="301.0">
+    <label>Order procedure</label>
+    <description>Algemene instructies, voorwaarden en services geleverd
+      door de distributeur.
+    </description>
+  </element>
+  <element name="mri:orientationParameterAvailability" id="172.0">
+    <label>Beschikbaarheid orientatie parameters</label>
+    <description>Indication of whether or not orientation parameters are
+      available
+    </description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mri:orientationParameterDescription" id="173.0">
+    <label>Beschrijving orientatie parameters</label>
+    <description>Description of parameters used to describe sensor orientation
+    </description>
+  </element>
+  <element name="mcc:other" id="155.0">
+    <label>Anders</label>
+    <description>Class of information that does not fall into the other
+      categories to which the
+      information applies
+    </description>
+    <condition/>
+  </element>
+  <element name="cit:otherCitationDetails" id="371.0">
+    <label>Overige citatie details</label>
+    <description>Overige informatie die nodig is om de citatie gegevens te
+      complementeren en welke elders niet is opgenomen.
+    </description>
+  </element>
+  <element name="mco:otherConstraints" id="72.0">
+    <label>Overige beperkingen</label>
+    <description>Andere restricties of beperkingen die niet in andere
+      velden kunnen worden ondergebracht, bijvoorbeeld de naam van de
+      copyrighthouder.
+    </description>
+    <condition>conditional</condition>
+  </element>
+  <element name="cit:page" id="416.0">
+    <label>Pagina</label>
+    <description>Details on which pages of the publication the article was
+      published
+    </description>
+  </element>
+  <element name="mri:parameterCitation" id="175.0">
+    <label>Parameter citatie</label>
+    <description>Reference providing description of the parameters</description>
+  </element>
+  <element name="mri:parentEntity" id="316.0">
+    <label>Parent entity</label>
+    <description>Name of the metadata entity(s) under which this extended
+      metadata element may
+      appear. The name(s) may be standard metadata element(s) or other extended
+      metadata
+      element(s).
+    </description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mri:parentIdentifier" id="5.0">
+    <label>Parent identifier</label>
+    <description>Unieke ID van de metadata waarvan deze metadata een
+      subset (child) is.
+    </description>
+  </element>
+  <element name="mri:pass" id="132.0">
+    <label>Pass</label>
+    <description>Indication of the conformance result where 0 = fail and 1 =
+      pass
+    </description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mrc:peakResponse" id="263.0">
+    <label>Peak response</label>
+    <description>Wavelength at which the response is the highest</description>
+  </element>
+  <element name="mri:phone" id="526.0">
+    <label>Telefoon/Fax</label>
+    <description>Telefoonnummer van de persoon of organisatie.</description>
+  </element>
+  <element name="mrd:plannedAvailableDateTime" id="300.0">
+    <label>Geplande beschikbaarheid (datum tijdstip)</label>
+    <description>date and time when the dataset will be available
+      (CCYY-MM-DDThh:mm:ss)
+    </description>
+  </element>
+  <element name="mri:pointInPixel" id="167.0">
+    <label>Point in Pixel</label>
+    <description>Point in a pixel corresponding to the Earth location of the
+      pixel
+    </description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mri:pointOfContact" id="29.0">
+    <label>Point of contact</label>
+    <description>Identification of, and means of communication with, person(s)
+      and
+      organizations(s) associated with the resource(s)
+    </description>
+  </element>
+  <element name="gex:polygon" id="342.0">
+    <label>polygoon</label>
+    <description>Sets of points defining the bounding polygon</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mpc:portrayalCatalogueCitation" id="269.0">
+    <label>Portrayal catalogus citatie</label>
+    <description>Bibliographic reference to the portrayal catalogue cited
+    </description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mdb:portrayalCatalogueInfo" id="19.0">
+    <label>Portrayal catalogus info</label>
+    <description>Provides information about the catalogue of rules defined for
+      the portrayal of
+      a resource(s)
+    </description>
+  </element>
+  <element name="cit:positionName" id="377.0">
+    <label>Rol contactpersoon</label>
+    <description>Beschrijving op welke manier de persoon betrokken is bij
+      de data.
+    </description>
+    <condition>conditional</condition>
+  </element>
+  <element name="cit:postalCode" id="392.0">
+    <label>Postcode</label>
+    <description>Postcode</description>
+  </element>
+  <element name="mri:presentationForm" id="368.0">
+    <label>Wijze van presentatie</label>
+    <description>Mode in which the resource is represented</description>
+  </element>
+  <element name="mrl:processStep" id="84.0">
+    <label>Uitgevoerde bewerkingen</label>
+    <description>Information about an event in the creation process for the data
+      specified by
+      the scope
+    </description>
+    <condition>conditional</condition>
+  </element>
+  <element name="mrc:processingLevelCode" id="249.0">
+    <label>Processing level code</label>
+    <description>Image distributor_s code that identifies the level of
+      radiometric and geometric
+      processing that has been applied
+    </description>
+  </element>
+  <element name="mrl:processor" id="90.0">
+    <label>Producent</label>
+    <description>Identification of, and means of communication with, person(s)
+      and
+      organization(s) associated with the process step
+    </description>
+  </element>
+  <element name="cit:protocol" id="398.0" alias="protocol">
+    <label>Protocol</label>
+    <description>Protocol waarmee de webkoppeling benaderbaar is</description>
+    <helper>
+      <!--<option value="WWW:LINK">Web link (URL)</option>
+      <option value="WWW:LINK-1.0-http&#45;&#45;publication-URL">Main publication link</option>
+      <option value="WWW:LINK-1.0-http&#45;&#45;metadata-URL">Point of truth URL of this metadata record</option>
+      <option value="FILE">Download (file)</option>
+      <option value="COPYFILE">Download (copy)</option>
+      <option value="DB">Download (database)</option>
+      <option value="WWW:DOWNLOAD-1.0-link&#45;&#45;download">Download (link)</option>
+      <option value="NETWORK:LINK">Download (visible path)</option>
+      <option value="OGC:WFS">Download (WFS)</option>
+      <option value="OGC:WCS">Download (WCS)</option>
+      <option value="OGC:WMS">View (WMS)</option>
+      <option value="OGC:WMTS">View (WMTS)</option>
+      <option value="OGC:WPS">OGC-WPS Web Processing Service</option>
+      <option value="OGC:OWS-C">View (OWS Context)</option>-->
+
+      <option value="OGC API - Coverages">OGC API - Coverages</option>
+      <option value="OGC API - Features">OGC API - Features</option>
+      <option value="OGC API - Maps">OGC API - Maps</option>
+      <option value="OGC API - Records">OGC API - Records</option>
+      <option value="OGC:3DTILES">OGC-3DTiles Dataset</option>
+      <option value="OGC:COG">OGC-Cloud Optimized GeoTIFF</option>
+      <option value="OGC:CSW">OGC-CSW Catalogue Service for the Web
+      </option>
+      <option value="OGC:KML">OGC-KML Keyhole Markup Language
+      </option>
+      <option value="OGC:GML">OGC-GML Geography Markup Language
+      </option>
+      <option value="OGC:ODS">OGC-ODS OpenLS Directory Service
+      </option>
+      <option value="OGC:OGS">OGC-ODS OpenLS Gateway Service</option>
+      <option value="OGC:OUS">OGC-ODS OpenLS Utility Service</option>
+      <option value="OGC:OPS">OGC-ODS OpenLS Presentation Service</option>
+      <option value="OGC:ORS">OGC-ODS OpenLS Route Service</option>
+      <option value="OGC:SOS">OGC-SOS Sensor Observation Service</option>
+      <option value="OGC:SPS">OGC-SPS Sensor Planning Service</option>
+      <option value="OGC:SAS">OGC-SAS Sensor Alert Service</option>
+      <option value="OGC:WCS">OGC-WCS Web Coverage Service</option>
+      <option value="OGC:WCTS">OGC-WCTS Web Coordinate Transformation Service</option>
+      <option value="OGC:WFS">OGC-WFS Web Feature Service</option>
+      <option value="INSPIRE Atom">INSPIRE Atom</option>
+      <option value="OGC:WMS">OGC-WMS Web Map Service</option>
+      <option value="OGC:WMTS">OGC-WMS Web Map Tile Service</option>
+      <option value="OGC:WNS">OGC-WNS Web Notification Service</option>
+      <option value="OGC:WPS">OGC-WPS Web Processing Service</option>
+      <option value="WWW:DOWNLOAD-1.0-ftp--download">File for download through FTP</option>
+      <option value="WWW:DOWNLOAD-1.0-http--download">File for download</option>
+      <option value="ESRI:REST">ESRI REST Service</option>
+      <option value="ESRI:REST-TILED">ESRI REST Tiled Service</option>
+      <option value="FILE:GEO">GIS file</option>
+      <option value="FILE:RASTER">GIS RASTER file</option>
+      <option value="WWW:LINK-1.0-http--link" default="">Web address (URL)</option>
+      <option value="WWW:LINK-1.0-http--rss">RSS News feed (URL)</option>
+      <option value="DB:POSTGIS">PostGIS database table</option>
+      <option value="DB:ORACLE">ORACLE database table</option>
+      <option value="WWW:LINK-1.0-http--opendap">OPeNDAP URL</option>
+      <option value="RBNB:DATATURBINE">Data Turbine</option>
+      <option value="UKST">Unknown Service Type</option>
+    </helper>
+  </element>
+  <element name="mri:purpose" id="26.0">
+    <label>Doel van vervaardiging</label>
+    <description>Doel waarvoor de data oorspronkelijk werd gemaakt of
+      bedoeld. Bijvoorbeeld de projectnaam.
+    </description>
+  </element>
+  <element name="mrc:radiometricCalibrationDataAvailability" id="252.0">
+    <label>Radiometric calibration data availability</label>
+    <description>Indication of whether or not the radiometric calibration
+      information for
+      generating the radiometrically calibrated standard data product is
+      available
+    </description>
+  </element>
+  <element name="mrl:rationale" id="88.0">
+    <label>Rationale</label>
+    <description>Requirement or purpose for the process step</description>
+  </element>
+  <element name="mri:rationale" id="318.0"
+           context="mri:MD_ExtendedElementInformation">
+    <label>Rationale</label>
+    <description>Reason for creating the extended element</description>
+  </element>
+  <element name="mrs:referenceSystemIdentifier" id="187.0">
+    <label>Referentiesysteem info</label>
+    <description>Beschrijving van de referentiesystemen welke van
+      toepassing zijn op de dataset.
+    </description>
+    <condition>conditional</condition>
+  </element>
+  <element name="mdb:referenceSystemInfo" id="13.0">
+    <label>Referentiesysteem info</label>
+    <description>Beschrijving van de referentiesystemen welke van
+      toepassing zijn op de dataset.
+    </description>
+  </element>
+  <element name="mco:reference" id="102.0">
+    <label>Référence</label>
+    <description iso="true">citation for the limitation or constraint EXAMPLE
+      Copyright statement,licence agreement, etc.
+    </description>
+    <help></help>
+    <condition/>
+  </element>
+  <element name="mco:releasability" id="103.0">
+    <label>Releasability</label>
+    <description iso="true">information concerning the parties to whom the
+      resource can or cannot be released
+    </description>
+    <help></help>
+    <condition/>
+  </element>
+  <element name="mco:responsibleParty" id="104.0">
+    <label>Party responsible</label>
+    <description iso="true">Party responsible for the resource constraints
+    </description>
+    <help></help>
+    <condition>mandatory</condition>
+  </element>
+  <element name="lan:responsibleParty" id="455.0"
+           context="lan:PT_LocaleContainer">
+    <label>Party responsible</label>
+    <description iso="true">Responsible parties of the locale container
+    </description>
+    <help></help>
+    <condition>mandatory</condition>
+  </element>
+
+  <element name="mco:MD_Releasability" id="114.0">
+    <label>Releasability</label>
+    <description iso="true">information about resource release constraints
+    </description>
+    <help></help>
+    <condition/>
+  </element>
+  <element name="mco:addressee" id="115.0" context="mco:MD_Releasability">
+    <label>Addressee</label>
+    <description iso="true">party to which the release statement applies
+    </description>
+    <help></help>
+    <condition/>
+  </element>
+  <element name="mco:statement" id="116.0" context="mco:MD_Releasability">
+    <label>Statement</label>
+    <description iso="true">Release statement</description>
+    <help></help>
+    <condition/>
+  </element>
+  <element name="mco:disseminationConstraints" id="117.0"
+           context="mco:MD_Releasability">
+    <label>Constraints of dissemination</label>
+    <description iso="true">Component in determining releasability</description>
+    <help></help>
+    <condition/>
+  </element>
+
+  <element name="mdq:report" id="80.0">
+    <label>Rapport</label>
+    <description>Quantitative quality information for the data specified by the
+      scope
+    </description>
+    <condition>conditional</condition>
+  </element>
+  <element name="mrl:resolution" id="182.0">
+    <label>Resolutie</label>
+    <description>Degree of detail in the grid dataset</description>
+  </element>
+  <element name="mri:vertical">
+    <label>Vertical sampling distance</label>
+    <description>Vertical sampling distance</description>
+  </element>
+  <element name="mri:angularDistance">
+    <label>Angular sampling measure</label>
+    <description>Angular sampling measure</description>
+  </element>
+  <element name="mri:levelOfDetail">
+    <label>Level of detail</label>
+    <description>Brief textual description of the spatial resolution of the
+      resource
+    </description>
+  </element>
+  <element name="mri:MD_Resolution_Type">
+    <label>Resolution type</label>
+    <description/>
+  </element>
+  <element name="mri:resourceConstraints" id="35.0">
+    <label>Beperkingen van de omschreven data</label>
+    <description>geeft informatie over de beperkingen van de beschreven
+      databron.
+    </description>
+  </element>
+  <element name="mri:resourceFormat" id="32.0">
+    <label>Formaat databron</label>
+    <description>Geeft een omschrijving van het formaat van de databron.</description>
+  </element>
+  <element name="mri:resourceMaintenance" id="30.0">
+    <label>Beheer van de bron</label>
+    <description>Geeft informatie over de frequentie en het bereik van het
+      bijwerken van de databron.
+    </description>
+  </element>
+  <element name="mri:resourceSpecificUsage" id="34.0">
+    <label>Potenteel gebruik</label>
+    <description>Geeft informatie over de toepassingen waarvoor de data
+      gebruikt kan worden.
+    </description>
+  </element>
+  <element name="mri:result" id="107.0">
+    <label>Resultaat</label>
+    <description>Value (or set of values) obtained from applying a data quality
+      measure or the
+      out come of evaluating the obtained value (or set of values) against a
+      specified
+      acceptable conformance quality level
+    </description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="cit:role" id="566.0" context="mri:MD_Association">
+    <label>Rol</label>
+    <description>Reference to the ends (roles) of a concrete association
+    </description>
+  </element>
+  <element name="mri:rule" id="317.0">
+    <label>Regel (rule)</label>
+    <description>Specifies how the extended element relates to other existing
+      elements and
+      entities
+    </description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mri:scaleDenominator" id="94.0">
+    <label>Schaal</label>
+    <description>Denominator of the representative fraction on a source map
+    </description>
+  </element>
+  <element name="mrc:scaleFactor" id="266.0">
+    <label>Schaalfaktor</label>
+    <description>Scale factor which has been applied to the cell value
+    </description>
+  </element>
+  <element name="mas:schemaAscii" id="324.0">
+    <description>Full application schema given as an ASCII file</description>
+    <label>Schema ASCII</label>
+  </element>
+  <element name="mas:schemaLanguage" id="322.0">
+    <label>Schema taal</label>
+    <description>Identificatie van de gebruikte taal van het
+      applicatieschema.
+    </description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mdq:scope" id="79.0">
+    <label>Scope</label>
+    <description>The specific data to which the data quality information
+      applies
+    </description>
+  </element>
+  <element name="mrc:sequenceIdentifier" id="257.0">
+    <label>Sequence identifier</label>
+    <description>Number that uniquely identifies instances of bands of
+      wavelengths on which a
+      sensor operates
+    </description>
+  </element>
+  <element name="mri:series" id="369.0">
+    <label>Series</label>
+    <description>Information about the series, or aggregate dataset, of which
+      the dataset is a
+      part
+    </description>
+  </element>
+  <element name="mri:shortName" id="308.0">
+    <label>Korte naam</label>
+    <description>Short form suitable for use in an implementation method such as
+      XML or SGML.
+      NOTE other methods may be used
+    </description>
+  </element>
+  <element name="mas:softwareDevelopmentFile" id="326.0">
+    <label>Bestand software ontwikkeling</label>
+    <description>Full application schema given as a software development file
+    </description>
+  </element>
+  <element name="mas:softwareDevelopmentFileFormat" id="327.0">
+    <label>Formaat bestand Software ontwikkeling</label>
+    <description>Software dependent format used for the application schema
+      software dependent
+      file
+    </description>
+  </element>
+  <element name="mrl:source" id="85.0">
+    <label>Source</label>
+    <description>Information about the source data used in creating the data
+      specified by the
+      scope
+    </description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mri:source" id="319.0"
+           context="mri:MD_ExtendedElementInformation">
+    <condition>mandatory</condition>
+    <label>Bron</label>
+    <description>Name of the person or organization creating the extended
+      element
+    </description>
+  </element>
+  <element name="mrl:sourceCitation" id="96.0">
+    <label>Bron citatie</label>
+    <description>Recommended reference to be used for the source data
+    </description>
+  </element>
+  <element name="mri:sourceExtent" id="97.0">
+    <label>Bron dekking (extent)</label>
+    <description>Information about the spatial, vertical and temporal extent of
+      the source
+      data
+    </description>
+    <condition>conditional</condition>
+  </element>
+  <element name="mrl:sourceReferenceSystem" id="95.0">
+    <label>Bron referentiesysteem</label>
+    <description>Spatial reference system used by the source data</description>
+  </element>
+  <element name="mrl:sourceStep" id="98.0">
+    <label>Bron process</label>
+    <description>Information about an event in the creation process for the
+      source
+      data
+    </description>
+  </element>
+  <element name="mri:southBoundLatitude" id="346.0">
+    <label>South bound</label>
+    <description>Southern-most coordinate of the limit of the dataset extent,
+      expressed in
+      latitude in decimal degrees (positive north)
+    </description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gex:spatialExtent" id="353.0">
+    <label>Ruimtelijke dekking</label>
+    <description>Spatial extent component of composite spatial and temporal
+      extent
+    </description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mdb:spatialRepresentationInfo" id="12.0">
+    <label>Ruimtelijke representatie info</label>
+    <description>digital representation of spatial information in the
+      dataset
+    </description>
+  </element>
+  <element name="mri:spatialRepresentationType" id="37.0">
+    <label>Ruimtelijk schema</label>
+    <description>Methode die gebruikt wordt om de geografische informatie
+      ruimtelijk te representeren (bijv. vector).
+    </description>
+  </element>
+  <element name="mri:spatialResolution" id="38.0">
+    <label>Ruimtelijke resolutie</label>
+    <description>Factor waarmee de dichtheid van de gegevens in de dataset
+      wordt aangegeven.
+    </description>
+  </element>
+  <element name="mri:specificUsage" id="63.0">
+    <label>Specific usage</label>
+    <description>Brief description of the resource and/or resource series
+      usage
+    </description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mri:specification" id="130.0"
+           context="mri:DQ_ConformanceResult">
+    <condition>mandatory</condition>
+    <label>Specificatie</label>
+    <description>Citation of product specification or user requirement against
+      which data is
+      being evaluated
+    </description>
+  </element>
+  <element name="mri:specification" id="288.0" context="mri:MD_Format">
+    <label>Specificatie</label>
+    <description>Name of a subset, profile, or product specification of the
+      format
+    </description>
+  </element>
+  <element name="mri:specification">
+    <label>Specificatie</label>
+  </element>
+  <element name="mrl:statement" id="83.0">
+    <label>Statement</label>
+    <description>General explanation of the data producer_s knowledge about the
+      lineage of a
+      dataset
+    </description>
+    <condition>conditional</condition>
+  </element>
+  <element name="mri:status" id="28.0">
+    <label>Status</label>
+    <description>Status of the resource(s)</description>
+  </element>
+  <element name="mri:supplementalInformation" id="46.0">
+    <label>Aanvullende informatie</label>
+    <description>Aanvullende informatie over de data, bijvoorbeeld
+      documentatie of handleiding.
+    </description>
+  </element>
+  <element name="gex:temporalElement" id="337.0">
+    <label>Temporeel element</label>
+    <description>provides temporal component of the extent of the
+      referring object
+    </description>
+    <condition>conditional</condition>
+  </element>
+  <element name="mri:textGroup" id="602.0">
+    <label>TextGroup</label>
+    <description>TextGroup</description>
+  </element>
+  <element name="mri:thesaurusName" id="55.0">
+    <label>Thesaurus naam</label>
+    <description>Naam van de formele thesaurus of een andere officiele
+      instantie/wijze waarop trefwoorden zijn gegroepeerd.
+    </description>
+  </element>
+  <element name="cit:title" id="285.0"
+           context="/mdb:MD_Metadata/mdb:distributionInfo/mrd:MD_Distribution/mrd:distributionFormat/mrd:MD_Format/mrd:formatSpecificationCitation/cit:CI_Citation/cit:title">
+    <label>Format name</label>
+    <description>Name of the data transfer format(s)</description>
+    <help>File or link format name</help>
+    <helper>
+      <option value="Text">Text</option>
+      <option value="XLS">XLS</option>
+      <option value="ESRI Shapefile">ESRI Shapefile</option>
+      <option value="Mapinfo MIF/MID">Mapinfo MIF/MID</option>
+      <option value="Mapinfo TAB">Mapinfo TAB</option>
+      <option value="KML">KML</option>
+      <option value="GML">GML</option>
+      <option value="XYZ Ascii">XYZ Ascii</option>
+      <option value="NetCDF">NetCDF</option>
+      <option value="GeoTIFF">GeoTIFF</option>
+      <option value="TIFF">TIFF</option>
+      <option value="ECW">ECW</option>
+      <option value="JPEG2000">JPEG2000</option>
+      <option value="ZIP">ZIP</option>
+      <option value="PDF">PDF</option>
+      <option value="PNG">PNG</option>
+      <option value="JPEG">JPEG</option>
+      <option value="OGC:WMC">OGC:WMC</option>
+      <option value="OGC:OWS-C">OGC OWS Context</option>
+    </helper>
+  </element>
+
+  <element name="cit:title" id="360.0"
+           context="/mdb:MD_Metadata/mdb:dataQualityInfo/mdq:DQ_DataQuality/mdq:report/mdq:DQ_DomainConsistency/mdq:result/mdq:DQ_ConformanceResult/mdq:specification/cit:CI_Citation/cit:title">
+    <label>Specification</label>
+    <description></description>
+    <help></help>
+    <helper editorMode="radio_linebreak"
+            displayIf="ancestor::node()[name()='mdb:MD_Metadata']/mdb:identificationInfo/mri:MD_DataIdentification">
+      <option value="COMMISSION REGULATION (EU) No 1089/2010 of 23 November 2010 implementing Directive 2007/2/EC of the European Parliament and of the Council as regards interoperability of spatial data sets and services">
+        COMMISSION REGULATION (EU) No 1089/2010 of 23 November 2010 implementing
+        Directive 2007/2/EC of the European Parliament and of the Council as
+        regards interoperability of spatial data sets and services
+      </option>
+      <option value="INSPIRE Data Specification on Administrative Units - Guidelines v3.0.1">
+        Guide INSPIRE sur les unités administratives
+      </option>
+      <option value="INSPIRE Data Specification on Cadastral Parcels - Guidelines v 3.0.1">
+        Guide INSPIRE sur les parcelles cadastrales
+      </option>
+      <option value="INSPIRE Data Specification on Geographical Names - Guidelines v 3.0.1">
+        Guide INSPIRE sur les dénominations géographiques
+      </option>
+      <option value="INSPIRE Data Specification on Hydrography - Guidelines v 3.0.1">
+        Guide INSPIRE sur l’hydrographie
+      </option>
+      <option value="INSPIRE Data Specification on Protected Sites - Guidelines v 3.1.0">
+        Guide INSPIRE sur les sites protégés
+      </option>
+      <option value="INSPIRE Data Specification on Transport Networks - Guidelines v 3.1.0">
+        Guide INSPIRE sur les réseaux de transport
+      </option>
+      <option value="INSPIRE Data Specification on Addresses - Guidelines v 3.0.1">
+        Guide INSPIRE sur les adresses
+      </option>
+      <option value="INSPIRE Specification on Coordinate Reference Systems - Guidelines v 3.1">
+        Guide INSPIRE sur les référentiels de coordonnées
+      </option>
+      <option value="INSPIRE Specification on Geographical Grid Systems - Guidelines v 3.0.1">
+        Guide INSPIRE sur les systèmes de maillage géographique
+      </option>
+    </helper>
+    <helper editorMode="radio_linebreak"
+            displayIf="ancestor::node()[name()='mdb:MD_Metadata']/mdb:identificationInfo/srv:SV_ServiceIdentification">
+      <option value="RÈGLEMENT (UE) N° 976/2009">Règlement service en réseau
+        INSPIRE (service de recherche et de consultation) - RÈGLEMENT (UE) N°
+        976/2009
+      </option>
+      <option value="RÈGLEMENT (UE) N° 1088/2010">Règlement service en réseau
+        INSPIRE (service de téléchargement et de transformation) - RÈGLEMENT
+        (UE) N° 1088/2010
+      </option>
+      <option value="Technical Guidance for the implementation of INSPIRE Discovery Services – v.3.1">
+        Guide INSPIRE sur les services de recherche
+      </option>
+      <option value="Technical Guidance for the implementation of INSPIRE View Services - v3.1 – part 4">
+        Guide INSPIRE sur les services de consultation – profil ISO 19128 (WMS)
+      </option>
+      <option value="Technical Guidance for the implementation of INSPIRE View Services - v3.1 – part 5">
+        Guide INSPIRE sur les services de consultation – profil ISO WMTS 1.0.0
+      </option>
+      <option value="Technical Guidance for the INSPIRE Schema Transformation Network Service - v3.0">
+        Guide INSPIRE sur les services de transformation de schéma
+      </option>
+      <option value="Technical Guidance for the implementation of INSPIRE Download Services – level1 - v3.0">
+        Guide INSPIRE sur les services de téléchargement – classe de conformité
+        1 (ATOM pré-défini)
+      </option>
+      <option value="Technical Guidance for the implementation of INSPIRE Download Services – level2 - v3.0">
+        Guide INSPIRE sur les services de téléchargement – classe de conformité
+        2 (WFS pré-défini)
+      </option>
+      <option value="Technical Guidance for the implementation of INSPIRE Download Services – level3 - v3.0">
+        Guide INSPIRE sur les services de téléchargement – classe de conformité
+        3 (WFS direct)
+      </option>
+    </helper>
+  </element>
+
+  <element name="cit:title" id="360.0"
+           context="/mdb:MD_Metadata/mdb:identificationInfo/mri:MD_DataIdentification/mri:citation/cit:CI_Citation/cit:title">
+    <label>Titel</label>
+    <description>Name by which the cited resource is known</description>
+  </element>
+
+  <element name="cit:title" id="360.0">
+    <label>Titel</label>
+    <description>Name by which the cited resource is known</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mri:title" id="507.0" context="mri:MD_Legislation">
+    <label>Titel</label>
+    <description>Reference to legal title</description>
+  </element>
+  <element name="mrc:toneGradation" id="265.0">
+    <label>Tone gradatie</label>
+    <description>Number of discrete numerical values in the grid data
+    </description>
+  </element>
+  <element name="mri:topicCategory" id="41.0">
+    <label>Onderwerp</label>
+    <description>Belangrijkste themas van de dataset</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mri:MD_TopicCategoryCode">
+    <label>Thema</label>
+    <description>High-level geographic data thematic classification to assist in
+      the grouping
+      and search of available geographic data sets. Can be used to group
+      keywords as well.
+      Listed examples are not exhaustive. NOTE It is understood there are
+      overlaps between
+      general categories and the user is encouraged to select the one most
+      appropriate.
+    </description>
+  </element>
+  <element name="mri:topologyLevel" id="177.0">
+    <label>Topologie level</label>
+    <description>code which identifies the degree of complexity of the
+      spatial
+      relationships
+    </description>
+  </element>
+  <element name="mrd:transferOptions" id="273.0">
+    <label>Leverings opties</label>
+    <description>provides information about technical means and media by
+      which a resource is
+      obtained from the distributor
+    </description>
+  </element>
+  <element name="mrd:transferSize" id="276.0">
+    <label>Bestands grootte</label>
+    <description>Verwachte grote van een eenheid van het bestand in
+      genoemd formaat in Megabyte
+    </description>
+  </element>
+  <element name="mri:transformationDimensionDescription" id="168.0">
+    <label>Transformation dimension description</label>
+    <description>Description of the information about which grid dimensions are
+      the spatial
+      dimensions
+    </description>
+  </element>
+  <element name="mri:transformationDimensionMapping" id="169.0">
+    <label>Transformation dimension mapping</label>
+    <description>Information about which grid dimensions are the spatial
+      dimensions
+    </description>
+  </element>
+  <element name="mri:transformationParameterAvailability" id="161.0">
+    <label>Transformation parameter availability</label>
+    <condition>mandatory</condition>
+    <description>Indication of whether or not parameters for transformation
+      between image
+      coordinates and geographic or map coordinates exist (are available)
+    </description>
+  </element>
+  <element name="mrc:triangulationIndicator" id="251.0">
+    <label>Triangulation indicator</label>
+    <description>Indication of whether or not triangulation has been performed
+      upon the
+      image
+    </description>
+  </element>
+  <element name="mrd:turnaround" id="302.0">
+    <label>Turnaround</label>
+    <description>Typical turnaround time for the filling of an order
+    </description>
+  </element>
+  <element name="mrd:orderOptionsType" id="302.0">
+    <label>Order options type</label>
+    <description>Description of the order options record</description>
+  </element>
+  <element name="mrd:orderOptions" id="302.0">
+    <label>Request/Purchase choices</label>
+    <description></description>
+  </element>
+  <element name="mri:type" id="54.0">
+    <label>Type</label>
+    <description>Subject matter used to group similar keywords</description>
+  </element>
+  <element name="mri:type" id="540.0" context="mri:MD_CodeDomain">
+    <label>Type</label>
+    <description>Datatype of the code domain</description>
+  </element>
+  <element name="mri:type" id="543.0" context="mri:MD_Type">
+    <label>Type definition</label>
+    <description>Data type definition</description>
+    <help>Data type definition, formal of informal (i.e. Text12, Line)</help>
+  </element>
+  <element name="mrc:units" id="262.0">
+    <label>eenheden</label>
+    <description>units in which sensor wavelengths are expressed</description>
+  </element>
+  <element name="mrd:unitsOfDistribution" id="275.0">
+    <label>Leverings gebruikseenheid</label>
+    <description>Eenheid waarin de data wordt geleverd.</description>
+  </element>
+  <element name="mri:updateScope" id="146.0">
+    <label>Bereik van de update</label>
+    <description>Deel van de data waarop het beheer van toepassing is.</description>
+  </element>
+  <element name="mri:updateScopeDescription" id="147.0">
+    <label>Omschrijving bereik update</label>
+    <description>aanvullende informatie over het bereik of de omvang van
+      de bron.
+    </description>
+  </element>
+  <element name="mri:usageDateTime" id="64.0">
+    <label>Toepassingstijd of datum</label>
+    <description>Datum en tijdstip van de toepassing van de datasets
+      (YYYY-MM-DDThh:mm:ss)
+    </description>
+  </element>
+  <element name="mco:useConstraints" id="71.0">
+    <label>(Juridische) gebruiksbeperking</label>
+    <description>Gebruikseisen die er zorg voor dragen dat privacy of
+      intellectueel eigendom gewaarborgd zijn en elke andere speciale
+      beperking(en) voor het verkrijgen van de metadata of data.
+    </description>
+  </element>
+  <element name="mco:useLimitation" id="99.0">
+    <label>Gebruiksbeperkingen</label>
+    <description>Toepassingen waarvoor de data niet geschikt is.
+      Bijvoorbeeld: Niet geschikt voor navigatie.
+    </description>
+  </element>
+  <element name="mco:constraintApplicationScope" id="100.0">
+    <label>Constraint application scope</label>
+    <description>Spatial and/or temporal extent and or level of the application
+      of the constraint restrictions
+    </description>
+    <help></help>
+    <condition/>
+  </element>
+  <element name="mri:userContactInfo" id="66.0">
+    <label>Organisatie welke gebruik maakt van de data</label>
+    <description>Naam en contactgegevens van personen die de dataset
+      gebruiken.
+    </description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mmi:userDefinedMaintenanceFrequency" id="145.0">
+    <label>Beheerfrequentie door de gebruiker bepaald</label>
+    <description>Beheer periode anders dan aangegeven.</description>
+  </element>
+  <element name="mri:userDeterminedLimitations" id="65.0">
+    <label>Door de gebruiker aangegeven gebruiksbeperkingen</label>
+    <description>applicaties/toepassingen (welke aangegeven zijn door de
+      gebruiker) waarvoor de dataset beter niet gebruikt kan worden.
+    </description>
+  </element>
+  <element name="mco:userNote" id="75.0">
+    <label>Toelichting</label>
+    <description>Explanation of the application of the legal constraints or
+      other restrictions
+      and legal prerequisites for obtaining and using the resource or metadata
+    </description>
+  </element>
+  <element name="mdq:value" id="137.0" context="/mdb:MD_Metadata/mdb:dataQualityInfo/mdq:DQ_DataQuality/mdq:report/mdq:DQ_DomainConsistency/mdq:result/mdq:DQ_QuantitativeResult/mdq:value">
+    <condition>mandatory</condition>
+    <label>Waarde</label>
+    <description>Quantitative value or values, content determined by the evaluation procedure
+            used</description>
+  </element>
+  <element name="mdq:value">
+    <label>Waarde</label>
+    <description/>
+  </element>
+  <element name="mdq:valueRecordType" id="134.0">
+    <label>Value type</label>
+    <description>Quantitative conformance quality level value or range of
+      values
+    </description>
+    <helper>
+      <option value="Boolean">Boolean</option>
+      <option value="Real">Real</option>
+      <option value="Integer">Integer</option>
+      <option value="Ratio">Ratio</option>
+      <option value="Percentage">Percentage</option>
+      <option value="Measure(s) (value(s) + unit(s))">Measure(s) (value(s) +
+        unit(s))
+      </option>
+    </helper>
+  </element>
+  <element name="mdq:valueUnit" id="135.0">
+    <label>Waarde eenheid</label>
+    <description>Value unit for reporting a data quality result</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="mri:version" id="208.2" context="mri:RS_Identifier">
+    <label>Version</label>
+    <description>Version identifier for the namespace</description>
+  </element>
+  <element name="mcc:version" id="208.2" context="mcc:MD_Identifier">
+    <label>Version</label>
+    <description>version identifier for the namespace</description>
+  </element>
+  <element name="mri:version" id="286.0">
+    <label>Version</label>
+    <description>Version of the format (date, number, etc.)</description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gex:verticalElement" id="338.0">
+    <label>Verticaal element</label>
+    <description>Provides vertical component of the extent of the referring
+      object
+    </description>
+    <condition>conditional</condition>
+  </element>
+  <element name="mri:voice" id="408.0">
+    <label>Voice</label>
+    <description>Telephone number by which individuals can speak to the
+      responsible organization
+      or individual
+    </description>
+  </element>
+  <element name="mrd:volumes" id="295.0">
+    <label>Volumes</label>
+    <description>Number of items in the media identified</description>
+  </element>
+  <element name="mri:westBoundLongitude" id="344.0">
+    <label>West bound</label>
+    <description>Western-most coordinate of the limit of the dataset extent,
+      expressed in
+      longitude in decimal degrees (positive east)
+    </description>
+    <condition>mandatory</condition>
+  </element>
+  <element name="gml:beginPosition">
+    <label>Begindatum</label>
+    <description>Als in 2007-09-12T15:00:00 (YYYY-MM-DDTHH:mm:ss)</description>
+  </element>
+
+  <element name="gml:endPosition">
+    <label>Einddatum</label>
+    <description>Als in 2007-09-12T15:00:00 (YYYY-MM-DDTHH:mm:ss)</description>
+  </element>
+
+  <element name="gml:relatedTime">
+    <label>Gerelateerd tijdstip</label>
+    <description>Beschrijft de relatie van een gegeven tijdstip tot het
+      object.
+    </description>
+  </element>
+
+  <element name="gml:coordinates">
+    <label>Coordinates</label>
+    <description>Used to record an array of tuples or coordinates.</description>
+  </element>
+
+  <element name="gml:Polygon">
+    <label>Polygon</label>
+    <description>A gml:Polygon is a special surface that is defined by a single
+      surface patch.
+      The boundary of this patch is coplanar and the polygon uses planar
+      interpolation in its
+      interior.
+    </description>
+  </element>
+
+  <element name="gml:Point">
+    <label>Point</label>
+    <description>A gml:Point is defined by a single coordinate tuple.
+    </description>
+    <example>74. -37.</example>
+  </element>
+
+  <element name="gml:LineString">
+    <label>Line</label>
+    <description>A gml:LineString is a special curve that consists of a single
+      segment with
+      linear interpolation. It is defined by two or more coordinate tuples, with
+      linear
+      interpolation between them.
+    </description>
+  </element>
+
+  <element name="gml:LinearRing">
+    <label>Linear ring</label>
+    <description>A gml:LinearRing is defined by four or more coordinate tuples,
+      with linear
+      interpolation between them; the first and last coordinates shall be
+      coincident.
+    </description>
+  </element>
+
+  <element name="gml:exterior">
+    <label>Outer boundary</label>
+    <description>The outer boundary of a solid.</description>
+  </element>
+
+  <element name="gml:interior">
+    <label>Inner boundary</label>
+    <description>The inner boundary of a solid</description>
+  </element>
+
+
+  <element name="gml:begin">
+    <label>Begin</label>
+    <description/>
+  </element>
+  <element name="gml:end">
+    <label>Eind</label>
+    <description/>
+  </element>
+  <element name="gml:duration">
+    <label>Duration</label>
+    <description>Conforms to the ISO 8601 syntax for temporal length as
+      implemented by the XML Schema duration type.
+    </description>
+  </element>
+  <element name="gml:timeInterval">
+    <label>Time interval</label>
+    <description>conforms to ISO 11404 which is based on floating point values
+      for temporal length.
+      ISO 11404 syntax specifies the use of a positiveInteger together with
+      appropriate values for radix and factor. The resolution of the time
+      interval is to one radix ^(-factor) of the specified time unit.
+      The value of the unit is either selected from the units for time intervals
+      from ISO 31-1:1992, or is another suitable unit. The encoding is defined
+      for GML in gml:TimeUnitType. The second component of this union type
+      provides a method for indicating time units other than the six standard
+      units given in the enumeration.
+    </description>
+  </element>
+  <element name="gml:name">
+    <label>Naam</label>
+    <description></description>
+  </element>
+  <element name="gml:metaDataProperty">
+    <label>Metadata eigenschap</label>
+    <description></description>
+  </element>
+  <element name="gml:identifier">
+    <label>Identificatie</label>
+    <description></description>
+  </element>
+  <element name="gml:description">
+    <label>Omschrijving</label>
+    <description>Text description of the element</description>
+  </element>
+  <element name="gml:descriptionReference">
+    <label>Referentie naar omschrijving</label>
+    <description></description>
+  </element>
+  <element name="gml:TimeInstant">
+    <label>Time instant</label>
+    <description/>
+  </element>
+  <element name="gml:TimePosition">
+    <label>Time position</label>
+    <description/>
+  </element>
+  <element name="gml:timePosition">
+    <label>Time position</label>
+    <description/>
+  </element>
+  <element name="gml:TimePeriod">
+    <label>Time period</label>
+    <description/>
+  </element>
+  <element name="gml:TimeNode">
+    <label>Time node</label>
+    <description/>
+  </element>
+  <element name="gml:TimeEdge">
+    <label>Time edge</label>
+    <description/>
+  </element>
+  <element name="gml:ProjectedCRS">
+    <label>Projected CRS</label>
+    <description/>
+  </element>
+
+  <element name="gml:id">
+    <label>Identifier</label>
+    <description>Unique identifier</description>
+  </element>
+
+  <element name="gml:id" id="191.0" context="mri:MD_CRS">
+    <label>Ellipsoid</label>
+    <description>Identity of the ellipsoid used</description>
+    <help>identity of the ellipsoid used</help>
+  </element>
+  <element name="id" id="191.0">
+    <label>Identifier</label>
+    <description>Unique identifier</description>
+  </element>
+  <element name="indeterminatePosition">
+    <label>Indeterminate position</label>
+    <description></description>
+  </element>
+  <element name="frame">
+    <label>Frame</label>
+    <description>Frame attribute provides a URI reference that identifies a
+      description of the reference system
+    </description>
+  </element>
+  <element name="calendarEraName">
+    <label>Name of the calendar era</label>
+    <description></description>
+  </element>
+
+  <element name="relativePosition">
+    <label>Relative position</label>
+    <description></description>
+  </element>
+  <element name="gml:remoteSchema">
+    <label>Remote schema</label>
+    <description></description>
+  </element>
+  <element name="owns">
+    <label>Owns</label>
+    <description></description>
+  </element>
+  <element name="xlink:type">
+    <label>Type of link</label>
+    <description></description>
+  </element>
+  <element name="unit">
+    <label>Unit</label>
+    <description></description>
+  </element>
+  <element name="radix">
+    <label>Radix</label>
+    <description></description>
+  </element>
+  <element name="factor">
+    <label>Factor</label>
+    <description></description>
+  </element>
+
+
+  <element name="srv:SV_ServiceIdentification">
+    <label>Service Identification</label>
+    <description>Service identification section</description>
+  </element>
+  <element name="srv:SV_ParameterDirection">
+    <label>Parameter direction</label>
+  </element>
+  <element name="srv:serviceType">
+    <label>Service Type</label>
+    <description>Service type name from a registry of services. For example, the
+      values of the
+      nameSpace and name attributes of GeneralName may be 'OGC' and 'catalogue'
+    </description>
+    <helper>
+      <option value="OGC:WMS">OGC Web Map Service</option>
+      <option value="OGC:WMTS">OGC Web Map Tile Service</option>
+      <option value="OGC:WFS">OGC Web Feature Service</option>
+      <option value="OGC:WCS">OGC Web Coverage Service</option>
+      <option value="OGC:WPS">OGC Web Processing Service</option>
+      <option value="atom:feed">ATOM feed</option>
+      <!--INSPIRE Service type defined in MD IR / 1.3.1 Spatial data service
+        type <option value="discovery">Discovery Service (discovery)</option> <option
+        value="view">View Service (view)</option> <option value="download">Download
+        Service (download)</option> <option value="transformation">Transformation
+        Service (transformation)</option> <option value="other">Other Services (other)</option> -->
+      <!--<option value="OGC:WMS">OGC Web Map Service (OGC:WMS)</option>
+      <option value="OGC:WFS">OGC Web Feature Service (OGC:WFS)</option>
+      <option value="OGC:WCS">OGC Web Coverage Service (OGC:WCS)</option>
+      <option value="W3C:HTML:DOWNLOAD">Download (W3C:HTML:DOWNLOAD)</option>
+      <option value="W3C:HTML:LINK">Information (W3C:HTML:LINK)</option>-->
+    </helper>
+  </element>
+  <element name="srv:serviceTypeVersion">
+    <label>Service Version</label>
+    <description>Provides for searching based on the version of serviceType. For
+      example, we may
+      only be interested in OGC Catalogue V1.1 services. If version is
+      maintained as a
+      separate attribute, users can easily search for all services of a type
+      regardless of the
+      version
+    </description>
+  </element>
+  <element name="srv:accessProperties">
+    <label>Access Properties</label>
+    <description>Information about the availability of the service eg. fees,
+      availability,
+      oredering instructions
+    </description>
+  </element>
+  <element name="srv:restrictions">
+    <label>Restrictions</label>
+    <description>Legal and security constraints on accessing the service and
+      distributing data
+      generated by the service
+    </description>
+  </element>
+  <element name="srv:containsOperations">
+    <label>Bevat operaties</label>
+    <description>De operaties die door een service worden aangeboden.</description>
+  </element>
+  <element name="srv:operatesOn">
+    <label>Operates On</label>
+    <description>Provides information on the datasets that the service operates
+      on
+    </description>
+  </element>
+  <element name="srv:operationName">
+    <label>Operatie naam</label>
+    <description>De naam van de operatie.</description>
+  </element>
+  <element name="srv:SV_OperationMetadata">
+    <label>Operation</label>
+    <description>Operation Metadata</description>
+  </element>
+  <element name="srv:DCP">
+    <label>Distributed Computing Platforms</label>
+    <description>Distributed computing platforms on which the operation has been
+      implemented
+    </description>
+  </element>
+  <element name="srv:operationDescription">
+    <label>Operation Description</label>
+    <description>Free text description of the intent of the operation and the
+      results of the
+      operation
+    </description>
+  </element>
+  <element name="srv:invocationName">
+    <label>Invocation Name</label>
+    <description>The name used to invoke this interface within the context of
+      the DCP. The name
+      is identical for all DCPs
+    </description>
+  </element>
+  <element name="srv:parameters">
+    <label>Parameters</label>
+    <description>The parameters that are required for this interface
+    </description>
+  </element>
+  <element name="srv:SV_Parameter">
+    <label>Parameter</label>
+    <description>The parameters that are required for this interface
+    </description>
+  </element>
+  <element name="srv:direction">
+    <label>Direction</label>
+  </element>
+  <element name="srv:valueType">
+    <label>Value type</label>
+  </element>
+  <element name="srv:connectPoint">
+    <label>Connect Point</label>
+    <description>Handle for accessing the service interface</description>
+  </element>
+  <element name="srv:dependsOn">
+    <label>Depends On</label>
+    <description>List of operations that must be completed immediately before
+      current operation
+      is invoked, structured as a list for capturing alternate predecessor paths
+      and sets for
+      capturing parallel predecessor paths
+    </description>
+  </element>
+  <element name="srv:providerName">
+    <label>Provider Name</label>
+    <description>A unique identifier for this organization</description>
+  </element>
+  <element name="srv:serviceContact">
+    <label>Service Contact</label>
+    <description>Information for contacting the service provider</description>
+  </element>
+  <element name="srv:name">
+    <label>Name</label>
+    <description>The name, as used by the service for this chain or parameter
+    </description>
+  </element>
+  <element name="srv:description">
+    <label>Description</label>
+    <description>Narrative explanation of the services in the chain and
+      resulting output or role
+      of the parameter
+    </description>
+  </element>
+  <element name="srv:optionality">
+    <label>Optionality</label>
+    <description>Indication if the parameter is required</description>
+  </element>
+  <element name="srv:repeatability">
+    <label>Repeatability</label>
+    <description>Indication if more than one value of the parameter may be
+      provided
+    </description>
+  </element>
+  <element name="srv:coupledResource">
+    <label>Gekoppelde bron</label>
+    <description>Een bron of dataset die gekoppeld is aan deze service.</description>
+    <inspireInfo>Optional in INSPIRE</inspireInfo>
+  </element>
+  <element name="srv:SV_CoupledResource">
+    <label>Coupled Resource</label>
+    <description>Details of services coupled with this one</description>
+  </element>
+  <element name="srv:identifier">
+    <label>Identifier</label>
+    <description>Identifier of resource to which the operation applies
+    </description>
+  </element>
+  <element name="srv:couplingType">
+    <label>Coupling Type</label>
+    <description>Type of Coupling</description>
+  </element>
+  <element name="gex:extent">
+    <label>Dekking</label>
+    <description>Informatie over de ruimtelijke, verticale en temporele
+      dekking van de dataset
+    </description>
+  </element>
+  <element name="srv:keywords">
+    <label>Keywords</label>
+    <description>Keywords describing service</description>
+  </element>
+  <element name="srv:operatedDataset">
+    <label>Operated dataset</label>
+    <description>Provides a reference to the resource on which the service operates. Note: For one resource either operated dataset or operates on may be used (not both).</description>
+  </element>
+  <element name="srv:profile">
+    <label>Profile</label>
+    <description>Profile to which the service adheres</description>
+  </element>
+  <element name="srv:serviceStandard">
+    <label>Service standard</label>
+    <description>Standard to which the service adheres</description>
+  </element>
+  <element name="srv:distributedComputingPlatform">
+    <label>Distributed computing platform (DCP)</label>
+    <description>DCP on which the operation has been implemented</description>
+  </element>
+  <element name="srv:parameter">
+    <label>Parameter</label>
+    <description></description>
+  </element>
+  <element name="srv:containsChain">
+    <label>Contains chain</label>
+    <description>Provide information about the chain applied by the service</description>
+  </element>
+  <element name="mrc:locale">
+    <label>Other language</label>
+    <description>Use this section to define other metadata language
+      (multilingual metadata).
+    </description>
+  </element>
+  <element name="mri:describes">
+    <label>beschrijft</label>
+    <description>beschrijft</description>
+  </element>
+  <element name="mri:propertyType">
+    <label>PropertyType</label>
+    <description>PropertyType</description>
+  </element>
+  <element name="lan:PT_Locale">
+    <label>Locale</label>
+    <description>Locale</description>
+  </element>
+  <element name="lan:PT_LocaleContainer">
+    <label>Container of localised character strings</label>
+    <description>Container of localised character strings. NOTE It provides a
+      means to isolate the localised strings related to a given locale.
+    </description>
+  </element>
+  <element name="mri:featureType">
+    <label>Feature type</label>
+    <description>Subset of feature types from cited feature catalogue occurring
+      in
+      data
+    </description>
+  </element>
+  <element name="mri:featureAttribute">
+    <label>feature Attribuut</label>
+    <description>feature Attribuut</description>
+  </element>
+  <element name="mri:DS_Association">
+    <label>DS_Association</label>
+    <description>DS_Association</description>
+  </element>
+  <element name="mri:DS_DataSet">
+    <label>DS_DataSet</label>
+    <description>DS_DataSet</description>
+  </element>
+  <element name="mri:DS_Initiative">
+    <label>DS_Initiative</label>
+    <description>DS_Initiative</description>
+  </element>
+  <element name="mri:DS_OtherAggregate">
+    <label>DS_OtherAggregate</label>
+    <description>DS_OtherAggregate</description>
+  </element>
+  <element name="mri:DS_Platform">
+    <label>DS_Platform</label>
+    <description>DS_Platform</description>
+  </element>
+  <element name="mri:DS_ProductionSeries">
+    <label>DS_ProductionSeries</label>
+    <description>DS_ProductionSeries</description>
+  </element>
+  <element name="mri:DS_Sensor">
+    <label>DS_Sensor</label>
+    <description>DS_Sensor</description>
+  </element>
+  <element name="mri:DS_Series">
+    <label>DS_Series</label>
+    <description>DS_Series</description>
+  </element>
+  <element name="mri:DS_StereoMate">
+    <label>DS_StereoMate</label>
+    <description>DS_StereoMate</description>
+  </element>
+  <element name="mri:languageCode">
+    <label>Taalcode</label>
+    <description>Language code</description>
+  </element>
+  <element name="lan:LanguageCode">
+    <label>ISO Language code</label>
+    <description>Language code</description>
+  </element>
+  <element name="mri:LanguageCode">
+    <label>ISO Language code</label>
+    <description>Language code</description>
+  </element>
+  <element name="lan:characterEncoding">
+    <label>Tekencodering</label>
+    <description>Tekencodering</description>
+  </element>
+  <element name="uuidref">
+    <label>Metadata uuid</label>
+    <description>Unique identifier</description>
+  </element>
+  <element name="uom">
+    <label>Units of measure</label>
+    <description/>
+    <helper>
+      <option value="m">meters</option>
+    </helper>
+  </element>
+  <element name="gco:Record">
+    <label>Record</label>
+    <description/>
+  </element>
+  <element name="gco:Binary">
+    <label>Binair</label>
+    <description/>
+  </element>
+  <element name="gco:MemberName">
+    <label>Member name</label>
+    <description/>
+  </element>
+  <element name="gco:aName">
+    <label>Name</label>
+    <description/>
+  </element>
+  <element name="gco:aName" context="gco:TypeName">
+    <label>Type name</label>
+    <description/>
+    <helper>
+      <option value="BOOLEAN">BOOLEAN</option>
+      <option value="BYTE">BYTE</option>
+      <option value="CHARACTER">CHARACTER</option>
+      <option value="DATE">DATE</option>
+      <option value="DATETIME">DATETIME</option>
+      <option value="DOUBLE">DOUBLE</option>
+      <option value="FLOAT">FLOAT</option>
+      <option value="INTEGER">INTEGER</option>
+      <option value="NUMERIC">NUMERIC</option>
+      <option value="REAL">REAL</option>
+      <option value="SERIAL">SERIAL</option>
+      <option value="VARCHAR">VARCHAR</option>
+      <option value="TEXT">TEXT</option>
+    </helper>
+  </element>
+  <element name="gco:attributeType">
+    <label>Attribute type</label>
+    <description/>
+  </element>
+  <element name="gco:TypeName">
+    <label>Type name</label>
+    <description/>
+  </element>
+  <element name="gco:LocalName">
+    <label>Local name</label>
+    <description/>
+  </element>
+  <element name="gco:ScopedName">
+    <label>Scoped name</label>
+    <description/>
+  </element>
+  <element name="mri:has">
+    <label>heeft</label>
+    <description>heeft</description>
+  </element>
+  <element name="mri:MD_ObligationCode">
+    <label>Verplichtings code</label>
+    <description>Obligation of the element or entity</description>
+  </element>
+  <element name="mri:maximumOccurrence">
+    <label>Maximaal aantal gebeurtenissen</label>
+    <description>Maximum occurrence of the extended element</description>
+  </element>
+  <element name="gco:localName">
+    <label>Name</label>
+    <description/>
+  </element>
+  <element name="mri:composedOf">
+    <label>bestaat uit</label>
+    <description>bestaat uit</description>
+  </element>
+  <element name="mri:partOf">
+    <label>PartOf</label>
+    <description>PartOf</description>
+  </element>
+  <element name="mri:seriesMetadata">
+    <label>SeriesMetadata</label>
+    <description>SeriesMetadata</description>
+  </element>
+  <element name="mri:subset">
+    <label>Subset</label>
+    <description>Subset</description>
+  </element>
+  <element name="mri:superset">
+    <label>Superset</label>
+    <description>Superset</description>
+  </element>
+  <element name="mri:CI_RoleCode">
+    <label>Rol code</label>
+    <description/>
+  </element>
+  <element name="cit:CI_RoleCode">
+    <label>Rol code</label>
+    <description/>
+  </element>
+  <element name="mcc:MD_SpatialRepresentationTypeCode">
+    <label>Spatial Representation Type</label>
+  </element>
+  <element name="mcc:MD_ProgressCode">
+    <label>Status</label>
+  </element>
+  <element name="gco:TM_PeriodDuration">
+    <label>Periode / Duur</label>
+    <description>
+      The duration data type is used to specify a time interval.
+
+      The time interval is specified in the following form "PnYnMnDTnHnMnS"
+      where:
+
+      * P indicates the period (required)
+      * nY indicates the number of years
+      * nM indicates the number of months
+      * nD indicates the number of days
+      * T indicates the start of a time section (required if you are going to
+      specify hours, minutes, or seconds)
+      * nH indicates the number of hours
+      * nM indicates the number of minutes
+      * nS indicates the number of seconds
+    </description>
+  </element>
+  <element name="gco:CharacterString">
+    <label>Tekst</label>
+    <description/>
+  </element>
+  <element name="gco:nilReason">
+    <label>Reden lege waarde</label>
+    <description>Geef de reden op waarom u dit veld leeg laat</description>
+  </element>
+  <element name="srv:DCPList">
+    <label>Distributed Computing Platforms list</label>
+  </element>
+  <element name="gex:verticalCRS">
+    <label>Vertical CRS</label>
+    <description>Provides information about the origin from which the maximum
+      and minimum elevation values are measured
+    </description>
+  </element>
+  <element name="gex:verticalCRSId">
+    <label>Vertical CRS identifier</label>
+    <description>Provides information about the origin from which the maximum
+      and minimum elevation values are measured
+    </description>
+  </element>
+  <element name="gcx:FileName">
+    <label>File name</label>
+    <description>File name and source URL.</description>
+  </element>
+  <element name="src">
+    <label>Source URL</label>
+    <description>URL of the document.</description>
+  </element>
+  <element name="gcx:Anchor">
+    <label>Anker</label>
+    <description>Geeft de mogelijkheid naast tekst ook een link naar aanvullende informatie op te nemen
+    </description>
+  </element>
+  <element name="xlink:href">
+    <label>Link href</label>
+    <description>Een link naar aanvullende informatie
+    </description>
+  </element>
+  <element name="hidden-elements">
+    <label>Verborgen Elementen</label>
+    <description>Child elements and attributes have been hidden because you do
+      no have access to view those elements
+    </description>
+  </element>
+  <element name="gml:axis">
+    <label>Axis</label>
+  </element>
+  <element name="gml:axisAbbrev">
+    <label>Afkorting as</label>
+    <description>De afkorting van de as van het coordinaatsysteem</description>
+  </element>
+  <element name="gml:axisDirection">
+    <label>Richting as</label>
+    <description>De richting van de as, bijvoorbeeld "up", "North"</description>
+  </element>
+  <element name="gml:maximumValue">
+    <label>Maximum value</label>
+  </element>
+  <element name="gml:minimumValue">
+    <label>Minimum value</label>
+  </element>
+  <element name="gml:scope">
+    <label>Scope</label>
+  </element>
+  <element name="gml:VerticalCRS">
+    <label>Vertical CRS</label>
+  </element>
+  <element name="gml:remarks">
+    <label>Opmerkingen</label>
+  </element>
+  <element name="gml:domainOfValidity">
+    <label>Domain of validity</label>
+  </element>
+  <element name="gml:verticalCS">
+    <label>Vertical CS</label>
+  </element>
+  <element name="gml:VerticalCS">
+    <label>Vertical CS</label>
+  </element>
+  <element name="gml:CoordinateSystemAxis">
+    <label>Coordinate system axis</label>
+  </element>
+  <element name="gml:rangeMeaning">
+    <label>Range meaning</label>
+  </element>
+  <element name="gml:verticalDatum">
+    <label>Vertical datum</label>
+  </element>
+  <element name="gml:VerticalDatum">
+    <label>Vertical datum</label>
+  </element>
+  <element name="gml:realizationEpoch">
+    <label>Realization epoch</label>
+  </element>
+
+  <element name="gfc:FC_FeatureCatalogue">
+    <label>Feature Catalogue description</label>
+    <description></description>
+  </element>
+  <element name="gfc:FC_FeatureAttribute">
+    <label>Attribute</label>
+  </element>
+  <element name="gfc:name">
+    <label>Name</label>
+    <description>Feature catalogue name</description>
+  </element>
+  <element name="gfc:scope">
+    <label>Scope</label>
+    <description>Scope definition</description>
+  </element>
+  <element name="gfc:versionNumber">
+    <label>Version</label>
+    <description>Catalogue version</description>
+  </element>
+  <element name="gfc:versionDate">
+    <label>Date</label>
+    <description>Catalogue date</description>
+  </element>
+  <element name="cat:name">
+    <label>Name</label>
+    <description>Feature catalogue name</description>
+  </element>
+  <element name="cat:scope">
+    <label>Scope</label>
+    <description>Scope definition</description>
+  </element>
+  <element name="cat:versionNumber">
+    <label>Version</label>
+    <description>Catalogue version</description>
+  </element>
+  <element name="cat:versionDate">
+    <label>Date</label>
+    <description>Catalogue date</description>
+  </element>
+  <element name="gfc:producer">
+    <label>Catalogue producer</label>
+    <description>Catalogue responsible</description>
+  </element>
+  <element name="gfc:featureType">
+    <label>Property description</label>
+    <description>Property description</description>
+  </element>
+  <element name="gfc:isAbstract">
+    <label>Abstract</label>
+    <description>Is this element an abstract element ?</description>
+  </element>
+  <element name="gfc:FC_FeatureType">
+    <label>Attribute table description</label>
+    <description>Attribute table description</description>
+  </element>
+  <element name="gfc:typeName">
+    <label>Property name</label>
+    <description></description>
+  </element>
+  <element name="cat:characterSet">
+    <label>Character set</label>
+    <description></description>
+  </element>
+  <element name="cat:language">
+    <label>Taal</label>
+    <description></description>
+  </element>
+  <element name="cat:locale">
+    <label>Language (locale)</label>
+    <description></description>
+  </element>
+  <element name="gfc:carrierOfCharacteristics">
+    <label>Elements</label>
+    <description>Association, attribute, operation, ...</description>
+  </element>
+  <element name="gfc:definition">
+    <label>Definition</label>
+    <description>Property definition</description>
+  </element>
+  <element name="gfc:fieldOfApplication">
+    <label>Field of application</label>
+    <description>Field of application</description>
+  </element>
+  <element name="cat:fieldOfApplication">
+    <label>Field of application</label>
+    <description>Field of application</description>
+  </element>
+  <element name="gco:lower">
+    <label>Lower cardinality</label>
+    <description>Lower cardinality</description>
+  </element>
+  <element name="gco:upper">
+    <label>Upper cardinality</label>
+    <description>Upper cardinality</description>
+  </element>
+  <element name="gfc:cardinality">
+    <label>Cardinalities</label>
+    <description>Cardinalities</description>
+    <helper>
+      <option value="0..1">0..1</option>
+      <option value="1..n">0..n</option>
+      <option value="1..1">1..1</option>
+      <option value="1..n">1..n</option>
+    </helper>
+  </element>
+  <element name="gfc:label">
+    <label>Label</label>
+    <description/>
+  </element>
+  <element name="gfc:listedValue">
+    <label>Codelist</label>
+    <description>List of values for this element.</description>
+  </element>
+  <element name="gfc:constrainedBy">
+    <label>Constrained by</label>
+    <description></description>
+  </element>
+  <element name="gfc:definitionReference">
+    <label>Definition reference</label>
+    <description></description>
+  </element>
+  <element name="gfc:code">
+    <label>Code</label>
+    <description></description>
+  </element>
+  <element name="gfc:isOrdered">
+    <label>Is ordered</label>
+    <description></description>
+  </element>
+  <element name="gfc:isNavigable">
+    <label>Is navigable</label>
+    <description></description>
+  </element>
+  <element name="gfc:roleType">
+    <label>Role type</label>
+    <description></description>
+  </element>
+  <element name="gfc:inheritsFrom">
+    <label>Inherits from</label>
+    <description></description>
+  </element>
+  <element name="gfc:inheritsTo">
+    <label>Inherits to</label>
+    <description></description>
+  </element>
+  <element name="gfc:FC_DefinitionReference">
+    <label>Definition reference</label>
+    <description></description>
+  </element>
+  <element name="gfc:FC_LocalisedDefinitionReference">
+    <label>Multilingual definition reference</label>
+    <description></description>
+  </element>
+  <element name="gfc:sourceIdentifier">
+    <label>Source identifier</label>
+    <description></description>
+  </element>
+  <element name="gfc:translation">
+    <label>Translation</label>
+    <description></description>
+  </element>
+  <element name="gfc:FC_InheritanceRelation">
+    <label>Heritance relation</label>
+    <description></description>
+  </element>
+  <element name="gfc:functionalLanguage">
+    <label>Functional language</label>
+    <description></description>
+  </element>
+  <element name="gfc:definitionSource">
+    <label>Definition source</label>
+    <description></description>
+  </element>
+  <element name="gfc:FC_FeatureOperation">
+    <label>Feature operation</label>
+    <description></description>
+  </element>
+  <element name="gfc:FC_FeatureAssociation">
+    <label>Feature association</label>
+    <description></description>
+  </element>
+  <element name="gfc:FC_AssociationRole">
+    <label>Association role</label>
+    <description></description>
+  </element>
+  <element name="gfc:FC_RoleType">
+    <label>Role type</label>
+    <description></description>
+  </element>
+  <element name="gfc:description">
+    <label>Description</label>
+    <description></description>
+  </element>
+  <element name="gfc:aliases">
+    <label>Aliases</label>
+    <description></description>
+  </element>
+  <element name="gfc:FC_ListedValue">
+    <label>Codelist</label>
+    <description></description>
+  </element>
+  <element name="gfc:valueType">
+    <label>Value type</label>
+    <description></description>
+  </element>
+  <element name="gfc:memberName">
+    <label>Member name</label>
+    <description></description>
+  </element>
+  <element name="gfc:FC_Constraint">
+    <label>Constraint</label>
+    <description></description>
+  </element>
+  <element name="gfc:uniqueInstance">
+    <label>Unique instance</label>
+    <description></description>
+  </element>
+  <element name="gfc:type">
+    <label>Type</label>
+    <description></description>
+  </element>
+  <element name="gfc:relation">
+    <label>Relation</label>
+    <description></description>
+  </element>
+  <element name="gfc:featureCatalogue">
+    <label>Feature catalogue</label>
+    <description></description>
+  </element>
+  <element name="gfc:roleName">
+    <label>Role name</label>
+    <description></description>
+  </element>
+  <element name="gfc:signature">
+    <label>Signature</label>
+    <description></description>
+  </element>
+  <element name="gfc:formalDefinition">
+    <label>Formal definition</label>
+    <description></description>
+  </element>
+  <element name="gfc:triggeredByValueOf">
+    <label>Triggered by value of</label>
+    <description></description>
+  </element>
+  <element name="gfc:affectsValueOf">
+    <label>Affects value of</label>
+  </element>
+  <element name="gfc:observesValueOf">
+    <label>Observes value of</label>
+  </element>
+  <element name="gfc:valueMeasurementUnit">
+    <label>Value measurement unit</label>
+  </element>
+
+
+  <element name="mdq:resultFile">
+    <label>Result file</label>
+    <description></description>
+  </element>
+  <element name="mdq:QualityResultFile">
+    <label>Quality result file</label>
+    <description></description>
+  </element>
+  <element name="mdq:fileName">
+    <label>Result file name</label>
+    <description></description>
+  </element>
+  <element name="mdq:fileFormat">
+    <label>File format</label>
+    <description></description>
+  </element>
+  <element name="mdq:resultFormat">
+    <label>Result format</label>
+    <description></description>
+  </element>
+  <element name="mrc:rangeElementDescription">
+    <label>Range element description</label>
+    <description></description>
+  </element>
+  <element name="mdq:fileType">
+    <label>File type</label>
+    <description></description>
+  </element>
+  <element name="gcx:MimeFileType">
+    <label>Mime file type</label>
+    <description></description>
+  </element>
+  <element name="mdq:fileDescription">
+    <label>File description</label>
+    <description></description>
+  </element>
+  <element name="mdq:resultSpatialRepresentation">
+    <label>Result spatial representation</label>
+    <description></description>
+  </element>
+  <element name="mdq:resultContentDescription">
+    <label>Result content description</label>
+    <description></description>
+  </element>
+  <element name="mdq:spatialRepresentationType">
+    <label>Spatial representation type</label>
+    <description></description>
+  </element>
+  <element name="reg:RE_AmendmentType">
+    <label>Amendment Type</label>
+    <description></description>
+  </element>
+  <element name="reg:RE_DecisionStatus">
+    <label>Decision status</label>
+    <description></description>
+  </element>
+  <element name="reg:RE_Disposition">
+    <label>Disposition</label>
+    <description></description>
+  </element>
+  <element name="reg:RE_ItemStatus">
+    <label>Item status</label>
+    <description></description>
+  </element>
+  <element name="mmi:MD_MaintenanceFrequencyCode">
+    <label>Beheer frequentie code</label>
+  </element>
+  <element name="mco:MD_RestrictionCode" context="mco:accessConstraints">
+    <label>Access constraints</label>
+  </element>
+  <element name="gco:RecordType">
+    <label>Record type</label>
+  </element>
+  <element name="msr:MD_DimensionNameTypeCode">
+    <label>Name</label>
+  </element>
+  <element name="mrc:MD_CoverageContentTypeCode">
+    <label>Coverage content</label>
+  </element>
+  <element name="gml:UnitDefinition">
+    <label>Unit definition</label>
+  </element>
+  <element name="mrc:MI_CoverageDescription">
+    <label>Coverage description (with range elements)</label>
+    <description>information about the content of a coverage, including the description of specific range elements</description>
+  </element>
+  <element name="mrc:MI_RangeElementDescription">
+    <label>Range element description</label>
+    <description>eg. storage_meth</description>
+  </element>
+  <element name="mrc:definition">
+    <label>Definition</label>
+    <description>Designation associated with a set of range elements. eg. "Indicates the sample storage method used."</description>
+  </element>
+  <element name="mrc:rangeElement">
+    <label>Range element</label>
+    <description>Specific range elements, i.e. range elements associated with a name and their definition. eg. "frozen: Samples are kept frozen.", "room temperature, dry: Samples are kept at room temperature, unsealed."</description>
+  </element>
+  <element name="mac:MI_EnvironmentalRecord">
+    <label>Environmental record</label>
+    <description>Information about the environmental conditions during the acquisition</description>
+  </element>
+  <element name="mac:solarAzimuth">
+    <label>Solar azimuth</label>
+    <description>Clockwise angle in degrees from north to the centre of the sun’s disc.
+      Note: This angle is calculated from the nadir point of the sensor, not at the centre point of the image</description>
+  </element>
+  <element name="mac:solarElevation">
+    <label>Solar elevation</label>
+    <description>Angle between the horizon and the centre of the Sun’s disk</description>
+  </element>
+  <element name="mac:MI_Objective">
+    <label>Objective</label>
+    <description>Describes the characteristics, spatial and temporal extent of the intended object to be observed
+    </description>
+  </element>
+  <element name="mac:function">
+    <label>Function</label>
+    <description></description>
+  </element>
+  <element name="mac:extent">
+    <label>Extent</label>
+    <description></description>
+  </element>
+  <element name="mac:sensingInstrument">
+    <label>Sensing instrument</label>
+    <description></description>
+  </element>
+  <element name="mac:pass">
+    <label>Pass</label>
+    <description></description>
+  </element>
+  <element name="mac:content">
+    <label>Content</label>
+    <description></description>
+  </element>
+  <element name="mac:context">
+    <label>Context</label>
+    <description>Meaning of the event</description>
+  </element>
+  <element name="mac:MI_PlatformPass">
+    <label>Platform pass</label>
+    <description>Identification of collection coverage.</description>
+  </element>
+  <element name="mac:MI_Platform">
+    <label>Platform</label>
+    <description>Designations for the platform used to acquire the dataset
+    </description>
+  </element>
+  <element name="mac:MI_Plan">
+    <label>Plan</label>
+    <description>Designations for the planning information related to meeting the data acquisition requirements
+    </description>
+  </element>
+  <element name="mac:sponsor">
+    <label>Sponsor</label>
+    <description></description>
+  </element>
+  <element name="mac:MI_InstrumentationEventList">
+    <label>Instrumentation event list</label>
+    <description>List of events related to platform/ instrument/sensor
+    </description>
+  </element>
+  <element name="mac:relatedEvent">
+    <label>Related event</label>
+    <description></description>
+  </element>
+  <element name="mac:revisionHistory">
+    <label>Revision history</label>
+    <description></description>
+  </element>
+  <element name="mac:MI_Revision">
+    <label>Revision</label>
+    <description>History of the revision of an event</description>
+  </element>
+  <element name="mac:author">
+    <label>Author</label>
+    <description></description>
+  </element>
+  <element name="mac:locale">
+    <label>Language (locale)</label>
+    <description></description>
+  </element>
+  <element name="mac:metadataConstraints">
+    <label>Metadata constraints</label>
+    <description></description>
+  </element>
+  <element name="mac:instrumentationEvent">
+    <label>Instrumentation event</label>
+    <description>An event related to a platform/instrument/sensor</description>
+  </element>
+  <element name="mac:MI_InstrumentationEvent">
+    <label>Instrumentation event</label>
+    <description></description>
+  </element>
+  <element name="mac:otherPropertyType">
+    <label>Other property type</label>
+    <description></description>
+  </element>
+  <element name="mac:otherProperty">
+    <label>Other property</label>
+    <description></description>
+  </element>
+  <element name="mac:sensor">
+    <label>Sensor</label>
+    <description></description>
+  </element>
+  <element name="mac:history">
+    <label>History</label>
+    <description></description>
+  </element>
+  <element name="mac:hosted">
+    <label>Hosted</label>
+    <description></description>
+  </element>
+  <element name="mac:objectiveOccurence">
+    <label>Objective occurrence</label>
+    <description></description>
+  </element>
+  <element name="mac:trigger">
+    <label>Trigger</label>
+    <description></description>
+  </element>
+  <element name="mac:sequence">
+    <label>Sequence</label>
+    <description>Relative time ordering of the event</description>
+  </element>
+  <element name="mac:time">
+    <label>Time</label>
+    <description></description>
+  </element>
+  <element name="mac:relatedPass">
+    <label>Related pass</label>
+    <description></description>
+  </element>
+  <element name="mac:relatedSensor">
+    <label>Related sensor</label>
+    <description></description>
+  </element>
+  <element name="mac:expectedObjective">
+    <label>Expected objective</label>
+    <description></description>
+  </element>
+  <element name="mac:MI_Event">
+    <label>Event</label>
+    <description>Identification of a significant collection point within an operation
+    </description>
+  </element>
+  <element name="mac:MI_Sensor">
+    <label>Sensor</label>
+    <description>Specific type of instrument </description>
+  </element>
+  <element name="mac:priority">
+    <label>Priority</label>
+    <description>Priority applied to the target</description>
+  </element>
+  <element name="msr:scope">
+    <label>Scope</label>
+    <description></description>
+  </element>
+  <element name="mac:scope">
+    <label>Scope</label>
+    <description>The specific data to which the acquisition information applies</description>
+  </element>
+</labels>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/loc/dut/schematron-rules-datacite.xml
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/loc/dut/schematron-rules-datacite.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2001-2025 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+
+<strings>
+  <datacite.mandatory>Mandatory fields</datacite.mandatory>
+
+  <datacite.identifier.missing>The identifier is missing. The Identifier is a unique
+    string that identifies a resource. This field is mandatory.
+  </datacite.identifier.missing>
+  <datacite.identifier.present>The identifier is: </datacite.identifier.present>
+
+  <datacite.type.missing>The type is missing. Check the metadata section and set the hierarchy level. This field is mandatory.
+  </datacite.type.missing>
+  <datacite.type.present>The resource type is: </datacite.type.present>
+
+  <datacite.title.missing>The title is missing. A name or title by which a
+    resource is known. May be
+    the title of a dataset or the
+    name of a piece of software. This field is mandatory.
+  </datacite.title.missing>
+  <datacite.title.present>The title is:</datacite.title.present>
+
+  <datacite.publicationDate.missing>Publication year is missing. The year when the data was
+    or will be made publicly
+    available. Check publication date in resource identification. This field is mandatory.
+  </datacite.publicationDate.missing>
+  <datacite.publicationDate.present>The publication date is: </datacite.publicationDate.present>
+
+  <datacite.creator.missing>Creator is missing. The main researchers involved
+    in producing the data, or the authors of the publication, in
+    priority order. To supply multiple creators, repeat this
+    property. Check point of contact in resource identification with role 'pointOfContact' or 'custodian'. This field is mandatory.
+  </datacite.creator.missing>
+  <datacite.creator.found> creator(s) found.</datacite.creator.found>
+
+  <datacite.publisher.missing>Publisher is missing. The name of the entity that
+    holds, archives, publishes
+    prints, distributes, releases,
+    issues, or produces the
+    resource. Check distribution section, the publisher is the first distributor contact. This field is mandatory.
+  </datacite.publisher.missing>
+  <datacite.publisher.present>The publisher is: </datacite.publisher.present>
+</strings>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/loc/dut/schematron-rules-url-check.xml
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/loc/dut/schematron-rules-url-check.xml
@@ -1,0 +1,6 @@
+<strings>
+  <schematron.title>URL Validation</schematron.title>
+  <invalidURLCheck>Online Resource Link Check</invalidURLCheck>
+  <alert.invalidURL><div>URL test failed. Current status is </div></alert.invalidURL>
+  <alert.validURL><div>Url is valid</div></alert.validURL>
+</strings>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/loc/dut/strings.xml
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/loc/dut/strings.xml
@@ -1,0 +1,110 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2001-2025 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+
+<strings>
+
+  <!-- XSD error translation -->
+  <invalidElement>Invalid content found at element </invalidElement>
+  <onElementOf>One of the following elements </onElementOf>
+  <isExpected> is expected.</isExpected>
+  <isNotComplete> is not complete.</isNotComplete>
+  <elementLocated> Parent element is </elementLocated>
+  <missingElement>Missing element in </missingElement>
+  <invalidValue>Invalid or missing value.</invalidValue>
+  <notValidFor> is not a valid value for </notValidFor>
+  <xsdErrorIs>XSD error is: </xsdErrorIs>
+  <inElement> in element </inElement>
+  <enum1>Value </enum1>
+  <enum2> is not valid for the field </enum2>
+  <enum3>Potential values are: </enum3>
+  <selectFeaturetype>Select a feature type</selectFeaturetype>
+  <missingFeatureTypeName>New feature type</missingFeatureTypeName>
+
+
+
+  <understandResource>Informatie over de dataset</understandResource>
+  <relatedResources>Gerelateerde services en gekoppelde data</relatedResources>
+  <techInfo>Technische informatie</techInfo>
+  <contactInfo>Contact informatie</contactInfo>
+  <mdContactInfo>Metadata contact</mdContactInfo>
+  <refDate>Referentie datum</refDate>
+  <temporalRef>Temporele informatie</temporalRef>
+  <constraintInfo>Toegang restrictie informatie</constraintInfo>
+  <xml_iso19139>Save this metadata as an ISO19139 XML file</xml_iso19139>
+  <xml_iso19139Tooai_dc>Save this metadata as an OAI Dublin Core XML file
+  </xml_iso19139Tooai_dc>
+  <resourceLineageTab>Lineage</resourceLineageTab>
+
+  <advanced>Volledig</advanced>
+  <default>Standaard</default>
+  <simple>Eenvoudig</simple>
+  <inspire>INSPIRE</inspire>
+  <inspireTheme>INSPIRE themes</inspireTheme>
+  <inspireThemeMandatory>INSPIRE themes*</inspireThemeMandatory>
+  <resource>Bron</resource>
+  <xml>XML</xml>
+  <metadata>Metadata</metadata>
+  <identificationInfo>Identificatie</identificationInfo>
+  <distributionInfo>Distributie</distributionInfo>
+  <dataQualityInfo>Kwaliteit</dataQualityInfo>
+  <resourceLineage>Lineage</resourceLineage>
+  <spatialRepresentationInfo>Ruimtelijke rep.</spatialRepresentationInfo>
+  <referenceSystemInfo>Ref. systeem</referenceSystemInfo>
+  <contentInfo>Inhoud</contentInfo>
+  <portrayalCatalogueInfo>Weergave</portrayalCatalogueInfo>
+  <metadataConstraints>Md. restricties</metadataConstraints>
+  <metadataMaintenance>Md. ouderhoud</metadataMaintenance>
+  <applicationSchemaInfo>Schema info</applicationSchemaInfo>
+  <acquisitionInformation>Acquisition info</acquisitionInformation>
+  <qualityMeasures>Q. measures</qualityMeasures>
+
+  <bboxesSection>Geographic coverage</bboxesSection>
+  <overviews>Overviews</overviews>
+  <metadataInXML>XML</metadataInXML>
+  <providedBy>Provided by</providedBy>
+  <shareOnSocialSite>Share on social sites</shareOnSocialSite>
+  <viewMode>Views</viewMode>
+  <linkToPortal>Access to the catalogue</linkToPortal>
+  <linkToPortal-help>Read here the full details and access to the data.</linkToPortal-help>
+  <citationProposal>Citation proposal</citationProposal>
+  <citationProposal-help>This proposal was automatically generated, check if the metadata authors did not specified custom citation requirements.</citationProposal-help>
+  <citationAdditional>When using this resource in a publication, also cite the related work(s) with:</citationAdditional>
+  <associatedResources>Associated resources</associatedResources>
+
+
+  <add-resource-id>Compute resource identifier</add-resource-id>
+  <add-resource-idHelp>Compose the resource identifier using the catalog URL and
+    the metadata identifier (eg.
+    http://www.organization.org/catalogue/5391bf69-44bc-4ea0-8cc0-6cf6c3bc81ae).
+  </add-resource-idHelp>
+  <add-extent-from-geokeywords>Add extent for each keywords</add-extent-from-geokeywords>
+  <add-one-extent-from-geokeywords>Add one extent from all keywords</add-one-extent-from-geokeywords>
+  <add-extent-from-geokeywordsHelp>Analyze each keyword of type place and add
+    matching extent.
+  </add-extent-from-geokeywordsHelp>
+  <extent>Geographic bounding box</extent>
+  <spatialExtent>Ruimtelijke dekking</spatialExtent>
+  <freeTextKeywords>Other keywords</freeTextKeywords>
+  <noThesaurusName>Trefwoorden</noThesaurusName>
+</strings>


### PR DESCRIPTION
Added translations of analog elements from the iso19139 metadata schema.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

