### PR TITLE
Pasting text in the metadata editor uploads an image to the catalogue store

### DIFF
--- a/web-ui/src/main/resources/catalog/components/filestore/FileStoreDirective.js
+++ b/web-ui/src/main/resources/catalog/components/filestore/FileStoreDirective.js
@@ -63,7 +63,6 @@
             scope.queue = [];
 
             var uploadFile = function () {
-              var uploadZone = $("#gn-upload-" + scope.id);
               scope.queue = [];
               scope.filestoreUploadOptions = angular.extend(
                 {
@@ -74,8 +73,8 @@
                     gnCurrentEdit.uuid +
                     "/attachments?visibility=" +
                     (scope.visibility || "public"),
-                  dropZone: uploadZone,
-                  pasteZone: uploadZone,
+                  dropZone: $("#gn-upload-" + scope.id),
+                  pasteZone: null,
                   // TODO: acceptFileTypes: /(\.|\/)(xml|skos|rdf)$/i,
                   done: uploadResourceSuccess,
                   fail: uploadResourceFailed,

--- a/web-ui/src/main/resources/catalog/components/filestore/FileStoreDirective.js
+++ b/web-ui/src/main/resources/catalog/components/filestore/FileStoreDirective.js
@@ -63,6 +63,7 @@
             scope.queue = [];
 
             var uploadFile = function () {
+              var uploadZone = $("#gn-upload-" + scope.id);
               scope.queue = [];
               scope.filestoreUploadOptions = angular.extend(
                 {
@@ -73,7 +74,8 @@
                     gnCurrentEdit.uuid +
                     "/attachments?visibility=" +
                     (scope.visibility || "public"),
-                  dropZone: $("#gn-upload-" + scope.id),
+                  dropZone: uploadZone,
+                  pasteZone: uploadZone,
                   // TODO: acceptFileTypes: /(\.|\/)(xml|skos|rdf)$/i,
                   done: uploadResourceSuccess,
                   fail: uploadResourceFailed,


### PR DESCRIPTION
Currently if you paste a file anywhere in the editor it will be uploaded to the catalogue store. This is problematic as applications like Microsoft OneNote copy multiple versions of the text to the clipboard. For example OneNote has text, html, and an image version of the text.

![image](https://github.com/user-attachments/assets/ed445402-80cd-4017-827e-91df072f90ed)

This means that when text is copied from OneNote and pasted into a field, the image version of the text is uploaded to the store.

![image](https://github.com/user-attachments/assets/b84d882f-f419-4be4-b53f-c2152b2f478d)
![image](https://github.com/user-attachments/assets/92e0b5c6-e40e-46ec-bc84-2e34c72b8683)
![image](https://github.com/user-attachments/assets/ddfd7287-d79e-4eda-98d4-e64d8098140f)

This behavior seems to come from `blueimp.fileupload` having its `pasteZone` set to `document`.

This PR aims to fix this issue by setting the `pasteZone` to the same element as the `dropZone`. It could also be set to `null` if the pasting functionality is not required. I suspect it may not be required as there is no field to actually paste in only a button.

![image](https://github.com/user-attachments/assets/99cecfc7-fdeb-447e-80e0-4f5df640d62e)

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation