### PR TITLE
Fix harvesting errors not always being reported

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/AbstractHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/AbstractHarvester.java
@@ -118,7 +118,12 @@ public abstract class AbstractHarvester<T extends HarvestResult, P extends Abstr
     /**
      * Should we cancel the harvester?
      */
-    protected volatile AtomicBoolean cancelMonitor = new AtomicBoolean(false);
+    protected final AtomicBoolean cancelMonitor = new AtomicBoolean(false);
+
+    /**
+     * Contains all the errors that were thrown during harvesting and that may have caused the harvesting to abort
+     */
+    protected final List<HarvestError> errors = Collections.synchronizedList(new LinkedList<>());
 
     protected ServiceContext context;
 
@@ -145,10 +150,6 @@ public abstract class AbstractHarvester<T extends HarvestResult, P extends Abstr
      * Exception that aborted the harvesting
      */
     private Throwable error;
-    /**
-     * Contains all the warnings and errors that didn't abort the execution, but were thrown during harvesting
-     */
-    private List<HarvestError> errors = Collections.synchronizedList(new LinkedList<>());
     private volatile boolean running = false;
 
     public static AbstractHarvester<?, ?> create(String type, ServiceContext context) throws BadParameterEx, OperationAbortedEx {
@@ -538,7 +539,7 @@ public abstract class AbstractHarvester<T extends HarvestResult, P extends Abstr
      * Nested class to handle harvesting with fast indexing.
      */
     public class HarvestWithIndexProcessor extends MetadataIndexerProcessor {
-        Logger logger;
+        private final Logger logger;
 
         public HarvestWithIndexProcessor(DataManager dm, Logger logger) {
             super(dm);
@@ -657,11 +658,6 @@ public abstract class AbstractHarvester<T extends HarvestResult, P extends Abstr
                         logger.error(t);
                         error = t;
                         errors.add(new HarvestError(context, t));
-                    } finally {
-                        List<HarvestError> harvesterErrors = getErrors();
-                        if (harvesterErrors != null) {
-                            errors.addAll(harvesterErrors);
-                        }
                     }
 
                     long elapsedTime = TimeUnit.MILLISECONDS.toSeconds(System.currentTimeMillis() - startTime);
@@ -758,14 +754,8 @@ public abstract class AbstractHarvester<T extends HarvestResult, P extends Abstr
         return res;
     }
 
-    /**
-     * Should be overriden to get a better insight on harvesting
-     * <p/>
-     * Returns the list of exceptions that ocurred during the harvesting but
-     * didn't really stop and abort the harvest.
-     */
     public List<HarvestError> getErrors() {
-        return Collections.synchronizedList(errors);
+        return Collections.unmodifiableList(errors);
     }
 
     public final String getType() {

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/IHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/IHarvester.java
@@ -35,11 +35,6 @@ import org.fao.geonet.Logger;
 public interface IHarvester<T extends HarvestResult> {
 
     /**
-     * Returns all the (important?) exceptions that were thrown during the execution
-     */
-    List<HarvestError> getErrors();
-
-    /**
      * Actual harvest function.
      */
     T harvest(Logger log) throws Exception;

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/CswHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/CswHarvester.java
@@ -91,7 +91,7 @@ public class CswHarvester extends AbstractHarvester<HarvestResult, CswParams> {
      * @throws Exception
      */
     public void doHarvest(Logger log) throws Exception {
-        Harvester h = new Harvester(cancelMonitor, log, context, params);
+        Harvester h = new Harvester(cancelMonitor, log, context, params, errors);
         result = h.harvest(log);
     }
 }

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Harvester.java
@@ -77,24 +77,25 @@ class Harvester implements IHarvester<HarvestResult> {
     private static String CONSTRAINT_LANGUAGE_VERSION = "1.1.0";
 
     //FIXME version should be parametrized
-    private static String GETCAPABILITIES_PARAMETERS = "SERVICE=CSW&REQUEST=GetCapabilities&VERSION=2.0.2";
+    private static final String GETCAPABILITIES_PARAMETERS = "SERVICE=CSW&REQUEST=GetCapabilities&VERSION=2.0.2";
     private final AtomicBoolean cancelMonitor;
 
     private Logger log;
-    private CswParams params;
-    private ServiceContext context;
+    private final CswParams params;
+    private final ServiceContext context;
 
     /**
      * Contains a list of accumulated errors during the executing of this harvest.
      */
-    private List<HarvestError> errors = new LinkedList<HarvestError>();
+    private final List<HarvestError> errors;
 
 
-    public Harvester(AtomicBoolean cancelMonitor, Logger log, ServiceContext context, CswParams params) {
+    public Harvester(AtomicBoolean cancelMonitor, Logger log, ServiceContext context, CswParams params, List<HarvestError> errors) {
         this.cancelMonitor = cancelMonitor;
         this.log = log;
         this.context = context;
         this.params = params;
+        this.errors = errors;
     }
 
     public HarvestResult harvest(Logger log) throws Exception {
@@ -733,9 +734,5 @@ class Harvester implements IHarvester<HarvestResult> {
         // UUID or date modified
         return null;
 
-    }
-
-    public List<HarvestError> getErrors() {
-        return errors;
     }
 }

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geoPREST/GeoPRESTHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geoPREST/GeoPRESTHarvester.java
@@ -70,7 +70,7 @@ public class GeoPRESTHarvester extends AbstractHarvester<HarvestResult, GeoPREST
     //---------------------------------------------------------------------------
 
     public void doHarvest(Logger log) throws Exception {
-        Harvester h = new Harvester(cancelMonitor, log, context, params);
+        Harvester h = new Harvester(cancelMonitor, log, context, params, errors);
         result = h.harvest(log);
     }
 }

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geoPREST/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geoPREST/Harvester.java
@@ -81,24 +81,23 @@ class Harvester implements IHarvester<HarvestResult> {
     //--- API methods
     //---
     //---------------------------------------------------------------------------
-    private GeoPRESTParams params;
+    private final GeoPRESTParams params;
 
     //---------------------------------------------------------------------------
-    private ServiceContext context;
+    private final ServiceContext context;
 
     //---------------------------------------------------------------------------
     /**
      * Contains a list of accumulated errors during the executing of this harvest.
      */
-    private List<HarvestError> errors = new LinkedList<HarvestError>();
+    private final List<HarvestError> errors;
 
-    public Harvester(AtomicBoolean cancelMonitor, Logger log, ServiceContext context, GeoPRESTParams params) {
-
+    public Harvester(AtomicBoolean cancelMonitor, Logger log, ServiceContext context, GeoPRESTParams params, List<HarvestError> errors) {
         this.cancelMonitor = cancelMonitor;
         this.log = log;
         this.context = context;
         this.params = params;
-
+        this.errors = errors;
     }
 
     public HarvestResult harvest(Logger log) throws Exception {
@@ -306,10 +305,6 @@ class Harvester implements IHarvester<HarvestResult> {
         }
 
         throw new ParseException("Can't parse date '" + pubDate + "'", 0);
-    }
-
-    public List<HarvestError> getErrors() {
-        return errors;
     }
 }
 

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/GeonetHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/GeonetHarvester.java
@@ -91,7 +91,7 @@ public class GeonetHarvester extends AbstractHarvester<HarvestResult, GeonetPara
     }
 
     public void doHarvest(Logger log) throws Exception {
-        Harvester h = new Harvester(cancelMonitor, log, context, params);
+        Harvester h = new Harvester(cancelMonitor, log, context, params, errors);
         result = h.harvest(log);
     }
 }

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/Harvester.java
@@ -71,21 +71,22 @@ class Harvester implements IHarvester<HarvestResult> {
     private final AtomicBoolean cancelMonitor;
     private Logger log;
 
-    private GeonetParams params;
-    private ServiceContext context;
+    private final GeonetParams params;
+    private final ServiceContext context;
 
     /**
      * Contains a list of accumulated errors during the executing of this harvest.
      */
-    private List<HarvestError> errors = new LinkedList<HarvestError>();
+    private final List<HarvestError> errors;
 
     //---------------------------------------------------------------------------
 
-    public Harvester(AtomicBoolean cancelMonitor, Logger log, ServiceContext context, GeonetParams params) {
+    public Harvester(AtomicBoolean cancelMonitor, Logger log, ServiceContext context, GeonetParams params, List<HarvestError> errors) {
         this.cancelMonitor = cancelMonitor;
         this.log = log;
         this.context = context;
         this.params = params;
+        this.errors = errors;
     }
 
     public HarvestResult harvest(Logger log) throws Exception {
@@ -425,9 +426,5 @@ class Harvester implements IHarvester<HarvestResult> {
 
             resources.copyUnknownLogo(context, uuid);
         }
-    }
-
-    public List<HarvestError> getErrors() {
-        return errors;
     }
 }

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/oaipmh/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/oaipmh/Harvester.java
@@ -101,13 +101,14 @@ class Harvester extends BaseAligner<OaiPmhParams> implements IHarvester<HarvestR
     /**
      * Contains a list of accumulated errors during the executing of this harvest.
      */
-    private List<HarvestError> errors = new LinkedList<>();
+    private final List<HarvestError> errors;
 
-    public Harvester(AtomicBoolean cancelMonitor, Logger log, ServiceContext context, OaiPmhParams params) {
+    public Harvester(AtomicBoolean cancelMonitor, Logger log, ServiceContext context, OaiPmhParams params, List<HarvestError> errors) {
         super(cancelMonitor);
         this.log = log;
         this.context = context;
         this.params = params;
+        this.errors = errors;
 
         result = new HarvestResult();
 
@@ -620,9 +621,5 @@ class Harvester extends BaseAligner<OaiPmhParams> implements IHarvester<HarvestR
             metadataIndexer.indexMetadata(id, true, IndexingMode.full);
             result.updatedMetadata++;
         }
-    }
-
-    public List<HarvestError> getErrors() {
-        return errors;
     }
 }

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/oaipmh/OaiPmhHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/oaipmh/OaiPmhHarvester.java
@@ -77,7 +77,7 @@ public class OaiPmhHarvester extends AbstractHarvester<HarvestResult, OaiPmhPara
     //---------------------------------------------------------------------------
 
     public void doHarvest(Logger log) throws Exception {
-        Harvester h = new Harvester(cancelMonitor, log, context, params);
+        Harvester h = new Harvester(cancelMonitor, log, context, params, errors);
         result = h.harvest(log);
     }
 }

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/ogcwxs/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/ogcwxs/Harvester.java
@@ -1045,14 +1045,6 @@ class Harvester extends BaseAligner<OgcWxSParams> implements IHarvester<HarvestR
         }
     }
 
-    /* (non-Javadoc)
-     * @see org.fao.geonet.kernel.harvest.harvester.IHarvester#getErrors()
-     */
-    @Override
-    public List<HarvestError> getErrors() {
-        return new ArrayList<>();
-    }
-
     private static class WxSLayerRegistry {
         public String uuid;
         public String id;

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/simpleurl/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/simpleurl/Harvester.java
@@ -78,8 +78,8 @@ class Harvester implements IHarvester<HarvestResult> {
 
     private final AtomicBoolean cancelMonitor;
     private Logger log;
-    private SimpleUrlParams params;
-    private ServiceContext context;
+    private final SimpleUrlParams params;
+    private final ServiceContext context;
 
     @Autowired
     GeonetHttpRequestFactory requestFactory;
@@ -87,13 +87,14 @@ class Harvester implements IHarvester<HarvestResult> {
     /**
      * Contains a list of accumulated errors during the executing of this harvest.
      */
-    private List<HarvestError> errors = new LinkedList<>();
+    private final List<HarvestError> errors;
 
-    public Harvester(AtomicBoolean cancelMonitor, Logger log, ServiceContext context, SimpleUrlParams params) {
+    public Harvester(AtomicBoolean cancelMonitor, Logger log, ServiceContext context, SimpleUrlParams params, List<HarvestError> errors) {
         this.cancelMonitor = cancelMonitor;
         this.log = log;
         this.context = context;
         this.params = params;
+        this.errors = errors;
     }
 
     public HarvestResult harvest(Logger log) throws Exception {
@@ -428,9 +429,5 @@ class Harvester implements IHarvester<HarvestResult> {
 
     private URI createUrl(String jsonUrl) throws URISyntaxException {
         return new URI(jsonUrl);
-    }
-
-    public List<HarvestError> getErrors() {
-        return errors;
     }
 }

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/simpleurl/SimpleUrlHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/simpleurl/SimpleUrlHarvester.java
@@ -61,7 +61,7 @@ public class SimpleUrlHarvester extends AbstractHarvester<HarvestResult, SimpleU
     }
 
     public void doHarvest(Logger log) throws Exception {
-        Harvester h = new Harvester(cancelMonitor, log, context, params);
+        Harvester h = new Harvester(cancelMonitor, log, context, params, errors);
         result = h.harvest(log);
     }
 }

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/thredds/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/thredds/Harvester.java
@@ -191,7 +191,7 @@ class Harvester extends BaseAligner<ThreddsParams> implements IHarvester<Harvest
     private HashSet<String> harvestUris = new HashSet<String>();
     private Map<String, ThreddsService> services = new HashMap<String, Harvester.ThreddsService>();
     private InvCatalogImpl catalog;
-    private List<HarvestError> errors = new LinkedList<HarvestError>();
+    private List<HarvestError> errors;
 
     private LatLonRect globalLatLonBox = null;
     private DateRange globalDateRange = null;
@@ -226,11 +226,12 @@ class Harvester extends BaseAligner<ThreddsParams> implements IHarvester<Harvest
      * @return null
      **/
 
-    public Harvester(AtomicBoolean cancelMonitor, Logger log, ServiceContext context, ThreddsParams params) {
+    public Harvester(AtomicBoolean cancelMonitor, Logger log, ServiceContext context, ThreddsParams params, List<HarvestError> errors) {
         super(cancelMonitor);
         this.log = log;
         this.context = context;
         this.params = params;
+        this.errors = errors;
 
         result = new HarvestResult();
 
@@ -318,11 +319,6 @@ class Harvester extends BaseAligner<ThreddsParams> implements IHarvester<Harvest
 
         result.totalMetadata = result.serviceRecords + result.collectionDatasetRecords;
         return result;
-    }
-
-    @Override
-    public List<HarvestError> getErrors() {
-        return errors;
     }
 
     //---------------------------------------------------------------------------

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/thredds/ThreddsHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/thredds/ThreddsHarvester.java
@@ -72,7 +72,7 @@ public class ThreddsHarvester extends AbstractHarvester<HarvestResult, ThreddsPa
     //---------------------------------------------------------------------------
 
     public void doHarvest(Logger log) throws Exception {
-        Harvester h = new Harvester(cancelMonitor, log, context, params);
+        Harvester h = new Harvester(cancelMonitor, log, context, params, errors);
         result = h.harvest(log);
     }
 }

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/webdav/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/webdav/Harvester.java
@@ -83,15 +83,16 @@ class Harvester extends BaseAligner<WebDavParams> implements IHarvester<HarvestR
     private UriMapper localUris;
     private HarvestResult result;
     private SchemaManager schemaMan;
-    private List<HarvestError> errors = new LinkedList<>();
+    private List<HarvestError> errors;
     private String processName;
     private Map<String, Object> processParams = new HashMap<>();
 
-    public Harvester(AtomicBoolean cancelMonitor, Logger log, ServiceContext context, WebDavParams params) {
+    public Harvester(AtomicBoolean cancelMonitor, Logger log, ServiceContext context, WebDavParams params, List<HarvestError> errors) {
         super(cancelMonitor);
         this.log = log;
         this.context = context;
         this.params = params;
+        this.errors = errors;
 
         result = new HarvestResult();
         result.addedMetadata = 0;
@@ -291,7 +292,7 @@ class Harvester extends BaseAligner<WebDavParams> implements IHarvester<HarvestR
         if (StringUtils.isNotEmpty(params.xslfilter)) {
             md = HarvesterUtil.processMetadata(dataMan.getSchema(schema),
                 md, processName, processParams);
-                
+
             schema = dataMan.autodetectSchema(md);
         }
 
@@ -524,10 +525,6 @@ class Harvester extends BaseAligner<WebDavParams> implements IHarvester<HarvestR
 
             dataMan.indexMetadata(recordInfo.id, true);
         }
-    }
-
-    public List<HarvestError> getErrors() {
-        return errors;
     }
 }
 

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/webdav/WebDavHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/webdav/WebDavHarvester.java
@@ -47,7 +47,7 @@ public class WebDavHarvester extends AbstractHarvester<HarvestResult, WebDavPara
 
     public void doHarvest(Logger log) throws Exception {
         log.info("WebDav doHarvest start");
-        Harvester h = new Harvester(cancelMonitor, log, context, params);
+        Harvester h = new Harvester(cancelMonitor, log, context, params, errors);
         result = h.harvest(log);
         log.info("WebDav doHarvest end");
     }

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/wfsfeatures/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/wfsfeatures/Harvester.java
@@ -145,7 +145,8 @@ class Harvester implements IHarvester<HarvestResult> {
     /**
      * Contains a list of accumulated errors during the executing of this harvest.
      */
-    private List<HarvestError> errors = new LinkedList<HarvestError>();
+    private List<HarvestError> errors;
+
     /**
      * Constructor
      *
@@ -153,11 +154,12 @@ class Harvester implements IHarvester<HarvestResult> {
      * @param params  harvesting configuration for the node
      * @return null
      */
-    public Harvester(AtomicBoolean cancelMonitor, Logger log, ServiceContext context, WfsFeaturesParams params) {
+    public Harvester(AtomicBoolean cancelMonitor, Logger log, ServiceContext context, WfsFeaturesParams params, List<HarvestError> errors) {
         this.cancelMonitor = cancelMonitor;
         this.log = log;
         this.context = context;
         this.params = params;
+        this.errors = errors;
 
         result = new HarvestResult();
 
@@ -380,9 +382,5 @@ class Harvester implements IHarvester<HarvestResult> {
         fragmentParams.uuid = params.getUuid();
         fragmentParams.owner = params.getOwnerId();
         return fragmentParams;
-    }
-
-    public List<HarvestError> getErrors() {
-        return errors;
     }
 }

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/wfsfeatures/WfsFeaturesHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/wfsfeatures/WfsFeaturesHarvester.java
@@ -68,7 +68,7 @@ public class WfsFeaturesHarvester extends AbstractHarvester<HarvestResult, WfsFe
     //---------------------------------------------------------------------------
 
     public void doHarvest(Logger log) throws Exception {
-        Harvester h = new Harvester(cancelMonitor, log, context, params);
+        Harvester h = new Harvester(cancelMonitor, log, context, params, errors);
         result = h.harvest(log);
     }
 }

--- a/harvesters/src/test/java/org/fao/geonet/kernel/harvest/harvester/geoPREST/HarvesterTest.java
+++ b/harvesters/src/test/java/org/fao/geonet/kernel/harvest/harvester/geoPREST/HarvesterTest.java
@@ -17,6 +17,7 @@
 package org.fao.geonet.kernel.harvest.harvester.geoPREST;
 
 import java.text.ParseException;
+import java.util.ArrayList;
 import java.util.Date;
 
 import org.apache.commons.lang3.SystemUtils;
@@ -38,7 +39,7 @@ public class HarvesterTest
     @Ignore("see https://github.com/georchestra/geonetwork/pull/191#issuecomment-1014424757")
     public void testParseDate() throws Exception {
 
-        Harvester h = new Harvester(null, Log.createLogger("TEST"), null, null);
+        Harvester h = new Harvester(null, Log.createLogger("TEST"), null, null, new ArrayList<>());
 
         // test EN date
         h.parseDate("Mon, 04 Feb 2013 10:19:00 +1000");
@@ -55,7 +56,7 @@ public class HarvesterTest
 
         assumeTrue(SystemUtils.IS_JAVA_1_8);
 
-        Harvester h = new Harvester(null, Log.createLogger("TEST"), null, null);
+        Harvester h = new Harvester(null, Log.createLogger("TEST"), null, null, new ArrayList<>());
         Date p0 = h.parseDate("Fr, 24 Mär 2017 10:58:59 +0100");
         Date p1 = h.parseDate("Fr, 24 Mrz 2017 10:58:59 +0100");
 
@@ -65,7 +66,7 @@ public class HarvesterTest
     @Test
     public void testUnparsableDate() throws Exception {
 
-        Harvester h = new Harvester(null, Log.createLogger("TEST"), null, null);
+        Harvester h = new Harvester(null, Log.createLogger("TEST"), null, null, new ArrayList<>());
 
         try {
             h.parseDate("Xyz, 04 Feb 2013 10:19:00 +1000");

--- a/harvesters/src/test/java/org/fao/geonet/kernel/harvest/harvester/simpleurl/HarvesterTest.java
+++ b/harvesters/src/test/java/org/fao/geonet/kernel/harvest/harvester/simpleurl/HarvesterTest.java
@@ -3,6 +3,7 @@ package org.fao.geonet.kernel.harvest.harvester.simpleurl;
 import org.fao.geonet.utils.Log;
 import org.junit.Test;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.junit.Assert.*;
@@ -18,7 +19,7 @@ public class HarvesterTest {
 
         int numberOfResult = 21;
 
-        final Harvester harvester = new Harvester(null, Log.createLogger("TEST"), null, params);
+        final Harvester harvester = new Harvester(null, Log.createLogger("TEST"), null, params, new ArrayList<>());
         List<String> list = harvester.buildListOfUrl(params, numberOfResult);
         assertEquals(3, list.size());
         assertEquals("http://dados.gov.br/api/3/action/package_search?q=&rows=10&start=1", list.get(0));


### PR DESCRIPTION
This Pull Request fixes an issue with the way how harvesters report their errors.
Currently, there are two lists that may contain error, one in [AbstractHarvester](https://github.com/geonetwork/core-geonetwork/blob/03c2aae7a0b59d8d70f50673d0121bfd99f2cfd7/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/AbstractHarvester.java#L151) and one in many harvester classes. The intent is to merge these two lists in AbstractHarvester via the `getErrors()` method.
This, however, does not work, as getErrors always returns the List that is present in AbstractHarvester. There seems to be an inheritance issue here: The subclasses of AbstractHarvester do not implement getErrors themself, but the classes that are called by the subclasses.
Let's take the CSW Harvester as an example: The subclass of AbstractHarvester [CswHarvester](https://github.com/geonetwork/core-geonetwork/blob/main/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/CswHarvester.java) does not override getErrors, but it contructs an instace of [Harvester](https://github.com/geonetwork/core-geonetwork/blob/main/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Harvester.java), which is an instace of [IHarvester](https://github.com/geonetwork/core-geonetwork/blob/main/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/IHarvester.java). IHarvester and AbstractHarvester are two distinct classes, and as the CSWHarvester does not forward the errors of the newly created Harvester, these errors are just lost.

This means that many errors just get swallowed, and in some cases a harvesting run seems successful, but upon closer inspection (log or harvesting result), there was actually an error!

The fix is simple: just give the actual IHarvester implementations a reference to the same error list that AbstractHarvester uses. 

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->
---
Funded by [LGL BW](https://www.lgl-bw.de/index.html)

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

