### PR TITLE
Fix version of json-smart library to avoid build issue:

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -183,10 +183,23 @@
 
 
     <dependency>
+      <groupId>net.minidev</groupId>
+      <artifactId>json-smart</artifactId>
+      <version>2.3</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-oauth2-client</artifactId>
       <version>${spring.security.version}</version>
+      <exclusions>
+        <exclusion>
+          <groupId>net.minidev</groupId>
+          <artifactId>json-smart</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
+
     <dependency>
       <groupId>org.springframework.security</groupId>
       <artifactId>spring-security-oauth2-jose</artifactId>


### PR DESCRIPTION
The build started failing in `main` and `4.2.x` branches:

```
[ERROR] Failed to execute goal on project gn-core: Could not resolve dependencies for project org.geonetwork-opensource:gn-core:jar:4.4.7-SNAPSHOT: 
Failed to collect dependencies at org.springframework.security:spring-security-oauth2-client:jar:5.8.15 -> com.nimbusds:oauth2-oidc-sdk:jar:9.43.3 -> net.minidev:json-smart:jar:[1.3.3,2.4.10]: 
No versions available for net.minidev:json-smart:jar:[1.3.3,2.4.10] within specified range -> [Help 1]
```

It's unclear the reason why this is happening now, but seems there are some old reports about this issue:

https://bitbucket.org/connect2id/oauth-2.0-sdk-with-openid-connect-extensions/issues/370/variable-range-of-netminidev-json-smart

New versions of nimbus `com.nimbusds:oauth2-oidc-sdk` (since 10.14.1) uses a fixed version of `json-smart` instead of defining a range, fixing the problem. But the spring security version used in GeoNetwork uses an older dependency of nimbus `com.nimbusds:oauth2-oidc-sdk` that uses a range of versions for `json-smart`.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

