### PR TITLE
Metadata editor / Avoid displaying the tooltip icon next to buttons to add new elements, when the toolstip mode is icon

### DIFF
--- a/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
@@ -934,11 +934,24 @@
         id="gn-el-{$id}"
         data-gn-cardinality="{$childEditInfo/@min}-{$childEditInfo/@max}"
         data-gn-field-highlight="">
-        <label class="col-sm-2 control-label"
-               data-gn-field-tooltip="{$schema}|{$qualifiedName}|{$parentName}|">
-          <xsl:value-of select="if (normalize-space($label) != '')
+
+        <xsl:choose>
+          <xsl:when test="$viewConfig/@displayTooltipsMode = 'icon'">
+            <!-- Avoid displaying the help icon next to buttons when the toolstip mode is icon -->
+            <label class="col-sm-2 control-label">
+              <xsl:value-of select="if (normalize-space($label) != '')
                                 then $label else '&#160;'"/>
-        </label>
+            </label>
+          </xsl:when>
+          <xsl:otherwise>
+            <label class="col-sm-2 control-label"
+                   data-gn-field-tooltip="{$schema}|{$qualifiedName}|{$parentName}|">
+              <xsl:value-of select="if (normalize-space($label) != '')
+                                then $label else '&#160;'"/>
+            </label>
+          </xsl:otherwise>
+        </xsl:choose>
+
         <div class="col-sm-9">
 
           <xsl:variable name="addDirective" select="$directive/@addDirective != ''"/>


### PR DESCRIPTION
When configuring the tooltip mode to icon in `config-editor.xml`:

```
<view name="default" default="true"
          displayTooltips="true" displayTooltipsMode="icon"
          class="gn-label-above-input gn-indent-bluescale">
```

Help icons are displayed next to the input fields, but also are displayed in the buttons to add new elements. In this mode the rendering is not very good. It seems better to define a descriptive label:

![tooltip-buttons-1](https://github.com/user-attachments/assets/049f257a-6a39-4dff-85f1-b049c98f0d8d)

With this change:

![tooltip-buttons-2](https://github.com/user-attachments/assets/eab09f5f-2f91-45c5-8997-a9088670bbf2)


# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

