### PR TITLE
Improved schematron localisation

### DIFF
--- a/web/src/main/webapp/WEB-INF/classes/schematron/iso_svrl_for_xslt2.xsl
+++ b/web/src/main/webapp/WEB-INF/classes/schematron/iso_svrl_for_xslt2.xsl
@@ -140,7 +140,8 @@
   xmlns:schold="http://www.ascc.net/xml/schematron"
   xmlns:iso="http://purl.oclc.org/dsdl/schematron"
   xmlns:svrl="http://purl.oclc.org/dsdl/svrl"
-  version="1.0"
+  xmlns:geonet="http://www.fao.org/geonetwork"
+  version="2.0"
 
 >
 
@@ -210,7 +211,25 @@
     <axsl:param name="thesaurusDir"/>
     <axsl:param name="rule"/>
 
-    <axsl:variable name="loc" select="document(concat('../loc/', $lang, '/', $rule, '.xml'))"/>
+    <!-- Retrieve localisation entries (one file specific to the rule, the other file is shared by all schematron). Fallback language is English. -->
+    <axsl:variable name="loc">
+      <axsl:choose>
+        <axsl:when test="document(concat('../loc/', $lang, '/', $rule, '.xml'))">
+          <axsl:copy-of select="document(concat('../loc/', $lang, '/', $rule, '.xml'))"/>
+        </axsl:when>
+        <axsl:otherwise>
+          <axsl:copy-of select="document(concat('../loc/', 'eng', '/', $rule, '.xml'))"/>
+        </axsl:otherwise>
+      </axsl:choose>
+      <axsl:choose>
+        <axsl:when test="count(document(concat('../loc/', $lang, '/', 'schematron-shared.xml')))">
+          <axsl:copy-of select="document(concat('../loc/', $lang, '/', 'schematron-shared.xml'))"/>
+        </axsl:when>
+        <axsl:otherwise>
+          <axsl:copy-of select="document(concat('../loc/', 'eng', '/', 'schematron-shared.xml'))"/>
+        </axsl:otherwise>
+      </axsl:choose>
+    </axsl:variable>
   </xsl:template>
 
   <!-- Overrides skeleton.xsl -->
@@ -525,7 +544,7 @@
   <xsl:template name="svrl-text">
     <svrl:text>
       <xsl:choose>
-        <xsl:when test="starts-with(., '$loc')">
+        <xsl:when test="contains(., '$loc/strings/')">
           <xsl:element name="xsl:copy-of">
             <xsl:attribute name="select">
               <xsl:apply-templates mode="text"/>
@@ -570,7 +589,7 @@
       <xsl:if test=" string( $name )">
         <axsl:attribute name="name">
           <xsl:choose>
-            <xsl:when test="starts-with($name, '$loc')">
+            <xsl:when test="contains($name, '$loc/strings/')">
               <axsl:value-of>
                 <xsl:attribute name="select">
                   <xsl:value-of select="$name"/>

--- a/web/src/main/webapp/xsl/utils-fn.xsl
+++ b/web/src/main/webapp/xsl/utils-fn.xsl
@@ -172,5 +172,19 @@
     </xsl:choose>
   </xsl:function>
 
+  <!-- Replace a given list of $placeholders by a list of respective $values in the given $string. -->
+  <xsl:function name="geonet:replacePlaceholders">
+    <xsl:param name="string"/>
+    <xsl:param name="placeholders"/>
+    <xsl:param name="values"/>
+    <xsl:choose>
+      <xsl:when test="count($placeholders)=1">
+        <xsl:value-of select="replace($string, $placeholders[position()=1], $values[position()=1])"/>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="geonet:replacePlaceholders(replace($string, $placeholders[position()=1], $values[position()=1]), $placeholders[position()>1], $values[position()>1])"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:function>
 
 </xsl:stylesheet>


### PR DESCRIPTION
In the dcat-ap schema plugin there is a need to translate schematron strings. One of the ways is to use the `loc/eng/schematron-rules-x.xml` files that are loaded by `iso_svrl_for_xslt2.xsl`. A helper function `replacePlaceholders` was added that makes sure the schematron rules remain language agnostic and the translations are easily adaptable to the needs of each language.

- English is proposed as the fallback language whenever a file cannot be found. 
- A shared schematron localisation file is introduced to prevent having to duplicate common schematron translation strings. Not having this file in place works fine.
- Fix in `iso_svrl_for_xslt2.xsl` to make sure $loc is also used when wrapped in a function.

In the schema plugin a PR was created that makes use of this change: https://github.com/metadata101/dcat-ap/pull/38.

@fxprunayre @CMath04 

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

