### PR TITLE
Editor / Keyword dropdown / Sort keywords by label

### DIFF
--- a/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusService.js
+++ b/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusService.js
@@ -212,13 +212,7 @@
               s1 = k1.label.toLowerCase();
               s2 = k2.label.toLowerCase();
             }
-            if (s1 < s2) {
-              return -1;
-            }
-            if (s1 > s2) {
-              return 1;
-            }
-            return 0;
+            return s1.localeCompare(s2);
           });
 
           if (dataToExclude && dataToExclude.length > 0) {

--- a/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusService.js
+++ b/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusService.js
@@ -192,7 +192,7 @@
           return result;
         };
 
-        var parseKeywordsResponse = function (data, dataToExclude) {
+        var parseKeywordsResponse = function (data, dataToExclude, orderById) {
           var listOfKeywords = [];
 
           var uiLangs = getUILangs();
@@ -200,6 +200,25 @@
             if (k.value) {
               listOfKeywords.push(new Keyword(k, uiLangs));
             }
+          });
+
+          listOfKeywords.sort(function(k1,k2) {
+            var s1;
+            var s2;
+            if (orderById == "true") {
+              s1 = k1.props.uri;
+              s2 = k2.props.uri;
+            } else {
+              s1 = k1.label.toLowerCase();
+              s2 = k2.label.toLowerCase();
+            }
+            if (s1 < s2) {
+              return -1;
+            }
+            if (s1 > s2) {
+              return 1;
+            }
+            return 0;
           });
 
           if (dataToExclude && dataToExclude.length > 0) {
@@ -303,20 +322,7 @@
                   config.outputLang
                 ),
                 filter: function (data) {
-                  if (config.orderById == "true") {
-                    data.sort(function (a, b) {
-                      var nameA = a.uri.toUpperCase();
-                      var nameB = b.uri.toUpperCase();
-                      if (nameA < nameB) {
-                        return -1;
-                      }
-                      if (nameA > nameB) {
-                        return 1;
-                      }
-                      return 0;
-                    });
-                  }
-                  return parseKeywordsResponse(data, config.dataToExclude);
+                  return parseKeywordsResponse(data, config.dataToExclude, config.orderById);
                 }
               }
             });


### PR DESCRIPTION
Thesaurus dropdowns in the editor were only sorted by label when presenting in English, not when switching to another language. This fix should alleviate that issue, while taking into account the existing configuration toggle that sorts by id/URI instead.

Before:
![image](https://github.com/user-attachments/assets/93c37c72-8431-4d58-93a4-d894cc29f16f)

After:
![image](https://github.com/user-attachments/assets/712455e5-d2dc-4304-b72a-251b52068e4e)

@fxprunayre @CMath04 

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

