### PR TITLE
Static pages / sort groups alphabetically

### DIFF
--- a/web-ui/src/main/resources/catalog/js/admin/StaticPagesController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/StaticPagesController.js
@@ -33,7 +33,16 @@
     "$translate",
     "$log",
     "gnGlobalSettings",
-    function ($scope, $http, $rootScope, $translate, $log, gnGlobalSettings) {
+    "gnUtilityService",
+    function (
+      $scope,
+      $http,
+      $rootScope,
+      $translate,
+      $log,
+      gnGlobalSettings,
+      gnUtilityService
+    ) {
       $scope.dbLanguages = [];
       $scope.staticPages = [];
       $scope.formats = [];
@@ -67,7 +76,7 @@
 
       function loadGroups() {
         $http.get("../api/groups").then(function (r) {
-          $scope.groups = r.data;
+          $scope.groups = gnUtilityService.sortByTranslation(r.data, $scope.lang, "name");
         });
       }
 


### PR DESCRIPTION
Sort the list of groups in the static pages form alphabetically.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
