### PR TITLE
Map viewer / Use 8 decimals for the bounding box of map in a metadata.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/mapDirective.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapDirective.js
@@ -24,12 +24,7 @@
 (function () {
   goog.provide("gn_map_directive");
 
-  var METRIC_DECIMALS = 4;
-  var DEGREE_DECIMALS = 8;
-
-  var getDigitNumber = function (proj) {
-    return proj == "EPSG:4326" ? DEGREE_DECIMALS : METRIC_DECIMALS;
-  };
+  var COORDS_NUM_DECIMALS = 8;
 
   angular.module("gn_map_directive", []).directive("gnDrawBbox", [
     "gnMap",
@@ -197,9 +192,8 @@
               scope.projs[to]
             );
             if (extent && extent.map) {
-              var decimals = getDigitNumber(scope.projs.form);
               scope.extent[to] = extent.map(function (coord) {
-                return coord === null ? null : coord.toFixed(decimals) / 1;
+                return coord === null ? null : coord.toFixed(COORDS_NUM_DECIMALS) / 1;
               });
             }
           };
@@ -227,10 +221,8 @@
           scope.$watch("projs.form", function (newValue, oldValue) {
             var extent = gnMap.reprojExtent(scope.extent.form, oldValue, newValue);
             if (extent && extent.map) {
-              var decimals = getDigitNumber(scope.projs.form);
-
               scope.extent.form = extent.map(function (coord) {
-                return coord.toFixed(decimals) / 1;
+                return coord.toFixed(COORDS_NUM_DECIMALS) / 1;
               });
             }
           });


### PR DESCRIPTION
Fixes #8668

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
