### PR TITLE
OIDC - manages single-valued roles in claims

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/OIDCRoleProcessor.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/OIDCRoleProcessor.java
@@ -34,6 +34,7 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -328,6 +329,11 @@ public class OIDCRoleProcessor {
             if (o == null) {
                 Log.debug(Geonet.SECURITY, "oidc: pathToRoles - cannot find path component named: " + path);
                 return new ArrayList<>();
+            }
+            if (o instanceof String) {
+                List<String> singleGroup = new ArrayList<>();
+                singleGroup.add((String) o);
+                return singleGroup;
             }
             if (o instanceof Map) {
                 info = (Map<String, Object>) o;

--- a/core/src/test/java/org/fao/geonet/kernel/security/openidconnect/OIDCRoleProcessorTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/security/openidconnect/OIDCRoleProcessorTest.java
@@ -242,6 +242,17 @@ public class OIDCRoleProcessorTest {
         return claims;
     }
 
+    public Map<String, Object> createSingleValuedRoleClaims() {
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("abc", "ABC");
+        Map<String, Map> resource_access = new HashMap<>();
+        Map<String, String> gn_key = new HashMap<>();
+        gn_key.put("roles", "SINGLE_ROLE_MEMBERSHIP");
+        resource_access.put("gn-key", gn_key);
+        claims.put("resource_access", resource_access);
+        return claims;
+    }
+
 
     // simple test - easiest example
     @Test
@@ -287,7 +298,15 @@ public class OIDCRoleProcessorTest {
         claims = createBadSimpleClaims6();
         roles = oidcRoleProcessor.getTokenRoles(claims);
         assertEquals(0, roles.size());
+    }
 
+    @Test
+    public void testGetTokenRolesSingleValue() {
+        OIDCRoleProcessor oidcRoleProcessor = getOIDCRoleProcessor();
+        Map<String, Object> claims = createSingleValuedRoleClaims();
+        List<String> roles = oidcRoleProcessor.getTokenRoles(claims);
+        assertEquals("Expected only one role from the claims", 1, roles.size());
+        assertEquals("Expected single role to match SINGLE_ROLE_MEMBERSHIP", "SINGLE_ROLE_MEMBERSHIP", roles.get(0));
     }
 
     //test with profile-groups


### PR DESCRIPTION
Adds support for OIDC provider implementations returning only a string as role claims when there is only one.

Our customer is using an implementation of OIDC (LLNG) which returns a single string as roles if the user which tries to log in is member of only one group / role, instead of an expected arraylist.

In this case, we had to come up with the following patch, which basically construct a single-valued arraylist with our unique role.

Tests: utest added.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

