### PR TITLE
Metadata editor / add visual indication when dragging a file to upload

### DIFF
--- a/web-ui/src/main/resources/catalog/components/filestore/FileStoreDirective.js
+++ b/web-ui/src/main/resources/catalog/components/filestore/FileStoreDirective.js
@@ -71,6 +71,18 @@
               input.attr("multiple", "multiple");
             }
 
+            var droparea = $(".file-drop-area");
+
+            // highlight drag area
+            input.on("dragenter focus click", function () {
+              droparea.addClass("is-active");
+            });
+
+            // back to normal state
+            input.on("dragleave blur drop", function () {
+              droparea.removeClass("is-active");
+            });
+
             var uploadFile = function () {
               scope.queue = [];
               scope.filestoreUploadOptions = angular.extend(

--- a/web-ui/src/main/resources/catalog/components/filestore/partials/dataUploaderButton.html
+++ b/web-ui/src/main/resources/catalog/components/filestore/partials/dataUploaderButton.html
@@ -1,5 +1,5 @@
 <div
-  class="form-horizontal"
+  class="form-horizontal file-drop-area"
   data-ng-show="uuid"
   id="gn-upload-{{id}}"
   data-file-upload="filestoreUploadOptions"

--- a/web-ui/src/main/resources/catalog/style/gn_editor.less
+++ b/web-ui/src/main/resources/catalog/style/gn_editor.less
@@ -1030,3 +1030,12 @@ gn-bounding-polygon {
     opacity: 0.65;
   }
 }
+
+.file-drop-area {
+  padding: 10px;
+}
+
+.is-active {
+  background-color: #e2edf7;
+  border-radius: 3px;
+}


### PR DESCRIPTION
Show visual indication when dragging a file to upload in the metadata editor. After the change, a light blue rectangle is displayed around the button when dragging a file:

<img width="541" alt="upload-file-2" src="https://github.com/user-attachments/assets/4a169e2c-995d-4e9e-98cb-c28dacd827f1" />


# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
