### PR TITLE
Fix DraftValidationWidget Elasticsearch query.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/utility/DraftValidationWidget.js
+++ b/web-ui/src/main/resources/catalog/components/utility/DraftValidationWidget.js
@@ -39,7 +39,7 @@
         link: function (scope) {
           var query = {
             _source: {
-              include: ["id", "uuid", "draft", "isTemplate", "valid"]
+              includes: ["id", "uuid", "draft", "isTemplate", "valid"]
             },
             size: 10,
             query: {


### PR DESCRIPTION
This was causing the issue in the widget, related to this backport: https://github.com/geonetwork/core-geonetwork/pull/8483 where `documentStandard` field is required in the backend code. Due to the wrong property name, was not added.

In `main` it contains the correct value.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
