### PR TITLE
Conversion from ISO19139 to ISO19115-3.2018: Manage organisation name with Anchor

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ISO19139/mapping/CI_ResponsibleParty.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ISO19139/mapping/CI_ResponsibleParty.xsl
@@ -42,9 +42,9 @@
                 xmlns:mdq="http://standards.iso.org/iso/19157/-2/mdq/1.0"
                 xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0"
                 exclude-result-prefixes="#all">
-    
+
     <xsl:import href="../utility/multiLingualCharacterStrings.xsl"/>
-    
+
     <xd:doc xmlns:xd="http://www.oxygenxml.com/ns/doc/xsl" scope="stylesheet">
         <xd:desc>
             <xd:p>
@@ -62,8 +62,8 @@
 
     <xsl:template match="gmd:CI_ResponsibleParty" mode="from19139to19115-3.2018">
         <xsl:choose>
-            <xsl:when test="count(gmd:individualName/gcoold:CharacterString) + count(gmd:organisationName/gcoold:CharacterString) + count(gmd:positionName/gcoold:CharacterString) > 0">
-                <!-- 
+            <xsl:when test="count(gmd:individualName/gcoold:CharacterString) + count(gmd:organisationName/(gcoold:CharacterString|gmx:Anchor)) + count(gmd:positionName/gcoold:CharacterString) > 0">
+                <!--
                 CI_ResponsibleParties that include name elements (individualName, organisationName, or positionName) are translated to CI_Responsibilities.
                 CI_ResponsibleParties without name elements are assummed to be placeholders for CI_OnlineResources. They are transformed later in the process
                 using the CI_ResponsiblePartyToOnlineResource template
@@ -142,11 +142,11 @@
         </xsl:choose>
     </xsl:template>
     <xsl:template name="CI_ResponsiblePartyToOnlineResource">
-        <!-- 
+        <!--
         CI_ResponsibleParties that have no name elements and only a CI_OnlineResource
         are assumed to be used to add CI_OnlineResources to CI_Citations in 19115 where
         CI_Citations do not include CI_OnlineResources. In this case we, transform
-        only the CI_OnlineResource element of the CI_ResponsibleParty 
+        only the CI_OnlineResource element of the CI_ResponsibleParty
     -->
         <xsl:apply-templates select=".//gmd:onlineResource" mode="from19139to19115-3.2018"/>
     </xsl:template>


### PR DESCRIPTION
Without the fix, contacts with organisation name using Anchor in ISO19139 are converted, but with empty content:

```
<gmd:pointOfContact>
  <gmd:CI_ResponsibleParty>
    <gmd:organisationName>
      <gmx:Anchor xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:xlink="http://www.w3.org/1999/xlink" 
                  xlink:href="http://test.organisation">Test organisation</gmx:Anchor>
    </gmd:organisationName>
...
```
is converted to: 

```
<mri:pointOfContact />
```

With the fix:

```
<mri:pointOfContact>
  <cit:CI_Responsibility>
    <cit:role>
      <cit:CI_RoleCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_RoleCode" codeListValue="custodian">custodian</cit:CI_RoleCode>
    </cit:role>
    <cit:party>
      <cit:CI_Organisation>
        <cit:name>
          <gcx:Anchor xlink:href="http://test.organisation">Test organisation</gcx:Anchor>
        </cit:name>
...
```

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation