### PR TITLE
Add sortLabel as override when applicable

### DIFF
--- a/schemas/config-editor.xsd
+++ b/schemas/config-editor.xsd
@@ -2331,6 +2331,11 @@ This can allow to build dynamic snippet based on the current record.
           <xs:documentation>Snippet label.</xs:documentation>
         </xs:annotation>
       </xs:attribute>
+      <xs:attribute name="sortLabel" type="xs:string" use="optional">
+        <xs:annotation>
+          <xs:documentation>When defined, @sortLabel should be used instead of @label for sorting purposes. Handy for putting values at the start of end of a list, for example.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
     </xs:complexType>
   </xs:element>
   <xs:element name="batchEditing">

--- a/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
@@ -602,9 +602,10 @@
                     </xsl:if>
                   </button>
                   <xsl:if test="$hasMultipleChoice">
-                    <!-- A combo with the list of snippet available -->
+                    <!-- A combo with the list of snippets available -->
                     <ul class="dropdown-menu">
                       <xsl:for-each select="$snippets">
+                        <xsl:sort select="if(current()/@sortLabel != '') then current()/@sortLabel else (if ($strings/*[name() = current()/@label] != '') then $strings/*[name() = current()/@label] else current()/@label)"/>
                         <xsl:variable name="label" select="@label"/>
                         <li><a id="{concat($id, $label)}">
                           <xsl:value-of select="if ($strings/*[name() = $label] != '') then $strings/*[name() = $label] else $label"/>


### PR DESCRIPTION
Added the following:
- sort snippets in the UI based on their label
- add an override for snippets when the sort should not occur based on their label (for example, when one value should be shown at the end of the list at all times)

Example implementation in the dcat-ap editor for a snippet that allows defining an empty `conformsTo`:
![image](https://github.com/user-attachments/assets/c63749fc-9f1e-414f-b691-71caf3c29fcf)
```xml
 <snippet label="protocol-51" sortLabel="ZZZZ">
        <dct:conformsTo>
          <dct:Standard xmlns:dct="http://purl.org/dc/terms/">
            <dct:identifier/>
            <dct:title xml:lang=""/>
            <dct:description xml:lang=""/>
          </dct:Standard>
        </dct:conformsTo>
      </snippet>
```

  
# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

