### PR TITLE
dcatview statuslabel

### DIFF
--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
@@ -156,12 +156,14 @@
 
             <header>
               <h1>
-                <i class="fa fa-fw gn-icon-{$type}"></i>
+                <i class="fa fa-fw gn-icon-{$type}"/>
                 <xsl:copy-of select="$title"/>
-                <span class="text-muted badge"
-                      data-ng-class="{{ 'text-success': md.mdStatus == 2, 'text-warning': md.mdStatus == 4 }}"
-                      data-ng-if="user.isEditorOrMore() &amp;&amp; md.mdStatus &lt; 50 &amp;&amp; isMdWorkflowEnable"
-                >{{('status-' + md.mdStatus) | translate}}</span>
+                <xsl:if test="$root = 'div'">
+                  <span class="text-muted badge"
+                        data-ng-class="{{ 'text-success': md.mdStatus == 2, 'text-warning': md.mdStatus == 4 }}"
+                        data-ng-if="user.isEditorOrMore() &amp;&amp; md.mdStatus &lt; 50 &amp;&amp; isMdWorkflowEnable"
+                  >{{('status-' + md.mdStatus) | translate}}</span>
+                </xsl:if>
               </h1>
 
               <xsl:call-template name="render-language-switcher"/>
@@ -407,7 +409,7 @@
     <xsl:if test="$isDisplayed">
       <div id="gn-view-{generate-id()}" class="gn-tab-content">
         <xsl:apply-templates mode="render-view" select="@xpath"/>
-        
+
       </div>
     </xsl:if>
   </xsl:template>

--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
@@ -158,6 +158,10 @@
               <h1>
                 <i class="fa fa-fw gn-icon-{$type}"></i>
                 <xsl:copy-of select="$title"/>
+                <span class="text-muted badge"
+                      data-ng-class="{{ 'text-success': md.mdStatus == 2, 'text-warning': md.mdStatus == 4 }}"
+                      data-ng-if="user.isEditorOrMore() &amp;&amp; md.mdStatus &lt; 50 &amp;&amp; isMdWorkflowEnable"
+                >{{('status-' + md.mdStatus) | translate}}</span>
               </h1>
 
               <xsl:call-template name="render-language-switcher"/>


### PR DESCRIPTION
When implementing the dcat-ap view, we noticed the generated title did not include the typical status label that we were used to seeing in ISO. This PR adds the same label, making use of the same markup as the ISO records. It also take into account displaying the records in an HTML view (see test on `$root = 'div'`).

added statuslabel to the dcatview
![image](https://github.com/user-attachments/assets/80b633da-ddcb-403e-96e9-ff6b2c33afc3)

same presentation as an ISO record
![image](https://github.com/user-attachments/assets/4871695f-efc4-47be-84d6-cff5e9470b46)

@fxprunayre 

  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

