### PR TITLE
ISO19139 to ISO19115.3-2008 conversion / preserve codelist text values

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ISO19139/mapping/CI_Citation.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ISO19139/mapping/CI_Citation.xsl
@@ -58,8 +58,8 @@
     <xsl:template match="gmd:CI_Citation" mode="from19139to19115-3.2018">
         <xsl:element name="cit:CI_Citation">
             <xsl:apply-templates mode="from19139to19115-3.2018"/>
-            <!-- Special attention is required for CI_ResponsibleParties that are included in the 
-                CI_Citation only for a URL. These are currently identified as those 
+            <!-- Special attention is required for CI_ResponsibleParties that are included in the
+                CI_Citation only for a URL. These are currently identified as those
                 with no name elements (individualName, organisationName, or positionName)
             -->
             <xsl:for-each
@@ -89,6 +89,7 @@
                             <xsl:with-param name="elementName" select="'cit:dateType'"/>
                             <xsl:with-param name="codeListName" select="'cit:CI_DateTypeCode'"/>
                             <xsl:with-param name="codeListValue" select="gmd:CI_DateTypeCode/@codeListValue"/>
+                            <xsl:with-param name="codeListText" select="gmd:CI_DateTypeCode/text()"/>
                         </xsl:call-template>
                     </xsl:for-each>
                 </cit:CI_Date>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ISO19139/mapping/CI_ResponsibleParty.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ISO19139/mapping/CI_ResponsibleParty.xsl
@@ -62,7 +62,7 @@
 
     <xsl:template match="gmd:CI_ResponsibleParty" mode="from19139to19115-3.2018">
         <xsl:choose>
-            <xsl:when test="count(gmd:individualName/gcoold:CharacterString) + count(gmd:organisationName/(gcoold:CharacterString|gmx:Anchor)) + count(gmd:positionName/gcoold:CharacterString) > 0">
+            <xsl:when test="count(gmd:individualName/gcoold:CharacterString) + count(gmd:organisationName/gcoold:CharacterString) + count(gmd:positionName/gcoold:CharacterString) > 0">
                 <!--
                 CI_ResponsibleParties that include name elements (individualName, organisationName, or positionName) are translated to CI_Responsibilities.
                 CI_ResponsibleParties without name elements are assummed to be placeholders for CI_OnlineResources. They are transformed later in the process
@@ -76,6 +76,7 @@
                                 <xsl:with-param name="elementName" select="'cit:role'"/>
                                 <xsl:with-param name="codeListName" select="'cit:CI_RoleCode'"/>
                                 <xsl:with-param name="codeListValue" select="gmd:role/gmd:CI_RoleCode/@codeListValue"/>
+                                <xsl:with-param name="codeListText" select="gmd:role/gmd:CI_RoleCode/text()"/>
                             </xsl:call-template>
                         </xsl:when>
                         <xsl:when test="./gmd:role/@*">

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ISO19139/mapping/DQ.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ISO19139/mapping/DQ.xsl
@@ -94,6 +94,7 @@
                           <xsl:with-param name="elementName" select="'mdq:evaluationMethodType'"/>
                           <xsl:with-param name="codeListName" select="'mdq:DQ_EvaluationMethodTypeCode'"/>
                           <xsl:with-param name="codeListValue" select="gmd:evaluationMethodType/gmd:DQ_EvaluationMethodTypeCode/@codeListValue"/>
+                          <xsl:with-param name="codeListText" select="gmd:evaluationMethodType/gmd:DQ_EvaluationMethodTypeCode/text()"/>
                         </xsl:call-template>
                       </mdq:DQ_FullInspection>
                     </mdq:evaluationMethod>
@@ -139,6 +140,8 @@
                   <xsl:with-param name="codeListValue"
                     select="$dataQualityScopeObject//gmd:MD_ScopeCode/@codeListValue|
                                           $dataQualityScopeObject//gmx:MX_ScopeCode/@codeListValue"/>
+                  <xsl:with-param name="codeListText" select="$dataQualityScopeObject//gmd:MD_ScopeCode/@codeListValue|
+                                          $dataQualityScopeObject//gmx:MX_ScopeCode/text()"/>
                 </xsl:call-template>
                 <xsl:for-each select="$dataQualityScopeObject//gmd:EX_Extent">
                   <mcc:extent>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ISO19139/mapping/SRV.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ISO19139/mapping/SRV.xsl
@@ -69,6 +69,8 @@
               <xsl:with-param name="codeListName" select="'srv:DCPList'"/>
               <xsl:with-param name="codeListValue" select="srvold:SV_OperationMetadata/srvold:DCP/
                                         srvold:DCPList/@codeListValue"/>
+              <xsl:with-param name="codeListText" select="srvold:SV_OperationMetadata/srvold:DCP/
+                                        srvold:DCPList/text()"/>
             </xsl:call-template>
           </xsl:when>
           <xsl:otherwise>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ISO19139/mapping/core.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ISO19139/mapping/core.xsl
@@ -115,6 +115,7 @@
               <xsl:with-param name="elementName" select="'lan:characterEncoding'"/>
               <xsl:with-param name="codeListName" select="'lan:MD_CharacterSetCode'"/>
               <xsl:with-param name="codeListValue" select="../gmd:characterSet/gmd:MD_CharacterSetCode/@codeListValue"/>
+              <xsl:with-param name="codeListText" select="../gmd:characterSet/gmd:MD_CharacterSetCode/text()"/>
             </xsl:call-template>
           </xsl:when>
           <xsl:otherwise>
@@ -140,6 +141,7 @@
               <xsl:with-param name="elementName" select="'lan:characterEncoding'"/>
               <xsl:with-param name="codeListName" select="'lan:MD_CharacterSetCode'"/>
               <xsl:with-param name="codeListValue" select="gmd:MD_CharacterSetCode/@codeListValue"/>
+              <xsl:with-param name="codeListText" select="gmd:MD_CharacterSetCode/text()"/>
             </xsl:call-template>
           </lan:PT_Locale>
         </xsl:element>
@@ -208,6 +210,7 @@
           <xsl:with-param name="elementName" select="'mcc:level'"/>
           <xsl:with-param name="codeListName" select="'mcc:MD_ScopeCode'"/>
           <xsl:with-param name="codeListValue" select="gmd:MD_ScopeCode/@codeListValue"/>
+          <xsl:with-param name="codeListText" select="gmd:MD_ScopeCode/text()"/>
         </xsl:call-template>
       </mcc:MD_Scope>
     </mmi:maintenanceScope>
@@ -225,6 +228,8 @@
           <xsl:with-param name="codeListName" select="'mcc:MD_ScopeCode'"/>
           <xsl:with-param name="codeListValue" select="gmd:MD_ScopeCode/@codeListValue|
                                   gmx:MX_ScopeCode/@codeListValue"/>
+          <xsl:with-param name="codeListText" select="gmd:MD_ScopeCode/@codeListValue|
+                                  gmx:MX_ScopeCode/text()"/>
         </xsl:call-template>
         <xsl:if test="../gmd:hierarchyLevelName">
           <mdb:name>
@@ -347,8 +352,9 @@
           <xsl:apply-templates select="gmd:credit" mode="from19139to19115-3.2018"/>
           <xsl:call-template name="writeCodelistElement">
             <xsl:with-param name="elementName" select="'mri:status'"/>
-            <xsl:with-param name="codeListValue" select="gmd:status/gmd:MD_ProgressCode/@codeListValue"/>
             <xsl:with-param name="codeListName" select="'mcc:MD_ProgressCode'"/>
+            <xsl:with-param name="codeListValue" select="gmd:status/gmd:MD_ProgressCode/@codeListValue"/>
+            <xsl:with-param name="codeListText" select="gmd:status/gmd:MD_ProgressCode/text()"/>
           </xsl:call-template>
           <xsl:apply-templates select="gmd:pointOfContact" mode="from19139to19115-3.2018"/>
             <xsl:call-template name="writeCodelistElement">
@@ -396,6 +402,7 @@
               <xsl:with-param name="elementName" select="'srv:couplingType'"/>
               <xsl:with-param name="codeListName" select="'srv:SV_CouplingType'"/>
               <xsl:with-param name="codeListValue" select="srvold:couplingType/srvold:SV_CouplingType/@codeListValue"/>
+              <xsl:with-param name="codeListText" select="srvold:couplingType/srvold:SV_CouplingType/text()"/>
             </xsl:call-template>
             <xsl:apply-templates select="srvold:containsOperations" mode="from19139to19115-3.2018"/>
             <xsl:apply-templates select="srvold:operatesOn" mode="from19139to19115-3.2018"/>
@@ -591,11 +598,13 @@
           <xsl:with-param name="elementName" select="'mri:associationType'"/>
           <xsl:with-param name="codeListName" select="'mri:DS_AssociationTypeCode'"/>
           <xsl:with-param name="codeListValue" select="gmd:MD_AggregateInformation/gmd:associationType/gmd:DS_AssociationTypeCode/@codeListValue"/>
+          <xsl:with-param name="codeListText" select="gmd:MD_AggregateInformation/gmd:associationType/gmd:DS_AssociationTypeCode/text()"/>
         </xsl:call-template>
         <xsl:call-template name="writeCodelistElement">
           <xsl:with-param name="elementName" select="'mri:initiativeType'"/>
           <xsl:with-param name="codeListName" select="'mri:DS_InitiativeTypeCode'"/>
           <xsl:with-param name="codeListValue" select="gmd:MD_AggregateInformation/gmd:initiativeType/gmd:DS_InitiativeTypeCode/@codeListValue"/>
+          <xsl:with-param name="codeListText" select="gmd:MD_AggregateInformation/gmd:initiativeType/gmd:DS_InitiativeTypeCode/text()"/>
         </xsl:call-template>
 
         <xsl:if test="$associatedResourceAsMetadataReferenceOnly">

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ISO19139/toISO19139.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ISO19139/toISO19139.xsl
@@ -245,8 +245,9 @@
           </xsl:call-template>
           <xsl:call-template name="writeCodelistElement">
             <xsl:with-param name="elementName" select="'gmd:status'"/>
-            <xsl:with-param name="codeListValue" select="mri:status/mcc:MD_ProgressCode/@codeListValue"/>
             <xsl:with-param name="codeListName" select="'gmd:MD_ProgressCode'"/>
+            <xsl:with-param name="codeListValue" select="mri:status/mcc:MD_ProgressCode/@codeListValue"/>
+            <xsl:with-param name="codeListText" select="mri:status/mcc:MD_ProgressCode/text()"/>
           </xsl:call-template>
           <xsl:apply-templates select="mri:pointOfContact"/>
           <xsl:apply-templates select="mri:resourceMaintenance"/>
@@ -260,6 +261,7 @@
             <xsl:with-param name="elementName" select="'gmd:spatialRepresentationType'"/>
             <xsl:with-param name="codeListName" select="'gmd:MD_SpatialRepresentationTypeCode'"/>
             <xsl:with-param name="codeListValue" select="mri:spatialRepresentationType/mcc:MD_SpatialRepresentationTypeCode/@codeListValue"/>
+            <xsl:with-param name="codeListText" select="mri:spatialRepresentationType/mcc:MD_SpatialRepresentationTypeCode/text()"/>
           </xsl:call-template>
           <xsl:apply-templates select="mri:spatialResolution"/>
           <!-- This is here to handle early adopters of temporalResolution -->
@@ -272,6 +274,7 @@
               <xsl:with-param name="elementName" select="'gmd:characterSet'"/>
               <xsl:with-param name="codeListName" select="'gmd:MD_CharacterSetCode'"/>
               <xsl:with-param name="codeListValue" select="lan:MD_CharacterSetCode/@codeListValue"/>
+              <xsl:with-param name="codeListText" select="lan:MD_CharacterSetCode/text()"/>
             </xsl:call-template>
           </xsl:for-each>
           <xsl:apply-templates select="mri:topicCategory"/>
@@ -305,6 +308,7 @@
             <xsl:with-param name="elementName" select="'srv:couplingType'"/>
             <xsl:with-param name="codeListName" select="'srv:SV_CouplingType'"/>
             <xsl:with-param name="codeListValue" select="srv2:couplingType/srv2:SV_CouplingType/@codeListValue"/>
+            <xsl:with-param name="codeListText" select="srv2:couplingType/srv2:SV_CouplingType/text()"/>
           </xsl:call-template>
           <xsl:apply-templates select="srv2:containsOperations"/>
 
@@ -509,6 +513,7 @@
                 <xsl:with-param name="elementName" select="'gmd:evaluationMethodType'"/>
                 <xsl:with-param name="codeListName" select="'gmd:DQ_EvaluationMethodTypeCode'"/>
                 <xsl:with-param name="codeListValue" select="mdq:evaluation/mdq:DQ_FullInspection/mdq:evaluationMethodType/mdq:DQ_EvaluationMethodTypeCode/@codeListValue"/>
+                <xsl:with-param name="codeListText" select="mdq:evaluation/mdq:DQ_FullInspection/mdq:evaluationMethodType/mdq:DQ_EvaluationMethodTypeCode/text()"/>
               </xsl:call-template>
 
               <xsl:call-template name="writeCharacterStringElement">
@@ -667,6 +672,7 @@
             <xsl:with-param name="elementName" select="'gmd:dateType'"/>
             <xsl:with-param name="codeListName" select="'gmd:CI_DateTypeCode'"/>
             <xsl:with-param name="codeListValue" select="cit:CI_DateTypeCode/@codeListValue"/>
+            <xsl:with-param name="codeListText" select="cit:CI_DateTypeCode/text()"/>
           </xsl:call-template>
         </xsl:for-each>
       </gmd:CI_Date>
@@ -771,7 +777,8 @@
               <xsl:call-template name="writeCodelistElement">
                 <xsl:with-param name="elementName" select="'gmd:role'"/>
                 <xsl:with-param name="codeListName" select="'gmd:CI_RoleCode'"/>
-                  <xsl:with-param name="codeListValue" select="ancestor::cit:CI_Responsibility/cit:role/cit:CI_RoleCode/@codeListValue"/>
+                <xsl:with-param name="codeListValue" select="ancestor::cit:CI_Responsibility/cit:role/cit:CI_RoleCode/@codeListValue"/>
+                <xsl:with-param name="codeListText" select="ancestor::cit:CI_Responsibility/cit:role/cit:CI_RoleCode/text()"/>
               </xsl:call-template>
             </xsl:when>
             <xsl:otherwise>
@@ -924,6 +931,7 @@
     <xsl:param name="elementName"/>
     <xsl:param name="codeListName"/>
     <xsl:param name="codeListValue"/>
+    <xsl:param name="codeListText" select="''"/>
     <!-- The correct codeList Location goes here -->
     <xsl:variable name="codeListLocation" select="'http://standards.iso.org/iso/19139/resources/gmxCodelists.xml'"/>
     <xsl:for-each select="$codeListValue">
@@ -940,7 +948,7 @@
             <!-- commented out for testing -->
             <!--<xsl:value-of select="$codeListValue"/>-->
           </xsl:attribute>
-          <xsl:value-of select="current()"/>
+          <xsl:value-of select="if ($codeListText[position()] != '') then $codeListText[position()] else current()"/>
         </xsl:element>
       </xsl:element>
     </xsl:for-each>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ISO19139/utility/multiLingualCharacterStrings.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ISO19139/utility/multiLingualCharacterStrings.xsl
@@ -66,6 +66,7 @@
         <xsl:param name="elementName"/>
         <xsl:param name="codeListName"/>
         <xsl:param name="codeListValue"/>
+        <xsl:param name="codeListText" select="''"/>
         <!-- The correct codeList Location goes here -->
         <xsl:variable name="codeListLocation" select="'https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml'"/>
 
@@ -84,7 +85,7 @@
                           <!-- commented out for testing -->
                           <xsl:value-of select="."/>
                       </xsl:attribute>
-                      <xsl:value-of select="."/>
+                      <xsl:value-of select="if ($codeListText[position()] != '') then $codeListText[position()] else ."/>
                   </xsl:element>
               </xsl:element>
               <!--<xsl:if test="@*">


### PR DESCRIPTION
Some schemas like Dutch ISO schemas add in the codelist text value a translated text. 

```xml
<gmd:role>
  <gmd:CI_RoleCode codeList="http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#CI_RoleCode" 
                   codeListValue="pointOfContact" codeSpace="dut">contactpunt</gmd:CI_RoleCode>
</gmd:role>
```
Update the conversion to ISO19115-3.2008 to preserve these values.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation