### PR TITLE
drop corresponding records from metadataStatus when deleting a metadata

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataManager.java
@@ -304,6 +304,7 @@ public class BaseMetadataManager implements IMetadataManager {
         int intId = Integer.parseInt(id);
         metadataRatingByIpRepository.deleteAllById_MetadataId(intId);
         metadataValidationRepository.deleteAllById_MetadataId(intId);
+        metadataStatusRepository.deleteAllById_MetadataId(intId);
         userSavedSelectionRepository.deleteAllByUuid(metadataUtils.getMetadataUuid(id));
 
         // Logical delete for metadata file uploads


### PR DESCRIPTION
<!--Include a few sentences describing the overall goals for this Pull Request-->
for some reason, on a catalog that went through several upgrades without a reinstall, i ended up with strong foreign key constraints between the metadata and metadatastatus tables (and other extra FK constraints that apparently shouldnt be here anymore either but that's another story):
```
$ \d metadata
Referenced by:
...
      TABLE "metadatastatus" CONSTRAINT "metadatastatus_metadataid_fkey" FOREIGN KEY (metadataid) REFERENCES metadata(id)

$\d metadatastatus

Foreign-key constraints:
...
    "metadatastatus_metadataid_fkey" FOREIGN KEY (metadataid) REFERENCES metadata(id)
```

in that current state of things, that prevents me from deleting a metadata, using 4.2.8. When going through the teardown of all the records in all related tables, the records in the metadatastatus table are left untouched
```
2025-03-13T13:25:26,913 DEBUG [org.hibernate.SQL] - delete from OperationAllowed where metadataId=?
2025-03-13T13:25:26,922 DEBUG [org.hibernate.SQL] - delete from MetadataRating where metadataId=?
2025-03-13T13:25:26,925 DEBUG [org.hibernate.SQL] - delete from Validation where metadataId=?
2025-03-13T13:25:26,939 DEBUG [org.hibernate.SQL] - delete from UserSavedSelections where metadataUuid=?
2025-03-13T13:25:27,244 DEBUG [org.hibernate.SQL] - delete from MetadataCateg where metadataId=?
2025-03-13T13:25:27,256 DEBUG [org.hibernate.SQL] - delete from Metadata where id=?
```
the `DELETE /geonetwork/srv/api/records/<id>` REST call returns a 204 code, leaving one think the MD has been deleted.

but in fact the metadata ends up being only removed from the ES index, left in the database tables. reindex the MD in ES, and the metadata you think you've just removed is back.

trying to manually delete the record in the `metadata` table clearly shows that the FK constraint is preventing the deletion:
```
[db3:5432] geonetwork@geonetwork=> delete from metadata where id=71673598;
ERROR:  update or delete on table "metadata" violates foreign key constraint "metadatastatus_metadataid_fkey" on table "metadatastatus"
```
so maybe the FK constraint shouldn't be here, but there will still be leftover records in `metadataStatus`.

with that PR on top of 4.2.8, the records are dropped in the `metadataStatus` table too:
```
2025-03-13T14:48:36,465 DEBUG [org.hibernate.SQL] - delete from OperationAllowed where metadataId=?
2025-03-13T14:48:36,479 DEBUG [org.hibernate.SQL] - delete from MetadataRating where metadataId=?
2025-03-13T14:48:36,482 DEBUG [org.hibernate.SQL] - delete from Validation where metadataId=?
2025-03-13T14:48:36,485 DEBUG [org.hibernate.SQL] - delete from MetadataStatus where metadataId=?
2025-03-13T14:48:36,500 DEBUG [org.hibernate.SQL] - delete from UserSavedSelections where metadataUuid=?
2025-03-13T14:48:36,656 DEBUG [org.hibernate.SQL] - delete from Metadata where id=?
```
and the metadata is then completely removed from the DB.

the issue is probably present in 4.4 or main, just 'hidden' if you dont have the foreign constraint key. STR:
- delete an existing MD which has entries in the `metadataStatus` table
- check that the corresponding entries are still in the `metadataStatus` table, while the record has been dropped from the other tables.

<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->
Funded by @gipcraig
