### PR TITLE
Update verify logic in AudienceAccessTokenValidator.java to match with OIDC

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/bearer/AudienceAccessTokenValidator.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/bearer/AudienceAccessTokenValidator.java
@@ -53,9 +53,9 @@ public class AudienceAccessTokenValidator implements AccessTokenValidator {
     @Autowired
     OIDCConfiguration oidcConfiguration;
 
-    /**
-     * "aud" must be our client id
-     * OR "azp" must be our client id (or, if its a list, contain our client id)
+   /**
+     * "aud" must be our client id (or, if its a list, contain our client id)
+     * OR "azp" must be our client id
      * OR "appid" must be our client id.
      * <p>
      * Otherwise, its a token not for us...
@@ -68,8 +68,9 @@ public class AudienceAccessTokenValidator implements AccessTokenValidator {
      */
     @Override
     public void verifyToken(Map claimsJWT, Map userInfoClaims) throws Exception {
-        if ((claimsJWT.get(AUDIENCE_CLAIM_NAME) != null)
-            && claimsJWT.get(AUDIENCE_CLAIM_NAME).equals(oidcConfiguration.getClientId())) {
+        //azp from keycloak
+        if ((claimsJWT.get(KEYCLOAK_AUDIENCE_CLAIM_NAME) != null)
+            && claimsJWT.get(KEYCLOAK_AUDIENCE_CLAIM_NAME).equals(oidcConfiguration.getClientId())) {
             return;
         }
 
@@ -78,15 +79,15 @@ public class AudienceAccessTokenValidator implements AccessTokenValidator {
             return; //azure specific
         }
 
-        //azp - keycloak
-        Object azp = claimsJWT.get(KEYCLOAK_AUDIENCE_CLAIM_NAME);
-        if (azp != null) {
-            if (azp instanceof String) {
-                if (((String) azp).equals(oidcConfiguration.getClientId()))
+        //aud
+        Object aud = claimsJWT.get(AUDIENCE_CLAIM_NAME);
+        if (aud != null) {
+            if (aud instanceof String) {
+                if (((String) aud).equals(oidcConfiguration.getClientId()))
                     return;
-            } else if (azp instanceof List) {
-                List azps = (List) azp;
-                for (Object o : azps) {
+            } else if (aud instanceof List) {
+                List auds = (List) aud;
+                for (Object o : auds) {
                     if ((o instanceof String) && (o.equals(oidcConfiguration.getClientId()))) {
                         return;
                     }


### PR DESCRIPTION
Fix verify logic based on the OIDC protocol
Based on [ rfc7519](https://www.rfc-editor.org/rfc/rfc7519#section-4.1.3) 

> In the general case, the "aud" value is an array of case-
>    sensitive strings

Based on [OIDC 1.0](https://openid.net/specs/openid-connect-core-1_0.html)

> The azp value is a case-sensitive string containing a StringOrURI value

 Without the fix, API access using openId bearer token will fail with 401 

# Checklist

- [✔️ ] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ✔️] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation



<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

