### PR TITLE
Fix jsonLocTranslator in MetadataWorkflowApi

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java
@@ -266,7 +266,7 @@ public class MetadataWorkflowApi {
 
             if (!minimumAllowedProfile.getProfileAndAllParents().contains(userProfile)) {
                 // If the user profile is not at least the minimum profile, then the user is not allowed to view record workflow status
-                String message = getMustBeProfileOrOwnerMessage(minimumAllowedProfileName, messages);
+                String message = getMustBeProfileOrOwnerMessage(minimumAllowedProfileName, messages, locale);
                 Log.debug(API.LOG_MODULE_NAME, message);
                 throw new NotAllowedException(message);
             }
@@ -740,6 +740,7 @@ public class MetadataWorkflowApi {
         Integer size,
         HttpServletRequest request) throws Exception {
         ServiceContext context = ApiUtils.createServiceContext(request);
+        Locale locale = languageUtils.parseAcceptLanguage(request.getLocales());
         ResourceBundle messages = ApiUtils.getMessagesResourceBundle(request.getLocales());
 
         Profile userProfile = context.getUserSession().getProfile();
@@ -749,7 +750,7 @@ public class MetadataWorkflowApi {
         );
         Profile minimumAllowedProfile = Profile.valueOf(minimumAllowedProfileName);
         boolean isMinimumAllowedProfile = minimumAllowedProfile.getProfileAndAllParents().contains(userProfile);
-        String mustBeProfileOrOwnerMessage = getMustBeProfileOrOwnerMessage(minimumAllowedProfileName, messages);
+        String mustBeProfileOrOwnerMessage = getMustBeProfileOrOwnerMessage(minimumAllowedProfileName, messages, locale);
 
         if (userProfile != Profile.Administrator) {
             if (CollectionUtils.isEmpty(recordIdentifier) &&
@@ -1392,8 +1393,8 @@ public class MetadataWorkflowApi {
      * @param minimumAllowedProfileName The name of the minimum allowed profile.
      * @return A formatted message indicating the required profile or ownership.
      */
-    private String getMustBeProfileOrOwnerMessage(String minimumAllowedProfileName, ResourceBundle messages) {
-        Translator jsonLocTranslator = translatorFactory.getTranslator("apploc:", messages.getLocale().getISO3Language());
+    private String getMustBeProfileOrOwnerMessage(String minimumAllowedProfileName, ResourceBundle messages, Locale locale) {
+        Translator jsonLocTranslator = translatorFactory.getTranslator("apploc:", locale.getISO3Language());
         return MessageFormat.format(
             messages.getString("exception.notAllowed.mustBeProfileOrOwner"),
             jsonLocTranslator.translate(minimumAllowedProfileName)


### PR DESCRIPTION
Currently the following is shown in the logs when a user is denied access to a record's status and the language is english:

```
Error creating translator apploc: ()
```

This is caused by #8667 as the resource bundle's locale is used to create the JsonLocTranslator. For english the resource bundle locale is not set and part of the initialization of JsonLocTranslator fails.

This PR aims to fix this issue by instead using the request's locale which is set even for English.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
