### PR TITLE
Fix username not set in link to profile

### DIFF
--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -2371,26 +2371,29 @@
             href,
             isCurrentService = false;
 
-          link = $filter("setUrlPlaceholder")(link);
+          function updateHref() {
+            link = $filter("setUrlPlaceholder")(link);
 
-          // Insert debug mode between service and route
-          if (link.indexOf("#") !== -1) {
-            var tokens = link.split("#");
-            isCurrentService =
-              window.location.pathname.match(".*" + tokens[0] + "$") !== null;
-            href =
-              (isCurrentService ? "" : tokens[0] + (scope.isDebug ? "?debug" : "")) +
-              "#" +
-              tokens[1];
-          } else {
-            isCurrentService = window.location.pathname.match(".*" + link + "$") !== null;
-            href = isCurrentService ? "#/" : link + (scope.isDebug ? "?debug" : "");
+            // Insert debug mode between service and route
+            if (link.indexOf("#") !== -1) {
+              var tokens = link.split("#");
+              isCurrentService =
+                window.location.pathname.match(".*" + tokens[0] + "$") !== null;
+              href =
+                (isCurrentService ? "" : tokens[0] + (scope.isDebug ? "?debug" : "")) +
+                "#" +
+                tokens[1];
+            } else {
+              isCurrentService =
+                window.location.pathname.match(".*" + link + "$") !== null;
+              href = isCurrentService ? "#/" : link + (scope.isDebug ? "?debug" : "");
+            }
+
+            // Set the href attribute for the element
+            // with the link containing the debug mode
+            // or not
+            element.attr("href", href);
           }
-
-          // Set the href attribute for the element
-          // with the link containing the debug mode
-          // or not
-          element.attr("href", href);
 
           function checkActive() {
             // regexps for getting the service & path
@@ -2416,6 +2419,14 @@
 
           scope.$on("$locationChangeSuccess", checkActive);
 
+          // Watch for changes in the link attribute
+          attrs.$observe('gnActiveTbItem', function (newLink) {
+            link = newLink;
+            updateHref();
+            checkActive();
+          });
+
+          updateHref();
           checkActive();
         }
       };


### PR DESCRIPTION
Currently the following links are not generated correctly:
![image](https://github.com/user-attachments/assets/081e3555-daa0-45c0-a86b-da876fca8200)

The issue is that the link is generated before the username is set leaving the `userOrGroup` query parameter empty:
```
<a
  data-gn-active-tb-item="../../{{node}}/{{lang}}/admin.console#/organization/users?userOrGroup=admin"
  class="ng-binding" href="../../srv/eng/admin.console#/organization/users?userOrGroup="
>
  admin admin
</a>
```

This PR aims to fix this issue by observing the link attribute (`gnActiveTbItem`) and updating the href when it changes.
  

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
