### PR TITLE
Do not build datahub by default

### DIFF
--- a/datastorages/README.md
+++ b/datastorages/README.md
@@ -10,3 +10,12 @@ For more information see:
 
 * org.fao.geonet.resource.Resources
 
+## Maven Profiles
+
+Maven profiles are used to enable the optional data storage modules:
+
+```
+mvn install -Pdatastorage-s3
+```
+
+These build profiles are also included in the `release` profile for distribution.

--- a/datastorages/cmis/pom.xml
+++ b/datastorages/cmis/pom.xml
@@ -140,7 +140,7 @@
               </execution>
             </executions>
           </plugin>
-          <!-- generate html conrtents-->
+          <!-- generate html contents-->
           <plugin>
             <groupId>com.ruleoftech</groupId>
             <artifactId>markdown-page-generator-plugin</artifactId>

--- a/datastorages/jcloud/pom.xml
+++ b/datastorages/jcloud/pom.xml
@@ -167,7 +167,7 @@
               </execution>
             </executions>
           </plugin>
-          <!-- generate html conrtents-->
+          <!-- generate html contents-->
           <plugin>
             <groupId>com.ruleoftech</groupId>
             <artifactId>markdown-page-generator-plugin</artifactId>

--- a/datastorages/s3/pom.xml
+++ b/datastorages/s3/pom.xml
@@ -167,7 +167,7 @@
               </execution>
             </executions>
           </plugin>
-          <!-- generate html conrtents-->
+          <!-- generate html contents-->
           <plugin>
             <groupId>com.ruleoftech</groupId>
             <artifactId>markdown-page-generator-plugin</artifactId>

--- a/plugins/README.md
+++ b/plugins/README.md
@@ -1,0 +1,13 @@
+# Plugins
+
+Extensions for optional GeoNetwork functionality. Plugins are package individually for distribution, and follow a manual download and installation process. 
+
+## Maven Profiles
+
+Maven profiles are used to enable the optional plugin modules:
+
+```
+mvn install -Pdatahub-integration
+```
+
+These build profiles are also included in the `release` profile for distribution.

--- a/plugins/datahub-integration/pom.xml
+++ b/plugins/datahub-integration/pom.xml
@@ -26,13 +26,11 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <parent>
-    <artifactId>geonetwork</artifactId>
-    <groupId>org.geonetwork-opensource</groupId>
+    <artifactId>gn-plugins</artifactId>
+    <groupId>org.geonetwork-opensource.plugins</groupId>
     <version>4.4.7-SNAPSHOT</version>
-    <relativePath>../../pom.xml</relativePath>
   </parent>
   <modelVersion>4.0.0</modelVersion>
-
 
   <groupId>org.geonetwork-opensource.plugins</groupId>
   <artifactId>gn-datahub-integration</artifactId>
@@ -73,7 +71,7 @@
   </profiles>
 
   <properties>
-    <geonetwork-ui.git.branch>main</geonetwork-ui.git.branch>
+    <geonetwork-ui.git.branch>v2.5.0</geonetwork-ui.git.branch>
     <rootProjectDir>../..</rootProjectDir>
   </properties>
 
@@ -83,7 +81,6 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>exec-maven-plugin</artifactId>
-        <version>3.3.0</version>
         <executions>
           <execution>
             <id>delete-existing</id>
@@ -109,6 +106,7 @@
               <executable>git</executable>
               <arguments>
                 <argument>clone</argument>
+                <argument>--depth=1</argument>
                 <argument>--branch</argument>
                 <argument>${geonetwork-ui.git.branch}</argument>
                 <argument>https://github.com/geonetwork/geonetwork-ui.git</argument>
@@ -128,6 +126,7 @@
           <execution>
             <!--   Installing node and npm   -->
             <id>install-node-and-npm</id>
+            <phase>initialize</phase>
             <goals>
               <goal>install-node-and-npm</goal>
             </goals>
@@ -139,6 +138,7 @@
           <!--   Install geonetwork-ui dependencies   -->
           <execution>
             <id>npm-install</id>
+            <phase>initialize</phase>
             <goals>
               <goal>npm</goal>
             </goals>
@@ -151,6 +151,7 @@
           <!--   Build datahub app   -->
           <execution>
             <id>npm-build</id>
+            <phase>compile</phase>
             <goals>
               <goal>npm</goal>
             </goals>
@@ -171,11 +172,10 @@
       <!--   Copy of datahub files   -->
       <plugin>
         <artifactId>maven-resources-plugin</artifactId>
-        <version>3.1.0</version>
         <executions>
           <execution>
             <id>copy-resources</id>
-            <phase>generate-resources</phase>
+            <phase>prepare-package</phase>
             <goals>
               <goal>copy-resources</goal>
             </goals>
@@ -194,6 +194,62 @@
         </executions>
       </plugin>
 
+      <!-- generate html contents-->
+      <plugin>
+        <groupId>com.ruleoftech</groupId>
+        <artifactId>markdown-page-generator-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>readme</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+            <configuration>
+              <inputDirectory>${project.basedir}/src/main/assembly</inputDirectory>
+              <outputDirectory>${project.build.directory}/html</outputDirectory>
+            </configuration>
+          </execution>
+          <execution>
+            <id>licenses</id>
+            <phase>prepare-package</phase>
+            <goals>
+              <goal>generate</goal>
+            </goals>
+            <configuration>
+              <inputDirectory>${project.basedir}/../../</inputDirectory>
+              <outputDirectory>${project.build.directory}/html/license</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+        <configuration>
+          <recursiveInput>false</recursiveInput>
+          <transformRelativeMarkdownLinks>true</transformRelativeMarkdownLinks>
+          <headerHtmlFile>${project.basedir}/../../release/src/markdown/html/header.html</headerHtmlFile>
+          <footerHtmlFile>${project.basedir}/../../release/src/markdown/html/footer.html</footerHtmlFile>
+          <pegdownExtensions>TABLES,FENCED_CODE_BLOCKS</pegdownExtensions>
+          <defaultTitle>true</defaultTitle>
+        </configuration>
+      </plugin>
+      <!-- assemble into zip for release -->
+      <plugin>
+        <artifactId>maven-assembly-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>release-zip</id>
+            <phase>package</phase>
+            <goals>
+              <goal>single</goal>
+            </goals>
+            <configuration>
+              <appendAssemblyId>false</appendAssemblyId>
+              <descriptors>
+                <descriptor>src/main/assembly/assembly.xml</descriptor>
+              </descriptors>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/plugins/datahub-integration/src/main/assembly/README.md
+++ b/plugins/datahub-integration/src/main/assembly/README.md
@@ -1,0 +1,22 @@
+# Datahub Plugin
+
+The Datahub is an application to provide a default, pure and simple UI for metadata and dataset search.
+
+More information here: https://geonetwork.github.io/geonetwork-ui/main/docs/apps/datahub.html
+
+See the [GeoNetwork-UI documentation](https://geonetwork.github.io/geonetwork-ui/main/docs/guide/run.html) to learn how to run and deploy the Datahub.
+
+To install the Datahub plugin in GeoNetwork:
+
+1. Copy the `lib` folder jar files into to `{GEONETWORK_DIR}/WEB-INF/lib` folder.
+   
+2. Start GeoNetwork.
+
+3. In portal configuration enable Datahub integration.
+
+   Use the default configuration, or adjust following the [data hub configuration guide](https://geonetwork.github.io/geonetwork-ui/main/docs/guide/configure.html) 
+
+Reference:
+
+* [Datahub integration: gn-datahub-integration](https://docs.geonetwork-opensource.org/latest/install-guide/plugins/#datahub-integration-gn-datahub-integration)
+* [Configuring a Datahub interface for a sub-portal](https://docs.geonetwork-opensource.org/latest/administrator-guide/configuring-the-catalog/portal-configuration/#configuring-a-datahub-interface-for-a-sub-portal)

--- a/plugins/datahub-integration/src/main/assembly/assembly.xml
+++ b/plugins/datahub-integration/src/main/assembly/assembly.xml
@@ -1,0 +1,31 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.0 http://maven.apache.org/xsd/assembly-1.1.0.xsd">
+  <id>bin</id>
+  <formats>
+    <format>zip</format>
+  </formats>
+  <fileSets>
+    <fileSet>
+      <directory>${project.build.directory}/lib</directory>
+      <outputDirectory>/lib</outputDirectory>
+    </fileSet>
+  </fileSets>
+
+  <files>
+    <file>
+      <source>${project.build.directory}/${project.artifactId}-${project.version}.jar</source>
+      <outputDirectory>/lib</outputDirectory>
+    </file>
+
+    <file>
+      <source>${project.build.directory}/html/README.html</source>
+      <outputDirectory>/</outputDirectory>
+    </file>
+
+    <file>
+      <source>${project.build.directory}/html/license/LICENSE.html</source>
+      <outputDirectory>/license</outputDirectory>
+    </file>
+  </files>
+</assembly>

--- a/plugins/pom.xml
+++ b/plugins/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Copyright (C) 2001-2025 Food and Agriculture Organization of the
+  ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
+  ~ and United Nations Environment Programme (UNEP)
+  ~
+  ~ This program is free software; you can redistribute it and/or modify
+  ~ it under the terms of the GNU General Public License as published by
+  ~ the Free Software Foundation; either version 2 of the License, or (at
+  ~ your option) any later version.
+  ~
+  ~ This program is distributed in the hope that it will be useful, but
+  ~ WITHOUT ANY WARRANTY; without even the implied warranty of
+  ~ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+  ~ General Public License for more details.
+  ~
+  ~ You should have received a copy of the GNU General Public License
+  ~ along with this program; if not, write to the Free Software
+  ~ Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+  ~
+  ~ Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+  ~ Rome - Italy. email: geonetwork@osgeo.org
+  -->
+
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>geonetwork</artifactId>
+    <groupId>org.geonetwork-opensource</groupId>
+    <version>4.4.7-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <groupId>org.geonetwork-opensource.plugins</groupId>
+  <artifactId>gn-plugins</artifactId>
+  <name>GeoNetwork Plugins</name>
+  <packaging>pom</packaging>
+
+  <profiles>
+    <profile>
+      <id>datahub-integration</id>
+      <activation>
+        <property>
+          <!-- include when making a release -->
+          <name>release</name>
+        </property>
+      </activation>
+      <modules>
+        <module>datahub-integration</module>
+      </modules>
+    </profile>
+  </profiles>
+
+  <properties>
+    <rootProjectDir>../..</rootProjectDir>
+  </properties>
+</project>

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,7 @@
         </plugin>
         <plugin>
           <artifactId>maven-resources-plugin</artifactId>
-          <version>3.3.0</version>
+          <version>3.3.1</version>
         </plugin>
         <plugin>
           <artifactId>maven-dependency-plugin</artifactId>
@@ -148,7 +148,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>exec-maven-plugin</artifactId>
-          <version>1.6.0</version>
+          <version>3.5.0</version>
         </plugin>
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
@@ -1423,6 +1423,7 @@
     <module>estest</module>
     <module>index</module>
     <module>datastorages</module>
+    <module>plugins</module>
     <module>translationproviders</module>
     <module>auditable</module>
   </modules>
@@ -1514,12 +1515,6 @@
          <kb.installer.extension>zip</kb.installer.extension>
        </properties>
      </profile>
-    <profile>
-      <id>datahub-integration</id>
-      <modules>
-        <module>plugins/datahub-integration</module>
-      </modules>
-    </profile>
   </profiles>
 
   <distributionManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -1425,7 +1425,6 @@
     <module>datastorages</module>
     <module>translationproviders</module>
     <module>auditable</module>
-    <module>plugins/datahub-integration</module>
   </modules>
 
   <profiles>
@@ -1515,6 +1514,12 @@
          <kb.installer.extension>zip</kb.installer.extension>
        </properties>
      </profile>
+    <profile>
+      <id>datahub-integration</id>
+      <modules>
+        <module>plugins/datahub-integration</module>
+      </modules>
+    </profile>
   </profiles>
 
   <distributionManagement>

--- a/software_development/BUILDING.md
+++ b/software_development/BUILDING.md
@@ -79,6 +79,7 @@ mvn install -Drelease
 ```
 
 The `release` flag above asks the following modukes to produce `zip` bundles for distribution:
+
 * `datastorage-s3`
 * `datastorage-jcloud`
 * `datastorage-cmis`


### PR DESCRIPTION
Taking over from https://github.com/geonetwork/core-geonetwork/pull/8702 to adjust for feedback.

* [ ] activate profile for release
* [ ] release assembly.xml so download can include license + readme
* [ ] use maven build lifecycle stages
* [ ] use target folder for build things to avoid risk of accidental commit
* [ ] use v2.5.0 release of geonetwork-ui (rather than main which changes each day)
* [ ] use of .gitignore to avoid accidental commit of node, geonetwork-ui, etc...
* [ ] use of pluginManagement for maven plugins

Things I am not comfortable with:

1. checkout of geonetwork-ui, this should probably be done as a submodule so specific revision is used
2. building with npm, would prefer build server does this and deploy to osgeo nexus

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [x] *Build documentation* provided for development instructions in `README.md` files
- [x] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

