### PR TITLE
Map viewer / show style selection menu on the right to avoid cropping it

### DIFF
--- a/web-ui/src/main/resources/catalog/components/viewer/wmsimport/partials/styles.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/wmsimport/partials/styles.html
@@ -6,7 +6,7 @@
       <span class="caret"></span>
     </button>
 
-    <ul class="dropdown-menu">
+    <ul class="dropdown-menu dropdown-menu-right">
       <li class="dropdown-header" data-translate="">selectStyle</li>
       <li data-ng-repeat="s in styles | orderBy:'Title'">
         <div class="flex-row">


### PR DESCRIPTION
This change request displays the style selection menu on the right to avoid cropping it.

Before:

<img width="480" alt="before-styles" src="https://github.com/user-attachments/assets/21311d74-ea1f-4c27-8fb0-71f99fde6176" />

After:

<img width="480" alt="after-styles" src="https://github.com/user-attachments/assets/5e82149a-97e7-468f-9dab-d2c4455cbeae" />


# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation