### PR TITLE
Update batch privileges dialog texts

### DIFF
--- a/web-ui/src/main/resources/catalog/locales/ca-search.json
+++ b/web-ui/src/main/resources/catalog/locales/ca-search.json
@@ -357,7 +357,7 @@
     "KMLfileURL": "URL d'un fitxer KML",
     "refineSearch": "Refinar Cerca",
     "backToList": "Tornar a la Llista",
-    "privilegesBatchAlert": "<span class='text-danger'>The privileges will be updated for all editable records in the selection. The privilege form is empty and does not reflect the selected records current privileges! Privileges are reset and replaced by the new one.</span><br/><br/>Clicking on <strong>Merge selected</strong> will add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.<br/><br/>Clicking on <strong>Replace by selected</strong> will remove record categories and then add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.",
+    "privilegesBatchAlert": "<span class='text-danger'>The privileges will be updated for all editable records in the selection. The privilege form is empty and does not reflect the selected records current privileges! Privileges are reset and replaced by the new one.</span><br/><br/>Clicking on <strong>Merge selected</strong> will add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.<br/><br/>Clicking on <strong>Update</strong> will remove record privileges and then add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.",
     "permalink": "Enllaç permanent",
     "permalinkTo": "Enllaç permanent a {{title}}",
     "shareOnTwitter": "Comparteix a Twitter",

--- a/web-ui/src/main/resources/catalog/locales/ca-v4.json
+++ b/web-ui/src/main/resources/catalog/locales/ca-v4.json
@@ -212,7 +212,7 @@
   "addThoseOperations-help": "Append (checked with +) or remove (checkbox with -) selected privileges.",
   "privilegesNeededForPublicationRecordGroupOnly-true": "To publish a record, you need to be administrator or reviewer of record group",
   "privilegesNeededForPublicationRecordGroupOnly-false": "To publish a record, you need to be administrator or reviewer of record group or reviewer of a group with editing rights.",
-  "replaceByThoseOperations-help": "Remove record priviliges and then add (checked with +) or remove (checkbox with -) selected privileges.",
+  "replaceByThoseOperations-help": "Remove record privileges and then add (checked with +) or remove (checkbox with -) selected privileges.",
   "chooseASelection": "Choose a selection",
   "e101": "Editor board selection [e101]",
   "s101": "Search app selection [s101]",

--- a/web-ui/src/main/resources/catalog/locales/cy-search.json
+++ b/web-ui/src/main/resources/catalog/locales/cy-search.json
@@ -357,7 +357,7 @@
     "KMLfileURL": "URL ffeil KML",
     "refineSearch": "Mireinio Chwilio",
     "backToList": "Yn ôl i'r Rhestr",
-    "privilegesBatchAlert": "<span class='text-danger'>Bydd y breintiau yn cael eu diweddaru ar gyfer yr holl gofnodion y gellir eu golygu yn y dewis. Mae'r ffurflen fraint yn wag ac nid yw'n adlewyrchu breintiau cyfredol y cofnodion a ddewiswyd! Mae breintiau yn cael eu hailosod a'u disodli gan yr un newydd. <br/><br/>Bydd clicio ar <strong>Merge selected</strong> yn ychwanegu (checked with <strong>+</strong>) neu’n tynnu (checkbox with <strong>-</strong>) breintiau wedi’u dewis. <br/><br/>Bydd clicio ar <strong>Update</strong> yn cael gwared ar gategorïau cofnodion ac yna ychwanegu (checked with <strong>+</strong>) neu dynnu (blwch gwirio gyda <strong>-</strong>) breintiau wedi’u dewis.",
+    "privilegesBatchAlert": "<span class='text-danger'>Bydd y breintiau yn cael eu diweddaru ar gyfer yr holl gofnodion y gellir eu golygu yn y dewis. Mae'r ffurflen fraint yn wag ac nid yw'n adlewyrchu breintiau cyfredol y cofnodion a ddewiswyd! Mae breintiau yn cael eu hailosod a'u disodli gan yr un newydd. <br/><br/>Bydd clicio ar <strong>Merge selected</strong> yn ychwanegu (checked with <strong>+</strong>) neu’n tynnu (checkbox with <strong>-</strong>) breintiau wedi’u dewis. <br/><br/>Bydd clicio ar <strong>Update</strong> yn cael gwared ar freintiau cofnodion ac yna ychwanegu (checked with <strong>+</strong>) neu dynnu (blwch gwirio gyda <strong>-</strong>) breintiau wedi’u dewis.",
     "permalink": "Permalink",
     "permalinkTo": "Permalinkl i {{title}}",
     "shareOnTwitter": "Rhannu ar Twitter",

--- a/web-ui/src/main/resources/catalog/locales/cy-search.json
+++ b/web-ui/src/main/resources/catalog/locales/cy-search.json
@@ -357,7 +357,7 @@
     "KMLfileURL": "URL ffeil KML",
     "refineSearch": "Mireinio Chwilio",
     "backToList": "Yn ôl i'r Rhestr",
-    "privilegesBatchAlert": "<span class='text-danger'>Bydd y breintiau yn cael eu diweddaru ar gyfer yr holl gofnodion y gellir eu golygu yn y dewis. Mae'r ffurflen fraint yn wag ac nid yw'n adlewyrchu breintiau cyfredol y cofnodion a ddewiswyd! Mae breintiau yn cael eu hailosod a'u disodli gan yr un newydd. <br/><br/>Bydd clicio ar <strong>Merge selected</strong> yn ychwanegu (checked with <strong>+</strong>) neu’n tynnu (checkbox with <strong>-</strong>) breintiau wedi’u dewis. <br/><br/>Bydd clicio ar <strong>Replace by selected</strong> yn cael gwared ar gategorïau cofnodion ac yna ychwanegu (checked with <strong>+</strong>) neu dynnu (blwch gwirio gyda <strong>-</strong>) breintiau wedi’u dewis.",
+    "privilegesBatchAlert": "<span class='text-danger'>Bydd y breintiau yn cael eu diweddaru ar gyfer yr holl gofnodion y gellir eu golygu yn y dewis. Mae'r ffurflen fraint yn wag ac nid yw'n adlewyrchu breintiau cyfredol y cofnodion a ddewiswyd! Mae breintiau yn cael eu hailosod a'u disodli gan yr un newydd. <br/><br/>Bydd clicio ar <strong>Merge selected</strong> yn ychwanegu (checked with <strong>+</strong>) neu’n tynnu (checkbox with <strong>-</strong>) breintiau wedi’u dewis. <br/><br/>Bydd clicio ar <strong>Update</strong> yn cael gwared ar gategorïau cofnodion ac yna ychwanegu (checked with <strong>+</strong>) neu dynnu (blwch gwirio gyda <strong>-</strong>) breintiau wedi’u dewis.",
     "permalink": "Permalink",
     "permalinkTo": "Permalinkl i {{title}}",
     "shareOnTwitter": "Rhannu ar Twitter",

--- a/web-ui/src/main/resources/catalog/locales/cy-v4.json
+++ b/web-ui/src/main/resources/catalog/locales/cy-v4.json
@@ -212,7 +212,7 @@
   "addThoseOperations-help": "Append (checked with +) or remove (checkbox with -) selected privileges.",
   "privilegesNeededForPublicationRecordGroupOnly-true": "To publish a record, you need to be administrator or reviewer of record group",
   "privilegesNeededForPublicationRecordGroupOnly-false": "To publish a record, you need to be administrator or reviewer of record group or reviewer of a group with editing rights.",
-  "replaceByThoseOperations-help": "Remove record priviliges and then add (checked with +) or remove (checkbox with -) selected privileges.",
+  "replaceByThoseOperations-help": "Remove record privileges and then add (checked with +) or remove (checkbox with -) selected privileges.",
   "chooseASelection": "Choose a selection",
   "e101": "Editor board selection [e101]",
   "s101": "Search app selection [s101]",

--- a/web-ui/src/main/resources/catalog/locales/en-search.json
+++ b/web-ui/src/main/resources/catalog/locales/en-search.json
@@ -358,7 +358,7 @@
   "KMLfileURL":"URL of a KML file",
   "refineSearch" : "Refine Search",
   "backToList": "Back To List",
-  "privilegesBatchAlert": "<span class='text-danger'>The privileges will be updated for all editable records in the selection. The privilege form is empty and does not reflect the selected records current privileges! Privileges are reset and replaced by the new one.</span><br/><br/>Clicking on <strong>Merge selected</strong> will add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.<br/><br/>Clicking on <strong>Replace by selected</strong> will remove record categories and then add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.",
+  "privilegesBatchAlert": "<span class='text-danger'>The privileges will be updated for all editable records in the selection. The privilege form is empty and does not reflect the selected records current privileges! Privileges are reset and replaced by the new one.</span><br/><br/>Clicking on <strong>Merge selected</strong> will add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.<br/><br/>Clicking on <strong>Update</strong> will remove record privileges and then add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.",
   "permalink" : "Permalink",
   "permalinkTo": "Permalink to {{title}}",
   "shareOnTwitter": "Share on Twitter",

--- a/web-ui/src/main/resources/catalog/locales/en-v4.json
+++ b/web-ui/src/main/resources/catalog/locales/en-v4.json
@@ -212,7 +212,7 @@
   "addThoseOperations-help": "Append (checked with +) or remove (checkbox with -) selected privileges.",
   "privilegesNeededForPublicationRecordGroupOnly-true": "To publish a record, you need to be administrator or reviewer of record group",
   "privilegesNeededForPublicationRecordGroupOnly-false": "To publish a record, you need to be administrator or reviewer of record group or reviewer of a group with editing rights.",
-  "replaceByThoseOperations-help": "Remove record priviliges and then add (checked with +) or remove (checkbox with -) selected privileges.",
+  "replaceByThoseOperations-help": "Remove record privileges and then add (checked with +) or remove (checkbox with -) selected privileges.",
   "chooseASelection": "Choose a selection",
   "e101": "Editor board selection [e101]",
   "s101": "Search app selection [s101]",

--- a/web-ui/src/main/resources/catalog/locales/es-search.json
+++ b/web-ui/src/main/resources/catalog/locales/es-search.json
@@ -357,7 +357,7 @@
     "KMLfileURL": "URL de un fichero KML",
     "refineSearch": "Refinar Búsqueda",
     "backToList": "Volver a la Lista",
-    "privilegesBatchAlert": "<span class='text-danger'>The privileges will be updated for all editable records in the selection. The privilege form is empty and does not reflect the selected records current privileges! Privileges are reset and replaced by the new one.</span><br/><br/>Clicking on <strong>Merge selected</strong> will add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.<br/><br/>Clicking on <strong>Update</strong> will remove record privileges and then add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.",
+     "privilegesBatchAlert": "<span class='text-danger'>Los privilegios se actualizarán para todos los registros editables en la selección. El formulario de privilegios está vacío y no refleja los privilegios actuales de los registros seleccionados. ¡Los privilegios se restablecen y se reemplazan por los nuevos!</span><br/><br/>Al hacer clic en <strong>Combinar seleccionados</strong> se añadirán (marcado con <strong>+</strong>) o eliminarán (casilla con <strong>-</strong>) los privilegios seleccionados.<br/><br/>Al hacer clic en <strong>Actualizar</strong> se eliminarán los privilegios de los registros y luego se añadirán (marcado con <strong>+</strong>) o eliminarán (casilla con <strong>-</strong>) los privilegios seleccionados.",
     "permalink": "Enlace Permanente",
     "permalinkTo": "Enlace permanente a {{title}}",
     "shareOnTwitter": "Compartir en Twitter",

--- a/web-ui/src/main/resources/catalog/locales/es-search.json
+++ b/web-ui/src/main/resources/catalog/locales/es-search.json
@@ -357,7 +357,7 @@
     "KMLfileURL": "URL de un fichero KML",
     "refineSearch": "Refinar Búsqueda",
     "backToList": "Volver a la Lista",
-    "privilegesBatchAlert": "<span class='text-danger'>The privileges will be updated for all editable records in the selection. The privilege form is empty and does not reflect the selected records current privileges! Privileges are reset and replaced by the new one.</span><br/><br/>Clicking on <strong>Merge selected</strong> will add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.<br/><br/>Clicking on <strong>Replace by selected</strong> will remove record categories and then add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.",
+    "privilegesBatchAlert": "<span class='text-danger'>The privileges will be updated for all editable records in the selection. The privilege form is empty and does not reflect the selected records current privileges! Privileges are reset and replaced by the new one.</span><br/><br/>Clicking on <strong>Merge selected</strong> will add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.<br/><br/>Clicking on <strong>Update</strong> will remove record privileges and then add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.",
     "permalink": "Enlace Permanente",
     "permalinkTo": "Enlace permanente a {{title}}",
     "shareOnTwitter": "Compartir en Twitter",

--- a/web-ui/src/main/resources/catalog/locales/fi-search.json
+++ b/web-ui/src/main/resources/catalog/locales/fi-search.json
@@ -357,7 +357,7 @@
     "KMLfileURL": "URL tai KML tiedosto",
     "refineSearch": "Tarkenna hakua",
     "backToList": "Takaisin luetteloon",
-    "privilegesBatchAlert": "<span class='text-danger'>The privileges will be updated for all editable records in the selection. The privilege form is empty and does not reflect the selected records current privileges! Privileges are reset and replaced by the new one.</span><br/><br/>Clicking on <strong>Merge selected</strong> will add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.<br/><br/>Clicking on <strong>Replace by selected</strong> will remove record categories and then add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.",
+    "privilegesBatchAlert": "<span class='text-danger'>The privileges will be updated for all editable records in the selection. The privilege form is empty and does not reflect the selected records current privileges! Privileges are reset and replaced by the new one.</span><br/><br/>Clicking on <strong>Merge selected</strong> will add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.<br/><br/>Clicking on <strong>Update</strong> will remove record privileges and then add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.",
     "permalink": "Pysyvä linkki",
     "permalinkTo": "Permalink kohteeseen {{title}}",
     "shareOnTwitter": "Jaa Twitterissä",

--- a/web-ui/src/main/resources/catalog/locales/fi-v4.json
+++ b/web-ui/src/main/resources/catalog/locales/fi-v4.json
@@ -212,7 +212,7 @@
   "addThoseOperations-help": "Append (checked with +) or remove (checkbox with -) selected privileges.",
   "privilegesNeededForPublicationRecordGroupOnly-true": "To publish a record, you need to be administrator or reviewer of record group",
   "privilegesNeededForPublicationRecordGroupOnly-false": "To publish a record, you need to be administrator or reviewer of record group or reviewer of a group with editing rights.",
-  "replaceByThoseOperations-help": "Remove record priviliges and then add (checked with +) or remove (checkbox with -) selected privileges.",
+  "replaceByThoseOperations-help": "Remove record privileges and then add (checked with +) or remove (checkbox with -) selected privileges.",
   "chooseASelection": "Choose a selection",
   "e101": "Editor board selection [e101]",
   "s101": "Search app selection [s101]",

--- a/web-ui/src/main/resources/catalog/locales/is-search.json
+++ b/web-ui/src/main/resources/catalog/locales/is-search.json
@@ -357,7 +357,7 @@
     "KMLfileURL": "URL af KML skrá",
     "refineSearch": "Fínstilla leit",
     "backToList": "Til baka í Lista",
-    "privilegesBatchAlert": "<span class='text-danger'>The privileges will be updated for all editable records in the selection. The privilege form is empty and does not reflect the selected records current privileges! Privileges are reset and replaced by the new one.</span><br/><br/>Clicking on <strong>Merge selected</strong> will add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.<br/><br/>Clicking on <strong>Replace by selected</strong> will remove record categories and then add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.",
+    "privilegesBatchAlert": "<span class='text-danger'>The privileges will be updated for all editable records in the selection. The privilege form is empty and does not reflect the selected records current privileges! Privileges are reset and replaced by the new one.</span><br/><br/>Clicking on <strong>Merge selected</strong> will add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.<br/><br/>Clicking on <strong>Update</strong> will remove record privileges and then add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.",
     "permalink": "Endanlegur hlekkur",
     "permalinkTo": "Endanlegur hlekkur á  {{title}}",
     "shareOnTwitter": "Deila á Twitter",

--- a/web-ui/src/main/resources/catalog/locales/is-v4.json
+++ b/web-ui/src/main/resources/catalog/locales/is-v4.json
@@ -212,7 +212,7 @@
   "addThoseOperations-help": "Append (checked with +) or remove (checkbox with -) selected privileges.",
   "privilegesNeededForPublicationRecordGroupOnly-true": "To publish a record, you need to be administrator or reviewer of record group",
   "privilegesNeededForPublicationRecordGroupOnly-false": "To publish a record, you need to be administrator or reviewer of record group or reviewer of a group with editing rights.",
-  "replaceByThoseOperations-help": "Remove record priviliges and then add (checked with +) or remove (checkbox with -) selected privileges.",
+  "replaceByThoseOperations-help": "Remove record privileges and then add (checked with +) or remove (checkbox with -) selected privileges.",
   "chooseASelection": "Choose a selection",
   "e101": "Editor board selection [e101]",
   "s101": "Search app selection [s101]",

--- a/web-ui/src/main/resources/catalog/locales/it-search.json
+++ b/web-ui/src/main/resources/catalog/locales/it-search.json
@@ -357,7 +357,7 @@
     "KMLfileURL": "URL di un file KML",
     "refineSearch": "Affinare la ricerca",
     "backToList": "Indietro alla lista",
-    "privilegesBatchAlert": "<span class='text-danger'>The privileges will be updated for all editable records in the selection. The privilege form is empty and does not reflect the selected records current privileges! Privileges are reset and replaced by the new one.</span><br/><br/>Clicking on <strong>Merge selected</strong> will add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.<br/><br/>Clicking on <strong>Replace by selected</strong> will remove record categories and then add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.",
+    "privilegesBatchAlert": "<span class='text-danger'>The privileges will be updated for all editable records in the selection. The privilege form is empty and does not reflect the selected records current privileges! Privileges are reset and replaced by the new one.</span><br/><br/>Clicking on <strong>Merge selected</strong> will add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.<br/><br/>Clicking on <strong>Update</strong> will remove record privileges and then add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.",
     "permalink": "Permalink",
     "permalinkTo": "Permalink a {{title}}",
     "shareOnTwitter": "Condividi su Twitter",

--- a/web-ui/src/main/resources/catalog/locales/it-v4.json
+++ b/web-ui/src/main/resources/catalog/locales/it-v4.json
@@ -212,7 +212,7 @@
   "addThoseOperations-help": "Append (checked with +) or remove (checkbox with -) selected privileges.",
   "privilegesNeededForPublicationRecordGroupOnly-true": "To publish a record, you need to be administrator or reviewer of record group",
   "privilegesNeededForPublicationRecordGroupOnly-false": "To publish a record, you need to be administrator or reviewer of record group or reviewer of a group with editing rights.",
-  "replaceByThoseOperations-help": "Remove record priviliges and then add (checked with +) or remove (checkbox with -) selected privileges.",
+  "replaceByThoseOperations-help": "Remove record privileges and then add (checked with +) or remove (checkbox with -) selected privileges.",
   "chooseASelection": "Choose a selection",
   "e101": "Editor board selection [e101]",
   "s101": "Search app selection [s101]",

--- a/web-ui/src/main/resources/catalog/locales/ko-search.json
+++ b/web-ui/src/main/resources/catalog/locales/ko-search.json
@@ -357,7 +357,7 @@
     "KMLfileURL": "KML 파일 URL 설정",
     "refineSearch": "검색 수정",
     "backToList": "리스트로 돌아가기",
-    "privilegesBatchAlert": "<span class='text-danger'>The privileges will be updated for all editable records in the selection. The privilege form is empty and does not reflect the selected records current privileges! Privileges are reset and replaced by the new one.</span><br/><br/>Clicking on <strong>Merge selected</strong> will add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.<br/><br/>Clicking on <strong>Replace by selected</strong> will remove record categories and then add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.",
+    "privilegesBatchAlert": "<span class='text-danger'>The privileges will be updated for all editable records in the selection. The privilege form is empty and does not reflect the selected records current privileges! Privileges are reset and replaced by the new one.</span><br/><br/>Clicking on <strong>Merge selected</strong> will add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.<br/><br/>Clicking on <strong>Update</strong> will remove record privileges and then add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.",
     "permalink": "퍼머링크",
     "permalinkTo": "{{title}}로 퍼머링크",
     "shareOnTwitter": "Twitter에 공유",

--- a/web-ui/src/main/resources/catalog/locales/ko-v4.json
+++ b/web-ui/src/main/resources/catalog/locales/ko-v4.json
@@ -212,7 +212,7 @@
   "addThoseOperations-help": "Append (checked with +) or remove (checkbox with -) selected privileges.",
   "privilegesNeededForPublicationRecordGroupOnly-true": "To publish a record, you need to be administrator or reviewer of record group",
   "privilegesNeededForPublicationRecordGroupOnly-false": "To publish a record, you need to be administrator or reviewer of record group or reviewer of a group with editing rights.",
-  "replaceByThoseOperations-help": "Remove record priviliges and then add (checked with +) or remove (checkbox with -) selected privileges.",
+  "replaceByThoseOperations-help": "Remove record privileges and then add (checked with +) or remove (checkbox with -) selected privileges.",
   "chooseASelection": "Choose a selection",
   "e101": "Editor board selection [e101]",
   "s101": "Search app selection [s101]",

--- a/web-ui/src/main/resources/catalog/locales/pl-search.json
+++ b/web-ui/src/main/resources/catalog/locales/pl-search.json
@@ -357,7 +357,7 @@
     "KMLfileURL": "Adres URL do pliku KML",
     "refineSearch": "Sprecyzuj wyszukiwanie",
     "backToList": "Wróć do listy",
-    "privilegesBatchAlert": "<span class='text-danger'>The privileges will be updated for all editable records in the selection. The privilege form is empty and does not reflect the selected records current privileges! Privileges are reset and replaced by the new one.</span><br/><br/>Clicking on <strong>Merge selected</strong> will add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.<br/><br/>Clicking on <strong>Replace by selected</strong> will remove record categories and then add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.",
+    "privilegesBatchAlert": "<span class='text-danger'>The privileges will be updated for all editable records in the selection. The privilege form is empty and does not reflect the selected records current privileges! Privileges are reset and replaced by the new one.</span><br/><br/>Clicking on <strong>Merge selected</strong> will add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.<br/><br/>Clicking on <strong>Update</strong> will remove record categories and then add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.",
     "permalink": "stały link",
     "permalinkTo": "Link do {{title}}",
     "shareOnTwitter": "Udostępnij na Twitterze",

--- a/web-ui/src/main/resources/catalog/locales/pl-search.json
+++ b/web-ui/src/main/resources/catalog/locales/pl-search.json
@@ -357,7 +357,7 @@
     "KMLfileURL": "Adres URL do pliku KML",
     "refineSearch": "Sprecyzuj wyszukiwanie",
     "backToList": "Wróć do listy",
-    "privilegesBatchAlert": "<span class='text-danger'>The privileges will be updated for all editable records in the selection. The privilege form is empty and does not reflect the selected records current privileges! Privileges are reset and replaced by the new one.</span><br/><br/>Clicking on <strong>Merge selected</strong> will add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.<br/><br/>Clicking on <strong>Update</strong> will remove record categories and then add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.",
+    "privilegesBatchAlert": "<span class='text-danger'>The privileges will be updated for all editable records in the selection. The privilege form is empty and does not reflect the selected records current privileges! Privileges are reset and replaced by the new one.</span><br/><br/>Clicking on <strong>Merge selected</strong> will add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.<br/><br/>Clicking on <strong>Update</strong> will remove record privileges and then add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.",
     "permalink": "stały link",
     "permalinkTo": "Link do {{title}}",
     "shareOnTwitter": "Udostępnij na Twitterze",

--- a/web-ui/src/main/resources/catalog/locales/pl-v4.json
+++ b/web-ui/src/main/resources/catalog/locales/pl-v4.json
@@ -212,7 +212,7 @@
   "addThoseOperations-help": "Append (checked with +) or remove (checkbox with -) selected privileges.",
   "privilegesNeededForPublicationRecordGroupOnly-true": "To publish a record, you need to be administrator or reviewer of record group",
   "privilegesNeededForPublicationRecordGroupOnly-false": "To publish a record, you need to be administrator or reviewer of record group or reviewer of a group with editing rights.",
-  "replaceByThoseOperations-help": "Remove record priviliges and then add (checked with +) or remove (checkbox with -) selected privileges.",
+  "replaceByThoseOperations-help": "Remove record privileges and then add (checked with +) or remove (checkbox with -) selected privileges.",
   "chooseASelection": "Choose a selection",
   "e101": "Editor board selection [e101]",
   "s101": "Search app selection [s101]",

--- a/web-ui/src/main/resources/catalog/locales/pt-search.json
+++ b/web-ui/src/main/resources/catalog/locales/pt-search.json
@@ -357,7 +357,7 @@
     "KMLfileURL": "URL de um arquivo KML",
     "refineSearch": "Refinar pesquisa",
     "backToList": "Voltar a Listagem",
-    "privilegesBatchAlert": "<span class='text-danger'>The privileges will be updated for all editable records in the selection. The privilege form is empty and does not reflect the selected records current privileges! Privileges are reset and replaced by the new one.</span><br/><br/>Clicking on <strong>Merge selected</strong> will add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.<br/><br/>Clicking on <strong>Replace by selected</strong> will remove record categories and then add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.",
+    "privilegesBatchAlert": "<span class='text-danger'>The privileges will be updated for all editable records in the selection. The privilege form is empty and does not reflect the selected records current privileges! Privileges are reset and replaced by the new one.</span><br/><br/>Clicking on <strong>Merge selected</strong> will add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.<br/><br/>Clicking on <strong>Update</strong> will remove record categories and then add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.",
     "permalink": "Permalink",
     "permalinkTo": "Permalink para {{title}}",
     "shareOnTwitter": "Compartilhar no Twitter",

--- a/web-ui/src/main/resources/catalog/locales/pt-search.json
+++ b/web-ui/src/main/resources/catalog/locales/pt-search.json
@@ -357,7 +357,7 @@
     "KMLfileURL": "URL de um arquivo KML",
     "refineSearch": "Refinar pesquisa",
     "backToList": "Voltar a Listagem",
-    "privilegesBatchAlert": "<span class='text-danger'>The privileges will be updated for all editable records in the selection. The privilege form is empty and does not reflect the selected records current privileges! Privileges are reset and replaced by the new one.</span><br/><br/>Clicking on <strong>Merge selected</strong> will add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.<br/><br/>Clicking on <strong>Update</strong> will remove record categories and then add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.",
+    "privilegesBatchAlert": "<span class='text-danger'>The privileges will be updated for all editable records in the selection. The privilege form is empty and does not reflect the selected records current privileges! Privileges are reset and replaced by the new one.</span><br/><br/>Clicking on <strong>Merge selected</strong> will add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.<br/><br/>Clicking on <strong>Update</strong> will remove record privileges and then add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.",
     "permalink": "Permalink",
     "permalinkTo": "Permalink para {{title}}",
     "shareOnTwitter": "Compartilhar no Twitter",

--- a/web-ui/src/main/resources/catalog/locales/pt-v4.json
+++ b/web-ui/src/main/resources/catalog/locales/pt-v4.json
@@ -212,7 +212,7 @@
   "addThoseOperations-help": "Append (checked with +) or remove (checkbox with -) selected privileges.",
   "privilegesNeededForPublicationRecordGroupOnly-true": "To publish a record, you need to be administrator or reviewer of record group",
   "privilegesNeededForPublicationRecordGroupOnly-false": "To publish a record, you need to be administrator or reviewer of record group or reviewer of a group with editing rights.",
-  "replaceByThoseOperations-help": "Remove record priviliges and then add (checked with +) or remove (checkbox with -) selected privileges.",
+  "replaceByThoseOperations-help": "Remove record privileges and then add (checked with +) or remove (checkbox with -) selected privileges.",
   "chooseASelection": "Choose a selection",
   "e101": "Editor board selection [e101]",
   "s101": "Search app selection [s101]",

--- a/web-ui/src/main/resources/catalog/locales/ru-search.json
+++ b/web-ui/src/main/resources/catalog/locales/ru-search.json
@@ -357,7 +357,7 @@
     "KMLfileURL": "URL-адрес KML файла",
     "refineSearch": "Refine Search",
     "backToList": "Back To List",
-    "privilegesBatchAlert": "<span class='text-danger'>The privileges will be updated for all editable records in the selection. The privilege form is empty and does not reflect the selected records current privileges! Privileges are reset and replaced by the new one.</span><br/><br/>Clicking on <strong>Merge selected</strong> will add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.<br/><br/>Clicking on <strong>Replace by selected</strong> will remove record categories and then add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.",
+    "privilegesBatchAlert": "<span class='text-danger'>The privileges will be updated for all editable records in the selection. The privilege form is empty and does not reflect the selected records current privileges! Privileges are reset and replaced by the new one.</span><br/><br/>Clicking on <strong>Merge selected</strong> will add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.<br/><br/>Clicking on <strong>Update</strong> will remove record privileges and then add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.",
     "permalink": "Permalink",
     "permalinkTo": "Permalink to {{title}}",
     "shareOnTwitter": "Поделиться в Twitter",

--- a/web-ui/src/main/resources/catalog/locales/ru-v4.json
+++ b/web-ui/src/main/resources/catalog/locales/ru-v4.json
@@ -212,7 +212,7 @@
   "addThoseOperations-help": "Append (checked with +) or remove (checkbox with -) selected privileges.",
   "privilegesNeededForPublicationRecordGroupOnly-true": "To publish a record, you need to be administrator or reviewer of record group",
   "privilegesNeededForPublicationRecordGroupOnly-false": "To publish a record, you need to be administrator or reviewer of record group or reviewer of a group with editing rights.",
-  "replaceByThoseOperations-help": "Remove record priviliges and then add (checked with +) or remove (checkbox with -) selected privileges.",
+  "replaceByThoseOperations-help": "Remove record privileges and then add (checked with +) or remove (checkbox with -) selected privileges.",
   "chooseASelection": "Choose a selection",
   "e101": "Editor board selection [e101]",
   "s101": "Search app selection [s101]",

--- a/web-ui/src/main/resources/catalog/locales/sk-search.json
+++ b/web-ui/src/main/resources/catalog/locales/sk-search.json
@@ -357,7 +357,7 @@
     "KMLfileURL": "URL súboru KML",
     "refineSearch": "Zúžiť výber",
     "backToList": "Späť na zoznam",
-    "privilegesBatchAlert": "<span class='text-danger'>The privileges will be updated for all editable records in the selection. The privilege form is empty and does not reflect the selected records current privileges! Privileges are reset and replaced by the new one.</span><br/><br/>Clicking on <strong>Merge selected</strong> will add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.<br/><br/>Clicking on <strong>Replace by selected</strong> will remove record categories and then add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.",
+    "privilegesBatchAlert": "<span class='text-danger'>The privileges will be updated for all editable records in the selection. The privilege form is empty and does not reflect the selected records current privileges! Privileges are reset and replaced by the new one.</span><br/><br/>Clicking on <strong>Merge selected</strong> will add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.<br/><br/>Clicking on <strong>Update</strong> will remove record privileges and then add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.",
     "permalink": "Permalink",
     "permalinkTo": "Permalink na {{title}}",
     "shareOnTwitter": "Zdieľaj na Twitter",

--- a/web-ui/src/main/resources/catalog/locales/sk-v4.json
+++ b/web-ui/src/main/resources/catalog/locales/sk-v4.json
@@ -212,7 +212,7 @@
   "addThoseOperations-help": "Append (checked with +) or remove (checkbox with -) selected privileges.",
   "privilegesNeededForPublicationRecordGroupOnly-true": "To publish a record, you need to be administrator or reviewer of record group",
   "privilegesNeededForPublicationRecordGroupOnly-false": "To publish a record, you need to be administrator or reviewer of record group or reviewer of a group with editing rights.",
-  "replaceByThoseOperations-help": "Remove record priviliges and then add (checked with +) or remove (checkbox with -) selected privileges.",
+  "replaceByThoseOperations-help": "Remove record privileges and then add (checked with +) or remove (checkbox with -) selected privileges.",
   "chooseASelection": "Choose a selection",
   "e101": "Editor board selection [e101]",
   "s101": "Search app selection [s101]",

--- a/web-ui/src/main/resources/catalog/locales/zh-search.json
+++ b/web-ui/src/main/resources/catalog/locales/zh-search.json
@@ -357,7 +357,7 @@
     "KMLfileURL": "KML文件的URL",
     "refineSearch": "优化搜索",
     "backToList": "返回目录",
-    "privilegesBatchAlert": "<span class='text-danger'>The privileges will be updated for all editable records in the selection. The privilege form is empty and does not reflect the selected records current privileges! Privileges are reset and replaced by the new one.</span><br/><br/>Clicking on <strong>Merge selected</strong> will add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.<br/><br/>Clicking on <strong>Replace by selected</strong> will remove record categories and then add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.",
+    "privilegesBatchAlert": "<span class='text-danger'>The privileges will be updated for all editable records in the selection. The privilege form is empty and does not reflect the selected records current privileges! Privileges are reset and replaced by the new one.</span><br/><br/>Clicking on <strong>Merge selected</strong> will add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.<br/><br/>Clicking on <strong>Update</strong> will remove record privileges and then add (checked with <strong>+</strong>) or remove (checkbox with <strong>-</strong>) selected privileges.",
     "permalink": "永久链接",
     "permalinkTo": "永久链接到{{title}}",
     "shareOnTwitter": "在Twitter上分享",

--- a/web-ui/src/main/resources/catalog/locales/zh-v4.json
+++ b/web-ui/src/main/resources/catalog/locales/zh-v4.json
@@ -212,7 +212,7 @@
   "addThoseOperations-help": "Append (checked with +) or remove (checkbox with -) selected privileges.",
   "privilegesNeededForPublicationRecordGroupOnly-true": "To publish a record, you need to be administrator or reviewer of record group",
   "privilegesNeededForPublicationRecordGroupOnly-false": "To publish a record, you need to be administrator or reviewer of record group or reviewer of a group with editing rights.",
-  "replaceByThoseOperations-help": "Remove record priviliges and then add (checked with +) or remove (checkbox with -) selected privileges.",
+  "replaceByThoseOperations-help": "Remove record privileges and then add (checked with +) or remove (checkbox with -) selected privileges.",
   "chooseASelection": "Choose a selection",
   "e101": "Editor board selection [e101]",
   "s101": "Search app selection [s101]",


### PR DESCRIPTION
Before:

- The text `Clicking on Replace by selected...` was not aligned with the button `Update`.
-  The text `remove record categories` was wrong, should be `remove record privileges`.
- `Update` button tooltip typo in `priviliges`.

<img width="781" alt="before-batch-privileges" src="https://github.com/user-attachments/assets/c2ca96db-6795-4d7e-966c-3e3c0b64a93b" />

After:

<img width="788" alt="after-batch-privileges" src="https://github.com/user-attachments/assets/b00da252-ce3f-437d-ba50-4021ba8c9049" />


# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
