### PR TITLE
Hide contactForResource header when there are none

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/tabbed.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/tabbed.html
@@ -25,6 +25,7 @@
     heading="{{'mdTabContact' | translate}}"
     role="tab"
     active="infoTabs.contact.active"
+    data-ng-if="mdView.current.record.contactForResource || mdView.current.record.resourceCredit"
   >
     <h2 data-translate="">resourceContact</h2>
     <div

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/type-dataset.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/type-dataset.html
@@ -199,7 +199,10 @@
   </div>
 </div>
 
-<div class="row gn-section gn-section-{{mdView.current.record.resourceType[0]}}">
+<div
+  class="row gn-section gn-section-{{mdView.current.record.resourceType[0]}}"
+  data-ng-if="mdView.current.record.contactForResource || mdView.current.record.resourceCredit"
+>
   <div class="col-md-8 gn-record gn-break">
     <div
       ng-include="'../../catalog/views/default/templates/recordView/contact.html'"

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/type-series.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/type-series.html
@@ -154,7 +154,10 @@
 </div>
 
 <!-- contact -->
-<div class="row gn-section">
+<div
+  class="row gn-section"
+  data-ng-if="mdView.current.record.contactForResource || mdView.current.record.resourceCredit"
+>
   <div class="col-md-8 gn-record gn-break">
     <div
       ng-include="'../../catalog/views/default/templates/recordView/contact.html'"


### PR DESCRIPTION
Currently the contactForResource header is always shown even when there are no contacts. This PR aims to fix this issue by hiding the header when contactsForResource is empty.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

