### PR TITLE
Translate roles in the feedback form

### DIFF
--- a/web-ui/src/main/resources/catalog/components/userfeedback/partials/mdFeedback.html
+++ b/web-ui/src/main/resources/catalog/components/userfeedback/partials/mdFeedback.html
@@ -201,11 +201,11 @@
                       <label>
                         <input
                           type="checkbox"
-                          aria-label="{{'fbSendTo' | translate}} {{c.email}} ({{c.role}})"
+                          aria-label="{{'fbSendTo' | translate}} {{c.email}} ({{c.role | translate}})"
                           data-ng-model="c.selected"
                           data-ng-change="updateList()"
                         />
-                        {{c.email}} ({{c.role}})
+                        {{c.email}} ({{c.role | translate}})
                       </label>
                     </li>
                   </ul>


### PR DESCRIPTION
Currently the roles in the feedback form are not translated:
![image](https://github.com/user-attachments/assets/c7e0e464-2265-4279-bd9e-f5707f416f68)

This PR aims to fix this issue by updating the template to translate the role codes.

After the fix the form should look like:
![image](https://github.com/user-attachments/assets/1a5ac2b3-3eed-493e-86cb-ed35d9bcf261)

<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
