### PR TITLE
Avoid null pointer when indexing overview data

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/search/EsSearchManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/EsSearchManager.java
@@ -142,7 +142,7 @@ public class EsSearchManager implements ISearchManager {
         FIELDLIST_RELATED_SCRIPTED = ImmutableMap.<String, String>builder()
             // Elasticsearch scripted field to get the first overview url. Scripted fields must return single values.
             .put("overview", "return params['_source'].overview == null ? [] : params['_source'].overview.stream().map(f -> f.url).findFirst().orElse('');")
-            .put("overview_data", "return params['_source'].overview == null ? [] : params['_source'].overview.stream().map(f -> f.data).findFirst().orElse('');")
+            .put("overview_data", "return params['_source'].overview == null ? [] : params['_source'].overview.stream().map(f -> f.data).filter(Objects::nonNull).findFirst().orElse('');")
             .build();
     }
 


### PR DESCRIPTION
This is some bug leftover from the previous pull request https://github.com/geonetwork/core-geonetwork/pull/8608

The issue is some parent or siblings record come with invalid resource url which means the resource is totally missing from the backend file store system

![image](https://github.com/user-attachments/assets/f647e1b8-300c-4f14-9417-c5eb707b46d7)
![image](https://github.com/user-attachments/assets/50744721-d2f0-40a5-8529-24021e111728)

So due to the file missing, the byte data cannot be stored in the index. Therefore, if we attempt to fetch it thru the painless script, it will causing some null pointer from the query.

This code change will filter out the null object in this case.