### PR TITLE
Remove wrong field name in  DOI server database migration

### DIFF
--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v445/DoiServerDatabaseMigration.java
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v445/DoiServerDatabaseMigration.java
@@ -87,20 +87,19 @@ public class DoiServerDatabaseMigration extends DatabaseMigrationTask {
             if (createDoiServer) {
                 try (PreparedStatement update = connection.prepareStatement(
                     "INSERT INTO doiservers " +
-                        "(id, isdefault, landingpagetemplate, name, url, username, password, pattern, prefix, publicurl) " +
-                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)")
+                        "(id, landingpagetemplate, name, url, username, password, pattern, prefix, publicurl) " +
+                        "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)")
                 ) {
 
                     update.setInt(1, 1);
-                    update.setString(2, "y");
-                    update.setString(3, doiLandingPageTemplate);
-                    update.setString(4, "Default DOI server");
-                    update.setString(5, doiUrl);
-                    update.setString(6, doiUsername);
-                    update.setString(7, doiPassword);
-                    update.setString(8, doiPattern);
-                    update.setString(9, doiKey);
-                    update.setString(10, doiPublicUrl);
+                    update.setString(2, doiLandingPageTemplate);
+                    update.setString(3, "Default DOI server");
+                    update.setString(4, doiUrl);
+                    update.setString(5, doiUsername);
+                    update.setString(6, doiPassword);
+                    update.setString(7, doiPattern);
+                    update.setString(8, doiKey);
+                    update.setString(9, doiPublicUrl);
 
                     update.execute();
 


### PR DESCRIPTION
Remove invalid field name in DOI servers database migration, causing the migration to fail. 

```
2025-04-10 12:33:08.353 UTC [5710] ERROR:  column "isdefault" of relation "doiservers" does not exist at character 29
2025-04-10 12:33:08.353 UTC [5710] STATEMENT:  INSERT INTO doiservers (id, isdefault, landingpagetemplate, name, url, username, password, pattern, prefix, publicurl) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)
```

Related to #8098

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
