### PR TITLE
DOI / Validation /  Improve schematron validation on organisation encoded using Anchor.

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/schematron/schematron-rules-datacite.sch
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/schematron/schematron-rules-datacite.sch
@@ -27,8 +27,6 @@
 
   <sch:title xmlns="http://www.w3.org/2001/XMLSchema">Datacite (DOI)</sch:title>
   <sch:ns prefix="gml" uri="http://www.opengis.net/gml"/>
-  <sch:ns prefix="gmd" uri="http://standards.iso.org/iso/19115/-3/gmd"/>
-  <sch:ns prefix="gmx" uri="http://standards.iso.org/iso/19115/-3/gmx"/>
   <sch:ns prefix="geonet" uri="http://www.fao.org/geonetwork"/>
   <sch:ns prefix="skos" uri="http://www.w3.org/2004/02/skos/core#"/>
   <sch:ns prefix="xlink" uri="http://www.w3.org/1999/xlink"/>
@@ -85,7 +83,7 @@
 
 
       <sch:let name="publisher"
-               value="(mdb:distributionInfo//mrd:distributorContact)[1]//cit:CI_Organisation/cit:name/gco:CharacterString"/>
+               value="(mdb:distributionInfo//mrd:distributorContact)[1]//cit:CI_Organisation/cit:name/(gco:CharacterString|gcx:Anchor)"/>
 
       <sch:assert test="$publisher != ''">$loc/strings/datacite.publisher.missing</sch:assert>
       <sch:report test="$publisher != ''">

--- a/schemas/iso19139/src/main/plugin/iso19139/schematron/schematron-rules-datacite.sch
+++ b/schemas/iso19139/src/main/plugin/iso19139/schematron/schematron-rules-datacite.sch
@@ -27,6 +27,7 @@
 
   <sch:title xmlns="http://www.w3.org/2001/XMLSchema">Datacite (DOI)</sch:title>
   <sch:ns prefix="gmd" uri="http://www.isotc211.org/2005/gmd"/>
+  <sch:ns prefix="gmx" uri="http://www.isotc211.org/2005/gmx"/>
   <sch:ns prefix="srv" uri="http://www.isotc211.org/2005/srv"/>
   <sch:ns prefix="gco" uri="http://www.isotc211.org/2005/gco"/>
   <sch:ns prefix="geonet" uri="http://www.fao.org/geonetwork"/>
@@ -68,7 +69,7 @@
 
 
       <sch:let name="publisher"
-               value="(gmd:distributionInfo//gmd:distributorContact)[1]/*/gmd:organisationName/gco:CharacterString"/>
+               value="(gmd:distributionInfo//gmd:distributorContact)[1]/*/gmd:organisationName/(gco:CharacterString|gmx:Anchor)"/>
 
       <sch:assert test="$publisher != ''">$loc/strings/datacite.publisher.missing</sch:assert>
       <sch:report test="$publisher != ''">


### PR DESCRIPTION
Some users are using ROR to add organisation identifier using `Anchor`.

```xml
<cit:CI_Organisation>
  <cit:name>
    <gcx:Anchor xlink:href="https://ror.org/05hnb7x64">Bureau de Recherches Géologiques et Minières (Orléans - France)</gcx:Anchor>
  </cit:name>
```

When creating DOI, schematron validation was not identifying publisher properly in that case (Datacite conversion is supporting it).



Nore: It may be more relevant to use party identifier

```xml
<cit:partyIdentifier>
 <mcc:MD_Identifier>
  <mcc:code>
    <gco:CharacterString>https://ror.org/05hnb7x64</gco:CharacterString>
  </mcc:code>
 </mcc:MD_Identifier>
</cit:partyIdentifier>
```


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->
