### PR TITLE
Standard / ISO19115-3 / Duplicate record / Remove record date.

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/duplicate-metadata.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/duplicate-metadata.xsl
@@ -26,6 +26,7 @@
                   xmlns:cit="http://standards.iso.org/iso/19115/-3/cit/2.0"
                   xmlns:mcc="http://standards.iso.org/iso/19115/-3/mcc/1.0"
                   xmlns:mrd="http://standards.iso.org/iso/19115/-3/mrd/1.0"
+                  xmlns:mdb="http://standards.iso.org/iso/19115/-3/mdb/2.0"
                   xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0"
                   xmlns:xlink="http://www.w3.org/1999/xlink"
                   exclude-result-prefixes="#all">
@@ -39,6 +40,7 @@
     <xsl:apply-templates select="*[1]"/>
   </xsl:template>
 
+  <xsl:template match="mdb:MD_Metadata/mdb:dateInfo"/>
 
   <!-- Remove DOI identifiers -->
   <xsl:template match="cit:identifier[
@@ -48,7 +50,6 @@
 
   <!-- Remove DOI links -->
   <xsl:template match="mrd:onLine[*/cit:protocol/gco:CharacterString = $doiProtocol]" />
-
 
   <!-- Do a copy of every nodes and attributes -->
   <xsl:template match="@*|node()">

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/templates/geodata.xml
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/templates/geodata.xml
@@ -78,16 +78,6 @@
       </cit:party>
     </cit:CI_Responsibility>
   </mdb:contact>
-  <mdb:dateInfo>
-    <cit:CI_Date>
-      <cit:date>
-        <gco:DateTime>2005-03-31T19:13:30</gco:DateTime>
-      </cit:date>
-      <cit:dateType>
-        <cit:CI_DateTypeCode codeList="codeListLocation#CI_DateTypeCode" codeListValue="creation">creation</cit:CI_DateTypeCode>
-      </cit:dateType>
-    </cit:CI_Date>
-  </mdb:dateInfo>
   <mdb:metadataStandard>
     <cit:CI_Citation>
       <cit:title>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/templates/map.xml
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/templates/map.xml
@@ -78,16 +78,6 @@
          </cit:party>
       </cit:CI_Responsibility>
    </mdb:contact>
-   <mdb:dateInfo>
-      <cit:CI_Date>
-         <cit:date>
-            <gco:DateTime>2013-04-09T13:28:30</gco:DateTime>
-         </cit:date>
-         <cit:dateType>
-            <cit:CI_DateTypeCode codeList="codeListLocation#CI_DateTypeCode" codeListValue="creation">creation</cit:CI_DateTypeCode>
-         </cit:dateType>
-      </cit:CI_Date>
-   </mdb:dateInfo>
    <mdb:metadataStandard>
       <cit:CI_Citation>
          <cit:title>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/templates/service.xml
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/templates/service.xml
@@ -79,16 +79,6 @@
       </cit:party>
     </cit:CI_Responsibility>
   </mdb:contact>
-  <mdb:dateInfo>
-    <cit:CI_Date>
-      <cit:date>
-        <gco:DateTime>2005-03-31T19:13:30</gco:DateTime>
-      </cit:date>
-      <cit:dateType>
-        <cit:CI_DateTypeCode codeList="codeListLocation#CI_DateTypeCode" codeListValue="creation">creation</cit:CI_DateTypeCode>
-      </cit:dateType>
-    </cit:CI_Date>
-  </mdb:dateInfo>
   <mdb:metadataStandard>
     <cit:CI_Citation>
       <cit:title>

--- a/schemas/iso19115-3.2018/src/test/java/org/fao/geonet/schema/DuplicateRecordXslProcessTest.java
+++ b/schemas/iso19115-3.2018/src/test/java/org/fao/geonet/schema/DuplicateRecordXslProcessTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2001-2024 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+package org.fao.geonet.schema;
+
+import org.fao.geonet.schema.iso19115_3_2018.ISO19115_3_2018SchemaPlugin;
+import org.fao.geonet.schemas.XslProcessTest;
+import org.fao.geonet.utils.Xml;
+import static org.hamcrest.CoreMatchers.equalTo;
+import org.jdom.Element;
+import static org.junit.Assert.assertThat;
+import org.junit.Test;
+
+public class DuplicateRecordXslProcessTest extends XslProcessTest {
+
+    public DuplicateRecordXslProcessTest() {
+        super();
+        this.setXslFilename("duplicate-metadata.xsl");
+        this.setXmlFilename("metadata.xml");
+        this.setNs(ISO19115_3_2018SchemaPlugin.allNamespaces);
+    }
+
+    private static final String XPATH_RECORD_DATE =
+        "mdb:dateInfo";
+    private static final String XPATH_RECORD_ONLINE_DOI =
+        ".//mrd:onLine[*/cit:protocol/*/text() = 'DOI']";
+    private static final String XPATH_RECORD_RESOURCE_IDENTIFIER =
+        ".//mri:citation/*/cit:identifier";
+
+    @Test
+    public void testDuplicateRecord() throws Exception {
+        Element inputElement = Xml.loadFile(xmlFile);
+        assertThat(Xml.selectNodes(inputElement, XPATH_RECORD_DATE).size(), equalTo(2));
+        assertThat(Xml.selectNodes(inputElement, XPATH_RECORD_ONLINE_DOI).size(), equalTo(1));
+        assertThat(Xml.selectNodes(inputElement, XPATH_RECORD_RESOURCE_IDENTIFIER).size(), equalTo(2));
+
+        Element resultElement = Xml.transform(inputElement, xslFile);
+        assertThat(Xml.selectNodes(resultElement, XPATH_RECORD_DATE).size(), equalTo(0));
+        assertThat(Xml.selectNodes(resultElement, XPATH_RECORD_ONLINE_DOI).size(), equalTo(0));
+        assertThat(Xml.selectNodes(resultElement, XPATH_RECORD_RESOURCE_IDENTIFIER).size(), equalTo(1));
+
+    }
+}

--- a/schemas/iso19115-3.2018/src/test/java/org/fao/geonet/schema/LanguageXslProcessTest.java
+++ b/schemas/iso19115-3.2018/src/test/java/org/fao/geonet/schema/LanguageXslProcessTest.java
@@ -62,7 +62,7 @@ public class LanguageXslProcessTest extends XslProcessTest {
     public void testSetDefaultLanguage() throws Exception {
         Element inputElement = Xml.loadFile(xmlFile);
         String resultString = Xml.getString(inputElement);
-        check(resultString, "eng", new String[]{}, 177, 0);
+        check(resultString, "eng", new String[]{}, 193, 0);
 //        TODO: We need to update Mockito for static method probably
 //        XslUtil xslUtil = Mockito.mock(XslUtil.class);
 //        Mockito.when(xslUtil.twoCharLangCode("eng")).thenReturn("en");
@@ -72,7 +72,7 @@ public class LanguageXslProcessTest extends XslProcessTest {
         params.put("defaultLanguage", "fre");
         Element resultElement = Xml.transform(inputElement, xslFile, params);
         resultString = Xml.getString(resultElement);
-        check(resultString, "fre", new String[]{}, 177, 0);
+        check(resultString, "fre", new String[]{}, 193, 0);
     }
 
     @Test

--- a/schemas/iso19115-3.2018/src/test/resources/metadata.xml
+++ b/schemas/iso19115-3.2018/src/test/resources/metadata.xml
@@ -138,6 +138,23 @@
               </cit:dateType>
             </cit:CI_Date>
           </cit:date>
+          <cit:identifier>
+            <mcc:MD_Identifier>
+              <mcc:code>
+                <gco:CharacterString>4bef2af5-422a-45b0-9e9a-fa692fb0f18c</gco:CharacterString>
+              </mcc:code>
+              <mcc:codeSpace>
+                <gco:CharacterString>http://geodata.wallonie.be/id/</gco:CharacterString>
+              </mcc:codeSpace>
+            </mcc:MD_Identifier>
+          </cit:identifier>
+          <cit:identifier>
+            <mcc:MD_Identifier>
+              <mcc:code>
+                <gco:CharacterString>https://doi.org/10.1234/ABC</gco:CharacterString>
+              </mcc:code>
+            </mcc:MD_Identifier>
+          </cit:identifier>
         </cit:CI_Citation>
       </mri:citation>
       <mri:abstract>
@@ -320,7 +337,18 @@
   <mdb:distributionInfo>
     <mrd:MD_Distribution>
       <mrd:transferOptions>
-        <mrd:MD_DigitalTransferOptions></mrd:MD_DigitalTransferOptions>
+        <mrd:MD_DigitalTransferOptions>
+          <mrd:onLine>
+            <cit:CI_OnlineResource>
+              <cit:linkage>
+                <gco:CharacterString>https://doi.org/10.1234/ABC</gco:CharacterString>
+              </cit:linkage>
+              <cit:protocol>
+                <gco:CharacterString>DOI</gco:CharacterString>
+              </cit:protocol>
+            </cit:CI_OnlineResource>
+          </mrd:onLine>
+        </mrd:MD_DigitalTransferOptions>
       </mrd:transferOptions>
     </mrd:MD_Distribution>
   </mdb:distributionInfo>


### PR DESCRIPTION
Compared to ISO19139 which only contains a `dateStamp` for the metadata record which GeoNetwork use to store the last update date, ISO19115-3 allows various date information about the record (eg. creation, revision, publication).
 
When duplicating a record, remove metadata dates of the source record. They will be initialized by db creation and update dates and this will avoid to have multiple creation dates.


![image](https://github.com/user-attachments/assets/3815c474-ae8c-4993-95d0-99ac1bcf1635)


For testing, duplicate an ISO19115-3 record having a creation date.


We could also at some point consider keeping only one date of each types?


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

Funded by Service Public de Wallonie
