### PR TITLE
[4.2.x] Fix cannot update groups for static page

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/pages/PagesAPI.java
+++ b/services/src/main/java/org/fao/geonet/api/pages/PagesAPI.java
@@ -297,11 +297,13 @@ public class PagesAPI {
             pageToUpdate.setSections(pageProperties.getSections() != null ? pageProperties.getSections() : pageToUpdate.getSections());
             pageToUpdate.setStatus(pageProperties.getStatus() != null ? pageProperties.getStatus() : pageToUpdate.getStatus());
             pageToUpdate.setLabel(newLabel);
-            pageRepository.save(pageToUpdate);
+
             pageToUpdate.getGroups().clear();
             if (pageToUpdate.getStatus() == Page.PageStatus.GROUPS) {
                 pageToUpdate.getGroups().addAll(_groups);
             }
+
+            pageRepository.save(pageToUpdate);
 
         }
 


### PR DESCRIPTION
There is a bug with the #8491 backport. The groups update logic was put below the page save logic resulting in the groups never being saved.
![image](https://github.com/user-attachments/assets/a13ecc6f-8bce-4271-9039-b72ab8c0d825)

This means that when a static page is created with access granted to a specific group, the group which is granted access can never be changed.

Given two groups (`A` & `B`):

1. Create a static page (Settings > Static pages > New static page)
  Status: Visible to users belonging to the groups
  Groups: A
2. Save the static page
3. Edit the static page
  Groups: B
4. Save the static page
5. Edit the static page to view the current groups
6. The groups are still set to "A"

This PR aims to fix this issue by updating the 4.2.x branch to have these calls in the correct order like the main branch.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

