### PR TITLE
Fix submenu still displays with no children

### DIFF
--- a/web-ui/src/main/resources/catalog/components/pages/partials/menu-page.html
+++ b/web-ui/src/main/resources/catalog/components/pages/partials/menu-page.html
@@ -1,4 +1,4 @@
-<li data-ng-class="{'dropdown': isSubmenu}" role="menuitem">
+<li data-ng-class="{'dropdown': isSubmenu}" role="menuitem" data-ng-hide="isSubmenu && page.pages.length < 1">
   <a
     data-ng-if="isSubmenu && section!='record_view_menu'"
     class="dropdown-toggle gn-menuheader-xs"


### PR DESCRIPTION
Currently a submenu with conditionally shown static page children will still display when none of the children are shown. This is confusing for users as they see a menu which suggests there are available options when there really are none.

Ex.

1. Set up a custom record view menu item with a static page as a child:
![image](https://github.com/user-attachments/assets/15012930-7750-4eb8-92c6-e0c86ebb92b6)
2. Set the static page to `Visible only to the administrator`.
![image](https://github.com/user-attachments/assets/d2c3bb95-e7c6-447a-aba3-d5a54087fe14)
3. Log in as a non-admin user.
4. Open a record.
5. An empty drop down menu is shown
![image](https://github.com/user-attachments/assets/273d03e5-16ba-4ecb-853d-897932d4ea1f)

This PR aims to fix this issue by hiding the menu item when there are no children.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
