### PR TITLE
Fix add-schema.sh

### DIFF
--- a/add-schema.sh
+++ b/add-schema.sh
@@ -54,7 +54,7 @@ then
 
   sed $sedopt -f /dev/stdin schemas/pom.xml << SED_SCRIPT
   ${insertLine} a\\
-\    <module>schema-${schema}</module>
+\    <module>${schema}</module>
 SED_SCRIPT
 fi
 

--- a/add-schema.sh
+++ b/add-schema.sh
@@ -47,22 +47,14 @@ line=$(grep -n ${schema} schemas/pom.xml | cut -d: -f1)
 
 if [ ! -n "$line" ]
 then
-  line=$(grep -n '</profiles>' schemas/pom.xml | cut -d: -f1)
+  line=$(grep -n '</modules>' schemas/pom.xml | cut -d: -f1)
   insertLine=$(($line - 1))
 
   echo "Adding schema ${schema} to schemas/pom.xml"
 
   sed $sedopt -f /dev/stdin schemas/pom.xml << SED_SCRIPT
   ${insertLine} a\\
-\    <profile>\\
-\      <id>schema-${schema}</id>\\
-\      <activation>\\
-\        <file><exists>${schema}</exists></file>\\
-\      </activation>\\
-\      <modules>\\
-\        <module>${schema}</module>\\
-\      </modules>\\
-\    </profile>
+\    <module>schema-${schema}</module>
 SED_SCRIPT
 fi
 

--- a/schemas/pom.xml
+++ b/schemas/pom.xml
@@ -44,6 +44,7 @@
     <module>iso19110</module>
     <module>iso19139</module>
     <module>iso19115-3.2018</module>
+    <module>iso19139.pt.mig.2.0</module>
   </modules>
 
   <properties>

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -256,6 +256,12 @@
       <groupId>commons-fileupload</groupId>
       <artifactId>commons-fileupload</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.geonetwork-opensource.schemas</groupId>
+      <artifactId>gn-schema-iso19139.pt.mig.2.0</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/web/pom.xml
+++ b/web/pom.xml
@@ -1178,6 +1178,11 @@
       <!-- Add dependencies to schema plugin having a custom Bean to be loaded. -->
       <dependencies>
         <!-- add schema_plugins -->
+        <dependency>
+          <groupId>org.geonetwork-opensource.schemas</groupId>
+          <artifactId>gn-schema-iso19139.pt.mig.2.0</artifactId>
+          <version>${project.version}</version>
+        </dependency>
       </dependencies>
       <build>
         <plugins>
@@ -1409,6 +1414,48 @@
         </dependency>
       </dependencies>
     </profile>
+    <!--
+    <profile>
+      <id>schema-iso19139.pt.mig.2.0</id>
+      <activation>
+        <property><name>schemasCopy</name><value>!true</value></property>
+        <file><exists>../schemas/iso19139.pt.mig.2.0</exists></file>
+      </activation>
+      <dependencies>
+        <dependency>
+          <groupId>org.geonetwork-opensource.schemas</groupId>
+          <artifactId>gn-schema-iso19139.pt.mig.2.0</artifactId>
+          <version>${project.version}</version>
+        </dependency>
+      </dependencies>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>iso19139.pt.mig.2.0-resources</id>
+                <phase>process-resources</phase>
+                <goals><goal>unpack</goal></goals>
+                <configuration>
+                  <artifactItems>
+                    <artifactItem>
+                      <groupId>org.geonetwork-opensource.schemas</groupId>
+                      <artifactId>gn-schema-iso19139.pt.mig.2.0</artifactId>
+                      <type>zip</type>
+                      <overWrite>false</overWrite>
+                      <outputDirectory>${schema-plugins.dir}</outputDirectory>
+                    </artifactItem>
+                  </artifactItems>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  -->
   </profiles>
 
   <properties>

--- a/web/src/main/webResources/WEB-INF/data/config/index/records.json
+++ b/web/src/main/webResources/WEB-INF/data/config/index/records.json
@@ -1125,6 +1125,10 @@
                 "type": "keyword",
                 "copy_to": ["any.langpol", "organisationName.langpol"]
               },
+              "langpor": {
+                "type": "keyword",
+                "copy_to": ["any.langpor", "organisationName.langpor"]
+              },
               "link": {
                 "type": "keyword"
               }
@@ -1320,6 +1324,17 @@
                   }
                 }
               },
+              "langpor": {
+                "type": "text",
+                "analyzer": "${es.index.analyzer.default}",
+                "copy_to": ["any.langpor"],
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": ${es.index.ignore_above}
+                  }
+                }
+              },
               "link": {
                 "type": "keyword"
               }
@@ -1433,6 +1448,10 @@
               "langpol": {
                 "type": "keyword",
                 "copy_to": ["any.langpol"]
+              },
+              "langpor": {
+                "type": "keyword",
+                "copy_to": ["any.langpor"]
               },
               "text": {
                 "type": "keyword"
@@ -1650,6 +1669,10 @@
           "langpol": {
             "type": "text",
             "analyzer": "${es.index.analyzer.default}"
+          },
+          "langpor": {
+            "type": "text",
+            "analyzer": "${es.index.analyzer.default}"
           }
         }
       },
@@ -1714,6 +1737,10 @@
           "langpol": {
             "type": "keyword",
             "copy_to": ["any.langpol"]
+          },
+          "langpor": {
+            "type": "keyword",
+            "copy_to": ["any.langpor"]
           },
           "link": {
             "type": "keyword"
@@ -2272,6 +2299,9 @@
             "type": "keyword"
           },
           "langpol": {
+            "type": "keyword"
+          },
+          "langpor": {
             "type": "keyword"
           }
         }


### PR DESCRIPTION
<!--Include a few sentences describing the overall goals for this Pull Request-->

This is a minor fix to the `add-schema.sh`  script. The script changes three files:
- schemas/pom.xml
- services/pom.xml
- web/pom.xml

**Changes to the first file were failing.**

The structure of `schemas/pom.xml` file is:
```xml
  <modules>
    <module>schema-core</module>
    <module>csw-record</module>
    <module>dublin-core</module>
    <module>iso19110</module>
    <module>iso19139</module>
    <module>iso19115-3.2018</module>
  </modules>
```

The fix changes this file to add just one line.

<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

