### PR TITLE
Fix md is null in record view

### DIFF
--- a/web-ui/src/main/resources/catalog/components/pages/partials/menu-page.html
+++ b/web-ui/src/main/resources/catalog/components/pages/partials/menu-page.html
@@ -1,4 +1,8 @@
-<li data-ng-class="{'dropdown': isSubmenu}" role="menuitem" data-ng-hide="isSubmenu && page.pages.length < 1">
+<li
+  data-ng-class="{'dropdown': isSubmenu}"
+  role="menuitem"
+  data-ng-hide="isSubmenu && page.pages.length < 1"
+>
   <a
     data-ng-if="isSubmenu && section!='record_view_menu'"
     class="dropdown-toggle gn-menuheader-xs"

--- a/web-ui/src/main/resources/catalog/components/search/mdview/mdviewModule.js
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/mdviewModule.js
@@ -108,6 +108,7 @@
       gnConfigService.load().then(function (c) {
         $scope.isRecordHistoryEnabled = gnConfig["metadata.history.enabled"];
         $scope.isPreferGroupLogo = gnConfig["system.metadata.prefergrouplogo"];
+        $scope.isMdWorkflowEnable = gnConfig["metadata.workflow.enable"];
 
         var statusSystemRating = gnConfig["system.localrating.enable"];
 

--- a/web-ui/src/main/resources/catalog/components/search/mdview/mdviewModule.js
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/mdviewModule.js
@@ -104,7 +104,6 @@
       $scope.showStatusTopBarFor =
         gnGlobalSettings.gnCfg.mods.recordview.showStatusTopBarFor;
 
-
       gnConfigService.load().then(function (c) {
         $scope.isRecordHistoryEnabled = gnConfig["metadata.history.enabled"];
         $scope.isPreferGroupLogo = gnConfig["system.metadata.prefergrouplogo"];

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/downloads.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/downloads.html
@@ -1,6 +1,6 @@
 <div
-  data-ng-if="md.link"
-  data-gn-distribution-resources-container="md"
+  data-ng-if="mdView.current.record.link"
+  data-gn-distribution-resources-container="mdView.current.record"
   data-mode="::viewConfig.distributionConfig.layout || ''"
   data-editable="false"
   data-related-config="::viewConfig.distributionConfig.sections"

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/recordView.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/recordView.html
@@ -13,7 +13,7 @@
       data-ng-if="mdView.current.record.draft == 'e'"
       class="see-draft see-draft-not-approved"
       title=" {{('status-' + mdView.current.record.mdStatus) | translate}}"
-      data-ng-href="#/metadraf/{{md.uuid}}"
+      data-ng-href="#/metadraf/{{mdView.current.record.uuid}}"
       data-ng-show="user.canEditRecord(mdView.current.record)"
     >
       {{'seeDraft' | translate}}
@@ -24,7 +24,7 @@
       data-ng-if="mdView.current.record.draft == 'y'"
       class="see-draft see-draft-approved"
       title=" {{('status-' + mdView.current.record.mdStatus) | translate}}"
-      data-ng-href="#/metadata/{{md.uuid}}"
+      data-ng-href="#/metadata/{{mdView.current.record.uuid}}"
       data-ng-show="user.canEditRecord(mdView.current.record)"
     >
       {{'seeNoDraft' | translate}}
@@ -137,7 +137,7 @@
       ></div>
 
       <div data-ng-show="!gnMdViewObj.usingFormatter" class="gn-metadata-display">
-        <div data-ng-switch on="md.resourceType[0]">
+        <div data-ng-switch on="mdView.current.record.resourceType[0]">
           <div data-ng-switch-when="series">
             <div
               ng-include="'../../catalog/views/default/templates/recordView/type-series.html'"

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/recordView.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/recordView.html
@@ -92,40 +92,40 @@
 
         <div class="pull-right">
           <ul class="nav navbar-nav gn-menu-xs" role="menu">
-            <li data-ng-repeat-start="menu in recordviewMenu"></li>
-            <!--record view menu static pages-->
-            <li
-              data-ng-if="isPage(menu)"
-              gn-static-page-menu="menu"
-              language="{{lang}}"
-              section="record_view_menu"
-            ></li>
+            <li data-ng-repeat="menu in recordviewMenu">
+              <!--record view menu static pages-->
+              <div
+                data-ng-if="isPage(menu)"
+                gn-static-page-menu="menu"
+                language="{{lang}}"
+                section="record_view_menu"
+              ></div>
 
-            <!-- edit -->
-            <div
-              data-ng-if="menu == 'gn-recordview-edit-menu'"
-              gn-record-view-edit-menu=""
-            ></div>
+              <!-- edit -->
+              <div
+                data-ng-if="menu == 'gn-recordview-edit-menu'"
+                gn-record-view-edit-menu=""
+              ></div>
 
-            <!-- delete -->
-            <div
-              data-ng-if="menu == 'gn-recordview-delete-menu'"
-              gn-record-view-delete-menu=""
-            ></div>
+              <!-- delete -->
+              <div
+                data-ng-if="menu == 'gn-recordview-delete-menu'"
+                gn-record-view-delete-menu=""
+              ></div>
 
-            <!-- manage -->
-            <div
-              data-ng-if="menu == 'gn-recordview-manage-menu' && mdView.current.record"
-              class="gn-md-actions-btn pull-left"
-              data-gn-md-actions-menu="mdView.current.record"
-            ></div>
+              <!-- manage -->
+              <div
+                data-ng-if="menu == 'gn-recordview-manage-menu' && mdView.current.record"
+                class="gn-md-actions-btn pull-left"
+                data-gn-md-actions-menu="mdView.current.record"
+              ></div>
 
-            <!-- display mode -->
-            <div
-              data-ng-if="menu == 'gn-recordview-display-menu'"
-              gn-record-view-display-mode-menu=""
-            ></div>
-            <li data-ng-repeat-end=""></li>
+              <!-- display mode -->
+              <div
+                data-ng-if="menu == 'gn-recordview-display-menu'"
+                gn-record-view-display-mode-menu=""
+              ></div>
+            </li>
           </ul>
         </div>
       </div>

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/title.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/title.html
@@ -7,13 +7,13 @@
     <span
       class="text-muted badge"
       data-ng-class="{
-              'text-success': md.mdStatus == 2,
-              'text-warning': md.mdStatus == 4
+              'text-success': mdView.current.record.mdStatus == 2,
+              'text-warning': mdView.current.record.mdStatus == 4
               }"
       data-ng-if="user.isEditorOrMore()
-                      && md.mdStatus < 50
+                      && mdView.current.record.mdStatus < 50
                       && isMdWorkflowEnable"
-      >{{('status-' + md.mdStatus) | translate}}</span
+      >{{('status-' + mdView.current.record.mdStatus) | translate}}</span
     >
   </h1>
 


### PR DESCRIPTION
Following #7802 the `md` object is not set in the `recordView` template. The reason is that `gnMdActionsMenu` set the `md` object and now it is in a different scope.

This causes several issues:

The working copy link is broken (UUID is missing):
![image](https://github.com/user-attachments/assets/8b0179e4-ab65-4955-ba98-a7f981854af1)

The record links are not shown:
![image](https://github.com/user-attachments/assets/509a1858-226b-43de-88cd-e75f56389e88)

The status label is not shown:
![image](https://github.com/user-attachments/assets/edb6b1bb-98c9-473e-8155-404f7426d41c)

This PR aims to fix this issue by changing the template and sub templates to use `mdView.current.record` instead of `md`. With the changes from this PR all three of these issues are fixed.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

