### PR TITLE
Fix localized watchlist emails

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/WatchListNotifier.java
+++ b/core/src/main/java/org/fao/geonet/kernel/WatchListNotifier.java
@@ -218,8 +218,7 @@ public class WatchListNotifier extends QuartzJobBean {
                         feedbackLocale,
                         new LocalizedEmailParameter(ParameterType.RAW_VALUE, 1, listOfUpdateMessage.toString()),
                         new LocalizedEmailParameter(ParameterType.RAW_VALUE, 2, lastNotificationDate),
-                        new LocalizedEmailParameter(ParameterType.RAW_VALUE, 3, url),
-                        new LocalizedEmailParameter(ParameterType.RAW_VALUE, 4, url)
+                        new LocalizedEmailParameter(ParameterType.RAW_VALUE, 3, url)
                         );
 
                 }

--- a/core/src/main/java/org/fao/geonet/util/LocalizedEmailComponent.java
+++ b/core/src/main/java/org/fao/geonet/util/LocalizedEmailComponent.java
@@ -245,7 +245,7 @@ public class LocalizedEmailComponent {
      */
     public String parseMessage(Locale locale) {
 
-        ArrayList<LocalizedEmailParameter> parametersForLocale = parameters.get(locale);
+        ArrayList<LocalizedEmailParameter> parametersForLocale = parameters.getOrDefault(locale, new ArrayList<>());
 
         String parsedMessage;
         switch (keyType) {

--- a/core/src/test/resources/org/fao/geonet/api/Messages.properties
+++ b/core/src/test/resources/org/fao/geonet/api/Messages.properties
@@ -143,7 +143,7 @@ metadata_unpublished_record_text=<li>The metadata <a href="{{link}}">{{index:res
 metadata_approved_published_record_text=<li>The metadata <a href="{{link}}">{{index:resourceTitleObject}}</a> has been published as a new version.</li>
 
 api.groups.group_not_found=Group with ID ''{0}'' not found in this catalog.
-user_watchlist_subject=%s / %d updates in your watch list since %s
+user_watchlist_subject=%s / %s updates in your watch list since %s
 user_watchlist_message_record=<li><a href="{{link}}">{{index:resourceTitleObject}}</a></li>
 user_watchlist_message=The following records have been updated:\n\
       <ul>%s</ul>\n\

--- a/core/src/test/resources/org/fao/geonet/api/Messages_fre.properties
+++ b/core/src/test/resources/org/fao/geonet/api/Messages_fre.properties
@@ -138,7 +138,7 @@ metadata_unpublished_record_text=<li>La m\u00E9tadonn\u00E9e <a href="{{link}}">
 metadata_approved_published_record_text=<li>Une nouvelle version de la m\u00E9tadonn\u00E9e <a href="{{link}}">{{index:resourceTitleObject}}</a> a \u00E9t\u00E9 publi\u00E9e.</li>
 
 api.groups.group_not_found=Le groupe avec l''identifiant ''{0}'' n''a pas \u00E9t\u00E9 trouv\u00E9 dans le catalogue.
-user_watchlist_subject=%s / %d mises \u00e0 jour dans vos fiches surveill\u00E9es %s
+user_watchlist_subject=%s / %s mises \u00e0 jour dans vos fiches surveill\u00E9es %s
 user_watchlist_message_record=<li><a href="{{link}}">{{index:resourceTitleObject}}</a></li>
 user_watchlist_message=Les fiches suivantes ont \u00E9t\u00E9 mises \u00e0 jour :\n\
       <ul>%s</ul>\n\

--- a/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages.properties
+++ b/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages.properties
@@ -149,7 +149,7 @@ metadata_unpublished_record_text=<li>The metadata <a href="{{link}}">{{index:res
 metadata_approved_published_record_text=<li>The metadata <a href="{{link}}">{{index:resourceTitleObject}}</a> has been published as a new version.</li>
 
 api.groups.group_not_found=Group with ID ''{0}'' not found in this catalog.
-user_watchlist_subject=%s / %d updates in your watch list since %s
+user_watchlist_subject=%s / %s updates in your watch list since %s
 user_watchlist_message_record=<li><a href="{{link}}">{{index:resourceTitleObject}}</a></li>
 user_watchlist_message=The following records have been updated:\n\
       <ul>%s</ul>\n\

--- a/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages_dut.properties
+++ b/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages_dut.properties
@@ -149,7 +149,7 @@ metadata_unpublished_record_text=<li>Het metadata record <a href="{{link}}">{{in
 metadata_approved_published_record_text=<li>Het metadata record <a href="{{link}}">{{index:resourceTitleObject}}</a> is gepubliceerd als een nieuwe versie.</li>
 
 api.groups.group_not_found=Groep met ID ''{0}'' is niet gevonden in de catalogus.
-user_watchlist_subject=%s / %d updates in je volglijst sinds %s
+user_watchlist_subject=%s / %s updates in je volglijst sinds %s
 user_watchlist_message_record=<li><a href="{{link}}">{{index:resourceTitleObject}}</a></li>
 user_watchlist_message=De volgende records zijn bijgewerkt:\n\
       <ul>%s</ul>\n\

--- a/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages_fre.properties
+++ b/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages_fre.properties
@@ -144,7 +144,7 @@ metadata_unpublished_record_text=<li>La m\u00E9tadonn\u00E9e <a href="{{link}}">
 metadata_approved_published_record_text=<li>Une nouvelle version de la m\u00E9tadonn\u00E9e <a href="{{link}}">{{index:resourceTitleObject}}</a> a \u00E9t\u00E9 publi\u00E9e.</li>
 
 api.groups.group_not_found=Le groupe avec l''identifiant ''{0}'' n''a pas \u00E9t\u00E9 trouv\u00E9 dans le catalogue.
-user_watchlist_subject=%s / %d mises \u00e0 jour dans vos fiches surveill\u00E9es %s
+user_watchlist_subject=%s / %s mises \u00e0 jour dans vos fiches surveill\u00E9es %s
 user_watchlist_message_record=<li><a href="{{link}}">{{index:resourceTitleObject}}</a></li>
 user_watchlist_message=Les fiches suivantes ont \u00E9t\u00E9 mises \u00e0 jour :\n\
       <ul>%s</ul>\n\


### PR DESCRIPTION
Localized emails (#7966) were not fully tested with the emails sent by the watchlist feature. There are a few issues preventing these emails from being sent:

- If an email component has no parameters (`user_watchlist_message_record` for example) a null pointer exception is thrown
- The subject message uses the `%d` placeholder but a string is provided so an exception is thrown
- The url parameter is added twice to the email message so the parameters and placeholders do not match and an exception is thrown

This PR aims to fix all these issues so that the watchlist emails can be sent again.

<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
