### PR TITLE
Add new recordProfileUserAdmin notification level

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/metadata/DefaultStatusActions.java
+++ b/core/src/main/java/org/fao/geonet/kernel/metadata/DefaultStatusActions.java
@@ -412,8 +412,10 @@ public class DefaultStatusActions implements StatusActions {
                 if (owner.isPresent()) {
                     users.add(owner.get());
                 }
-            } else if (notificationLevel == StatusValueNotificationLevel.recordProfileReviewer) {
-                List<Pair<Integer, User>> results = userRepository.findAllByGroupOwnerNameAndProfile(recordIds, Profile.Reviewer);
+            } else if (notificationLevel.name().startsWith("recordProfile")) {
+                String profileId = notificationLevel.name().replace("recordProfile", "");
+                Profile profile = Profile.findProfileIgnoreCase(profileId);
+                List<Pair<Integer, User>> results = userRepository.findAllByGroupOwnerNameAndProfile(recordIds, profile);
                 Collections.sort(results, Comparator.comparing(s -> s.two().getName()));
                 for (Pair<Integer, User> p : results) {
                     users.add(p.two());

--- a/core/src/main/java/org/fao/geonet/kernel/metadata/DefaultStatusActions.java
+++ b/core/src/main/java/org/fao/geonet/kernel/metadata/DefaultStatusActions.java
@@ -415,6 +415,10 @@ public class DefaultStatusActions implements StatusActions {
             } else if (notificationLevel.name().startsWith("recordProfile")) {
                 String profileId = notificationLevel.name().replace("recordProfile", "");
                 Profile profile = Profile.findProfileIgnoreCase(profileId);
+                if (profile == null) {
+                    Log.error(Geonet.DATA_MANAGER, "Invalid notification level is configured '" + notificationLevel + "' The associated profile '" + profileId + "' does not exist.");
+                    return users;
+                }
                 List<Pair<Integer, User>> results = userRepository.findAllByGroupOwnerNameAndProfile(recordIds, profile);
                 Collections.sort(results, Comparator.comparing(s -> s.two().getName()));
                 for (Pair<Integer, User> p : results) {
@@ -443,6 +447,10 @@ public class DefaultStatusActions implements StatusActions {
             } else if (notificationLevel.name().startsWith("catalogueProfile")) {
                 String profileId = notificationLevel.name().replace("catalogueProfile", "");
                 Profile profile = Profile.findProfileIgnoreCase(profileId);
+                if (profile == null) {
+                    Log.error(Geonet.DATA_MANAGER, "Invalid notification level is configured '" + notificationLevel + "' The associated profile '" + profileId + "' does not exist.");
+                    return users;
+                }
                 users = userRepository.findAllByProfile(profile);
             } else if (notificationLevel == StatusValueNotificationLevel.catalogueAdministrator) {
                 SettingManager settingManager = ApplicationContextHolder.get().getBean(SettingManager.class);

--- a/domain/src/main/java/org/fao/geonet/domain/StatusValueNotificationLevel.java
+++ b/domain/src/main/java/org/fao/geonet/domain/StatusValueNotificationLevel.java
@@ -64,6 +64,10 @@ public enum StatusValueNotificationLevel {
      */
     recordProfileReviewer,
     /**
+     * When assigned should notify the user administrators part of the record group owner.
+     */
+    recordProfileUserAdmin,
+    /**
      * When assigned should notify the record author.
      */
     recordUserAuthor,

--- a/services/src/main/java/org/fao/geonet/util/MetadataPublicationMailNotifier.java
+++ b/services/src/main/java/org/fao/geonet/util/MetadataPublicationMailNotifier.java
@@ -78,6 +78,7 @@ public class MetadataPublicationMailNotifier {
                 if (notificationLevel.name().startsWith("recordProfile")) {
                     Map<Integer, List<MetadataPublicationNotificationInfo>> metadataListToNotifyPublicationPerGroup =
                         metadataListToNotifyPublication.stream()
+                            .filter(metadata -> metadata.getGroupId() != null)
                             .collect(Collectors.groupingBy(MetadataPublicationNotificationInfo::getGroupId));
 
                     // Process the metadata published by group owner

--- a/services/src/main/java/org/fao/geonet/util/MetadataPublicationMailNotifier.java
+++ b/services/src/main/java/org/fao/geonet/util/MetadataPublicationMailNotifier.java
@@ -75,7 +75,7 @@ public class MetadataPublicationMailNotifier {
                 StatusValueNotificationLevel.valueOf(notificationSetting);
             if (notificationLevel != null) {
 
-                if (notificationLevel == StatusValueNotificationLevel.recordProfileReviewer) {
+                if (notificationLevel.name().startsWith("recordProfile")) {
                     Map<Integer, List<MetadataPublicationNotificationInfo>> metadataListToNotifyPublicationPerGroup =
                         metadataListToNotifyPublication.stream()
                             .collect(Collectors.groupingBy(MetadataPublicationNotificationInfo::getGroupId));

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1499,6 +1499,7 @@
     "notificationLevel-catalogueProfileRegisteredUser": "Notify the catalogue registered user",
     "notificationLevel-catalogueProfileGuest": "Notify the catalogue guest",
     "notificationLevel-recordProfileReviewer": "Notify the reviewers part of the record group owner",
+    "notificationLevel-recordProfileUserAdmin": "Notify the user administrators part of the record group owner",
     "notificationLevel-recordUserAuthor": "Notify the record author",
     "notificationLevel-recordGroupEmail": "Notify the group(s) emails",
     "confirmMapserverDelete": "Are you sure you want to delete this Map server?",


### PR DESCRIPTION
Currently there is no notification level for user administrators part of the record group owner. This means if we want to use user administrators as the notified party, all user administrators are notified not only user administrators for the group which owns the record.

This PR aims to fix this issue by implementing a "Notify the user administrators part of the record group owner" option.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
