### PR TITLE
WebDav harvester / update database change date when updating a metadata.

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/webdav/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/webdav/Harvester.java
@@ -1,5 +1,5 @@
 //=============================================================================
-//===	Copyright (C) 2001-2024 Food and Agriculture Organization of the
+//===	Copyright (C) 2001-2025 Food and Agriculture Organization of the
 //===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
 //===	and United Nations Environment Programme (UNEP)
 //===
@@ -50,23 +50,23 @@ import jeeves.server.context.ServiceContext;
 //=============================================================================
 
 interface RemoteRetriever {
-    public void init(AtomicBoolean cancelMonitor, Logger log, ServiceContext context, WebDavParams params);
+    void init(AtomicBoolean cancelMonitor, Logger log, ServiceContext context, WebDavParams params);
 
-    public List<RemoteFile> retrieve() throws Exception;
+    List<RemoteFile> retrieve() throws Exception;
 
-    public void destroy();
+    void destroy();
 }
 
 //=============================================================================
 
 interface RemoteFile {
-    public String getPath();
+    String getPath();
 
-    public ISODate getChangeDate();
+    ISODate getChangeDate();
 
-    public Element getMetadata(SchemaManager schemaMan) throws Exception;
+    Element getMetadata(SchemaManager schemaMan) throws Exception;
 
-    public boolean isMoreRecentThan(String localDate);
+    boolean isMoreRecentThan(String localDate);
 }
 
 //=============================================================================
@@ -117,7 +117,7 @@ class Harvester extends BaseAligner<WebDavParams> implements IHarvester<HarvestR
         this.log = log;
         if (log.isDebugEnabled())
             log.debug("Retrieving remote metadata information for : " + params.getName());
-        RemoteRetriever rr = null;
+        RemoteRetriever rr;
         if (params.subtype.equals("webdav")) {
             rr = new WebDavRetriever();
         } else if (params.subtype.equals("waf")) {
@@ -502,7 +502,7 @@ class Harvester extends BaseAligner<WebDavParams> implements IHarvester<HarvestR
             String language = context.getLanguage();
 
             final AbstractMetadata metadata = metadataManager.updateMetadata(context, recordInfo.id, md, validate, ufo, language,
-                date, false, IndexingMode.none);
+                date, true, IndexingMode.none);
 
             if(force) {
                 //change ownership of metadata to new harvester


### PR DESCRIPTION
The WebDav harvester was not updating the database change date when updating a metadata as other harvesters do.

For ISO metadata, when doing a reharvest if the metadata was updated the XML contained a different value (`gmd:dateStamp`) than the value in the database, that was preserving the value from the 1st harvesting. 

Included Sonarlint improvements in the change request.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

