### PR TITLE
Editor / Filestore / Add possibility to upload file from URL

### DIFF
--- a/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
@@ -26,6 +26,7 @@ package org.fao.geonet.api.records.attachments;
 
 import jeeves.server.context.ServiceContext;
 import org.apache.commons.io.FilenameUtils;
+import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.api.exception.NotAllowedException;
 import org.fao.geonet.api.exception.InputStreamLimitExceededException;
@@ -232,7 +233,14 @@ public abstract class AbstractStore implements Store {
         if (contentDisposition != null) {
             filename = ContentDisposition.parse(contentDisposition).getFilename();
         }
-        if (filename == null || filename.isEmpty()) {
+        // If follow redirect, get the filename from the redirected URL
+        if (StringUtils.isEmpty(filename) && connection.getInstanceFollowRedirects()) {
+            URL redirectUrl = connection.getURL();
+            if (redirectUrl != null) {
+                filename = getFilenameFromUrl(redirectUrl);
+            }
+        }
+        if (StringUtils.isEmpty(filename)) {
             filename = getFilenameFromUrl(fileUrl);
         }
 

--- a/web-ui/src/main/resources/catalog/components/filestore/FileStoreDirective.js
+++ b/web-ui/src/main/resources/catalog/components/filestore/FileStoreDirective.js
@@ -258,7 +258,7 @@
                     }
                   },
                   function (response) {
-                    var message = response.data.message || "";
+                    var message = (response.data && response.data.message) || "";
                     var errorMessage =
                       {
                         uploadNetworkErrorException: $translate.instant(

--- a/web-ui/src/main/resources/catalog/components/filestore/FileStoreDirective.js
+++ b/web-ui/src/main/resources/catalog/components/filestore/FileStoreDirective.js
@@ -281,7 +281,10 @@
                       timeout: 0,
                       type: "danger"
                     });
-                    if (angular.isFunction(scope.afterUploadErrorCb)) {
+                    if (
+                      scope.afterUploadErrorCb &&
+                      angular.isFunction(scope.afterUploadErrorCb())
+                    ) {
                       scope.afterUploadErrorCb()(message);
                     }
                   }

--- a/web-ui/src/main/resources/catalog/components/filestore/FileStoreDirective.js
+++ b/web-ui/src/main/resources/catalog/components/filestore/FileStoreDirective.js
@@ -250,7 +250,10 @@
                 .then(
                   function (response) {
                     $rootScope.$broadcast("gnFileStoreUploadDone");
-                    if (angular.isFunction(scope.afterUploadCb())) {
+                    if (
+                      scope.afterUploadCb &&
+                      angular.isFunction(scope.afterUploadCb())
+                    ) {
                       scope.afterUploadCb()(response.data);
                     }
                   },

--- a/web-ui/src/main/resources/catalog/components/filestore/partials/dataUploaderFromUrl.html
+++ b/web-ui/src/main/resources/catalog/components/filestore/partials/dataUploaderFromUrl.html
@@ -1,0 +1,20 @@
+<div class="row form-horizontal" data-ng-show="uuid" id="gn-upload-from-url-{{id}}">
+  <label for="gn-upload-from-url-{{id}}-input" data-translate=""
+    >filestoreUploadFromUrl</label
+  >
+
+  <div class="input-group">
+    <input
+      type="text"
+      class="form-control"
+      id="gn-upload-from-url-{{id}}-input"
+      data-ng-model="url"
+      placeholder="{{'https://...'}}"
+    />
+    <span class="input-group-btn">
+      <button class="btn btn-primary" data-ng-click="uploadFromUrl()">
+        <i class="fa fa-fw fa-file-upload"></i>
+      </button>
+    </span>
+  </div>
+</div>

--- a/web-ui/src/main/resources/catalog/components/filestore/partials/filestore.html
+++ b/web-ui/src/main/resources/catalog/components/filestore/partials/filestore.html
@@ -15,6 +15,8 @@
       data-after-upload-cb="setResource"
       data-upload-options="filestoreUploadOptionsSetResource"
     ></div>
+
+    <div data-gn-data-uploader-from-url="" data-after-upload-cb="setResource"></div>
   </div>
   <div data-ng-if="layout !== 'select'">
     <div
@@ -101,6 +103,11 @@
       data-gn-data-uploader-button="'chooseOnlinesrc'"
       data-after-upload-cb="linkUploadedFileToRecord"
       data-upload-options="filestoreUploadOptions"
+    ></div>
+
+    <div
+      data-gn-data-uploader-from-url=""
+      data-after-upload-cb="linkUploadedFileToRecord"
     ></div>
   </div>
 </div>

--- a/web-ui/src/main/resources/catalog/locales/en-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/en-editor.json
@@ -172,6 +172,7 @@
     "linkUrl": "URL to remove",
     "fileStore": "Metadata file store",
     "filestoreUploadAFile": "or upload a new file",
+    "filestoreUploadFromUrl": "or upload a file from a URL",
     "filestoreChooseAFile": "or choose a file from the filestore",
     "openResource": "Open resource",
     "linkMetadata": "Link metadata",


### PR DESCRIPTION
Use the existing API to upload a file in the store from a URL. 


![image](https://github.com/user-attachments/assets/19b08247-43ee-41b1-8b37-34ec0eb6beb1)


Also improve file naming in case of redirect. eg. Microsoft datalake does not provide `content-disposition` header https://discodata.eea.europa.eu/download/AirQualityIndicators/latest/hra_pm25_EU_SDG_11_52 fallback on using the redirected URL to build the file name.




<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

Funded by EEA