### PR TITLE
Set UTF-8 on sent mails

### DIFF
--- a/core/src/main/java/org/fao/geonet/util/MailUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/MailUtil.java
@@ -378,6 +378,8 @@ public class MailUtil {
             }
         }
 
+        email.setCharset(EmailConstants.UTF_8);
+
         if (ignoreSslCertificateErrors != null && ignoreSslCertificateErrors) {
             try {
                 email.setSSLCheckServerIdentity(false);


### PR DESCRIPTION
A small bugfix: our mails contained special characters (éë...) that were misinterpreted by the receiving end. By setting the charSet explicitly before sending it gets fixed. As the charSet is not set anywhere explicitly (except for test mails, which do it correctly) I'd figure we'd best have an explicit default here?

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

