### PR TITLE
Fix ES search for Portuguese

### DIFF
--- a/web/src/main/webResources/WEB-INF/data/config/index/records.json
+++ b/web/src/main/webResources/WEB-INF/data/config/index/records.json
@@ -1125,6 +1125,10 @@
                 "type": "keyword",
                 "copy_to": ["any.langpol", "organisationName.langpol"]
               },
+              "langpor": {
+                "type": "keyword",
+                "copy_to": ["any.langpor", "organisationName.langpor"]
+              },
               "link": {
                 "type": "keyword"
               }
@@ -1320,6 +1324,17 @@
                   }
                 }
               },
+              "langpor": {
+                "type": "text",
+                "analyzer": "${es.index.analyzer.default}",
+                "copy_to": ["any.langpor"],
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": ${es.index.ignore_above}
+                  }
+                }
+              },
               "link": {
                 "type": "keyword"
               }
@@ -1433,6 +1448,10 @@
               "langpol": {
                 "type": "keyword",
                 "copy_to": ["any.langpol"]
+              },
+              "langpor": {
+                "type": "keyword",
+                "copy_to": ["any.langpor"]
               },
               "text": {
                 "type": "keyword"
@@ -1650,6 +1669,10 @@
           "langpol": {
             "type": "text",
             "analyzer": "${es.index.analyzer.default}"
+          },
+          "langpor": {
+            "type": "text",
+            "analyzer": "${es.index.analyzer.default}"
           }
         }
       },
@@ -1714,6 +1737,10 @@
           "langpol": {
             "type": "keyword",
             "copy_to": ["any.langpol"]
+          },
+          "langpor": {
+            "type": "keyword",
+            "copy_to": ["any.langpor"]
           },
           "link": {
             "type": "keyword"
@@ -2272,6 +2299,9 @@
             "type": "keyword"
           },
           "langpol": {
+            "type": "keyword"
+          },
+          "langpor": {
             "type": "keyword"
           }
         }

--- a/web/src/main/webResources/WEB-INF/data/config/index/records.json
+++ b/web/src/main/webResources/WEB-INF/data/config/index/records.json
@@ -1326,7 +1326,7 @@
               },
               "langpor": {
                 "type": "text",
-                "analyzer": "${es.index.analyzer.default}",
+                "analyzer": "portuguese",
                 "copy_to": ["any.langpor"],
                 "fields": {
                   "keyword": {
@@ -1672,7 +1672,7 @@
           },
           "langpor": {
             "type": "text",
-            "analyzer": "${es.index.analyzer.default}"
+            "analyzer": "portuguese"
           }
         }
       },


### PR DESCRIPTION
# Goal

This is a minor fix, to support Portuguese language in `records.json`. This json is used to initialize ES.
  
Without this changes, we are not able to search in Portuguese.

Example error, when the user navigates to 'Map', for example:

```
Fielddata is disabled on [tag.langpor] in [gn-records]. Text fields are not optimised for operations that require per-document field data like aggregations and sorting, so these operations are disabled by default.  Please use a keyword field instead. Alternatively, set fielddata=true on [tag.langpor] in order to load field data by uninverting the inverted index. Note that this can use significant memory.
```

<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

# Version

This was tested with 4.4.7 and elesticsearch 8.18.1.

