### PR TITLE
Update z-index for citation buttons

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -53,7 +53,7 @@ div[gn-transfer-ownership] * .list-group {
   right: 4px;
   top: 4px;
   float: right;
-  z-index: 9999;
+  z-index: 1000;
   opacity: 0.6;
 }
 


### PR DESCRIPTION
Before:

<img width="827" alt="citationbuttons-1" src="https://github.com/user-attachments/assets/737a469d-d2b7-4b21-9be2-94a9fc41c5b8" />

After:

<img width="812" alt="citationbuttons-2" src="https://github.com/user-attachments/assets/d3f02bda-d676-453b-92a9-9a2683e31dad" />


# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation