### PR TITLE
Fix layer styles dropdown open direction.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/viewer/layermanager/partials/layermanageritem.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/layermanager/partials/layermanageritem.html
@@ -128,6 +128,7 @@
         <div data-ng-if="::layer.get('style').length > 0">
           <div
             data-gn-layer-styles="layer.get('style')"
+            data-gn-layer-styles-dropdown-direction="left"
             data-gn-layer-styles-on-click="setLayerStyle(layer, style)"
             data-gn-layer-styles-current="layer.get('currentStyle')"
           ></div>

--- a/web-ui/src/main/resources/catalog/components/viewer/wmsimport/WmsImportDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/wmsimport/WmsImportDirective.js
@@ -643,10 +643,13 @@
           onClick: "&gnLayerStylesOnClick",
           current: "=gnLayerStylesCurrent",
           // 'select' or default is list
-          layout: "@gnLayerStylesLayout"
+          layout: "@gnLayerStylesLayout",
+          // dropdown open to the left or right
+          dropdownDirection: "@gnLayerStylesDropdownDirection"
         },
         link: function (scope) {
           scope.data = { currentStyle: scope.current };
+          scope.dropdownDirection = scope.dropdownDirection || "left";
           scope.$watch("data.currentStyle", function (n, o) {
             if (n && n !== o) {
               scope.clickFn(n);

--- a/web-ui/src/main/resources/catalog/components/viewer/wmsimport/partials/layer.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/wmsimport/partials/layer.html
@@ -25,6 +25,7 @@
         >
           <div
             data-gn-layer-styles="member.Style"
+            data-gn-layer-styles-dropdown-direction="right"
             data-gn-layer-styles-on-click="addLayer(style)"
           ></div>
         </div>

--- a/web-ui/src/main/resources/catalog/components/viewer/wmsimport/partials/styles.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/wmsimport/partials/styles.html
@@ -5,8 +5,10 @@
       <span class="fa fa-paint-brush"></span>
       <span class="caret"></span>
     </button>
-
-    <ul class="dropdown-menu dropdown-menu-right">
+    <ul
+      class="dropdown-menu"
+      data-ng-class="{'dropdown-menu-right': dropdownDirection === 'right'}"
+    >
       <li class="dropdown-header" data-translate="">selectStyle</li>
       <li data-ng-repeat="s in styles | orderBy:'Title'">
         <div class="flex-row">


### PR DESCRIPTION
Follow up of #8724, that updated the styles in the WMS service panel to be opened to the left:

<img width="471" alt="styles-list-0" src="https://github.com/user-attachments/assets/898f1819-192e-4523-a236-162002227b0f" />


, causing an issue in the layer styles from the layer legend panel:

Without the change, the layer styles from the layer legend panel is displayed with a wrong aligment.

<img width="468" alt="styles-list-1" src="https://github.com/user-attachments/assets/5cc53130-8614-482e-ba50-92211c32bca1" />

With the change:

<img width="469" alt="styles-list-2" src="https://github.com/user-attachments/assets/ef8e649d-c7ae-4e94-9c17-67b12f171dac" />



# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
