### PR TITLE
Admin console / Settings / Ensure section order

### DIFF
--- a/web-ui/src/main/resources/catalog/js/admin/SystemSettingsController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/SystemSettingsController.js
@@ -241,6 +241,13 @@
             $scope.inspireApiUrl = undefined;
             $scope.inspireApiKey = undefined;
 
+            // Ensure settings are sorted by position property.
+            // The API response is sorted by name but the list
+            // is displayed by section and then by position.
+            $scope.settings.sort(function (a, b) {
+              return a.position - b.position;
+            });
+
             for (var i = 0; i < $scope.settings.length; i++) {
               if ($scope.settings[i].name == "metadata/workflow/enable") {
                 $scope.workflowEnable = $scope.settings[i].value == "true";


### PR DESCRIPTION
API response of `api/site/settings/details` is ordered by setting name and the configuration panel extracting sections was not ordering settings before hand. Depending on setting names, sections may be wrongly ordered (issue present in 4.4.7 with default db).

Ensure order of section whatever the setting names.

## Future actions:

* Maybe position range should be different for each sections (see also https://github.com/geonetwork/core-geonetwork/pull/6981)


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

