### PR TITLE
Feature indexing / Restrict client to _search API.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/index/IndexRequest.js
+++ b/web-ui/src/main/resources/catalog/components/index/IndexRequest.js
@@ -37,7 +37,7 @@
   var FACET_RANGE_DELIMITER = " - ";
 
   geonetwork.gnIndexRequest = function (config, $injector) {
-    this.ES_URL = config.url + "?_=_search";
+    this.ES_URL = config.url;
 
     this.$http = $injector.get("$http");
     this.$q = $injector.get("$q");

--- a/web-ui/src/main/resources/catalog/js/admin/DashboardWfsIndexingController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/DashboardWfsIndexingController.js
@@ -86,7 +86,7 @@
       ];
 
       // URL of the index service endpoint
-      $scope.indexUrl = gnHttp.getService("featureindexproxy") + "?_=_search";
+      $scope.indexUrl = gnHttp.getService("featureindexproxy");
 
       // URL of the message producer CRUD API endpoint
       $scope.messageProducersApiUrl = "../api/msg_producers";

--- a/web/src/main/webResources/WEB-INF/web.xml
+++ b/web/src/main/webResources/WEB-INF/web.xml
@@ -475,7 +475,7 @@
     <servlet-class>org.fao.geonet.proxy.URITemplateProxyServlet</servlet-class>
     <init-param>
       <param-name>targetUri</param-name>
-      <param-value>${es.protocol}://${es.host}:${es.port}/${es.index.features}/{_}</param-value>
+      <param-value>${es.protocol}://${es.host}:${es.port}/${es.index.features}/_search</param-value>
     </init-param>
     <init-param>
       <param-name>log</param-name>


### PR DESCRIPTION
In case, installation does not use a readonly user for the feature index, restrict access to the Elasticsearch _search API endpoint which is the only resource used by the client side.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

