### PR TITLE
allow  URITemplateProxyServlet to remove response headers - ie. BASIC  challenge if elastic has a password

### DIFF
--- a/web/src/main/webResources/WEB-INF/web.xml
+++ b/web/src/main/webResources/WEB-INF/web.xml
@@ -495,6 +495,11 @@
       <param-name>isSecured</param-name>
       <param-value>true</param-value>
     </init-param>-->
+    <init-param>
+      <param-name>disallowResponseHeaders</param-name>
+      <param-value>WWW-Authenticate</param-value>
+    </init-param>
+
   </servlet>
   <servlet-mapping>
     <servlet-name>ESFeaturesProxy</servlet-name>


### PR DESCRIPTION
This allows the URITemplateProxyServlet to remove response headers, in a similar was to the `disallowHeaders` init-param that removes headers from requests.

An example of usage would be: if you put a username/password on your elastic, the metadata-record page will use the `ESFeaturesProxy` (a URITemplateProxyServlet) to access the features.  Elastic will respond with a 401 and the `WWW-Authenticate` challenge header and the user will get a login pop-up.  This isn't a good user experience.


NOTE: Elastic likely shouldn't be directly available on the internet.
NOTE: It looks you can configure Elastic with a Read-only username password and have the proxy supply the username and password in the proxied requests - see the `web.xml` config for `ESFeaturesProxy`.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [x] *API Changes* are identified in commit messages
- [x ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [x] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [x] *Build documentation* provided for development instructions in `README.md` files
- [x] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

