### PR TITLE
[Backport 4.2.x]OpenID Connect - Fix Login failure with empty address info (#8817)

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/SimpleOidcUser.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/SimpleOidcUser.java
@@ -112,12 +112,9 @@ public class SimpleOidcUser {
 
 
             if (idToken.getAddress() != null) {
+                //https://openid.net/specs/openid-connect-core-1_0.html#AddressClaim
                 address = new Address();
                 address.setAddress(idToken.getAddress().getStreetAddress());
-                if ( (address.getAddress() == null) && attributes.containsKey(StandardClaimNames.ADDRESS)) {
-                    address.setAddress((String) attributes.get(StandardClaimNames.ADDRESS));
-
-                }
                 address.setCity(idToken.getAddress().getLocality());
                 address.setState(idToken.getAddress().getRegion());
                 address.setZip(idToken.getAddress().getPostalCode());


### PR DESCRIPTION
Backport https://github.com/geonetwork/core-geonetwork/pull/8817
