### PR TITLE
Improve error logging of exceptions when building the metadata schema validation rules

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/schema/MetadataSchema.java
+++ b/core/src/main/java/org/fao/geonet/kernel/schema/MetadataSchema.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2023 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2025 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -424,16 +424,16 @@ public class MetadataSchema {
                         Xml.transform(schematronExpandXml, schematronCompilationFile, schematronXsl);
                     } catch (FileNotFoundException e) {
                         Log.error(Geonet.SCHEMA_MANAGER, "     Schematron rule file not found " + schematronXslFilePath
-                            + ". Error is " + e.getMessage());
+                            + ". Error is " + e.getMessage(), e);
                     } catch (Exception e) {
                         Log.error(Geonet.SCHEMA_MANAGER, "     Schematron rule compilation failed for " + schematronXslFilePath
-                            + ". Error is " + e.getMessage());
+                            + ". Error is " + e.getMessage(), e);
                     }
 
                 }
             } catch (IOException e) {
                 Log.error(Geonet.SCHEMA_MANAGER, "     Schematron rule file not found " + schemaSchematronDir
-                    + ". Error is " + e.getMessage());
+                    + ". Error is " + e.getMessage(), e);
             }
         }
     }


### PR DESCRIPTION
The log file doesn't contain meaningful error when an error occurs building the metadata schema validation rules. For example, 

```
May 19 11:31:20 2025-05-19T09:31:20,513 ERROR [geonetwork.schemamanager] -      Schematron rule compilation failed
 for /PATH/geonetwork/WEB-INF/data/config/schema_plugins/iso19139/schematron/schematron-rules-geonetwork.xsl. 
Error is /PATH/geonetwork/WEB-INF/data/config/schema_plugins/iso19139/schematron/schematron-rules-geonetwork.xsl
```

WIth this change request, the exception details are added to the log file:

```
2025-05-26T12:51:40,972 ERROR [geonetwork.schemamanager] -      Schematron rule compilation failed for /PATH/geonetwork/WEB-INF/data/config/schema_plugins/iso19139/schematron/schematron-rules-geonetwork.xsl. Error is /PATH/geonetwork/WEB-INF/data/config/schema_plugins/iso19139/schematron/schematron-rules-geonetwork.xsl
java.nio.file.AccessDeniedException: /PATH/geonetwork/WEB-INF/data/config/schema_plugins/iso19139/schematron/schematron-rules-geonetwork.xsl
#011at sun.nio.fs.UnixException.translateToIOException(UnixException.java:84) ~[?:1.8.0_452]
#011at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:102) ~[?:1.8.0_452]
#011at sun.nio.fs.UnixException.rethrowAsIOException(UnixException.java:107) ~[?:1.8.0_452]
#011at sun.nio.fs.UnixFileSystemProvider.newByteChannel(UnixFileSystemProvider.java:214) ~[?:1.8.0_452]
#011at java.nio.file.spi.FileSystemProvider.newOutputStream(FileSystemProvider.java:434) ~[?:1.8.0_452]
```

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation


