### PR TITLE
Fix in the metadata selection widget the number of metadata selected

### DIFF
--- a/web-ui/src/main/resources/catalog/components/search/resultsview/partials/selection-widget.html
+++ b/web-ui/src/main/resources/catalog/components/search/resultsview/partials/selection-widget.html
@@ -38,12 +38,7 @@
       >
       <span class="caret"></span>
     </button>
-    <ul
-      class="dropdown-menu"
-      role="menu"
-      data-ng-if="!operationOnSelectionInProgress"
-      data-ng-init="translateValues = {selectedCount: searchResults.selectedCount}"
-    >
+    <ul class="dropdown-menu" role="menu" data-ng-if="!operationOnSelectionInProgress">
       <li data-ng-show="!excludePattern.test('exportMEF')">
         <a
           href=""
@@ -162,7 +157,7 @@
         <a
           href=""
           data-ng-click="mdService.validateMd(undefined, searchResults.selectionBucket)"
-          data-gn-confirm-click="{{'validateSelectedRecordConfirm' | translate:translateValues}}"
+          data-gn-confirm-click="{{'validateSelectedRecordConfirm' | translate:({selectedCount: searchResults.selectedCount})}}"
         >
           <i class="fa fa-fw fa-check"></i>&nbsp;<span translate>validate</span>
         </a>
@@ -174,7 +169,7 @@
         <a
           href=""
           data-ng-click="mdService.validateMdLinks(searchResults.selectionBucket)"
-          data-gn-confirm-click="{{'validateLinksSelectedRecordConfirm' | translate:translateValues}}"
+          data-gn-confirm-click="{{'validateLinksSelectedRecordConfirm' | translate:({selectedCount: searchResults.selectedCount})}}"
         >
           <i class="fa fa-fw fa-link"></i>&nbsp;<span translate>validateLinks</span>
         </a>
@@ -186,7 +181,7 @@
         <a
           href=""
           data-ng-click="mdService.validateMdInspire(searchResults.selectionBucket)"
-          data-gn-confirm-click="{{'validateSelectedRecordINSPIREConfirm' | translate:translateValues}}"
+          data-gn-confirm-click="{{'validateSelectedRecordINSPIREConfirm' | translate:({selectedCount: searchResults.selectedCount})}}"
         >
           <i class="fa fa-fw fa-inspire"></i>&nbsp;<span translate>validateInspire</span>
         </a>
@@ -198,7 +193,7 @@
         <a
           href=""
           data-ng-click="mdService.validateMdInspire(searchResults.selectionBucket, validationNode)"
-          data-gn-confirm-click="{{'validateSelectedRecordINSPIREConfirm' | translate:translateValues}}"
+          data-gn-confirm-click="{{'validateSelectedRecordINSPIREConfirm' | translate:({selectedCount: searchResults.selectedCount})}}"
         >
           <i class="fa fa-fw fa-inspire"></i>&nbsp;<span translate
             >validateInspireUsingNode</span
@@ -244,7 +239,7 @@
         <a
           href=""
           data-ng-click="mdService.deleteMd(undefined, searchResults.selectionBucket)"
-          data-gn-confirm-click="{{'deleteSelectedRecordConfirm' | translate:translateValues}}"
+          data-gn-confirm-click="{{'deleteSelectedRecordConfirm' | translate:({selectedCount: searchResults.selectedCount})}}"
         >
           <i class="fa fa-fw fa-times"></i>&nbsp;<span translate>delete</span>
         </a>


### PR DESCRIPTION
Without the change, the dialog to confirm a batch action always displays 1 metadata selected:
![wrong-selection](https://github.com/user-attachments/assets/c692c571-e616-475b-9601-1664dd2b5f3e)

With the change, it displays the correct value:
![ok-selection](https://github.com/user-attachments/assets/ce60bdf2-a89a-495e-8583-db0bc6bd74a7)

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
