### PR TITLE
CSW Server / Fix processing of wildcard queries

### DIFF
--- a/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/es/CswFilter2Es.java
+++ b/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/es/CswFilter2Es.java
@@ -150,19 +150,15 @@ public class CswFilter2Es extends AbstractFilterVisitor {
         String wildcardChar = filter.getWildCard();
         String escapeWildcardDefault = filter.getEscape() + "*";
 
-        //result = result.replaceAll(Pattern.quote(escapeWildcard), "\\\\*");
-        System.out.println("Result (replacement 1): " + result);
         // Replace wildcard character with default wildcard (asterisk)
         // For example, if the wildcard is % and the escape character is \:
         //  - %afr\%ca% becomes *afr\*ca*
         result = result.replaceAll(Pattern.quote(wildcardChar), "*");
-        System.out.println("Result (replacement 2): " + result);
         // Replace the escaped wildcard character with the wildcard character
         // For example, if the wildcard is % and the escape character is \:
         //  - in the previous replacement %afr\%ca% becomes *afr\*ca*
         //  - and with this replacement *afr\*ca* becomes *afr\%ca*
         result = result.replaceAll(Pattern.quote(escapeWildcardDefault), wildcardChar);
-        System.out.println("Result (replacement 3): " + result);
 
         if (wildcardChar.equals("%")) {
             // Escape % for String.format used in SearchController to process the csw filter

--- a/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/es/CswFilter2Es.java
+++ b/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/getrecords/es/CswFilter2Es.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2024 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2025 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -146,19 +146,40 @@ public class CswFilter2Es extends AbstractFilterVisitor {
 
     protected static String convertLikePattern(PropertyIsLike filter) {
         String result = filter.getLiteral();
-        if (!filter.getWildCard().equals("*")) {
-            final String wildcardRe =
-                StringUtils.isNotEmpty(filter.getEscape())
-                    ? Pattern.quote(filter.getEscape() + filter.getWildCard())
-                    : filter.getWildCard();
-            result = result.replaceAll(wildcardRe, "*");
+
+        String wildcardChar = filter.getWildCard();
+        String escapeWildcardDefault = filter.getEscape() + "*";
+
+        //result = result.replaceAll(Pattern.quote(escapeWildcard), "\\\\*");
+        System.out.println("Result (replacement 1): " + result);
+        // Replace wildcard character with default wildcard (asterisk)
+        // For example, if the wildcard is % and the escape character is \:
+        //  - %afr\%ca% becomes *afr\*ca*
+        result = result.replaceAll(Pattern.quote(wildcardChar), "*");
+        System.out.println("Result (replacement 2): " + result);
+        // Replace the escaped wildcard character with the wildcard character
+        // For example, if the wildcard is % and the escape character is \:
+        //  - in the previous replacement %afr\%ca% becomes *afr\*ca*
+        //  - and with this replacement *afr\*ca* becomes *afr\%ca*
+        result = result.replaceAll(Pattern.quote(escapeWildcardDefault), wildcardChar);
+        System.out.println("Result (replacement 3): " + result);
+
+        if (wildcardChar.equals("%")) {
+            // Escape % for String.format used in SearchController to process the csw filter
+            result = result.replace( wildcardChar, "%%");
         }
+
         if (!filter.getSingleChar().equals("?")) {
-            final String singleCharRe =
-                StringUtils.isNotEmpty(filter.getEscape())
-                    ? Pattern.quote(filter.getEscape() + filter.getSingleChar())
-                    : filter.getSingleChar();
-            result = result.replaceAll(singleCharRe, "?");
+            // Analog processing as for the wildcard character
+            String singleChar = filter.getSingleChar();
+            String escapeSinglecharDefault = filter.getEscape() + "?";
+
+            result = result.replaceAll(Pattern.quote(singleChar), "?");
+            result = result.replaceAll(Pattern.quote(escapeSinglecharDefault), singleChar);
+
+            if (singleChar.equals("%")) {
+                result = result.replace( singleChar, "%%");
+            }
         }
 
         result = StringEscapeUtils.escapeJson(escapeLikeLiteral(result));

--- a/csw-server/src/test/java/org/fao/geonet/kernel/csw/services/getrecords/es/CswFilter2EsTest.java
+++ b/csw-server/src/test/java/org/fao/geonet/kernel/csw/services/getrecords/es/CswFilter2EsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2024 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2025 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -182,7 +182,7 @@ class CswFilter2EsTest {
             "<Filter xmlns=\"http://www.opengis.net/ogc\">\n" //
                 + "    <PropertyIsLike wildCard=\"%\" singleChar=\"_\" escapeChar=\"\\\">\n" //
                 + "          <PropertyName>AnyText</PropertyName>\n" //
-                + "          <Literal>s\\_rvice\\%</Literal>\n" //
+                + "          <Literal>s_rvice%</Literal>\n" //
                 + "    </PropertyIsLike>\n" //
                 + "      </Filter>";
 
@@ -219,7 +219,7 @@ class CswFilter2EsTest {
             "<Filter xmlns=\"http://www.opengis.net/ogc\">\n" //
                 + "    <PropertyIsLike wildCard=\"%\" singleChar=\"_\" escapeChar=\"\\\">\n" //
                 + "          <PropertyName>AnyText</PropertyName>\n" //
-                + "          <Literal>OGC:WMS\\%</Literal>\n" //
+                + "          <Literal>OGC:WMS%</Literal>\n" //
                 + "    </PropertyIsLike>\n" //
                 + "      </Filter>";
 


### PR DESCRIPTION
The parsing of queryables with wildcard queries like:

```xml
<csw:GetRecords xmlns:csw="http://www.opengis.net/cat/csw/2.0.2"
    xmlns:ogc="http://www.opengis.net/ogc" xmlns:gml="http://www.opengis.net/gml"
    xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:dct="http://purl.org/dc/terms/"
    xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:gco="http://www.isotc211.org/2005/gco"
    xmlns:gmi="http://www.isotc211.org/2005/gmi" xmlns:ows="http://www.opengis.net/ows"
    service="CSW" version="2.0.2" resultType="results" startPosition="1" maxRecords="4">
    <csw:Query typeNames="csw:Record">
        <csw:ElementSetName>full</csw:ElementSetName>
        <csw:Constraint version="1.1.0">
            <ogc:Filter>
                <ogc:PropertyIsLike wildCard="%" singleChar="_" escapeChar="\">
                    <ogc:PropertyName>csw:AnyText</ogc:PropertyName>
                    <ogc:Literal>%africa%</ogc:Literal>
                </ogc:PropertyIsLike>
            </ogc:Filter>
        </csw:Constraint>
    </csw:Query>
</csw:GetRecords>
```

throws an error like:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<ows:ExceptionReport xmlns:ows="http://www.opengis.net/ows" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="1.2.0" xsi:schemaLocation="http://www.opengis.net/ows http://schemas.opengis.net/ows/1.0.0/owsExceptionReport.xsd">
  <ows:Exception exceptionCode="NoApplicableCode">
    <ows:ExceptionText>java.lang.RuntimeException: java.util.UnknownFormatConversionException: Conversion = 'r'</ows:ExceptionText>
  </ows:Exception>
</ows:ExceptionReport>
```

Escaping the wildcard chars, fixed the problem, using (`\%africa\%` instead of `%africa%`), but that was not correct as escaping the wildcard char should search for that exact value, not use it as a wildcard.

This pull request fixes the parsing of the wildcard characters.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
