### PR TITLE
Record page / restrict formatters to view / export metadata to those supported by the metadata schema

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterApi.java
@@ -1,5 +1,5 @@
 //==============================================================================
-//===	Copyright (C) 2001-2008 Food and Agriculture Organization of the
+//===	Copyright (C) 2001-2025 Food and Agriculture Organization of the
 //===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
 //===	and United Nations Environment Programme (UNEP)
 //===
@@ -84,6 +84,8 @@ import java.nio.file.*;
 import java.nio.file.attribute.BasicFileAttributes;
 import java.util.*;
 import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static com.google.common.io.Files.getNameWithoutExtension;
 import static org.fao.geonet.api.ApiParams.API_PARAM_RECORD_UUID;
@@ -112,6 +114,9 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
 
     @Autowired
     PdfOrHtmlResponseWriter writer;
+
+    @Autowired
+    SchemaManager schemaManager;
 
     /**
      * Map (canonical path to formatter dir -> Element containing all xml files in Formatter
@@ -152,7 +157,7 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
 
     public void copyNewerFilesToDataDir(final Path fromDir, final Path toDir) throws IOException {
         if (Files.exists(fromDir)) {
-            Files.walkFileTree(fromDir, new SimpleFileVisitor<Path>() {
+            Files.walkFileTree(fromDir, new SimpleFileVisitor<>() {
                 @Override
                 public FileVisitResult visitFile(Path file, BasicFileAttributes attrs) throws IOException {
                     final Path path = IO.relativeFile(fromDir, file, toDir);
@@ -165,6 +170,41 @@ public class FormatterApi extends AbstractFormatService implements ApplicationLi
                 }
             });
         }
+    }
+
+    @GetMapping(value =
+        "/{portal}/api/records/{metadataUuid}/formatters",
+        produces = MediaType.APPLICATION_JSON_VALUE)
+    @io.swagger.v3.oas.annotations.Operation(
+        summary = "Get the list of formatters available for a metadata record"
+    )
+    @ResponseBody
+    public Set<String> getRecordFormatters(
+        @Parameter(
+            description = API_PARAM_RECORD_UUID,
+            required = true)
+        @PathVariable
+        String metadataUuid,
+        final HttpServletRequest servletRequest) throws Exception {
+
+        AbstractMetadata metadata = ApiUtils.canViewRecord(metadataUuid, true, servletRequest);
+
+        Path styleSheetPath = schemaManager.getSchemaDir(metadata.getDataInfo().getSchemaId()).resolve("formatter");
+
+        Set<String> formatters = new HashSet<>();
+        // Add the default formatters
+        formatters.add("xml");
+        formatters.add("zip");
+
+        try (Stream<Path> paths = Files.list(styleSheetPath)) {
+            formatters.addAll(paths
+                .filter(Files::isDirectory)
+                .map(Path::getFileName)
+                .map(Path::toString)
+                .collect(Collectors.toSet()));
+        }
+
+        return formatters;
     }
 
     @RequestMapping(value = {

--- a/web-ui/src/main/resources/catalog/components/search/mdview/mdviewModule.js
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/mdviewModule.js
@@ -346,21 +346,33 @@
       // in default mode.
       function loadFormatter(n, o) {
         if (n === true) {
-          $scope.recordFormatterList = gnMdFormatter.getFormatterForRecord(
-            $scope.mdView.current.record
-          );
+          gnMdFormatter
+            .getAvailableFormattersForRecord($scope.mdView.current.record)
+            .then(function (availableFormatters) {
+              var formattersForRecord = gnMdFormatter.getFormatterForRecord(
+                $scope.mdView.current.record
+              );
 
-          checkIfCitationIsDisplayed($scope.mdView.current.record);
+              $scope.recordFormatterList =
+                gnMdFormatter.calculateValidFormattersForRecord(
+                  formattersForRecord,
+                  availableFormatters
+                );
 
-          var f = gnSearchLocation.getFormatterPath($scope.recordFormatterList[0].url);
-          $scope.currentFormatter = "";
+              checkIfCitationIsDisplayed($scope.mdView.current.record);
 
-          gnMdViewObj.usingFormatter = f !== undefined;
+              var f = gnSearchLocation.getFormatterPath(
+                $scope.recordFormatterList[0].url
+              );
+              $scope.currentFormatter = "";
 
-          if (f != undefined) {
-            $scope.currentFormatter = f.replace(/.*(\/formatters.*)/, "$1");
-            $scope.loadFormatter(f);
-          }
+              gnMdViewObj.usingFormatter = f !== undefined;
+
+              if (f != undefined) {
+                $scope.currentFormatter = f.replace(/.*(\/formatters.*)/, "$1");
+                $scope.loadFormatter(f);
+              }
+            });
         }
       }
       $scope.$watch("mdView.recordsLoaded", loadFormatter);

--- a/web-ui/src/main/resources/catalog/components/search/mdview/mdviewService.js
+++ b/web-ui/src/main/resources/catalog/components/search/mdview/mdviewService.js
@@ -424,6 +424,56 @@
       gnUtilityService
     ) {
       /**
+       * Calculates the valid formatters for a record based on the formatters defined in the configuration
+       * and the formatters available for the record.
+       *
+       * @param formattersForRecord Defined formatters in the configuration.
+       * @param recordAvailableFormatters Available formatter names for the record.
+       * @returns {*[]}
+       */
+      this.calculateValidFormattersForRecord = function (
+        formattersForRecord,
+        recordAvailableFormatters
+      ) {
+        var recordFormatterList = [];
+        // Check if the formatter is available for the metadata record
+        var formatterNameExpression = /\/formatters\/([a-zA-Z0-9-_]+)/;
+
+        for (var i = 0; i < formattersForRecord.length; i++) {
+          var f = formattersForRecord[i];
+          var formatterInfo = formatterNameExpression.exec(f.url);
+
+          if (formatterInfo != null) {
+            if (recordAvailableFormatters.indexOf(formatterInfo[1]) > -1) {
+              recordFormatterList.push(f);
+            }
+          } else {
+            recordFormatterList.push(f);
+          }
+        }
+
+        return recordFormatterList;
+      };
+
+      this.getAvailableFormattersForRecord = function (record) {
+        var deferred = $q.defer();
+
+        $http
+          .get("../api/records/" + record.uuid + "/formatters", {
+            cache: true
+          })
+          .then(
+            function (r) {
+              deferred.resolve(r.data);
+            },
+            function (r) {
+              deferred.reject();
+            }
+          );
+
+        return deferred.promise;
+      };
+      /**
        * First matching view for each formatter is returned.
        *
        * @param record

--- a/web-ui/src/main/resources/catalog/views/default/directives/directive.js
+++ b/web-ui/src/main/resources/catalog/views/default/directives/directive.js
@@ -122,6 +122,7 @@
     "gnConfigService",
     "gnGlobalSettings",
     "gnLangs",
+    "gnMdFormatter",
     function (
       gnMetadataActions,
       $http,
@@ -129,7 +130,8 @@
       gnConfig,
       gnConfigService,
       gnGlobalSettings,
-      gnLangs
+      gnLangs,
+      gnMdFormatter
     ) {
       return {
         restrict: "A",
@@ -138,7 +140,18 @@
         link: function linkFn(scope, element, attrs) {
           scope.mdService = gnMetadataActions;
           scope.md = scope.$eval(attrs.gnMdActionsMenu);
-          scope.formatterList = gnGlobalSettings.gnCfg.mods.search.downloadFormatter;
+          scope.formatterList = [];
+
+          gnMdFormatter
+            .getAvailableFormattersForRecord(scope.md)
+            .then(function (availableFormatters) {
+              var formatterList = gnGlobalSettings.gnCfg.mods.search.downloadFormatter;
+
+              scope.formatterList = gnMdFormatter.calculateValidFormattersForRecord(
+                formatterList,
+                availableFormatters
+              );
+            });
 
           scope.tasks = [];
           scope.hasVisibletasks = false;


### PR DESCRIPTION
View and download formatter are configured globally. But not all metadata schemas support the same formatters. This is specially true for DCAT-AP formatters and metadata from schemas like Dublin Core or ISO19110.

This change request adds a new API endpoint to retrieve a list of formatter names available for a metadata:

`GET` `​/records​/{metadataUuid}​/formatters`

Example:

http://localhost:8080/geonetwork/srv/api/records/b41b7ce1-9695-435c-858d-d017b05d5934/formatters

```
[
  "zip",
  "iso19115-3.2018",
  "citation",
  "datacite",
  "jsonld",
  "eu-dcat-ap",
  "eu-geodcat-ap-semiceu",
  "xml",
  "xsl-view",
  "eu-dcat-ap-hvd",
  "eu-geodcat-ap",
  "dcat",
  "eu-po-doi"
]
```

The metadata record page is updated to filter out the view and download formatters not supported by the metadata schema.

Download formatters:

<img width="1144" alt="download-formatters-1" src="https://github.com/user-attachments/assets/291de7ab-288b-4343-84b6-50e4ebc854c6" />

<img width="1120" alt="download-formatters-2" src="https://github.com/user-attachments/assets/63d405da-743a-449b-8606-188bdfbe9f64" />

View formatters:

<img width="1154" alt="view-formatters-1" src="https://github.com/user-attachments/assets/571b819c-0ede-4c9d-bc3e-b708d1cde22f" />

<img width="1147" alt="view-formatters-2" src="https://github.com/user-attachments/assets/4554a982-f086-4a83-9553-0b3738fc39c0" />



# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
