### PR TITLE
Workflow / Check workflow only when setting a workflow status

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataWorkflowApi.java
@@ -517,8 +517,9 @@ public class MetadataWorkflowApi {
                 .withDescriptionKey("exception.resourceNotEnabled.workflow.description");
         }
 
-        // If the metadata workflow status is unset and the new status is DRAFT, workflow is being enabled
-        if (metadataStatus.getStatus(metadata.getId()) == null) {
+        // If the metadata workflow status is unset and the new status is a workflow status, workflow is being enabled
+        if (metadataStatusValue.getStatusValue().getType() == StatusValueType.workflow
+            && metadataStatus.getStatus(metadata.getId()) == null) {
             // Retrieve the group owner ID from the metadata source information
             Integer groupOwnerId = metadata.getSourceInfo().getGroupOwner();
 


### PR DESCRIPTION
See discussion with @tylerjmchugh https://github.com/geonetwork/core-geonetwork/pull/8699#discussion_r2142740518


Task status is blocked when workflow disabled eg. when requesting creation of a DOI.

The following call:

```
curl 'http://localhost:8080/geonetwork/srv/api/records/1693/status' \
  -X 'PUT' \
  --data-raw '{"status":100,"owner":null,"dueDate":null,"changeMessage":""}'
```

is failing with 

```
{
    "message": "Le workflow de groupe 'ABC' est désactivé",
    "code": "feature_disabled",
    "description": "Impossible de définir l'état des fiches dans le groupe 'ABC'"
}

```

but a task does not require to have the workflow mode enabled.





<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->


Funded by Ifremer
