### PR TITLE
Remove include for config-service-dcat-rdf.xml

### DIFF
--- a/web/src/main/webapp/WEB-INF/config.xml
+++ b/web/src/main/webapp/WEB-INF/config.xml
@@ -147,7 +147,6 @@
   <include>config/config-service-sru.xml</include>
   <include>config/config-service-oai.xml</include>
   <include>config/config-service-rss.xml</include>
-  <include>config/config-service-dcat-rdf.xml</include>
   <include>config/config-service-thesaurus.xml</include>
   <include>config/config-service-admin.xml</include>
   <include>config/config-service-admin-harvesting.xml</include>


### PR DESCRIPTION
Related to #8845, causing startup issues due to the include of the removed file.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation



