### PR TITLE
Editor / Associated panel / Reset search on popup open.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -2196,6 +2196,10 @@
                   };
 
                   $(scope.popupid).modal("show");
+
+                  $("#linktomd-search input").val("");
+                  scope.searchObj.any = "";
+
                   var searchParams =
                     scope.config.sources && scope.config.sources.metadataStore
                       ? scope.config.sources.metadataStore.params || {}
@@ -2300,13 +2304,14 @@
 
                   $(scope.popupid).modal("show");
 
-                  scope.$broadcast("resetSearch");
+                  scope.clearSearch();
                   scope.selection = [];
                 });
 
                 // Clear the search params and input
                 scope.clearSearch = function () {
                   $("#siblingdd input").val("");
+                  scope.searchObj.any = "";
                   scope.$broadcast("resetSearch");
                 };
 

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/linkToMd.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/linkToMd.html
@@ -11,7 +11,7 @@
           >
         </label>
         <div class="col-sm-10">
-          <div class="input-group gn-margin-bottom">
+          <div class="input-group gn-margin-bottom" id="linktomd-search">
             <span class="input-group-addon"><i class="fa fa-search"></i></span>
             <input
               class="form-control"


### PR DESCRIPTION
Properly reset search in all types of associations when opening popup.

![image](https://github.com/user-attachments/assets/04b2002d-3f10-4473-942e-0d90552bfff4)


Test:

* open the dialog, type in "data"
* result: the list is being filtered on "data"
* do some things, close the dialog
* then open the dialog again: "data" is prefilled, but the list is not filtered on "data"




# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->


Funded by https://metadata.vlaanderen.be/