### PR TITLE
Access manager / fix published group label key

### DIFF
--- a/web-ui/src/main/resources/catalog/templates/editor/accessManager.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/accessManager.html
@@ -20,7 +20,7 @@
               aria-label="{{'anyPlaceHolder' | translate}}"
             />
             <br />
-            <label class="control-label" data-translate>_groupPublished</label>
+            <label class="control-label" data-translate>groupPublished</label>
             <select class="form-control" data-ng-model="params.group">
               <option value=""></option>
               <option data-ng-repeat="g in groups | orderBy:'name'" value="{{g.name}}">


### PR DESCRIPTION
Before:

![Screenshot 2025-06-18 at 13 38 47](https://github.com/user-attachments/assets/25dc037b-29e2-4797-838a-3e0697ff5d3f)

After:

![Screenshot 2025-06-18 at 13 39 09](https://github.com/user-attachments/assets/c931b636-4c67-42f8-b794-bff2a8463a1a)

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

