### PR TITLE
Lineage / handle process steps with multiple sources

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
@@ -1141,18 +1141,16 @@
             <xsl:if test="normalize-space(mrl:stepDateTime) != ''">
               ,"date": "<xsl:value-of select="mrl:stepDateTime//gml:timePosition/text()"/>"
             </xsl:if>
-            <xsl:if test="normalize-space(mrl:source) != ''">
-              ,"source": [
-              <xsl:for-each select="mrl:source/*[mrl:description/gco:CharacterString != '']">
-                {
-                "descriptionObject": <xsl:value-of
-                select="gn-fn-index:add-multilingual-field(
-                                            'description', mrl:description, $allLanguages, true())"/>
-                }
-                <xsl:if test="position() != last()">,</xsl:if>
-              </xsl:for-each>
-              ]
-            </xsl:if>
+            ,"source": [
+            <xsl:for-each select="mrl:source/*[mrl:description/gco:CharacterString != '']">
+              {
+              "descriptionObject": <xsl:value-of
+              select="gn-fn-index:add-multilingual-field(
+                                          'description', mrl:description, $allLanguages, true())"/>
+              }
+              <xsl:if test="position() != last()">,</xsl:if>
+            </xsl:for-each>
+            ]
 
             <xsl:variable name="processor"
                           select="mrl:processor/*[.//cit:CI_Organisation/cit:name != '']"/>

--- a/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/index-fields/index.xsl
@@ -1051,18 +1051,16 @@
             <xsl:if test="normalize-space(gmd:dateTime) != ''">
               ,"date": "<xsl:value-of select="gmd:dateTime/gco:*/text()"/>"
             </xsl:if>
-            <xsl:if test="normalize-space(gmd:source) != ''">
-              ,"source": [
-              <xsl:for-each select="gmd:source/*[gmd:description/gco:CharacterString != '']">
-                {
-                  "descriptionObject": <xsl:value-of
-                                          select="gn-fn-index:add-multilingual-field(
-                                            'description', gmd:description, $allLanguages, true())"/>
-                }
-                <xsl:if test="position() != last()">,</xsl:if>
-              </xsl:for-each>
-              ]
-            </xsl:if>
+            ,"source": [
+            <xsl:for-each select="gmd:source/*[gmd:description/gco:CharacterString != '']">
+              {
+                "descriptionObject": <xsl:value-of
+                                        select="gn-fn-index:add-multilingual-field(
+                                          'description', gmd:description, $allLanguages, true())"/>
+              }
+              <xsl:if test="position() != last()">,</xsl:if>
+            </xsl:for-each>
+            ]
 
             <xsl:variable name="processors"
                           select="gmd:processor/*[gmd:organisationName/gco:CharacterString != '']"/>

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/processsteps.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/processsteps.html
@@ -30,7 +30,7 @@
               <br data-ng-if="p.date || p.processor" />
               {{p.description}}
             </div>
-            <div class="timeline-body" data-ng-if="p.source">
+            <div class="timeline-body" data-ng-if="p.source.length">
               <span data-translate="">sourceDescription</span>
               <p data-ng-repeat="s in p.source">{{s.description}}</p>
             </div>


### PR DESCRIPTION
This PR modifies the ISO 19139 and ISO19115-3 plugins to correctly index process steps having multiple sources.

This was already handled by the UI but unfortunately for both schemas the indexation was failing because of this line:

```xsl
<xsl:if test="normalize-space(gmd:source)">
```
with the following error:
```
Error on line 1054 of index.xsl:
  XPTY0004: A sequence of more than one item is not allowed as the first argument of
  normalize-space() ("...", "...") 
```

This error has been removed by not using `normalize-space()` any more and instead checking whether the `source` array in the index document is empty or not.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

Funded by [UFZ](https://www.ufz.de/)
