### PR TITLE
Fix issue with oidc invalid session by adding session filter

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/GeonetworkOidcPreAuthActionsLoginFilter.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/GeonetworkOidcPreAuthActionsLoginFilter.java
@@ -32,6 +32,7 @@ import org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequest
 import javax.servlet.*;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
 import java.io.IOException;
 import java.net.URLEncoder;
 import org.apache.commons.lang3.StringUtils;
@@ -105,6 +106,8 @@ public class GeonetworkOidcPreAuthActionsLoginFilter  implements Filter, Servlet
         HttpServletRequest servletRequest = (HttpServletRequest) request;
         HttpServletResponse servletResponse = (HttpServletResponse) response;
 
+        final HttpSession httpSession = servletRequest.getSession(false);
+
         String requestUri = servletRequest.getRequestURI();
         String contextPath = servletRequest.getContextPath();
         String clientRegistrationId = GeonetworkClientRegistrationProvider.CLIENTREGISTRATION_NAME;
@@ -118,7 +121,7 @@ public class GeonetworkOidcPreAuthActionsLoginFilter  implements Filter, Servlet
             servletRequest.getHeader("Authorization").startsWith("Bearer ");
         boolean isAuthenticated = SecurityContextHolder.getContext().getAuthentication() != null &&
             SecurityContextHolder.getContext().getAuthentication().isAuthenticated() &&
-            !(SecurityContextHolder.getContext().getAuthentication() instanceof AnonymousAuthenticationToken);
+            !(SecurityContextHolder.getContext().getAuthentication() instanceof AnonymousAuthenticationToken) && httpSession != null;
 
         boolean isPublicEndpoint = excludedPathsMatchers.stream()
             .anyMatch(matcher -> matcher.matches(servletRequest));

--- a/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/SessionExpirationFilter.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/SessionExpirationFilter.java
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2025 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+package org.fao.geonet.kernel.security.openidconnect;
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.ClientAuthorizationException;
+import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import java.io.IOException;
+import java.time.Instant;
+
+/**
+ * A fix for the token life span issue based on
+ *      https://stackoverflow.com/questions/77438484/solved-keycloak-spring-security-oidc-backchannel-logout-unable-to-trigger-re
+ *
+ * This resolved the issue where keycloak or OIDC session is killed therefor when detected, we also need to kill the spring sessions as well.
+ */
+
+public class SessionExpirationFilter implements Filter {
+    /**
+     * Service to retrieve OAuth2 authorized clients inorder to get access token.
+     */
+    @Autowired(required = false)
+    private OAuth2AuthorizedClientManager authorizedClientManager;
+
+    private static final org.slf4j.Logger log = LoggerFactory.getLogger(SessionExpirationFilter.class);
+
+    @Override
+    public void init(FilterConfig filterConfig) throws ServletException {
+
+    }
+
+    /**
+     * Token filter to check and invalidate the expired token
+     *
+     * @param request     http request object
+     * @param response    http response
+     * @param filterChain Servlet filterChain
+     */
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        final HttpServletRequest httpRequest = (HttpServletRequest) request;
+        final HttpServletResponse httpResponse = (HttpServletResponse) response;
+        // Get the session without creating a new one.
+        final HttpSession httpSession = httpRequest.getSession(false);
+        // Only proceed if
+        //      the current session is not null - otherwise there is nothing to expire
+        //      the response is not committed  - otherwise we may get an error indicating that the response is already committed when attempting to expire the session.
+        if (httpSession != null && !response.isCommitted()) {
+            final Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+            if (authentication instanceof OAuth2AuthenticationToken) {
+                OAuth2AuthenticationToken oauth2Token = (OAuth2AuthenticationToken) authentication;
+                OidcUser principal = (OidcUser) oauth2Token.getPrincipal();
+
+                if (principal.getExpiresAt() != null && principal.getExpiresAt().isBefore(Instant.now())) {
+                    try {
+                        OAuth2AuthorizedClient authorizedClient = authorizedClientManager.authorize(
+                            OAuth2AuthorizeRequest.withClientRegistrationId(oauth2Token.getAuthorizedClientRegistrationId())
+                                .principal(oauth2Token)
+                                .build()
+                        );
+
+                        if (authorizedClient == null || authorizedClient.getAccessToken() == null) {
+                            log.warn("Session '{}' for subject '{}', user '{}' is expired due to terminated/expired authentication server session.", httpSession.getId(), principal.getSubject(), principal.getPreferredUsername());
+                            httpSession.invalidate();
+                        }
+                    } catch (ClientAuthorizationException e) {
+                        log.warn("Authorization exception occurred for session '{}' for user '{}'.", httpSession.getId(), principal.getPreferredUsername(), e);
+                        httpSession.invalidate();
+                    }
+                }
+            }
+        }
+        filterChain.doFilter(httpRequest, httpResponse);
+    }
+
+    @Override
+    public void destroy() {
+
+    }
+}

--- a/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/SessionExpirationFilter.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/SessionExpirationFilter.java
@@ -92,10 +92,14 @@ public class SessionExpirationFilter implements Filter {
 
                         if (authorizedClient == null || authorizedClient.getAccessToken() == null) {
                             log.warn("Session '{}' for subject '{}', user '{}' is expired due to terminated/expired authentication server session.", httpSession.getId(), principal.getSubject(), principal.getPreferredUsername());
+                            httpRequest.logout();
+                            SecurityContextHolder.getContext().setAuthentication(null);
                             httpSession.invalidate();
                         }
                     } catch (ClientAuthorizationException e) {
                         log.warn("Authorization exception occurred for session '{}' for user '{}'.", httpSession.getId(), principal.getPreferredUsername(), e);
+                        httpRequest.logout();
+                        SecurityContextHolder.getContext().setAuthentication(null);
                         httpSession.invalidate();
                     }
                 }

--- a/web/src/main/webapp/WEB-INF/config-security/config-security-openidconnectbearer.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-openidconnectbearer.xml
@@ -199,6 +199,9 @@
     </constructor-arg>
     <property name="filterProcessesUrl" value="/signout"/>
   </bean>
+
+  <bean id="sessionExpirationFilter" class="org.fao.geonet.kernel.security.openidconnect.SessionExpirationFilter"/>
+
   <bean id="geonetworkOidcPreAuthActionsLoginFilter" class="org.fao.geonet.kernel.security.openidconnect.GeonetworkOidcPreAuthActionsLoginFilter"/>
 
   <bean id="oAuth2Configuration" class="org.fao.geonet.kernel.security.openidconnect.OAuth2Configuration"/>
@@ -239,6 +242,7 @@
     <ref bean="openidconnectOAuth2AuthorizationRequestRedirectFilter"/>
     <ref bean="openidconnectOAuth2LoginAuthenticationFilter"/>
     <ref bean="logoutFilter"/>
+    <ref bean="sessionExpirationFilter"/>
     <!--     include a pre login filter-->
     <ref bean="geonetworkOidcPreAuthActionsLoginFilter"/>
 


### PR DESCRIPTION
- Add session filter for OIDC to detect invalidated session from OIDC provider such as Keycloak, and end the http session in spring
- Modify the condition in [GeonetworkOidcPreAuthActionsLoginFilter.java](https://github.com/geonetwork/core-geonetwork/compare/main...xiechangning20:core-geonetwork:main?expand=1#diff-ba9a74ea7e017e4859bcc65fefc8fbc72270685ecf78092fde3f8ff17202f9ad) to redirect the user to re-authentication if there session does not exists

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

