### PR TITLE
Schematron validation message: restore the logic to resolve validation  messages starting with '$loc'

### DIFF
--- a/web/src/main/webapp/WEB-INF/classes/schematron/iso_svrl_for_xslt2.xsl
+++ b/web/src/main/webapp/WEB-INF/classes/schematron/iso_svrl_for_xslt2.xsl
@@ -544,7 +544,7 @@
   <xsl:template name="svrl-text">
     <svrl:text>
       <xsl:choose>
-        <xsl:when test="contains(., '$loc/strings/')">
+        <xsl:when test="starts-with(., '$loc') or contains(., '$loc/strings/')">
           <xsl:element name="xsl:copy-of">
             <xsl:attribute name="select">
               <xsl:apply-templates mode="text"/>
@@ -589,7 +589,7 @@
       <xsl:if test=" string( $name )">
         <axsl:attribute name="name">
           <xsl:choose>
-            <xsl:when test="contains($name, '$loc/strings/')">
+            <xsl:when test="starts-with(., '$loc') or contains($name, '$loc/strings/')">
               <axsl:value-of>
                 <xsl:attribute name="select">
                   <xsl:value-of select="$name"/>


### PR DESCRIPTION
Follow up of #8665 where the change expects to contain `$loc/strings`

This breaks the messages displayed that used variables starting with `$loc`. For example, with the change in #8665, the following code instead of displaying in the validation the translation text value as previously:

https://github.com/metadata101/iso19139.ca.HNAP/blob/76791b4be27f1b9e111ebeffd83c7c4edc3b6ea4/src/main/plugin/iso19139.ca.HNAP/schematron/schematron-rules-multilingual.sch#L287-L288

It displays the text `$locMsgMainLang`

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
