### PR TITLE
Metadata editor / add configurable thumbnail edit option

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/config-editor.xml
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/config-editor.xml
@@ -649,7 +649,8 @@
       <sidePanel>
         <directive data-gn-need-help="creating-metadata"/>
         <directive data-gn-overview-manager=""
-                   data-file-types=".png,.gif,.jpeg,.jpg"/>
+                   data-file-types=".png,.gif,.jpeg,.jpg"
+                   data-editable-thumbnail="true"/>
 
         <directive data-gn-distribution-resources-panel="gnCurrentEdit.metadata"
                    data-mode="viewConfig.distributionConfig.layout || ''"
@@ -756,7 +757,8 @@
       <sidePanel>
         <directive data-gn-need-help="creating-metadata"/>
         <directive data-gn-overview-manager=""
-                   data-file-types=".png,.gif,.jpeg,.jpg"/>
+                   data-file-types=".png,.gif,.jpeg,.jpg"
+                   data-editable-thumbnail="true"/>
 
         <directive data-gn-distribution-resources-panel="gnCurrentEdit.metadata"
                    data-mode="viewConfig.distributionConfig.layout || ''"
@@ -893,7 +895,8 @@
       <sidePanel>
         <directive data-gn-need-help="creating-metadata"/>
         <directive data-gn-overview-manager=""
-                   data-file-types=".png,.gif,.jpeg,.jpg"/>
+                   data-file-types=".png,.gif,.jpeg,.jpg"
+                   data-editable-thumbnail="true"/>
 
         <directive data-gn-distribution-resources-panel="gnCurrentEdit.metadata"
                    data-mode="viewConfig.distributionConfig.layout || ''"

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
@@ -544,7 +544,8 @@
         <directive data-gn-validation-report=""/>
 
         <directive data-gn-overview-manager=""
-                   data-file-types=".png,.gif,.jpeg,.jpg"/>
+                   data-file-types=".png,.gif,.jpeg,.jpg"
+                   data-editable-thumbnail="true"/>
 
         <directive data-gn-distribution-resources-panel="gnCurrentEdit.metadata"
                    data-mode="viewConfig.distributionConfig.layout || ''"
@@ -3232,7 +3233,8 @@
         <directive data-gn-validation-report=""/>
 
         <directive data-gn-overview-manager=""
-                   data-file-types=".png,.gif,.jpeg,.jpg"/>
+                   data-file-types=".png,.gif,.jpeg,.jpg"
+                   data-editable-thumbnail="true"/>
 
         <directive data-gn-distribution-resources-panel="gnCurrentEdit.metadata"
                    data-mode="viewConfig.distributionConfig.layout || ''"
@@ -3362,7 +3364,8 @@
         <directive data-gn-validation-report=""/>
 
         <directive data-gn-overview-manager=""
-                   data-file-types=".png,.gif,.jpeg,.jpg"/>
+                   data-file-types=".png,.gif,.jpeg,.jpg"
+                   data-editable-thumbnail="true"/>
 
         <directive data-gn-distribution-resources-panel="gnCurrentEdit.metadata"
                    data-mode="viewConfig.distributionConfig.layout || ''"
@@ -3464,7 +3467,8 @@
         <directive data-gn-validation-report=""/>
 
         <directive data-gn-overview-manager=""
-                   data-file-types=".png,.gif,.jpeg,.jpg"/>
+                   data-file-types=".png,.gif,.jpeg,.jpg"
+                   data-editable-thumbnail="true"/>
 
         <directive data-gn-distribution-resources-panel="gnCurrentEdit.metadata"
                    data-mode="viewConfig.distributionConfig.layout || ''"

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -41,7 +41,9 @@
         restrict: "A",
         templateUrl:
           "../../catalog/components/edit/onlinesrc/" + "partials/fileUploader.html",
-        scope: {},
+        scope: {
+          editableThumbnail: "@"
+        },
         link: function (scope, element, attrs) {
           scope.relations = {};
           scope.uuid = undefined;

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/fileUploader.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/fileUploader.html
@@ -32,6 +32,17 @@
         >
           <i class="fa fa-times text-danger"></i>
         </a>
+
+        <a
+          href=""
+          class="btn btn-link onlinesrc-edit"
+          data-ng-if="readonly !== true"
+          data-ng-click="onlinesrcService.onOpenPopup('onlinesrc', f)"
+          data-ng-show="editableThumbnail==='true'"
+          title="{{'edit' | translate}}"
+        >
+          <i class="fa fa-pencil"></i>
+        </a>
       </li>
     </ul>
 


### PR DESCRIPTION
Previously the information related to thumbnails in the metadata editor could not be edited in the side panel. Thumbnails could just added or removed.

With this change it can be configured the thumbnails manager to allow to edit the information related. In `config-editor.xml`, configure the `data-gn-overview-manager` with the attribute `data-editable-thumbnail="true"`:

```xsml
<directive data-gn-overview-manager=""
                   data-file-types=".png,.gif,.jpeg,.jpg"/>
                   data-editable-thumbnail="true"/>
```

![Screenshot 2025-06-19 at 17 11 51](https://github.com/user-attachments/assets/6ba6f817-3e2d-43c6-bacd-496218c1dcbf)
![Screenshot 2025-06-19 at 17 12 08](https://github.com/user-attachments/assets/d56a8488-3158-468c-b8e5-0e14321256c9)


Useful feature taken from:

- https://github.com/GIM-be/core-geonetwork/commit/5127b596b64f99d5df5930a86c29a0e43fba020e
- https://github.com/GIM-be/core-geonetwork/commit/7b7532daff8c5b67b65fc32f8a697be06955ac96

@joachimnielandt I have created this pull request with your work, preserving you as an author. It's a nice feature, please if you can review it, thanks.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
