### PR TITLE
Metadata page / fix javascript error

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/directives/directive.js
+++ b/web-ui/src/main/resources/catalog/views/default/directives/directive.js
@@ -157,6 +157,49 @@
 
           scope.status = undefined;
 
+          scope.statusEffects = {
+            editor: [
+              {
+                from: "draft",
+                to: "submitted"
+              },
+              {
+                from: "retired",
+                to: "draft"
+              },
+              {
+                from: "submitted",
+                to: "draft"
+              }
+            ],
+            reviewer: [
+              {
+                from: "draft",
+                to: "submitted"
+              },
+              {
+                from: "submitted",
+                to: "approved"
+              },
+              {
+                from: "submitted",
+                to: "draft"
+              },
+              {
+                from: "draft",
+                to: "approved"
+              },
+              {
+                from: "approved",
+                to: "retired"
+              },
+              {
+                from: "retired",
+                to: "draft"
+              }
+            ]
+          };
+
           scope.buildFormatter = function (url, uuid, isDraft) {
             if (url.indexOf("${uuid}") !== -1) {
               return url.replace("${lang}", scope.lang).replace("${uuid}", uuid);
@@ -180,49 +223,6 @@
                 response.data.forEach(function (s) {
                   scope.status[s.name] = s.id;
                 });
-
-                scope.statusEffects = {
-                  editor: [
-                    {
-                      from: "draft",
-                      to: "submitted"
-                    },
-                    {
-                      from: "retired",
-                      to: "draft"
-                    },
-                    {
-                      from: "submitted",
-                      to: "draft"
-                    }
-                  ],
-                  reviewer: [
-                    {
-                      from: "draft",
-                      to: "submitted"
-                    },
-                    {
-                      from: "submitted",
-                      to: "approved"
-                    },
-                    {
-                      from: "submitted",
-                      to: "draft"
-                    },
-                    {
-                      from: "draft",
-                      to: "approved"
-                    },
-                    {
-                      from: "approved",
-                      to: "retired"
-                    },
-                    {
-                      from: "retired",
-                      to: "draft"
-                    }
-                  ]
-                };
               });
           }
 


### PR DESCRIPTION
Related to #8699 (see [details](https://github.com/geonetwork/core-geonetwork/pull/8699#issuecomment-2990221631))

Fixes the following Javascript error when displaying the metadata page

```
angular.js?v=867f9c48f67de777c83da5cc3d514440438d19cb:15697 TypeError: Cannot read properties of undefined (reading 'reviewer')
    at scope.getStatusEffects (directive.js:351:39)
    at fn (eval at compile (angular.js?v=867f9c48f67de777c83da5cc3d514440438d19cb:16548:15), <anonymous>:4:235)
    at interceptedExpression (angular.js?v=867f9c48f67de777c83da5cc3d514440438d19cb:17682:55)
    at Scope.$digest (angular.js?v=867f9c48f67de777c83da5cc3d514440438d19cb:19262:34)
    at Scope.$apply (angular.js?v=867f9c48f67de777c83da5cc3d514440438d19cb:19630:24)
    at done (angular.js?v=867f9c48f67de777c83da5cc3d514440438d19cb:13473:47)
    at completeRequest (angular.js?v=867f9c48f67de777c83da5cc3d514440438d19cb:13730:7)
    at XMLHttpRequest.requestLoaded (angular.js?v=867f9c48f67de777c83da5cc3d514440438d19cb:13635:9)
```

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
