### PR TITLE
Metadata page / Improve distribution section in full view

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/xsl-view/view.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/xsl-view/view.xsl
@@ -498,9 +498,14 @@
 
 
   <!-- Some elements are only containers so bypass them
-  unless they are flat mode exceptions -->
+       unless they are flat mode exceptions.
+       Excluded mrd:MD_DigitalTransferOptions, otherwise is rendered differently
+       when contains 1 or more mrd:onLine elements. Probably template affects
+       other similar container elements.
+  -->
   <xsl:template mode="render-field"
                 match="*[
+                          name() != 'mrd:MD_DigitalTransferOptions' and
                           count(*[name() != 'lan:PT_FreeText']) = 1 and
                           count(*/@codeListValue) = 0
                           ]"
@@ -519,6 +524,7 @@
   * if part of fieldsWithFieldset exception
   * has content
   * only if more than one child to be displayed (non flat mode only) bypass container elements
+  * digital transfer options (mrd:transferOptions/*)
   . -->
   <xsl:template mode="render-field"
                 match="*[$isFlatMode = true() and not(gco:CharacterString) and (
@@ -527,7 +533,7 @@
                        *[$isFlatMode = false() and not(gco:CharacterString) and (
                             name() = $configuration/editor/fieldsWithFieldset/name
                             or @gco:isoType = $configuration/editor/fieldsWithFieldset/name
-                            or count(*) > 1)]"
+                            or count(*) > 1)]|mrd:transferOptions/*"
                 priority="100">
 
     <xsl:variable name="content">
@@ -836,7 +842,7 @@
 
   <!-- Linkage -->
   <xsl:template mode="render-field"
-                match="*[cit:CI_OnlineResource and */cit:linkage/* != '']"
+                match="*[cit:CI_OnlineResource]"
                 priority="100">
     <dl class="gn-link">
       <dt>
@@ -849,10 +855,20 @@
           <xsl:apply-templates mode="render-value"
                                select="*/cit:description"/>
         </xsl:variable>
-        <a href="{*/cit:linkage/*}" target="_blank">
-          <xsl:apply-templates mode="render-value"
-                               select="if (*/cit:name != '') then */cit:name else */cit:linkage"/>
-        </a>
+
+        <xsl:choose>
+          <xsl:when test="string(*/cit:linkage/*)">
+            <a href="{*/cit:linkage/*}" target="_blank">
+              <xsl:apply-templates mode="render-value"
+                                   select="if (*/cit:name != '') then */cit:name else */cit:linkage"/>
+            </a>
+          </xsl:when>
+          <xsl:otherwise>
+            <span>
+              <xsl:value-of select="if (*/cit:name != '') then */cit:name else */cit:linkage"/>
+            </span>
+          </xsl:otherwise>
+        </xsl:choose>
         <p>
           <xsl:value-of select="normalize-space($linkDescription)"/>
         </p>

--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
@@ -201,7 +201,7 @@
             <xsl:value-of select="$schemaStrings/spatialExtent"/>
           </span>
         </h2>
-  
+
         <xsl:choose>
           <xsl:when test=".//gmd:EX_BoundingPolygon">
             <xsl:copy-of select="gn-fn-render:extent($metadataUuid)"/>
@@ -507,9 +507,14 @@
   </xsl:template>
 
 
-  <!-- Some elements are only containers so bypass them -->
+  <!-- Some elements are only containers so bypass them
+       Excluded gmd:MD_DigitalTransferOptions, otherwise is rendered differently
+       when contains 1 or more gmd:onLine elements. Probably template affects
+       other similar container elements.
+  -->
   <xsl:template mode="render-field"
                 match="*[
+                          name() != 'gmd:MD_DigitalTransferOptions' and
                           count(gmd:*[name() != 'gmd:PT_FreeText']) = 1 and
                           count(*/@codeListValue) = 0
                         ]"
@@ -525,6 +530,7 @@
       gmd:report/*|
       gmd:result/*|
       gmd:extent[name(..)!='gmd:EX_TemporalExtent']|
+      gmd:transferOptions/*|
       *[$isFlatMode = false() and gmd:* and
         not(gco:CharacterString) and not(gmd:URL)]">
     <div class="entry name">
@@ -767,7 +773,7 @@
 
   <!-- Linkage -->
   <xsl:template mode="render-field"
-                match="*[gmd:CI_OnlineResource and */gmd:linkage/gmd:URL != '']"
+                match="*[gmd:CI_OnlineResource]"
                 priority="100">
     <dl class="gn-link">
       <dt>
@@ -793,11 +799,22 @@
             </xsl:otherwise>
           </xsl:choose>
         </xsl:variable>
+
+        <xsl:choose>
+          <xsl:when test="string($linkUrl)">
         <a href="{$linkUrl}" title="{$linkName}">
           <span>
             <xsl:value-of select="$linkName"/>
           </span>
         </a>
+          </xsl:when>
+          <xsl:otherwise>
+            <span>
+              <xsl:value-of select="$linkName"/>
+            </span>
+          </xsl:otherwise>
+        </xsl:choose>
+
         <xsl:if test="*/gmd:protocol[normalize-space(gco:CharacterString|gmx:Anchor) != '']">
           (<span>
           <xsl:apply-templates mode="render-value-no-breaklines"


### PR DESCRIPTION
1) Avoid bypassing `gmd:MD_DigitalTransferOptions` element (otherwise it was rendered differently when contained 1 or more elements). This template probably affects other elements.

2) Update template to display online resources to be used for resources with a URL or without it, previously depending on this the rendering of the online resources was different.

Before:

![onlineresources-before](https://github.com/user-attachments/assets/0fa9f6b8-b79a-4b1e-9e45-0e778376d277)

After:

<img width="603" alt="onlineresources-after" src="https://github.com/user-attachments/assets/2e130ab8-2573-4ca4-bbf5-1d496e735a87" />


# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
