### PR TITLE
Fix build on newer java versions

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/registries/vocabularies/KeywordsApi.java
@@ -686,7 +686,7 @@ public class KeywordsApi {
 
         // Remove file
         if (Files.exists(item)) {
-            IO.deleteFile(item, true, Geonet.THESAURUS);
+            org.fao.geonet.utils.IO.deleteFile(item, true, Geonet.THESAURUS);
         } else {
             throw new IllegalArgumentException(String.format(
                 "Thesaurus RDF file was not found for thesaurus with identifier '%s'.",
@@ -1460,7 +1460,7 @@ public class KeywordsApi {
             Thesaurus gst = new Thesaurus(languagesMapper, fname, type, dir, path, siteURL, thesaurusMan.getThesaurusCacheMaxSize());
             thesaurusMan.addThesaurus(gst, false);
         } else {
-            IO.deleteFile(rdfFile, false, Geonet.THESAURUS);
+            org.fao.geonet.utils.IO.deleteFile(rdfFile, false, Geonet.THESAURUS);
             throw new WebApplicationException("Unknown format (Must be in SKOS format).");
         }
     }


### PR DESCRIPTION
Java 23 has a preview feature that defines `java.io.IO`. This results in a ambigous reference. To this fix this specify the fully qualified name.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

