### PR TITLE
Validation report / Show schema validation after optional rules

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/validationreport/ValidationReportDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/validationreport/ValidationReportDirective.js
@@ -91,10 +91,13 @@
                     });
                   });
 
+                  scope.ruleTypes = scope.ruleTypes.concat(optional);
+
+                  // Display xsd validation section at the end
                   if (scope.ruleTypes[0].id === "xsd") {
                     scope.ruleTypes.push(scope.ruleTypes.splice(0, 1)[0]);
                   }
-                  scope.ruleTypes = scope.ruleTypes.concat(optional);
+
                   scope.hasSuccess = scope.ruleTypes.length > 0;
                   scope.loading = false;
                 })


### PR DESCRIPTION
Follow up: #6456

If a schema has optional validation rules, the schema validation was not displayed at the bottom.

Before:

![before-xsd](https://github.com/user-attachments/assets/831c64ca-4958-43b3-af03-9414c3cac148)

After:

![after-xsd](https://github.com/user-attachments/assets/4cd4505d-24a2-4d05-84aa-3028a2772f75)


# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
