### PR TITLE
Fix user appears logged out in ratings panel

### DIFF
--- a/web-ui/src/main/resources/catalog/components/userfeedback/GnUserfeedbackDirective.js
+++ b/web-ui/src/main/resources/catalog/components/userfeedback/GnUserfeedbackDirective.js
@@ -386,6 +386,11 @@
               return;
             }
 
+            // Re-check login status
+            if ($rootScope.user && $rootScope.user.username) {
+              scope.userName = $rootScope.user.username;
+            }
+
             scope.uf = {
               rating: {},
               ratingAVG: null


### PR DESCRIPTION
Currently if a user refreshes the record view then tries to add a rating they will appear as logged out in the ratings panel:
![image](https://github.com/user-attachments/assets/3357429e-a435-4136-9b67-4730a41d45ec)

This causes confusion for the users as the message says they are not logged in even though they are logged in. In this circumstance he user must re-enter their information if they want to submit a rating.

This PR aims to fix this issue by rechecking the logged in status when the rating panel is opened.

After these changes the user can refresh the page and submit a rating without needing to re-enter their details.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation


