### PR TITLE
Add back removed types from buildAddToMapConfig

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/mapService.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/mapService.js
@@ -2316,14 +2316,23 @@
             var addToMapLayerNameUrlParam =
               gnGlobalSettings.gnCfg.mods.search.addWMSLayersToMap.urlLayerParam;
 
+            var type = "wms";
+            if (link.protocol.indexOf("WMTS") > -1) {
+              type = "wmts";
+            } else if (
+              link.protocol === "ESRI:REST" ||
+              link.protocol.startsWith("ESRI REST")
+            ) {
+              type = "esrirest";
+            } else if (link.protocol === "OGC:3DTILES") {
+              type = "3dtiles";
+            } else if (link.protocol === "OGC:COG") {
+              type = "cog";
+            }
+
             var config = {
               uuid: md ? md.uuid : null,
-              type:
-                link.protocol.indexOf("WMTS") > -1
-                  ? "wmts"
-                  : link.protocol == "ESRI:REST" || link.protocol.startsWith("ESRI REST")
-                  ? "esrirest"
-                  : "wms",
+              type: type,
               url: $filter("gnLocalized")(link.url) || link.url
             };
 
@@ -2373,6 +2382,19 @@
               );
               return;
             }
+
+            // no support for COG or 3DTiles for now
+            if (config.type === "cog" || config.type === "3dtiles") {
+              gnAlertService.addAlert({
+                msg: $translate.instant("layerProtocolNotSupported", {
+                  type: link.protocol
+                }),
+                delay: 20,
+                type: "warning"
+              });
+              return;
+            }
+
             return config;
           },
 


### PR DESCRIPTION
Due to some differences between main and 4.2.x the `3dtiles` and `cog` types were mistakenly removed in #8866 when the function was moved from `module.js` to `mapService.js`

This PR aims to fix this issue by adding back the code that was removed.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
