### PR TITLE
Editor / Vocabulary browser / Improve UI.

### DIFF
--- a/services/src/main/java/org/fao/geonet/services/thesaurus/GetTopConcept.java
+++ b/services/src/main/java/org/fao/geonet/services/thesaurus/GetTopConcept.java
@@ -74,6 +74,7 @@ public class GetTopConcept implements Service {
 
             KeywordBean topConcept = new KeywordBean(the.getIsoLanguageMapper());
             topConcept.setThesaurusInfo(the);
+            topConcept.setValue("topConcepts", "eng");
             topConcept.setValue("topConcepts", langForThesaurus);
             topConcept.setUriCode(sThesaurusName);
             Element root = KeywordsSearcher.toRawElement(response, topConcept);

--- a/web-ui/src/main/resources/catalog/components/ng-skos/ngSkosBrowserDirective.js
+++ b/web-ui/src/main/resources/catalog/components/ng-skos/ngSkosBrowserDirective.js
@@ -110,8 +110,16 @@
           });
 
           // Select concept for navigation, push previous concept onto stack
-          scope.selectConcept = function (concept, previousConcept) {
-            if (!previousConcept) scope.previous.unshift(concept);
+          scope.selectConcept = function (concept, previousConcept, previousIndex) {
+            if (!previousConcept) {
+              scope.previous.unshift(concept);
+            } else {
+              // Remove from previous list all concepts after the previousIndex
+              scope.previous =
+                previousIndex === 0
+                  ? scope.previous.slice(0, 0)
+                  : scope.previous.slice(-(previousIndex + 1));
+            }
             if (scope.selectURI && concept.uri) {
               scope.selectURI(concept.thesaurus, concept.uri);
             } else if (

--- a/web-ui/src/main/resources/catalog/components/ng-skos/templates/skos-concept.html
+++ b/web-ui/src/main/resources/catalog/components/ng-skos/templates/skos-concept.html
@@ -1,43 +1,40 @@
-<div class="skos-concept">
-  <div class="top top-alt">
-    <div class="btn-group pull-right">
-      <button
-        class="btn btn-default"
+<div title="{{'browseThesaurus' | translate}}">
+  <div data-gn-slide-toggle="true">{{'browseThesaurus' | translate}}</div>
+  <ol class="breadcrumb">
+    <li>
+      <a
+        class="btn btn-xs btn-link"
         title="{{'moveToTopConcept' | translate}}"
         ng-click="topConcept(concept.thesaurus)"
       >
-        <i class="fa fa-level-up"></i>
-      </button>
-      <button
-        class="btn btn-default dropdown-toggle"
-        type="button"
-        id="previous"
-        data-toggle="dropdown"
-        data-ng-disabled="!concept.previous"
-        title="{{'previousKeywords' | translate}}"
+        <i class="fa fa-home"></i>
+      </a>
+    </li>
+    <li ng-repeat="c in concept.previous.slice(1).reverse()">
+      <a
+        class="skos-concept-relation-previous"
+        ng-click="navigateConcept(c, true, $index)"
       >
-        <i class="fa fa-angle-left"></i>
-        <span class="caret"></span>
-      </button>
-      <ul class="dropdown-menu" role="menu" aria-labelledby="previous">
-        <li role="presentation" ng-repeat="c in concept.previous">
-          <a class="skos-concept-relation-previous" ng-click="navigateConcept(c, true)">
-            <span role="menuitem" tabindex="-1" skos-label="c" lang="{{language}}"></span>
-          </a>
-        </li>
-      </ul>
-    </div>
-    <strong>{{'currentConcept' | translate}}</strong>
-    <button
-      class="btn btn-link"
-      data-ng-disabled="concept.prefLabel[language] == 'topConcepts'"
-      ng-click="addConcept(concept)"
-    >
+        <span
+          role="menuitem"
+          tabindex="-1"
+          ng-if="prefLabel"
+          skos-label="c"
+          lang="{{language}}"
+        ></span>
+      </a>
+    </li>
+    <li class="active" data-ng-hide="concept.prefLabel['eng'] == 'topConcepts'">
       <span ng-if="prefLabel" skos-label="concept" lang="{{language}}"></span>
-      <i class="fa fa-plus-circle"></i>
-    </button>
-    <hr />
-  </div>
+      <button
+        class="skos-btn-icons btn-small btn-link"
+        title="{{'addConcept' | translate}}"
+        ng-click="addConcept(concept)"
+      >
+        <i class="fa fa-plus-circle"></i>
+      </button>
+    </li>
+  </ol>
 
   <!-- TODO: use language, too -->
   <div ng-if="altLabel.length" class="skos-concept-altlabel">
@@ -52,80 +49,50 @@
       </li>
     </ul>
   </div>
+
   <div
-    ng-if="broader.length || narrower.length || related.length"
-    class="skos-concept-connected"
+    class="row"
+    data-ng-repeat="(key, value) in {broader: 'parent', narrower: 'moreSpecific', related: 'associated'}"
   >
-    <div ng-if="broader.length">
-      <strong>{{'parentConcept' | translate}}</strong>
-      <hr />
+    <div class="col-md-12" data-ng-if="concept[key].length">
+      <label
+        class="control-label"
+        data-ng-show="concept.prefLabel['eng'] == 'topConcepts'"
+        >{{'topConcepts' | translate}}</label
+      >
+      <label
+        class="control-label"
+        data-ng-hide="concept.prefLabel['eng'] == 'topConcepts'"
+        >{{(value + 'Concept') | translate}}</label
+      >
       <ul>
-        <li ng-repeat="c in broader" data-ng-mouseover="initConceptNavigationHelp(c)">
-          <a class="skos-btn-icons btn-small btn-link" ng-click="addConcept(c)">
-            <i class="fa fa-plus-circle" title="{{'addConcept' | translate}}"></i> </a
-          >&nbsp;
+        <li
+          ng-repeat="c in concept[key]"
+          data-ng-mouseover="initConceptNavigationHelp(c)"
+        >
           <a
             class="btn-small btn-link"
             ng-click="navigateConcept(c)"
             ng-mouseenter="c.over = true"
             ng-mouseleave="c.over = false"
           >
-            <i title="{{c.help.broader}}"></i>
+            <i title="{{c.help[key]}}"></i>
             <span title="{{'makeConceptCurrent' | translate}}">
               {{c.prefLabel[mainLanguage] || c.prefLabel['eng']}}
             </span>
           </a>
-        </li>
-      </ul>
-    </div>
-    <div ng-if="narrower.length">
-      <strong>{{'moreSpecificConcept' | translate}}</strong>
-      <hr />
-      <ul>
-        <li ng-repeat="c in narrower" data-ng-mouseover="initConceptNavigationHelp(c)">
-          <a class="skos-btn-icons btn-small btn-link" ng-click="addConcept(c)">
-            <i class="fa fa-plus-circle" title="{{'addConcept' | translate}}"></i> </a
-          >&nbsp;
           <a
-            class="btn-small btn-link"
-            ng-click="navigateConcept(c)"
-            ng-mouseenter="c.over = true"
-            ng-mouseleave="c.over = false"
+            class="skos-btn-icons btn-small btn-link"
+            title="{{'addConcept' | translate}}"
+            ng-click="addConcept(c)"
           >
-            <i title="{{c.help.narrower}}"></i>
-            <span title="{{'makeConceptCurrent' | translate}}">
-              {{c.prefLabel[mainLanguage] || c.prefLabel['eng']}}
-            </span>
-          </a>
-        </li>
-      </ul>
-    </div>
-    <div ng-if="related.length">
-      <strong>{{'associatedConcept' | translate}}</strong>
-      <hr />
-      <ul>
-        <li ng-repeat="c in related" data-ng-mouseover="initConceptNavigationHelp(c)">
-          <a class="skos-btn-icons btn-small btn-link" ng-click="addConcept(c)">
-            <i class="fa fa-plus-circle" title="{{'addConcept' | translate}}"></i> </a
+            <i class="fa fa-plus-circle"></i> </a
           >&nbsp;
-          <a
-            class="btn-small btn-link"
-            ng-click="navigateConcept(c)"
-            ng-mouseenter="c.over = true"
-            ng-mouseleave="c.over = false"
-          >
-            <i title="{{c.help.related}}"></i>
-            <span
-              skos-label="c"
-              lang="{{mainLanguage}}"
-              title="{{'makeConceptCurrent' | translate}}"
-            ></span>
-          </a>
         </li>
       </ul>
     </div>
   </div>
-  <!-- TODO: select by language, only show a limited number -->
+
   <div ng-if="!isEmptyObject(note)" style="margin-top: 10px">
     <div
       ng-repeat="note in note.en"

--- a/web-ui/src/main/resources/catalog/locales/en-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/en-editor.json
@@ -10,6 +10,7 @@
     "contactRole": "Contact role",
     "addConcept": "Add concept to keyword list",
     "moveToTopConcept": "Display top concepts",
+    "browseThesaurus": "Browse vocabulary",
     "addContact": "Add contact",
     "addContactAsLink-help": "Add a link to the contact in the contact directory. The contact will be updated if updated in the directory.",
     "addContactAsText-help": "Default mode. Add the contact into the record.",

--- a/web-ui/src/main/resources/catalog/style/ng-skos.css
+++ b/web-ui/src/main/resources/catalog/style/ng-skos.css
@@ -3,9 +3,9 @@
 
 .tmpl-border {
     background-color:#FFFFFF;
-    border: 1px solid #ccc;
+    border: 1px solid #ddd;
     border-radius: 4px;
-    padding:5px 5px 5px 5px;
+    padding:0px 5px 5px 0px;
     /*margin:5px 0px 10px 0px;*/
     display:inline-block;
 }
@@ -56,6 +56,9 @@
 /* 'skos-concept-thesaurus' template styles  */
 /*  template also uses: .notation, .uri */
 
+ul {
+  padding-left: 15px;
+}
 ul.ancestors{
     padding-left:0px;
 }


### PR DESCRIPTION
Based on mockups made by @MichelGabriel some time ago, facilitate navigation in the skos browser directive.

* More clear and consistent icons
* First list is top concepts

<img width="261" height="296" alt="image" src="https://github.com/user-attachments/assets/1e04f23d-c901-4fed-ab53-e90fe789bbc2" />

* Navigation history in breadcrumb

<img width="649" height="336" alt="image" src="https://github.com/user-attachments/assets/995b4cc1-503a-4dd9-be34-10bb4a741386" />



<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

Funded by Ifremer