### PR TITLE
Fix url is not multilingual in rating email

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/userfeedback/UserFeedbackAPI.java
+++ b/services/src/main/java/org/fao/geonet/api/userfeedback/UserFeedbackAPI.java
@@ -525,7 +525,6 @@ public class UserFeedbackAPI {
                     if (toAddress.size() > 0) {
                         try {
                             Locale[] feedbackLocales = feedbackLanguages.getLocales(locale);
-                            String recordUrl = metadataUtils.getDefaultUrl(userFeedbackDto.getMetadataUUID(), locale.getISO3Language());
 
                             LocalizedEmailComponent emailSubjectComponent = new LocalizedEmailComponent(SUBJECT, "new_user_rating", KeyType.MESSAGE_KEY, POSITIONAL_FORMAT);
                             LocalizedEmailComponent emailMessageComponent = new LocalizedEmailComponent(MESSAGE, "new_user_rating_text", KeyType.MESSAGE_KEY, POSITIONAL_FORMAT);
@@ -539,7 +538,7 @@ public class UserFeedbackAPI {
 
                                 emailMessageComponent.addParameters(
                                     feedbackLocale,
-                                    new LocalizedEmailParameter(ParameterType.RAW_VALUE, 1, recordUrl)
+                                    new LocalizedEmailParameter(ParameterType.RAW_VALUE, 1, metadataUtils.getDefaultUrl(userFeedbackDto.getMetadataUUID(), feedbackLocale.getISO3Language()))
                                 );
                             }
 


### PR DESCRIPTION
<!--Include a few sentences describing the overall goals for this Pull Request-->
When changing rating emails to be multilingual in #8916 the url was missed. When users click the url in the localized message it should bring them to the record page in that language. Currently all of the links point to the record page in the default locale.

<img width="1115" height="145" alt="image" src="https://github.com/user-attachments/assets/ac830e73-0b2e-43cf-94fd-ab1fa3c0599c" />

This PR aims to fix this issue by moving the url generation logic into the `feedbackLocales` loop.

<img width="1129" height="147" alt="image" src="https://github.com/user-attachments/assets/6b8eebf6-9c8b-465c-92ca-702fc01ea094" />

<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
