### PR TITLE
Change email link to point to UI view not API.

### DIFF
--- a/core/src/main/java/org/fao/geonet/util/LocalizedEmailComponent.java
+++ b/core/src/main/java/org/fao/geonet/util/LocalizedEmailComponent.java
@@ -367,6 +367,6 @@ public class LocalizedEmailComponent {
         } else {
             newPlaceholder = "'{{'index:uuid'}}'";
         }
-        return message.replace("{{link}}", settingManager.getNodeURL() + "api/records/" + newPlaceholder);
+        return message.replace("{{link}}", settingManager.getNodeURL() + "eng/catalog.search#/metadata/" + newPlaceholder);
     }
 }


### PR DESCRIPTION
The emails sent to reviewers for workflow changes include a link to the associated record. This is a link to the API which does not provide a nice view when opened in a browser. The proposed change is to generate a link that uses the geonetwork UI instead of the API.

For example, currently link like http://<geonetwork-host.com>/geonetwork/srv/api/records/<uuid> looks like:

<img width="613" height="826" alt="image" src="https://github.com/user-attachments/assets/42805cd4-314e-4fe1-958c-9478095d8e3c" />

Instead, it could be nicer to just use a link to the UI view. This would also prompt users to log if they need to inorder to access the record, as opposed to API simply returning 403 and browsers rendering not very helpful error:

<img width="850" height="435" alt="image" src="https://github.com/user-attachments/assets/dcf900c5-7741-4950-a292-6db3a186605c" />


Here is where the link is currently used. I havent been able to see where else it could be used, but im confident it is only in the email utils and feel that links sent via email to reviewers should point to UI views:

<img width="1040" height="310" alt="image" src="https://github.com/user-attachments/assets/b7ca4aee-990f-4cd2-a8de-4c51bf805e36" />


# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [x] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

