### PR TITLE
Fix image modal style for small images

### DIFF
--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -243,7 +243,8 @@ a {
   cursor: pointer;
 }
 .gn-img-modal {
-  width: 95vw;
+  width: fit-content;
+  max-width: 95vw;
   background-color: #fff;
   img {
     max-width: 100%;


### PR DESCRIPTION
There are issues with the display of images in the image modal.

Currently a large image displays correctly in the modal:
<img width="2135" height="1431" alt="image" src="https://github.com/user-attachments/assets/133b9c6d-cc8f-4a04-9c08-8607ef0dc10e" />

But with a small image the modal is too wide and there is extra whitespace:
<img width="2139" height="843" alt="image" src="https://github.com/user-attachments/assets/63ae4c66-4063-45ed-8f4b-bf1e5676c086" />

This PR aims to fix this issue by updating the styles from `width` to `max-width` so the modal only grows when required.

After the changes with a large image:
<img width="2141" height="1435" alt="image" src="https://github.com/user-attachments/assets/e608ad0d-414a-4ed1-8929-b0d849a65da9" />

After the changes with a small image:
<img width="2129" height="839" alt="image" src="https://github.com/user-attachments/assets/29548f8e-68ec-4016-8a2f-4c79e4a094af" />

  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
