### PR TITLE
Settings / Fix INSPIRE Atom type setting value selected

### DIFF
--- a/web-ui/src/main/resources/catalog/js/admin/SystemSettingsController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/SystemSettingsController.js
@@ -170,7 +170,6 @@
       $scope.defaultConfigId = "srv";
 
       $scope.loadTplReport = null;
-      $scope.atomFeedType = "";
 
       $scope.isGroupPublicationNotificationLevel = false;
       $scope.isGroupLocalRatingNotificationLevel = false;

--- a/web-ui/src/main/resources/catalog/templates/admin/settings/system.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/settings/system.html
@@ -509,7 +509,6 @@
                         data-ng-switch-when="system/inspire/atom"
                         class="form-control"
                         name="{{s.name}}"
-                        data-ng-model="atomFeedType"
                       >
                         <option value="disabled" ng-selected="'disabled' == s.value">
                           {{'system/inspire/atomDisabled' | translate}}


### PR DESCRIPTION
The INSPIRE Atom type setting was retrieved fine from the database, but the user interface didn't select the correct value, displaying the entry as empty. When saving the settings, the value was reset to an invalid value.

<img width="729" height="98" alt="Screenshot 2025-07-17 at 11 03 27" src="https://github.com/user-attachments/assets/0f09bd18-344d-4708-8d2e-b9940eedc747" />


With this fix, the user interface is fixed, selecting properly the value:

<img width="848" height="104" alt="Screenshot 2025-07-17 at 10 59 42" src="https://github.com/user-attachments/assets/c3446a27-f658-4512-9bb7-750e42eb2d37" />


# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

