### PR TITLE
Remote INSPIRE ATOM harvester / fix scheduling

### DIFF
--- a/domain/src/main/java/org/fao/geonet/domain/Setting.java
+++ b/domain/src/main/java/org/fao/geonet/domain/Setting.java
@@ -23,6 +23,8 @@
 
 package org.fao.geonet.domain;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.fao.geonet.entitylistener.SettingEntityListenerManager;
 import org.hibernate.annotations.Type;
@@ -251,4 +253,12 @@ public class Setting extends GeonetEntity {
         return "Setting{'" + name + "' = '" + value + "'}";
     }
 
+    public static Setting createDeepCopy(Setting setting) {
+        ObjectMapper objectMapper = new ObjectMapper();
+        try {
+            return objectMapper.readValue(objectMapper.writeValueAsString(setting), Setting.class);
+        } catch (JsonProcessingException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
 }

--- a/events/src/main/java/org/fao/geonet/events/setting/SettingsChanged.java
+++ b/events/src/main/java/org/fao/geonet/events/setting/SettingsChanged.java
@@ -22,10 +22,9 @@
  */
 package org.fao.geonet.events.setting;
 
+import java.util.List;
 import org.fao.geonet.domain.Setting;
 import org.springframework.context.ApplicationEvent;
-
-import java.util.List;
 
 public class SettingsChanged extends ApplicationEvent {
     private final List<Setting> newSettings;

--- a/events/src/main/java/org/fao/geonet/events/setting/SettingsChanged.java
+++ b/events/src/main/java/org/fao/geonet/events/setting/SettingsChanged.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2001-2025 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+package org.fao.geonet.events.setting;
+
+import org.fao.geonet.domain.Setting;
+import org.springframework.context.ApplicationEvent;
+
+import java.util.List;
+
+public class SettingsChanged extends ApplicationEvent {
+    private final List<Setting> newSettings;
+    private final List<Setting> oldSettings;
+
+    public SettingsChanged(List<Setting> newSettings, List<Setting> oldSettings) {
+        super(newSettings);
+        this.newSettings = newSettings;
+        this.oldSettings = oldSettings;
+    }
+
+    public List<Setting> getOldSettings() {
+        return oldSettings;
+    }
+
+    public List<Setting> getNewSettings() {
+        return newSettings;
+    }
+}

--- a/inspire-atom/src/main/java/org/fao/geonet/inspireatom/listener/setting/InspireAtomSettingsChangedListener.java
+++ b/inspire-atom/src/main/java/org/fao/geonet/inspireatom/listener/setting/InspireAtomSettingsChangedListener.java
@@ -1,0 +1,110 @@
+/*
+ * Copyright (C) 2001-2025 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+package org.fao.geonet.inspireatom.listener.setting;
+
+import org.fao.geonet.ApplicationContextHolder;
+import org.fao.geonet.GeonetContext;
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.domain.Setting;
+import org.fao.geonet.events.setting.SettingsChanged;
+import org.fao.geonet.inspireatom.harvester.InspireAtomHarvesterScheduler;
+import org.fao.geonet.kernel.setting.Settings;
+import org.fao.geonet.utils.Log;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.Optional;
+
+@Component
+public class InspireAtomSettingsChangedListener implements ApplicationListener<SettingsChanged> {
+    @Override
+    public void onApplicationEvent(SettingsChanged event) {
+        String oldSettingInspireScheduleValue = value(event.getOldSettings(), Settings.SYSTEM_INSPIRE_ATOM_SCHEDULE);
+        String newSettingInspireScheduleValue = value(event.getNewSettings(), Settings.SYSTEM_INSPIRE_ATOM_SCHEDULE);
+
+        String newSettingInspireEnabled = value(event.getNewSettings(), Settings.SYSTEM_INSPIRE_ENABLE);
+
+        // INSPIRE setting enabled
+        if (newSettingInspireEnabled.equalsIgnoreCase("true")) {
+            String oldSettingInspireTypeValue = value(event.getOldSettings(), Settings.SYSTEM_INSPIRE_ATOM);
+            String newSettingInspireTypeValue = value(event.getNewSettings(), Settings.SYSTEM_INSPIRE_ATOM);
+
+            // INSPIRE Atom type changed
+            if (!oldSettingInspireTypeValue.equalsIgnoreCase(newSettingInspireTypeValue)) {
+
+                // If the value is "remote", we enable the harvester with the new schedule.
+                if (newSettingInspireTypeValue.equalsIgnoreCase("remote")) {
+                    enableInspireAtomHarvester(newSettingInspireScheduleValue);
+                } else {
+                    disableInspireAtomHarvester();
+                }
+            } else {
+                // If the type is still "remote", we check if the schedule has changed to reschedule the harvester.
+                if (newSettingInspireTypeValue.equalsIgnoreCase("remote")) {
+                    if (!oldSettingInspireScheduleValue.equalsIgnoreCase(newSettingInspireScheduleValue)) {
+                        enableInspireAtomHarvester(newSettingInspireScheduleValue);
+                    }
+                }
+            }
+        // INSPIRE setting disabled
+        } else {
+            disableInspireAtomHarvester();
+        }
+    }
+
+    private void enableInspireAtomHarvester(String schedule) {
+        try {
+            GeonetContext gnContext = new GeonetContext(ApplicationContextHolder.get(), false);
+            InspireAtomHarvesterScheduler.schedule(schedule, null, gnContext);
+        } catch (Exception e) {
+            Log.error(Geonet.ATOM, "Error enabling INSPIRE Atom Harvester with schedule: " + schedule, e);
+        }
+    }
+
+    private void disableInspireAtomHarvester() {
+        try {
+            InspireAtomHarvesterScheduler.unSchedule();
+        } catch (Exception e) {
+            Log.error(Geonet.ATOM, "Error disabling INSPIRE Atom Harvester: ", e);
+        }
+    }
+
+    /**
+     * Returns the value of a setting by its name from a list of settings.
+     *
+     * @param settings      List of settings to search in.
+     * @param settingName   Setting name to look for.
+     * @return              The value of the setting if found, otherwise an empty string.
+     */
+    private String value(List<Setting> settings, String settingName) {
+        Optional<Setting> settingOptional = settings.stream().filter(setting -> setting.getName().equalsIgnoreCase(settingName)).findFirst();
+
+        if (settingOptional.isPresent()) {
+            return settingOptional.get().getValue();
+        } else {
+            return "";
+        }
+
+    }
+}

--- a/inspire-atom/src/main/java/org/fao/geonet/inspireatom/listener/setting/InspireAtomSettingsChangedListener.java
+++ b/inspire-atom/src/main/java/org/fao/geonet/inspireatom/listener/setting/InspireAtomSettingsChangedListener.java
@@ -22,6 +22,8 @@
  */
 package org.fao.geonet.inspireatom.listener.setting;
 
+import java.util.List;
+import java.util.Optional;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.GeonetContext;
 import org.fao.geonet.constants.Geonet;
@@ -32,9 +34,6 @@ import org.fao.geonet.kernel.setting.Settings;
 import org.fao.geonet.utils.Log;
 import org.springframework.context.ApplicationListener;
 import org.springframework.stereotype.Component;
-
-import java.util.List;
-import java.util.Optional;
 
 @Component
 public class InspireAtomSettingsChangedListener implements ApplicationListener<SettingsChanged> {
@@ -61,14 +60,13 @@ public class InspireAtomSettingsChangedListener implements ApplicationListener<S
                 }
             } else {
                 // If the type is still "remote", we check if the schedule has changed to reschedule the harvester.
-                if (newSettingInspireTypeValue.equalsIgnoreCase("remote")) {
-                    if (!oldSettingInspireScheduleValue.equalsIgnoreCase(newSettingInspireScheduleValue)) {
-                        enableInspireAtomHarvester(newSettingInspireScheduleValue);
-                    }
+                if (newSettingInspireTypeValue.equalsIgnoreCase("remote")
+                    && !oldSettingInspireScheduleValue.equalsIgnoreCase(newSettingInspireScheduleValue)) {
+                    enableInspireAtomHarvester(newSettingInspireScheduleValue);
                 }
             }
-        // INSPIRE setting disabled
         } else {
+            // INSPIRE setting disabled
             disableInspireAtomHarvester();
         }
     }
@@ -93,9 +91,9 @@ public class InspireAtomSettingsChangedListener implements ApplicationListener<S
     /**
      * Returns the value of a setting by its name from a list of settings.
      *
-     * @param settings      List of settings to search in.
-     * @param settingName   Setting name to look for.
-     * @return              The value of the setting if found, otherwise an empty string.
+     * @param settings    List of settings to search in.
+     * @param settingName Setting name to look for.
+     * @return The value of the setting if found, otherwise an empty string.
      */
     private String value(List<Setting> settings, String settingName) {
         Optional<Setting> settingOptional = settings.stream().filter(setting -> setting.getName().equalsIgnoreCase(settingName)).findFirst();


### PR DESCRIPTION
The scheduler for the remote INSPIRE ATOM harvester is processed during application start-up, 

https://github.com/geonetwork/core-geonetwork/blob/f8042c0c229a6a9568d48c5ff9860e2c4cd8e002/web/src/main/java/org/fao/geonet/Geonetwork.java#L322-L336

but when the related system settings are updated, the scheduler is not updated.

This change request adds a new application event that is triggered when the system settings are updated. This event receives the old and new values of the settings. This event can be used to create listeners to execute for example this code defined currently in `SiteApi`: https://github.com/geonetwork/core-geonetwork/blob/f8042c0c229a6a9568d48c5ff9860e2c4cd8e002/services/src/main/java/org/fao/geonet/api/site/SiteApi.java#L146-L176

The `inspire-atom` module includes a listener for this event, that checks if the related settings for INSPIRE ATOM harvester are updated to update the harvester scheduler.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

