### PR TITLE
Support attachments greater than 2GB

### DIFF
--- a/core/src/main/java/jeeves/server/JeevesEngine.java
+++ b/core/src/main/java/jeeves/server/JeevesEngine.java
@@ -91,7 +91,7 @@ public class JeevesEngine {
     private Vector<ApplicationHandler> _appHandlers = new Vector<ApplicationHandler>();
     private List<Element> _dbServices = new ArrayList<Element>();
     private Path _appPath;
-    private int _maxUploadSize;
+    private long _maxUploadSize;
 
 
     public static void handleStartupError(Throwable e) {
@@ -325,7 +325,7 @@ public class JeevesEngine {
         info("Initializing general configuration...");
 
         try {
-            _maxUploadSize = Integer.parseInt(Util.getParam(general, ConfigFile.General.Child.MAX_UPLOAD_SIZE));
+            _maxUploadSize = Long.parseLong(Util.getParam(general, ConfigFile.General.Child.MAX_UPLOAD_SIZE));
         } catch (Exception e) {
             _maxUploadSize = DEFAULT_MAX_UPLOAD_SIZE_MD;
             error("Maximum upload size not properly configured in config.xml. Using default size of 50MB");
@@ -544,7 +544,7 @@ public class JeevesEngine {
 
     //---------------------------------------------------------------------------
 
-    public int getMaxUploadSize() {
+    public long getMaxUploadSize() {
         return _maxUploadSize;
     }
 

--- a/core/src/main/java/jeeves/server/context/ServiceContext.java
+++ b/core/src/main/java/jeeves/server/context/ServiceContext.java
@@ -63,7 +63,7 @@ public class ServiceContext extends BasicContext {
     private String _language;
     private String _service;
     private String _ipAddress;
-    private int _maxUploadSize;
+    private long _maxUploadSize;
     private JeevesServlet _servlet;
     private boolean _startupError = false;
     private Map<String, String> _startupErrors;
@@ -156,11 +156,11 @@ public class ServiceContext extends BasicContext {
         return getBean(GeonetworkDataDirectory.class).getUploadDir();
     }
 
-    public int getMaxUploadSize() {
+    public long getMaxUploadSize() {
         return _maxUploadSize;
     }
 
-    public void setMaxUploadSize(final int size) {
+    public void setMaxUploadSize(final long size) {
         _maxUploadSize = size;
     }
 

--- a/core/src/main/java/jeeves/server/dispatchers/ServiceManager.java
+++ b/core/src/main/java/jeeves/server/dispatchers/ServiceManager.java
@@ -84,7 +84,7 @@ public class ServiceManager {
     private List<ErrorPage> vErrorPipe = new ArrayList<ErrorPage>();
     private List<GuiService> vDefaultGui = new ArrayList<GuiService>();
     private String baseUrl;
-    private int maxUploadSize;
+    private long maxUploadSize;
     private String defaultLang;
     private String defaultContType;
     private boolean defaultLocal;
@@ -118,7 +118,7 @@ public class ServiceManager {
         defaultContType = type;
     }
 
-    public void setMaxUploadSize(int size) {
+    public void setMaxUploadSize(long size) {
         maxUploadSize = size;
     }
 

--- a/core/src/main/java/jeeves/server/sources/ServiceRequestFactory.java
+++ b/core/src/main/java/jeeves/server/sources/ServiceRequestFactory.java
@@ -74,7 +74,7 @@ public final class ServiceRequestFactory {
                                         String portal,
                                         String lang,
                                         String service,
-                                        Path uploadDir, int maxUploadSize) throws Exception {
+                                        Path uploadDir, long maxUploadSize) throws Exception {
         String url = req.getPathInfo();
 
         // FIXME: if request character encoding is undefined set it to UTF-8
@@ -236,7 +236,7 @@ public final class ServiceRequestFactory {
     //---------------------------------------------------------------------------
 
     @SuppressWarnings("unchecked")
-    private static Element extractParameters(HttpServletRequest req, Path uploadDir, int maxUploadSize) throws Exception {
+    private static Element extractParameters(HttpServletRequest req, Path uploadDir, long maxUploadSize) throws Exception {
         //--- set parameters from multipart request
         if (req instanceof MultipartRequest) {
             AbstractMultipartHttpServletRequest request = (AbstractMultipartHttpServletRequest) req;
@@ -269,7 +269,7 @@ public final class ServiceRequestFactory {
 
     //---------------------------------------------------------------------------
 
-    private static Element getMultipartParams(AbstractMultipartHttpServletRequest req, Path uploadDir, int maxUploadSize) throws Exception {
+    private static Element getMultipartParams(AbstractMultipartHttpServletRequest req, Path uploadDir, long maxUploadSize) throws Exception {
         Element params = new Element("params");
 
         long maxSizeInBytes = maxUploadSize * 1024L * 1024L;

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
@@ -67,7 +67,7 @@ public abstract class AbstractStore implements Store {
     private static final Logger log = LoggerFactory.getLogger(AbstractStore.class);
 
     @Value("${api.params.maxUploadSize}")
-    protected int maxUploadSize;
+    protected long maxUploadSize;
 
     @Override
     public final List<MetadataResource> getResources(final ServiceContext context, final String metadataUuid, final Sort sort,


### PR DESCRIPTION
Because `maxUploadSize` is defined as an integer the max upload size is limited to `2147483647` bytes. This means that files over 2GB cannot be uploaded because the `maxUploadSize` parameter cannot be set that high.

This poses an issue for users with attachments/resources greater than 2GB.

This PR aims to fix this issue by updating `maxUploadSize` from an integer to a long which will allow `maxUploadSize` to be set much higher.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation


