### PR TITLE
Add service associated resource. Fix add link from service distribution section.

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -2035,6 +2035,7 @@
                       scope.srcParams.remote = false;
                       if (links.length > 0) {
                         scope.onlineSrcLink = links[0].url;
+                        scope.srcParams.name = links[0].name || "";
                         scope.srcParams.protocol = links[0].protocol || "OGC:WMS";
                         scope.loadCurrentLink(scope.onlineSrcLink);
                         scope.srcParams.url = scope.onlineSrcLink;

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcService.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcService.js
@@ -130,13 +130,19 @@
 
           var addLayersInUrl = params.addLayersInUrl;
 
-          if (addLayersInUrl != "" && params.protocol.indexOf("OGC:WMS") >= 0) {
-            params.url = gnUrlUtils.remove(params.url, [addLayersInUrl], true);
-            params.url = gnUrlUtils.append(
-              params.url,
-              addLayersInUrl + "=" + names.join(",")
-            );
+          if (addLayersInUrl != undefined && addLayersInUrl != "") {
+            // Add layers in the resource URL
+
+            if (params.protocol.indexOf("OGC:WMS") >= 0) {
+              params.url = gnUrlUtils.remove(params.url, [addLayersInUrl], true);
+              params.url = gnUrlUtils.append(
+                params.url,
+                addLayersInUrl + "=" + names.join(",")
+              );
+            }
           } else {
+            // Add layers in resource name
+
             angular.extend(params, {
               name: names.join(",")
             });


### PR DESCRIPTION
The online resource added to the dataset contained the text 'undefined' instead of the service online resource name

Test case:

1) Create a service metadata with an online resource.

2) Create a dataset metadata and add a link to the previous service, selecting the option `Add the following link to the dataset (as an online source in the distribution section): ...`

<img width="1037" height="606" alt="Screenshot 2025-07-28 at 17 47 47" src="https://github.com/user-attachments/assets/d77f027f-0d36-424d-8726-31c508383522" />

3) Without the fix: the service link is added and an online resource with the name `undefined` --> **NO OK**

<img width="371" height="505" alt="Screenshot 2025-07-28 at 17 46 46" src="https://github.com/user-attachments/assets/210d34f8-ae30-402c-8d71-f018d09c53df" />


3) With the fix: the service link is added and an online resource with the name of the online resource in the service metadata is added --> **OK**

<img width="357" height="523" alt="Screenshot 2025-07-28 at 17 47 56" src="https://github.com/user-attachments/assets/2493833e-defd-4d6d-a6fe-eedf9f529135" />


# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation


