### PR TITLE
Fix attachment caching issue

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsApi.java
@@ -47,12 +47,12 @@ import org.fao.geonet.events.history.AttachmentAddedEvent;
 import org.fao.geonet.events.history.AttachmentDeletedEvent;
 import org.fao.geonet.util.ImageUtil;
 import org.springframework.context.ApplicationContext;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
+import org.springframework.core.io.ByteArrayResource;
+import org.springframework.core.io.PathResource;
+import org.springframework.core.io.Resource;
+import org.springframework.http.*;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
-import org.springframework.util.StreamUtils;
 import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.InitBinder;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -61,13 +61,13 @@ import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.bind.annotation.ResponseStatus;
+import org.springframework.web.context.request.ServletWebRequest;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
 import javax.annotation.PostConstruct;
 import javax.imageio.ImageIO;
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 import java.awt.image.BufferedImage;
 import java.io.*;
 import java.net.URL;
@@ -259,7 +259,6 @@ public class AttachmentsApi {
     @io.swagger.v3.oas.annotations.Operation(summary = "Get a metadata resource")
     // @PreAuthorize("permitAll")
     @RequestMapping(value = "/{resourceId:.+}", method = RequestMethod.GET)
-    @ResponseStatus(value = HttpStatus.OK)
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Record attachment.",
             content = @Content(schema = @Schema(type = "string", format = "binary"))),
@@ -267,72 +266,48 @@ public class AttachmentsApi {
             content = @Content(schema = @Schema(type = "string", format = "binary"))),
         @ApiResponse(responseCode = "403", description = "Operation not allowed. "
             + "User needs to be able to download the resource.")})
-    public void getResource(
+    public ResponseEntity<Resource> getResource(
         @Parameter(description = "The metadata UUID", required = true, example = "43d7c186-2187-4bcd-8843-41e575a5ef56") @PathVariable String metadataUuid,
         @Parameter(description = "The resource identifier (ie. filename)", required = true) @PathVariable String resourceId,
         @Parameter(description = "Use approved version or not", example = "true") @RequestParam(required = false, defaultValue = "true") Boolean approved,
         @Parameter(description = "Size (only applies to images). From 1px to 2048px.", example = "200") @RequestParam(required = false) Integer size,
-        @Parameter(hidden = true) HttpServletRequest request,
-        @Parameter(hidden = true) HttpServletResponse response
+        @Parameter(hidden = true) HttpServletRequest request
     ) throws Exception {
         ServiceContext context = ApiUtils.createServiceContext(request);
 
         ApiUtils.canViewRecord(metadataUuid, request);
 
         try (Store.ResourceHolder file = store.getResource(context, metadataUuid, resourceId, approved)) {
-            response.setHeader(HttpHeaders.CACHE_CONTROL, "no-cache");
+            long fileSize = Files.size(file.getPath());
+            long fileLastModified = file.getMetadata().getLastModification().getTime();
+            MediaType fileMediaType = MediaType.parseMediaType(getFileContentType(file.getPath()));
+            String fileETag = "\"" + DigestUtils.md5Hex(file.getMetadata().getFilename() + fileLastModified + fileSize) + "\"";
 
-            Path filePath = file.getPath();
-            String filename = file.getMetadata().getFilename();
-            String contentType = getFileContentType(filePath);
+            // Set common headers
+            HttpHeaders responseHeaders = new HttpHeaders();
+            responseHeaders.setCacheControl(CacheControl.noCache());
+            responseHeaders.setLastModified(fileLastModified);
+            responseHeaders.setETag(fileETag);
 
-            // If the image is being resized, always return as PNG and update
-            // filename and content-type accordingly
-            if (contentType.startsWith("image/") && size != null) {
-                if (size >= MIN_IMAGE_SIZE && size <= MAX_IMAGE_SIZE) {
-                    serveResizedImage(response, filePath, filename, size);
-                } else {
-                    throw new IllegalArgumentException(String.format(
-                        "Image can only be resized from %d to %d. You requested %d.",
-                        MIN_IMAGE_SIZE, MAX_IMAGE_SIZE, size));
-                }
-            } else {
-                // For all other files, use the original content type and filename
-                response.setHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + filename + "\"");
-                response.setHeader(HttpHeaders.CONTENT_TYPE, contentType);
-
-                long lastModified = file.getMetadata().getLastModification().getTime();
-                response.setDateHeader(HttpHeaders.LAST_MODIFIED, lastModified);
-
-                long fileSize = Files.size(filePath);
-
-                // Create an ETag
-                String etagValue = "\"" + DigestUtils.md5Hex(filename + lastModified + fileSize) + "\"";
-                response.setHeader(HttpHeaders.ETAG, etagValue);
-                String ifNoneMatch = request.getHeader(HttpHeaders.IF_NONE_MATCH);
-                if (ifNoneMatch != null && ifNoneMatch.equals(etagValue)) {
-                    response.setStatus(HttpServletResponse.SC_NOT_MODIFIED); // 304
-                    return;
-                }
-
-                // Set headers for range requests to enable resumable downloads
-                response.setHeader(HttpHeaders.ACCEPT_RANGES, "bytes");
-
-                // Get the range header for resumable downloads
-                String rangeHeader = request.getHeader(HttpHeaders.RANGE);
-
-                if (rangeHeader != null && rangeHeader.startsWith("bytes=")) {
-                    // Handle range requests for resumable downloads
-                    serveAttachmentWithRange(response, filePath, rangeHeader, fileSize);
-                } else {
-                    // Handle full downloads
-                    response.setContentLengthLong(fileSize);
-                    try (InputStream inputStream = Files.newInputStream(filePath);
-                         BufferedInputStream bufferedStream = new BufferedInputStream(inputStream, BUFFER_SIZE)) {
-                        StreamUtils.copy(bufferedStream, response.getOutputStream());
-                    }
-                }
+            // Check if the request is not modified based on ETag or Last-Modified
+            if (new ServletWebRequest(request).checkNotModified(fileETag, fileLastModified)) {
+                return ResponseEntity.status(HttpStatus.NOT_MODIFIED).headers(responseHeaders).build();
             }
+
+            // Check if the file is an image and if a size is requested
+            if (fileMediaType.getType().equals("image") && size != null) {
+                return serveResizedImage(file.getPath(), file.getMetadata().getFilename(), responseHeaders, size);
+            }
+
+            // Set headers for downloads
+            responseHeaders.setContentType(fileMediaType);
+            responseHeaders.setContentDisposition(ContentDisposition.attachment().filename(file.getMetadata().getFilename()).build());
+            responseHeaders.setContentLength(fileSize);
+
+            // Spring automatically handles range requests when returning ResponseEntity<Resource> to support resumable downloads.
+            return ResponseEntity.ok()
+                .headers(responseHeaders)
+                .body(new PathResource(file.getPath()));
         }
     }
 
@@ -380,105 +355,36 @@ public class AttachmentsApi {
     /**
      * Serves a resized image in PNG format.
      *
-     * @param response HTTP response to write the image to
      * @param imagePath Path to the original image file
-     * @param originalFilename Original filename of the image
+     * @param originalImageName Original filename of the image
+     * @param responseHeaders HTTP headers to be set in the response
      * @param size Desired size for the resized image (in pixels)
      * @throws IOException If an I/O error occurs while reading or writing the image
      */
-    private void serveResizedImage(HttpServletResponse response, Path imagePath,
-                                   String originalFilename, int size) throws IOException {
-        // Set headers before processing image
-        String filename = originalFilename.substring(0, originalFilename.lastIndexOf('.')) + ".png";
-        response.setHeader(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + filename + "\"");
-        response.setHeader(HttpHeaders.CONTENT_TYPE, "image/png");
-
-        // Use ByteArrayOutputStream to capture the image data first
-        ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-
-        try (InputStream input = new BufferedInputStream(Files.newInputStream(imagePath))) {
-            // Process and resize the image
-            BufferedImage resized = ImageUtil.resize(ImageIO.read(input), size);
-
-            // Write to the byte array first to determine size
-            ImageIO.write(resized, "png", byteArrayOutputStream);
-
-            // Now we know the content length
-            byte[] imageData = byteArrayOutputStream.toByteArray();
-            response.setContentLength(imageData.length);
-
-            // Write the data to the actual response
-            response.getOutputStream().write(imageData);
+    private ResponseEntity<Resource> serveResizedImage(Path imagePath,
+                                   String originalImageName, HttpHeaders responseHeaders, int size) throws IOException {
+        if (size < MIN_IMAGE_SIZE || size > MAX_IMAGE_SIZE) {
+            throw new IllegalArgumentException(String.format(
+                "Image can only be resized from %d to %d. You requested %d.",
+                MIN_IMAGE_SIZE, MAX_IMAGE_SIZE, size));
         }
+
+        // Resize the image
+        BufferedImage originalImage = ImageIO.read(imagePath.toFile());
+        BufferedImage resizedImage = ImageUtil.resize(originalImage, size);
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        ImageIO.write(resizedImage, "png", outputStream);
+        ByteArrayResource imgResource = new ByteArrayResource(outputStream.toByteArray());
+
+        // Generate a new filename for the resized image
+        // Use the original filename without extension and append .png
+        String pngFilename = originalImageName.substring(0, originalImageName.lastIndexOf('.')) + ".png";
+
+        // Resized image headers
+        responseHeaders.setContentType(MediaType.IMAGE_PNG);
+        responseHeaders.setContentDisposition(ContentDisposition.attachment().filename(pngFilename).build());
+        responseHeaders.setContentLength(imgResource.contentLength());
+
+        return ResponseEntity.ok().headers(responseHeaders).body(imgResource);
     }
-
-    /**
-     * Handles range requests for partial content delivery.
-     * Supports resumable downloads by serving only the requested byte range.
-     *
-     * @param response HTTP response to write the content to
-     * @param filePath Path to the file being served
-     * @param rangeHeader Range header from the request (e.g. "bytes=0-499")
-     * @param fileSize Size of the file being served
-     * @throws IOException If an I/O error occurs while reading or writing the file
-     */
-    private void serveAttachmentWithRange(HttpServletResponse response, Path filePath,
-                                          String rangeHeader, long fileSize) throws IOException {
-        // Parse the range header (format: "bytes=start-end" or "bytes=start-")
-        String range = rangeHeader.substring("bytes=".length());
-        String[] parts = range.split("-");
-
-        long start = 0;
-        long end = fileSize - 1;
-
-        if (parts.length > 0 && !parts[0].isEmpty()) {
-            start = Long.parseLong(parts[0]);
-        }
-
-        if (parts.length > 1 && !parts[1].isEmpty()) {
-            end = Long.parseLong(parts[1]);
-        }
-
-        // Validate range
-        if (start < 0 || start >= fileSize || start > end) {
-            response.setStatus(HttpServletResponse.SC_REQUESTED_RANGE_NOT_SATISFIABLE);
-            response.setHeader(HttpHeaders.CONTENT_RANGE, "bytes */" + fileSize);
-            return;
-        }
-
-        // Adjust end if necessary
-        if (end >= fileSize) {
-            end = fileSize - 1;
-        }
-
-        // Calculate content length
-        long contentLength = end - start + 1;
-
-        // Set partial content response headers
-        response.setStatus(HttpServletResponse.SC_PARTIAL_CONTENT);
-        response.setHeader(HttpHeaders.CONTENT_RANGE, "bytes " + start + "-" + end + "/" + fileSize);
-        response.setContentLengthLong(contentLength);
-
-        // Stream the requested byte range with appropriate buffer size
-        try (InputStream inputStream = Files.newInputStream(filePath);
-             BufferedInputStream bufferedStream = new BufferedInputStream(inputStream, BUFFER_SIZE)) {
-            long skipped = 0;
-            while (skipped < start) {
-                long toSkip = start - skipped;
-                long actuallySkipped = bufferedStream.skip(toSkip);
-                if (actuallySkipped <= 0) break; // EOF
-                skipped += actuallySkipped;
-            }
-            byte[] buffer = new byte[BUFFER_SIZE];
-            long bytesRemaining = contentLength;
-            int bytesRead;
-
-            while (bytesRemaining > 0 && (bytesRead = bufferedStream.read(buffer, 0,
-                (int) Math.min(buffer.length, bytesRemaining))) != -1) {
-                response.getOutputStream().write(buffer, 0, bytesRead);
-                bytesRemaining -= bytesRead;
-            }
-        }
-    }
-
 }


### PR DESCRIPTION
Currently there are issues downloading attachments and displaying thumbnails. These issues seem to be caused by the newly introduced `etag`/`lastModifiedDate`/`304` logic. The server attempts to send `304` to the client but the `@ResponseStatus(value = HttpStatus.OK)` annotation was forcing a `200`.

Identified by @josegar74 in #8940

Reproduction steps:
1. Load ISO19139 samples
2. Go to the metadata page of Hydrological Basins in Africa (Sample record, please remove!)--> thumbnails are displayed.
3. Copy the URL of one of the thumbnails
4. Refresh the browser page --> Thumbnails are not displayed.
5. Paste the URL from item 3 in a new browser tab. A dialog to save the file is displayed, saving the file, the size is 0.
  
This PR aims to fix this issue by removing the above mentioned annotation and setting the response code manually.

**Additionally it seems that spring can handle the range requests automatically when a `ResponseEntity<Resource>` is returned. This greatly simplifies the code and removes the need for the `serveAttachmentWithRange` method.**
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

