### PR TITLE
Fix batch validation and editor validation do not output the same result

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataManager.java
@@ -285,4 +285,16 @@ public interface IMetadataManager {
 
 
 	public Map<Integer, MetadataSourceInfo> findAllSourceInfo(Specification<? extends AbstractMetadata> specs);
+
+    /**
+     * Inflates a metadata XML document by applying a transformation using a specified XSLT stylesheet.
+     * If the stylesheet does not exist, the original metadata is returned unchanged.
+     *
+     * @param metadataXml The metadata XML document to be inflated.
+     * @param schema The schema associated with the metadata, used to locate the XSLT stylesheet.
+     * @param lang The language to be used in the transformation environment.
+     * @return The transformed metadata XML document, or the original metadata if no stylesheet is found.
+     * @throws Exception If an error occurs during the transformation process.
+     */
+    public Element inflateMetadata(Element metadataXml, String schema, String lang) throws Exception;
 }

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataValidator.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataValidator.java
@@ -73,7 +73,7 @@ public interface IMetadataValidator {
      * @param metadata metadata
      * @param lang     Language from context
      */
-    Pair<Element, Boolean> doValidate(AbstractMetadata metadata, String lang);
+    Pair<Element, Boolean> doValidate(AbstractMetadata metadata, String lang) throws Exception;
 
     /**
      * Used by the validate embedded service. The validation report is stored in the session.

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataValidator.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataValidator.java
@@ -364,7 +364,7 @@ public class BaseMetadataValidator implements org.fao.geonet.kernel.datamanager.
      * @param lang     Language from context
      */
     @Override
-    public Pair<Element, Boolean> doValidate(AbstractMetadata metadata, String lang) {
+    public Pair<Element, Boolean> doValidate(AbstractMetadata metadata, String lang) throws Exception {
         String schema = metadata.getDataInfo().getSchemaId();
         int metadataId = metadata.getId();
         Element errorReport = new Element("report", Edit.NAMESPACE);
@@ -376,6 +376,9 @@ public class BaseMetadataValidator implements org.fao.geonet.kernel.datamanager.
         } catch (IOException | JDOMException e) {
             return Pair.read(errorReport, false);
         }
+
+        // Inflate the metadata so that it contains all the necessary information for validation.
+        md = metadataManager.inflateMetadata(md, schema, lang);
 
         List<MetadataValidation> validations = new ArrayList<>();
         boolean valid = true;
@@ -408,7 +411,7 @@ public class BaseMetadataValidator implements org.fao.geonet.kernel.datamanager.
 
             // Apply custom schematron rules
             Element schemaTronReport = applyCustomSchematronRules(schema, metadataId, md, lang, validations);
-            if (valid && schemaTronReport != null) {
+            if (schemaTronReport != null) {
                 List<Namespace> theNSs = new ArrayList<Namespace>();
                 theNSs.add(Namespace.getNamespace("geonet", "http://www.fao.org/geonetwork"));
                 theNSs.add(Namespace.getNamespace("svrl", "http://purl.oclc.org/dsdl/svrl"));


### PR DESCRIPTION
Currently the batch validation from the search page and editor board does not output the same results as the validation from within the metadata editor.

For example the iso19139.ca.HNAP rule for topicCategory is defined as:
```XML
<sch:rule context="//gmd:identificationInfo/*/gmd:topicCategory  
        |//*[@gco:isoType='gmd:MD_DataIdentification']/gmd:topicCategory
        |//*[@gco:isoType='srv:SV_ServiceIdentification']/gmd:topicCategory">  
  
  <sch:let name="missing" value="not(string(gmd:MD_TopicCategoryCode))  
            " />  
  
  <sch:assert  
    test="not($missing)"  
  >$loc/strings/TopicCategory</sch:assert>  
</sch:rule>
```

The validation from the editor shows:
<img width="434" height="230" alt="image" src="https://github.com/user-attachments/assets/0613f5d3-d282-4427-82f9-55d636a3d6ed" />

But the batch validation outputs:
<img width="750" height="452" alt="image" src="https://github.com/user-attachments/assets/96b58583-aeff-4d17-ad25-e3a0b140f470" />

This issue occurs on the above mentioned rule because the rule is checking for a `gmd:MD_TopicCategoryCode` on the `gmd:topicCategory`. If the `gmd:topicCategory` itself is missing the rule is never fired so no error message is produced.

This PR aims to fix this issue by inflating the metadata before performing the batch validation. This aligns with the metadata editor validation logic as the metadata is inflated when the metadata editor is opened. For the above mentioned rule the inflation would add the missing `gmd:topicCategory` so the validation can fail as expected.

Additionally the schematron errors are not output if there are any xsd errors. This is confusing for users as there could be more error messages than the ones they are seeing. The schematron error messages also seem to be easier to understand for users.

This PR aims to fix this issue by removing the condition which only adds schematron errors if the xsd is valid.

With the fixes:
<img width="732" height="554" alt="image" src="https://github.com/user-attachments/assets/d9c954c1-5ff4-4d6c-93b3-7c02e0f81bbf" />
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
