### PR TITLE
Allow rename files in metadata file store

### DIFF
--- a/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
@@ -311,6 +311,11 @@ public abstract class AbstractStore implements Store {
         }
     }
 
+    @Override
+    public MetadataResource renameResource(ServiceContext context, String metadataUuid, String resourceId, String newName, Boolean approved) throws Exception {
+        throw new UnsupportedOperationException("renameResource is not supported by " + getClass().getSimpleName());
+    }
+
     protected String getFilename(final String metadataUuid, final String resourceId) {
         // It's not always clear when we get a resourceId or a filename
         String prefix = metadataUuid + "/attachments/";

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
@@ -55,6 +55,7 @@ import java.net.URLDecoder;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Base64;
+import java.util.Date;
 import java.util.List;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -313,7 +314,21 @@ public abstract class AbstractStore implements Store {
 
     @Override
     public MetadataResource renameResource(ServiceContext context, String metadataUuid, String resourceId, String newName, Boolean approved) throws Exception {
-        throw new UnsupportedOperationException("renameResource is not supported by " + getClass().getSimpleName());
+        int metadataId = canEdit(context, metadataUuid, approved);
+        checkResourceId(newName);
+        try (ResourceHolder resourceHolder = getResource(context, metadataUuid, resourceId, approved)) {
+            MetadataResource metadataResource = resourceHolder.getMetadata();
+            MetadataResourceVisibility visibility = metadataResource != null ? metadataResource.getVisibility() : MetadataResourceVisibility.PRIVATE;
+            Date changeDate = metadataResource != null ? metadataResource.getLastModification() : null;
+            try (InputStream is = resourceHolder.getResource().getInputStream()) {
+                MetadataResource newResource = putResource(context, metadataUuid, newName, is, changeDate, visibility, approved);
+                delResource(context, metadataUuid, visibility, resourceId, approved);
+                return newResource;
+            }
+        } catch (Exception e) {
+            log.error("Unable to rename resource '{}' for metadata {} ({}). {}", resourceId, metadataId, metadataUuid, e.getMessage(), e);
+            throw e;
+        }
     }
 
     protected String getFilename(final String metadataUuid, final String resourceId) {

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
@@ -326,8 +326,8 @@ public abstract class AbstractStore implements Store {
                 return newResource;
             }
         } catch (Exception e) {
-            log.error("Unable to rename resource '{}' for metadata {} ({}). {}", resourceId, metadataId, metadataUuid, e.getMessage(), e);
-            throw e;
+            throw new Exception(String.format("Unable to rename resource '%s' for metadata %d (%s): %s",
+                resourceId, metadataId, metadataUuid, e.getMessage()), e);
         }
     }
 

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
@@ -344,8 +344,14 @@ public abstract class AbstractStore implements Store {
     }
 
     protected void checkResourceId(final String resourceId) {
+        if (resourceId == null) {
+            throw new IllegalArgumentException("Resource identifier cannot be null.");
+        }
         if (resourceId.contains("..") || resourceId.startsWith("/") || resourceId.startsWith("file:/")) {
             throw new SecurityException(String.format("Invalid resource identifier '%s'.", resourceId));
+        }
+        if (resourceId.length() > 255) {
+            throw new IllegalArgumentException(String.format("Resource identifier '%s' exceeds maximum allowed length of 255 characters.", resourceId));
         }
     }
 

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
@@ -30,6 +30,7 @@ import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.api.exception.NotAllowedException;
 import org.fao.geonet.api.exception.InputStreamLimitExceededException;
+import org.fao.geonet.api.exception.ResourceAlreadyExistException;
 import org.fao.geonet.api.exception.ResourceNotFoundException;
 import org.fao.geonet.domain.AbstractMetadata;
 import org.fao.geonet.domain.MetadataResource;
@@ -320,11 +321,27 @@ public abstract class AbstractStore implements Store {
             MetadataResource metadataResource = resourceHolder.getMetadata();
             MetadataResourceVisibility visibility = metadataResource != null ? metadataResource.getVisibility() : MetadataResourceVisibility.PRIVATE;
             Date changeDate = metadataResource != null ? metadataResource.getLastModification() : null;
+            MetadataResource newResource;
             try (InputStream is = resourceHolder.getResource().getInputStream()) {
-                MetadataResource newResource = putResource(context, metadataUuid, newName, is, changeDate, visibility, approved);
-                delResource(context, metadataUuid, visibility, resourceId, approved);
-                return newResource;
+                newResource = putResource(context, metadataUuid, newName, is, changeDate, visibility, approved);
             }
+            try {
+                delResource(context, metadataUuid, visibility, resourceId, approved);
+            } catch (Exception deleteException) {
+                // Roll back the newly created copy so a failed rename doesn't leave the resource duplicated
+                try {
+                    delResource(context, metadataUuid, visibility, newName, approved);
+                } catch (Exception rollbackException) {
+                    log.error(String.format(
+                        "Unable to roll back resource '%s' created while renaming '%s' for metadata %d (%s): %s",
+                        newName, resourceId, metadataId, metadataUuid, rollbackException.getMessage()), rollbackException);
+                }
+                throw deleteException;
+            }
+            return newResource;
+        } catch (SecurityException | IllegalArgumentException | ResourceNotFoundException | ResourceAlreadyExistException e) {
+            // Rethrow as-is so the original exception type (and its mapped HTTP status) is preserved.
+            throw e;
         } catch (Exception e) {
             throw new Exception(String.format("Unable to rename resource '%s' for metadata %d (%s): %s",
                 resourceId, metadataId, metadataUuid, e.getMessage()), e);

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
@@ -66,8 +66,8 @@ public abstract class AbstractStore implements Store {
     protected static final String RESOURCE_MANAGEMENT_EXTERNAL_PROPERTIES_ESCAPED_SEPARATOR = "\\:";
     private static final Logger log = LoggerFactory.getLogger(AbstractStore.class);
 
-    @Value("${api.params.maxUploadSize}")
-    protected long maxUploadSize;
+    @Value("${api.params.maxUploadSize:104857600}")
+    protected long maxUploadSize = 104857600L;
 
     @Override
     public final List<MetadataResource> getResources(final ServiceContext context, final String metadataUuid, final Sort sort,

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStore.java
@@ -226,9 +226,10 @@ public class FilesystemStore extends AbstractStore {
     public MetadataResource renameResource(ServiceContext context, String metadataUuid, String resourceId, String newName, Boolean approved) throws Exception {
         int metadataId = getAndCheckMetadataId(metadataUuid, approved);
         checkResourceId(newName);
-        try (ResourceHolder filePath = getResource(context, metadataUuid, resourceId, approved)) {
+        try (ResourceHolder resourceHolder = getResource(context, metadataUuid, resourceId, approved)) {
+            Path currentFilePath = getResourcePath(resourceHolder.getResource(), context);
             Path newFilePath = getPath(context, metadataId, MetadataResourceVisibility.PRIVATE, newName, approved);
-            Files.move(filePath.getPath(), newFilePath, StandardCopyOption.REPLACE_EXISTING);
+            Files.move(currentFilePath, newFilePath, StandardCopyOption.REPLACE_EXISTING);
             return getResourceDescription(context, metadataUuid, MetadataResourceVisibility.PRIVATE, newFilePath, approved);
         } catch (IOException e) {
             Log.error(Geonet.RESOURCES,

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStore.java
@@ -222,6 +222,21 @@ public class FilesystemStore extends AbstractStore {
         return new FilesystemStoreResourceContainer(metadataUuid, metadataId, metadataUuid, settingManager.getNodeURL() + "api/records/", approved);
     }
 
+    @Override
+    public MetadataResource renameResource(ServiceContext context, String metadataUuid, String resourceId, String newName, Boolean approved) throws Exception {
+        int metadataId = getAndCheckMetadataId(metadataUuid, approved);
+        checkResourceId(newName);
+        try (ResourceHolder filePath = getResource(context, metadataUuid, resourceId, approved)) {
+            Path newFilePath = getPath(context, metadataId, MetadataResourceVisibility.PRIVATE, newName, approved);
+            Files.move(filePath.getPath(), newFilePath, StandardCopyOption.REPLACE_EXISTING);
+            return getResourceDescription(context, metadataUuid, MetadataResourceVisibility.PRIVATE, newFilePath, approved);
+        } catch (IOException e) {
+            Log.error(Geonet.RESOURCES,
+                String.format("Unable to rename resource '%s' for metadata %d (%s). %s", resourceId, metadataId, metadataUuid, e.getMessage()));
+        }
+        return null;
+    }
+
 
     @Override
     public MetadataResource putResource(final ServiceContext context, final String metadataUuid, final String filename,

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStore.java
@@ -227,15 +227,19 @@ public class FilesystemStore extends AbstractStore {
         int metadataId = getAndCheckMetadataId(metadataUuid, approved);
         checkResourceId(newName);
         try (ResourceHolder resourceHolder = getResource(context, metadataUuid, resourceId, approved)) {
+            MetadataResourceVisibility visibility = resourceHolder.getMetadata().getVisibility();
             Path currentFilePath = getResourcePath(resourceHolder.getResource(), context);
-            Path newFilePath = getPath(context, metadataId, MetadataResourceVisibility.PRIVATE, newName, approved);
-            Files.move(currentFilePath, newFilePath, StandardCopyOption.REPLACE_EXISTING);
-            return getResourceDescription(context, metadataUuid, MetadataResourceVisibility.PRIVATE, newFilePath, approved);
+            Path newFilePath = getPath(context, metadataId, visibility, newName, approved);
+            if (Files.exists(newFilePath)) {
+                throw new ResourceAlreadyExistException(
+                    String.format("A resource with name '%s' and status '%s' already exists for metadata '%d'.", newName, visibility, metadataId));
+            }
+            Files.move(currentFilePath, newFilePath);
+            return getResourceDescription(context, metadataUuid, visibility, newFilePath, approved);
         } catch (IOException e) {
-            Log.error(Geonet.RESOURCES,
-                String.format("Unable to rename resource '%s' for metadata %d (%s). %s", resourceId, metadataId, metadataUuid, e.getMessage()));
+            throw new IOException(
+                String.format("Unable to rename resource '%s' for metadata %d (%s). %s", resourceId, metadataId, metadataUuid, e.getMessage()), e);
         }
-        return null;
     }
 
 

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/ResourceLoggerStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/ResourceLoggerStore.java
@@ -294,4 +294,13 @@ public class ResourceLoggerStore extends AbstractStore {
         }
 
     }
+
+    @Override
+    public MetadataResource renameResource(ServiceContext context, String metadataUuid, String resourceId, String newName, Boolean approved) throws Exception {
+        if (decoratedStore != null) {
+            return decoratedStore.renameResource(context, metadataUuid, resourceId, newName, approved);
+        }
+
+        return null;
+    }
 }

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/ResourceLoggerStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/ResourceLoggerStore.java
@@ -295,10 +295,38 @@ public class ResourceLoggerStore extends AbstractStore {
 
     }
 
+    /**
+     * Stores a file upload rename request in the MetadataFileUploads table.
+     */
+    private void storeRenameRequest(final String metadataUuid, final String resourceId, final String newName, Boolean approved) throws Exception {
+        final ConfigurableApplicationContext context = ApplicationContextHolder.get();
+        final int metadataId = getAndCheckMetadataId(metadataUuid, approved);
+
+        MetadataFileUploadRepository repo = context.getBean(MetadataFileUploadRepository.class);
+        String oldFileName = getFilename(metadataUuid, resourceId);
+        String newFileName = getFilename(metadataUuid, newName);
+
+        try {
+            MetadataFileUpload metadataFileUpload = repo.findByMetadataIdAndFileNameNotDeleted(metadataId, oldFileName);
+            if (metadataFileUpload != null) {
+                metadataFileUpload.setFileName(newFileName);
+                repo.save(metadataFileUpload);
+            }
+        } catch (Exception ex) {
+            Log.debug(Geonet.RESOURCES, String.format(
+                "No references in MetadataFileUploads repository for metadata '%s', resource '%s' when renaming to '%s'.",
+                metadataUuid, oldFileName, newFileName));
+        }
+    }
+
     @Override
     public MetadataResource renameResource(ServiceContext context, String metadataUuid, String resourceId, String newName, Boolean approved) throws Exception {
         if (decoratedStore != null) {
-            return decoratedStore.renameResource(context, metadataUuid, resourceId, newName, approved);
+            MetadataResource renamedResource = decoratedStore.renameResource(context, metadataUuid, resourceId, newName, approved);
+            if (renamedResource != null) {
+                storeRenameRequest(metadataUuid, resourceId, newName, approved);
+            }
+            return renamedResource;
         }
 
         return null;

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/ResourceLoggerStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/ResourceLoggerStore.java
@@ -298,24 +298,35 @@ public class ResourceLoggerStore extends AbstractStore {
     /**
      * Stores a file upload rename request in the MetadataFileUploads table.
      */
-    private void storeRenameRequest(final String metadataUuid, final String resourceId, final String newName, Boolean approved) throws Exception {
+    private void storeRenameRequest(final String metadataUuid, final String resourceId, final MetadataResource renamedResource, Boolean approved) throws Exception {
         final ConfigurableApplicationContext context = ApplicationContextHolder.get();
         final int metadataId = getAndCheckMetadataId(metadataUuid, approved);
 
         MetadataFileUploadRepository repo = context.getBean(MetadataFileUploadRepository.class);
         String oldFileName = getFilename(metadataUuid, resourceId);
-        String newFileName = getFilename(metadataUuid, newName);
+        String fullResourceId = metadataUuid + "/attachments/" + oldFileName;
 
+        MetadataFileUpload metadataFileUpload = null;
         try {
-            MetadataFileUpload metadataFileUpload = repo.findByMetadataIdAndFileNameNotDeleted(metadataId, oldFileName);
-            if (metadataFileUpload != null) {
-                metadataFileUpload.setFileName(newFileName);
-                repo.save(metadataFileUpload);
-            }
+            metadataFileUpload = repo.findByMetadataIdAndFileNameNotDeleted(metadataId, fullResourceId);
         } catch (Exception ex) {
-            Log.debug(Geonet.RESOURCES, String.format(
-                "No references in MetadataFileUploads repository for metadata '%s', resource '%s' when renaming to '%s'.",
-                metadataUuid, oldFileName, newFileName));
+            try {
+                metadataFileUpload = repo.findByMetadataIdAndFileNameNotDeleted(metadataId, resourceId);
+            } catch (Exception ex2) {
+                try {
+                    metadataFileUpload = repo.findByMetadataIdAndFileNameNotDeleted(metadataId, oldFileName);
+                } catch (Exception ex3) {
+                    Log.debug(Geonet.RESOURCES, String.format(
+                        "No references in MetadataFileUploads repository for metadata '%s', resource '%s' when renaming to '%s'.",
+                        metadataUuid, resourceId, renamedResource.getId()));
+                }
+            }
+        }
+
+        if (metadataFileUpload != null) {
+            String targetName = metadataFileUpload.getFileName().contains("/") ? renamedResource.getId() : renamedResource.getFilename();
+            metadataFileUpload.setFileName(targetName);
+            repo.save(metadataFileUpload);
         }
     }
 
@@ -324,7 +335,7 @@ public class ResourceLoggerStore extends AbstractStore {
         if (decoratedStore != null) {
             MetadataResource renamedResource = decoratedStore.renameResource(context, metadataUuid, resourceId, newName, approved);
             if (renamedResource != null) {
-                storeRenameRequest(metadataUuid, resourceId, newName, approved);
+                storeRenameRequest(metadataUuid, resourceId, renamedResource, approved);
             }
             return renamedResource;
         }

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/ResourceLoggerStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/ResourceLoggerStore.java
@@ -309,13 +309,13 @@ public class ResourceLoggerStore extends AbstractStore {
         MetadataFileUpload metadataFileUpload = null;
         try {
             metadataFileUpload = repo.findByMetadataIdAndFileNameNotDeleted(metadataId, fullResourceId);
-        } catch (Exception ex) {
+        } catch (org.springframework.dao.EmptyResultDataAccessException ex) {
             try {
                 metadataFileUpload = repo.findByMetadataIdAndFileNameNotDeleted(metadataId, resourceId);
-            } catch (Exception ex2) {
+            } catch (org.springframework.dao.EmptyResultDataAccessException ex2) {
                 try {
                     metadataFileUpload = repo.findByMetadataIdAndFileNameNotDeleted(metadataId, oldFileName);
-                } catch (Exception ex3) {
+                } catch (org.springframework.dao.EmptyResultDataAccessException ex3) {
                     Log.debug(Geonet.RESOURCES, String.format(
                         "No references in MetadataFileUploads repository for metadata '%s', resource '%s' when renaming to '%s'.",
                         metadataUuid, resourceId, renamedResource.getId()));

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/Store.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/Store.java
@@ -418,6 +418,8 @@ public interface Store {
      */
     MetadataResource getResourceMetadata(ServiceContext context, String metadataUuid, String resourceId, Boolean approved) throws Exception;
 
+    MetadataResource renameResource(ServiceContext context, String metadataUuid, String resourceId, String newName, Boolean approved) throws Exception;
+
     interface ResourceHolder extends Closeable {
         Resource getResource();
         MetadataResource getMetadata();

--- a/datastorages/s3/src/main/java/org/fao/geonet/api/records/attachments/S3Store.java
+++ b/datastorages/s3/src/main/java/org/fao/geonet/api/records/attachments/S3Store.java
@@ -217,6 +217,45 @@ public class S3Store extends AbstractStore {
     }
 
     @Override
+    public MetadataResource renameResource(ServiceContext context, String metadataUuid, String resourceId, String newName, Boolean approved) throws Exception {
+        int metadataId = canEdit(context, metadataUuid, approved);
+        checkResourceId(newName);
+
+        String sourceKey = null;
+        ObjectMetadata objectMetadata = null;
+        MetadataResourceVisibility sourceVisibility = null;
+        for (MetadataResourceVisibility visibility : MetadataResourceVisibility.values()) {
+            final String key = getKey(metadataUuid, metadataId, visibility, resourceId);
+            try {
+                objectMetadata = s3.getClient().getObjectMetadata(s3.getBucket(), key);
+                sourceKey = key;
+                sourceVisibility = visibility;
+                break;
+            } catch (AmazonServiceException ignored) {
+                // ignored
+            }
+        }
+
+        if (sourceKey != null) {
+            final String destKey = getKey(metadataUuid, metadataId, sourceVisibility, newName);
+            if (sourceKey.equals(destKey)) {
+                return createResourceDescription(metadataUuid, sourceVisibility, newName, objectMetadata.getContentLength(),
+                                                 objectMetadata.getLastModified(), metadataId, approved);
+            }
+            final CopyObjectResult copyResult = s3.getClient().copyObject(
+                s3.getBucket(), sourceKey, s3.getBucket(), destKey);
+            s3.getClient().deleteObject(s3.getBucket(), sourceKey);
+            return createResourceDescription(metadataUuid, sourceVisibility, newName, objectMetadata.getContentLength(),
+                                             copyResult.getLastModifiedDate(), metadataId, approved);
+        } else {
+            throw new ResourceNotFoundException(
+                    String.format("Metadata resource '%s' not found for metadata '%s'", resourceId, metadataUuid))
+                    .withMessageKey("exception.resourceNotFound.resource", new String[]{resourceId})
+                    .withDescriptionKey("exception.resourceNotFound.resource.description", new String[]{resourceId, metadataUuid});
+        }
+    }
+
+    @Override
     public String delResources(final ServiceContext context, final int metadataId) throws Exception {
         try {
             final ListObjectsV2Result objects = s3.getClient().listObjectsV2(

--- a/datastorages/s3/src/main/java/org/fao/geonet/api/records/attachments/S3Store.java
+++ b/datastorages/s3/src/main/java/org/fao/geonet/api/records/attachments/S3Store.java
@@ -27,6 +27,7 @@ package org.fao.geonet.api.records.attachments;
 import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.s3.model.*;
 import jeeves.server.context.ServiceContext;
+import org.fao.geonet.api.exception.ResourceAlreadyExistException;
 import org.fao.geonet.api.exception.ResourceNotFoundException;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.MetadataResource;
@@ -241,6 +242,14 @@ public class S3Store extends AbstractStore {
             if (sourceKey.equals(destKey)) {
                 return createResourceDescription(metadataUuid, sourceVisibility, newName, objectMetadata.getContentLength(),
                                                  objectMetadata.getLastModified(), metadataId, approved);
+            }
+            try {
+                s3.getClient().getObjectMetadata(s3.getBucket(), destKey);
+                throw new ResourceAlreadyExistException(
+                    String.format("A resource with name '%s' and status '%s' already exists for metadata '%s'.",
+                        newName, sourceVisibility, metadataUuid));
+            } catch (AmazonServiceException ignored) {
+                // destination does not exist, safe to proceed
             }
             final CopyObjectResult copyResult = s3.getClient().copyObject(
                 s3.getBucket(), sourceKey, s3.getBucket(), destKey);

--- a/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsActionsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsActionsApi.java
@@ -36,14 +36,11 @@ import org.fao.geonet.api.ApiParams;
 import org.fao.geonet.api.ApiUtils;
 import org.fao.geonet.domain.MetadataResource;
 import org.fao.geonet.domain.MetadataResourceVisibility;
-import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.thumbnail.ThumbnailMaker;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.io.PathResource;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
-import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.stereotype.Service;
 import org.springframework.web.bind.annotation.*;
@@ -64,8 +61,7 @@ import static org.fao.geonet.api.ApiParams.API_PARAM_RECORD_UUID;
     description = API_CLASS_RECORD_OPS)
 public class AttachmentsActionsApi {
     private final ApplicationContext appContext = ApplicationContextHolder.get();
-    @Autowired
-    DataManager dataMan;
+
     @Autowired
     ThumbnailMaker thumbnailMaker;
     private Store store;
@@ -140,22 +136,5 @@ public class AttachmentsActionsApi {
                 FileUtils.deleteQuietly(thumbnailFile.toFile());
             }
         }
-    }
-
-    @io.swagger.v3.oas.annotations.Operation(summary = "Rename a metadata resource name")
-    @PreAuthorize("hasAuthority('Editor')")
-    @ApiResponses(value = {@ApiResponse(responseCode = "201", description = "Resource name updated."),
-        @ApiResponse(responseCode = "403", description = ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_EDIT)})
-    @RequestMapping(value = "/{portal}/api/records/{metadataUuid}/attachments/{resourceId:.+}/rename", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
-    @ResponseStatus(value = HttpStatus.CREATED)
-    @ResponseBody
-    public MetadataResource renameResource(
-        @Parameter(description = "The metadata UUID", required = true, example = "43d7c186-2187-4bcd-8843-41e575a5ef56") @PathVariable String metadataUuid,
-        @Parameter(description = "The resource identifier (ie. filename)", required = true) @PathVariable String resourceId,
-        @Parameter(description = "The new name for the resource", required = true) @RequestParam(required = true) String newName,
-        @Parameter(description = "Use approved version or not", example = "true") @RequestParam(required = false, defaultValue = "false") Boolean approved,
-        @Parameter(hidden = true) HttpServletRequest request) throws Exception {
-        ServiceContext context = ApiUtils.createServiceContext(request);
-        return store.renameResource(context, metadataUuid, resourceId, newName, approved);
     }
 }

--- a/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsActionsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsActionsApi.java
@@ -1,6 +1,6 @@
 /*
  * =============================================================================
- * ===	Copyright (C) 2001-2023 Food and Agriculture Organization of the
+ * ===	Copyright (C) 2001-2025 Food and Agriculture Organization of the
  * ===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * ===	and United Nations Environment Programme (UNEP)
  * ===
@@ -42,6 +42,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.io.PathResource;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.stereotype.Service;
 import org.springframework.web.bind.annotation.*;
@@ -138,5 +140,22 @@ public class AttachmentsActionsApi {
                 FileUtils.deleteQuietly(thumbnailFile.toFile());
             }
         }
+    }
+
+    @io.swagger.v3.oas.annotations.Operation(summary = "Rename a metadata resource name")
+    @PreAuthorize("hasAuthority('Editor')")
+    @ApiResponses(value = {@ApiResponse(responseCode = "201", description = "Resource name updated."),
+        @ApiResponse(responseCode = "403", description = ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_EDIT)})
+    @RequestMapping(value = "/{portal}/api/records/{metadataUuid}/attachments/{resourceId:.+}/rename", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
+    @ResponseStatus(value = HttpStatus.CREATED)
+    @ResponseBody
+    public MetadataResource renameResource(
+        @Parameter(description = "The metadata UUID", required = true, example = "43d7c186-2187-4bcd-8843-41e575a5ef56") @PathVariable String metadataUuid,
+        @Parameter(description = "The resource identifier (ie. filename)", required = true) @PathVariable String resourceId,
+        @Parameter(description = "The new name for the resource", required = true) @RequestParam(required = true) String newName,
+        @Parameter(description = "Use approved version or not", example = "true") @RequestParam(required = false, defaultValue = "false") Boolean approved,
+        @Parameter(hidden = true) HttpServletRequest request) throws Exception {
+        ServiceContext context = ApiUtils.createServiceContext(request);
+        return store.renameResource(context, metadataUuid, resourceId, newName, approved);
     }
 }

--- a/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsApi.java
@@ -50,6 +50,7 @@ import org.fao.geonet.events.history.AttachmentDeletedEvent;
 import org.fao.geonet.kernel.datamanager.IMetadataIndexer;
 import org.fao.geonet.kernel.datamanager.IMetadataManager;
 import org.fao.geonet.kernel.search.IndexingMode;
+import org.fao.geonet.kernel.search.submission.DirectIndexSubmitter;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.kernel.setting.Settings;
 import org.fao.geonet.util.FileMimetypeChecker;
@@ -403,7 +404,7 @@ public class AttachmentsApi {
             // Update the metadata references to the resource
             metadata.setData(metadata.getData().replaceAll(metadataResourceToUpdate.getMetadata().getUrl(), metadataResource.getUrl()));
             metadataManager.save(metadata);
-            metadataIndexer.indexMetadata(String.valueOf(metadata.getId()), true, IndexingMode.full);
+            metadataIndexer.indexMetadata(String.valueOf(metadata.getId()), DirectIndexSubmitter.INSTANCE, IndexingMode.full);
 
         }
         if (visibility != null) {

--- a/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsApi.java
@@ -41,11 +41,15 @@ import org.apache.commons.codec.digest.DigestUtils;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.api.ApiParams;
 import org.fao.geonet.api.ApiUtils;
+import org.fao.geonet.domain.AbstractMetadata;
 import org.fao.geonet.domain.MetadataResource;
 import org.fao.geonet.domain.MetadataResourceVisibility;
 import org.fao.geonet.domain.MetadataResourceVisibilityConverter;
 import org.fao.geonet.events.history.AttachmentAddedEvent;
 import org.fao.geonet.events.history.AttachmentDeletedEvent;
+import org.fao.geonet.kernel.datamanager.IMetadataIndexer;
+import org.fao.geonet.kernel.datamanager.IMetadataManager;
+import org.fao.geonet.kernel.search.IndexingMode;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.kernel.setting.Settings;
 import org.fao.geonet.util.FileMimetypeChecker;
@@ -100,6 +104,10 @@ public class AttachmentsApi {
     FileMimetypeChecker fileMimetypeChecker;
     @Autowired
     SettingManager settingManager;
+    @Autowired
+    private IMetadataManager metadataManager;
+    @Autowired
+    private IMetadataIndexer metadataIndexer;
 
     public AttachmentsApi() {
     }
@@ -381,13 +389,22 @@ public class AttachmentsApi {
         @Parameter(hidden = true) HttpServletRequest request) throws Exception {
         ServiceContext context = ApiUtils.createServiceContext(request);
 
+        AbstractMetadata metadata = ApiUtils.canViewRecord(metadataUuid, request);
+
         if (visibility == null && newResourceName == null) {
             throw new IllegalArgumentException("Either visibility or new resource name must be provided.");
         }
 
         MetadataResource metadataResource = null;
         if (newResourceName != null) {
+            Store.ResourceHolder metadataResourceToUpdate = store.getResource(context, metadataUuid, resourceId, approved);
             metadataResource = store.renameResource(context, metadataUuid, resourceId, newResourceName, approved);
+
+            // Update the metadata references to the resource
+            metadata.setData(metadata.getData().replaceAll(metadataResourceToUpdate.getMetadata().getUrl(), metadataResource.getUrl()));
+            metadataManager.save(metadata);
+            metadataIndexer.indexMetadata(String.valueOf(metadata.getId()), true, IndexingMode.full);
+
         }
         if (visibility != null) {
             metadataResource = store.patchResourceStatus(context, metadataUuid, resourceId, visibility, approved);

--- a/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsApi.java
@@ -365,9 +365,9 @@ public class AttachmentsApi {
     }
 
 
-    @io.swagger.v3.oas.annotations.Operation(summary = "Update the metadata resource visibility")
+    @io.swagger.v3.oas.annotations.Operation(summary = "Update the metadata resource visibility and/or the resource name")
     @PreAuthorize("hasAuthority('Editor')")
-    @ApiResponses(value = {@ApiResponse(responseCode = "201", description = "Attachment visibility updated."),
+    @ApiResponses(value = {@ApiResponse(responseCode = "201", description = "Attachment updated."),
         @ApiResponse(responseCode = "403", description = ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_EDIT)})
     @RequestMapping(value = "/{resourceId:.+}", method = RequestMethod.PATCH, produces = MediaType.APPLICATION_JSON_VALUE)
     @ResponseStatus(value = HttpStatus.CREATED)
@@ -375,11 +375,24 @@ public class AttachmentsApi {
     public MetadataResource patchResource(
         @Parameter(description = "The metadata UUID", required = true, example = "43d7c186-2187-4bcd-8843-41e575a5ef56") @PathVariable String metadataUuid,
         @Parameter(description = "The resource identifier (ie. filename)", required = true) @PathVariable String resourceId,
-        @Parameter(description = "The visibility", required = true, example = "public") @RequestParam(required = true) MetadataResourceVisibility visibility,
+        @Parameter(description = "The visibility", required = true, example = "public") @RequestParam(required = false) MetadataResourceVisibility visibility,
+        @Parameter(description = "The visibility", required = true, example = "public") @RequestParam(required = false) String newResourceName,
         @Parameter(description = "Use approved version or not", example = "true") @RequestParam(required = false, defaultValue = "false") Boolean approved,
         @Parameter(hidden = true) HttpServletRequest request) throws Exception {
         ServiceContext context = ApiUtils.createServiceContext(request);
-        return store.patchResourceStatus(context, metadataUuid, resourceId, visibility, approved);
+
+        if (visibility == null && newResourceName == null) {
+            throw new IllegalArgumentException("Either visibility or new resource name must be provided.");
+        }
+
+        MetadataResource metadataResource = null;
+        if (newResourceName != null) {
+            metadataResource = store.renameResource(context, metadataUuid, resourceId, newResourceName, approved);
+        }
+        if (visibility != null) {
+            metadataResource = store.patchResourceStatus(context, metadataUuid, resourceId, visibility, approved);
+        }
+        return metadataResource;
     }
 
     @io.swagger.v3.oas.annotations.Operation(summary = "Delete a metadata resource")

--- a/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsApi.java
@@ -101,13 +101,9 @@ public class AttachmentsApi {
     private final ApplicationContext appContext = ApplicationContextHolder.get();
     private Store store;
 
-    @Autowired
-    FileMimetypeChecker fileMimetypeChecker;
-    @Autowired
-    SettingManager settingManager;
-    @Autowired
+    private FileMimetypeChecker fileMimetypeChecker;
+    private SettingManager settingManager;
     private IMetadataManager metadataManager;
-    @Autowired
     private IMetadataIndexer metadataIndexer;
 
     public AttachmentsApi() {
@@ -115,6 +111,24 @@ public class AttachmentsApi {
 
     public AttachmentsApi(Store store) {
         this.store = store;
+    }
+
+    public AttachmentsApi(Store store, IMetadataManager metadataManager, IMetadataIndexer metadataIndexer) {
+        this.store = store;
+        this.metadataManager = metadataManager;
+        this.metadataIndexer = metadataIndexer;
+    }
+
+    @Autowired
+    public AttachmentsApi(
+        FileMimetypeChecker fileMimetypeChecker,
+        SettingManager settingManager,
+        IMetadataManager metadataManager,
+        IMetadataIndexer metadataIndexer) {
+        this.fileMimetypeChecker = fileMimetypeChecker;
+        this.settingManager = settingManager;
+        this.metadataManager = metadataManager;
+        this.metadataIndexer = metadataIndexer;
     }
 
     /**

--- a/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsApi.java
@@ -398,8 +398,8 @@ public class AttachmentsApi {
     public MetadataResource patchResource(
         @Parameter(description = "The metadata UUID", required = true, example = "43d7c186-2187-4bcd-8843-41e575a5ef56") @PathVariable String metadataUuid,
         @Parameter(description = "The resource identifier (ie. filename)", required = true) @PathVariable String resourceId,
-        @Parameter(description = "The visibility", required = true, example = "public") @RequestParam(required = false) MetadataResourceVisibility visibility,
-        @Parameter(description = "The visibility", required = true, example = "public") @RequestParam(required = false) String newResourceName,
+        @Parameter(description = "The visibility", example = "public") @RequestParam(required = false) MetadataResourceVisibility visibility,
+        @Parameter(description = "The new resource name") @RequestParam(required = false) String newResourceName,
         @Parameter(description = "Use approved version or not", example = "true") @RequestParam(required = false, defaultValue = "false") Boolean approved,
         @Parameter(hidden = true) HttpServletRequest request) throws Exception {
         ServiceContext context = ApiUtils.createServiceContext(request);
@@ -412,16 +412,14 @@ public class AttachmentsApi {
 
         MetadataResource metadataResource = null;
         if (newResourceName != null) {
-            try (Store.ResourceHolder metadataResourceToUpdate = store.getResource(context, metadataUuid, resourceId, approved)) {
-                metadataResource = store.renameResource(context, metadataUuid, resourceId, newResourceName, approved);
+            MetadataResource previousResource = store.getResourceMetadata(context, metadataUuid, resourceId, approved);
+            metadataResource = store.renameResource(context, metadataUuid, resourceId, newResourceName, approved);
 
-                if (metadataResourceToUpdate != null && metadataResourceToUpdate.getMetadata() != null
-                    && metadataResource != null && metadata != null && metadata.getData() != null) {
-                    // Update the metadata references to the resource
-                    metadata.setData(metadata.getData().replaceAll(metadataResourceToUpdate.getMetadata().getUrl(), metadataResource.getUrl()));
-                    metadataManager.save(metadata);
-                    metadataIndexer.indexMetadata(String.valueOf(metadata.getId()), DirectIndexSubmitter.INSTANCE, IndexingMode.full);
-                }
+            if (previousResource != null && metadataResource != null && metadata != null && metadata.getData() != null) {
+                // Update the metadata references to the resource
+                metadata.setData(metadata.getData().replace(previousResource.getUrl(), metadataResource.getUrl()));
+                metadataManager.save(metadata);
+                metadataIndexer.indexMetadata(String.valueOf(metadata.getId()), DirectIndexSubmitter.INSTANCE, IndexingMode.full);
             }
             resourceId = newResourceName;
         }

--- a/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsApi.java
@@ -412,14 +412,18 @@ public class AttachmentsApi {
 
         MetadataResource metadataResource = null;
         if (newResourceName != null) {
-            Store.ResourceHolder metadataResourceToUpdate = store.getResource(context, metadataUuid, resourceId, approved);
-            metadataResource = store.renameResource(context, metadataUuid, resourceId, newResourceName, approved);
+            try (Store.ResourceHolder metadataResourceToUpdate = store.getResource(context, metadataUuid, resourceId, approved)) {
+                metadataResource = store.renameResource(context, metadataUuid, resourceId, newResourceName, approved);
 
-            // Update the metadata references to the resource
-            metadata.setData(metadata.getData().replaceAll(metadataResourceToUpdate.getMetadata().getUrl(), metadataResource.getUrl()));
-            metadataManager.save(metadata);
-            metadataIndexer.indexMetadata(String.valueOf(metadata.getId()), DirectIndexSubmitter.INSTANCE, IndexingMode.full);
-
+                if (metadataResourceToUpdate != null && metadataResourceToUpdate.getMetadata() != null
+                    && metadataResource != null && metadata != null && metadata.getData() != null) {
+                    // Update the metadata references to the resource
+                    metadata.setData(metadata.getData().replaceAll(metadataResourceToUpdate.getMetadata().getUrl(), metadataResource.getUrl()));
+                    metadataManager.save(metadata);
+                    metadataIndexer.indexMetadata(String.valueOf(metadata.getId()), DirectIndexSubmitter.INSTANCE, IndexingMode.full);
+                }
+            }
+            resourceId = newResourceName;
         }
         if (visibility != null) {
             metadataResource = store.patchResourceStatus(context, metadataUuid, resourceId, visibility, approved);

--- a/services/src/test/java/org/fao/geonet/api/records/attachments/AbstractStoreTest.java
+++ b/services/src/test/java/org/fao/geonet/api/records/attachments/AbstractStoreTest.java
@@ -160,6 +160,41 @@ public abstract class AbstractStoreTest extends AbstractServiceIntegrationTest {
     }
 
     @Test
+    public void testRenameResource() throws Exception {
+        final ServiceContext context = createServiceContext();
+        loginAsAdmin(context);
+        String metadataId = importMetadata(context);
+        String metadataUuid = metadataUtils.getMetadataUuid(metadataId);
+
+        getStore().delResources(context, metadataUuid, true);
+
+        String filename = "record-with-old-links.xml";
+        String newFilename = "renamed-record.xml";
+        MultipartFile file = new MockMultipartFile(filename,
+            filename,
+            "application/xml",
+            Files.newInputStream(
+                Paths.get(resources, filename)
+            ));
+        getStore().putResource(context, metadataUuid, file, MetadataResourceVisibility.PUBLIC, true);
+
+        MetadataResource renamedResource = getStore().renameResource(context, metadataUuid, filename, newFilename, true);
+        assertEquals("Renamed resource id is correct",
+            metadataUuid + "/attachments/" + newFilename,
+            renamedResource.getId());
+        assertEquals("Renamed resource URL is correct",
+            "http://localhost:8080/srv/api/records/" + metadataUuid + "/attachments/" + newFilename,
+            renamedResource.getUrl());
+
+        List<MetadataResource> resourcesList =
+            getStore().getResources(context, metadataUuid, Sort.name, null, true);
+        assertEquals("1 resource for record after rename", 1, resourcesList.size());
+        assertEquals("Resource in list has new filename", newFilename, resourcesList.get(0).getFilename());
+
+        getStore().delResources(context, metadataUuid, true);
+    }
+
+    @Test
     public void testPutResourceFromURL() throws Exception {
         final ServiceContext context = createServiceContext();
         loginAsAdmin(context);

--- a/services/src/test/java/org/fao/geonet/api/records/attachments/AbstractStoreTest.java
+++ b/services/src/test/java/org/fao/geonet/api/records/attachments/AbstractStoreTest.java
@@ -251,6 +251,22 @@ public abstract class AbstractStoreTest extends AbstractServiceIntegrationTest {
         api.patchResource(metadataUuid, "somefile.xml", null, null, true, request);
     }
 
+    @Test(expected = IllegalArgumentException.class)
+    public void testRenameResourceExceedsMaxLength() throws Exception {
+        final ServiceContext context = createServiceContext();
+        loginAsAdmin(context);
+        String metadataId = importMetadata(context);
+        String metadataUuid = metadataUtils.getMetadataUuid(metadataId);
+
+        StringBuilder longName = new StringBuilder();
+        for (int i = 0; i < 260; i++) {
+            longName.append("a");
+        }
+        longName.append(".xml");
+
+        getStore().renameResource(context, metadataUuid, "somefile.xml", longName.toString(), true);
+    }
+
     @Test
     public void testResourceLoggerStoreRenameUploadRecord() throws Exception {
         final ServiceContext context = createServiceContext();

--- a/services/src/test/java/org/fao/geonet/api/records/attachments/AbstractStoreTest.java
+++ b/services/src/test/java/org/fao/geonet/api/records/attachments/AbstractStoreTest.java
@@ -53,6 +53,8 @@ import static org.junit.Assert.assertTrue;
 /**
  * Created by francois on 19/01/16.
  */
+import org.fao.geonet.domain.MetadataFileUpload;
+import org.fao.geonet.repository.MetadataFileUploadRepository;
 import org.fao.geonet.kernel.datamanager.IMetadataIndexer;
 import org.fao.geonet.kernel.datamanager.IMetadataManager;
 import org.springframework.mock.web.MockHttpServletRequest;
@@ -70,6 +72,8 @@ public abstract class AbstractStoreTest extends AbstractServiceIntegrationTest {
     protected IMetadataManager metadataManager;
     @Autowired
     protected IMetadataIndexer metadataIndexer;
+    @Autowired
+    protected MetadataFileUploadRepository uploadRepository;
 
     protected abstract Store getStore();
 
@@ -245,6 +249,41 @@ public abstract class AbstractStoreTest extends AbstractServiceIntegrationTest {
         MockHttpServletRequest request = new MockHttpServletRequest();
 
         api.patchResource(metadataUuid, "somefile.xml", null, null, true, request);
+    }
+
+    @Test
+    public void testResourceLoggerStoreRenameUploadRecord() throws Exception {
+        final ServiceContext context = createServiceContext();
+        loginAsAdmin(context);
+        String metadataIdStr = importMetadata(context);
+        int metadataId = Integer.parseInt(metadataIdStr);
+        String metadataUuid = metadataUtils.getMetadataUuid(metadataIdStr);
+
+        Store loggerStore = new ResourceLoggerStore(getStore());
+
+        String filename = "record-with-old-links.xml";
+        String newFilename = "logger-renamed-record.xml";
+        MultipartFile file = new MockMultipartFile(filename,
+            filename,
+            "application/xml",
+            Files.newInputStream(
+                Paths.get(resources, filename)
+            ));
+        loggerStore.putResource(context, metadataUuid, file, MetadataResourceVisibility.PUBLIC, true);
+
+        MetadataFileUpload initialUpload = uploadRepository.findByMetadataIdAndFileNameNotDeleted(metadataId, filename);
+        assertNotNull("Initial upload record in MetadataFileUploads should exist", initialUpload);
+        assertEquals("Initial upload record has old filename", filename, initialUpload.getFileName());
+
+        MetadataResource renamedResource = loggerStore.renameResource(context, metadataUuid, filename, newFilename, true);
+        assertNotNull("Renamed resource should not be null", renamedResource);
+
+        MetadataFileUpload updatedUpload = uploadRepository.findByMetadataIdAndFileNameNotDeleted(metadataId, newFilename);
+        assertNotNull("Updated upload record in MetadataFileUploads should exist with new filename", updatedUpload);
+        assertEquals("Updated upload record ID matches initial record ID", initialUpload.getId(), updatedUpload.getId());
+        assertEquals("Updated upload record has new filename", newFilename, updatedUpload.getFileName());
+
+        loggerStore.delResources(context, metadataUuid, true);
     }
 
     @Test

--- a/services/src/test/java/org/fao/geonet/api/records/attachments/AbstractStoreTest.java
+++ b/services/src/test/java/org/fao/geonet/api/records/attachments/AbstractStoreTest.java
@@ -287,17 +287,23 @@ public abstract class AbstractStoreTest extends AbstractServiceIntegrationTest {
             ));
         loggerStore.putResource(context, metadataUuid, file, MetadataResourceVisibility.PUBLIC, true);
 
-        MetadataFileUpload initialUpload = uploadRepository.findByMetadataIdAndFileNameNotDeleted(metadataId, filename);
+        MetadataFileUpload initialUpload = uploadRepository.findByMetadataIdAndFileNameNotDeleted(metadataId, metadataUuid + "/attachments/" + filename);
+        if (initialUpload == null) {
+            initialUpload = uploadRepository.findByMetadataIdAndFileNameNotDeleted(metadataId, filename);
+        }
         assertNotNull("Initial upload record in MetadataFileUploads should exist", initialUpload);
-        assertEquals("Initial upload record has old filename", filename, initialUpload.getFileName());
+        assertTrue("Initial upload record has old filename", initialUpload.getFileName().endsWith(filename));
 
         MetadataResource renamedResource = loggerStore.renameResource(context, metadataUuid, filename, newFilename, true);
         assertNotNull("Renamed resource should not be null", renamedResource);
 
-        MetadataFileUpload updatedUpload = uploadRepository.findByMetadataIdAndFileNameNotDeleted(metadataId, newFilename);
+        MetadataFileUpload updatedUpload = uploadRepository.findByMetadataIdAndFileNameNotDeleted(metadataId, renamedResource.getId());
+        if (updatedUpload == null) {
+            updatedUpload = uploadRepository.findByMetadataIdAndFileNameNotDeleted(metadataId, newFilename);
+        }
         assertNotNull("Updated upload record in MetadataFileUploads should exist with new filename", updatedUpload);
         assertEquals("Updated upload record ID matches initial record ID", initialUpload.getId(), updatedUpload.getId());
-        assertEquals("Updated upload record has new filename", newFilename, updatedUpload.getFileName());
+        assertTrue("Updated upload record has new filename", updatedUpload.getFileName().endsWith(newFilename));
 
         loggerStore.delResources(context, metadataUuid, true);
     }

--- a/services/src/test/java/org/fao/geonet/api/records/attachments/AbstractStoreTest.java
+++ b/services/src/test/java/org/fao/geonet/api/records/attachments/AbstractStoreTest.java
@@ -53,6 +53,11 @@ import static org.junit.Assert.assertTrue;
 /**
  * Created by francois on 19/01/16.
  */
+import org.fao.geonet.kernel.datamanager.IMetadataIndexer;
+import org.fao.geonet.kernel.datamanager.IMetadataManager;
+import org.springframework.mock.web.MockHttpServletRequest;
+import static org.junit.Assert.assertNotNull;
+
 public abstract class AbstractStoreTest extends AbstractServiceIntegrationTest {
 
     protected static String resources =
@@ -61,6 +66,10 @@ public abstract class AbstractStoreTest extends AbstractServiceIntegrationTest {
     protected IMetadataUtils metadataUtils;
     @Autowired
     private MetadataRepository _metadataRepo;
+    @Autowired
+    protected IMetadataManager metadataManager;
+    @Autowired
+    protected IMetadataIndexer metadataIndexer;
 
     protected abstract Store getStore();
 
@@ -192,6 +201,50 @@ public abstract class AbstractStoreTest extends AbstractServiceIntegrationTest {
         assertEquals("Resource in list has new filename", newFilename, resourcesList.get(0).getFilename());
 
         getStore().delResources(context, metadataUuid, true);
+    }
+
+    @Test
+    public void testAttachmentsApiPatchResourceRename() throws Exception {
+        final ServiceContext context = createServiceContext();
+        loginAsAdmin(context);
+        String metadataId = importMetadata(context);
+        String metadataUuid = metadataUtils.getMetadataUuid(metadataId);
+
+        getStore().delResources(context, metadataUuid, true);
+
+        String filename = "record-with-old-links.xml";
+        String newFilename = "api-renamed-record.xml";
+        MultipartFile file = new MockMultipartFile(filename,
+            filename,
+            "application/xml",
+            Files.newInputStream(
+                Paths.get(resources, filename)
+            ));
+        getStore().putResource(context, metadataUuid, file, MetadataResourceVisibility.PUBLIC, true);
+
+        AttachmentsApi api = new AttachmentsApi(getStore(), metadataManager, metadataIndexer);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+        request.setMethod("PATCH");
+        request.setRequestURI("/srv/api/records/" + metadataUuid + "/attachments/" + filename);
+
+        MetadataResource result = api.patchResource(metadataUuid, filename, null, newFilename, true, request);
+        assertNotNull("Renamed metadata resource should not be null", result);
+        assertEquals("Renamed resource filename is updated", newFilename, result.getFilename());
+
+        getStore().delResources(context, metadataUuid, true);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void testAttachmentsApiPatchResourceValidation() throws Exception {
+        final ServiceContext context = createServiceContext();
+        loginAsAdmin(context);
+        String metadataId = importMetadata(context);
+        String metadataUuid = metadataUtils.getMetadataUuid(metadataId);
+
+        AttachmentsApi api = new AttachmentsApi(getStore(), metadataManager, metadataIndexer);
+        MockHttpServletRequest request = new MockHttpServletRequest();
+
+        api.patchResource(metadataUuid, "somefile.xml", null, null, true, request);
     }
 
     @Test

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcService.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcService.js
@@ -508,6 +508,10 @@
           openCb[type] = fn;
         },
 
+        refresh: function () {
+          refreshForm(this);
+        },
+
         /**
          * @ngdoc method
          * @methodOf gn_onlinesrc.service:gnOnlinesrc

--- a/web-ui/src/main/resources/catalog/components/filestore/FileStoreDirective.js
+++ b/web-ui/src/main/resources/catalog/components/filestore/FileStoreDirective.js
@@ -346,7 +346,59 @@
             scope.gnCurrentEdit = gnCurrentEdit;
             scope.selectOptions = { current: undefined };
             scope.metadataResources = [];
+            scope.editingResource = false;
 
+            function updateVisibilityEditingPanel(index, editing) {
+              if (editing) {
+                $("#resource_" + index).addClass("hidden");
+                $("#resource_edit_" + index).removeClass("hidden");
+              } else {
+                $("#resource_" + index).removeClass("hidden");
+                $("#resource_edit_" + index).addClass("hidden");
+              }
+            }
+            scope.editResource = function (r, index) {
+              r.filename_edit = r.filename;
+              scope.editingResource = true;
+              scope.duplicatedFilename = false;
+
+              updateVisibilityEditingPanel(index, true);
+            };
+
+            scope.cancelEditResource = function (r, index) {
+              delete r.filename_edit;
+              scope.duplicatedFilename = false;
+              updateVisibilityEditingPanel(index, false);
+            };
+
+            scope.saveEditResource = function (r, index) {
+              // TODO: check if the resource is already in the list and update it in the backend
+
+              gnfilestoreService.get(scope.gnCurrentEdit.uuid, "").then(function (data) {
+                var files = data.data;
+                var fileNameExists = false;
+                for (var i = 0; i < files.length; i++) {
+                  if (files[i].filename == r.filename_edit) {
+                    fileNameExists = true;
+                    break;
+                  }
+                }
+
+                if (!fileNameExists) {
+                  scope.duplicatedFilename = false;
+
+                  gnfilestoreService
+                    .updateResourceName(scope.gnCurrentEdit.uuid, r, r.filename_edit)
+                    .then(function (response) {
+                      scope.editingResource = false;
+                      updateVisibilityEditingPanel(index, false);
+                      scope.loadMetadataResources();
+                    });
+                } else {
+                  scope.duplicatedFilename = true;
+                }
+              });
+            };
             scope.setResource = function (r) {
               scope.selectCallback({ selected: r });
             };

--- a/web-ui/src/main/resources/catalog/components/filestore/FileStoreDirective.js
+++ b/web-ui/src/main/resources/catalog/components/filestore/FileStoreDirective.js
@@ -393,6 +393,10 @@
                       scope.editingResource = false;
                       updateVisibilityEditingPanel(index, false);
                       scope.loadMetadataResources();
+
+                      // Refresh the onlinesrc service to update the resource list and the metadata form
+                      // with the new resource name.
+                      gnOnlinesrc.refresh();
                     });
                 } else {
                   scope.duplicatedFilename = true;

--- a/web-ui/src/main/resources/catalog/components/filestore/FileStoreDirective.js
+++ b/web-ui/src/main/resources/catalog/components/filestore/FileStoreDirective.js
@@ -368,6 +368,7 @@
             scope.cancelEditResource = function (r, index) {
               delete r.filename_edit;
               scope.duplicatedFilename = false;
+              scope.editingResource = false;
               updateVisibilityEditingPanel(index, false);
             };
 

--- a/web-ui/src/main/resources/catalog/components/filestore/FileStoreService.js
+++ b/web-ui/src/main/resources/catalog/components/filestore/FileStoreService.js
@@ -53,12 +53,11 @@
         delete: function (resource) {
           return $http.delete(resource.url);
         },
-        updateResourceName: function (metadataUuid, resource, newName) {
-          return $http.put("../api/records/" + resource.id + "/rename", null, {
+        updateResourceName: function (metadataUuid, resource, newResourceName) {
+          return $http.patch("../api/records/" + resource.id, null, {
             params: {
               approved: resource.approved,
-              newName: newName,
-              visibility: resource.visibility == "PRIVATE" ? "public" : "private"
+              newResourceName: newResourceName
             }
           });
         }

--- a/web-ui/src/main/resources/catalog/components/filestore/FileStoreService.js
+++ b/web-ui/src/main/resources/catalog/components/filestore/FileStoreService.js
@@ -52,6 +52,15 @@
         },
         delete: function (resource) {
           return $http.delete(resource.url);
+        },
+        updateResourceName: function (metadataUuid, resource, newName) {
+          return $http.put("../api/records/" + resource.id + "/rename", null, {
+            params: {
+              approved: resource.approved,
+              newName: newName,
+              visibility: resource.visibility == "PRIVATE" ? "public" : "private"
+            }
+          });
         }
       };
     }

--- a/web-ui/src/main/resources/catalog/components/filestore/partials/filestore.html
+++ b/web-ui/src/main/resources/catalog/components/filestore/partials/filestore.html
@@ -38,15 +38,46 @@
 
     <table class="table gn-data-store">
       <tbody>
-        <tr data-ng-repeat="r in metadataResources">
+        <tr data-ng-repeat="r in metadataResources track by $index">
           <td>
             <a
               href=""
+              id="resource_{{$index}}"
               title="{{'clickToAddResource' | translate}}"
               data-ng-click="setResource(r)"
             >
               {{r.id.split('/').splice(2).join('/') | decodeURIComponent}}
             </a>
+
+            <div id="resource_edit_{{$index}}" class="hidden">
+              <input
+                type="text"
+                name="fileName"
+                class="form-control"
+                data-ng-model="r.filename_edit"
+              />
+
+              <a
+                class="btn btn-link"
+                title="{{'save' | translate}}"
+                data-ng-click="saveEditResource(r, $index)"
+                data-ng-disabled="r.filename_edit == r.filename"
+              >
+                <span class="fa fa-save"></span>
+              </a>
+
+              <a
+                class="btn btn-link"
+                title="{{'cancel' | translate}}"
+                data-ng-click="cancelEditResource(r, $index)"
+              >
+                <span class="fa fa-cancel"></span>
+              </a>
+
+              <div data-ng-show="duplicatedFilename" data-translate="">
+                fileStoreDuplicatedFilename
+              </div>
+            </div>
           </td>
           <td data-ng-if="r.version.length > 0">{{r.version}}</td>
           <td
@@ -83,6 +114,16 @@
                 data-ng-class="{'fa-lock text-danger': r.visibility == 'PRIVATE',
                                'fa-lock-open text-success': r.visibility == 'PUBLIC'}"
               ></i>
+            </a>
+          </td>
+          <td>
+            <a
+              class="btn btn-link"
+              title="{{'renameResource' | translate}}"
+              data-ng-click="editResource(r, $index)"
+              data-ng-disabled="editingResource"
+            >
+              <i class="fa fa-edit"></i>
             </a>
           </td>
           <td>

--- a/web-ui/src/main/resources/catalog/components/filestore/partials/filestore.html
+++ b/web-ui/src/main/resources/catalog/components/filestore/partials/filestore.html
@@ -55,6 +55,7 @@
                 name="fileName"
                 class="form-control"
                 data-ng-model="r.filename_edit"
+                maxlength="255"
               />
 
               <a

--- a/web-ui/src/main/resources/catalog/components/filestore/partials/filestore.html
+++ b/web-ui/src/main/resources/catalog/components/filestore/partials/filestore.html
@@ -75,7 +75,11 @@
                 <span class="fa fa-cancel"></span>
               </a>
 
-              <div data-ng-show="duplicatedFilename" data-translate="" class="alert alert-danger">
+              <div
+                data-ng-show="duplicatedFilename"
+                data-translate=""
+                class="alert alert-danger"
+              >
                 fileStoreDuplicatedFilename
               </div>
             </div>

--- a/web-ui/src/main/resources/catalog/components/filestore/partials/filestore.html
+++ b/web-ui/src/main/resources/catalog/components/filestore/partials/filestore.html
@@ -74,7 +74,7 @@
                 <span class="fa fa-cancel"></span>
               </a>
 
-              <div data-ng-show="duplicatedFilename" data-translate="">
+              <div data-ng-show="duplicatedFilename" data-translate="" class="alert alert-danger">
                 fileStoreDuplicatedFilename
               </div>
             </div>

--- a/web-ui/src/main/resources/catalog/locales/en-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/en-editor.json
@@ -478,5 +478,6 @@
     "metadataDuplicatedField-identifier": "The metadata resource identifier is used in another metadata record.",
     "indexingIssues": "Indexing issues",
     "indexingErrors": "Errors",
-    "indexingWarnings": "Warnings"
+    "indexingWarnings": "Warnings",
+    "fileStoreDuplicatedFilename": "The filename is already used in the file store."
 }

--- a/web-ui/src/main/resources/catalog/locales/en-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/en-editor.json
@@ -479,5 +479,6 @@
     "indexingIssues": "Indexing issues",
     "indexingErrors": "Errors",
     "indexingWarnings": "Warnings",
-    "fileStoreDuplicatedFilename": "The filename is already used in the file store."
+    "fileStoreDuplicatedFilename": "The filename is already used in the file store.",
+    "renameResource": "Rename resource"
 }


### PR DESCRIPTION
This change request allows to rename files in the datastore:
* move file on the filesystem
* updating the references in the metadata
* updating the database `metadatafileuploads`

[edit-resource-name.webm](https://github.com/user-attachments/assets/1ff76b74-256e-4b19-b8ec-ae8299f9c8a8)


If filename is already used, error is reported

<img width="372" height="201" alt="image" src="https://github.com/user-attachments/assets/e23be14d-7c6b-41ad-8ab2-2bde5fd67591" />





# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

Funded by: EEA
