### PR TITLE
Editor / Keywords / Use keyword id when available.

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/layout-custom-fields-keywords.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/layout-custom-fields-keywords.xsl
@@ -77,7 +77,7 @@
         <!-- Create form for all existing attribute (not in gn namespace)
         and all non existing attributes not already present. -->
         <xsl:apply-templates mode="render-for-field-for-attribute"
-          select="
+                             select="
           @*|
           gn:attribute[not(@name = parent::node()/@*/name())]">
           <xsl:with-param name="ref" select="gn:element/@ref"/>
@@ -109,7 +109,7 @@
       <xsl:otherwise>
         <xsl:call-template name="render-boxed-element">
           <xsl:with-param name="label"
-            select="if ($thesaurusTitle != '')
+                          select="if ($thesaurusTitle != '')
                     then $thesaurusTitle
                     else gn-fn-metadata:getLabel($schema, name(), $labels, name(..), $isoType, $xpath)/label"/>
           <xsl:with-param name="editInfo" select="gn:element"/>
@@ -160,7 +160,7 @@
           get it from the list of thesaurus based on its title.
           -->
         <xsl:variable name="thesaurusInternalKey"
-          select="if ($thesaurusIdentifier)
+                      select="if ($thesaurusIdentifier)
                   then $thesaurusIdentifier
                   else $thesaurusConfig/key"/>
         <xsl:variable name="thesaurusKey"
@@ -182,6 +182,8 @@
                   if ($guiLangId and mri:keyword//*[@locale = concat('#', $guiLangId)][*/text() != ''])
                   then mri:keyword//*[@locale = concat('#', $guiLangId)][. != '']/replace(text(), ',', ',,')
                   else mri:keyword/*[1][. != '']/replace(text(), ',', ',,'), ',')"/>
+        <xsl:variable name="keywordIds"
+                      select="string-join(mri:keyword/*:Anchor/@xlink:href, ',')"/>
 
         <!-- Define the list of transformation mode available. -->
         <xsl:variable name="listOfTransformation"
@@ -203,7 +205,7 @@
         <!-- Current transformation is the editor configuration if only one mode is allowed
          and if not then the mode is based on the XML fragment analysis -->
         <xsl:variable name="transformation"
-          select="if (count($listOfTransformation) = 1)
+                      select="if (count($listOfTransformation) = 1)
                   then $listOfTransformation[1]
                   else if (parent::node()/@xlink:href)
                   then 'to-iso19115-3.2018-keyword-as-xlink'
@@ -253,6 +255,7 @@
              data-thesaurus-title="{$thesaurusTitle}"
              data-thesaurus-key="{$thesaurusKey}"
              data-keywords="{$keywords}"
+             data-keyword-ids="{$keywordIds}"
              data-transformations="{$transformations}"
              data-current-transformation="{$transformation}"
              data-max-tags="{$maxTags}"

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields-keywords.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields-keywords.xsl
@@ -219,7 +219,8 @@
                   if ($guiLangId and gmd:keyword//*[@locale = concat('#', $guiLangId)]) then
                     gmd:keyword//*[@locale = concat('#', $guiLangId)][. != '']/replace(text(), ',', ',,')
                   else gmd:keyword/*[1][. != '']/replace(text(), ',', ',,'), ',')"/>
-
+        <xsl:variable name="keywordIds"
+                      select="string-join(gmd:keyword/*:Anchor/@xlink:href, ',')"/>
 
         <!-- Define the list of transformation mode available. -->
         <xsl:variable name="listOfTransformation"
@@ -292,6 +293,7 @@
              data-thesaurus-title="{if (($isFlatMode and not($thesaurusConfig/@fieldset)) or $thesaurusConfig/@fieldset = 'false') then $thesaurusTitleForEditor else ''}"
              data-thesaurus-key="{$thesaurusKey}"
              data-keywords="{$keywords}"
+             data-keyword-ids="{$keywordIds}"
              data-transformations="{$transformations}"
              data-current-transformation="{$transformation}"
              data-max-tags="{$maxTags}"

--- a/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
+++ b/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
@@ -246,6 +246,7 @@
           wrapper: "@",
           thesaurusKey: "@",
           keywords: "@",
+          keywordIds: "@",
           transformations: "@",
           currentTransformation: "@",
           lang: "@",
@@ -259,8 +260,7 @@
           browsable: "@",
           required: "@"
         },
-        templateUrl:
-          "../../catalog/components/thesaurus/" + "partials/keywordselector.html",
+        templateUrl: "../../catalog/components/thesaurus/partials/keywordselector.html",
         link: function (scope, element, attrs) {
           $compile(element.contents())(scope);
           // pick up skos browser directive with compiler
@@ -286,7 +286,9 @@
           scope.foundKeywords = [];
           scope.selected = [];
           scope.initialKeywords = [];
-          if (scope.keywords) {
+          if (scope.keywordIds) {
+            scope.initialKeywords = scope.keywordIds.split(",");
+          } else if (scope.keywords) {
             var buffer = "";
             for (var i = 0; i < scope.keywords.length; i++) {
               var next = scope.keywords.charAt(i);


### PR DESCRIPTION
Follow up of https://github.com/geonetwork/core-geonetwork/pull/8118

When available, the keyword picker should use keyword ids to limit impact of a renamed concept in thesaurus. Currently, on init, the keyword picker check if the concept label exist in the thesaurus. If not, a warning indicate that the current record reference a concept which does not exist in the target thesaurus. Usually, thesaurus do not change much, but it can happen. Using the keyword id when available make the keyword picker more robust and will update the label if changed.

Example of a renamed concept in a vocabulary
https://vocab.nerc.ac.uk/collection/P36/current/MRNLTTR/ https://vocab.nerc.ac.uk/collection/P36/current/MRNLTTR/1/

At some point, we may even support concept versioning. It does not always make sense to update the label, but rather point to the deprecated concept.

Funded by Ifremer


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

