### PR TITLE
Fix attachment download for jcloud

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsApi.java
@@ -309,7 +309,7 @@ public class AttachmentsApi {
         responseHeaders.setContentLength(fileSize);
 
         // Wrap a PathResource so that closing its InputStream also closes the holder
-        // Auto-closing will not work here as it will prematurely delete the temporary file for jcloud
+        // Auto-closing will not work here as it will prematurely delete the temporary file for storage implementations that use temporary files.
         PathResource resource = new PathResource(file.getPath()) {
             @Override
             @NonNull

--- a/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsApi.java
@@ -307,7 +307,7 @@ public class AttachmentsApi {
             // Spring automatically handles range requests when returning ResponseEntity<Resource> to support resumable downloads.
             return ResponseEntity.ok()
                 .headers(responseHeaders)
-                .body(new PathResource(file.getPath()));
+                .body(new ByteArrayResource(Files.readAllBytes(file.getPath())));
         }
     }
 


### PR DESCRIPTION
Introduced while implementing resumable downloads #8940 #8959

Currently attachment downloads are not working for the jcloud store. This is caused by the temporary file being deleted before the file is served.

This PR aims to solve this issue by removing the auto closing logic for the resource holder. This will prevent the temporary file from being deleted prematurely. The PathResource is also customized to close the ResourceHolder when it's InputStream is closed to ensure the temporary file is deleted.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

