### PR TITLE
Standard / ISO19115-3 / ISO19139 mapping improvement

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ISO19139/mapping/DQ.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ISO19139/mapping/DQ.xsl
@@ -41,16 +41,10 @@
             <xsl:for-each select="*">
               <xsl:element name="mdq:report">
                 <!-- DQ_NonQuantitativeAttributeAccuracy changed to DQ_NonQuantitativeAttributeCorrectness -->
-                <xsl:variable name="dataQualityReportType">
-                  <xsl:choose>
-                    <xsl:when test="local-name()='DQ_NonQuantitativeAttributeAccuracy'">
-                      <xsl:value-of select="'DQ_NonQuantitativeAttributeCorrectness'"/>
-                    </xsl:when>
-                    <xsl:otherwise>
-                      <xsl:value-of select="local-name()"/>
-                    </xsl:otherwise>
-                  </xsl:choose>
-                </xsl:variable>
+                <xsl:variable name="dataQualityReportType"
+                                    select="if (local-name()='DQ_NonQuantitativeAttributeAccuracy')
+                                                 then 'DQ_NonQuantitativeAttributeCorrectness' else local-name()"/>
+
                 <xsl:element name="{concat('mdq:',$dataQualityReportType)}">
                   <xsl:if test="gmd:nameOfMeasure or gmd:measureIdentification or gmd:measureDescription">
                     <!-- output quality measure information only if gmd:measureIdentification or gmd:measureDescription exist -->

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ISO19139/toISO19139.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ISO19139/toISO19139.xsl
@@ -491,9 +491,13 @@
           </gmd:scope>
         </xsl:if>
 
-        <xsl:for-each select="mdq:DQ_DataQuality/mdq:report/*">
+        <xsl:for-each select="mdq:DQ_DataQuality/mdq:report/*[local-name() != 'DQ_UsabilityElement']">
           <gmd:report>
-            <xsl:element name="{concat('gmd:',local-name())}">
+            <xsl:variable name="dataQualityReportType"
+                          select="if (local-name()='DQ_NonQuantitativeAttributeCorrectness')
+                                       then 'DQ_NonQuantitativeAttributeAccuracy' else local-name()"/>
+
+            <xsl:element name="{concat('gmd:', $dataQualityReportType)}">
               <xsl:call-template name="writeCharacterStringElement">
                 <xsl:with-param name="elementName" select="'gmd:nameOfMeasure'"/>
                 <xsl:with-param name="nodeWithStringToWrite" select="mdq:measure/mdq:DQ_MeasureReference/mdq:nameOfMeasure"/>


### PR DESCRIPTION
* DQ_UsabilityElement does not exist in ISO19139. Exclude it from the mapping. (test can be done with https://metawal.wallonie.be/geonetwork/srv/api/records/74fe32b4-09b2-4ade-9b3b-373c7877eeae/formatters/xml)
* DQ_NonQuantitativeAttributeAccuracy is DQ_NonQuantitativeAttributeCorrectness in ISO19115-3. Conversion was done when mapping to 115-3 (https://github.com/geonetwork/core-geonetwork/blob/main/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ISO19139/mapping/DQ.xsl#L43-L53) but not when mapping to ISO19139.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

Funded by Service Public de Wallonie