### PR TITLE
[4.2.x] ISO1915-3.2018 / Metadata editor / Allow to write the value of the unit of measure for spatial representation of grid spatial representation

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/layout-custom-fields.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/layout-custom-fields.xsl
@@ -7,6 +7,7 @@
   xmlns:cit="http://standards.iso.org/iso/19115/-3/cit/2.0"
   xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0"
   xmlns:mrs="http://standards.iso.org/iso/19115/-3/mrs/1.0"
+  xmlns:msr="http://standards.iso.org/iso/19115/-3/msr/2.0"
   xmlns:gml="http://www.opengis.net/gml/3.2"
   xmlns:xlink="http://www.w3.org/1999/xlink"
   xmlns:gn="http://www.fao.org/geonetwork"
@@ -140,7 +141,7 @@
 
 
   <!-- Measure elements, gco:Distance, gco:Angle, gco:Scale, gco:Length, ... -->
-  <xsl:template mode="mode-iso19115-3.2018" priority="2000" match="mri:*[gco:*/@uom]">
+  <xsl:template mode="mode-iso19115-3.2018" priority="2000" match="mri:*[gco:*/@uom]|msr:*[gco:*/@uom]">
     <xsl:param name="schema" select="$schema" required="no"/>
     <xsl:param name="labels" select="$labels" required="no"/>
     <xsl:param name="refToDelete" select="''" required="no"/>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/loc/eng/labels.xml
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/loc/eng/labels.xml
@@ -594,14 +594,6 @@
     <label>Resolution</label>
     <description iso="true">Degree of detail in the grid dataset</description>
     <condition>optional</condition>
-    <helper relAtt="uom">
-      <option value="1" title="second">seconds</option>
-      <option value="1" title="minute">minutes</option>
-      <option value="1" title="hour">hours</option>
-      <option value="1" title="day">days</option>
-      <option value="1" title="month">months</option>
-      <option value="1" title="year">years</option>
-    </helper>
   </element>
   <element name="msr:dimensionTitle" id="174.0">
     <label>Dimension title</label>


### PR DESCRIPTION
This pull request affects `4.2.x`  branch. In `main` branch units of measure are managed a bit differently:  https://github.com/geonetwork/core-geonetwork/pull/8245, which is not backported to `4.2.x`

Without the changes, the units can only be selected from the suggestions list

<img width="1265" height="903" alt="image" src="https://github.com/user-attachments/assets/b38275e9-6979-4084-9060-dc4e9533bb72" />

With the changes, the user can write the units:

<img width="1261" height="761" alt="image" src="https://github.com/user-attachments/assets/4d3c56e2-9fd7-4b27-a14a-1385ddda1205" />


# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

