### PR TITLE
Fix SessionExpirationFilter - cannot be cast to OidcUser

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/OAuth2Configuration.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/OAuth2Configuration.java
@@ -27,6 +27,8 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.oauth2.client.*;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.client.web.AuthenticatedPrincipalOAuth2AuthorizedClientRepository;
+import org.springframework.security.oauth2.client.web.OAuth2AuthorizedClientRepository;
 
 public class OAuth2Configuration {
 
@@ -38,6 +40,16 @@ public class OAuth2Configuration {
 
     @Autowired
     private OAuth2AuthorizedClientService oAuth2AuthorizedClientService;
+
+    /**
+     * This method is used to obtain the OAuth2 authorized client repository
+     * which is used to persist the OAuth2 authorized clients
+     */
+    @Bean
+    public OAuth2AuthorizedClientRepository authorizedClientRepository(
+        OAuth2AuthorizedClientService service) {
+        return new AuthenticatedPrincipalOAuth2AuthorizedClientRepository(service);
+    }
 
     /**
      * This method is used to obtain the OAuth2 authorized clients


### PR DESCRIPTION
Currently the `SessionExpirationFilter` is doing an unsafe cast from `DefaultOAuth2User` to `OidcUser`. This produces the following exceptions intermittently for requests using a bearer token:

```
java.lang.ClassCastException: org.springframework.security.oauth2.core.user.DefaultOAuth2User cannot be cast to org.springframework.security.oauth2.core.oidc.user.OidcUser
    org.fao.geonet.kernel.security.openidconnect.SessionExpirationFilter.doFilter(SessionExpirationFilter.java:83)
    org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:346)
    org.springframework.security.web.authentication.logout.LogoutFilter.doFilter(LogoutFilter.java:103)
    org.springframework.security.web.authentication.logout.LogoutFilter.doFilter(LogoutFilter.java:89)
    org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:346)
    org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter.doFilter(AbstractAuthenticationProcessingFilter.java:223)
    org.springframework.security.web.authentication.AbstractAuthenticationProcessingFilter.doFilter(AbstractAuthenticationProcessingFilter.java:217)
    org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:346)
    org.springframework.security.oauth2.client.web.OAuth2AuthorizationRequestRedirectFilter.doFilterInternal(OAuth2AuthorizationRequestRedirectFilter.java:178)
    org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:117)
    org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:346)
    org.springframework.security.web.csrf.CsrfFilter.doFilterInternal(CsrfFilter.java:117)
    org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:117)
    org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:346)
    org.springframework.security.web.context.SecurityContextPersistenceFilter.doFilter(SecurityContextPersistenceFilter.java:112)
    org.springframework.security.web.context.SecurityContextPersistenceFilter.doFilter(SecurityContextPersistenceFilter.java:82)
    org.springframework.security.web.FilterChainProxy$VirtualFilterChain.doFilter(FilterChainProxy.java:346)
    org.springframework.security.web.FilterChainProxy.doFilterInternal(FilterChainProxy.java:221)
    org.springframework.security.web.FilterChainProxy.doFilter(FilterChainProxy.java:186)
    org.springframework.web.filter.DelegatingFilterProxy.invokeDelegate(DelegatingFilterProxy.java:354)
    org.springframework.web.filter.DelegatingFilterProxy.doFilter(DelegatingFilterProxy.java:267)
    jeeves.config.springutil.JeevesDelegatingFilterProxy.doFilter(JeevesDelegatingFilterProxy.java:74)
    org.springframework.web.filter.CharacterEncodingFilter.doFilterInternal(CharacterEncodingFilter.java:201)
    org.springframework.web.filter.OncePerRequestFilter.doFilter(OncePerRequestFilter.java:117)
```
I have not yet found a pattern or a reliable method to reproduce this issue. 

This PR aims to fix this issue by removing the cast to `OidcUser` and getting the token expiration from the `OAuth2AccessToken` instead of the `OidcUser`.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

