### PR TITLE
Fix the back channel logout config that is missing in the current version of spring security

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/GeonetworkClientRegistrationProvider.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/GeonetworkClientRegistrationProvider.java
@@ -63,7 +63,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  */
 public class GeonetworkClientRegistrationProvider {
 
-    public static String CLIENTREGISTRATION_NAME = "geonetwork-oicd";
+    public static String CLIENTREGISTRATION_NAME = "geonetwork-oidc";
 
     ClientRegistration clientRegistration;
 

--- a/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/HardcodedRegistrationIdOAuth2AuthorizationRequestResolver.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/HardcodedRegistrationIdOAuth2AuthorizationRequestResolver.java
@@ -38,7 +38,7 @@ import static org.fao.geonet.kernel.security.openidconnect.GeonetworkClientRegis
  * Spring's oauth allows for multiple oauth providers - and the /signin/... path would normally indicate which one
  * (by the name).
  * <p>
- * We're only using one provider (called CLIENTREGISTRATION_NAME - "geonetwork-oicd") and it works better in GN if
+ * We're only using one provider (called CLIENTREGISTRATION_NAME - "geonetwork-oidc") and it works better in GN if
  * you just use a simple "/signin" URL instead of a more complicated one.
  * <p>
  * This class bridges between the two methods (spring and GN's).

--- a/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/oidclogout/InMemoryOidcSessionRegistry.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/oidclogout/InMemoryOidcSessionRegistry.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2025 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+package org.fao.geonet.kernel.security.openidconnect.oidclogout;
+
+
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.utils.Log;
+import org.springframework.security.oauth2.jwt.Jwt;
+
+import java.util.*;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Predicate;
+
+/** * An in-memory implementation of OidcSessionRegistry that stores OIDC session information.
+      Referencing org.springframework.security.oauth2.client.oidc.session.InMemoryOidcSessionRegistry
+ */
+public final class InMemoryOidcSessionRegistry implements OidcSessionRegistry {
+
+    private final Map<String, OidcSessionInformation> sessions = new ConcurrentHashMap();
+
+    public InMemoryOidcSessionRegistry() {
+    }
+
+    public void saveSessionInformation(OidcSessionInformation info) {
+        this.sessions.put(info.getSessionId(), info);
+    }
+
+    public OidcSessionInformation removeSessionInformation(String clientSessionId) {
+        OidcSessionInformation information = (OidcSessionInformation)this.sessions.remove(clientSessionId);
+        if (information != null) {
+            Log.debug(Geonet.SECURITY,"Removed client session");
+        }
+
+        return information;
+    }
+
+    public Iterable<OidcSessionInformation> removeSessionInformation(Jwt token) {
+        List<String> audience = token.getClaimAsStringList("aud");
+        String issuer = token.getIssuer().toString();
+        String subject = token.getSubject();
+        String providerSessionId = token.getClaimAsString("sid");
+        Predicate<OidcSessionInformation> matcher = providerSessionId != null ? sessionIdMatcher(audience, issuer, providerSessionId) : subjectMatcher(audience, issuer, subject);
+
+            String message = "Looking up sessions by issuer [%s] and %s [%s]";
+            if (providerSessionId != null) {
+                Log.debug(Geonet.SECURITY,String.format(message, issuer, "sid", providerSessionId));
+            } else {
+                Log.debug(Geonet.SECURITY,String.format(message, issuer, "sub", subject));
+            }
+
+
+        int size = this.sessions.size();
+            Log.debug(Geonet.SECURITY,String.format("There are currently %d session(s) in the mapping", size));
+            Log.debug(Geonet.SECURITY,this.sessions.values().toString());
+        Set<OidcSessionInformation> infos = new HashSet();
+        this.sessions.values().removeIf((info) -> {
+            boolean result = matcher.test(info);
+            if (result) {
+                infos.add(info);
+            }
+
+            return result;
+        });
+        if (infos.isEmpty()) {
+            Log.debug(Geonet.SECURITY,"Failed to remove any sessions since none matched");
+        } else  {
+            Log.debug(Geonet.SECURITY,String.format("Found and removed %d session(s) from mapping of %d session(s)", infos.size(), size));
+        }
+
+        return infos;
+    }
+
+    private static Predicate<OidcSessionInformation> sessionIdMatcher(List<String> audience, String issuer, String sessionId) {
+        return (session) -> {
+            List<String> thatAudience = session.getPrincipal().getAudience();
+            String thatIssuer = session.getPrincipal().getIssuer().toString();
+            String thatSessionId = session.getPrincipal().getClaimAsString("sid");
+            if (thatAudience == null) {
+                return false;
+            } else {
+                return !Collections.disjoint(audience, thatAudience) && issuer.equals(thatIssuer) && sessionId.equals(thatSessionId);
+            }
+        };
+    }
+
+    private static Predicate<OidcSessionInformation> subjectMatcher(List<String> audience, String issuer, String subject) {
+        return (session) -> {
+            List<String> thatAudience = session.getPrincipal().getAudience();
+            String thatIssuer = session.getPrincipal().getIssuer().toString();
+            String thatSubject = session.getPrincipal().getSubject();
+            if (thatAudience == null) {
+                return false;
+            } else {
+                return !Collections.disjoint(audience, thatAudience) && issuer.equals(thatIssuer) && subject.equals(thatSubject);
+            }
+        };
+    }
+}

--- a/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/oidclogout/OidcBackchannelLogoutFilter.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/oidclogout/OidcBackchannelLogoutFilter.java
@@ -1,0 +1,269 @@
+/*
+ * Copyright (C) 2025 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+package org.fao.geonet.kernel.security.openidconnect.oidclogout;
+
+import com.nimbusds.jose.JOSEObjectType;
+import com.nimbusds.jose.proc.DefaultJOSEObjectTypeVerifier;
+import com.nimbusds.jose.proc.JOSEObjectTypeVerifier;
+import com.nimbusds.jose.proc.SecurityContext;
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.security.web.csrf.GeonetworkCsrfSecurityRequestMatcher;
+import org.fao.geonet.utils.Log;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.security.oauth2.client.oidc.authentication.OidcIdTokenDecoderFactory;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
+import org.springframework.security.oauth2.core.converter.ClaimTypeConverter;
+import org.springframework.security.oauth2.jwt.Jwt;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.security.oauth2.jwt.NimbusJwtDecoder;
+import org.springframework.security.web.csrf.CsrfFilter;
+import org.springframework.security.web.util.UrlUtils;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.NegatedRequestMatcher;
+import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestOperations;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.filter.OncePerRequestFilter;
+import org.springframework.web.util.UriComponents;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+
+/**
+ * Filter for handling OpenID Connect (OIDC) backchannel logout requests.
+ * This filter processes logout requests by validating the logout token and invalidating sessions in compliance with OIDC standards.
+ * https://openid.net/specs/openid-connect-backchannel-1_0.html
+ *
+ * Referencing the following classes from Spring Security 6.5.x:
+ * org.springframework.security.config.annotation.web.configurers.oauth2.client.OidcBackChannelLogoutFilter
+ * org.springframework.security.config.annotation.web.configurers.oauth2.client.OidcBackChannelLogoutHandler
+ *
+ */
+public class OidcBackchannelLogoutFilter extends OncePerRequestFilter {
+
+    @Autowired
+    private OidcSessionRegistry oidcSessionRegistry;
+
+    @Autowired
+    private ClientRegistrationRepository clientRegistrationRepository;
+
+
+    private final RequestMatcher requestMatcher;
+    private String sessionCookieName = "JSESSIONID";
+    private RestOperations restOperations = new RestTemplate();
+
+    public OidcBackchannelLogoutFilter(CsrfFilter csrfFilter, GeonetworkCsrfSecurityRequestMatcher csrfRequestMatcher) {
+        this.requestMatcher = new AntPathRequestMatcher("/**/logout/connect/back-channel/{registrationId}", HttpMethod.POST.name());
+        csrfRequestMatcher.addRequestMatcher(new NegatedRequestMatcher(this.requestMatcher));
+        csrfFilter.setRequireCsrfProtectionMatcher(csrfRequestMatcher);
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request,
+                                    HttpServletResponse response,
+                                    FilterChain filterChain)
+        throws IOException, ServletException {
+        RequestMatcher.MatchResult result = requestMatcher.matcher(request);
+        if(!result.isMatch()){
+            Log.debug(Geonet.SECURITY,"Request does not match OIDC backchannel logout filter, skipping.");
+            filterChain.doFilter(request, response);
+        }else {
+            String registrationId = result.getVariables().get("registrationId");
+            try {
+                String logoutToken = request.getParameter("logout_token");
+                if (logoutToken == null) {
+                    Log.error(Geonet.SECURITY, "Missing logout_token parameter in request");
+                    response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Missing logout_token");
+                    return;
+                }
+
+                ClientRegistration clientRegistration = this.clientRegistrationRepository.findByRegistrationId(registrationId);
+
+                if (registrationId == null || clientRegistration == null) {
+                    Log.error(Geonet.SECURITY, "Invalid or missing registrationId: " + registrationId);
+                    response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid or missing registrationId");
+                    return;
+                }
+
+                //handle null uri
+                if (clientRegistration.getProviderDetails().getJwkSetUri() == null) {
+                    Log.error(Geonet.SECURITY, "JWK Set URI is null for client registration: " + registrationId);
+                    response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Missing JWK Set URI in client registration");
+                    return;
+                }
+
+                JOSEObjectTypeVerifier<SecurityContext> typeVerifier = new DefaultJOSEObjectTypeVerifier<>(null,
+                    JOSEObjectType.JWT, new JOSEObjectType("logout+jwt"));
+                NimbusJwtDecoder jwtDecoder = NimbusJwtDecoder.withJwkSetUri(clientRegistration.getProviderDetails().getJwkSetUri())
+                    .jwtProcessorCustomizer((processor) -> processor.setJWSTypeVerifier(typeVerifier))
+                    .build();
+                jwtDecoder.setClaimSetConverter(new ClaimTypeConverter(OidcIdTokenDecoderFactory.createDefaultClaimTypeConverters()));
+
+                Jwt jwt = jwtDecoder.decode(logoutToken);
+                validateLogoutToken(jwt);
+
+                // Handle logout logic here (e.g., session invalidation)
+                logout(request, response, jwt, registrationId);
+
+                response.setStatus(HttpServletResponse.SC_OK);
+            } catch (Exception ex) {
+                Log.error(Geonet.SECURITY, "Error processing OIDC Backchannel Logout request: " + ex.getMessage(), ex);
+                response.sendError(HttpServletResponse.SC_BAD_REQUEST, "Invalid logout request: " + ex.getMessage());
+            }
+        }
+    }
+
+    private void validateLogoutToken(Jwt jwt)  {
+        Map<String, Object> claims = jwt.getClaims();
+
+        // Required claims
+
+        if (!claims.containsKey("iss")) {
+            throw new JwtException("Logout Token must contain 'iss' claim");
+        }
+
+        if (!claims.containsKey("aud")) {
+            throw new JwtException("Logout Token must contain 'aud' claim");
+        }
+
+        if (!claims.containsKey("iat")) {
+            throw new JwtException("Logout Token must contain 'iat' claim");
+        }
+
+        if (!claims.containsKey("jti")) {
+            throw new JwtException("Logout Token must contain 'jti' claim");
+        }
+        if (!(claims.containsKey("sub") || claims.containsKey("sid"))) {
+            throw new JwtException("Logout Token must contain 'sub' or 'sid'");
+        }
+
+        if (!claims.containsKey("events")) {
+            throw new JwtException("Missing 'events' claim in logout token");
+        }
+
+        Map<String, Object> events = (Map<String, Object>) claims.get("events");
+        if (!events.containsKey("http://schemas.openid.net/event/backchannel-logout")) {
+            throw new JwtException("Invalid 'events' claim value");
+        }
+
+        if (claims.containsKey("nonce")) {
+            throw new JwtException("Logout Token must not contain 'nonce'");
+        }
+
+
+    }
+
+
+    public void logout(HttpServletRequest request, HttpServletResponse response, Jwt token, String registrationId) throws Exception {
+            Log.debug(Geonet.SECURITY,"Invalidating OIDC sessions for token: " + token.getTokenValue());
+            Iterable sessions = this.oidcSessionRegistry.removeSessionInformation(token);
+            ArrayList errors = new ArrayList();
+            int totalCount = 0;
+            int invalidatedCount = 0;
+            Iterator iterator = sessions.iterator();
+
+            while(iterator.hasNext()) {
+                OidcSessionInformation session = (OidcSessionInformation)iterator.next();
+                ++totalCount;
+
+                try {
+
+                    this.eachLogout(request, token, session, registrationId);
+                    ++invalidatedCount;
+                } catch (RestClientException ex) {
+                    Log.error(Geonet.SECURITY,"Failed to invalidate session", ex);
+                    errors.add(ex.getMessage());
+                    this.oidcSessionRegistry.saveSessionInformation(session);
+                }
+            }
+
+            Log.debug(Geonet.SECURITY,String.format("Invalidated %d out of %d sessions", invalidatedCount, totalCount));
+
+            if (!errors.isEmpty()) {
+                response.setStatus(400);
+                Log.error(Geonet.SECURITY,"Failed to invalidate some sessions: " + String.join(", ", errors));
+                throw new Exception("Failed to invalidate some sessions: " + String.join(", ", errors));
+            }
+    }
+
+    private void eachLogout(HttpServletRequest request, Jwt token, OidcSessionInformation session, String registrationId) {
+        HttpHeaders headers = new HttpHeaders();
+        String sessionCookieName = this.sessionCookieName;
+        headers.add("Cookie", sessionCookieName + "=" + session.getSessionId());
+        Iterator iterator = session.getAuthorities().entrySet().iterator();
+
+        while(iterator.hasNext()) {
+            Map.Entry<String, String> credential = (Map.Entry)iterator.next();
+            headers.add((String)credential.getKey(), (String)credential.getValue());
+        }
+
+        headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
+        String logout = this.computeLogoutEndpoint(request,  registrationId);
+        MultiValueMap<String, String> body = new LinkedMultiValueMap();
+        body.add("logout_token", token.getTokenValue());
+        body.add("_spring_security_internal_logout", "true");
+        HttpEntity<?> entity = new HttpEntity(body, headers);
+        Log.debug(Geonet.SECURITY,"Sending internal logout request to: " + logout);
+        this.restOperations.postForEntity(logout, entity, Object.class, new Object[0]);
+    }
+
+    String computeLogoutEndpoint(HttpServletRequest request, String registrationId) {
+
+        // Only include the port if it's not the default for the scheme
+        String protocol = request.getScheme();
+        int port = request.getServerPort();
+        String host = request.getServerName();
+        boolean isDefaultPort = ("https".equalsIgnoreCase(protocol) && port == 443)
+            || ("http".equalsIgnoreCase(protocol) && port == 80);
+
+        String internalLogoutUri = protocol + "://" + host + (isDefaultPort ? "" : ":" + port) + request.getContextPath() + "/signout";
+        UriComponents uriComponents = UriComponentsBuilder.fromUriString(UrlUtils.buildFullRequestUrl(request)).replacePath(request.getContextPath()).replaceQuery((String)null).fragment((String)null).build();
+        Map<String, String> uriVariables = new HashMap();
+        String scheme = uriComponents.getScheme();
+        uriVariables.put("baseScheme", scheme != null ? scheme : "");
+        uriVariables.put("baseUrl", uriComponents.toUriString());
+        uriVariables.put("baseHost", host != null ? host : "");
+        String path = uriComponents.getPath();
+        uriVariables.put("basePath", path != null ? path : "");
+        uriVariables.put("basePort", port == -1 ? "" : ":" + port);
+
+        uriVariables.put("registrationId", registrationId);
+        return UriComponentsBuilder.fromUriString(internalLogoutUri).buildAndExpand(uriVariables).toUriString();
+    }
+}

--- a/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/oidclogout/OidcSessionInformation.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/oidclogout/OidcSessionInformation.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2025 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+package org.fao.geonet.kernel.security.openidconnect.oidclogout;
+
+import org.springframework.security.core.session.SessionInformation;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+
+import java.util.Collections;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+
+/** *
+ *     An OIDC session information class that extends Spring Security's SessionInformation.
+      Referencing org.springframework.security.oauth2.client.oidc.session.OidcSessionInformation
+ */
+public class OidcSessionInformation extends SessionInformation {
+    private static final long serialVersionUID = -1703808683027974918L;
+    private final Map<String, String> authorities;
+
+    public OidcSessionInformation(String sessionId, Map<String, String> authorities, OidcUser user) {
+        super(user, sessionId, new Date());
+        this.authorities = (Map)(authorities != null ? new LinkedHashMap(authorities) : Collections.emptyMap());
+    }
+
+    public Map<String, String> getAuthorities() {
+        return this.authorities;
+    }
+
+    public OidcUser getPrincipal() {
+        return (OidcUser)super.getPrincipal();
+    }
+
+    public OidcSessionInformation withSessionId(String sessionId) {
+        return new OidcSessionInformation(sessionId, this.getAuthorities(), this.getPrincipal());
+    }
+}

--- a/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/oidclogout/OidcSessionRegistry.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/oidclogout/OidcSessionRegistry.java
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2025 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+package org.fao.geonet.kernel.security.openidconnect.oidclogout;
+
+import org.springframework.security.oauth2.jwt.Jwt;
+
+public interface OidcSessionRegistry {
+    void saveSessionInformation(OidcSessionInformation info);
+
+    OidcSessionInformation removeSessionInformation(String clientSessionId);
+
+    Iterable<OidcSessionInformation> removeSessionInformation(Jwt logoutToken);
+}

--- a/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/oidclogout/OidcSessionRegistryAuthenticationStrategy.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/oidclogout/OidcSessionRegistryAuthenticationStrategy.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2025 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+package org.fao.geonet.kernel.security.openidconnect.oidclogout;
+
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.utils.Log;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.web.authentication.session.SessionAuthenticationException;
+import org.springframework.security.web.authentication.session.SessionAuthenticationStrategy;
+import org.springframework.security.web.csrf.CsrfToken;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import javax.servlet.http.HttpSession;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * This class implements a session authentication strategy that links an OIDC user session
+ * to the current HTTP session. It saves the session information in an OIDC session registry.
+ *
+ * Referencing org.springframework.security.config.annotation.web.configurers.oauth2.client.OidcSessionRegistryAuthenticationStrategy
+ */
+public final class OidcSessionRegistryAuthenticationStrategy implements SessionAuthenticationStrategy {
+
+    @Autowired
+    private OidcSessionRegistry oidcSessionRegistry;
+
+    private OidcSessionRegistryAuthenticationStrategy() {
+    }
+
+    public void onAuthentication(Authentication authentication, HttpServletRequest request, HttpServletResponse response) throws SessionAuthenticationException {
+        HttpSession session = request.getSession(false);
+        if (session != null) {
+            Object auth = authentication.getPrincipal();
+            if (auth instanceof OidcUser) {
+                OidcUser user = (OidcUser)auth;
+                String sessionId = session.getId();
+                CsrfToken csrfToken = (CsrfToken)request.getAttribute(CsrfToken.class.getName());
+               Map<String, String> headers = csrfToken != null ? new HashMap<String, String>() {{put(csrfToken.getHeaderName(), csrfToken.getToken());
+    }} : Collections.emptyMap();
+                OidcSessionInformation registration = new OidcSessionInformation(sessionId, headers, user);
+
+                Log.debug(Geonet.SECURITY, String.format("Linking a provider [%s] session to this client's session", user.getIssuer()));
+
+                this.oidcSessionRegistry.saveSessionInformation(registration);
+            }
+        }
+    }
+
+
+}

--- a/core/src/test/java/org/fao/geonet/security/web/csrf/GeonetworkCsrfSecurityRequestMatcherTest.java
+++ b/core/src/test/java/org/fao/geonet/security/web/csrf/GeonetworkCsrfSecurityRequestMatcherTest.java
@@ -30,6 +30,8 @@ import org.keycloak.adapters.springsecurity.filter.KeycloakCsrfRequestMatcher;
 import org.keycloak.constants.AdapterConstants;
 import org.springframework.http.HttpMethod;
 import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
+import org.springframework.security.web.util.matcher.NegatedRequestMatcher;
 
 import java.util.Set;
 
@@ -177,6 +179,19 @@ public class GeonetworkCsrfSecurityRequestMatcherTest {
         prepareRequest(HttpMethod.POST, SUB_CONTEXT_PATH, AdapterConstants.K_TEST_AVAILABLE);
         assertFalse(matcher.matches(request));
 
+    }
+
+    @Test
+    public void testOidcBackchannellogoutCsrfilter(){
+        matcher.addRequestMatcher(new NegatedRequestMatcher(new AntPathRequestMatcher("/**/logout/connect/back-channel/{registrationId}", HttpMethod.POST.name())));
+        prepareRequest(HttpMethod.POST, ROOT_CONTEXT_PATH, "logout/connect/back-channel/myRegistrationId");
+        assertFalse(matcher.matches(request));
+        prepareRequest(HttpMethod.POST, SUB_CONTEXT_PATH, "/myapplication/logout/connect/back-channel/myRegistrationId2");
+        assertFalse(matcher.matches(request));
+        prepareRequest(HttpMethod.POST, SUB_CONTEXT_PATH, "/myapplication/logout/connect/back-channel/myRegistrationId2/extra path");
+        assertTrue(matcher.matches(request));
+        prepareRequest(HttpMethod.POST, SUB_CONTEXT_PATH, "myapplication/logout/connect/back-channel/myRegistrationId2");
+        assertFalse(matcher.matches(request));
     }
 
     private void prepareRequest(HttpMethod method, String contextPath, String uri) {

--- a/docs/manual/docs/administrator-guide/managing-users-and-groups/authentication-mode.md
+++ b/docs/manual/docs/administrator-guide/managing-users-and-groups/authentication-mode.md
@@ -484,7 +484,7 @@ Basic Setup Steps:
 
 1.  Configure your IDP Server (i.e. Keycloak or Azure AD)
     1.  Ensure that the ID Token provides role/group information
-    2.  Authorize your Geonetwork URLs for redirects (i.e. `http://localhost:8080/geonetwork/login/oauth2/code/geonetwork-oicd`)
+    2.  Authorize your Geonetwork URLs for redirects (i.e. `http://localhost:8080/geonetwork/login/oauth2/code/geonetwork-oidc`)
     3.  Record the Client ID
     4.  Record the Client Secret
     5.  Get the Server's JSON metadata document
@@ -641,7 +641,7 @@ There are two ways to setup Azure AD. The first is with user and groups (a more 
 Setup the Azure Application:
 
 1.  Create a new `App Registration`
-2.  use `http://localhost:8080/geonetwork/login/oauth2/code/geonetwork-oicd` as a redirect URIs
+2.  use `http://localhost:8080/geonetwork/login/oauth2/code/geonetwork-oidc` as a redirect URIs
 3.  On the "Certificates & Secrets" add a new secret and record it (make sure you get the secret value and NOT the object id)
 4.  Make sure the groups are in the ID token - on the "Manifest" tab, edit the JSON so that "groupMembershipClaims": "SecurityGroup" is set
 5.  On the summary page, get the Application (client) ID
@@ -679,7 +679,7 @@ OPENIDCONNECT_ROLECONVERTER='3a94275f-7d53-4205-8d78-11f39e9ffa5a=Administrator,
 Setup the Azure Application:
 
 1.  Create a new Enterprise application
-2.  use `http://localhost:8080/geonetwork/login/oauth2/code/geonetwork-oicd` as a redirect URIs
+2.  use `http://localhost:8080/geonetwork/login/oauth2/code/geonetwork-oidc` as a redirect URIs
 3.  On the "Certificates & Secrets" add a new secret and record it (make sure you get the secret value and NOT the object id)
 4.  Make sure the groups are in the ID token - on the "Manifest" tab, edit the JSON so that "groupMembershipClaims": "ApplicationGroup" is set
 5.  On the summary page, get the Application (client) ID

--- a/web/src/main/webapp/WEB-INF/config-security/config-security-core.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-core.xml
@@ -381,6 +381,7 @@
         <value>/[a-zA-Z0-9_\-]+/[a-z]{2,3}/csw!?.*</value>
         <value>/[a-zA-Z0-9_\-]+/api/search/.*</value>
         <value>/[a-zA-Z0-9_\-]+/api/site</value>
+        <value>/signout</value>
       </set>
     </constructor-arg>
   </bean>

--- a/web/src/main/webapp/WEB-INF/config-security/config-security-openidconnect-overrides.properties
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-openidconnect-overrides.properties
@@ -48,7 +48,7 @@
 
 
 # make sure you IDP will allow redirects to:
-# http://localhost:7777/geonetwork/login/oauth2/code/geonetwork-oicd
+# http://localhost:7777/geonetwork/login/oauth2/code/geonetwork-oidc
 # (change to match you server's URL)
 
 # Also, make sure you set the location of the roles in the object your IDP Returns

--- a/web/src/main/webapp/WEB-INF/config-security/config-security-openidconnect.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-openidconnect.xml
@@ -76,6 +76,7 @@
     <constructor-arg ref ="openidconnectClientRegistrationRepository" />
     <constructor-arg ref ="openidconnectInMemoryOAuth2AuthorizedClientService" />
     <property name="authenticationManager" ref="openidconnectProviderManager"/>
+    <property name="sessionAuthenticationStrategy" ref="sessionAuthenticationStrategy"/>
   </bean>
 
   <bean id="openidconnectDefaultAuthorizationCodeTokenResponseClient" class="org.springframework.security.oauth2.client.endpoint.DefaultAuthorizationCodeTokenResponseClient"/>
@@ -117,6 +118,18 @@
     <constructor-arg ref="openidconnectLogoutSuccessHandlerBase"/>
   </bean>
 
+  <bean id="oidcSessionRegistry" class="org.fao.geonet.kernel.security.openidconnect.oidclogout.InMemoryOidcSessionRegistry"/>
+  <bean id="sessionAuthenticationStrategy"
+        class="org.fao.geonet.kernel.security.openidconnect.oidclogout.OidcSessionRegistryAuthenticationStrategy"/>
+
+  <bean id="sessionMgmtFilter"
+        class="org.springframework.security.web.session.SessionManagementFilter">
+    <constructor-arg ref="securityContextRepository"/>
+    <constructor-arg ref="sessionAuthenticationStrategy"/>
+  </bean>
+  <bean id="backchannellogoutFilter"
+        class="org.fao.geonet.kernel.security.openidconnect.oidclogout.OidcBackchannelLogoutFilter"/>
+
   <bean id="logoutFilter"
         class="org.springframework.security.web.authentication.logout.LogoutFilter">
     <constructor-arg ref="openidconnectLogoutSuccessHandler"/>
@@ -150,6 +163,7 @@
 
         <ref bean="openidconnectOAuth2AuthorizationRequestRedirectFilter"/>
         <ref bean="openidconnectOAuth2LoginAuthenticationFilter"/>
+        <ref bean="backchannellogoutFilter"/>
         <ref bean="logoutFilter"/>
 
 

--- a/web/src/main/webapp/WEB-INF/config-security/config-security-openidconnectbearer-overrides.properties
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-openidconnectbearer-overrides.properties
@@ -48,7 +48,7 @@
 
 
 # make sure you IDP will allow redirects to:
-# http://localhost:7777/geonetwork/login/oauth2/code/geonetwork-oicd
+# http://localhost:7777/geonetwork/login/oauth2/code/geonetwork-oidc
 # (change to match you server's URL)
 
 # Also, make sure you set the location of the roles in the object your IDP Returns

--- a/web/src/main/webapp/WEB-INF/config-security/config-security-openidconnectbearer.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-openidconnectbearer.xml
@@ -76,6 +76,7 @@
     <constructor-arg ref ="openidconnectClientRegistrationRepository" />
     <constructor-arg ref ="openidconnectInMemoryOAuth2AuthorizedClientService" />
     <property name="authenticationManager" ref="openidconnectProviderManager"/>
+    <property name="sessionAuthenticationStrategy" ref="sessionAuthenticationStrategy"/>
   </bean>
 
   <bean id="openidconnectBearerTokenAuthenticationFilter" class="org.springframework.security.oauth2.server.resource.web.BearerTokenAuthenticationFilter">
@@ -212,6 +213,23 @@
 
     </constructor-arg>
   </bean>
+
+  <bean id="oidcSessionRegistry" class="org.fao.geonet.kernel.security.openidconnect.oidclogout.InMemoryOidcSessionRegistry"/>
+  <bean id="sessionAuthenticationStrategy"
+        class="org.fao.geonet.kernel.security.openidconnect.oidclogout.OidcSessionRegistryAuthenticationStrategy"/>
+
+  <bean id="sessionMgmtFilter"
+        class="org.springframework.security.web.session.SessionManagementFilter">
+    <constructor-arg ref="securityContextRepository"/>
+    <constructor-arg ref="sessionAuthenticationStrategy"/>
+  </bean>
+
+  <bean id="backchannellogoutFilter"
+        class="org.fao.geonet.kernel.security.openidconnect.oidclogout.OidcBackchannelLogoutFilter">
+    <constructor-arg ref="csrfFilter" />
+    <constructor-arg ref="geonetworkCsrfSecurityRequestMatcher" />
+  </bean>
+
   <util:list id="openidConnectFilterChanFiltersExclusive">
 
     <ref bean="securityContextPersistenceFilter"/>
@@ -221,6 +239,7 @@
 
     <ref bean="openidconnectOAuth2AuthorizationRequestRedirectFilter"/>
     <ref bean="openidconnectOAuth2LoginAuthenticationFilter"/>
+    <ref bean="backchannellogoutFilter"/>
     <ref bean="logoutFilter"/>
 
     <ref bean="openidconnectBearerTokenAuthenticationFilter"/>
@@ -241,6 +260,7 @@
 
     <ref bean="openidconnectOAuth2AuthorizationRequestRedirectFilter"/>
     <ref bean="openidconnectOAuth2LoginAuthenticationFilter"/>
+    <ref bean="backchannellogoutFilter"/>
     <ref bean="logoutFilter"/>
     <ref bean="sessionExpirationFilter"/>
     <!--     include a pre login filter-->


### PR DESCRIPTION
Implement OIDC Logout based on Spring security 6.5.x 
Add OidcBackchannelLogoutFilter that handles backchannel logout request and invalidate OIDC and http sessions
Add InMemoryOidcSessionRegistry that handles stores and removes OIDC sessions
Add OidcSessionRegistryAuthenticationStrategy that save the OIDC session during authentication
Modify xml configuration to config the filters and classes
Fix the typo of registrationId

# Checklist

- [✔️ ] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [✔️ ] *Pull request* provided for `main` branch, backports managed with label
- [ ✔️] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [✔️ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [✔️ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation


