### PR TITLE
Record page / Update metadata full view formatter to Use context information with xpath from labels.xml

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/xsl-view/common.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/xsl-view/common.xsl
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsl:stylesheet xmlns:xsl="http://www.w3.org/1999/XSL/Transform" xmlns:xs="http://www.w3.org/2001/XMLSchema"
+                xmlns:gn-fn-metadata="http://geonetwork-opensource.org/xsl/functions/metadata"
+                xmlns:saxon="http://saxon.sf.net/"
+                version="2.0" extension-element-prefixes="saxon"
+                exclude-result-prefixes="#all">
+
+
+  <xsl:function name="gn-fn-metadata:getXPath" as="xs:string">
+    <xsl:param name="node" as="node()"/>
+
+    <xsl:value-of select="gn-fn-metadata:getXPath($node, false())"/>
+  </xsl:function>
+
+  <xsl:function name="gn-fn-metadata:positionOfType" as="xs:string">
+    <xsl:param name="node" as="node()"/>
+    <xsl:variable name="nodePosition" select="$node/position()"/>
+    <xsl:variable name="allPrecedingSiblings"
+                  select="$node/preceding-sibling::*[name() = name($node)]"/>
+    <xsl:value-of select="count($allPrecedingSiblings) + 1"/>
+  </xsl:function>
+
+  <!--
+    Return the xpath of a node.
+  -->
+  <xsl:function name="gn-fn-metadata:getXPath" as="xs:string">
+    <xsl:param name="node" as="node()"/>
+    <xsl:param name="withPosition" as="xs:boolean"/>
+
+    <!-- Avoid root element. -->
+    <xsl:variable name="untilIndex" select="1"/>
+    <xsl:variable name="xpathSeparator">/</xsl:variable>
+    <xsl:variable name="elementName" select="name($node)"/>
+    <xsl:variable name="isAttribute" select="$node/../attribute::*[name() = $elementName]"/>
+    <xsl:variable name="ancestors" select="$node/ancestor::*"/>
+
+    <xsl:variable name="xpath">
+      <xsl:for-each select="$ancestors[position() != $untilIndex]">
+        <xsl:value-of select="if ($withPosition)
+          then concat($xpathSeparator, name(.), '[', gn-fn-metadata:positionOfType(.), ']')
+          else concat($xpathSeparator, name(.))"/>
+      </xsl:for-each>
+    </xsl:variable>
+
+    <xsl:value-of
+      select="if ($isAttribute)
+      then concat($xpath, $xpathSeparator, '@', $elementName)
+      else if ($withPosition)
+        then concat($xpath, $xpathSeparator, $elementName, '[', gn-fn-metadata:positionOfType($node), ']')
+        else concat($xpath, $xpathSeparator, $elementName)
+      "
+    />
+  </xsl:function>
+</xsl:stylesheet>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/xsl-view/view.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/xsl-view/view.xsl
@@ -61,6 +61,7 @@
   <xsl:include href="../jsonld/iso19115-3.2018-to-jsonld.xsl"/>
   <xsl:include href="../citation/base.xsl"/>
   <xsl:include href="../citation/common.xsl"/>
+  <xsl:include href="./common.xsl"/>
 
   <!-- The core formatter XSL layout based on the editor configuration -->
   <xsl:include href="sharedFormatterDir/xslt/render-layout.xsl"/>
@@ -447,7 +448,9 @@
     <xsl:variable name="name"
                   select="name()"/>
 
-    <xsl:variable name="context"
+    <xsl:variable name="contextXpath"
+                  select="gn-fn-metadata:getXPath(.)" />
+    <xsl:variable name="contextParent"
                   select="name(..)"/>
 
     <xsl:choose>
@@ -455,7 +458,7 @@
       <xsl:when test="$fieldName = '' and $language = 'all' and count($languages/lang) > 0">
         <xsl:for-each select="$languages/lang">
           <div xml:lang="{@code}">
-            <xsl:value-of select="tr:nodeLabel(tr:create($schema, @code), $name, $context)"/>
+            <xsl:value-of select="tr:nodeLabel(tr:create($schema, @code), $name, $contextParent, $contextXpath)"/>
             <xsl:if test="$contextLabel">
               <xsl:variable name="extraLabel">
                 <xsl:apply-templates mode="render-value"
@@ -476,7 +479,7 @@
           <xsl:variable name="lang3"
                         select="$metadata//mdb:otherLocale/*[@id = $id]/lan:languageCode/*/@codeListValue"/>
           <div xml:lang="{$lang3}">
-            <xsl:value-of select="tr:nodeLabel(tr:create($schema, $lang3), $name, $context)"/>
+            <xsl:value-of select="tr:nodeLabel(tr:create($schema, $lang3), $name, $contextParent, $contextXpath)"/>
           </div>
         </xsl:for-each>
       </xsl:when>
@@ -484,7 +487,7 @@
         <!-- Overriden label or element name in current UI language. -->
         <xsl:value-of select="if ($fieldName)
                                 then $fieldName
-                                else tr:nodeLabel(tr:create($schema), $name, $context)"/>
+                                else tr:nodeLabel(tr:create($schema), $name, $contextParent, $contextXpath)"/>
         <xsl:if test="$contextLabel">
           <xsl:variable name="extraLabel">
             <xsl:apply-templates mode="render-value"

--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
@@ -70,6 +70,7 @@
   <xsl:include href="../../formatter/jsonld/iso19139-to-jsonld.xsl"/>
   <xsl:include href="../../formatter/citation/base.xsl"/>
   <xsl:include href="../../../iso19115-3.2018/formatter/citation/common.xsl"/>
+  <xsl:include href="../../../iso19115-3.2018/formatter/xsl-view/common.xsl"/>
 
   <!-- The core formatter XSL layout based on the editor configuration -->
   <xsl:include href="sharedFormatterDir/xslt/render-layout.xsl"/>
@@ -84,7 +85,6 @@
   <xsl:variable name="allLanguages">
     <xsl:call-template name="get-iso19139-other-languages"/>
   </xsl:variable>
-
 
   <!-- Ignore some fields displayed in header or in right column -->
   <xsl:template mode="render-field"
@@ -457,7 +457,9 @@
     <xsl:variable name="name"
                   select="name()"/>
 
-    <xsl:variable name="context"
+    <xsl:variable name="contextXpath"
+                  select="gn-fn-metadata:getXPath(.)" />
+    <xsl:variable name="contextParent"
                   select="name(..)"/>
 
     <xsl:choose>
@@ -465,7 +467,7 @@
       <xsl:when test="$fieldName = '' and $language = 'all' and count($languages/lang) > 0">
         <xsl:for-each select="$languages/lang">
           <div xml:lang="{@code}">
-            <xsl:value-of select="tr:nodeLabel(tr:create($schema, @code), $name, $context)"/>
+            <xsl:value-of select="tr:nodeLabel(tr:create($schema, @code), $name, $contextParent, $contextXpath)"/>
             <xsl:if test="$contextLabel">
               <xsl:variable name="extraLabel">
                 <xsl:apply-templates mode="render-value"
@@ -486,7 +488,7 @@
           <xsl:variable name="lang3"
                         select="$metadata//gmd:locale/*[@id = $id]/gmd:languageCode/*/@codeListValue"/>
           <div xml:lang="{$lang3}">
-            <xsl:value-of select="tr:nodeLabel(tr:create($schema, $lang3), $name, $context)"/>
+            <xsl:value-of select="tr:nodeLabel(tr:create($schema, $lang3), $name, $contextParent, $contextXpath)"/>
           </div>
         </xsl:for-each>
       </xsl:when>
@@ -494,7 +496,7 @@
         <!-- Overriden label or element name in current UI language. -->
         <xsl:value-of select="if ($fieldName)
                                 then $fieldName
-                                else tr:nodeLabel(tr:create($schema), $name, $context)"/>
+                                else  tr:nodeLabel(tr:create($schema), $name, $contextParent, $contextXpath)"/>
         <xsl:if test="$contextLabel">
           <xsl:variable name="extraLabel">
             <xsl:apply-templates mode="render-value"

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/SchemaLocalizations.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/SchemaLocalizations.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2025 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -83,9 +83,7 @@ public class SchemaLocalizations {
      *
      * @return Map(SchemaName, SchemaLocalizations)
      */
-    static Map<String, SchemaLocalization> loadSchemaLocalizations(ApplicationContext context, SchemaManager schemaManager)
-        throws IOException, JDOMException {
-
+    static Map<String, SchemaLocalization> loadSchemaLocalizations(ApplicationContext context, SchemaManager schemaManager) {
         Map<String, SchemaLocalization> localization = Maps.newHashMap();
         final Set<String> allSchemas = schemaManager.getSchemas();
         for (String schema : allSchemas) {
@@ -155,39 +153,107 @@ public class SchemaLocalizations {
     }
 
     /**
-     * Look up a translation in the schema's labels.xml file
+     * Look up a translation in the schema's labels.xml file.
+     *   - qualifiedParentNodeName is used as the second lookup key.
+     *   - if not found the default value will be returned.
      *
      * @param qualifiedNodeName       the name to use as a key for the lookup
      * @param qualifiedParentNodeName the name of the parent, used as the second lookup key.  This
-     *                                can be null and the default value will be returned
+     *                                can be null
      */
     public String nodeLabel(String qualifiedNodeName, String qualifiedParentNodeName) throws Exception {
-        return nodeTranslation(qualifiedNodeName, qualifiedParentNodeName, "label");
+        return nodeTranslation(qualifiedNodeName, qualifiedParentNodeName, "", "label");
     }
 
     /**
-     * Look up a description in the schema's labels.xml file
+     * Look up a translation in the schema's labels.xml file:
+     *   - qualifiedXpath is used as the second lookup key.
+     *   - if not found and provided the qualifiedParentNodeName is used as the second lookup key.
+     *   - if still not found the default value will be returned.
      *
      * @param qualifiedNodeName       the name to use as a key for the lookup
      * @param qualifiedParentNodeName the name of the parent, used as the second lookup key.  This
-     *                                can be null and the default value will be returned
+     *                                can be null
+     * @param qualifiedXpath          the element XPath, used as the second lookup key.  This
+     *                                can be null
+     */
+    public String nodeLabel(String qualifiedNodeName, String qualifiedParentNodeName, String qualifiedXpath) throws Exception {
+        return nodeTranslation(qualifiedNodeName, qualifiedParentNodeName, qualifiedXpath, "label");
+    }
+
+    /**
+     * Look up a description in the schema's labels.xml file.
+     *   - qualifiedParentNodeName is used as the second lookup key.
+     *   - If not found the default value will be returned.
+     *
+     * @param qualifiedNodeName       the name to use as a key for the lookup
+     * @param qualifiedParentNodeName the name of the parent, used as the second lookup key. This can be null
+     *
      */
     public String nodeDesc(String qualifiedNodeName, String qualifiedParentNodeName) throws Exception {
 
-        return nodeTranslation(qualifiedNodeName, qualifiedParentNodeName, "description");
+        return nodeTranslation(qualifiedNodeName, qualifiedParentNodeName, "", "description");
     }
 
-    public String nodeTranslation(String qualifiedNodeName, String qualifiedParentNodeName, String type) throws Exception {
+    /**
+     * Look up a description in the schema's labels.xml file.
+     *   - qualifiedXpath is used as the second lookup key.
+     *   - if not found and provided the qualifiedParentNodeName is used as the second lookup key.
+     *   - if still not found the default value will be returned.
+     *
+     * @param qualifiedNodeName       the name to use as a key for the lookup
+     * @param qualifiedParentNodeName the name of the parent, used as the second lookup key.  This
+     *                                can be null
+     * @param qualifiedXpath          the element XPath, used as the second lookup key.  This
+     *                                can be null
+     */
+    public String nodeDesc(String qualifiedNodeName, String qualifiedParentNodeName, String qualifiedXpath) throws Exception {
+
+        return nodeTranslation(qualifiedNodeName, qualifiedParentNodeName, qualifiedXpath, "description");
+    }
+
+    /**
+     * Look up a translation in the schema's labels.xml file.
+     *   - qualifiedXpath is used as the second lookup key.
+     *   - if not found and provided the qualifiedParentNodeName is used as the second lookup key.
+     *   - if still not found the default value will be returned.
+     *
+     * @param qualifiedNodeName       the name to use as a key for the lookup
+     * @param qualifiedParentNodeName the name of the parent, used as the second lookup key.  This
+     *                                can be null
+     * @param qualifiedXpath          the element XPath, used as the second lookup key.  This
+     *                                can be null
+     * @param type                    the type of translation to look up, label or description
+     */
+    public String nodeTranslation(String qualifiedNodeName, String qualifiedParentNodeName, String qualifiedXpath, String type) throws Exception {
         if (qualifiedParentNodeName == null) {
             qualifiedParentNodeName = "";
         }
 
+        if (qualifiedXpath == null) {
+            qualifiedXpath = "";
+        }
+
         for (SchemaLocalization schemaLocalization : this.schemaLocalizations) {
             final ImmutableTable<String, String, Element> labelIndex = schemaLocalization.getLabelIndex(this.languageHolder.getLang3());
-            Element element = labelIndex.get(qualifiedNodeName, qualifiedParentNodeName);
+            Element element = null;
+
+            // First try with the xpath if provided.
+            if (!qualifiedXpath.isEmpty()) {
+                element = labelIndex.get(qualifiedNodeName, qualifiedXpath);
+            }
+
+            // Next try with the parent node name.
+            if (element == null) {
+                element = labelIndex.get(qualifiedNodeName, qualifiedParentNodeName);
+            }
+
+            // Finally try with no parent node name.
             if (element == null) {
                 element = labelIndex.get(qualifiedNodeName, "");
             }
+
+            // If there are multiple elements with the same name just take the first one.
             if (element == null) {
                 final ImmutableCollection<Element> values = labelIndex.row(qualifiedNodeName).values();
                 if (!values.isEmpty()) {
@@ -198,7 +264,6 @@ public class SchemaLocalizations {
                 return element.getChildText(type);
             }
         }
-
 
         return qualifiedNodeName;
     }

--- a/services/src/test/java/org/fao/geonet/api/records/formatters/SchemaLocalizationsIntegrationTest.java
+++ b/services/src/test/java/org/fao/geonet/api/records/formatters/SchemaLocalizationsIntegrationTest.java
@@ -43,11 +43,11 @@ public class SchemaLocalizationsIntegrationTest extends AbstractServiceIntegrati
         CurrentLanguageHolder currentLanguageHolder = new TestLanguageHolder("fre");
         final SchemaLocalizations freIso19139 = new SchemaLocalizations(context, currentLanguageHolder, "iso19139", null);
 
-        final String keywordLabel = freIso19139.nodeTranslation("gmd:descriptiveKeywords", "srv:SV_ServiceIdentification", "label");
+        final String keywordLabel = freIso19139.nodeTranslation("gmd:descriptiveKeywords", "srv:SV_ServiceIdentification", null, "label");
         assertTrue("'" + keywordLabel + "' should contain 'mots'", keywordLabel.toLowerCase().contains("mots"));
         assertTrue("'" + keywordLabel + "' should contain 'clés'", keywordLabel.toLowerCase().contains("clés"));
 
-        String identifierLabel = freIso19139.nodeTranslation("gmd:identifier", "gmd:CI_Citation", "label");
+        String identifierLabel = freIso19139.nodeTranslation("gmd:identifier", "gmd:CI_Citation", null, "label");
         assertTrue("'" + identifierLabel + "' should contain 'identificateur'", identifierLabel.toLowerCase().contains("identificateur"));
     }
 

--- a/services/src/test/java/org/fao/geonet/api/records/formatters/SchemaLocalizationsTest.java
+++ b/services/src/test/java/org/fao/geonet/api/records/formatters/SchemaLocalizationsTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2025 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -29,13 +29,11 @@ import org.fao.geonet.domain.IsoLanguage;
 import org.fao.geonet.kernel.SchemaManager;
 import org.fao.geonet.repository.IsoLanguageRepository;
 import org.jdom.Element;
-import org.jdom.JDOMException;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
 import org.springframework.context.ApplicationContext;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Map;
@@ -43,6 +41,7 @@ import java.util.Map;
 import static org.fao.geonet.api.records.formatters.SchemaLocalizations.LANG_CODELIST_NS;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 public class SchemaLocalizationsTest {
 
@@ -87,7 +86,7 @@ public class SchemaLocalizationsTest {
             setAttribute(jeeves.constants.ConfigFile.Xml.Attr.BASE, "loc");
         return new XmlFile(config, "eng", true) {
             @Override
-            public Element getXml(ApplicationContext context, String lang, boolean makeCopy) throws JDOMException, IOException {
+            public Element getXml(ApplicationContext context, String lang, boolean makeCopy) {
                 return xml;
             }
         };
@@ -112,8 +111,7 @@ public class SchemaLocalizationsTest {
 
         localizations = new SchemaLocalizations(appContext, env, SCHEMA, null) {
             @Override
-            protected Map<String, SchemaLocalization> getSchemaLocalizations(ApplicationContext context, SchemaManager schemaManager)
-                throws IOException, JDOMException {
+            protected Map<String, SchemaLocalization> getSchemaLocalizations(ApplicationContext context, SchemaManager schemaManager) {
                 Map<String, SchemaLocalization> localizations = Maps.newHashMap();
                 Map<String, XmlFile> schemaInfo = Maps.newHashMap();
                 schemaInfo.put("labels.xml", createXmlFile(new Element("labels").addContent(Arrays.asList(
@@ -139,7 +137,7 @@ public class SchemaLocalizationsTest {
             }
 
             @Override
-            protected ConfigFile getConfigFile(SchemaManager schemaManager, String schema) throws IOException {
+            protected ConfigFile getConfigFile(SchemaManager schemaManager, String schema) {
                 return Mockito.mock(ConfigFile.class);
             }
         };
@@ -171,7 +169,7 @@ public class SchemaLocalizationsTest {
         assertEquals("German", localizations.codelistValueLabel(LANG_CODELIST_NS, "deu"));
         assertEquals("xyz", localizations.codelistValueLabel(LANG_CODELIST_NS, "xyz"));
         assertEquals("dd", localizations.codelistValueLabel(LANG_CODELIST_NS, "dd"));
-        assertEquals(null, localizations.codelistValueLabel(LANG_CODELIST_NS, null));
+        assertNull(localizations.codelistValueLabel(LANG_CODELIST_NS, null));
     }
 
     @Test

--- a/services/src/test/java/org/fao/geonet/api/records/formatters/SchemaLocalizationsTest.java
+++ b/services/src/test/java/org/fao/geonet/api/records/formatters/SchemaLocalizationsTest.java
@@ -59,10 +59,10 @@ public class SchemaLocalizationsTest {
         return sort;
     }
 
-    private static Element createLabelElement(String name, String parentName, String label, String desc) {
+    private static Element createLabelElement(String name, String parentNameOrXpath, String label, String desc) {
         final Element element = new Element("element");
-        if (parentName != null) {
-            element.setAttribute("context", parentName);
+        if (parentNameOrXpath != null) {
+            element.setAttribute("context", parentNameOrXpath);
         }
         return element.setAttribute("name", name).addContent(Arrays.asList(
             new Element("label").setText(label),
@@ -116,6 +116,7 @@ public class SchemaLocalizationsTest {
                 Map<String, XmlFile> schemaInfo = Maps.newHashMap();
                 schemaInfo.put("labels.xml", createXmlFile(new Element("labels").addContent(Arrays.asList(
                     createLabelElement("elem1", "parent", "Element One", "Desc Element One"),
+                    createLabelElement("elem1", "/path1/subpath1", "Element One XPath", "Desc Element One XPath"),
                     createLabelElement("elem1", null, "Element One No Parent", "Desc Element One No Parent"),
                     createLabelElement("elem2", null, "Element Two", "Desc Element Two")
                 ))));
@@ -148,6 +149,11 @@ public class SchemaLocalizationsTest {
         assertEquals("Element One", localizations.nodeLabel("elem1", "parent"));
         assertEquals("Element One No Parent", localizations.nodeLabel("elem1", null));
         assertEquals("Desc Element One No Parent", localizations.nodeDesc("elem1", null));
+
+        // If exact match on parent xpath then return that label
+        assertEquals("Element One XPath", localizations.nodeLabel("elem1", null, "/path1/subpath1"));
+
+        // If no exact match on parent or xpath then return the label without parent or xpath
         assertEquals("Desc Element One No Parent", localizations.nodeDesc("elem1", "random parent"));
         assertEquals("Desc Element Two", localizations.nodeDesc("elem2", "random parent"));
     }

--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
@@ -156,7 +156,7 @@
 
             <header>
               <h1>
-                <i class="fa fa-fw gn-icon-{$type}"/>
+                <i class="fa fa-fw gn-icon-{$type}"></i>
                 <xsl:copy-of select="$title"/>
                 <xsl:if test="$root = 'div'">
                   <span class="text-muted badge"
@@ -570,7 +570,10 @@
       </xsl:if>
     </xsl:variable>
 
-    <xsl:for-each select="$nodes">
+    <!-- The matching nodes when using evaluate loose their context, re-calculate it -->
+    <xsl:variable name="originalNodes" select="$metadata//*[deep-equal(., $nodes/*)]"/>
+
+    <xsl:for-each select="$originalNodes">
       <xsl:apply-templates mode="render-field">
         <xsl:with-param name="fieldName" select="$fieldName"/>
         <xsl:with-param name="collapsible" select="$collapsible"/>


### PR DESCRIPTION
The full view formatter was not calculating the label to display for an element when the element context property contained the full xpath instead of the parent element name.

For example, previously if the `gmd:element` was defined with different values depending on the xpath, like:

https://github.com/metadata101/iso19139.nl.geografie.2.0.0/blob/6b24bb8735e4ad6a7163de0ada3fbe9cf0a436dd/src/main/plugin/iso19139.nl.geografie.2.0.0/loc/dut/labels.xml#L540-L555

```xml
  <element name="gmd:description" context="/gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:description">
    <label>Beschrijving temporele dekking</label>
    <description>temporele dekking van de data, gespecificeerd als een periode.</description>
  </element>
  <element name="gmd:description" context="/gmd:MD_Metadata/gmd:dataQualityInfo/gmd:DQ_DataQuality/gmd:lineage/gmd:LI_Lineage/gmd:processStep/gmd:LI_ProcessStep/gmd:description">
    <label>Beschrijving uitgevoerde bewerkingen</label>
    <description>Beschrijving van de uitgevoerde bewerkingen.</description>
  </element>
  <element name="gmd:description" context="/gmd:MD_Metadata/gmd:dataQualityInfo/gmd:DQ_DataQuality/gmd:lineage/gmd:LI_Lineage/gmd:source/gmd:LI_Source/gmd:description">
    <label>Beschrijving brondata</label>
    <description>Algemene beschrijving of opmerking te geven betreft de kwaliteit van de (verschillende) brongegevens.</description>
  </element>
  <element name="gmd:description" context="/gmd:MD_Metadata/gmd:dataQualityInfo/gmd:DQ_DataQuality/gmd:lineage/gmd:LI_Lineage/gmd:source/gmd:LI_Source/gmd:sourceStep/gmd:LI_ProcessStep/gmd:description">
    <label>Inwinningsmethode</label>
    <description>Omschrijving processtap in bronproces.</description>
  </element>
```

For the description label for the lineage process step instead of displaying `Beschrijving uitgevoerde bewerkingen` was displaying incorrectly the first entry `Beschrijving temporele dekking` in the list.

With this change, the correct label is displayed

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation



