### PR TITLE
simplify the default configuration for datahub

### DIFF
--- a/plugins/datahub-integration/src/main/java/org/fao/geonet/datahub/DatahubController.java
+++ b/plugins/datahub-integration/src/main/java/org/fao/geonet/datahub/DatahubController.java
@@ -38,15 +38,15 @@ import static org.fao.geonet.kernel.schema.SchemaPlugin.LOGGER_NAME;
 public class DatahubController {
     public static final String INDEX_PATH = "/datahub/index.html";
     public static final String DATAHUB_FILES_PATH = "/datahub/";
-    public static final String DEFAULT_CONFIGURATION_FILE_PATH = DATAHUB_FILES_PATH + "assets/configuration/default.toml";
+    public static final String DEFAULT_CONFIGURATION_FILE_PATH = "/config/simplest-default.toml";
 
     @Autowired
     SourceRepository sourceRepository;
 
     @GetMapping("/datahub/status")
     public ResponseEntity<String> getDatahubStatus() throws IOException {
-        File configFile = FileUtils.getFileFromJar(DEFAULT_CONFIGURATION_FILE_PATH);
-        String defaultConfig = FileUtils.readFromInputStream(new FileInputStream(configFile));
+        InputStream configStream = getClass().getResourceAsStream(DEFAULT_CONFIGURATION_FILE_PATH);
+        String defaultConfig = FileUtils.readFromInputStream(configStream);
         JSONObject body = new JSONObject();
         body.put("defaultConfig", defaultConfig);
 
@@ -205,8 +205,8 @@ public class DatahubController {
         }
         // 3. fallback: read from default.toml file in resource
         else {
-            File defaultConfig = FileUtils.getFileFromJar(DEFAULT_CONFIGURATION_FILE_PATH);
-            return FileUtils.readFromInputStream(new FileInputStream(defaultConfig));
+            InputStream configStream = getClass().getResourceAsStream(DEFAULT_CONFIGURATION_FILE_PATH);
+            return FileUtils.readFromInputStream(configStream);
         }
     }
 

--- a/plugins/datahub-integration/src/main/resources/config/simplest-default.toml
+++ b/plugins/datahub-integration/src/main/resources/config/simplest-default.toml
@@ -1,0 +1,14 @@
+[global]
+geonetwork4_api_url = "/geonetwork/srv/api"
+datahub_url = "/datahub"
+proxy_path = ""
+
+[theme]
+primary_color = "#c82850"
+secondary_color = "#001638"
+main_color = "#555"
+background_color = "#fdfbff"
+
+[search]
+
+[map]


### PR DESCRIPTION
<!--Include a few sentences describing the overall goals for this Pull Request-->
The main goal is to provide a simple configuration, simplier than the default configuration used in geonetwork-UI. It's 
the same config as GNUI default, but without any commented configuration or any comments. 
<img width="1682" height="797" alt="image" src="https://github.com/user-attachments/assets/96e61500-8747-4fdf-adf5-b8350c2e17d6" />
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist


- [ ] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

