### PR TITLE
ISO19139 / ISO19115-3.2018 / Update resource identifier suggestion to use a random UUID instead of use the metadata identifier value.

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/process/add-resource-id.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/process/add-resource-id.xsl
@@ -8,14 +8,16 @@
                 xmlns:cit="http://standards.iso.org/iso/19115/-3/cit/2.0"
                 xmlns:mdb="http://standards.iso.org/iso/19115/-3/mdb/2.0"
                 xmlns:mri="http://standards.iso.org/iso/19115/-3/mri/1.0"
+                xmlns:util="java:org.fao.geonet.util.XslUtil"
+                xmlns:util-uuid="java:java.util.UUID"
                 version="2.0" exclude-result-prefixes="#all">
 
   <xsl:import href="../../iso19139/process/process-utility.xsl"/>
 
   <!-- i18n information -->
   <xsl:variable name="add-resource-id-loc">
-    <msg id="a" xml:lang="eng">Current record does not contain resource identifier. Compute resource identifier from metadata record identifier.</msg>
-    <msg id="a" xml:lang="fre">Cette fiche ne contient pas d'identifiant pour la ressource. Calculer l'identifiant à partir de l'identifiant de la fiche.</msg>
+    <msg id="a" xml:lang="eng">Current record does not contain resource identifier. Compute a resource identifier.</msg>
+    <msg id="a" xml:lang="fre">Cette fiche ne contient pas d'identifiant pour la ressource.  Calculer un identifiant de ressource.</msg>
   </xsl:variable>
 
 
@@ -72,10 +74,19 @@
                 cit:edition|
                 cit:editionDate"/>
 
-      <!-- Create resource identifier based on metadata record identifier -->
-      <xsl:variable name="urlWithoutLang" select="substring-before($catalogUrl, $nodeId)"/>
-      <xsl:variable name="prefix" select="if ($resource-id-url-prefix != '') then $resource-id-url-prefix else $urlWithoutLang"/>
-      <xsl:variable name="code" select="concat($prefix, /*/mdb:metadataIdentifier/mcc:MD_Identifier/mcc:code/gco:CharacterString)"/>
+      <!-- Create a random resource identifier -->
+      <xsl:variable name="resource-id-url-prefix-tmp"
+                    select="util:getSettingValue('metadata/resourceIdentifierPrefix')"/>
+
+      <xsl:variable name="resource-id-url-prefix-local"
+                    select="if (ends-with($resource-id-url-prefix-tmp, '/'))
+                            then $resource-id-url-prefix-tmp
+                            else concat($resource-id-url-prefix-tmp, '/')"/>
+
+
+      <xsl:variable name="resourceUuid" select="util-uuid:toString(util-uuid:randomUUID())" />
+      <xsl:variable name="prefix" select="if ($resource-id-url-prefix != '') then $resource-id-url-prefix else $resource-id-url-prefix-local"/>
+      <xsl:variable name="code" select="concat($prefix, $resourceUuid)"/>
 
       <xsl:copy-of
               select="cit:identifier[mcc:MD_Identifier/mcc:code/gco:CharacterString != $code]"/>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/process/add-resource-id.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/process/add-resource-id.xsl
@@ -23,6 +23,9 @@
 
   <xsl:variable name="resource-id-url-prefix" select="''"/>
 
+  <xsl:param name="useMetadataIdentifier" select="'0'"/>
+
+  <xsl:variable name="useMetadataIdentifierMode" select="geonet:parseBoolean($useMetadataIdentifier)"/>
 
   <xsl:template name="list-add-resource-id">
     <suggestion process="add-resource-id"/>
@@ -42,6 +45,9 @@
       <suggestion process="add-resource-id" id="{generate-id()}" category="identification" target="identification">
         <name><xsl:value-of select="geonet:i18n($add-resource-id-loc, 'a', $guiLang)"/></name>
         <operational>true</operational>
+        <params>
+          "useMetadataIdentifier":{"type":"boolean", "defaultValue":"<xsl:value-of select="$useMetadataIdentifier"/>"},
+        </params>
       </suggestion>
     </xsl:if>
 
@@ -74,19 +80,10 @@
                 cit:edition|
                 cit:editionDate"/>
 
-      <!-- Create a random resource identifier -->
-      <xsl:variable name="resource-id-url-prefix-tmp"
-                    select="util:getSettingValue('metadata/resourceIdentifierPrefix')"/>
-
-      <xsl:variable name="resource-id-url-prefix-local"
-                    select="if (ends-with($resource-id-url-prefix-tmp, '/'))
-                            then $resource-id-url-prefix-tmp
-                            else concat($resource-id-url-prefix-tmp, '/')"/>
-
-
-      <xsl:variable name="resourceUuid" select="util-uuid:toString(util-uuid:randomUUID())" />
-      <xsl:variable name="prefix" select="if ($resource-id-url-prefix != '') then $resource-id-url-prefix else $resource-id-url-prefix-local"/>
-      <xsl:variable name="code" select="concat($prefix, $resourceUuid)"/>
+      <xsl:variable name="code"
+                    select="if ($useMetadataIdentifierMode)
+                            then geonet:generateCodeFromMetadataIdentifier($catalogUrl, $nodeId, $resource-id-url-prefix, /*/mdb:metadataIdentifier/mcc:MD_Identifier/mcc:code/gco:CharacterString)
+                            else geonet:generateRandomCode($resource-id-url-prefix)"/>
 
       <xsl:copy-of
               select="cit:identifier[mcc:MD_Identifier/mcc:code/gco:CharacterString != $code]"/>
@@ -110,5 +107,36 @@
 
     </xsl:copy>
   </xsl:template>
+
+  <xsl:function name="geonet:generateCodeFromMetadataIdentifier">
+    <xsl:param name="catalogUrl"/>
+    <xsl:param name="nodeId"/>
+    <xsl:param name="resource-id-url-prefix"/>
+    <xsl:param name="metadataIdentifier"/>
+
+    <xsl:variable name="urlWithoutLang" select="substring-before($catalogUrl, $nodeId)"/>
+    <xsl:variable name="prefix"
+                  select="if ($resource-id-url-prefix != '') then $resource-id-url-prefix else $urlWithoutLang"/>
+
+    <xsl:value-of select="concat($prefix, $metadataIdentifier)"/>
+  </xsl:function>
+
+
+  <xsl:function name="geonet:generateRandomCode">
+    <xsl:param name="resource-id-url-prefix"/>
+
+    <xsl:variable name="resource-id-url-prefix-tmp"
+                  select="util:getSettingValue('metadata/resourceIdentifierPrefix')"/>
+
+    <xsl:variable name="resource-id-url-prefix-local"
+                  select="if (ends-with($resource-id-url-prefix-tmp, '/'))
+                            then $resource-id-url-prefix-tmp
+                            else concat($resource-id-url-prefix-tmp, '/')"/>
+    <xsl:variable name="resourceUuid" select="util-uuid:toString(util-uuid:randomUUID())"/>
+    <xsl:variable name="prefix"
+                  select="if ($resource-id-url-prefix != '') then $resource-id-url-prefix else $resource-id-url-prefix-local"/>
+
+    <xsl:value-of select="concat($prefix, $resourceUuid)"/>
+  </xsl:function>
 
 </xsl:stylesheet>

--- a/schemas/iso19139/src/main/plugin/iso19139/process/add-resource-id.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/process/add-resource-id.xsl
@@ -42,13 +42,10 @@
   </xsl:variable>
 
 
-  <xsl:variable name="resource-id-url-prefix-tmp"
-                select="util:getSettingValue('metadata/resourceIdentifierPrefix')"/>
+  <xsl:variable name="resource-id-url-prefix" select="''"/>
+  <xsl:param name="useMetadataIdentifier" select="'0'"/>
 
-  <xsl:variable name="resource-id-url-prefix"
-                select="if (ends-with($resource-id-url-prefix-tmp, '/'))
-                            then $resource-id-url-prefix-tmp
-                            else concat($resource-id-url-prefix-tmp, '/')"/>
+  <xsl:variable name="useMetadataIdentifierMode" select="geonet:parseBoolean($useMetadataIdentifier)"/>
 
 
 
@@ -72,6 +69,9 @@
           <xsl:value-of select="geonet:i18n($add-resource-id-loc, 'a', $guiLang)"/>
         </name>
         <operational>true</operational>
+        <params>
+          "useMetadataIdentifier":{"type":"boolean", "defaultValue":"<xsl:value-of select="$useMetadataIdentifier"/>"},
+        </params>
       </suggestion>
     </xsl:if>
 
@@ -88,14 +88,35 @@
   <!-- Remove geonet:* elements. -->
   <xsl:template match="geonet:*" priority="2"/>
 
-  <xsl:function name="gn-fn-iso19139:resource-id-generate" as="xs:string">
-    <xsl:param name="resourceIdentifier" as="xs:string"/>
+  <xsl:function name="geonet:generateCodeFromMetadataIdentifier">
+    <xsl:param name="catalogUrl"/>
+    <xsl:param name="nodeId"/>
+    <xsl:param name="resource-id-url-prefix"/>
+    <xsl:param name="metadataIdentifier"/>
 
-    <!-- Create resource identifier based on metadata record identifier -->
     <xsl:variable name="urlWithoutLang" select="substring-before($catalogUrl, $nodeId)"/>
     <xsl:variable name="prefix"
                   select="if ($resource-id-url-prefix != '') then $resource-id-url-prefix else $urlWithoutLang"/>
-    <xsl:value-of select="concat($prefix, $resourceIdentifier)"/>
+
+    <xsl:value-of select="concat($prefix, $metadataIdentifier)"/>
+  </xsl:function>
+
+
+  <xsl:function name="geonet:generateRandomCode">
+    <xsl:param name="resource-id-url-prefix"/>
+
+    <xsl:variable name="resource-id-url-prefix-tmp"
+                  select="util:getSettingValue('metadata/resourceIdentifierPrefix')"/>
+
+    <xsl:variable name="resource-id-url-prefix-local"
+                  select="if (ends-with($resource-id-url-prefix-tmp, '/'))
+                            then $resource-id-url-prefix-tmp
+                            else concat($resource-id-url-prefix-tmp, '/')"/>
+    <xsl:variable name="resourceUuid" select="util-uuid:toString(util-uuid:randomUUID())"/>
+    <xsl:variable name="prefix"
+                  select="if ($resource-id-url-prefix != '') then $resource-id-url-prefix else $resource-id-url-prefix-local"/>
+
+    <xsl:value-of select="concat($prefix, $resourceUuid)"/>
   </xsl:function>
 
   <xsl:template
@@ -112,10 +133,13 @@
                 gmd:edition|
                 gmd:editionDate"/>
 
-      <xsl:variable name="code" select="gn-fn-iso19139:resource-id-generate(util-uuid:toString(util-uuid:randomUUID()))" />
+      <xsl:variable name="code"
+                    select="if ($useMetadataIdentifierMode)
+                            then geonet:generateCodeFromMetadataIdentifier($catalogUrl, $nodeId, $resource-id-url-prefix, /*/gmd:fileIdentifier/gco:CharacterString)
+                            else geonet:generateRandomCode($resource-id-url-prefix)"/>
 
       <xsl:copy-of
-        select="gmd:identifier"/>
+        select="gmd:identifier[gmd:MD_Identifier/gmd:code/gco:CharacterString != $code]"/>
       <gmd:identifier>
         <gmd:MD_Identifier>
           <gmd:code>
@@ -133,7 +157,8 @@
                 gmd:otherCitationDetails|
                 gmd:collectiveTitle|
                 gmd:ISBN|
-                gmd:ISSN"/>
+                gmd:ISSN|
+                gmd:onlineResource"/>
 
     </xsl:copy>
   </xsl:template>


### PR DESCRIPTION
Using the metadata uuid for the resource identifier uuid is not recommended. With this change a random UUID is generated in the metadata editor suggestion to generate a resource identifier

Updated the ISO19115-3.2018 suggestion  to use the `metadata/resourceIdentifierPrefix` setting in both processes to generate similar identifiers in both schemas.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation


