### PR TITLE
Stream metadata resources

### DIFF
--- a/core/src/main/java/org/fao/geonet/api/records/attachments/ResourceLoggerStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/ResourceLoggerStore.java
@@ -34,7 +34,6 @@ import org.fao.geonet.domain.MetadataFileUpload;
 import org.fao.geonet.domain.MetadataResource;
 import org.fao.geonet.domain.MetadataResourceContainer;
 import org.fao.geonet.domain.MetadataResourceVisibility;
-import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.repository.MetadataFileDownloadRepository;
 import org.fao.geonet.repository.MetadataFileUploadRepository;
 import org.fao.geonet.util.ThreadPool;
@@ -80,6 +79,27 @@ public class ResourceLoggerStore extends AbstractStore {
                                       final String resourceId, Boolean approved) throws Exception {
         if (decoratedStore != null) {
             ResourceHolder holder = decoratedStore.getResource(context, metadataUuid, visibility, resourceId, approved);
+            if (holder != null) {
+                // TODO: Add Requester details which may have been provided by a form ?
+                storeGetRequest(context, metadataUuid, holder.getMetadata().getId(), "", "", "", "", new ISODate().toString(), approved);
+            }
+            return holder;
+        }
+        return null;
+    }
+
+    @Override
+    public MetadataResource getResourceMetadata(ServiceContext context, String metadataUuid, MetadataResourceVisibility visibility, String resourceId, Boolean approved) throws Exception {
+        if (decoratedStore != null) {
+            return decoratedStore.getResourceMetadata(context, metadataUuid, visibility, resourceId, approved);
+        }
+        return null;
+    }
+
+    @Override
+    public ResourceHolder getResourceWithRange(ServiceContext context, String metadataUuid, MetadataResourceVisibility visibility, String resourceId, Boolean approved, long start, long end) throws Exception {
+        if (decoratedStore != null) {
+            ResourceHolder holder = decoratedStore.getResourceWithRange(context, metadataUuid, visibility, resourceId, approved, start, end);
             if (holder != null) {
                 // TODO: Add Requester details which may have been provided by a form ?
                 storeGetRequest(context, metadataUuid, holder.getMetadata().getId(), "", "", "", "", new ISODate().toString(), approved);

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/Store.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/Store.java
@@ -29,6 +29,7 @@ import jeeves.server.context.ServiceContext;
 import org.fao.geonet.domain.MetadataResource;
 import org.fao.geonet.domain.MetadataResourceContainer;
 import org.fao.geonet.domain.MetadataResourceVisibility;
+import org.springframework.core.io.Resource;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.Closeable;
@@ -38,9 +39,6 @@ import java.nio.file.Path;
 import java.util.Date;
 import java.util.List;
 import javax.annotation.Nullable;
-
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 /**
  * A store allows user to upload resources (eg. files) to a metadata record and retrieve them.
@@ -104,7 +102,7 @@ public interface Store {
     List<MetadataResource> getResources(ServiceContext context, String metadataUuid, MetadataResourceVisibility metadataResourceVisibility, String filter, Boolean approved) throws Exception;
 
     /**
-     * Retrieve a metadata resource path.
+     * Retrieve a resource.
      *
      *
      * @param context
@@ -116,7 +114,7 @@ public interface Store {
     ResourceHolder getResource(ServiceContext context, String metadataUuid, String resourceId) throws Exception;
 
     /**
-     * Retrieve a metadata resource path.
+     * Retrieve a resource.
      *
      *
      * @param context
@@ -129,7 +127,7 @@ public interface Store {
             String resourceId, Boolean approved) throws Exception;
 
     /**
-     * Retrieve a metadata resource path.
+     * Retrieve a resource.
      *
      *
      * @param context
@@ -141,12 +139,41 @@ public interface Store {
     ResourceHolder getResource(ServiceContext context, String metadataUuid, String resourceId, Boolean approved) throws Exception;
 
     /**
-     * Retrieve a metadata resource path (for internal use eg. indexing)
+     * Retrieve a resource (for internal use eg. indexing)
      */
     ResourceHolder getResourceInternal(String metadataUuid,
                                        final MetadataResourceVisibility visibility,
                                        String resourceId,
                                        Boolean approved) throws Exception;
+
+
+    /**
+     * Retrieve the metadata of a resource.
+     *
+     *
+     * @param context       The service context
+     * @param metadataUuid  The metadata UUID
+     * @param visibility    The type of sharing policy {@link MetadataResourceVisibility}
+     * @param resourceId    The resource identifier of its filename
+     * @return The resource
+     */
+    MetadataResource getResourceMetadata(ServiceContext context, String metadataUuid, MetadataResourceVisibility visibility,
+                                         String resourceId, Boolean approved) throws Exception;
+
+    /**
+     * Retrieve a range of bytes from a resource.
+     *
+     *
+     * @param context       The service context
+     * @param metadataUuid  The metadata UUID
+     * @param visibility    The type of sharing policy {@link MetadataResourceVisibility}
+     * @param resourceId    The resource identifier of its filename
+     * @param start         The start byte
+     * @param end           The end byte
+     * @return The specified range of the resource
+     */
+    ResourceHolder getResourceWithRange(ServiceContext context, String metadataUuid, MetadataResourceVisibility visibility,
+                                        String resourceId, Boolean approved, long start, long end) throws Exception;
 
     /**
      * Add a new resource from a file.
@@ -192,30 +219,30 @@ public interface Store {
         throws Exception;
 
     /**
-     * Add a new resource from a local file path.
+     * Add a new resource.
      *
      *
      * @param context
      * @param metadataUuid               The metadata UUID
-     * @param filePath                   The resource local filepath
+     * @param resource                   The resource
      * @param metadataResourceVisibility The type of sharing policy {@link MetadataResourceVisibility}
-     * @param approved   Return the approved version or not
+     * @param approved                   Return the approved version or not
      * @return The resource description
      */
-    MetadataResource putResource(ServiceContext context, String metadataUuid, Path filePath, MetadataResourceVisibility metadataResourceVisibility, Boolean approved) throws Exception;
+    MetadataResource putResource(ServiceContext context, String metadataUuid, Resource resource, MetadataResourceVisibility metadataResourceVisibility, Boolean approved) throws Exception;
 
     /**
-     * Add a new resource from a local file path.
+     * Add a new resource.
      *
      *
      * @param context
      * @param metadataUuid               The metadata UUID
-     * @param filePath                   The resource local filepath
+     * @param resource                   The resource
      * @param metadataResourceVisibility The type of sharing policy {@link MetadataResourceVisibility}
      * @return The resource description
      */
-	@Deprecated
-    MetadataResource putResource(ServiceContext context, String metadataUuid, Path filePath, MetadataResourceVisibility metadataResourceVisibility) throws Exception;
+    @Deprecated
+    MetadataResource putResource(ServiceContext context, String metadataUuid, Resource resource, MetadataResourceVisibility metadataResourceVisibility) throws Exception;
 
     /**
      * Add a new resource from a URL.
@@ -360,8 +387,32 @@ public interface Store {
      */
     void copyResources(ServiceContext context, String sourceUuid, String targetUuid, MetadataResourceVisibility metadataResourceVisibility, boolean sourceApproved, boolean targetApproved) throws Exception;
 
+    /**
+     * Retrieve a range of bytes from a resource.
+     *
+     *
+     * @param context       The service context
+     * @param metadataUuid  The metadata UUID
+     * @param resourceId    The resource identifier of its filename
+     * @param start         The start byte
+     * @param end           The end byte
+     * @return The specified range of the resource
+     */
+    ResourceHolder getResourceWithRange(ServiceContext context, String metadataUuid, String resourceId, Boolean approved, long start, long end) throws Exception;
+
+    /**
+     * Retrieve the metadata of a resource.
+     *
+     *
+     * @param context       The service context
+     * @param metadataUuid  The metadata UUID
+     * @param resourceId    The resource identifier of its filename
+     * @return The metadata of the resource
+     */
+    MetadataResource getResourceMetadata(ServiceContext context, String metadataUuid, String resourceId, Boolean approved) throws Exception;
+
     interface ResourceHolder extends Closeable {
-        Path getPath();
+        Resource getResource();
         MetadataResource getMetadata();
     }
 

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/StoreUtils.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/StoreUtils.java
@@ -155,7 +155,7 @@ public abstract class StoreUtils {
             try (
               Store.ResourceHolder holder = store.getResource(context, metadataUuid, resource.getVisibility(),
                     resource.getFilename(), approved);
-              InputStream inputStream = Files.newInputStream(holder.getPath())
+              InputStream inputStream = holder.getResource().getInputStream();
             ) {
                 Files.copy(inputStream, destinationDir.resolve(resource.getFilename()));
             }

--- a/core/src/main/java/org/fao/geonet/util/XslUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/XslUtil.java
@@ -1248,11 +1248,12 @@ public final class XslUtil {
                 BufferedImage image;
                 if (m.find()) {
                     Store store = ApplicationContextHolder.get().getBean("filesystemStore", Store.class);
-                    try (Store.ResourceHolder file = store.getResourceInternal(
+                    try (Store.ResourceHolder resourceHolder = store.getResourceInternal(
                         URLDecoder.decode(m.group(1), Constants.ENCODING),
                         MetadataResourceVisibility.PUBLIC,
-                        URLDecoder.decode(m.group(2), Constants.ENCODING), true)) {
-                        image = ImageIO.read(file.getPath().toFile());
+                        URLDecoder.decode(m.group(2), Constants.ENCODING), true);
+                        InputStream is = resourceHolder.getResource().getInputStream()) {
+                        image = ImageIO.read(is);
                     }
                 } else {
                     URL imageUrl = new URL(url);

--- a/datastorages/cmis/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
+++ b/datastorages/cmis/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
@@ -50,9 +50,12 @@ import org.fao.geonet.resources.CMISUtils;
 import org.fao.geonet.utils.IO;
 import org.fao.geonet.utils.Log;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.core.io.Resource;
 import org.springframework.util.StringUtils;
 
 import java.io.*;
+import java.math.BigInteger;
 import java.nio.file.*;
 import java.util.*;
 import java.util.regex.Pattern;
@@ -178,8 +181,40 @@ public class CMISStore extends AbstractStore {
         int metadataId = canDownload(context, metadataUuid, visibility, approved);
         try {
             final CmisObject object = cmisConfiguration.getClient().getObjectByPath(getKey(context, metadataUuid, metadataId, visibility, resourceId));
-            return new ResourceHolderImpl(object, createResourceDescription(context, metadataUuid, visibility, resourceId,
+            return new CMISResourceHolder(object, createResourceDescription(context, metadataUuid, visibility, resourceId,
                 (Document) object, metadataId, approved));
+        } catch (CmisObjectNotFoundException e) {
+            throw new ResourceNotFoundException(
+                String.format("Metadata resource '%s' not found for metadata '%s'", resourceId, metadataUuid))
+                .withMessageKey("exception.resourceNotFound.resource", new String[]{resourceId})
+                .withDescriptionKey("exception.resourceNotFound.resource.description", new String[]{resourceId, metadataUuid});
+        }
+    }
+
+    @Override
+    public MetadataResource getResourceMetadata(ServiceContext context, String metadataUuid, MetadataResourceVisibility visibility, String resourceId, Boolean approved) throws Exception {
+        // Those characters should not be allowed by URL structure
+        int metadataId = canDownload(context, metadataUuid, visibility, approved);
+        try {
+            final CmisObject object = cmisConfiguration.getClient().getObjectByPath(getKey(context, metadataUuid, metadataId, visibility, resourceId));
+            return createResourceDescription(context, metadataUuid, visibility, resourceId,
+                (Document) object, metadataId, approved);
+        } catch (CmisObjectNotFoundException e) {
+            throw new ResourceNotFoundException(
+                String.format("Metadata resource '%s' not found for metadata '%s'", resourceId, metadataUuid))
+                .withMessageKey("exception.resourceNotFound.resource", new String[]{resourceId})
+                .withDescriptionKey("exception.resourceNotFound.resource.description", new String[]{resourceId, metadataUuid});
+        }
+    }
+
+    @Override
+    public ResourceHolder getResourceWithRange(ServiceContext context, String metadataUuid, MetadataResourceVisibility metadataResourceVisibility, String resourceId, Boolean approved, long start, long end) throws Exception {
+        // Those characters should not be allowed by URL structure
+        int metadataId = canDownload(context, metadataUuid, metadataResourceVisibility, approved);
+        try {
+            final CmisObject object = cmisConfiguration.getClient().getObjectByPath(getKey(context, metadataUuid, metadataId, metadataResourceVisibility, resourceId));
+            return new CMISResourceHolder(object, createResourceDescription(context, metadataUuid, metadataResourceVisibility, resourceId,
+                (Document) object, metadataId, approved), start, end);
         } catch (CmisObjectNotFoundException e) {
             throw new ResourceNotFoundException(
                 String.format("Metadata resource '%s' not found for metadata '%s'", resourceId, metadataUuid))
@@ -196,7 +231,7 @@ public class CMISStore extends AbstractStore {
         try {
             ServiceContext context = ServiceContext.get();
             final CmisObject object = cmisConfiguration.getClient().getObjectByPath(getKey(context, metadataUuid, metadataId, visibility, resourceId));
-            return new ResourceHolderImpl(object, createResourceDescription(context, metadataUuid, visibility, resourceId,
+            return new CMISResourceHolder(object, createResourceDescription(context, metadataUuid, visibility, resourceId,
                 (Document) object, metadataId, approved));
         } catch (CmisObjectNotFoundException e) {
             throw new ResourceNotFoundException(
@@ -778,27 +813,29 @@ public class CMISStore extends AbstractStore {
         };
     }
 
-    protected static class ResourceHolderImpl implements ResourceHolder {
+    protected static class CMISResourceHolder implements ResourceHolder {
+        private final InputStreamResource resource;
+        private final MetadataResource metadata;
         private final CmisObject cmisObject;
-        private Path tempFolderPath;
-        private Path path;
-        private final MetadataResource metadataResource;
+        private final InputStream inputStream;
 
-        public ResourceHolderImpl(final CmisObject cmisObject, MetadataResource metadataResource) throws IOException {
-            // Preserve filename by putting the files into a temporary folder and using the same filename.
-            tempFolderPath = Files.createTempDirectory("gn-meta-res-" + metadataResource.getMetadataId() + "-");
-            tempFolderPath.toFile().deleteOnExit();
-            path = tempFolderPath.resolve(getFilename(cmisObject.getName()));
-            this.metadataResource = metadataResource;
+        public CMISResourceHolder(final CmisObject cmisObject, MetadataResource metadata) throws IOException {
+            this.metadata = metadata;
             this.cmisObject = cmisObject;
-            try (InputStream in = ((Document) cmisObject).getContentStream().getStream()) {
-                Files.copy(in, path, StandardCopyOption.REPLACE_EXISTING);
-            }
+            this.inputStream = ((Document) cmisObject).getContentStream().getStream();
+            this.resource = new InputStreamResource(inputStream);
+        }
+
+        public CMISResourceHolder(final CmisObject cmisObject, MetadataResource metadata, long start, long end) throws IOException {
+            this.metadata = metadata;
+            this.cmisObject = cmisObject;
+            this.inputStream = ((Document) cmisObject).getContentStream(BigInteger.valueOf(start), BigInteger.valueOf(end - start + 1)).getStream();
+            this.resource = new InputStreamResource(inputStream);
         }
 
         @Override
-        public Path getPath() {
-            return path;
+        public Resource getResource() {
+            return resource;
         }
 
         public CmisObject getCmisObject() {
@@ -807,15 +844,12 @@ public class CMISStore extends AbstractStore {
 
         @Override
         public MetadataResource getMetadata() {
-            return metadataResource;
+            return metadata;
         }
 
         @Override
         public void close() throws IOException {
-            // Delete temporary file and folder.
-            IO.deleteFileOrDirectory(tempFolderPath, true);
-            path=null;
-            tempFolderPath = null;
+            inputStream.close();
         }
     }
 }

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/ogcwxs/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/ogcwxs/Harvester.java
@@ -61,6 +61,7 @@ import org.jdom.Element;
 import org.jdom.JDOMException;
 import org.jdom.Namespace;
 import org.jdom.xpath.XPath;
+import org.springframework.core.io.PathResource;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.client.ClientHttpResponse;
 
@@ -916,7 +917,7 @@ class Harvester extends BaseAligner<OgcWxSParams> implements IHarvester<HarvestR
                 store.delResource(context, layer.uuid, filename.getFileName().toString());
             } catch (Exception e) {}
             MetadataResource resource = store.putResource(context, layer.uuid,
-                filename,
+                new PathResource(filename),
                 MetadataResourceVisibility.PUBLIC);
             Path xslProcessing = schemaMan
                 .getSchemaDir(schema).resolve("process")

--- a/services/src/main/java/org/fao/geonet/api/groups/GroupsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/groups/GroupsApi.java
@@ -33,7 +33,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jeeves.server.UserSession;
 import jeeves.server.context.ServiceContext;
-import org.apache.commons.collections4.CollectionUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang.StringUtils;
 import org.apache.commons.lang.exception.ExceptionUtils;
@@ -219,7 +218,7 @@ public class GroupsApi {
                             // webRequest.checkNotModified sets the right HTTP headers
                             return;
                         }
-                        response.setContentType(AttachmentsApi.getFileContentType(image.getPath()));
+                        response.setContentType(AttachmentsApi.getMediaType(image.getPath().getFileName().toString()).toString());
                         response.setContentLength((int) Files.size(image.getPath()));
                         response.addHeader("Cache-Control", "max-age=" + SIX_HOURS + ", public");
                         FileUtils.copyFile(image.getPath().toFile(), response.getOutputStream());

--- a/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsActionsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsActionsApi.java
@@ -40,6 +40,7 @@ import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.thumbnail.ThumbnailMaker;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
+import org.springframework.core.io.PathResource;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Controller;
 import org.springframework.stereotype.Service;
@@ -131,7 +132,7 @@ public class AttachmentsActionsApi {
                 jsonConfig,
                 rotationAngle);
 
-            return store.putResource(context, metadataUuid, thumbnailFile, MetadataResourceVisibility.PUBLIC, false);
+            return store.putResource(context, metadataUuid, new PathResource(thumbnailFile), MetadataResourceVisibility.PUBLIC, false);
         } finally {
             if (thumbnailFile != null) {
                 FileUtils.deleteQuietly(thumbnailFile.toFile());

--- a/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsApi.java
@@ -66,6 +66,7 @@ import org.springframework.web.context.request.ServletWebRequest;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
+import javax.activation.MimetypesFileTypeMap;
 import javax.annotation.PostConstruct;
 import javax.imageio.ImageIO;
 import javax.servlet.http.HttpServletRequest;
@@ -101,40 +102,17 @@ public class AttachmentsApi {
     }
 
     /**
-     * Based on the file content or file extension return an appropiate mime type.
+     * Based on the file extension return an appropriate mime type.
      *
      * @return The mime type or application/{{file_extension}} if none found.
      */
-    public static String getFileContentType(Path file) throws IOException {
-        String contentType = Files.probeContentType(file);
-        if (contentType == null) {
-            String ext = com.google.common.io.Files.getFileExtension(file.getFileName().toString()).toLowerCase();
-            switch (ext) {
-                case "png":
-                case "gif":
-                case "bmp":
-                    contentType = "image/" + ext;
-                    break;
-                case "tif":
-                case "tiff":
-                    contentType = "image/tiff";
-                    break;
-                case "jpg":
-                case "jpeg":
-                    contentType = "image/jpeg";
-                    break;
-                case "txt":
-                    contentType = "text/plain";
-                    break;
-                case "htm":
-                case "html":
-                    contentType = "text/html";
-                    break;
-                default:
-                    contentType = "application/" + ext;
-            }
+    public static MediaType getMediaType(String filename) {
+        String mimeType = null;
+
+        if (filename != null) {
+            mimeType = new MimetypesFileTypeMap().getContentType(filename);
         }
-        return contentType;
+        return (mimeType != null ? MediaType.parseMediaType(mimeType) : MediaType.APPLICATION_OCTET_STREAM);
     }
 
     public Store getStore() {

--- a/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsApi.java
@@ -48,10 +48,8 @@ import org.fao.geonet.events.history.AttachmentDeletedEvent;
 import org.fao.geonet.util.ImageUtil;
 import org.springframework.context.ApplicationContext;
 import org.springframework.core.io.ByteArrayResource;
-import org.springframework.core.io.PathResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.*;
-import org.springframework.lang.NonNull;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Service;
 import org.springframework.web.bind.WebDataBinder;
@@ -73,8 +71,7 @@ import javax.servlet.http.HttpServletRequest;
 import java.awt.image.BufferedImage;
 import java.io.*;
 import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Path;
+import java.time.ZonedDateTime;
 import java.util.List;
 
 /**
@@ -253,63 +250,111 @@ public class AttachmentsApi {
         @Parameter(hidden = true) HttpServletRequest request
     ) throws Exception {
         ServiceContext context = ApiUtils.createServiceContext(request);
-
         ApiUtils.canViewRecord(metadataUuid, request);
 
-        // Get the resource holder for the requested resource
-        Store.ResourceHolder file = store.getResource(context, metadataUuid, resourceId, approved);
+        // Get the resource metadata
+        // We need size, last modified date and etag for the conditional headers
+        MetadataResource resourceMetadata = store.getResourceMetadata(context, metadataUuid, resourceId, approved);
 
-        // Get the resource properties
-        long fileSize = Files.size(file.getPath());
-        long fileLastModified = file.getMetadata().getLastModification().getTime();
-        MediaType fileMediaType = MediaType.parseMediaType(getFileContentType(file.getPath()));
-        String fileETag = "\"" + DigestUtils.md5Hex(file.getMetadata().getFilename() + fileLastModified + fileSize) + "\"";
+        if (resourceMetadata == null) {
+            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+        }
+
+        String fileName = resourceMetadata.getFilename();
+        long fileLastModifiedDate = resourceMetadata.getLastModification().getTime();
+        long fileSize = resourceMetadata.getSize();
+        MediaType fileMediaType = getMediaType(fileName);
+        String fileETag = "\"" + DigestUtils.md5Hex(fileName + fileSize + resourceMetadata.getVersion() + fileLastModifiedDate) + "\"";
 
         // Set common headers
         HttpHeaders responseHeaders = new HttpHeaders();
         responseHeaders.setCacheControl(CacheControl.noCache());
-        responseHeaders.setLastModified(fileLastModified);
+        responseHeaders.setLastModified(fileLastModifiedDate);
         responseHeaders.setETag(fileETag);
+        responseHeaders.set(HttpHeaders.ACCEPT_RANGES, "bytes");
 
         // Check if the request is not modified based on ETag or Last-Modified
-        if (new ServletWebRequest(request).checkNotModified(fileETag, fileLastModified)) {
+        if (new ServletWebRequest(request).checkNotModified(fileETag, fileLastModifiedDate)) {
             return ResponseEntity.status(HttpStatus.NOT_MODIFIED).headers(responseHeaders).build();
         }
 
-        // Check if the file is an image and if a size is requested
+        HttpRange range = null;
+        try {
+            List<HttpRange> ranges = HttpRange.parseRanges(request.getHeader(HttpHeaders.RANGE));
+            if (!ranges.isEmpty()) {
+                range = ranges.get(0);
+                if (range.getRangeStart(fileSize) >= fileSize) {
+                    throw new IllegalArgumentException("Range start (" + range.getRangeStart(fileSize) +
+                        ") must be lower than file size (" + fileSize + ").");
+                }
+            }
+        } catch (IllegalArgumentException e) {
+            // invalid range -> 416 with real size
+            return ResponseEntity.status(HttpStatus.REQUESTED_RANGE_NOT_SATISFIABLE)
+                .header(HttpHeaders.CONTENT_RANGE, "bytes */" + fileSize)
+                .headers(responseHeaders)
+                .build();
+        }
+
+        // If the request is a range request, check the If-Range header
+        String ifRange = request.getHeader(HttpHeaders.IF_RANGE);
+        if (range != null && ifRange != null) {
+            if (ifRange.startsWith("W/")) {
+                range = null; // weak ETag -> serve full resource
+            } else if (ifRange.startsWith("\"")) {
+                if (fileETag == null || !fileETag.equals(ifRange)) {
+                    range = null; // strong ETag mismatch -> serve full resource
+                }
+            } else {
+                try {
+                    long ifRangeMillis = ZonedDateTime
+                        .parse(ifRange, java.time.format.DateTimeFormatter.RFC_1123_DATE_TIME)
+                        .toInstant().toEpochMilli();
+                    if (fileLastModifiedDate > ifRangeMillis) {
+                        range = null; // newer -> serve full resource
+                    }
+                } catch (Exception ignored) {
+                    range = null; // invalid date -> full
+                }
+            }
+        }
+
+        // If the resource is an image and a size is requested, resize the image and return it
         if (fileMediaType.getType().equals("image") && size != null) {
-            return serveResizedImage(file.getPath(), file.getMetadata().getFilename(), responseHeaders, size);
+            Store.ResourceHolder resourceHolder = store.getResource(context, metadataUuid, resourceId, approved);
+            return serveResizedImage(resourceHolder.getResource(), fileName, responseHeaders, size);
         }
 
         // Set headers for downloads
         responseHeaders.setContentType(fileMediaType);
-        responseHeaders.setContentDisposition(ContentDisposition.attachment().filename(file.getMetadata().getFilename()).build());
-        responseHeaders.setContentLength(fileSize);
+        responseHeaders.setContentDisposition(ContentDisposition.attachment().filename(fileName).build());
 
-        // Wrap a PathResource so that closing its InputStream also closes the holder
-        // Auto-closing will not work here as it will prematurely delete the temporary file for storage implementations that use temporary files.
-        PathResource resource = new PathResource(file.getPath()) {
-            @Override
-            @NonNull
-            public InputStream getInputStream() throws IOException {
-                InputStream delegate = super.getInputStream();
-                return new FilterInputStream(delegate) {
-                    @Override
-                    public void close() throws IOException {
-                        try {
-                            super.close();
-                        } finally {
-                            file.close();
-                        }
-                    }
-                };
+        // Get the resource or a range of it
+        Store.ResourceHolder resourceHolder;
+        if (range != null) {
+            // Get the range start and end
+            long start = range.getRangeStart(fileSize);
+            long end = range.getRangeEnd(fileSize);
+            // Get the resource for the requested range
+            resourceHolder = store.getResourceWithRange(context, metadataUuid, resourceId, approved, start, end);
+            // If the resource is not a file (ie. a stream) we must serve it manually
+            if (!resourceHolder.getResource().isFile()) {
+                responseHeaders.setContentLength(end - start + 1);
+                responseHeaders.set(HttpHeaders.CONTENT_RANGE, "bytes " + start + "-" + end + "/" + fileSize);
+                return ResponseEntity.status(HttpStatus.PARTIAL_CONTENT)
+                    .headers(responseHeaders)
+                    .body(resourceHolder.getResource());
             }
-        };
+        } else {
+            // Get the full resource
+            resourceHolder = store.getResource(context, metadataUuid, resourceId, approved);
+            responseHeaders.setContentLength(fileSize);
+        }
 
-        // Spring automatically handles range requests when returning ResponseEntity<Resource> with a PathResource
+        // If no range is requested or the resource is a file we can let Spring handle the range request
         return ResponseEntity.ok()
             .headers(responseHeaders)
-            .body(resource);
+            .body(resourceHolder.getResource());
     }
 
 
@@ -356,36 +401,41 @@ public class AttachmentsApi {
     /**
      * Serves a resized image in PNG format.
      *
-     * @param imagePath Path to the original image file
+     * @param resource Resource representing the original image
      * @param originalImageName Original filename of the image
      * @param responseHeaders HTTP headers to be set in the response
      * @param size Desired size for the resized image (in pixels)
      * @throws IOException If an I/O error occurs while reading or writing the image
      */
-    private ResponseEntity<Resource> serveResizedImage(Path imagePath,
-                                   String originalImageName, HttpHeaders responseHeaders, int size) throws IOException {
+    private ResponseEntity<Resource> serveResizedImage(Resource resource,
+                                                       String originalImageName, HttpHeaders responseHeaders, int size) throws IOException {
         if (size < MIN_IMAGE_SIZE || size > MAX_IMAGE_SIZE) {
             throw new IllegalArgumentException(String.format(
                 "Image can only be resized from %d to %d. You requested %d.",
                 MIN_IMAGE_SIZE, MAX_IMAGE_SIZE, size));
         }
 
-        // Resize the image
-        BufferedImage originalImage = ImageIO.read(imagePath.toFile());
-        BufferedImage resizedImage = ImageUtil.resize(originalImage, size);
-        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        ImageIO.write(resizedImage, "png", outputStream);
-        ByteArrayResource imgResource = new ByteArrayResource(outputStream.toByteArray());
+        try (InputStream inputStream = resource.getInputStream()) {
+            // Resize the image
+            BufferedImage resizedImage = ImageUtil.resize(ImageIO.read(inputStream), size);
+            ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+            ImageIO.write(resizedImage, "png", outputStream);
 
-        // Generate a new filename for the resized image
-        // Use the original filename without extension and append .png
-        String pngFilename = originalImageName.substring(0, originalImageName.lastIndexOf('.')) + ".png";
+            // Generate a new filename for the resized image
+            // Use the original filename without extension and append .png
+            String pngFilename = originalImageName.substring(0, originalImageName.lastIndexOf('.')) + ".png";
 
-        // Resized image headers
-        responseHeaders.setContentType(MediaType.IMAGE_PNG);
-        responseHeaders.setContentDisposition(ContentDisposition.attachment().filename(pngFilename).build());
-        responseHeaders.setContentLength(imgResource.contentLength());
+            // Resized image headers
+            responseHeaders.setContentType(MediaType.IMAGE_PNG);
+            responseHeaders.setContentDisposition(ContentDisposition.attachment().filename(pngFilename).build());
+            responseHeaders.setContentLength(outputStream.size());
+            responseHeaders.setLastModified(System.currentTimeMillis());
 
-        return ResponseEntity.ok().headers(responseHeaders).body(imgResource);
+            // Generate a new ETag based on the original ETag and the size
+            String originalETag = responseHeaders.getETag();
+            responseHeaders.setETag("\"" + DigestUtils.md5Hex(originalETag + size) + "\"");
+
+            return ResponseEntity.ok().headers(responseHeaders).body(new ByteArrayResource(outputStream.toByteArray()));
+        }
     }
 }

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/ImageReplacedElementFactory.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/ImageReplacedElementFactory.java
@@ -338,12 +338,13 @@ public class ImageReplacedElementFactory implements ReplacedElementFactory {
         public Image loadImage() throws Exception {
             Store store = ApplicationContextHolder.get().getBean("filesystemStore", Store.class);
             BufferedImage bufferedImage;
-            try (Store.ResourceHolder imageFile = store.getResourceInternal(
+            try (Store.ResourceHolder resourceHolder = store.getResourceInternal(
                 this.uuid,
                 MetadataResourceVisibility.PUBLIC,
-                this.file, true)) {
+                this.file, true);
+            InputStream is = resourceHolder.getResource().getInputStream()) {
                 ByteArrayOutputStream baos = new ByteArrayOutputStream();
-                bufferedImage = ImageIO.read(imageFile.getPath().toFile());
+                bufferedImage = ImageIO.read(is);
                 ImageIO.write(bufferedImage, "png", baos);
                 return Image.getInstance(baos.toByteArray());
             }

--- a/services/src/main/java/org/fao/geonet/services/feedback/AddLimitations.java
+++ b/services/src/main/java/org/fao/geonet/services/feedback/AddLimitations.java
@@ -131,7 +131,7 @@ public class AddLimitations implements Service {
 
             Element fileInfo = new Element("file");
             try (Store.ResourceHolder resource = store.getResource(context, info.getUuid(), fname)) {
-                BinaryFile bFile = BinaryFile.encode(200, resource.getPath(), false);
+                BinaryFile bFile = BinaryFile.encode(200, resource.getResource(), resource.getMetadata().getMetadataId(), resource.getMetadata().getFilename(), false);
                 Element details = bFile.getElement();
                 String remoteURL = details.getAttributeValue("remotepath");
                 if (remoteURL != null) {

--- a/services/src/main/java/org/fao/geonet/services/resources/DownloadArchive.java
+++ b/services/src/main/java/org/fao/geonet/services/resources/DownloadArchive.java
@@ -120,7 +120,7 @@ public class DownloadArchive implements Service {
             String fname = Util.getParam(params, Params.FNAME);
             FilePathChecker.verify(fname);
             try (Store.ResourceHolder resource = store.getResource(context, uuid, MetadataResourceVisibility.PUBLIC, fname, true)) {
-                return BinaryFile.encode(200, resource.getPath(), false).getElement();
+                return BinaryFile.encode(200, resource.getResource(), resource.getMetadata().getMetadataId(), resource.getMetadata().getFilename(), false).getElement();
             }
         }
 
@@ -187,7 +187,7 @@ public class DownloadArchive implements Service {
                     true)) {
                     Element fileInfo = new Element("file");
 
-                    BinaryFile details = BinaryFile.encode(200, resource.getPath(), false);
+                    BinaryFile details = BinaryFile.encode(200, resource.getResource(), resource.getMetadata().getMetadataId(), resource.getMetadata().getFilename(), false);
                     String remoteURL = details.getElement().getAttributeValue("remotepath");
                     if (remoteURL != null) {
                         if (context.isDebugEnabled())
@@ -196,7 +196,7 @@ public class DownloadArchive implements Service {
                         fileInfo.setAttribute("datemodified", "unknown");
                         fileInfo.setAttribute("name", remoteURL);
                         notifyAndLog(doNotify, id, info.getUuid(), access, username,
-                            remoteURL + " (local config: " + resource.getPath() + ")", context);
+                            remoteURL + " (local config: " + resource.getMetadata().getFilename() + ")", context);
                         fname = details.getElement().getAttributeValue("remotefile");
                     } else {
                         if (context.isDebugEnabled())
@@ -204,7 +204,7 @@ public class DownloadArchive implements Service {
                         fileInfo.setAttribute("size", Long.toString(resource.getMetadata().getSize()));
                         fileInfo.setAttribute("name", fname);
                         fileInfo.setAttribute("datemodified", sdf.format(resource.getMetadata().getLastModification()));
-                        notifyAndLog(doNotify, id, info.getUuid(), access, username, resource.getPath().toString(), context);
+                        notifyAndLog(doNotify, id, info.getUuid(), access, username, resource.getMetadata().getFilename(), context);
                     }
                     final Path dest = zipFs.getPath(fname);
                     try (OutputStream zos = Files.newOutputStream(dest)) {

--- a/services/src/main/java/org/fao/geonet/services/resources/handlers/DefaultResourceDownloadHandler.java
+++ b/services/src/main/java/org/fao/geonet/services/resources/handlers/DefaultResourceDownloadHandler.java
@@ -46,7 +46,7 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
 
-import static org.fao.geonet.api.records.attachments.AttachmentsApi.getFileContentType;
+import static org.fao.geonet.api.records.attachments.AttachmentsApi.getMediaType;
 
 public class DefaultResourceDownloadHandler implements IResourceDownloadHandler {
 
@@ -76,7 +76,7 @@ public class DefaultResourceDownloadHandler implements IResourceDownloadHandler 
             MultiValueMap<String, String> headers = new HttpHeaders();
             headers.add("Content-Disposition", "inline; filename=\"" + fileName + "\"");
             headers.add("Cache-Control", "no-cache");
-            headers.add("Content-Type", getFileContentType(file));
+            headers.add("Content-Type", getMediaType(file.getFileName().toString()).toString());
 
             return new HttpEntity<>(Files.readAllBytes(file), headers);
 

--- a/services/src/main/java/org/fao/geonet/services/resources/handlers/DefaultResourceUploadHandler.java
+++ b/services/src/main/java/org/fao/geonet/services/resources/handlers/DefaultResourceUploadHandler.java
@@ -35,6 +35,7 @@ import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.repository.MetadataFileUploadRepository;
 import org.fao.geonet.utils.Log;
 import org.jdom.Element;
+import org.springframework.core.io.PathResource;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -77,7 +78,7 @@ public class DefaultResourceUploadHandler implements IResourceUploadHandler {
                 throw new Exception("File upload unsuccessful because "
                     + fileName + " already exists and overwrite was not permitted");
             }
-            store.putResource(context, uuid, source, visibility);
+            store.putResource(context, uuid, new PathResource(source), visibility);
         } finally {
             Files.delete(source);
         }

--- a/services/src/test/java/org/fao/geonet/api/records/attachments/AbstractStoreTest.java
+++ b/services/src/test/java/org/fao/geonet/api/records/attachments/AbstractStoreTest.java
@@ -143,11 +143,6 @@ public abstract class AbstractStoreTest extends AbstractServiceIntegrationTest {
             "http://localhost:8080/srv/api/records/" + metadataUuid + "/attachments/" + filename,
             resource.getUrl());
 
-        try (final Store.ResourceHolder path = getStore().getResource(
-                context, metadataUuid, MetadataResourceVisibility.PUBLIC, filename, true)) {
-            assertTrue("File exists on the disk", Files.isRegularFile(path.getPath()));
-        }
-
         MetadataResource patchedResource = getStore().patchResourceStatus(context, metadataUuid, filename,
                                                                       MetadataResourceVisibility.PRIVATE, true);
         assertEquals("Patched resource type is correct",


### PR DESCRIPTION
Currently if configured to use a remote store (jclouds, cmis, s3), when a user downloads a resource it first needs to create a local copy which is then streamed to the client. This is not ideal and may be problematic for large files since #8946 removed the 2GB limit. Instead the file should be streamed directly from the remote store so the user does not need to wait for the initial copy.

Additionally, the resume download logic always gets the full attachment from the store. When we are resuming a download (or a request specifies the range of bytes) we should specifically request those bytes from the remote store.

This PR aims to fix these issues by changing the `Store` interface to use `Resource` instead of `Path` and by adding a method to request a range of bytes from the store.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
