### PR TITLE
Update map list saved selections label

### DIFF
--- a/web-ui/src/main/resources/catalog/locales/en-core.json
+++ b/web-ui/src/main/resources/catalog/locales/en-core.json
@@ -5,7 +5,7 @@
     "addToSelection": "Add to ...",
     "removeFromSelection": "Remove from ...",
     "AnonymousUserlist": "Preferred records",
-    "MapLayerlist": "Add to map list",
+    "MapLayerlist": "Map list",
     "basket": "Basket",
     "emptyBasket": "Nothing in basket",
     "searchSelectedRecord": "Search records",


### PR DESCRIPTION
The label to add / remove layers from the Saved selections / Map list doesn't seem correct:

Before:

<img width="343" height="265" alt="image" src="https://github.com/user-attachments/assets/c8b9dce3-fe69-49ce-a6d1-0924a37ae9eb" />

<img width="270" height="241" alt="image" src="https://github.com/user-attachments/assets/00948c56-e80d-4035-a536-7ece3969d822" />


After:

<img width="211" height="201" alt="image" src="https://github.com/user-attachments/assets/e67b08a9-71d5-419b-b1ad-4a00b9878a1c" />

<img width="202" height="210" alt="image" src="https://github.com/user-attachments/assets/085828f2-6ad0-4274-af41-8724273b485a" />


# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

