### PR TITLE
Corrected the formatting on validation log messages.

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/SchematronValidatorExternalMd.java
+++ b/core/src/main/java/org/fao/geonet/kernel/SchematronValidatorExternalMd.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2025 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -61,7 +61,7 @@ public class SchematronValidatorExternalMd extends AbstractSchematronValidator {
             }
         } catch (Throwable e) {
             Element errorReport = new Element("schematronVerificationError", Edit.NAMESPACE);
-            errorReport.addContent("Schematron error ocurred, rules could not be verified: " + e.getMessage());
+            errorReport.addContent("Schematron error occurred, rules could not be verified: " + e.getMessage());
             schemaTronXmlOut.addContent(errorReport);
         }
 

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataValidator.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataValidator.java
@@ -1,5 +1,5 @@
 //=============================================================================
-//===	Copyright (C) 2001-2011 Food and Agriculture Organization of the
+//===	Copyright (C) 2001-2025 Food and Agriculture Organization of the
 //===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
 //===	and United Nations Environment Programme (UNEP)
 //===
@@ -148,15 +148,16 @@ public class BaseMetadataValidator implements org.fao.geonet.kernel.datamanager.
 
             if ((!failedAssert.isEmpty()) || (!failedSchematronVerification.isEmpty())) {
                 StringBuilder errorReport = new StringBuilder();
+                String errorReportSeparator = "";
 
                 Iterator reports = schemaTronReport.getDescendants(ReportFinder);
                 while (reports.hasNext()) {
                     Element report = (Element) reports.next();
                     Element schematronVerificationError = report.getChild("schematronVerificationError", Edit.NAMESPACE);
 
-
                     if (schematronVerificationError != null) {
-                        errorReport.append("schematronVerificationError: " + schematronVerificationError.getTextTrim());
+                        errorReport.append(errorReportSeparator).append("schematronVerificationError: " + schematronVerificationError.getTextTrim());
+                        errorReportSeparator = ", ";
                     } else {
                         Iterator errors = report.getDescendants(ErrorFinder);
                         while (errors.hasNext()) {
@@ -182,14 +183,15 @@ public class BaseMetadataValidator implements org.fao.geonet.kernel.datamanager.
                             }
 
                             if (msg.length() > 0) {
-                                errorReport.append(reportType).append(':').append(msg);
+                                errorReport.append(errorReportSeparator).append(reportType).append(':').append(msg);
+                                errorReportSeparator = ", ";
                             }
                         }
                     }
                 }
 
                 throw new SchematronValidationErrorEx(
-                    "Schematron errors detected for file " + fileName + " - " + errorReport + " for more details", schemaTronReport);
+                    "Schematron errors detected for file '" + fileName + "' - " + errorReport, schemaTronReport);
             }
         }
 


### PR DESCRIPTION
Correcting some log messages that were not clear.

i.e. 

**Before** **for more details** is confusing.
`2025-09-18T13:00:57,181 ERROR [geonetwork.harvester] - Cannot validate XML from file /home/site/geonetwork/data/harvester/xml-files/test.xml, ignoring. Error was: Schematron errors detected for file   - schematronVerificationError: Failed to validate resources associated with the catalogue entry. for more details`

**After** 
`2025-09-18T13:00:57,181 ERROR [geonetwork.harvester] - Cannot validate XML from file /home/site/geonetwork/data/harvester/xml-files/test.xml, ignoring. Error was: Schematron errors detected for file ' ' - schematronVerificationError: Failed to validate resources associated with the catalogue entry.`
  
**Before** Missing ", " when there are multiple errors and it shows like **java.lang.NullPointerExceptionschematronVerificationError**
`2025-09-12T10:53:49,938 ERROR [geonetwork.harvester] - Cannot validate XML from file /home/site/geonetwork/data/harvester/xml-files/test.xml, ignoring. Error was: Schematron errors detected for file   - schematronVerificationError: Exception in extension function java.lang.NullPointerExceptionschematronVerificationError: Failed to validate resources associated with the catalogue entry. for more details`

**After**
`2025-09-12T10:53:49,938 ERROR [geonetwork.harvester] - Cannot validate XML from file /home/site/geonetwork/data/harvester/xml-files/test.xml, ignoring. Error was: Schematron errors detected for file   - schematronVerificationError: Exception in extension function java.lang.NullPointerException, schematronVerificationError: Failed to validate resources associated with the catalogue entry. for more details`


# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

