### PR TITLE
Use default locale for harvester validation.

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/formatters/SchemaLocalizations.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/SchemaLocalizations.java
@@ -39,6 +39,7 @@ import org.jdom.Element;
 import org.jdom.JDOMException;
 import org.locationtech.jts.util.Assert;
 import org.springframework.context.ApplicationContext;
+import org.springframework.util.StringUtils;
 import org.springframework.web.context.request.RequestContextHolder;
 import org.springframework.web.context.request.ServletRequestAttributes;
 
@@ -97,14 +98,23 @@ public class SchemaLocalizations {
     public static SchemaLocalizations create(String schema) throws IOException, JDOMException {
         Object obj = RequestContextHolder.getRequestAttributes();
 
-        ServletRequestAttributes attributes = (ServletRequestAttributes) obj;
-        HttpServletRequest request = attributes.getRequest();
+        String lang3 = null;
+        if (obj instanceof ServletRequestAttributes) {
 
-        final ApplicationContext appContext = ApplicationContextHolder.get();
-        final ServiceContext serviceContext = ServiceContext.get();
-        final String lang3 = serviceContext != null ?
-            serviceContext.getLanguage() :
-            appContext.getBean(LanguageUtils.class).getIso3langCode(request.getLocales());
+            ServletRequestAttributes attributes = (ServletRequestAttributes) obj;
+            HttpServletRequest request = attributes.getRequest();
+
+            final ApplicationContext appContext = ApplicationContextHolder.get();
+            final ServiceContext serviceContext = ServiceContext.get();
+            lang3 = serviceContext != null ?
+                serviceContext.getLanguage() :
+                appContext.getBean(LanguageUtils.class).getIso3langCode(request.getLocales());
+        }
+        if (!StringUtils.hasLength(lang3)) {
+            // It may be null if executed from a jobs which don't have servlet request attributes.
+            // Use the system default locale when language not detected.
+            lang3 = Locale.getDefault().getISO3Language();
+        }
         return create(schema, lang3);
     }
 


### PR DESCRIPTION
Fixes issue where harvester validation did not have an http request attributes which was causing null pointer error.

This is a sample error that was previously generated.

`2025-09-12T10:43:45,637 ERROR [geonetwork.harvester] - Cannot validate XML from file /home/site/geonetwork/data/harvester/xml-files/test.xml, ignoring. Error was: Schematron errors detected for file   - schematronVerificationError: Exception in extension function java.lang.NullPointerException, schematronVerificationError: Failed to validate resources associated with the catalogue entry. for more details`
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

