### PR TITLE
Added support to login via service account connection when using security type openidconnectbearer

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/security/SecurityProviderUtil.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/SecurityProviderUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2021 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2025 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -44,6 +44,13 @@ public interface SecurityProviderUtil {
      * @return the user details information
      */
     UserDetails getUserDetails(Authentication auth);
+
+    /**
+     * Login the service account.  This is used for job processing where there is no user context.
+     *
+     * @return true if login is successful
+     */
+    boolean loginServiceAccount();
 }
 
 

--- a/core/src/main/java/org/fao/geonet/kernel/security/keycloak/KeycloakUtil.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/keycloak/KeycloakUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2017 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2025 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -106,5 +106,12 @@ public class KeycloakUtil implements SecurityProviderUtil {
             return null;
         }
 
+    }
+
+    @Override
+    public boolean loginServiceAccount() {
+        // Todo: returning false to keep old functionality the same.  If needed, this could login as a service account which could be used by the harvester or any other jobs.
+        //       Note: It is suggested that openidconnectbearer is used instead of keycloak if this functionality is required as keycloak driver will be deprecated soon.
+        return false;
     }
 }

--- a/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/GeonetworkClientRegistrationRepository.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/GeonetworkClientRegistrationRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Food and Agriculture Organization of the
+ * Copyright (C) 2025 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -26,6 +26,8 @@ package org.fao.geonet.kernel.security.openidconnect;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 
+import static org.fao.geonet.kernel.security.openidconnect.GeonetworkClientRegistrationProvider.CLIENT_REGISTRATION_NAME;
+import static org.fao.geonet.kernel.security.openidconnect.bearer.GeonetworkClientServiceAccountRegistrationProvider.CLIENT_SERVICE_ACCOUNT_REGISTRATION_NAME;
 
 /**
  * trivial implementation of ClientRegistrationRepository.
@@ -35,16 +37,33 @@ public class GeonetworkClientRegistrationRepository implements ClientRegistratio
 
     ClientRegistration clientRegistration;
 
+    ClientRegistration clientServiceAccountRegistration;
 
     public GeonetworkClientRegistrationRepository(GeonetworkClientRegistrationProvider clientRegistrationProvider) throws Exception {
         if (clientRegistrationProvider == null)
             throw new Exception("clientRegistration must not be null!");
         clientRegistration = clientRegistrationProvider.getClientRegistration();
+        clientServiceAccountRegistration = null;
+    }
+
+
+    public GeonetworkClientRegistrationRepository(GeonetworkClientRegistrationProvider clientRegistrationProvider,
+                                                  GeonetworkClientRegistrationProvider clientServiceAccountRegistrationProvider) throws Exception {
+        if (clientRegistrationProvider == null)
+            throw new Exception("clientRegistration must not be null!");
+        clientRegistration = clientRegistrationProvider.getClientRegistration();
+        clientServiceAccountRegistration = clientServiceAccountRegistrationProvider.getClientRegistration();
     }
 
 
     @Override
     public ClientRegistration findByRegistrationId(String registrationId) {
-        return clientRegistration;
+        if (CLIENT_REGISTRATION_NAME.equals(registrationId)) {
+            return clientRegistration;
+        } else if (CLIENT_SERVICE_ACCOUNT_REGISTRATION_NAME.equals(registrationId)) {
+            return clientServiceAccountRegistration;
+        } else {
+            return null;
+        }
     }
 }

--- a/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/GeonetworkOidcPreAuthActionsLoginFilter.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/GeonetworkOidcPreAuthActionsLoginFilter.java
@@ -110,7 +110,7 @@ public class GeonetworkOidcPreAuthActionsLoginFilter  implements Filter, Servlet
 
         String requestUri = servletRequest.getRequestURI();
         String contextPath = servletRequest.getContextPath();
-        String clientRegistrationId = GeonetworkClientRegistrationProvider.CLIENTREGISTRATION_NAME;
+        String clientRegistrationId = GeonetworkClientRegistrationProvider.CLIENT_REGISTRATION_NAME;
         // Grab the first (or default) registrationId from repository
         String registrationId = clientRegistrationRepository.findByRegistrationId(clientRegistrationId).getRegistrationId();
         String loginPath = contextPath + OAuth2AuthorizationRequestRedirectFilter.DEFAULT_AUTHORIZATION_REQUEST_BASE_URI + "/" + registrationId;

--- a/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/HardcodedRegistrationIdOAuth2AuthorizationRequestResolver.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/HardcodedRegistrationIdOAuth2AuthorizationRequestResolver.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Food and Agriculture Organization of the
+ * Copyright (C) 2025 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -31,7 +31,7 @@ import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
 
-import static org.fao.geonet.kernel.security.openidconnect.GeonetworkClientRegistrationProvider.CLIENTREGISTRATION_NAME;
+import static org.fao.geonet.kernel.security.openidconnect.GeonetworkClientRegistrationProvider.CLIENT_REGISTRATION_NAME;
 
 /**
  * This is to make things work well in Geonetwork.
@@ -80,7 +80,7 @@ public class HardcodedRegistrationIdOAuth2AuthorizationRequestResolver implement
                 return value;
             }
         };
-        return wrappedResolver.resolve(wrappedRequest, CLIENTREGISTRATION_NAME);
+        return wrappedResolver.resolve(wrappedRequest, CLIENT_REGISTRATION_NAME);
     }
 
     //defaults the "action" to "authorize" and uses the GN default oidc provider name
@@ -101,7 +101,7 @@ public class HardcodedRegistrationIdOAuth2AuthorizationRequestResolver implement
                 return value;
             }
         };
-        return wrappedResolver.resolve(wrappedRequest, CLIENTREGISTRATION_NAME);
+        return wrappedResolver.resolve(wrappedRequest, CLIENT_REGISTRATION_NAME);
     }
 
 }

--- a/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/OAuth2SecurityProviderUtil.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/OAuth2SecurityProviderUtil.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Food and Agriculture Organization of the
+ * Copyright (C) 2025 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -22,10 +22,13 @@
  */
 package org.fao.geonet.kernel.security.openidconnect;
 
+import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.kernel.security.SecurityProviderUtil;
+import org.fao.geonet.kernel.security.openidconnect.bearer.OIDCServiceAccountLogin;
 import org.fao.geonet.utils.Log;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -53,6 +56,11 @@ public class OAuth2SecurityProviderUtil implements SecurityProviderUtil {
     @Autowired
     private OAuth2AuthorizedClientManager authorizedClientManager;
 
+    /**
+     * OIDC configuration Service
+     */
+    @Autowired
+    OIDCConfiguration oidcConfiguration;
 
    // setup for BEARER authentication
     public String getSSOAuthenticationHeaderValue() {
@@ -102,5 +110,20 @@ public class OAuth2SecurityProviderUtil implements SecurityProviderUtil {
         }
     }
 
+
+    @Override
+    public boolean loginServiceAccount() {
+        if (!oidcConfiguration.getServiceAccountConfig().isEnabled()) {
+            return false;
+        }
+        final ConfigurableApplicationContext applicationContext = ApplicationContextHolder.get();
+        OIDCServiceAccountLogin serviceAccountLogin;
+        try {
+            serviceAccountLogin = applicationContext.getBean(OIDCServiceAccountLogin.class);
+        } catch (Exception e) {
+            return false;
+        }
+        return serviceAccountLogin.loginServiceAccount();
+    }
 
 }

--- a/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/OIDCRoleProcessor.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/OIDCRoleProcessor.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Food and Agriculture Organization of the
+ * Copyright (C) 2025 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -74,7 +74,7 @@ public class OIDCRoleProcessor {
      */
     public Map<Profile, List<String>> getProfileGroups(OidcIdToken idToken) {
         List<String> oidcOriginalRoleNames = getTokenRoles(idToken);
-        oidcOriginalRoleNames.add(oidcConfiguration.minimumProfile);
+        oidcOriginalRoleNames.add(oidcConfiguration.getMinimumProfile().name());
         List<String> roleNames = simpleConvertRoles(oidcOriginalRoleNames);
 
         return getProfileGroups(roleNames);
@@ -82,7 +82,7 @@ public class OIDCRoleProcessor {
 
     public Map<Profile, List<String>> getProfileGroups(Map attributes) {
         List<String> oidcOriginalRoleNames = getTokenRoles(attributes);
-        oidcOriginalRoleNames.add(oidcConfiguration.minimumProfile);
+        oidcOriginalRoleNames.add(oidcConfiguration.getMinimumProfile().name());
         List<String> roleNames = simpleConvertRoles(oidcOriginalRoleNames);
 
         return getProfileGroups(roleNames);
@@ -96,7 +96,7 @@ public class OIDCRoleProcessor {
      */
     public Map<Profile, List<String>> getProfileGroups(OAuth2User user) {
         List<String> oidcOriginalRoleNames = getTokenRoles(user);
-        oidcOriginalRoleNames.add(oidcConfiguration.minimumProfile);
+        oidcOriginalRoleNames.add(oidcConfiguration.getMinimumProfile().name());
         List<String> roleNames = simpleConvertRoles(oidcOriginalRoleNames);
 
         return getProfileGroups(roleNames);
@@ -155,7 +155,7 @@ public class OIDCRoleProcessor {
      */
     public List<String> simpleConvertRoles(List<String> originalRoleNames) {
         return originalRoleNames.stream()
-            .map(x -> oidcConfiguration.roleConverter.get(x) == null ? x : oidcConfiguration.roleConverter.get(x))
+            .map(x -> oidcConfiguration.getRoleConverter().get(x) == null ? x : oidcConfiguration.getRoleConverter().get(x))
             .distinct()
             .collect(Collectors.toList());
     }
@@ -186,7 +186,7 @@ public class OIDCRoleProcessor {
     }
 
     public Collection<? extends GrantedAuthority> createAuthorities(RoleHierarchy roleHierarchy, List<String> oidcOriginalRoleNames) {
-        oidcOriginalRoleNames.add(oidcConfiguration.minimumProfile);
+        oidcOriginalRoleNames.add(oidcConfiguration.getMinimumProfile().name());
 
         List<String> roleNames = simpleConvertRoles(oidcOriginalRoleNames);
         Map<Profile, List<String>> profileGroups = getProfileGroups(roleNames);
@@ -206,7 +206,7 @@ public class OIDCRoleProcessor {
      */
     public Profile getProfile(Map<String, Object> attributes) {
         List<String> oidcOriginalRoleNames = getTokenRoles(attributes);
-        oidcOriginalRoleNames.add(oidcConfiguration.minimumProfile);
+        oidcOriginalRoleNames.add(oidcConfiguration.getMinimumProfile().name());
 
         List<String> roleNames = simpleConvertRoles(oidcOriginalRoleNames);
 
@@ -248,7 +248,7 @@ public class OIDCRoleProcessor {
     //from GN keycloak plugin
     public Map<Profile, List<String>> getProfileGroups(List<String> rolesInToken) {
 
-        String roleGroupSeparator = oidcConfiguration.groupPermissionSeparator;
+        String roleGroupSeparator = oidcConfiguration.getGroupPermissionSeparator();
         Map<Profile, List<String>> profileGroups = new HashMap<>();
 
         Set<String> roleGroupList = new HashSet<>();

--- a/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/SimpleOidcUser.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/SimpleOidcUser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Food and Agriculture Organization of the
+ * Copyright (C) 2025 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -103,11 +103,11 @@ public class SimpleOidcUser {
             }
 
 
-            if (idToken.getClaims() != null && idToken.getClaims().containsKey(oidcConfiguration.organizationProperty)) {
-                organisation = (String) idToken.getClaims().get(oidcConfiguration.organizationProperty);
+            if (idToken.getClaims() != null && idToken.getClaims().containsKey(oidcConfiguration.getOrganizationProperty())) {
+                organisation = (String) idToken.getClaims().get(oidcConfiguration.getOrganizationProperty());
             }
-            if ( (organisation == null) && attributes.containsKey(oidcConfiguration.organizationProperty) ) {
-                organisation = (String) attributes.get(oidcConfiguration.organizationProperty);
+            if ( (organisation == null) && attributes.containsKey(oidcConfiguration.getOrganizationProperty()) ) {
+                organisation = (String) attributes.get(oidcConfiguration.getOrganizationProperty());
             }
 
 
@@ -155,8 +155,8 @@ public class SimpleOidcUser {
 
             email = (String) attributes.get(StandardClaimNames.EMAIL);
 
-            if (attributes.containsKey(oidcConfiguration.organizationProperty)) {
-                organisation = (String) attributes.get(oidcConfiguration.organizationProperty);
+            if (attributes.containsKey(oidcConfiguration.getOrganizationProperty())) {
+                organisation = (String) attributes.get(oidcConfiguration.getOrganizationProperty());
             }
 
             Map<Profile, List<String>> profileGroups = oidcRoleProcessor.getProfileGroups(attributes);

--- a/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/bearer/AudienceAccessTokenValidator.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/bearer/AudienceAccessTokenValidator.java
@@ -70,12 +70,12 @@ public class AudienceAccessTokenValidator implements AccessTokenValidator {
     public void verifyToken(Map claimsJWT, Map userInfoClaims) throws Exception {
         //azp from keycloak
         if ((claimsJWT.get(KEYCLOAK_AUDIENCE_CLAIM_NAME) != null)
-            && claimsJWT.get(KEYCLOAK_AUDIENCE_CLAIM_NAME).equals(oidcConfiguration.getClientId())) {
+            && claimsJWT.get(KEYCLOAK_AUDIENCE_CLAIM_NAME).equals(oidcConfiguration.getClientConfig().getClientId())) {
             return;
         }
 
         if ((claimsJWT.get(APPID_CLAIM_NAME) != null)
-            && claimsJWT.get(APPID_CLAIM_NAME).equals(oidcConfiguration.getClientId())) {
+            && claimsJWT.get(APPID_CLAIM_NAME).equals(oidcConfiguration.getClientConfig().getClientId())) {
             return; //azure specific
         }
 
@@ -83,12 +83,12 @@ public class AudienceAccessTokenValidator implements AccessTokenValidator {
         Object aud = claimsJWT.get(AUDIENCE_CLAIM_NAME);
         if (aud != null) {
             if (aud instanceof String) {
-                if (((String) aud).equals(oidcConfiguration.getClientId()))
+                if (((String) aud).equals(oidcConfiguration.getClientConfig().getClientId()))
                     return;
             } else if (aud instanceof List) {
                 List auds = (List) aud;
                 for (Object o : auds) {
-                    if ((o instanceof String) && (o.equals(oidcConfiguration.getClientId()))) {
+                    if ((o instanceof String) && (o.equals(oidcConfiguration.getClientConfig().getClientId()))) {
                         return;
                     }
                 }

--- a/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/bearer/GeonetworkClientServiceAccountRegistrationProvider.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/bearer/GeonetworkClientServiceAccountRegistrationProvider.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2025 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+package org.fao.geonet.kernel.security.openidconnect.bearer;
+
+import com.nimbusds.oauth2.sdk.ParseException;
+import org.fao.geonet.kernel.security.openidconnect.GeonetworkClientRegistrationProvider;
+import org.fao.geonet.kernel.security.openidconnect.OIDCConfiguration;
+import org.springframework.core.io.Resource;
+import org.springframework.security.oauth2.core.AuthorizationGrantType;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+
+/**
+ * Reads from the Open ID server's JSON configuration and creates a spring-security ClientRegistration.
+ * This defines how to communicate with the remote oauth2 open id connect server.
+ * <p>
+ * This extended from GeonetworkClientRegistrationProvider but only changes the registered name and grant type to CLIENT_CREDENTIALS which is used for service account login.
+ */
+
+public class GeonetworkClientServiceAccountRegistrationProvider extends GeonetworkClientRegistrationProvider {
+
+    public static String CLIENT_SERVICE_ACCOUNT_REGISTRATION_NAME = "geonetwork-oidc-service-account";
+
+    private static final AuthorizationGrantType GRANT_TYPE = AuthorizationGrantType.CLIENT_CREDENTIALS;
+
+    /**
+     * Create a spring ClientRegistration from either a Resource (i.e. file containing the JSON) or from
+     * a string containing the JSON text.
+     * <p>
+     * It also requires the server's clientid and clientsecret.
+     * <p>
+     * <p>
+     * NOTE: either set metadataResource OR serverMetadataJsonText.  If both are set then serverMetadataJsonText is used.
+     * Allowing both makes the spring.xml configuration simpler.
+     *
+     * @param metadataResource       - reference to a file (spring will convert a fname to Resource for us)
+     * @param serverMetadataJsonText - text of JSON file
+     * @param oidcMetadataConfigURL  - URL to the OIDC configuration JSON document (/.well-known/openid-configuration)
+     * @param oidcConfiguration      - GN's oidc configuration
+     * @throws IOException
+     * @throws ParseException
+     */
+    public GeonetworkClientServiceAccountRegistrationProvider(Resource metadataResource,
+                                                              String serverMetadataJsonText,
+                                                              String oidcMetadataConfigURL,
+                                                              OIDCConfiguration oidcConfiguration) throws IOException, ParseException {
+        super(metadataResource, serverMetadataJsonText, oidcMetadataConfigURL, oidcConfiguration);
+    }
+
+    //get the JSON from an inputstream (i.e. from a file, string, or resource)
+    public GeonetworkClientServiceAccountRegistrationProvider(InputStream inputStream,
+                                                              OIDCConfiguration oidcConfiguration) throws IOException, ParseException {
+        super(inputStream, oidcConfiguration);
+    }
+
+    @Override
+    protected OIDCConfiguration.ClientConfig getClientConfig(OIDCConfiguration oidcConfiguration) {
+        return oidcConfiguration.getServiceAccountConfig();
+    };
+
+    @Override
+    protected String getClientRegistrationName() {
+        return CLIENT_SERVICE_ACCOUNT_REGISTRATION_NAME;
+    };
+
+    @Override
+    protected AuthorizationGrantType getAuthorizationGrantType() {
+        return GRANT_TYPE;
+    };
+}

--- a/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/bearer/GeonetworkJwtAuthenticationProvider.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/bearer/GeonetworkJwtAuthenticationProvider.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Food and Agriculture Organization of the
+ * Copyright (C) 2025 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -52,7 +52,7 @@ import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.oauth2.jwt.Jwt;
-import org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthenticationToken;
+import org.springframework.security.oauth2.server.resource.BearerTokenAuthenticationToken;
 import org.springframework.security.oauth2.server.resource.BearerTokenError;
 import org.springframework.security.oauth2.server.resource.BearerTokenErrorCodes;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
@@ -63,7 +63,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 
-import static org.fao.geonet.kernel.security.openidconnect.GeonetworkClientRegistrationProvider.CLIENTREGISTRATION_NAME;
+import static org.fao.geonet.kernel.security.openidconnect.GeonetworkClientRegistrationProvider.CLIENT_REGISTRATION_NAME;
 import static org.fao.geonet.kernel.security.openidconnect.bearer.RoleInserter.insertRoles;
 
 /**
@@ -173,7 +173,7 @@ public class GeonetworkJwtAuthenticationProvider implements AuthenticationProvid
         }
 
         //execute the userinfo endpoint
-        ClientRegistration clientRegistration = clientRegistrationRepository.findByRegistrationId(CLIENTREGISTRATION_NAME);
+        ClientRegistration clientRegistration = clientRegistrationRepository.findByRegistrationId(CLIENT_REGISTRATION_NAME);
         OAuth2AccessToken accessToken = new OAuth2AccessToken(
             OAuth2AccessToken.TokenType.BEARER,
             bearer.getToken(),
@@ -223,6 +223,10 @@ public class GeonetworkJwtAuthenticationProvider implements AuthenticationProvid
      */
     @Override
     public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        return authenticate(authentication, CLIENT_REGISTRATION_NAME);
+    }
+
+    public Authentication authenticate(Authentication authentication, String registrationName) throws AuthenticationException {
         BearerTokenAuthenticationToken bearer = (BearerTokenAuthenticationToken) authentication;
 
         // has this access token been evaluated before?
@@ -236,7 +240,7 @@ public class GeonetworkJwtAuthenticationProvider implements AuthenticationProvid
         // final result
         OAuth2User user = item.getUser();
         Collection<? extends GrantedAuthority> authorities = item.getAuthorities();
-        OAuth2AuthenticationToken authenticationResult = new OAuth2AuthenticationToken(user, authorities, CLIENTREGISTRATION_NAME);
+        OAuth2AuthenticationToken authenticationResult = new OAuth2AuthenticationToken(user, authorities, registrationName);
         authenticationResult.setDetails(authentication.getDetails());
 
         // user logs in event

--- a/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/bearer/OIDCServiceAccountLogin.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/bearer/OIDCServiceAccountLogin.java
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) 2025 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+package org.fao.geonet.kernel.security.openidconnect.bearer;
+
+import org.fao.geonet.kernel.security.openidconnect.GeonetworkClientRegistrationRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.server.resource.BearerTokenAuthenticationToken;
+
+import static org.fao.geonet.kernel.security.openidconnect.bearer.GeonetworkClientServiceAccountRegistrationProvider.CLIENT_SERVICE_ACCOUNT_REGISTRATION_NAME;
+
+/**
+ * Class to perform login of a service account using OAuth2 client credentials flow.
+ *
+ * Used when making backend to backend calls where no user is involved.
+ *
+ * Only works with openidconnectbearer configuration as it needs to support bearer tokens.
+ */
+public class OIDCServiceAccountLogin {
+
+    public final static String PRINCIPAL_NAME="service-account";
+
+    private final OAuth2AuthorizedClientManager clientManager;
+    private final ClientRegistration clientRegistration;
+
+    private final GeonetworkJwtAuthenticationProvider geonetworkJwtAuthenticationProvider;
+
+    @Autowired
+    public OIDCServiceAccountLogin(OAuth2AuthorizedClientManager clientManager,
+                                   GeonetworkClientRegistrationRepository registrations,
+                                   @Autowired(required = false) GeonetworkJwtAuthenticationProvider geonetworkJwtAuthenticationProvider) {
+        this.clientManager = clientManager;
+        clientRegistration = registrations.findByRegistrationId(CLIENT_SERVICE_ACCOUNT_REGISTRATION_NAME);
+        this.geonetworkJwtAuthenticationProvider = geonetworkJwtAuthenticationProvider;
+    }
+
+    /**
+     * Logs in the service account using OAuth2 client credentials flow and sets the authentication in the security context.
+     *
+     * @return true if the login was successful and the authentication is authenticated, false otherwise.
+     * @throws IllegalStateException if the authorization fails.
+     */
+    public boolean loginServiceAccount() {
+        // If GeonetworkJwtAuthenticationProvider is not configured then we cannot log in the service account so return false.
+        // This is only supported when using OIDC with bearer tokens.
+        if (geonetworkJwtAuthenticationProvider == null) {
+            return false;
+        }
+
+        OAuth2AuthorizeRequest oAuth2AuthorizeRequest = OAuth2AuthorizeRequest
+            .withClientRegistrationId(clientRegistration.getRegistrationId())
+            .principal(PRINCIPAL_NAME)
+            .build();
+
+        OAuth2AuthorizedClient client = clientManager.authorize(oAuth2AuthorizeRequest);
+        if (client == null) {
+            throw new IllegalStateException("Failed to authorize service account.");
+        }
+
+        BearerTokenAuthenticationToken bearerTokenAuthenticationToken = new BearerTokenAuthenticationToken(client.getAccessToken().getTokenValue());
+
+        Authentication authentication = geonetworkJwtAuthenticationProvider.authenticate(bearerTokenAuthenticationToken, clientRegistration.getRegistrationId());
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        return authentication.isAuthenticated();
+    }
+}

--- a/core/src/test/java/org/fao/geonet/kernel/security/openidconnect/GeonetworkClientRegistrationProviderTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/security/openidconnect/GeonetworkClientRegistrationProviderTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Food and Agriculture Organization of the
+ * Copyright (C) 2025 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -29,7 +29,7 @@ import org.springframework.security.oauth2.core.ClientAuthenticationMethod;
 import java.io.ByteArrayInputStream;
 import java.io.InputStream;
 
-import static org.fao.geonet.kernel.security.openidconnect.GeonetworkClientRegistrationProvider.CLIENTREGISTRATION_NAME;
+import static org.fao.geonet.kernel.security.openidconnect.GeonetworkClientRegistrationProvider.CLIENT_REGISTRATION_NAME;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
@@ -123,9 +123,9 @@ public class GeonetworkClientRegistrationProviderTest {
     @Test
     public void testScopes_all() throws Exception {
         OIDCConfiguration configuration = new OIDCConfiguration();
-        configuration.setClientId("clientid");
-        configuration.setClientSecret("clientsecret");
-        configuration.setScopes("");//use all scopes from server
+        configuration.getClientConfig().setClientId("clientid");
+        configuration.getClientConfig().setClientSecret("clientsecret");
+        configuration.getClientConfig().setScopes("");//use all scopes from server
         GeonetworkClientRegistrationProvider out = new GeonetworkClientRegistrationProvider(
             string2InputStream(keycloakConfig),
             configuration
@@ -139,9 +139,9 @@ public class GeonetworkClientRegistrationProviderTest {
     @Test
     public void testScopes_limited() throws Exception {
         OIDCConfiguration configuration = new OIDCConfiguration();
-        configuration.setClientId("clientid");
-        configuration.setClientSecret("clientsecret");
-        configuration.setScopes("openid email");//use 2 scopes
+        configuration.getClientConfig().setClientId("clientid");
+        configuration.getClientConfig().setClientSecret("clientsecret");
+        configuration.getClientConfig().setScopes("openid email");//use 2 scopes
         GeonetworkClientRegistrationProvider out = new GeonetworkClientRegistrationProvider(
             string2InputStream(keycloakConfig),
             configuration
@@ -157,9 +157,9 @@ public class GeonetworkClientRegistrationProviderTest {
     @Test
     public void testParsingKeycloakConfigurationMetadataJson() throws Exception {
         OIDCConfiguration configuration = new OIDCConfiguration();
-        configuration.setClientId("clientid");
-        configuration.setClientSecret("clientsecret");
-        configuration.setScopes("");//use all scopes
+        configuration.getClientConfig().setClientId("clientid");
+        configuration.getClientConfig().setClientSecret("clientsecret");
+        configuration.getClientConfig().setScopes("");//use all scopes
         GeonetworkClientRegistrationProvider out = new GeonetworkClientRegistrationProvider(
             string2InputStream(keycloakConfig),
             configuration
@@ -169,7 +169,7 @@ public class GeonetworkClientRegistrationProviderTest {
 
         assertEquals("clientid", out.getClientRegistration().getClientId());
         assertEquals("clientsecret", out.getClientRegistration().getClientSecret());
-        assertEquals(CLIENTREGISTRATION_NAME, out.getClientRegistration().getRegistrationId());
+        assertEquals(CLIENT_REGISTRATION_NAME, out.getClientRegistration().getRegistrationId());
         assertEquals(9, out.getClientRegistration().getScopes().size());
         assertTrue(out.getClientRegistration().getScopes().contains("openid"));
 
@@ -186,9 +186,9 @@ public class GeonetworkClientRegistrationProviderTest {
     @Test
     public void testParsingAzureADConfigurationMetadataJson() throws Exception {
         OIDCConfiguration configuration = new OIDCConfiguration();
-        configuration.setClientId("clientid");
-        configuration.setClientSecret("clientsecret");
-        configuration.setScopes("");//use all scopes
+        configuration.getClientConfig().setClientId("clientid");
+        configuration.getClientConfig().setClientSecret("clientsecret");
+        configuration.getClientConfig().setScopes("");//use all scopes
         GeonetworkClientRegistrationProvider out = new GeonetworkClientRegistrationProvider(
             string2InputStream(azureADConfig),
             configuration
@@ -198,7 +198,7 @@ public class GeonetworkClientRegistrationProviderTest {
 
         assertEquals("clientid", out.getClientRegistration().getClientId());
         assertEquals("clientsecret", out.getClientRegistration().getClientSecret());
-        assertEquals(CLIENTREGISTRATION_NAME, out.getClientRegistration().getRegistrationId());
+        assertEquals(CLIENT_REGISTRATION_NAME, out.getClientRegistration().getRegistrationId());
         assertEquals(4, out.getClientRegistration().getScopes().size());
         assertTrue(out.getClientRegistration().getScopes().contains("openid"));
 

--- a/core/src/test/java/org/fao/geonet/kernel/security/openidconnect/GeonetworkClientRegistrationRepositoryTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/security/openidconnect/GeonetworkClientRegistrationRepositoryTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Food and Agriculture Organization of the
+ * Copyright (C) 2025 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -22,6 +22,7 @@
  */
 package org.fao.geonet.kernel.security.openidconnect;
 
+import org.fao.geonet.kernel.security.openidconnect.bearer.GeonetworkClientServiceAccountRegistrationProvider;
 import org.junit.Test;
 
 import static org.fao.geonet.kernel.security.openidconnect.GeonetworkClientRegistrationProviderTest.keycloakConfig;
@@ -37,9 +38,9 @@ public class GeonetworkClientRegistrationRepositoryTest {
     @Test
     public void testRepo() throws Exception {
         OIDCConfiguration configuration = new OIDCConfiguration();
-        configuration.setClientId("clientid");
-        configuration.setClientSecret("clientsecret");
-        configuration.setScopes("");//use all scopes
+        configuration.getClientConfig().setClientId("clientid");
+        configuration.getClientConfig().setClientSecret("clientsecret");
+        configuration.getClientConfig().setScopes("");//use all scopes
         GeonetworkClientRegistrationProvider clientRegistrationProvider = new GeonetworkClientRegistrationProvider(
             string2InputStream(keycloakConfig),
             configuration
@@ -48,6 +49,33 @@ public class GeonetworkClientRegistrationRepositoryTest {
         GeonetworkClientRegistrationRepository out = new GeonetworkClientRegistrationRepository(clientRegistrationProvider);
 
         assertEquals(clientRegistrationProvider.getClientRegistration(),
-            out.findByRegistrationId(GeonetworkClientRegistrationProvider.CLIENTREGISTRATION_NAME));
+            out.findByRegistrationId(GeonetworkClientRegistrationProvider.CLIENT_REGISTRATION_NAME));
+    }
+
+    @Test
+    public void testRepoServiceAccount() throws Exception {
+        OIDCConfiguration configuration = new OIDCConfiguration();
+        configuration.getClientConfig().setClientId("clientid");
+        configuration.getClientConfig().setClientSecret("clientsecret");
+        configuration.getClientConfig().setScopes("");//use all scopes
+        configuration.getServiceAccountConfig().setClientId("clientid");
+        configuration.getServiceAccountConfig().setClientSecret("clientsecret");
+        configuration.getServiceAccountConfig().setScopes("");//use all scopes
+        GeonetworkClientRegistrationProvider clientRegistrationProvider = new GeonetworkClientRegistrationProvider(
+            string2InputStream(keycloakConfig),
+            configuration
+        );
+        GeonetworkClientServiceAccountRegistrationProvider clientServiceAccountRegistrationProvider = new GeonetworkClientServiceAccountRegistrationProvider(
+            string2InputStream(keycloakConfig),
+            configuration
+        );
+
+        GeonetworkClientRegistrationRepository out = new GeonetworkClientRegistrationRepository(clientRegistrationProvider, clientServiceAccountRegistrationProvider);
+
+        assertEquals(clientRegistrationProvider.getClientRegistration(),
+            out.findByRegistrationId(GeonetworkClientRegistrationProvider.CLIENT_REGISTRATION_NAME));
+
+        assertEquals(clientServiceAccountRegistrationProvider.getClientRegistration(),
+            out.findByRegistrationId(GeonetworkClientServiceAccountRegistrationProvider.CLIENT_SERVICE_ACCOUNT_REGISTRATION_NAME));
     }
 }

--- a/core/src/test/java/org/fao/geonet/kernel/security/openidconnect/OIDCConfigurationTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/security/openidconnect/OIDCConfigurationTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2025 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+package org.fao.geonet.kernel.security.openidconnect;
+
+import org.apache.jcs.access.exception.InvalidArgumentException;
+import org.fao.geonet.exceptions.BadParameterEx;
+import org.fao.geonet.kernel.security.SecurityProviderConfiguration;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class OIDCConfigurationTest {
+
+    @Test
+    public void testDefaultValues() {
+        OIDCConfiguration config = new OIDCConfiguration();
+        assertEquals("email", config.getUserNameAttribute());
+        assertEquals("organization", config.getOrganizationProperty());
+        assertEquals(":", config.getGroupPermissionSeparator());
+        assertEquals("groups", config.getIdTokenRoleLocation());
+        assertEquals("Guest", config.getMinimumProfile().name());
+        assertTrue(config.isUpdateProfile());
+        assertTrue(config.isUpdateGroup());
+        assertFalse(config.isLogSensitiveInformation());
+    }
+
+    @Test
+    public void testSetters() {
+        OIDCConfiguration config = new OIDCConfiguration();
+        config.setUserNameAttribute("username");
+        assertEquals("username", config.getUserNameAttribute());
+
+        config.setOrganizationProperty("org");
+        assertEquals("org", config.getOrganizationProperty());
+
+        config.setGroupPermissionSeparator("-");
+        assertEquals("-", config.getGroupPermissionSeparator());
+
+        config.setIdTokenRoleLocation("roles");
+        assertEquals("roles", config.getIdTokenRoleLocation());
+
+        config.setUpdateProfile(false);
+        assertFalse(config.isUpdateProfile());
+
+        config.setUpdateGroup(false);
+        assertFalse(config.isUpdateGroup());
+
+        config.setLogSensitiveInformation(true);
+        assertTrue(config.isLogSensitiveInformation());
+    }
+
+    @Test
+    public void testRoleConverterString() {
+        OIDCConfiguration config = new OIDCConfiguration();
+        config.setRoleConverterString("admin=Editor,user=Guest");
+        assertEquals("Editor", config.getRoleConverter().get("admin"));
+        assertEquals("Guest", config.getRoleConverter().get("user"));
+    }
+
+    @Test
+    public void testLoginType() throws Exception {
+        OIDCConfiguration config = new OIDCConfiguration();
+        config.setLoginType(SecurityProviderConfiguration.LoginType.LINK.name());
+        assertEquals(SecurityProviderConfiguration.LoginType.LINK.toString(), config.getLoginType());
+
+        config.setLoginType(SecurityProviderConfiguration.LoginType.AUTOLOGIN.name());
+        assertEquals(SecurityProviderConfiguration.LoginType.AUTOLOGIN.toString(), config.getLoginType());
+
+        assertThrows(InvalidArgumentException.class, () -> {
+            config.setLoginType(SecurityProviderConfiguration.LoginType.FORM.name());
+        });
+
+        assertThrows(BadParameterEx.class, () -> {
+            config.setLoginType("INVALID");
+        });
+    }
+}

--- a/core/src/test/java/org/fao/geonet/kernel/security/openidconnect/OIDCRoleProcessorTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/security/openidconnect/OIDCRoleProcessorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Food and Agriculture Organization of the
+ * Copyright (C) 2025 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -50,11 +50,11 @@ public class OIDCRoleProcessorTest {
         OIDCRoleProcessor result = new OIDCRoleProcessor();
 
         result.oidcConfiguration = new OIDCConfiguration();
-        result.oidcConfiguration.roleConverter = new HashMap<String, String>() {{
+        result.oidcConfiguration.setRoleConverter(new HashMap<String, String>() {{
             put("CHANGEME", "CHANGED");
-        }};
-        result.oidcConfiguration.idTokenRoleLocation = "resource_access.gn-key.roles";
-        result.oidcConfiguration.minimumProfile = "RegisteredUser";
+        }});
+        result.oidcConfiguration.setIdTokenRoleLocation("resource_access.gn-key.roles");
+        result.oidcConfiguration.setMinimumProfile("RegisteredUser");
 
         return result;
     }

--- a/core/src/test/java/org/fao/geonet/kernel/security/openidconnect/bearer/AudienceAccessTokenValidatorTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/security/openidconnect/bearer/AudienceAccessTokenValidatorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2022 Food and Agriculture Organization of the
+ * Copyright (C) 2025 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -40,7 +40,7 @@ public class AudienceAccessTokenValidatorTest {
     public  AudienceAccessTokenValidator   getValidator(){
         AudienceAccessTokenValidator validator = new AudienceAccessTokenValidator();
         validator.oidcConfiguration = new OIDCConfiguration();
-        validator.oidcConfiguration.setClientId(clientId);
+        validator.oidcConfiguration.getClientConfig().setClientId(clientId);
         return validator;
     }
 

--- a/core/src/test/java/org/fao/geonet/kernel/security/openidconnect/bearer/OIDCServiceAccountLoginTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/security/openidconnect/bearer/OIDCServiceAccountLoginTest.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (C) 2025 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+
+package org.fao.geonet.kernel.security.openidconnect.bearer;
+
+import org.fao.geonet.kernel.security.openidconnect.GeonetworkClientRegistrationRepository;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
+import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
+import org.springframework.security.oauth2.client.registration.ClientRegistration;
+import org.springframework.security.oauth2.core.OAuth2AccessToken;
+
+import static org.fao.geonet.kernel.security.openidconnect.bearer.OIDCServiceAccountLogin.PRINCIPAL_NAME;
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+public class OIDCServiceAccountLoginTest {
+
+    private OAuth2AuthorizedClientManager clientManager;
+    private GeonetworkClientRegistrationRepository registrations;
+    private GeonetworkJwtAuthenticationProvider jwtProvider;
+    private OIDCServiceAccountLogin serviceAccountLogin;
+
+    @Before
+    public void setUp() {
+        clientManager = mock(OAuth2AuthorizedClientManager.class);
+        registrations = mock(GeonetworkClientRegistrationRepository.class);
+        ClientRegistration clientRegistration = mock(ClientRegistration.class);
+        jwtProvider = mock(GeonetworkJwtAuthenticationProvider.class);
+
+        when(registrations.findByRegistrationId(any())).thenReturn(clientRegistration);
+        when(clientRegistration.getRegistrationId()).thenReturn(PRINCIPAL_NAME);
+
+    }
+
+    @Test
+    public void testLoginServiceAccountSuccess() {
+        serviceAccountLogin = new OIDCServiceAccountLogin(clientManager, registrations, jwtProvider);
+
+        OAuth2AuthorizedClient authorizedClient = mock(OAuth2AuthorizedClient.class);
+        Authentication authentication = mock(Authentication.class);
+
+        when(clientManager.authorize(any(OAuth2AuthorizeRequest.class))).thenReturn(authorizedClient);
+        when(authorizedClient.getAccessToken()).thenReturn(new OAuth2AccessToken(OAuth2AccessToken.TokenType.BEARER, "tokenValue", null, null));
+        when(jwtProvider.authenticate(any(), any())).thenReturn(authentication);
+        when(authentication.isAuthenticated()).thenReturn(true);
+
+        boolean result = serviceAccountLogin.loginServiceAccount();
+        assertTrue(result);
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void testLoginServiceAccountAuthorizationFails() {
+        serviceAccountLogin = new OIDCServiceAccountLogin(clientManager, registrations, jwtProvider);
+        when(clientManager.authorize(any(OAuth2AuthorizeRequest.class))).thenReturn(null);
+        serviceAccountLogin.loginServiceAccount();
+    }
+
+    @Test
+    public void testLoginServiceAccountJwtProviderNull() {
+        serviceAccountLogin = new OIDCServiceAccountLogin(clientManager, registrations, null);
+        boolean result = serviceAccountLogin.loginServiceAccount();
+        assertFalse(result);
+    }
+}

--- a/docs/manual/docs/administrator-guide/managing-users-and-groups/authentication-mode.md
+++ b/docs/manual/docs/administrator-guide/managing-users-and-groups/authentication-mode.md
@@ -758,6 +758,28 @@ Inside `WEB-INF/config-security/config-security-openidconnectbearer.xml`:
 
 The easiest way to test is to obtain a Bearer Token, and then use a browser plugin to add the ``Authorization: Bearer <token>`` header to all requests. When you visit the Geonetwork website, you should see yourself logged in with the appropriate permissions.
 
+#### Service account Configuration {#service_account_configuration}
+
+If using background jobs such as harvester and there is a requirement to connect to external services which are also authenticated by the same provider then service accounts may be required.
+
+To enable service accounts use `OPENIDCONNECT_SERVICE_ACCOUNT_ENABLED=true`. 
+
+!!! note
+
+    This will currently only work with `GEONETWORK_SECURITY_TYPE=openidconnectbearer`
+
+!!! note
+
+    The service account client must be configured in the IDP to allow the `client_credentials` grant type.
+
+By default the same client as used for user authentication will be used for service accounts. To configure a different client for service accounts then use the following environment variables:
+
+``` properties
+OPENIDCONNECT_SERVICE_ACCOUNT_CLIENTSECRET='...'
+OPENIDCONNECT_SERVICE_ACCOUNT_CLIENTID='...'
+```
+If special scope is required for the service account then the following environment variable can be used `OPENIDCONNECT_SERVICE_ACCOUNT_SCOPES`
+
 #### Other Providers
 
 This has been tested with Azure AD (groups in the MS Graph API) and KeyCloak (groups in the `userinfo`).

--- a/web/src/main/webapp/WEB-INF/config-security/config-security-openidconnect-overrides.properties
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-openidconnect-overrides.properties
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 Food and Agriculture Organization of the
+# Copyright (C) 2025 Food and Agriculture Organization of the
 # United Nations (FAO-UN), United Nations World Food Programme (WFP)
 # and United Nations Environment Programme (UNEP)
 #
@@ -88,10 +88,9 @@ openidconnectConfiguration.updateGroup=${OPENIDCONNECT_USERGROUPUPDATEENABLED:tr
 openidconnectConfiguration.organizationProperty=${OPENIDCONNECT_ORGANIZATIONPROPERTY:organization}
 
 
-openidconnectConfiguration.scopes=${OPENIDCONNECT_SCOPES:#{'openid email profile'}}
-
-openidconnectConfiguration.clientId=${OPENIDCONNECT_CLIENTID}
-openidconnectConfiguration.clientSecret=${OPENIDCONNECT_CLIENTSECRET}
+openidconnectConfiguration.clientConfig.scopes=${OPENIDCONNECT_SCOPES:#{'openid email profile'}}
+openidconnectConfiguration.clientConfig.clientId=${OPENIDCONNECT_CLIENTID}
+openidconnectConfiguration.clientConfig.clientSecret=${OPENIDCONNECT_CLIENTSECRET}
 
 openidconnectConfiguration.userNameAttribute=${OPENIDCONNECT_USERNAME_ATTRIBUTE:#{'email'}}
 

--- a/web/src/main/webapp/WEB-INF/config-security/config-security-openidconnectbearer-overrides.properties
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-openidconnectbearer-overrides.properties
@@ -1,4 +1,4 @@
-# Copyright (C) 2020 Food and Agriculture Organization of the
+# Copyright (C) 2025 Food and Agriculture Organization of the
 # United Nations (FAO-UN), United Nations World Food Programme (WFP)
 # and United Nations Environment Programme (UNEP)
 #
@@ -88,10 +88,14 @@ openidconnectConfiguration.updateGroup=${OPENIDCONNECT_USERGROUPUPDATEENABLED:tr
 openidconnectConfiguration.organizationProperty=${OPENIDCONNECT_ORGANIZATIONPROPERTY:organization}
 
 
-openidconnectConfiguration.scopes=${OPENIDCONNECT_SCOPES:#{'openid email profile offline_access'}}
-
-openidconnectConfiguration.clientId=${OPENIDCONNECT_CLIENTID}
-openidconnectConfiguration.clientSecret=${OPENIDCONNECT_CLIENTSECRET}
+openidconnectConfiguration.clientConfig.scopes=${OPENIDCONNECT_SCOPES:#{'openid email profile offline_access'}}
+openidconnectConfiguration.clientConfig.clientId=${OPENIDCONNECT_CLIENTID}
+openidconnectConfiguration.clientConfig.clientSecret=${OPENIDCONNECT_CLIENTSECRET}
 
 openidconnectConfiguration.userNameAttribute=${OPENIDCONNECT_USERNAME_ATTRIBUTE:#{'email'}}
 openidconnectConfiguration.loginType=${OPENIDCONNECT_LOGINTYPE:#{'LINK'}}
+
+openidconnectConfiguration.serviceAccountConfig.scopes=${OPENIDCONNECT_SERVICE_ACCOUNT_SCOPES:${OPENIDCONNECT_SCOPES:#{'openid email profile offline_access'}}}
+openidconnectConfiguration.serviceAccountConfig.clientId=${OPENIDCONNECT_SERVICE_ACCOUNT_CLIENTID:${OPENIDCONNECT_CLIENTID}}
+openidconnectConfiguration.serviceAccountConfig.clientSecret=${OPENIDCONNECT_SERVICE_ACCOUNT_CLIENTSECRET:${OPENIDCONNECT_CLIENTSECRET}}
+openidconnectConfiguration.serviceAccountConfig.enabled=${OPENIDCONNECT_SERVICE_ACCOUNT_ENABLED:#{'false'}}

--- a/web/src/main/webapp/WEB-INF/config-security/config-security-openidconnectbearer.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-openidconnectbearer.xml
@@ -1,5 +1,5 @@
 <!--
-  ~ Copyright (C) 2022 Food and Agriculture Organization of the
+  ~ Copyright (C) 2025 Food and Agriculture Organization of the
   ~ United Nations (FAO-UN), United Nations World Food Programme (WFP)
   ~ and United Nations Environment Programme (UNEP)
   ~
@@ -48,11 +48,18 @@
     <constructor-arg ref="openidconnectConfiguration"/>
   </bean>
 
-
+  <!-- Reads from the .json file and creates a Service Account ClientRegistration -->
+  <bean id="openidconnectClientServiceAccountRegistration" class="org.fao.geonet.kernel.security.openidconnect.bearer.GeonetworkClientServiceAccountRegistrationProvider">
+    <constructor-arg value="${OPENIDCONNECT_SERVERMETADATA_SERVICE_ACCOUNT_FNAME:${OPENIDCONNECT_SERVERMETADATA_FNAME:#{''}}}"/>
+    <constructor-arg value="${OPENIDCONNECT_SERVERMETADATA_SERVICE_ACCOUNT_JSON_TEXT:${OPENIDCONNECT_SERVERMETADATA_JSON_TEXT:#{''}}}"/>
+    <constructor-arg value="${OPENIDCONNECT_SERVERMETADATA_SERVICE_ACCOUNT_CONFIG_URL:${OPENIDCONNECT_SERVERMETADATA_CONFIG_URL:#{''}}}"/>
+    <constructor-arg ref="openidconnectConfiguration"/>
+  </bean>
 
   <!-- Provides a hardcoded  ClientRegistrationRepository with exactly one  ClientRegistration-->
   <bean id="openidconnectClientRegistrationRepository" class="org.fao.geonet.kernel.security.openidconnect.GeonetworkClientRegistrationRepository">
     <constructor-arg ref="openidconnectClientRegistration"/>
+    <constructor-arg ref="openidconnectClientServiceAccountRegistration"/>
   </bean>
 
   <bean id="openidconnectAuthorizationRequestResolver" class="org.fao.geonet.kernel.security.openidconnect.HardcodedRegistrationIdOAuth2AuthorizationRequestResolver">
@@ -217,6 +224,8 @@
   <bean id="oidcSessionRegistry" class="org.fao.geonet.kernel.security.openidconnect.oidclogout.InMemoryOidcSessionRegistry"/>
   <bean id="sessionAuthenticationStrategy"
         class="org.fao.geonet.kernel.security.openidconnect.oidclogout.OidcSessionRegistryAuthenticationStrategy"/>
+
+  <bean id="oidcServiceAccountLogin" class="org.fao.geonet.kernel.security.openidconnect.bearer.OIDCServiceAccountLogin"/>
 
   <bean id="sessionMgmtFilter"
         class="org.springframework.security.web.session.SessionManagementFilter">


### PR DESCRIPTION
Added support to login via service account connection when using security type openidconnectbearer
   - This fixes an issue for cases where harvester performs validation which requires authentication - such as calling external api.
   - Create new client config to support having separate client for service account if needed. Fix some fields that were public and should have been private


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

