### PR TITLE
Skip BOM chars from XML documents

### DIFF
--- a/common/src/main/java/org/fao/geonet/utils/Xml.java
+++ b/common/src/main/java/org/fao/geonet/utils/Xml.java
@@ -1,5 +1,5 @@
 //=============================================================================
-//===	Copyright (C) 2001-2005 Food and Agriculture Organization of the
+//===	Copyright (C) 2001-2025 Food and Agriculture Organization of the
 //===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
 //===	and United Nations Environment Programme (UNEP)
 //===
@@ -26,6 +26,7 @@ package org.fao.geonet.utils;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.annotations.VisibleForTesting;
 import net.sf.json.JSON;
 import net.sf.json.xml.XMLSerializer;
 import net.sf.saxon.Configuration;
@@ -52,6 +53,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.json.XML;
 import org.mozilla.universalchardet.UniversalDetector;
+import org.springframework.util.StringUtils;
 import org.xml.sax.SAXException;
 
 import javax.xml.XMLConstants;
@@ -94,6 +96,7 @@ public final class Xml {
 
     public static final Namespace xsiNS = Namespace.getNamespace("xsi", XMLConstants.W3C_XML_SCHEMA_INSTANCE_NS_URI);
     public static final NioPathAwareEntityResolver PATH_RESOLVER = new NioPathAwareEntityResolver();
+    private static final byte[] BOM_MARKER_TEMPLATE = { (byte) 0xEF, (byte) 0xBB, (byte) 0xBF };
 
     // http://www.w3.org/TR/REC-xml/#charsets
     public static final String XML10_ILLEGAL_CHAR_PATTERN = "[^"
@@ -217,10 +220,10 @@ public final class Xml {
                 byte[] content = convertFileToUTF8ByteArray(file);
                 return loadStream(new ByteArrayInputStream(content));
 
-                // no charset detection and conversion allowed
+            // no charset detection and conversion allowed
             } else {
-                try (InputStream in = IO.newInputStream(file)) {
-                    Document jdoc = builder.build(in);
+                try (InputStream in = IO.newInputStream(file); PushbackInputStream f = processBOMMarker(in, file.getFileName().toString())) {
+                    Document jdoc = builder.build(f);
                     return (Element) jdoc.getRootElement().detach();
                 }
             }
@@ -329,12 +332,44 @@ public final class Xml {
      * Loads xml from an input stream and returns its root node.
      */
     public static Element loadStream(InputStream input) throws IOException, JDOMException {
-        SAXBuilder builder = getSAXBuilderWithPathXMLResolver(false, null); //new SAXBuilder();
-        builder.setFeature("http://apache.org/xml/features/validation/schema", false);
-        builder.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
-        Document jdoc = builder.build(input);
+        try (PushbackInputStream f = processBOMMarker(input, "")) {
+            SAXBuilder builder = getSAXBuilderWithPathXMLResolver(false, null); //new SAXBuilder();
+            builder.setFeature("http://apache.org/xml/features/validation/schema", false);
+            builder.setFeature("http://apache.org/xml/features/nonvalidating/load-external-dtd", false);
+            Document jdoc = builder.build(f);
 
-        return (Element) jdoc.getRootElement().detach();
+            return (Element) jdoc.getRootElement().detach();
+        }
+    }
+
+    /**
+     * Removes UTF-8 BOM marker if it exists.
+     *
+     * @param input InputStream to process.
+     * @param file  File name (for logging purposes).
+     * @return PushbackInputStream without the BOM marker.
+     *
+     * @throws IOException
+     */
+    @VisibleForTesting
+    protected static PushbackInputStream processBOMMarker(InputStream input, String file) throws IOException {
+        PushbackInputStream f = new PushbackInputStream(input, 3);
+
+        byte[] bomMarkerToCheck = new byte[3];
+
+        int c = f.read(bomMarkerToCheck, 0, bomMarkerToCheck.length);
+
+        if (Arrays.equals(bomMarkerToCheck, BOM_MARKER_TEMPLATE)) {
+            if (StringUtils.hasLength(file)) {
+                Log.debug(Log.ENGINE, "Found UTF-8 BOM marker in XML file " + file + ", skipping");
+            } else {
+                Log.debug(Log.ENGINE, "Found UTF-8 BOM marker in XML document, skipping");
+                }
+        } else {
+            f.unread(bomMarkerToCheck, 0, c);
+        }
+
+        return f;
     }
 
     //--------------------------------------------------------------------------


### PR DESCRIPTION
XML documents that begin with a Byte Order Mark (BOM) cause the following exception:

```
org.jdom.JDOMException: Error occurred while trying to load an xml file: ...: Error on line 1: Content is not allowed in prolog.
at org.fao.geonet.utils.Xml.loadFile(Xml.java:232) ~[gn-common-4.2.13-0.jar:?]
```

This change request checks whether the XML document begins with a BOM and, if so, removes it so that the XML load works as intended.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
