### PR TITLE
Release notes for 4.2.14 - update change log page

### DIFF
--- a/docs/manual/docs/overview/change-log/index.md
+++ b/docs/manual/docs/overview/change-log/index.md
@@ -3,5 +3,5 @@
 Notable changes made to GeoNetwork opensource including new features, migration instructions, and bug fixes.
 
 -   [Version 4.4.9](version-4.4.9.md)
--   [Version 4.2.13](version-4.2.13.md)
+-   [Version 4.2.14](version-4.2.14.md)
 -   [Release History](history/index.md)


### PR DESCRIPTION
Update change log page, that was referencing to the release notes of 4.2.13 instead of 4.2.14