### PR TITLE
ISO19115-3.2018 / Configure the xpath for the feature catalogue metadata titles

### DIFF
--- a/schemas/iso19115-3.2018/src/main/resources/config-spring-geonetwork.xml
+++ b/schemas/iso19115-3.2018/src/main/resources/config-spring-geonetwork.xml
@@ -25,6 +25,8 @@
       <util:list value-type="java.lang.String">
         <value>mdb:identificationInfo/*/mri:citation/*/cit:title/gco:CharacterString</value>
         <value>mdb:identificationInfo/*/mri:citation/*/cit:title/*/lan:textGroup/lan:LocalisedCharacterString</value>
+        <!-- Feature catalogue metadata title -->
+        <value>mdb:contentInfo/mrc:MD_FeatureCatalogue/mrc:featureCatalogue/gfc:FC_FeatureCatalogue/cat:name/gco:CharacterString</value>
       </util:list>
     </property>
     <!--


### PR DESCRIPTION
When creating a new metadata, the title is set to `Copy of template TEMPLATE_TITLE  created at CURRENT_DATE`.

This did not work  with the ISO19115-3.2018 template for creating Feature Catalogue metadata, so the title of the newly created metadata was the same as the template.

This change request fixes this case.

- Before: `Template for feature catalogue`
- After: `Copy of template Template for feature catalogue created at 2025-10-07T14:39:57.819565+02:00[Europe/Madrid]`

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

