### PR TITLE
Fix db upgrade script to avoid errors when settings already exists

### DIFF
--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v442/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v442/migrate-default.sql
@@ -1,6 +1,6 @@
 UPDATE Settings SET value='4.4.2' WHERE name='system/platform/version';
 UPDATE Settings SET value='0' WHERE name='system/platform/subVersion';
 
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('region/getmap/useGeodesicExtents', 'false', 2, 9591, 'n');
+INSERT INTO Settings (name, value, datatype, position, internal) SELECT distinct'region/getmap/useGeodesicExtents', 'false', 2, 9591, 'n' from settings WHERE NOT EXISTS (SELECT name FROM Settings WHERE name = 'region/getmap/useGeodesicExtents');
 
 DELETE FROM Settings WHERE name = 'system/index/indexingTimeRecordLink';

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v443/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v443/migrate-default.sql
@@ -1,5 +1,5 @@
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/documentation/url', 'https://docs.geonetwork-opensource.org/{{version}}/{{lang}}', 0, 570, 'n');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/userFeedback/metadata/enable', 'false', 2, 1913, 'n');
+INSERT INTO Settings (name, value, datatype, position, internal) SELECT distinct'system/documentation/url', 'https://docs.geonetwork-opensource.org/{{version}}/{{lang}}', 0, 570, 'n' from settings WHERE NOT EXISTS (SELECT name FROM Settings WHERE name = 'system/documentation/url');
+INSERT INTO Settings (name, value, datatype, position, internal) SELECT distinct'system/userFeedback/metadata/enable', 'false', 2, 1913, 'n' from settings WHERE NOT EXISTS (SELECT name FROM Settings WHERE name = 'system/userFeedback/metadata/enable');
 
 
 UPDATE Settings SET value='4.4.3' WHERE name='system/platform/version';

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v445/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v445/migrate-default.sql
@@ -1,9 +1,9 @@
 UPDATE Settings SET value='4.4.5' WHERE name='system/platform/version';
 UPDATE Settings SET value='0' WHERE name='system/platform/subVersion';
 
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/translation/provider', '', 0, 7301, 'n');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/translation/serviceUrl', '', 0, 7302, 'n');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/translation/apiKey', '', 0, 7303, 'y');
+INSERT INTO Settings (name, value, datatype, position, internal) SELECT distinct 'system/translation/provider', '', 0, 7301, 'n' from settings WHERE NOT EXISTS (SELECT name FROM Settings WHERE name = 'system/translation/provider');
+INSERT INTO Settings (name, value, datatype, position, internal) SELECT distinct 'system/translation/serviceUrl', '', 0, 7302, 'n' from settings WHERE NOT EXISTS (SELECT name FROM Settings WHERE name = 'system/translation/serviceUrl');
+INSERT INTO Settings (name, value, datatype, position, internal) SELECT distinct 'system/translation/apiKey', '', 0, 7303, 'y' from settings WHERE NOT EXISTS (SELECT name FROM Settings WHERE name = 'system/translation/apiKey');
 
 INSERT INTO Settings (name, value, datatype, position, internal) SELECT distinct 'system/feedback/languages', '', 0, 646, 'n' from settings WHERE NOT EXISTS (SELECT name FROM Settings WHERE name = 'system/feedback/languages');
 INSERT INTO Settings (name, value, datatype, position, internal) SELECT distinct 'system/feedback/translationFollowsText', '', 0, 647, 'n' from settings WHERE NOT EXISTS (SELECT name FROM Settings WHERE name = 'system/feedback/translationFollowsText');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v446/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v446/migrate-default.sql
@@ -1,4 +1,4 @@
 UPDATE Settings SET value='4.4.6' WHERE name='system/platform/version';
 UPDATE Settings SET value='0' WHERE name='system/platform/subVersion';
 
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/userSelfRegistration/domainsAllowed', '', 0, 1911, 'y');
+INSERT INTO Settings (name, value, datatype, position, internal) SELECT distinct 'system/userSelfRegistration/domainsAllowed', '', 0, 1911, 'y' from settings WHERE NOT EXISTS (SELECT name FROM Settings WHERE name = 'system/userSelfRegistration/domainsAllowed');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v447/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v447/migrate-default.sql
@@ -1,5 +1,5 @@
 UPDATE Settings SET value='4.4.7' WHERE name='system/platform/version';
 UPDATE Settings SET value='0' WHERE name='system/platform/subVersion';
 
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/banner/enable', 'false', 2, 1920, 'n');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/auditable/enable', 'false', 2, 12010, 'n');
+INSERT INTO Settings (name, value, datatype, position, internal) SELECT distinct 'system/banner/enable', 'false', 2, 1920, 'n' from settings WHERE NOT EXISTS (SELECT name FROM Settings WHERE name = 'system/banner/enable');
+INSERT INTO Settings (name, value, datatype, position, internal) SELECT distinct 'system/auditable/enable', 'false', 2, 12010, 'n' from settings WHERE NOT EXISTS (SELECT name FROM Settings WHERE name = 'system/auditable/enable');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v448/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v448/migrate-default.sql
@@ -1,4 +1,4 @@
 UPDATE Settings SET value='4.4.8' WHERE name='system/platform/version';
 UPDATE Settings SET value='0' WHERE name='system/platform/subVersion';
 
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('metadata/delete/backupOptions', 'UseAPIParameter', 0, 12012, 'n');
+INSERT INTO Settings (name, value, datatype, position, internal) SELECT distinct 'metadata/delete/backupOptions', 'UseAPIParameter', 0, 12012, 'n' from settings WHERE NOT EXISTS (SELECT name FROM Settings WHERE name = 'metadata/delete/backupOptions');

--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v449/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v449/migrate-default.sql
@@ -1,4 +1,4 @@
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/publication/doi/doimailnotification', 'false', 2, 100192, 'n');
+INSERT INTO Settings (name, value, datatype, position, internal) SELECT distinct 'system/publication/doi/doimailnotification', 'false', 2, 100192, 'n' from settings WHERE NOT EXISTS (SELECT name FROM Settings WHERE name = 'system/publication/doi/doimailnotification');
 
 -- Migration to 4.4.5 only removed the old DOI settings, when the DOI server was defined.
 -- Related to https://github.com/geonetwork/core-geonetwork/pull/8098


### PR DESCRIPTION
Tried to perform an upgrade from 4.2.13 to 4.4.9 but got lots of errrors similar to the following 

```
2025-10-07T14:15:59.119Z [main] WARN  [,] org.springframework.orm.jpa.persistenceunit.DefaultPersistenceUnitManager - Found explicit default persistence unit with name 'default' in persistence.xml - overriding local default persistence unit settings ('packagesToScan'/'mappingResources')
2025-10-07T14:16:06.004Z [main] WARN  [,] geonetwork.database - SQL failure for:  INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/documentation/url', 'https://docs.geonetwork-opensource.org/{{version}}/{{lang}}', 0, 570, 'n'), error is:ERROR: duplicate key value violates unique constraint "settings_pkey"
  Detail: Key (name)=(system/documentation/url) already exists.
2025-10-07T14:16:06.006Z [main] ERROR [,] geonetwork.databasemigration - ERROR: duplicate key value violates unique constraint "settings_pkey"
  Detail: Key (name)=(system/documentation/url) already exists.
org.postgresql.util.PSQLException: ERROR: duplicate key value violates unique constraint "settings_pkey"
  Detail: Key (name)=(system/documentation/url) already exists.
```

This PR updated the migration script sql still work if the key already exists from older geonetwork.


# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

