### PR TITLE
Editor / Associated panel / Search exclude already associated records

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -1898,7 +1898,7 @@
                       searchParams["-resourceType"] = "service";
                     }
 
-                    scope.uuidsAlreadyLinked = [currentUuid];
+                    scope.uuidsAlreadyLinked = currentUuid ? [currentUuid] : [];
                     if (existingRelations && existingRelations.length) {
                       for (var i = 0; i < existingRelations.length; i++) {
                         scope.uuidsAlreadyLinked.push(existingRelations[i].uuid);
@@ -2221,7 +2221,7 @@
                     $("#linktomd-search input").val("");
                     scope.searchObj.any = "";
 
-                    scope.uuidsAlreadyLinked = [currentUuid];
+                    scope.uuidsAlreadyLinked = currentUuid ? [currentUuid] : [];
                     if (existingRelations && existingRelations.length) {
                       for (var i = 0; i < existingRelations.length; i++) {
                         scope.uuidsAlreadyLinked.push(existingRelations[i].uuid);
@@ -2317,7 +2317,7 @@
                       config = angular.fromJson(config);
                     }
 
-                    scope.uuidsAlreadyLinked = [currentUuid];
+                    scope.uuidsAlreadyLinked = currentUuid ? [currentUuid] : [];
                     if (existingRelations && existingRelations.length) {
                       for (var i = 0; i < existingRelations.length; i++) {
                         scope.uuidsAlreadyLinked.push(existingRelations[i].uuid);

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -2142,9 +2142,10 @@
      */
     .directive("gnLinkToMetadata", [
       "gnOnlinesrc",
+      "gnCurrentEdit",
       "$translate",
       "gnGlobalSettings",
-      function (gnOnlinesrc, $translate, gnGlobalSettings) {
+      function (gnOnlinesrc, gnCurrentEdit, $translate, gnGlobalSettings) {
         return {
           restrict: "A",
           scope: {},
@@ -2205,47 +2206,46 @@
                  * Register a method on popup open to reset
                  * the search form and trigger a search.
                  */
-                gnOnlinesrc.register(
-                  scope.mode,
-                  function (config, existingRelations, currentUuid) {
-                    if (config && !angular.isObject(config)) {
-                      config = angular.fromJson(config);
-                    }
-
-                    scope.config = {
-                      sources: config && config.sources
-                    };
-
-                    $(scope.popupid).modal("show");
-
-                    $("#linktomd-search input").val("");
-                    scope.searchObj.any = "";
-
-                    scope.uuidsAlreadyLinked = currentUuid ? [currentUuid] : [];
-                    if (existingRelations && existingRelations.length) {
-                      for (var i = 0; i < existingRelations.length; i++) {
-                        scope.uuidsAlreadyLinked.push(existingRelations[i].uuid);
-                      }
-                    }
-                    if (scope.uuidsAlreadyLinked.length > 0) {
-                      scope.searchObj.filters = [
-                        {
-                          query_string: {
-                            query:
-                              '-_id:("' + scope.uuidsAlreadyLinked.join('" OR "') + '")'
-                          }
-                        }
-                      ];
-                    }
-
-                    var searchParams =
-                      scope.config.sources && scope.config.sources.metadataStore
-                        ? scope.config.sources.metadataStore.params || {}
-                        : {};
-                    scope.$broadcast("resetSearch", searchParams);
-                    scope.selectRecords = [];
+                gnOnlinesrc.register(scope.mode, function (config) {
+                  if (config && !angular.isObject(config)) {
+                    config = angular.fromJson(config);
                   }
-                );
+
+                  scope.config = {
+                    sources: config && config.sources
+                  };
+
+                  $(scope.popupid).modal("show");
+
+                  $("#linktomd-search input").val("");
+                  scope.searchObj.any = "";
+
+                  scope.uuidsAlreadyLinked = [gnCurrentEdit.uuid];
+                  var existingRelations = gnCurrentEdit.getRelations(scope.mode);
+
+                  if (existingRelations && existingRelations.length) {
+                    for (var i = 0; i < existingRelations.length; i++) {
+                      scope.uuidsAlreadyLinked.push(existingRelations[i].uuid);
+                    }
+                  }
+                  if (scope.uuidsAlreadyLinked.length > 0) {
+                    scope.searchObj.filters = [
+                      {
+                        query_string: {
+                          query:
+                            '-_id:("' + scope.uuidsAlreadyLinked.join('" OR "') + '")'
+                        }
+                      }
+                    ];
+                  }
+
+                  var searchParams =
+                    scope.config.sources && scope.config.sources.metadataStore
+                      ? scope.config.sources.metadataStore.params || {}
+                      : {};
+                  scope.$broadcast("resetSearch", searchParams);
+                  scope.selectRecords = [];
+                });
                 scope.gnOnlinesrc = gnOnlinesrc;
               }
             };
@@ -2273,9 +2273,10 @@
      */
     .directive("gnLinkToSibling", [
       "gnOnlinesrc",
+      "gnCurrentEdit",
       "gnGlobalSettings",
       "gnOnlinesrcConfig",
-      function (gnOnlinesrc, gnGlobalSettings, gnOnlinesrcConfig) {
+      function (gnOnlinesrc, gnCurrentEdit, gnGlobalSettings, gnOnlinesrcConfig) {
         return {
           restrict: "A",
           scope: {},
@@ -2310,51 +2311,49 @@
                  * Register a method on popup open to reset
                  * the search form and trigger a search.
                  */
-                gnOnlinesrc.register(
-                  "siblings",
-                  function (config, existingRelations, currentUuid) {
-                    if (config && !angular.isObject(config)) {
-                      config = angular.fromJson(config);
-                    }
-
-                    scope.uuidsAlreadyLinked = currentUuid ? [currentUuid] : [];
-                    if (existingRelations && existingRelations.length) {
-                      for (var i = 0; i < existingRelations.length; i++) {
-                        scope.uuidsAlreadyLinked.push(existingRelations[i].uuid);
-                      }
-                    }
-                    if (scope.uuidsAlreadyLinked.length > 0) {
-                      scope.searchObj.filters = [
-                        {
-                          query_string: {
-                            query:
-                              '-_id:("' + scope.uuidsAlreadyLinked.join('" OR "') + '")'
-                          }
-                        }
-                      ];
-                    }
-
-                    scope.config = {
-                      associationTypeForced: angular.isDefined(
-                        config && config.fields && config.fields.associationType
-                      ),
-                      associationType:
-                        (config && config.fields && config.fields.associationType) ||
-                        null,
-                      initiativeTypeForced: angular.isDefined(
-                        config && config.fields && config.fields.initiativeType
-                      ),
-                      initiativeType:
-                        (config && config.fields && config.fields.initiativeType) || null,
-                      sources: config && config.sources
-                    };
-
-                    $(scope.popupid).modal("show");
-
-                    scope.clearSearch();
-                    scope.selection = [];
+                gnOnlinesrc.register("siblings", function (config) {
+                  if (config && !angular.isObject(config)) {
+                    config = angular.fromJson(config);
                   }
-                );
+
+                  scope.uuidsAlreadyLinked = [gnCurrentEdit.uuid];
+                  var existingRelations = gnCurrentEdit.getRelations("siblings");
+
+                  if (existingRelations && existingRelations.length) {
+                    for (var i = 0; i < existingRelations.length; i++) {
+                      scope.uuidsAlreadyLinked.push(existingRelations[i].uuid);
+                    }
+                  }
+                  if (scope.uuidsAlreadyLinked.length > 0) {
+                    scope.searchObj.filters = [
+                      {
+                        query_string: {
+                          query:
+                            '-_id:("' + scope.uuidsAlreadyLinked.join('" OR "') + '")'
+                        }
+                      }
+                    ];
+                  }
+
+                  scope.config = {
+                    associationTypeForced: angular.isDefined(
+                      config && config.fields && config.fields.associationType
+                    ),
+                    associationType:
+                      (config && config.fields && config.fields.associationType) || null,
+                    initiativeTypeForced: angular.isDefined(
+                      config && config.fields && config.fields.initiativeType
+                    ),
+                    initiativeType:
+                      (config && config.fields && config.fields.initiativeType) || null,
+                    sources: config && config.sources
+                  };
+
+                  $(scope.popupid).modal("show");
+
+                  scope.clearSearch();
+                  scope.selection = [];
+                });
 
                 // Clear the search params and input
                 scope.clearSearch = function () {

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcService.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcService.js
@@ -411,19 +411,15 @@
          *
          * @param {string} type of the directive that calls it.
          */
-        onOpenPopup: function (type, additionalParams) {
-          if (
-            type === "parent" &&
-            additionalParams.fields &&
-            additionalParams.fields.associationType
-          ) {
+        onOpenPopup: function (type, config, existingRelations) {
+          if (type === "parent" && config.fields && config.fields.associationType) {
             // In ISO19115-3, parents are usually encoded using the association records
             // Configured in config/associated-panel/default.json
             type = "siblings";
           }
           var fn = openCb[type];
           if (angular.isFunction(fn)) {
-            openCb[type](additionalParams);
+            openCb[type].apply(null, Array.prototype.slice.call(arguments, 1));
           } else {
             console.warn(
               "No callback functions available for '" + type + "'. Check the type value."

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcService.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcService.js
@@ -278,6 +278,26 @@
           searchObj.params = angular.extend({}, searchObj.defaultParams);
           return searchObj;
         },
+        getSearchFilterForType: function (gnCurrentEdit, type) {
+          var uuidsAlreadyLinked = [gnCurrentEdit.uuid];
+          var existingRelations = gnCurrentEdit.getRelations(type);
+
+          if (existingRelations && existingRelations.length) {
+            for (var i = 0; i < existingRelations.length; i++) {
+              uuidsAlreadyLinked.push(existingRelations[i].uuid);
+            }
+          }
+          if (uuidsAlreadyLinked.length > 0) {
+            return [
+              {
+                query_string: {
+                  query: '-_id:("' + uuidsAlreadyLinked.join('" OR "') + '")'
+                }
+              }
+            ];
+          }
+          return [];
+        },
 
         /**
          * @ngdoc method
@@ -411,7 +431,7 @@
          *
          * @param {string} type of the directive that calls it.
          */
-        onOpenPopup: function (type, config, existingRelations) {
+        onOpenPopup: function (type) {
           if (type === "parent" && config.fields && config.fields.associationType) {
             // In ISO19115-3, parents are usually encoded using the association records
             // Configured in config/associated-panel/default.json

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcService.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcService.js
@@ -431,7 +431,7 @@
          *
          * @param {string} type of the directive that calls it.
          */
-        onOpenPopup: function (type) {
+        onOpenPopup: function (type, config) {
           if (type === "parent" && config.fields && config.fields.associationType) {
             // In ISO19115-3, parents are usually encoded using the association records
             // Configured in config/associated-panel/default.json

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/linktosibling.html
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/partials/linktosibling.html
@@ -106,7 +106,7 @@
             </div>
           </div>
 
-          <div>
+          <div data-ng-show="searchResults.records.length > 0">
             <div class="list-group fixed gn-nopadding-left gn-nopadding-right">
               <div class="list-group-item" data-ng-repeat="md in searchResults.records">
                 <a
@@ -130,6 +130,7 @@
             </div>
           </div>
           <div
+            data-ng-show="searchResults.records.length > 0"
             data-gn-pagination="paginationInfo"
             data-hits-values="searchObj.hitsperpageValues"
           ></div>

--- a/web-ui/src/main/resources/catalog/components/metadataactions/RelatedDirective.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/RelatedDirective.js
@@ -1367,6 +1367,7 @@
           scope.gnCurrentEdit = gnCurrentEdit;
           scope.relations = [];
           scope.relatedConfigUI = [];
+          gnCurrentEdit.relatedConfigUI = scope.relatedConfigUI;
           scope.relatedResourcesConfig = gnRelatedResources;
           if ($injector.has("gnOnlinesrc")) {
             scope.onlinesrcService = $injector.get("gnOnlinesrc");

--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/associatedResourcesContainer.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/associatedResourcesContainer.html
@@ -11,7 +11,7 @@
           title="{{(config.type + '-help') | translate}}"
           class="btn btn-default btn-xs pull-right"
           data-ng-if="config.allowToAddRelation"
-          data-ng-click="onlinesrcService.onOpenPopup(config.type, config.config)"
+          data-ng-click="onlinesrcService.onOpenPopup(config.type, config.config, config.relations, gnCurrentEdit.uuid)"
         >
           <i class="fa fa-fw fa-plus"></i>
           <span>{{ config.label | translate}}</span>

--- a/web-ui/src/main/resources/catalog/components/metadataactions/partials/associatedResourcesContainer.html
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/partials/associatedResourcesContainer.html
@@ -11,7 +11,7 @@
           title="{{(config.type + '-help') | translate}}"
           class="btn btn-default btn-xs pull-right"
           data-ng-if="config.allowToAddRelation"
-          data-ng-click="onlinesrcService.onOpenPopup(config.type, config.config, config.relations, gnCurrentEdit.uuid)"
+          data-ng-click="onlinesrcService.onOpenPopup(config.type, config.config)"
         >
           <i class="fa fa-fw fa-plus"></i>
           <span>{{ config.label | translate}}</span>

--- a/web-ui/src/main/resources/catalog/components/metadatamanager/EditorService.js
+++ b/web-ui/src/main/resources/catalog/components/metadatamanager/EditorService.js
@@ -64,6 +64,17 @@
        */
       var duration = 300;
 
+      gnCurrentEdit.getRelations = function (type) {
+        var c = gnCurrentEdit.relatedConfigUI.filter(function (c) {
+          return c.type === type;
+        });
+        if (c.length === 1) {
+          return c[0].relations;
+        } else {
+          return [];
+        }
+      };
+
       var isFirstElementOfItsKind = function (element) {
         return !isSameKindOfElement(element, $(element).prev().get(0));
       };

--- a/web-ui/src/main/resources/catalog/components/search/searchmanager/partials/searchresults.html
+++ b/web-ui/src/main/resources/catalog/components/search/searchmanager/partials/searchresults.html
@@ -88,6 +88,7 @@
     </div>
   </div>
   <div
+    data-ng-show="searchResults.records.length > 0"
     data-gn-pagination="paginationInfo"
     data-hits-values="searchObj.hitsperpageValues"
   ></div>

--- a/web-ui/src/main/resources/catalog/views/default/templates/results.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/results.html
@@ -131,7 +131,10 @@
               <i class="fa fa-fw fa-chevron-up"></i>
             </button>
           </div>
-          <div class="col-xs-12 col-sm-6 text-center">
+          <div
+            class="col-xs-12 col-sm-6 text-center"
+            data-ng-show="searchResults.records.length > 0"
+          >
             <div
               class=""
               data-gn-pagination="paginationInfo"


### PR DESCRIPTION
* Filter current record from the search (does not make sense to link record to itself)
* Filter already associated records from the search
* Do not display pagination component if no results.

<img width="477" height="357" alt="image" src="https://github.com/user-attachments/assets/be1d6cd5-0bac-42a0-a016-5f5468408afb" />

<img width="1264" height="398" alt="image" src="https://github.com/user-attachments/assets/93085df7-6226-48d8-ade6-2d0bae0d4612" />



<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

Funded by https://metadata.vlaanderen.be/
