### PR TITLE
ISO19139 / ISO19115-3.2018 / Full record view improvements

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/xsl-view/view.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/xsl-view/view.xsl
@@ -995,31 +995,34 @@
   <xsl:template mode="render-field"
                 match="mrd:distributionFormat[1]"
                 priority="100">
-    <dl class="gn-format">
-      <dt>
-        <xsl:call-template name="render-field-label">
-          <xsl:with-param name="languages" select="$allLanguages"/>
-        </xsl:call-template>
-      </dt>
-      <dd>
-        <ul>
-          <xsl:for-each select="parent::node()/mrd:distributionFormat">
-            <li>
-              <xsl:apply-templates mode="render-value"
-                                   select="*/mrd:formatSpecificationCitation/*/
+    <xsl:if test="count(parent::node()/mrd:distributionFormat/*/mrd:formatSpecificationCitation/*/
+                                    cit:title/*[text() != '']) > 0">
+      <dl class="gn-format">
+        <dt>
+          <xsl:call-template name="render-field-label">
+            <xsl:with-param name="languages" select="$allLanguages"/>
+          </xsl:call-template>
+        </dt>
+        <dd>
+          <ul>
+            <xsl:for-each select="parent::node()/mrd:distributionFormat">
+              <li>
+                <xsl:apply-templates mode="render-value"
+                                     select="*/mrd:formatSpecificationCitation/*/
                                     cit:title"/>
-              <p>
-                <xsl:apply-templates mode="render-field"
-                                     select="*/(mrd:amendmentNumber|
+                <p>
+                  <xsl:apply-templates mode="render-field"
+                                       select="*/(mrd:amendmentNumber|
                               mrd:fileDecompressionTechnique|
                               mrd:medium|
                               mrd:formatDistributor)"/>
-              </p>
-            </li>
-          </xsl:for-each>
-        </ul>
-      </dd>
-    </dl>
+                </p>
+              </li>
+            </xsl:for-each>
+          </ul>
+        </dd>
+      </dl>
+    </xsl:if>
   </xsl:template>
 
 

--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/xsl-view/view.xsl
@@ -951,32 +951,36 @@
   <xsl:template mode="render-field"
                 match="gmd:distributionFormat[1]"
                 priority="100">
-    <dl class="gn-format">
-      <dt>
-        <xsl:call-template name="render-field-label">
-          <xsl:with-param name="languages" select="$allLanguages"/>
-        </xsl:call-template>
-      </dt>
-      <dd>
-        <ul>
-          <xsl:for-each select="parent::node()/gmd:distributionFormat">
-            <xsl:if test="*/gmd:name[. != '']">
-              <li>
-                <xsl:apply-templates mode="render-value-no-breaklines"
-                                    select="*/gmd:name"/>
-                (<xsl:apply-templates mode="render-value-no-breaklines"
-                                      select="*/gmd:version"/>)
-                <p>
-                  <xsl:apply-templates mode="render-field"
-                                      select="*/(gmd:amendmentNumber|gmd:specification|
+    <xsl:if test="count(parent::node()/gmd:distributionFormat/*/gmd:name/*[text() != '']) > 0">
+      <dl class="gn-format">
+        <dt>
+          <xsl:call-template name="render-field-label">
+            <xsl:with-param name="languages" select="$allLanguages"/>
+          </xsl:call-template>
+        </dt>
+        <dd>
+          <ul>
+            <xsl:for-each select="parent::node()/gmd:distributionFormat">
+              <xsl:if test="*/gmd:name/*[text() != '']">
+                <li>
+                  <xsl:apply-templates mode="render-value-no-breaklines"
+                                       select="*/gmd:name"/>
+                  <xsl:if test="*/gmd:version/*[text() != '']">
+                    (<xsl:apply-templates mode="render-value-no-breaklines"
+                                          select="*/gmd:version"/>)
+                  </xsl:if>
+                  <p>
+                    <xsl:apply-templates mode="render-field"
+                                         select="*/(gmd:amendmentNumber|gmd:specification|
                                 gmd:fileDecompressionTechnique|gmd:formatDistributor)"/>
-                </p>
-              </li>
-            </xsl:if>
-          </xsl:for-each>
-        </ul>
-      </dd>
-    </dl>
+                  </p>
+                </li>
+              </xsl:if>
+            </xsl:for-each>
+          </ul>
+        </dd>
+      </dl>
+    </xsl:if>
   </xsl:template>
 
 


### PR DESCRIPTION
1. Don't display keyword panel if there are no keywords to display: unify logic for ISO19139 metadata with ISO19115-3.2018 metadata.

Before:

<img width="402" height="207" alt="before-keywords-header" src="https://github.com/user-attachments/assets/0c002bd6-719a-45a5-ae5a-3ae41b6f5b08" />

After:

<img width="406" height="156" alt="after-keywords-header" src="https://github.com/user-attachments/assets/8719df85-8836-44f1-b5cc-5ad820c83da7" />

2. Hide distribution format if have empty values

Before:
<img width="704" height="172" alt="before-distribution-format" src="https://github.com/user-attachments/assets/d8cf8f29-3bc1-4fc4-9342-7a685de3e3a4" />

After:
<img width="732" height="149" alt="after-distribution-format" src="https://github.com/user-attachments/assets/4cc52d8a-6253-47fb-83cb-41a2c33a4752" />

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
