### PR TITLE
Standard / 19115-3 / Fix maintenance date type in 19139 conversion

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ISO19139/mapping/core.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ISO19139/mapping/core.xsl
@@ -687,7 +687,7 @@
         <xsl:call-template name="writeCodelistElement">
           <xsl:with-param name="elementName" select="'cit:dateType'"/>
           <xsl:with-param name="codeListName" select="'cit:CI_DateTypeCode'"/>
-          <xsl:with-param name="codeListValue" select="'update'"/>
+          <xsl:with-param name="codeListValue" select="'nextUpdate'"/>
         </xsl:call-template>
       </cit:CI_Date>
     </mmi:maintenanceDate>


### PR DESCRIPTION
Maintenance date was using codeListValue 'update' (which is not a value in the default codelist) instead of 'nextUpdate'

See https://github.com/geonetwork/core-geonetwork/blob/main/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/loc/eng/codelists.xml#L76


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->


Funded by EEA.