### PR TITLE
avoid bad url forging when contact logo from existing org

### DIFF
--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -1561,10 +1561,10 @@
           '             viewBox="0 0 500 500">' +
           "    <defs>" +
           '      <pattern id="image{{imageId}}" x="0" y="0" patternUnits="userSpaceOnUse" height="100%" width="100%">' +
-          '        <image ng-if="hasIcon" x="0" y="0" height="100%" width="100%" xlink:href="{{\'../../images/harvesting/\' + orgKey + \'.png\'}}"></image>' +
+          '        <image ng-if="hasIcon" x="0" y="0" height="100%" width="100%" ng-attr-href="{{\'../api/logos/\' + orgKey + \'.png\'}}"></image>' +
           "      </pattern>" +
           "    </defs>" +
-          '    <circle fill="url(\'#image{{imageId}}\')" style="stroke-miterlimit:10;" cx="250" cy="250" r="240"/>' +
+          '    <circle fill="url(#image{{imageId}})" style="stroke-miterlimit:10;" cx="250" cy="250" r="240"/>' +
           '    <text x="50%" y="50%"' +
           '          text-anchor="middle" alignment-baseline="central" dominant-baseline="central"' +
           "          font-size=\"300\">{{hasIcon ? '' : org.substr(0, 1).toUpperCase()}}</text>" +


### PR DESCRIPTION
observed:
When displaying simple view,  a bad url if forged (which can lead to session revocation at spring security level when anonymous).

<img width="3226" height="433" alt="wrong_forged_url" src="https://github.com/user-attachments/assets/f3b313bf-13ea-4fb3-9ae4-c09f15dec75d" />

-> Have indeed to use ng-attr-xlink:href or ng-attr-href so to allow expression evalution in angular template for xlink:href.

So to have the logo correctly displayed:
-> If 'link' test for '../api/logos', have to href '../api/logos', not '../../images/harvesting'.

when logo available
<img width="861" height="295" alt="when_logo_available" src="https://github.com/user-attachments/assets/de62dc4b-9273-4624-8176-654355c1ea39" />

when logo not available
<img width="970" height="282" alt="when_logo_not_available" src="https://github.com/user-attachments/assets/ffc35a80-a8b9-4153-b0fe-a7c42daacb14" />



# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
