### PR TITLE
Fix use of deprecated BearerTokenAuthenticationToken class

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/bearer/GeonetworkJwtAuthenticationProvider.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/bearer/GeonetworkJwtAuthenticationProvider.java
@@ -52,7 +52,7 @@ import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.oauth2.jwt.Jwt;
-import org.springframework.security.oauth2.server.resource.BearerTokenAuthenticationToken;
+import org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthenticationToken;
 import org.springframework.security.oauth2.server.resource.BearerTokenError;
 import org.springframework.security.oauth2.server.resource.BearerTokenErrorCodes;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;

--- a/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/bearer/OIDCServiceAccountLogin.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/openidconnect/bearer/OIDCServiceAccountLogin.java
@@ -31,7 +31,7 @@ import org.springframework.security.oauth2.client.OAuth2AuthorizeRequest;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClient;
 import org.springframework.security.oauth2.client.OAuth2AuthorizedClientManager;
 import org.springframework.security.oauth2.client.registration.ClientRegistration;
-import org.springframework.security.oauth2.server.resource.BearerTokenAuthenticationToken;
+import org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthenticationToken;
 
 import static org.fao.geonet.kernel.security.openidconnect.bearer.GeonetworkClientServiceAccountRegistrationProvider.CLIENT_SERVICE_ACCOUNT_REGISTRATION_NAME;
 


### PR DESCRIPTION
Addresses an issue introduced by #9038

Spring deprecated `org.springframework.security.oauth2.server.resource.BearerTokenAuthenticationToken` in favor of `org.springframework.security.oauth2.server.resource.authentication.BearerTokenAuthenticationToken`.

This PR updates all usages to reference the new class. The previous class is no longer supported by Spring’s `AuthenticationProvider` chain, which can and has resulted in `401` responses when attempting to authenticate using bearer tokens.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

