### PR TITLE
Support harvester log in subdirectory

### DIFF
--- a/core/src/main/java/org/fao/geonet/util/LogUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/LogUtil.java
@@ -95,7 +95,7 @@ public class LogUtil {
      *
      * @return the path to the harvester logfile
      */
-    private static String getHarvesterLogfilePath() {
+    public static String getHarvesterLogfilePath() {
         // Get the top-level log directory
         Path logDir = Paths.get(Log.getLogfile().getParent());
 

--- a/core/src/main/java/org/fao/geonet/util/LogUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/LogUtil.java
@@ -82,7 +82,12 @@ public class LogUtil {
         ThreadContext.put("logfile", logfile);
         ThreadContext.put("timeZone", timeZoneSetting);
 
-        return getHarvesterLogfilePath();
+        try {
+            return getHarvesterLogfilePath();
+        } catch (Exception e) {
+            Log.error("Error retrieving harvester logfile path. Defaulting to base file name.", e);
+            return logfile;
+        }
     }
 
     /**
@@ -90,7 +95,7 @@ public class LogUtil {
      *
      * @return the path to the harvester logfile
      */
-    public static String getHarvesterLogfilePath() {
+    private static String getHarvesterLogfilePath() {
         // Get the top-level log directory
         Path logDir = Paths.get(Log.getLogfile().getParent());
 

--- a/core/src/main/java/org/fao/geonet/util/LogUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/LogUtil.java
@@ -24,14 +24,22 @@
 package org.fao.geonet.util;
 
 import org.apache.commons.lang.StringUtils;
+import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.ThreadContext;
+import org.apache.logging.log4j.core.appender.routing.RoutingAppender;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.config.Node;
 import org.fao.geonet.ApplicationContextHolder;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.kernel.setting.Settings;
+import org.fao.geonet.utils.Log;
 
+import java.nio.file.Paths;
 import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimeZone;
+import java.nio.file.Path;
 
 public class LogUtil {
 
@@ -74,6 +82,41 @@ public class LogUtil {
         ThreadContext.put("logfile", logfile);
         ThreadContext.put("timeZone", timeZoneSetting);
 
-        return logfile;
+        return getHarvesterLogfilePath();
+    }
+
+    /**
+     * Retrieves the path to the current harvester logfile based on Log4J configuration.
+     *
+     * @return the path to the harvester logfile
+     */
+    public static String getHarvesterLogfilePath() {
+        // Get the top-level log directory
+        Path logDir = Paths.get(Log.getLogfile().getParent());
+
+        // Access Log4J configuration
+        LoggerContext ctx = (LoggerContext) LogManager.getContext(false);
+        Configuration config = ctx.getConfiguration();
+
+        // Get the Routing appender
+        RoutingAppender routing = config.getAppender("Harvester");
+        if (routing == null) {
+            throw new IllegalStateException("Routing appender 'Harvester' not found");
+        }
+
+        // Find the first <File> node
+        Node fileNode = routing.getRoutes().getRoutes()[0]
+            .getNode()
+            .getChildren()
+            .stream()
+            .filter(n -> "File".equalsIgnoreCase(n.getName()))
+            .findFirst()
+            .orElseThrow(() -> new IllegalStateException("No <File> node found in Harvester routes"));
+
+        // Resolve the full path using the StrSubstitutor
+        Path fullPath = Paths.get(config.getStrSubstitutor().replace(fileNode.getAttributes().get("fileName")));
+
+        // Return the path relative to the log directory
+        return logDir.relativize(fullPath).toString();
     }
 }

--- a/core/src/test/java/org/fao/geonet/util/LogUtilTest.java
+++ b/core/src/test/java/org/fao/geonet/util/LogUtilTest.java
@@ -1,19 +1,13 @@
 package org.fao.geonet.util;
 
-import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.ThreadContext;
-import org.apache.logging.log4j.core.LoggerContext;
-import org.apache.logging.log4j.core.appender.routing.RoutingAppender;
-import org.apache.logging.log4j.core.config.Configuration;
 import org.fao.geonet.utils.Log;
 import org.junit.Test;
 import org.mockito.MockedStatic;
 
 import java.nio.file.Paths;
-import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.*;
 
 public class LogUtilTest {
@@ -21,45 +15,10 @@ public class LogUtilTest {
     @Test
     public void retrievesHarvesterLogfilePath() {
         ThreadContext.put("logfile", "harvester_geonetwork40_TestHarvester_20251030083002.log");
-        assertEquals("harvester_geonetwork40_TestHarvester_20251030083002.log", LogUtil.getHarvesterLogfilePath());
-    }
+        try (MockedStatic<Log> logMock = mockStatic(Log.class)) {
+            logMock.when(Log::getLogfile).thenReturn(Paths.get("logs/mock.log").toFile());
 
-    @Test
-    public void throwsExceptionWhenRoutingAppenderNotFound() {
-        LoggerContext mockCtx = mock(LoggerContext.class);
-        Configuration mockConfig = mock(Configuration.class);
-
-        when(mockCtx.getConfiguration()).thenReturn(mockConfig);
-        when(mockConfig.getAppender("Harvester")).thenReturn(null);
-
-        try (MockedStatic<LogManager> logManagerMock = mockStatic(LogManager.class);
-             MockedStatic<Log> logMock = mockStatic(Log.class)) {
-
-            logManagerMock.when(() -> LogManager.getContext(false)).thenReturn(mockCtx);
-            logMock.when(Log::getLogfile).thenReturn(Paths.get("/mock/log/dir/mock.log").toFile());
-
-            assertThrows(IllegalStateException.class, LogUtil::getHarvesterLogfilePath);
-        }
-    }
-
-    @Test
-    public void throwsExceptionWhenFileNodeNotFound() {
-        LoggerContext mockCtx = mock(LoggerContext.class);
-        Configuration mockConfig = mock(Configuration.class);
-        RoutingAppender mockRoutingAppender = mock(RoutingAppender.class);
-
-        when(mockCtx.getConfiguration()).thenReturn(mockConfig);
-        when(mockConfig.getAppender("Harvester")).thenReturn(mockRoutingAppender);
-        when(mockRoutingAppender.getRoutes().getRoutes()[0].getNode().getChildren())
-            .thenReturn(Collections.emptyList());
-
-        try (MockedStatic<LogManager> logManagerMock = mockStatic(LogManager.class);
-             MockedStatic<Log> logMock = mockStatic(Log.class)) {
-
-            logManagerMock.when(() -> LogManager.getContext(false)).thenReturn(mockCtx);
-            logMock.when(Log::getLogfile).thenReturn(Paths.get("/mock/log/dir/mock.log").toFile());
-
-            assertThrows(IllegalStateException.class, LogUtil::getHarvesterLogfilePath);
+            assertEquals("harvester_geonetwork40_TestHarvester_20251030083002.log", LogUtil.getHarvesterLogfilePath());
         }
     }
 }

--- a/core/src/test/java/org/fao/geonet/util/LogUtilTest.java
+++ b/core/src/test/java/org/fao/geonet/util/LogUtilTest.java
@@ -1,0 +1,65 @@
+package org.fao.geonet.util;
+
+import org.apache.logging.log4j.LogManager;
+import org.apache.logging.log4j.ThreadContext;
+import org.apache.logging.log4j.core.LoggerContext;
+import org.apache.logging.log4j.core.appender.routing.RoutingAppender;
+import org.apache.logging.log4j.core.config.Configuration;
+import org.fao.geonet.utils.Log;
+import org.junit.Test;
+import org.mockito.MockedStatic;
+
+import java.nio.file.Paths;
+import java.util.Collections;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+import static org.mockito.Mockito.*;
+
+public class LogUtilTest {
+
+    @Test
+    public void retrievesHarvesterLogfilePath() {
+        ThreadContext.put("logfile", "harvester_geonetwork40_TestHarvester_20251030083002.log");
+        assertEquals("harvester_geonetwork40_TestHarvester_20251030083002.log", LogUtil.getHarvesterLogfilePath());
+    }
+
+    @Test
+    public void throwsExceptionWhenRoutingAppenderNotFound() {
+        LoggerContext mockCtx = mock(LoggerContext.class);
+        Configuration mockConfig = mock(Configuration.class);
+
+        when(mockCtx.getConfiguration()).thenReturn(mockConfig);
+        when(mockConfig.getAppender("Harvester")).thenReturn(null);
+
+        try (MockedStatic<LogManager> logManagerMock = mockStatic(LogManager.class);
+             MockedStatic<Log> logMock = mockStatic(Log.class)) {
+
+            logManagerMock.when(() -> LogManager.getContext(false)).thenReturn(mockCtx);
+            logMock.when(Log::getLogfile).thenReturn(Paths.get("/mock/log/dir/mock.log").toFile());
+
+            assertThrows(IllegalStateException.class, LogUtil::getHarvesterLogfilePath);
+        }
+    }
+
+    @Test
+    public void throwsExceptionWhenFileNodeNotFound() {
+        LoggerContext mockCtx = mock(LoggerContext.class);
+        Configuration mockConfig = mock(Configuration.class);
+        RoutingAppender mockRoutingAppender = mock(RoutingAppender.class);
+
+        when(mockCtx.getConfiguration()).thenReturn(mockConfig);
+        when(mockConfig.getAppender("Harvester")).thenReturn(mockRoutingAppender);
+        when(mockRoutingAppender.getRoutes().getRoutes()[0].getNode().getChildren())
+            .thenReturn(Collections.emptyList());
+
+        try (MockedStatic<LogManager> logManagerMock = mockStatic(LogManager.class);
+             MockedStatic<Log> logMock = mockStatic(Log.class)) {
+
+            logManagerMock.when(() -> LogManager.getContext(false)).thenReturn(mockCtx);
+            logMock.when(Log::getLogfile).thenReturn(Paths.get("/mock/log/dir/mock.log").toFile());
+
+            assertThrows(IllegalStateException.class, LogUtil::getHarvesterLogfilePath);
+        }
+    }
+}

--- a/domain/src/test/resources/log4j2.xml
+++ b/domain/src/test/resources/log4j2.xml
@@ -1,9 +1,24 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Configuration status="warn" dest="out">
+    <Properties>
+      <Property name="logs_dir">logs</Property>
+    </Properties>
     <Appenders>
         <Console name="Console" target="SYSTEM_OUT">
             <PatternLayout pattern="%date{HH:mm:ss.SSS} %-6level [%logger{2}] - %msg%n"/>
         </Console>
+        <Routing name="Harvester">
+          <Routes pattern="$${ctx:logfile}">
+            <!-- value dynamically determines the name of the log file. -->
+            <Route>
+              <File name="harvester-${ctx:harvester}" fileName="${sys:log_dir:-${logs_dir}}/${ctx:logfile:-harvester_default.log}">
+                <PatternLayout>
+                  <pattern>%date{ISO8601}{${ctx:timeZone}} %-5level [%logger] - %message%n</pattern>
+                </PatternLayout>
+              </File>
+            </Route>
+          </Routes>
+        </Routing>
     </Appenders>
     <Loggers>
         <Logger name="org.springframework.aop.framework.CglibAopProxy" level="error"/>


### PR DESCRIPTION
Currently the harvest logs are assumed to be in the top level log directory. This causes issues if the `log4j2.xml` files are customized to put the harvester logs in a subdirectory.

For example the following will put the logs in a `harvester` subdirectory:

```XML
<Routing name="Harvester">
  <Routes pattern="$${ctx:logfile}">
    <!-- value dynamically determines the name of the log file. -->
    <Route>
      <File name="harvester-${ctx:harvester}" fileName="${sys:log_dir:-${logs_dir}}/harvester/${ctx:logfile:-harvester_default.log}">
        <PatternLayout>
          <pattern>%date{ISO8601}{${ctx:timeZone}} %-5level [%logger] - %message%n</pattern>
        </PatternLayout>
      </File>
    </Route>
  </Routes>
</Routing>
```

But the code only appends the filename to the top level log directory.

This PR aims to fix this issue by computing the actual path to the file using the log4j config.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation