### PR TITLE
Fetch formatters only when md has loaded

### DIFF
--- a/web-ui/src/main/resources/catalog/views/default/directives/directive.js
+++ b/web-ui/src/main/resources/catalog/views/default/directives/directive.js
@@ -142,17 +142,6 @@
           scope.md = scope.$eval(attrs.gnMdActionsMenu);
           scope.formatterList = [];
 
-          gnMdFormatter
-            .getAvailableFormattersForRecord(scope.md)
-            .then(function (availableFormatters) {
-              var formatterList = gnGlobalSettings.gnCfg.mods.search.downloadFormatter;
-
-              scope.formatterList = gnMdFormatter.calculateValidFormattersForRecord(
-                formatterList,
-                availableFormatters
-              );
-            });
-
           scope.tasks = [];
           scope.hasVisibletasks = false;
 
@@ -407,6 +396,18 @@
                   scope.ownerGroupName = name;
                 });
               }
+
+              gnMdFormatter
+                .getAvailableFormattersForRecord(scope.md)
+                .then(function (availableFormatters) {
+                  var formatterList =
+                    gnGlobalSettings.gnCfg.mods.search.downloadFormatter;
+
+                  scope.formatterList = gnMdFormatter.calculateValidFormattersForRecord(
+                    formatterList,
+                    availableFormatters
+                  );
+                });
             }
           });
 


### PR DESCRIPTION
After merging 4.4.9 we noticed an issue in our download dropdown where all download urls are missing. This can be "fixed" by adding the `debug` flag in the url, which lead me to believe this is some asynchronous behaviour. After debugging, `md` is not initialised at the moment of loading the available formatters, when the issue occurs. I have moved the function call to the $watch function, ensuring md is present when needed. 

Is this the right approach? Or should the directive only load when `md` is present, deprecating the need to null check the variable?

**Before**
<img width="203" height="108" alt="image" src="https://github.com/user-attachments/assets/55f85181-8df3-4c61-a273-a367473afbd0" />

**After**
<img width="203" height="210" alt="image" src="https://github.com/user-attachments/assets/3a75a82c-3b61-4b3e-a4d4-5570613e222c" />


# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

