### PR TITLE
Update migration script to remove the duplicate insert

### DIFF
--- a/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v4410/migrate-default.sql
+++ b/web/src/main/webapp/WEB-INF/classes/setup/sql/migrate/v4410/migrate-default.sql
@@ -4,12 +4,8 @@ INSERT INTO Settings (name, value, datatype, position, internal) SELECT distinct
 
 INSERT INTO Settings (name, value, datatype, position, internal) SELECT distinct 'system/metadata/edit/supportedFileMimetypes', 'image/png|image/gif|image/jpeg|text/plain|application/xml|application/pdf', 0, 9107, 'n' from settings WHERE NOT EXISTS (SELECT name FROM Settings WHERE name = 'system/metadata/edit/supportedFileMimetypes');
 
-UPDATE Settings SET value='4.4.10' WHERE name='system/platform/version';
-UPDATE Settings SET value='SNAPSHOT' WHERE name='system/platform/subVersion';
-
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/metadatacreate/publishForGroupEditors', 'false', 2, 9101, 'n');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/metadatacreate/copyAttachments', 'true', 2, 9102, 'n');
-INSERT INTO Settings (name, value, datatype, position, internal) VALUES ('system/metadatacreate/skipMetadataCreationPage', 'false', 2, 9103, 'n');
-
 UPDATE groups SET type='RecordPrivilege' WHERE id<2 AND type IS NULL;
 UPDATE groups SET type='Workspace' WHERE id>=2 AND type IS NULL;
+
+UPDATE Settings SET value='4.4.10' WHERE name='system/platform/version';
+UPDATE Settings SET value='SNAPSHOT' WHERE name='system/platform/subVersion';


### PR DESCRIPTION
#9079 and #8741 had conflicting changes causing duplicate insert statements.

Additionally the `UPDATE groups` statements should be before the `UPDATE Settings`

This PR aims to fix these issues by removing the duplicate statement and by moving up the `UPDATE groups` statements.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
