### PR TITLE
Configuration options discovered from source (documentation change suggestions)

### DIFF
--- a/docs/manual/docs/install-guide/configuring-database.md
+++ b/docs/manual/docs/install-guide/configuring-database.md
@@ -18,7 +18,7 @@ By default, a [H2](https://www.h2database.com/html/main.html) database is config
 
 ## Configuring a database via config files
 
-The database dialect is configured in **`/WEB-INF/config-node/srv.xml`**. Uncomment the dialect to use.
+The database dialect is configured in **`/WEB-INF/config-node/srv.xml`**. Uncomment the dialect to use or use Java System property to configure it with `-Dgeonetwork.db.type=postgres` as described in https://github.com/geonetwork/core-geonetwork/blob/4.2.13/web/src/main/webResources/WEB-INF/config-node/srv.xml#L36.
 
 A jdbc driver is included for PostgreSQL, Oracle and H2. Other dialects require a jdbc driver to be installed. Download the jdbc library for the dialect and place it in `/WEB-INF/lib` or in the tomcat or GeoNetwork lib folder.
 
@@ -73,6 +73,18 @@ Setting configuration properties via environment variables is common in containe
     ```
 
 Within PostgreSQL it is possible to configure `postgres` or `postgis`. In the latter case GeoNetwork will use spatial capabilities of PostGIS to filter metadata. In the first case (and for other database dialects) a Shapefile is created for storage of metadata coverage.
+
+Alternative environment variables are also supported for non-container (WAR-file) environments:
+
+  ``` text
+    GEONETWORK_DB_USERNAME=example
+    GEONETWORK_DB_PASSWORD=xx
+    GEONETWORK_DB_NAME=example
+    GEONETWORK_DB_HOST=localhost
+    GEONETWORK_DB_PORT=5432
+  ```
+
+Based on compile-time default settings: https://github.com/geonetwork/core-geonetwork/blob/4.2.13/pom.xml#L1515-L1520 that are used to set these https://github.com/geonetwork/core-geonetwork/blob/4.2.13/web/src/main/webResources/WEB-INF/config-db/jdbc.properties#L24-L28.
 
 ## Logging
 

--- a/docs/manual/docs/install-guide/configuring-database.md
+++ b/docs/manual/docs/install-guide/configuring-database.md
@@ -18,7 +18,7 @@ By default, a [H2](https://www.h2database.com/html/main.html) database is config
 
 ## Configuring a database via config files
 
-The database dialect is configured in **`/WEB-INF/config-node/srv.xml`**. Uncomment the dialect to use or use Java System property to configure it with `-Dgeonetwork.db.type=postgres` as described in https://github.com/geonetwork/core-geonetwork/blob/4.2.13/web/src/main/webResources/WEB-INF/config-node/srv.xml#L36.
+The database dialect is configured in **`/WEB-INF/config-node/srv.xml`**. Uncomment the dialect to use or use Java System property to configure it with `-Dgeonetwork.db.type=postgres` as described in https://github.com/geonetwork/core-geonetwork/blob/e8cee088ca714789788d9de0cb8f143d09a8e9ba/web/src/main/webResources/WEB-INF/config-node/srv.xml#L36.
 
 A jdbc driver is included for PostgreSQL, Oracle and H2. Other dialects require a jdbc driver to be installed. Download the jdbc library for the dialect and place it in `/WEB-INF/lib` or in the tomcat or GeoNetwork lib folder.
 

--- a/docs/manual/docs/install-guide/configuring-database.md
+++ b/docs/manual/docs/install-guide/configuring-database.md
@@ -84,7 +84,7 @@ Alternative environment variables are also supported for non-container (WAR-file
     GEONETWORK_DB_PORT=5432
   ```
 
-Based on compile-time default settings: https://github.com/geonetwork/core-geonetwork/blob/4.2.13/pom.xml#L1515-L1520 that are used to set these https://github.com/geonetwork/core-geonetwork/blob/4.2.13/web/src/main/webResources/WEB-INF/config-db/jdbc.properties#L24-L28.
+Based on compile-time default settings: https://github.com/geonetwork/core-geonetwork/blob/e8cee088ca714789788d9de0cb8f143d09a8e9ba/pom.xml#L1556-L1562 that are used to set these https://github.com/geonetwork/core-geonetwork/blob/e8cee088ca714789788d9de0cb8f143d09a8e9ba/web/src/main/webResources/WEB-INF/config-db/jdbc.properties#L24-L28
 
 ## Logging
 

--- a/docs/manual/docs/install-guide/configuring-database.md
+++ b/docs/manual/docs/install-guide/configuring-database.md
@@ -82,6 +82,7 @@ Alternative environment variables are also supported for non-container (WAR-file
     GEONETWORK_DB_NAME=example
     GEONETWORK_DB_HOST=localhost
     GEONETWORK_DB_PORT=5432
+    GEONETWORK_DB_TYPE=postgres
   ```
 
 Based on compile-time default settings: https://github.com/geonetwork/core-geonetwork/blob/e8cee088ca714789788d9de0cb8f143d09a8e9ba/pom.xml#L1556-L1562 that are used to set these https://github.com/geonetwork/core-geonetwork/blob/e8cee088ca714789788d9de0cb8f143d09a8e9ba/web/src/main/webResources/WEB-INF/config-db/jdbc.properties#L24-L28

--- a/docs/manual/docs/install-guide/installing-index.md
+++ b/docs/manual/docs/install-guide/installing-index.md
@@ -89,13 +89,13 @@ Older version may be supported but are untested.
     
     ``` shell
     cd $GN_DATA_DIRECTORY/config/index
-    curl -X DELETE http://localhost:9200/features
-    curl -X DELETE http://localhost:9200/records
-    curl -X DELETE http://localhost:9200/searchlogs
+    curl -X DELETE http://localhost:9200/gn-features
+    curl -X DELETE http://localhost:9200/gn-records
+    curl -X DELETE http://localhost:9200/gn-searchlogs
     
-    curl -X PUT http://localhost:9200/features -H 'Content-Type: application/json' -d @features.json
-    curl -X PUT http://localhost:9200/records -H 'Content-Type: application/json' -d @records.json
-    curl -X PUT http://localhost:9200/searchlogs -H 'Content-Type: application/json' -d @searchlogs.json
+    curl -X PUT http://localhost:9200/gn-features -H 'Content-Type: application/json' -d @features.json
+    curl -X PUT http://localhost:9200/gn-records -H 'Content-Type: application/json' -d @records.json
+    curl -X PUT http://localhost:9200/gn-searchlogs -H 'Content-Type: application/json' -d @searchlogs.json
     ```
 
 ## Check Elasticsearch installation


### PR DESCRIPTION
Apparently documentation has moved to the main repository so I'm suggesting the changes made in https://github.com/geonetwork/doc/pull/248 to be migrated to this documentation. We've been tinkering with GeoNetwork migration from 3.x to 4.x for some time now and looking at the code I noticed these configuration options as well. Also noticed that the indexes are by default prefixed with `gn-` (https://github.com/geonetwork/core-geonetwork/blob/4.2.13/pom.xml#L1565-L1569).

I'm not sure if you want to have links to source code in the documentation or if the defaults are different in the prepackaged versions of WAR-file or the Containerized setup. These are the ones that are defaulted when building from source. As we are migrating to 4.2.x before continuing to go for 4.4.x things might have changed, but at least raising awareness for someone more experienced with GN to take a look at the docs.

Maybe also take a look at this: https://github.com/geonetwork/doc/pull/249 as it seems the path to `encryptor.properties` on the docs was wrong (in our experience).
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

