### PR TITLE
Index external additional resource properties

### DIFF
--- a/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
@@ -80,15 +80,27 @@ public abstract class AbstractStore implements Store {
     }
 
     @Override
+    public List<MetadataResource> getResources(ServiceContext context, String metadataUuid, MetadataResourceVisibility metadataResourceVisibility, String filter, Boolean approved)
+            throws Exception {
+        return getResources(context, metadataUuid, metadataResourceVisibility, filter, approved, false);
+    }
+
+    @Override
     public List<MetadataResource> getResources(ServiceContext context, String metadataUuid, Sort sort, String filter, Boolean approved)
             throws Exception {
+        return getResources(context, metadataUuid, sort, filter, approved, false);
+    }
+
+    @Override
+    public List<MetadataResource> getResources(ServiceContext context, String metadataUuid, Sort sort, String filter, Boolean approved, boolean includeAdditionalIndexedProperties)
+        throws Exception {
         int metadataId = getAndCheckMetadataId(metadataUuid, approved);
         boolean canEdit = getAccessManager(context).canEdit(context, String.valueOf(metadataId));
 
         List<MetadataResource> resourceList = new ArrayList<>(
-                getResources(context, metadataUuid, MetadataResourceVisibility.PUBLIC, filter, approved));
+            getResources(context, metadataUuid, MetadataResourceVisibility.PUBLIC, filter, approved, includeAdditionalIndexedProperties));
         if (canEdit) {
-            resourceList.addAll(getResources(context, metadataUuid, MetadataResourceVisibility.PRIVATE, filter, approved));
+            resourceList.addAll(getResources(context, metadataUuid, MetadataResourceVisibility.PRIVATE, filter, approved, includeAdditionalIndexedProperties));
         }
 
         if (sort == Sort.name) {
@@ -289,7 +301,7 @@ public abstract class AbstractStore implements Store {
 
     @Override
     public void copyResources(ServiceContext context, String sourceUuid, String targetUuid, MetadataResourceVisibility metadataResourceVisibility, boolean sourceApproved, boolean targetApproved) throws Exception {
-        final List<MetadataResource> resources = getResources(context, sourceUuid, metadataResourceVisibility, null, sourceApproved);
+        final List<MetadataResource> resources = getResources(context, sourceUuid, metadataResourceVisibility, null, sourceApproved, false);
         for (MetadataResource resource: resources) {
             try (Store.ResourceHolder holder = getResource(context, sourceUuid, metadataResourceVisibility, resource.getFilename(), sourceApproved)) {
                 putResource(context, targetUuid, holder.getResource(), metadataResourceVisibility, targetApproved);

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/FilesystemStore.java
@@ -80,7 +80,7 @@ public class FilesystemStore extends AbstractStore {
 
     @Override
     public List<MetadataResource> getResources(ServiceContext context, String metadataUuid, MetadataResourceVisibility visibility,
-                                               String filter, Boolean approved) throws Exception {
+                                               String filter, Boolean approved, boolean includeAdditionalIndexedProperties) throws Exception {
         int metadataId = canDownload(context, metadataUuid, visibility, approved);
 
         Path metadataDir = Lib.resource.getMetadataDir(getDataDirectory(context), metadataId);

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/ResourceLoggerStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/ResourceLoggerStore.java
@@ -75,6 +75,16 @@ public class ResourceLoggerStore extends AbstractStore {
     }
 
     @Override
+    public List<MetadataResource> getResources(ServiceContext context, String metadataUuid,
+                                               MetadataResourceVisibility metadataResourceVisibility, String filter, Boolean approved, boolean includeAdditionalIndexedProperties)
+        throws Exception {
+        if (decoratedStore != null) {
+            return decoratedStore.getResources(context, metadataUuid, metadataResourceVisibility, filter, approved, includeAdditionalIndexedProperties);
+        }
+        return null;
+    }
+
+    @Override
     public ResourceHolder getResource(final ServiceContext context, final String metadataUuid, final MetadataResourceVisibility visibility,
                                       final String resourceId, Boolean approved) throws Exception {
         if (decoratedStore != null) {

--- a/core/src/main/java/org/fao/geonet/api/records/attachments/Store.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/Store.java
@@ -102,6 +102,57 @@ public interface Store {
     List<MetadataResource> getResources(ServiceContext context, String metadataUuid, MetadataResourceVisibility metadataResourceVisibility, String filter, Boolean approved) throws Exception;
 
     /**
+     * Retrieve all resources for a metadata. The list of resources depends on current user
+     * privileges.
+     *
+     * <p>This overload allows callers to control whether additional indexed properties
+     * are populated on each returned {@link MetadataResource}. Callers should set
+     * {@code includeAdditionalIndexedProperties} to {@code true} only when they actually
+     * need those extra indexed values (for example, when preparing data for search or
+     * indexing purposes). For simple listing or download operations where these extra
+     * properties are not required, it is recommended to set this flag to {@code false}.</p>
+     *
+     * @param context      the service context
+     * @param metadataUuid the metadata UUID
+     * @param sort         sort by resource name or sharing policy {@link Sort}
+     * @param filter       a {@link java.nio.file.Files#newDirectoryStream(Path) GLOB
+     *                     expression} to filter resources eg. *.{png|jpg}
+     * @param approved     return the approved version or not
+     * @param includeAdditionalIndexedProperties whether to populate additional indexed
+     *                     properties on returned resources ({@code true}) or to skip them
+     *                     for better performance when they are not needed ({@code false})
+     * @return A list of resources
+     * @throws Exception if an error occurs while retrieving the resources
+     */
+    List<MetadataResource> getResources(ServiceContext context, String metadataUuid, Sort sort, String filter, Boolean approved, boolean includeAdditionalIndexedProperties) throws Exception;
+
+    /**
+     * Retrieve all resources for a metadata having a specific sharing policy.
+     *
+     * <p>This overload allows callers to control whether additional indexed properties
+     * are populated on each returned {@link MetadataResource}. Callers should set
+     * {@code includeAdditionalIndexedProperties} to {@code true} only when they actually
+     * need those extra indexed values (for example, when preparing data for search or
+     * indexing purposes). For simple listing or download operations where these extra
+     * properties are not required, it is recommended to set this flag to {@code false}.</p>
+     *
+     * @param context                     the service context
+     * @param metadataUuid                the metadata UUID
+     * @param metadataResourceVisibility  the type of sharing policy
+     *                                    {@link MetadataResourceVisibility}
+     * @param filter                      a {@link java.nio.file.Files#newDirectoryStream(Path) GLOB
+     *                                    expression} to filter resources eg. *.{png|jpg}
+     * @param approved                    return the approved version or not
+     * @param includeAdditionalIndexedProperties whether to populate additional indexed
+     *                                    properties on returned resources ({@code true})
+     *                                    or to skip them for better performance when they
+     *                                    are not needed ({@code false})
+     * @return A list of resources
+     * @throws Exception if an error occurs while retrieving the resources
+     */
+    List<MetadataResource> getResources(ServiceContext context, String metadataUuid, MetadataResourceVisibility metadataResourceVisibility, String filter, Boolean approved, boolean includeAdditionalIndexedProperties) throws Exception;
+
+    /**
      * Retrieve a resource.
      *
      *

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataIndexer.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataIndexer.java
@@ -705,7 +705,8 @@ public class BaseMetadataIndexer implements IMetadataIndexer, ApplicationEventPu
                 fullMd.getUuid(),
                 (org.fao.geonet.api.records.attachments.Sort) null,
                 null,
-                !(fullMd instanceof MetadataDraft));
+                !(fullMd instanceof MetadataDraft),
+                true);
 
             if (metadataResources != null && !metadataResources.isEmpty()) {
                 JsonNode jsonNode = indexObjectMapper.valueToTree(metadataResources);

--- a/datastorages/cmis/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
+++ b/datastorages/cmis/src/main/java/org/fao/geonet/api/records/attachments/CMISStore.java
@@ -81,7 +81,7 @@ public class CMISStore extends AbstractStore {
 
     @Override
     public List<MetadataResource> getResources(final ServiceContext context, final String metadataUuid,
-                                               final MetadataResourceVisibility visibility, String filter, Boolean approved) throws Exception {
+                                               final MetadataResourceVisibility visibility, String filter, Boolean approved, boolean includeAdditionalIndexedProperties) throws Exception {
         final int metadataId = canDownload(context, metadataUuid, visibility, approved);
 
         final String resourceTypeDir = getMetadataDir(context, metadataId) + cmisConfiguration.getFolderDelimiter() + visibility.toString();

--- a/datastorages/jcloud/src/main/java/org/fao/geonet/api/records/attachments/JCloudStore.java
+++ b/datastorages/jcloud/src/main/java/org/fao/geonet/api/records/attachments/JCloudStore.java
@@ -193,21 +193,21 @@ public class JCloudStore extends AbstractStore {
 
         MetadataResourceExternalManagementProperties metadataResourceExternalManagementProperties;
         if (includeAdditionalIndexedProperties) {
-            Map<String, Object> additionalProperties = new HashMap<>();
-            if (jCloudConfiguration.getAdditionalProperties() != null && !jCloudConfiguration.getAdditionalProperties().isEmpty()) {
-                for (String propertyName : jCloudConfiguration.getAdditionalProperties()) {
+            Map<String, Object> additionalIndexedProperties = new HashMap<>();
+            if (jCloudConfiguration.getAdditionalIndexedProperties() != null && !jCloudConfiguration.getAdditionalIndexedProperties().isEmpty()) {
+                for (String propertyName : jCloudConfiguration.getAdditionalIndexedProperties()) {
                     String propertyValue = null;
                     if (storageMetadata.getUserMetadata().containsKey(propertyName)) {
                         propertyValue = storageMetadata.getUserMetadata().get(propertyName);
                     }
                     if (StringUtils.hasLength(propertyValue)) {
-                        additionalProperties.put(propertyName, propertyValue);
+                        additionalIndexedProperties.put(propertyName, propertyValue);
                     }
                 }
             }
             metadataResourceExternalManagementProperties =
                 getIndexedMetadataResourceExternalManagementProperties(context, metadataId, metadataUuid, visibility, resourceId, filename, storageMetadata.getETag(), storageMetadata.getType(),
-                    validationStatus, additionalProperties);
+                    validationStatus, additionalIndexedProperties);
         } else {
             metadataResourceExternalManagementProperties =
                 getMetadataResourceExternalManagementProperties(context, metadataId, metadataUuid, visibility, resourceId, filename, storageMetadata.getETag(), storageMetadata.getType(),

--- a/datastorages/jcloud/src/main/java/org/fao/geonet/resources/JCloudConfiguration.java
+++ b/datastorages/jcloud/src/main/java/org/fao/geonet/resources/JCloudConfiguration.java
@@ -31,6 +31,7 @@ import org.springframework.util.StringUtils;
 
 import javax.annotation.Nonnull;
 import javax.annotation.PostConstruct;
+import java.util.List;
 
 public class JCloudConfiguration {
 
@@ -54,6 +55,11 @@ public class JCloudConfiguration {
      * Property name for storing the metadata uuid that is expected to be a String
      */
     private String metadataUUIDPropertyName;
+    /**
+     * List of field names that are copied from the storage metadata into the geonetwork index.
+     * Can be set as a comma-separated string which will be automatically parsed into a List.
+     */
+    private List<String> additionalProperties;
     /**
      * Url used for managing enhanced resource properties related to the metadata.
      */
@@ -286,6 +292,32 @@ public class JCloudConfiguration {
 
     public void setMetadataUUIDPropertyName(String metadataUUIDPropertyName) {
         this.metadataUUIDPropertyName = metadataUUIDPropertyName;
+    }
+
+    /**
+     * Gets the additional properties as a list of field names.
+     *
+     * @return List of field names
+     */
+    public List<String> getAdditionalProperties() {
+        return this.additionalProperties;
+    }
+
+    /**
+     * Sets the additional properties from a comma-separated string.
+     * Empty values are filtered out.
+     *
+     * @param additionalProperties Comma-separated list of field names
+     */
+    public void setAdditionalProperties(String additionalProperties) {
+        if (StringUtils.hasLength(additionalProperties)) {
+            this.additionalProperties = java.util.Arrays.stream(additionalProperties.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .collect(java.util.stream.Collectors.toList());
+        } else {
+            this.additionalProperties = null;
+        }
     }
 
     public String getExternalResourceManagementChangedDatePropertyName() {

--- a/datastorages/jcloud/src/main/java/org/fao/geonet/resources/JCloudConfiguration.java
+++ b/datastorages/jcloud/src/main/java/org/fao/geonet/resources/JCloudConfiguration.java
@@ -59,7 +59,7 @@ public class JCloudConfiguration {
      * List of field names that are copied from the storage metadata into the geonetwork index.
      * Can be set as a comma-separated string which will be automatically parsed into a List.
      */
-    private List<String> additionalProperties;
+    private List<String> additionalIndexedProperties;
     /**
      * Url used for managing enhanced resource properties related to the metadata.
      */
@@ -295,28 +295,28 @@ public class JCloudConfiguration {
     }
 
     /**
-     * Gets the additional properties as a list of field names.
+     * Gets the additional indexed properties as a list of field names.
      *
      * @return List of field names
      */
-    public List<String> getAdditionalProperties() {
-        return this.additionalProperties;
+    public List<String> getAdditionalIndexedProperties() {
+        return this.additionalIndexedProperties;
     }
 
     /**
-     * Sets the additional properties from a comma-separated string.
+     * Sets the additional indexed properties from a comma-separated string.
      * Empty values are filtered out.
      *
-     * @param additionalProperties Comma-separated list of field names
+     * @param additionalIndexedProperties Comma-separated list of field names
      */
-    public void setAdditionalProperties(String additionalProperties) {
-        if (StringUtils.hasLength(additionalProperties)) {
-            this.additionalProperties = java.util.Arrays.stream(additionalProperties.split(","))
+    public void setAdditionalIndexedProperties(String additionalIndexedProperties) {
+        if (StringUtils.hasLength(additionalIndexedProperties)) {
+            this.additionalIndexedProperties = java.util.Arrays.stream(additionalIndexedProperties.split(","))
                 .map(String::trim)
                 .filter(s -> !s.isEmpty())
                 .collect(java.util.stream.Collectors.toList());
         } else {
-            this.additionalProperties = null;
+            this.additionalIndexedProperties = null;
         }
     }
 

--- a/datastorages/jcloud/src/main/resources/config-store/config-jcloud-overrides.properties
+++ b/datastorages/jcloud/src/main/resources/config-store/config-jcloud-overrides.properties
@@ -25,4 +25,4 @@ jcloud.external.resource.management.version.property.name=${JCLOUD_EXTERNAL_RESO
 jcloud.metadata.uuid.property.name=${JCLOUD_METADATA_UUID_PROPERTY_NAME:#{null}}
 
 # Comma-separated list of field names to copy from storage metadata into the geonetwork index
-jcloud.additional.properties=${JCLOUD_ADDITIONAL_PROPERTIES:#{null}}
+jcloud.additional.indexed.properties=${JCLOUD_ADDITIONAL_INDEXED_PROPERTIES:#{null}}

--- a/datastorages/jcloud/src/main/resources/config-store/config-jcloud-overrides.properties
+++ b/datastorages/jcloud/src/main/resources/config-store/config-jcloud-overrides.properties
@@ -23,3 +23,6 @@ jcloud.versioning.strategy=${JCLOUD_VERSIONING_STRATEGY:#{null}}
 jcloud.external.resource.management.version.property.name=${JCLOUD_EXTERNAL_RESOURCE_MANAGEMENT_VERSION_PROPERTY_NAME:#{null}}
 
 jcloud.metadata.uuid.property.name=${JCLOUD_METADATA_UUID_PROPERTY_NAME:#{null}}
+
+# Comma-separated list of field names to copy from storage metadata into the geonetwork index
+jcloud.additional.properties=${JCLOUD_ADDITIONAL_PROPERTIES:#{null}}

--- a/datastorages/jcloud/src/main/resources/config-store/config-jcloud.xml
+++ b/datastorages/jcloud/src/main/resources/config-store/config-jcloud.xml
@@ -61,6 +61,9 @@
         <property name="externalResourceManagementVersionPropertyName" value="${jcloud.external.resource.management.version.property.name}"/>
 
         <property name="metadataUUIDPropertyName" value="${jcloud.metadata.uuid.property.name}"/>
+
+        <!-- List of field names to be copied from storage metadata into the geonetwork index (comma-separated) -->
+        <property name="additionalProperties" value="${jcloud.additional.properties}"/>
     </bean>
     <bean id="filesystemStore" class="org.fao.geonet.api.records.attachments.JCloudStore" />
     <bean id="resourceStore"

--- a/datastorages/jcloud/src/main/resources/config-store/config-jcloud.xml
+++ b/datastorages/jcloud/src/main/resources/config-store/config-jcloud.xml
@@ -63,7 +63,7 @@
         <property name="metadataUUIDPropertyName" value="${jcloud.metadata.uuid.property.name}"/>
 
         <!-- List of field names to be copied from storage metadata into the geonetwork index (comma-separated) -->
-        <property name="additionalProperties" value="${jcloud.additional.properties}"/>
+        <property name="additionalIndexedProperties" value="${jcloud.additional.indexed.properties}"/>
     </bean>
     <bean id="filesystemStore" class="org.fao.geonet.api.records.attachments.JCloudStore" />
     <bean id="resourceStore"

--- a/datastorages/s3/src/main/java/org/fao/geonet/api/records/attachments/S3Store.java
+++ b/datastorages/s3/src/main/java/org/fao/geonet/api/records/attachments/S3Store.java
@@ -58,7 +58,7 @@ public class S3Store extends AbstractStore {
 
     @Override
     public List<MetadataResource> getResources(final ServiceContext context, final String metadataUuid,
-            final MetadataResourceVisibility visibility, String filter, Boolean approved) throws Exception {
+            final MetadataResourceVisibility visibility, String filter, Boolean approved, boolean includeAdditionalIndexedProperties) throws Exception {
         final int metadataId = canEdit(context, metadataUuid, approved);
 
         final String resourceTypeDir = getMetadataDir(metadataId) + "/" + visibility.toString();

--- a/docs/manual/docs/customizing-application/index.md
+++ b/docs/manual/docs/customizing-application/index.md
@@ -11,5 +11,6 @@
 -   [Advanced configuration](advanced-configuration.md)
 -   [Adding static pages](adding-static-pages.md)
 -   [Implementing schema plugins](implementing-a-schema-plugin.md)
+-   [Integrating External Resource Properties](integrating-external-resource-properties.md)
 -   [Characterset](characterset.md)
 -   [Miscellaneous](misc.md)

--- a/docs/manual/docs/customizing-application/integrating-external-resource-properties.md
+++ b/docs/manual/docs/customizing-application/integrating-external-resource-properties.md
@@ -1,0 +1,80 @@
+# Integrating External Resource Properties
+
+Add custom metadata properties to resources stored in JCloud-based storage. These properties are stored as metadata in the cloud storage and are automatically indexed into GeoNetwork's catalog.
+
+## Quick Start
+
+### 1. Configure GeoNetwork
+
+Add this property or environment variable to your GeoNetwork configuration to specify which metadata fields from cloud storage should be included in the catalog index:
+
+```properties
+jcloud.additional.properties=field1,field2,field3
+```
+
+```bash
+export JCLOUD_ADDITIONAL_PROPERTIES=field1,field2,field3
+```
+
+**Property Explanation:**
+
+- **`jcloud.additional.properties`** - Comma-separated list of metadata field names to copy from cloud storage into the catalog index
+  - Each field name must correspond to a metadata property that you store with your resources in cloud storage
+  - Example: `jcloud.additional.properties=department,owner,budget,status`
+  - Environment variable: `JCLOUD_ADDITIONAL_PROPERTIES`
+  - Properties are optional - if not configured, only standard resource metadata is indexed
+
+### 2. Store Metadata with Your Resources
+
+When uploading resources to cloud storage, attach metadata properties with the names you specified in the configuration:
+
+**Example using blob metadata:**
+```
+Blob Name: documents/report.pdf
+
+Metadata Properties:
+  - department: "Planning"
+  - owner: "John Doe"
+  - budget: "$50,000"
+  - status: "Active"
+```
+
+**Metadata Requirements:**
+- Property names must match exactly those configured in `jcloud.additional.properties`
+- Property values should be simple types (strings, numbers, booleans)
+- Properties are optional - resources without configured properties will simply not include those fields
+
+### 3. Verify in Catalog
+
+After indexing, resources will contain the custom properties in the `additionalProperties` field of the `metadataResourceExternalManagementProperties` object:
+
+```json
+{
+  "lastModification": "2025-10-28T15:43:03.000+00:00",
+  "metadataResourceExternalManagementProperties": {
+    "id": "resource-001",
+    "url": "http://example.com/resource/resource-001",
+    "validationStatus": "INCOMPLETE",
+    "additionalProperties": {
+      "department": "Planning",
+      "owner": "John Doe",
+      "budget": "$50,000",
+      "status": "Active"
+    }
+  },
+  "size": 112339,
+  "url": "http://localhost:8084/catalogue/srv/api/records/37aecae5-7783-4274-b595-df02aa003ac3/attachments/Sample1.pdf",
+  "version": "1",
+  "visibility": "PUBLIC"
+}
+```
+
+## How It Works
+
+1. When resources are retrieved for indexing, GeoNetwork reads the metadata properties stored with each blob in cloud storage
+2. For any properties that match the configured `jcloud.additional.properties` names, the values are extracted
+3. These properties are stored in the `additionalProperties` map within the `MetadataResourceExternalManagementProperties` object
+4. The enriched resource data is indexed and becomes searchable in the catalog
+
+**Properties are extracted automatically during metadata indexing** - no additional setup required once configured and metadata is stored with your resources.
+

--- a/docs/manual/docs/customizing-application/integrating-external-resource-properties.md
+++ b/docs/manual/docs/customizing-application/integrating-external-resource-properties.md
@@ -9,19 +9,19 @@ Add custom metadata properties to resources stored in JCloud-based storage. Thes
 Add this property or environment variable to your GeoNetwork configuration to specify which metadata fields from cloud storage should be included in the catalog index:
 
 ```properties
-jcloud.additional.properties=field1,field2,field3
+jcloud.additional.indexed.properties=field1,field2,field3
 ```
 
 ```bash
-export JCLOUD_ADDITIONAL_PROPERTIES=field1,field2,field3
+export JCLOUD_ADDITIONAL_INDEXED_PROPERTIES=field1,field2,field3
 ```
 
 **Property Explanation:**
 
-- **`jcloud.additional.properties`** - Comma-separated list of metadata field names to copy from cloud storage into the catalog index
+- **`jcloud.additional.indexed.properties`** - Comma-separated list of metadata field names to copy from cloud storage into the catalog index
   - Each field name must correspond to a metadata property that you store with your resources in cloud storage
-  - Example: `jcloud.additional.properties=department,owner,budget,status`
-  - Environment variable: `JCLOUD_ADDITIONAL_PROPERTIES`
+  - Example: `jcloud.additional.indexed.properties=department,owner,budget,status`
+  - Environment variable: `JCLOUD_ADDITIONAL_INDEXED_PROPERTIES`
   - Properties are optional - if not configured, only standard resource metadata is indexed
 
 ### 2. Store Metadata with Your Resources
@@ -40,7 +40,7 @@ Metadata Properties:
 ```
 
 **Metadata Requirements:**
-- Property names must match exactly those configured in `jcloud.additional.properties`
+- Property names must match exactly those configured in `jcloud.additional.indexed.properties`
 - Property values should be simple types (strings, numbers, booleans)
 - Properties are optional - resources without configured properties will simply not include those fields
 
@@ -72,7 +72,7 @@ After indexing, resources will contain the custom properties in the `additionalP
 ## How It Works
 
 1. When resources are retrieved for indexing, GeoNetwork reads the metadata properties stored with each blob in cloud storage
-2. For any properties that match the configured `jcloud.additional.properties` names, the values are extracted
+2. For any properties that match the configured `jcloud.additional.indexed.properties` names, the values are extracted
 3. These properties are stored in the `additionalProperties` map within the `MetadataResourceExternalManagementProperties` object
 4. The enriched resource data is indexed and becomes searchable in the catalog
 

--- a/docs/manual/mkdocs.yml
+++ b/docs/manual/mkdocs.yml
@@ -396,8 +396,9 @@ nav:
       - customizing-application/configuring-faceted-search.md
       - customizing-application/advanced-configuration.md
       - customizing-application/adding-static-pages.md
-      - customizing-application/characterset.md
       - customizing-application/implementing-a-schema-plugin.md
+      - customizing-application/integrating-external-resource-properties.md
+      - customizing-application/characterset.md
       - customizing-application/misc.md
     - 'Contributing':
       - contributing/index.md

--- a/domain/src/main/java/org/fao/geonet/domain/IndexedMetadataResourceExternalManagementProperties.java
+++ b/domain/src/main/java/org/fao/geonet/domain/IndexedMetadataResourceExternalManagementProperties.java
@@ -1,0 +1,72 @@
+/*
+ * =============================================================================
+ * ===	Copyright (C) 2001-2026 Food and Agriculture Organization of the
+ * ===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * ===	and United Nations Environment Programme (UNEP)
+ * ===
+ * ===	This program is free software; you can redistribute it and/or modify
+ * ===	it under the terms of the GNU General Public License as published by
+ * ===	the Free Software Foundation; either version 2 of the License, or (at
+ * ===	your option) any later version.
+ * ===
+ * ===	This program is distributed in the hope that it will be useful, but
+ * ===	WITHOUT ANY WARRANTY; without even the implied warranty of
+ * ===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * ===	General Public License for more details.
+ * ===
+ * ===	You should have received a copy of the GNU General Public License
+ * ===	along with this program; if not, write to the Free Software
+ * ===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ * ===
+ * ===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * ===	Rome - Italy. email: geonetwork@osgeo.org
+ * ==============================================================================
+ */
+
+package org.fao.geonet.domain;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Extends MetadataResourceExternalManagementProperties to add additional properties for indexing purposes.
+ */
+@XmlRootElement(name = "metadataResourceExternalManagementProperties")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class IndexedMetadataResourceExternalManagementProperties extends MetadataResourceExternalManagementProperties {
+    /**
+     * Additional properties for indexing.
+     */
+    private Map<String, Object> additionalProperties = new HashMap<>();
+
+    /**
+     * Constructor for IndexedMetadataResourceExternalManagementProperties.
+     *
+     * @param id                The identifier of the metadata resource.
+     * @param url               The URL of the metadata resource.
+     * @param validationStatus  The validation status of the metadata resource.
+     * @param additionalProperties Additional properties for indexing (can be null).
+     */
+    public IndexedMetadataResourceExternalManagementProperties(@Nonnull String id, @Nonnull String url, @Nonnull ValidationStatus validationStatus, @Nullable Map<String, Object> additionalProperties) {
+        super(id, url, validationStatus);
+        if (additionalProperties != null) {
+            this.additionalProperties = additionalProperties;
+        }
+    }
+
+    /**
+     * Gets the additional properties for indexing.
+     *
+     * @return A map of additional properties.
+     */
+    public Map<String, Object> getAdditionalProperties() {
+        return additionalProperties;
+    }
+}
+
+

--- a/domain/src/main/java/org/fao/geonet/domain/IndexedMetadataResourceExternalManagementProperties.java
+++ b/domain/src/main/java/org/fao/geonet/domain/IndexedMetadataResourceExternalManagementProperties.java
@@ -30,7 +30,6 @@ import javax.annotation.Nullable;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
-import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -41,8 +40,9 @@ import java.util.Map;
 public class IndexedMetadataResourceExternalManagementProperties extends MetadataResourceExternalManagementProperties {
     /**
      * Additional properties for indexing.
+     * Null when there are no additional properties, so it is excluded from serialization.
      */
-    private Map<String, Object> additionalProperties = new HashMap<>();
+    private Map<String, Object> additionalProperties = null;
 
     /**
      * Constructor for IndexedMetadataResourceExternalManagementProperties.
@@ -50,11 +50,11 @@ public class IndexedMetadataResourceExternalManagementProperties extends Metadat
      * @param id                The identifier of the metadata resource.
      * @param url               The URL of the metadata resource.
      * @param validationStatus  The validation status of the metadata resource.
-     * @param additionalProperties Additional properties for indexing (can be null).
+     * @param additionalProperties Additional properties for indexing (can be null or empty).
      */
     public IndexedMetadataResourceExternalManagementProperties(@Nonnull String id, @Nonnull String url, @Nonnull ValidationStatus validationStatus, @Nullable Map<String, Object> additionalProperties) {
         super(id, url, validationStatus);
-        if (additionalProperties != null) {
+        if (additionalProperties != null && !additionalProperties.isEmpty()) {
             this.additionalProperties = additionalProperties;
         }
     }


### PR DESCRIPTION
Resources stored in cloud backends (JCloud, Azure Blob, etc.) often carry valuable metadata (e.g. ownership, department, sensitivity) directly on the storage object.

Currently, GeoNetwork completely ignores these cloud-side resource properties. While they may exist in cloud storage, any application that needs them must make direct calls to the storage backend to retrieve them.

This PR addresses this gap by allowing selected cloud storage properties to be copied into the catalogue index, enabling fast access and search without requiring additional cloud storage calls.

```
export JCLOUD_ADDITIONAL_INDEXED_PROPERTIES=department,owner,sensitivity
```
```
jcloud.additional.indexed.properties=department,owner,sensitivity
```

``` JSON
"filestore": [
  {
    "lastModification": "2025-12-09T18:22:36.000+00:00",
    "metadataResourceExternalManagementProperties": {
      "id": "resource-001",
      "url": "http://localhost:8080/resources/resource-001",
      "validationStatus": "INCOMPLETE",
      "additionalProperties": {
        "department": "Planning",
        "owner": "John Doe",
        "sensitivity": "Unclassified"
      }
    },
    "size": 112339,
    "url": "http://localhost:8084/catalogue/srv/api/records/37aecae5-7783-4274-b595-df02aa003ac3/attachments/Sample1.pdf",
    "version": "1",
    "visibility": "PUBLIC"
  }
]
```
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
