### PR TITLE
Fix element creation via <gn_create/> with XPATH ending on predicate

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/EditLib.java
+++ b/core/src/main/java/org/fao/geonet/kernel/EditLib.java
@@ -1909,7 +1909,17 @@ public class EditLib {
         String DELETE = "gn_delete";
 
         /**
-         * Multiple target updates
+         * Multiple target updates.
+         *
+         * <p>
+         * When using this mode, a gn_delete operation is applied first,
+         * then gn_create is applied for each element.
+         * </p>
+         *
+         * <p>
+         * If a predicate is used, the predicate is applied to the gn_delete operation.
+         * Therefor the gn_create will only create the element targeting the xpath without the predicate.
+         * </p>
          */
         String REPLACE_ALL = "gn_replace_all";
     }

--- a/core/src/test/java/org/fao/geonet/Assert.java
+++ b/core/src/test/java/org/fao/geonet/Assert.java
@@ -68,7 +68,7 @@ public final class Assert extends junit.framework.TestCase {
         } else {
             element = Xml.selectNodes(xml, xpath, Arrays.asList(namespaces));
         }
-        assertEquals("Expected 1 element but found " + element.size() + "No element found at: " + xpath + " in \n" + Xml.getString(xml),
+        assertEquals("Expected 1 element but found " + element.size() + ". No element found at: " + xpath + " in \n" + Xml.getString(xml),
             1, element.size());
         String text;
         if (element.get(0) instanceof Element) {
@@ -77,6 +77,8 @@ public final class Assert extends junit.framework.TestCase {
             text = ((Attribute) element.get(0)).getValue();
         } else if (element.get(0) instanceof Text) {
             text = ((Text) element.get(0)).getTextTrim();
+        }  else if (element.get(0) instanceof String) {
+            text = ((String) element.get(0)).trim();
         } else {
             fail("Handling of " + element.get(0).getClass() + " is not yet implemented");
             text = "";

--- a/core/src/test/java/org/fao/geonet/kernel/EditLibIntegrationTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/EditLibIntegrationTest.java
@@ -31,6 +31,7 @@ import org.fao.geonet.AbstractCoreIntegrationTest;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.Pair;
 import org.fao.geonet.kernel.schema.MetadataSchema;
+import org.fao.geonet.schema.iso19115_3_2018.ISO19115_3_2018Namespaces;
 import org.fao.geonet.utils.Xml;
 import org.jdom.Content;
 import org.jdom.Element;
@@ -806,6 +807,52 @@ public class EditLibIntegrationTest extends AbstractCoreIntegrationTest {
 
         assertTrue(updated);
         assertEqualsText(newValue, metadataElement, xpath, GMD, GCO);
+    }
+
+    /**
+     * This does not affect ISO editor but DCAT is using edits targeting a node with a predicate and expect the node to be replaced.
+     * This test ensures that this works: replace_all mode remove the target node and restore it with the fragment without NPE.
+     * eg.
+     * <pre>
+     *     ./dcat:Catalog/dcat:dataset/dcat:Dataset/dcat:theme[skos:Concept/skos:inScheme/@rdf:resource='http://vocab.belgif.be/auth/datatheme']
+     * </pre>
+     *
+     * <pre>
+     *         <gn_replace_all>
+     *                <dcat:theme xmlns:dcat="http://www.w3.org/ns/dcat#">
+     *                     <skos:Concept xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" xmlns:skos="http://www.w3.org/2004/02/skos/core#" rdf:about="http://vocab.belgif.be/auth/datatheme/CULT">
+     *                     <skos:prefLabel xml:lang="nl">Cultuur en sport</skos:prefLabel>
+     *                     <skos:inScheme rdf:resource="http://vocab.belgif.be/auth/datatheme"/>
+     *                     </skos:Concept>
+     *                </dcat:theme>
+     * </pre>
+     *
+     *  ISO editor is using replace_all for topic category and directory (without predicate).
+     */
+    @Test
+    public void testCreateWithPredicate() throws Exception {
+        MetadataSchema schema = _schemaManager.getSchema("iso19115-3.2018");
+
+        final Element metadataElement = Xml.loadFile(EditLibIntegrationTest.class.getResource("metadata.iso19115-3.xml"));
+
+        String newValue = "<mri:descriptiveKeywords xmlns:gco=\"http://standards.iso.org/iso/19115/-3/gco/1.0\" xmlns:mri=\"http://standards.iso.org/iso/19115/-3/mri/1.0\">" +
+            "             <mri:MD_Keywords>" +
+            "               <mri:keyword>" +
+            "                  <gco:CharacterString>KEYWORD1</gco:CharacterString>" +
+            "               </mri:keyword>" +
+            "             </mri:MD_Keywords>" +
+            "</mri:descriptiveKeywords>";
+
+        final String xpath = "mdb:identificationInfo/mri:MD_DataIdentification/mri:descriptiveKeywords[*/mri:thesaurusName/*/cit:title/gcx:Anchor = 'Mots-clés InfraSIG']";
+        final String xpathProperty = "/mdb:MD_Metadata/" + xpath;
+        boolean updated = new EditLib(_schemaManager).addElementOrFragmentFromXpath(metadataElement, schema, xpathProperty,
+            new AddElemValue("<gn_create>" + newValue + "</gn_create>"),
+            true);
+
+        assertTrue(updated);
+        assertEqualsText("1", metadataElement,
+            "concat(count(mdb:identificationInfo/mri:MD_DataIdentification/mri:descriptiveKeywords/*/mri:keyword[gco:CharacterString = 'KEYWORD1']), '')",
+            ISO19115_3_2018Namespaces.MDB, ISO19115_3_2018Namespaces.MRI, ISO19115_3_2018Namespaces.GCO);
     }
 
     @Test


### PR DESCRIPTION
# Summary

While working on DCAT-AP 3 support for the [metadata101/dcat-ap](https://github.com/metadata101/dcat-ap) plugin, we hit a `NullPointerException` in `MetadataEditingApi` whenever `<gn_create/>` or `<gn_replace_all/>` is used with an XPath that ends directly with a predicate (for example, `./dcat:Catalog/dcat:dataset/dcat:Dataset/dcat:theme[skos:Concept/skos:inScheme/rdf:resource='http://publications.europa.eu/resource/authority/data-theme']`). In these cases, the code attempts to descend past the predicate even though there is no following element, so node creation failed.

This PR fixes this by: 

  - Ensuring `MetadataEditingApi` can create nodes for XPaths whose last segment is only a predicate by reusing the already-built base XPath rather than attempting to descend into a non-existent child.
  - Adding a `containsOnlyPredicates` helper so `EditLib.addElementOrFragmentFromXpath` can detect predicate-only tails and safely route back through `createAndAddFromXPath` on the parent element.  

Unfortunately, I am not able to reproduce such a scenario with the native GeoNetwork schema plugin only. This can, however, be reproduced with a DCAT-ap VL dataset metadata using the DCAT schema plugin at commit https://github.com/metadata101/dcat-ap/commit/fb777bd682acb92b7ab42066563bd31c91231dce
 and adding themes from both thesaurus picker fields:
<img width="487" height="221" alt="image" src="https://github.com/user-attachments/assets/fe6ba71c-7c3c-433d-8343-b19dea0d8eb9" />


CC: @fxprunayre, @joachimnielandt 

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation