### PR TITLE
Exclude legacy XML API dependencies and use java.xml module instead

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -563,13 +563,6 @@
     <dependency>
       <groupId>org.owasp.esapi</groupId>
       <artifactId>esapi</artifactId>
-      <version>2.5.4.0</version>
-      <exclusions>
-        <exclusion>
-          <groupId>log4j</groupId>
-          <artifactId>log4j</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.xmlunit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -266,6 +266,14 @@
             </goals>
             <configuration>
               <rules>
+                <bannedDependencies>
+                    <excludes>
+                        <exclude>xml-apis:xml-apis</exclude>
+                        <exclude>xml-apis:xml-apis-ext</exclude>
+                        <exclude>xml-apis:xmlParserAPIs</exclude>
+                        <exclude>xerces:xmlParserAPIs</exclude>
+                    </excludes>
+                </bannedDependencies>
                 <requireMavenVersion>
                   <version>3.8.3</version>
                 </requireMavenVersion>
@@ -482,6 +490,16 @@
         <groupId>org.apache.xmlgraphics</groupId>
         <artifactId>fop</artifactId>
         <version>${fop.version}</version>
+        <exclusions>
+          <exclusion>
+            <groupId>xml-apis</groupId>
+            <artifactId>xml-apis</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>xml-apis</groupId>
+            <artifactId>xml-apis-ext</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
 
       <dependency>
@@ -522,7 +540,7 @@
       <dependency>
         <groupId>commons-digester</groupId>
         <artifactId>commons-digester</artifactId>
-        <version>1.6</version>
+        <version>1.8.1</version>
       </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
@@ -621,11 +639,28 @@
         <groupId>xerces</groupId>
         <artifactId>xercesImpl</artifactId>
         <version>2.12.2</version>
+        <exclusions>
+          <exclusion>
+            <groupId>xml-apis</groupId>
+            <artifactId>xml-apis</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>xml-apis</groupId>
+            <artifactId>xml-apis-ext</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>xml-apis</groupId>
         <artifactId>xml-apis</artifactId>
         <version>1.4.01</version>
+        <scope>provided</scope>
+      </dependency>
+      <dependency>
+        <groupId>xml-apis</groupId>
+        <artifactId>xml-apis-ext</artifactId>
+        <version>1.3.04</version>
+        <scope>provided</scope>
       </dependency>
 
       <dependency>
@@ -850,7 +885,7 @@
       <dependency>
         <groupId>jaxen</groupId>
         <artifactId>jaxen</artifactId>
-        <version>1.1.4</version>
+        <version>1.2.0</version>
       </dependency>
       <dependency>
         <groupId>org.quartz-scheduler</groupId>
@@ -859,6 +894,25 @@
       </dependency>
 
       <!-- Security stuff -->
+      <dependency>
+        <groupId>org.owasp.esapi</groupId>
+        <artifactId>esapi</artifactId>
+        <version>2.5.4.0</version>
+        <exclusions>
+          <exclusion>
+            <groupId>log4j</groupId>
+            <artifactId>log4j</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>xml-apis</groupId>
+            <artifactId>xml-apis</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>xml-apis</groupId>
+            <artifactId>xml-apis-ext</artifactId>
+          </exclusion>
+        </exclusions>
+      </dependency>
       <dependency>
         <groupId>com.github.mwiede</groupId>
         <artifactId>jsch</artifactId>
@@ -887,6 +941,14 @@
           <exclusion>
             <groupId>log4j</groupId>
             <artifactId>log4j</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>xml-apis</groupId>
+            <artifactId>xml-apis</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>xml-apis</groupId>
+            <artifactId>xml-apis-ext</artifactId>
           </exclusion>
         </exclusions>
       </dependency>
@@ -1196,7 +1258,13 @@
       <dependency>
         <groupId>xom</groupId>
         <artifactId>xom</artifactId>
-        <version>1.1</version>
+        <version>1.3.9</version>
+        <exclusions>
+          <exclusion>
+            <groupId>xml-apis</groupId>
+            <artifactId>xml-apis</artifactId>
+          </exclusion>
+        </exclusions>
       </dependency>
       <dependency>
         <groupId>org.xhtmlrenderer</groupId>


### PR DESCRIPTION
Fixes #9118

Java 9 and higher provide the standard XML APIs (javax.xml.parsers, org.w3c.dom, org.xml.sax, etc.) in the java.xml module. Several dependencies in the project depended directly or transitively on older versions of these APIs via artifacts such as xml-apis:xml-apis, xml-apis:xml-apis-ext and xerces:xmlParserAPIs. When both the JDK and a dependency define the same package, certain compilers, especially the Eclipse Java Compiler (ECJ), fail with errors such as `X is accessible from more than one module: javax.xml, <unnamed>`.

Ensure that Maven does not include the legacy artifacts xml-apis:xml-apis, xml-apis:xml-apis-ext, xml-apis:xmlParserAPIs or xerces:xmlParserAPIs; but relies on the java.xml module instead (GeoNetwork requires at least Java 11).

Update xom:xom from 1.1 to 1.3.9, which no longer bundles org.w3c.dom classes and improves compatibility with more JDK versions (see https://xom.nu/history.html).

Update jaxen:jaxen from to 1.1.4 to 1.2.0, which no longer bundles org.w3c.dom classes (see
https://www.cafeconleche.org/jaxen/releases.html).

Update commons-digester:commons-digester from 1.6 to 1.8.1, which marks xml-apis as provided instead of compile (see
https://github.com/apache/commons-digester/commit/05b3ffc988d8dad0db461b fb35598a244e32f4f6).


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation


