### PR TITLE
Fix index field escaping in email templates

### DIFF
--- a/core/src/main/java/org/fao/geonet/util/LocalizedEmailComponent.java
+++ b/core/src/main/java/org/fao/geonet/util/LocalizedEmailComponent.java
@@ -369,7 +369,7 @@ public class LocalizedEmailComponent {
         // Add the uuid placeholder to the link in the specified format
         UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder
             .fromHttpUrl(settingManager.getNodeURL())
-            .pathSegment("api", "records", replaceLinksWithHtmlFormat ? "{{index:uuid}}" : "'{{'index:uuid'}}'");
+            .pathSegment("api", "records", replaceLinksWithHtmlFormat ? "{{index:uuid}}" : "'{{index:uuid}}'");
 
         // When building the record URL, the formatter is passed as the `recordViewFormatter` query parameter
         // because the API expects that parameter name to decide which formatter to use when displaying the record.

--- a/core/src/test/resources/org/fao/geonet/api/Messages.properties
+++ b/core/src/test/resources/org/fao/geonet/api/Messages.properties
@@ -113,8 +113,8 @@ metadata_save_submit_text=Save and submit metadata
 metadata_save_approve_text=Save and approve metadata
 metadata_status_editing_instance_created_text=Editing instance created
 # SiteName / Workflow / recordTitle statusName by userName
-status_change_default_email_subject={0} / Workflow / '{{'index:resourceTitleObject'}}' {1} by {2}
-status_change_default_email_text={0} modified the status of the record '{{'index:resourceTitleObject'}}'.\n\
+status_change_default_email_subject={0} / Workflow / '{{index:resourceTitleObject}}' {1} by {2}
+status_change_default_email_text={0} modified the status of the record '{{index:resourceTitleObject}}'.\n\
 The status is now: {2}.\n\
  \n\
 Message: \n\
@@ -124,9 +124,9 @@ View record: \n\
 {{link}}
 
 # SiteName / Task / recordTitle statusName by userName
-status_change_doiCreationTask_email_subject={0} / Task / {1} for '{{'index:resourceTitleObject'}}'
+status_change_doiCreationTask_email_subject={0} / Task / {1} for '{{index:resourceTitleObject}}'
 # author
-status_change_doiCreationTask_email_text={0} requested creation of the DOI for the record '{{'index:resourceTitleObject'}}'. Could you proceed to the DOI creation by {4}.\n\
+status_change_doiCreationTask_email_text={0} requested creation of the DOI for the record '{{index:resourceTitleObject}}'. Could you proceed to the DOI creation by {4}.\n\
 \n\
 Responsible of the task: \n\
 Message: \n\

--- a/core/src/test/resources/org/fao/geonet/api/Messages_fre.properties
+++ b/core/src/test/resources/org/fao/geonet/api/Messages_fre.properties
@@ -113,8 +113,8 @@ metadata_save_submit_text=Enregistrer et soumettre les métadonnées
 metadata_save_approve_text=Enregistrer et approuver les métadonnées
 metadata_status_editing_instance_created_text=L''instance de modification a été créée
 # SiteName / Workflow / recordTitle statusName by userName
-status_change_default_email_subject={0} / Cycle de vie / ''{{'index:resourceTitleObject'}}'' {1} par {2}
-status_change_default_email_text={0} a modifié l''état de la fiche ''{{'index:resourceTitleObject'}}''.\n\
+status_change_default_email_subject={0} / Cycle de vie / '{{index:resourceTitleObject}}' {1} par {2}
+status_change_default_email_text={0} a modifié l''état de la fiche '{{index:resourceTitleObject}}'.\n\
 L''état est maintenant : {2}.\n\
  \n\
 Message: \n\
@@ -124,10 +124,10 @@ Consulter la fiche : \n\
 {{link}}
 
 # SiteName / Task / recordTitle statusName by userName
-status_change_doiCreationTask_email_subject={0} / Action / {1} pour ''{{'index:resourceTitleObject'}}''
+status_change_doiCreationTask_email_subject={0} / Action / {1} pour '{{index:resourceTitleObject}}'
 # author
 
-status_change_doiCreationTask_email_text={0} a demandé la création d''un DOI pour la fiche ''{{'index:resourceTitleObject'}}''. Pouvez-vous créer le DOI pour le {4}.\n\
+status_change_doiCreationTask_email_text={0} a demandé la création d''un DOI pour la fiche '{{index:resourceTitleObject}}'. Pouvez-vous créer le DOI pour le {4}.\n\
 \n\
 Responsable de l''action : \n\
 Message: \n\

--- a/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages.properties
+++ b/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages.properties
@@ -119,8 +119,8 @@ metadata_save_submit_text=Save and submit metadata
 metadata_save_approve_text=Save and approve metadata
 metadata_status_editing_instance_created_text=Editing instance created
 # SiteName / Workflow / recordTitle statusName by userName
-status_change_default_email_subject={0} / Workflow / '{{'index:resourceTitleObject'}}' {1} by {2}
-status_change_default_email_text={0} modified the status of the record '{{'index:resourceTitleObject'}}'.\n\
+status_change_default_email_subject={0} / Workflow / '{{index:resourceTitleObject}}' {1} by {2}
+status_change_default_email_text={0} modified the status of the record '{{index:resourceTitleObject}}'.\n\
 The status is now: {2}.\n\
  \n\
 Message: \n\
@@ -130,9 +130,9 @@ View record: \n\
 {{link}}
 
 # SiteName / Task / taskName for recordTitle
-status_change_doiCreationTask_email_subject={0} / Task / {1} for '{{'index:resourceTitleObject'}}'
+status_change_doiCreationTask_email_subject={0} / Task / {1} for '{{index:resourceTitleObject}}'
 # author
-status_change_doiCreationTask_email_text={0} requested creation of the DOI for the record '{{'index:resourceTitleObject'}}'. Could you proceed to the DOI creation by {4}.\n\
+status_change_doiCreationTask_email_text={0} requested creation of the DOI for the record '{{index:resourceTitleObject}}'. Could you proceed to the DOI creation by {4}.\n\
 \n\
 Responsible of the task: \n\
 Message: \n\

--- a/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages_dut.properties
+++ b/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages_dut.properties
@@ -119,8 +119,8 @@ metadata_save_submit_text=Opslaan en metadata indienen
 metadata_save_approve_text=Opslaan en metadata goedkeuren
 metadata_status_editing_instance_created_text=Werkkopie aangemaakt
 # SiteName / Workflow / recordTitle statusName by userName
-status_change_default_email_subject={0} / Workflow / '{{'index:resourceTitleObject'}}' {1} van {2}
-status_change_default_email_text={0} heeft de status van record '{{'index:resourceTitleObject'}}' aangepast.\n\
+status_change_default_email_subject={0} / Workflow / '{{index:resourceTitleObject}}' {1} van {2}
+status_change_default_email_text={0} heeft de status van record '{{index:resourceTitleObject}}' aangepast.\n\
 De status is nu: {2}.\n\
  \n\
 Bericht: \n\
@@ -130,9 +130,9 @@ Record bekijken: \n\
 {{link}}
 
 # SiteName / Task / taskName for recordTitle
-status_change_doiCreationTask_email_subject={0} / Taak / {1} voor '{{'index:resourceTitleObject'}}'
+status_change_doiCreationTask_email_subject={0} / Taak / {1} voor '{{index:resourceTitleObject}}'
 # author
-status_change_doiCreationTask_email_text={0} heeft een DOI aangevraagd voor record '{{'index:resourceTitleObject'}}'. Maak een DOI aan voor {4}.\n\
+status_change_doiCreationTask_email_text={0} heeft een DOI aangevraagd voor record '{{index:resourceTitleObject}}'. Maak een DOI aan voor {4}.\n\
 \n\
 Verantwoordelijke voor de taak: \n\
 Bericht: \n\

--- a/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages_fre.properties
+++ b/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages_fre.properties
@@ -113,8 +113,8 @@ metadata_save_submit_text=Enregistrer et soumettre les métadonnées
 metadata_save_approve_text=Enregistrer et approuver les métadonnées
 metadata_status_editing_instance_created_text=L''instance de modification a été créée
 # SiteName / Workflow / recordTitle statusName by userName
-status_change_default_email_subject={0} / Cycle de vie / ''{{'index:resourceTitleObject'}}'' {1} par {2}
-status_change_default_email_text={0} a modifié l''état de la fiche ''{{'index:resourceTitleObject'}}''.\n\
+status_change_default_email_subject={0} / Cycle de vie / '{{index:resourceTitleObject}}' {1} par {2}
+status_change_default_email_text={0} a modifié l''état de la fiche '{{index:resourceTitleObject}}'.\n\
 L''état est maintenant : {2}.\n\
  \n\
 Message: \n\
@@ -124,10 +124,10 @@ Consulter la fiche : \n\
 {{link}}
 
 # SiteName / Task / recordTitle statusName by userName
-status_change_doiCreationTask_email_subject={0} / Action / {1} pour ''{{'index:resourceTitleObject'}}''
+status_change_doiCreationTask_email_subject={0} / Action / {1} pour '{{index:resourceTitleObject}}'
 # author
 
-status_change_doiCreationTask_email_text={0} a demandé la création d''un DOI pour la fiche ''{{'index:resourceTitleObject'}}''. Pouvez-vous créer le DOI pour le {4}.\n\
+status_change_doiCreationTask_email_text={0} a demandé la création d''un DOI pour la fiche '{{index:resourceTitleObject}}'. Pouvez-vous créer le DOI pour le {4}.\n\
 \n\
 Responsable de l''action : \n\
 Message: \n\


### PR DESCRIPTION
Currently when multilingual emails contain french they are failing to send. In #8820 the index field placeholders (`{{index:resourceTitleObject}}`) were updated so they were escaped using two single quotes instead of a one single quote. This confuses `MessageFormat.format` into thinking the index placeholder `{{index:resourceTitleObject}}` is a numeric placeholder intended for the `MessageFormat.format` call.

This PR aims to fix this issue by reverting the fields to consistently use one single quote instead of two.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

