### PR TITLE
Identification info locale and iso19139 to iso19115-3 conversion

### DIFF
--- a/schemas/iso19115-3.2018/pom.xml
+++ b/schemas/iso19115-3.2018/pom.xml
@@ -52,8 +52,12 @@
       </exclusions>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>net.sf.saxon</groupId>
+      <artifactId>saxon-dom</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
-
   <build>
     <resources>
       <resource>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ISO19139/mapping/core.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ISO19139/mapping/core.xsl
@@ -90,11 +90,15 @@
     </gfc:cardinality>
   </xsl:template>
 
-  <xsl:template match="gmd:language|gmd:locale" priority="5" mode="from19139to19115-3.2018">
+  <xsl:variable name="mainLanguage" select="*/gmd:language/*/@codeListValue"/>
+
+  <xsl:template match="gmd:locale[*/gmd:languageCode/*/@codeListValue = $mainLanguage]" priority="5" mode="from19139to19115-3.2018"/>
+
+  <xsl:template match="gmd:language|gmd:locale|gmd:locale[*/gmd:languageCode/*/@codeListValue != $mainLanguage]" priority="5" mode="from19139to19115-3.2018">
     <xsl:variable name="nameSpacePrefix">
       <xsl:call-template name="getNamespacePrefix"/>
     </xsl:variable>
-    <xsl:variable name="elementName" select="if (local-name() = 'language') then 'defaultLocale' else 'otherLocale'"/>
+    <xsl:variable name="elementName" select="if (local-name() = 'language' and gmd:LanguageCode/@codeListValue = $mainLanguage) then 'defaultLocale' else 'otherLocale'"/>
     <xsl:element name="{concat($nameSpacePrefix, ':', $elementName)}">
       <!--<xsl:element name="{'mdb:defaultLocale'}">-->
       <xsl:apply-templates select="@*" mode="from19139to19115-3.2018"/>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
@@ -464,7 +464,7 @@
 
 
         <xsl:for-each
-          select="mri:defaultLocale/lan:PT_Locale/lan:language/lan:LanguageCode/@codeListValue">
+          select="mri:defaultLocale/lan:PT_Locale/lan:language/lan:LanguageCode/@codeListValue|mri:otherLocale/lan:PT_Locale/lan:language/lan:LanguageCode/@codeListValue">
           <resourceLanguage>
             <xsl:value-of select="."/>
           </resourceLanguage>

--- a/schemas/iso19115-3.2018/src/test/java/org/fao/geonet/kernel/search/EsSearchManager.java
+++ b/schemas/iso19115-3.2018/src/test/java/org/fao/geonet/kernel/search/EsSearchManager.java
@@ -1,0 +1,8 @@
+package org.fao.geonet.kernel.search;
+
+public class EsSearchManager {
+	public static String analyzeField(String analyzer,
+									  String fieldValue) {
+		return "";
+	}
+}

--- a/schemas/iso19115-3.2018/src/test/java/org/fao/geonet/schema/FromIso19139ConversionTest.java
+++ b/schemas/iso19115-3.2018/src/test/java/org/fao/geonet/schema/FromIso19139ConversionTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2001-2025 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+package org.fao.geonet.schema;
+
+import org.fao.geonet.utils.TransformerFactoryFactory;
+import org.fao.geonet.utils.Xml;
+import org.jdom.Document;
+import org.jdom.Element;
+import org.jdom.output.Format;
+import org.jdom.output.XMLOutputter;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.nio.file.Path;
+
+import static org.fao.geonet.schema.TestSupport.getResource;
+import static org.fao.geonet.schema.TestSupport.getResourceInsideSchema;
+
+public class FromIso19139ConversionTest {
+
+	private static final boolean GENERATE_EXPECTED_FILE = false;
+
+	@BeforeClass
+	public static void initSaxon() {
+		TransformerFactoryFactory.init("net.sf.saxon.TransformerFactoryImpl");
+	}
+
+	@Test
+	public void upperRhineCastles() throws Exception {
+		transformAndCompare("convert/fromISO19139.xsl", "UpperRhineCastles-iso19139.xml", "UpperRhineCastles-iso19115-3.2018.xml");
+	}
+
+	private void transformAndCompare(String scriptName, String inputFileName, String expectedFileName) throws Exception {
+		Path xslFile = getResourceInsideSchema(scriptName);
+		Path xmlFile = getResource( inputFileName);
+		Element md = Xml.loadFile(xmlFile);
+
+		Element mdIso19115_3 = Xml.transform(md, xslFile);
+
+		XMLOutputter xmlOutputter = new XMLOutputter(Format.getPrettyFormat().setLineSeparator("\n"));
+		String actual = xmlOutputter.outputString(new Document(mdIso19115_3));
+		TestSupport.assertGeneratedDataByteMatchExpected(expectedFileName, actual, GENERATE_EXPECTED_FILE);
+	}
+
+}

--- a/schemas/iso19115-3.2018/src/test/java/org/fao/geonet/schema/IndexationTest.java
+++ b/schemas/iso19115-3.2018/src/test/java/org/fao/geonet/schema/IndexationTest.java
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2001-2025 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+package org.fao.geonet.schema;
+
+import org.fao.geonet.util.XslUtil;
+import org.fao.geonet.utils.ResolverWrapper;
+import org.fao.geonet.utils.TransformerFactoryFactory;
+import org.fao.geonet.utils.Xml;
+import org.jdom.Document;
+import org.jdom.Element;
+import org.jdom.output.Format;
+import org.jdom.output.XMLOutputter;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.lang.reflect.Field;
+import java.net.URISyntaxException;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.fao.geonet.schema.TestSupport.getResource;
+
+public class IndexationTest {
+
+	private static Field resolverMapField;
+
+	private static final boolean GENERATE_EXPECTED_FILE = false;
+
+	@BeforeClass
+	public static void initOasis() throws NoSuchFieldException, IllegalAccessException, URISyntaxException {
+		resolverMapField = ResolverWrapper.class.getDeclaredField("resolverMap");
+		resolverMapField.setAccessible(true);
+		((Map<?, ?>) resolverMapField.get(null)).clear();
+		ResolverWrapper.createResolverForSchema("DEFAULT", Path.of(IndexationTest.class.getClassLoader().getResource("gn-site/WEB-INF/oasis-catalog.xml").getPath()));
+	}
+
+	@Before
+	public void initSaxon() {
+		TransformerFactoryFactory.init("net.sf.saxon.TransformerFactoryImpl");
+	}
+
+	@AfterClass
+	public static void clearOasis() throws IllegalAccessException {
+		((Map<?,?>) resolverMapField.get(null)).clear();
+	}
+
+	@Test
+	public void upperRhineCastles() throws Exception {
+		XslUtil.IS_INSPIRE_ENABLED = false;
+		transformAndCompare("gn-site/WEB-INF/data/config/schema_plugins/iso19115-3.2018/index-fields/index.xsl",  "UpperRhineCastles-iso19115-3.2018.xml", "UpperRhineCastles-index.xml");
+	}
+
+	private void transformAndCompare(String scriptName, String inputFileName, String expectedFileName) throws Exception {
+		Path xslFile = getResource(scriptName);
+		Path xmlFile = getResource( inputFileName);
+		Element md = Xml.loadFile(xmlFile);
+
+		Element mdIso19115_3 = Xml.transform(md, xslFile);
+
+		XMLOutputter xmlOutputter = new XMLOutputter(Format.getPrettyFormat().setLineSeparator("\n"));
+		String actual = xmlOutputter.outputString(new Document(mdIso19115_3))
+				.replaceAll("<indexingDate>.*</indexingDate>", "<indexingDate>2025-04-11T17:46:21+02:00</indexingDate>");;
+		TestSupport.assertGeneratedDataByteMatchExpected(expectedFileName, actual, GENERATE_EXPECTED_FILE);
+	}
+}

--- a/schemas/iso19115-3.2018/src/test/java/org/fao/geonet/schema/IndexationTest.java
+++ b/schemas/iso19115-3.2018/src/test/java/org/fao/geonet/schema/IndexationTest.java
@@ -47,7 +47,6 @@ import static org.fao.geonet.schema.TestSupport.getResource;
 public class IndexationTest {
 
 	private static Field resolverMapField;
-
 	private static final boolean GENERATE_EXPECTED_FILE = false;
 	private static TimeZone timeZoneToReset;
 

--- a/schemas/iso19115-3.2018/src/test/java/org/fao/geonet/schema/IndexationTest.java
+++ b/schemas/iso19115-3.2018/src/test/java/org/fao/geonet/schema/IndexationTest.java
@@ -40,6 +40,7 @@ import java.lang.reflect.Field;
 import java.net.URISyntaxException;
 import java.nio.file.Path;
 import java.util.Map;
+import java.util.TimeZone;
 
 import static org.fao.geonet.schema.TestSupport.getResource;
 
@@ -48,6 +49,7 @@ public class IndexationTest {
 	private static Field resolverMapField;
 
 	private static final boolean GENERATE_EXPECTED_FILE = false;
+	private static TimeZone timeZoneToReset;
 
 	@BeforeClass
 	public static void initOasis() throws NoSuchFieldException, IllegalAccessException, URISyntaxException {
@@ -65,6 +67,17 @@ public class IndexationTest {
 	@AfterClass
 	public static void clearOasis() throws IllegalAccessException {
 		((Map<?,?>) resolverMapField.get(null)).clear();
+	}
+
+	@BeforeClass
+	public static void setTimeZoneUtc() {
+		timeZoneToReset = TimeZone.getDefault();
+		TimeZone.setDefault(TimeZone.getTimeZone("GMT"));
+	}
+
+	@BeforeClass
+	public static void resetTimeZone() {
+		TimeZone.setDefault(timeZoneToReset);
 	}
 
 	@Test

--- a/schemas/iso19115-3.2018/src/test/java/org/fao/geonet/util/XslUtil.java
+++ b/schemas/iso19115-3.2018/src/test/java/org/fao/geonet/util/XslUtil.java
@@ -24,10 +24,13 @@ package org.fao.geonet.util;
 
 import org.apache.commons.text.StringEscapeUtils;
 import org.owasp.esapi.reference.DefaultEncoder;
+import org.w3c.dom.Node;
 
 import java.util.List;
 
 public class XslUtil {
+    public static Boolean IS_INSPIRE_ENABLED = false;
+
     public static String twoCharLangCode(String iso3code) {
         return iso3code.substring(0, 2);
     }
@@ -39,6 +42,8 @@ public class XslUtil {
         switch (key) {
             case "system/metadata/validation/removeSchemaLocation":
                 return "false";
+            case "system/inspire/enable":
+                return IS_INSPIRE_ENABLED.toString();
             default:
                 return "true";
         }
@@ -139,4 +144,23 @@ public class XslUtil {
         return false;
     }
 
+    public static String gmlToGeoJson(String gml, Boolean applyPrecisionModel, Integer numberOfDecimals) {
+        return "";
+    }
+
+    public static Node getUrlContent(String surl) {
+        return null;
+    }
+
+    public static Node getRecord(String uuid) {
+        return null;
+    }
+
+    public static String getKeywordUri(String keyword, String thesaurusId, String langCode) {
+        return "";
+    }
+
+    public static String getThesaurusIdByTitle(String title) {
+        return "";
+    }
 }

--- a/schemas/iso19115-3.2018/src/test/resources/UpperRhineCastles-index.xml
+++ b/schemas/iso19115-3.2018/src/test/resources/UpperRhineCastles-index.xml
@@ -116,6 +116,7 @@
             
             }</overview>
   <resourceLanguage>fre</resourceLanguage>
+  <resourceLanguage>ger</resourceLanguage>
   <tag type="object">[
       {
       "default":"Rhin Sup\u00E9rieur", "langfre":"Rhin Sup\u00E9rieur", "langger":"Oberrhein", "langeng":"Upper Rhine"

--- a/schemas/iso19115-3.2018/src/test/resources/UpperRhineCastles-index.xml
+++ b/schemas/iso19115-3.2018/src/test/resources/UpperRhineCastles-index.xml
@@ -53,20 +53,20 @@
   <revisionDateForResource>2024-07-15</revisionDateForResource>
   <revisionYearForResource>2024</revisionYearForResource>
   <revisionMonthForResource>2024-07</revisionMonthForResource>
-  <resourceDate type="object">{"type": "creation", "date": "2024-02-14T23:00:00.000Z"}</resourceDate>
-  <resourceDate type="object">{"type": "publication", "date": "2024-03-13T23:00:00.000Z"}</resourceDate>
-  <resourceDate type="object">{"type": "revision", "date": "2024-07-14T22:00:00.000Z"}</resourceDate>
+  <resourceDate type="object">{"type": "creation", "date": "2024-02-15T00:00:00.000Z"}</resourceDate>
+  <resourceDate type="object">{"type": "publication", "date": "2024-03-14T00:00:00.000Z"}</resourceDate>
+  <resourceDate type="object">{"type": "revision", "date": "2024-07-15T00:00:00.000Z"}</resourceDate>
   <resourceTemporalDateRange type="object">{
-                  "gte": "2024-02-14T23:00:00.000Z",
-                  "lte": "2024-02-14T23:00:00.000Z"
+                  "gte": "2024-02-15T00:00:00.000Z",
+                  "lte": "2024-02-15T00:00:00.000Z"
                   }</resourceTemporalDateRange>
   <resourceTemporalDateRange type="object">{
-                  "gte": "2024-03-13T23:00:00.000Z",
-                  "lte": "2024-03-13T23:00:00.000Z"
+                  "gte": "2024-03-14T00:00:00.000Z",
+                  "lte": "2024-03-14T00:00:00.000Z"
                   }</resourceTemporalDateRange>
   <resourceTemporalDateRange type="object">{
-                  "gte": "2024-07-14T22:00:00.000Z",
-                  "lte": "2024-07-14T22:00:00.000Z"
+                  "gte": "2024-07-15T00:00:00.000Z",
+                  "lte": "2024-07-15T00:00:00.000Z"
                   }</resourceTemporalDateRange>
   <resourceAbstractObject type="object">{"default":"Pr\u00E9sentation des ch\u00E2teaux forts du Rhin Sup\u00E9rieur selon des donn\u00E9es d\u2019accessibilit\u00E9 d\u2019itin\u00E9rance, d\u2019int\u00E9r\u00EAt touristique, de billetterie ou encore d\u2019offre de restauration. \nCette action b\u00E9n\u00E9ficie d\u2019un cofinancement de l\u2019UE dans le cadre du projet Interreg VI \u00AB Ch\u00E2teaux rh\u00E9nans \u2013 Burgen am Oberrhein \u00BB.\n\nSite web du projet \"Ch\u00E2teaux rh\u00E9nans\" : www.chateaux-rhenans.eu\/fr", "langfre":"Pr\u00E9sentation des ch\u00E2teaux forts du Rhin Sup\u00E9rieur selon des donn\u00E9es d\u2019accessibilit\u00E9 d\u2019itin\u00E9rance, d\u2019int\u00E9r\u00EAt touristique, de billetterie ou encore d\u2019offre de restauration. \nCette action b\u00E9n\u00E9ficie d\u2019un cofinancement de l\u2019UE dans le cadre du projet Interreg VI \u00AB Ch\u00E2teaux rh\u00E9nans \u2013 Burgen am Oberrhein \u00BB.\n\nSite web du projet \"Ch\u00E2teaux rh\u00E9nans\" : www.chateaux-rhenans.eu\/fr", "langger":"Vorstellung der Burgen am Oberrhein anhand von Daten zur Zug\u00E4nglichkeit der Wanderwege, zum touristischen Interesse, zum Ticketverkauf oder auch zum Gastronomieangebot. \nDiese Aktion wird von der EU im Rahmen des Interreg VI-Projekts \"Rheinische Burgen - Burgen am Oberrhein\" kofinanziert.\n\nWebsite des Projekts \"Burgen am Oberrhein\" : www.chateaux-rhenans.eu\/de", "langeng":"Presentation of the fortified castles of the Upper Rhine according to data on accessibility, itinerancy, tourist interest, ticketing and catering facilities. \nThis project is co-financed by the EU as part of the Interreg VI project \"Ch\u00E2teaux rh\u00E9nans - Burgen am Oberrhein\".\n\n\"Ch\u00E2teaux rh\u00E9nans \u2013 Burgen am Oberrhein\" project website: www.chateaux-rhenans.eu"}</resourceAbstractObject>
   <cl_resourceCharacterSet type="object">{"key":"utf8","default":"lan:MD_CharacterSetCode--utf8--fre","langfre":"lan:MD_CharacterSetCode--utf8--fre","langger":"lan:MD_CharacterSetCode--utf8--ger","langeng":"lan:MD_CharacterSetCode--utf8--eng","langfre":"lan:MD_CharacterSetCode--utf8--fre","link":"https:\/\/standards.iso.org\/iso\/19115\/resources\/Codelists\/cat\/codelists.xml#MD_CharacterSetCode","text":"utf8"}</cl_resourceCharacterSet>
@@ -274,15 +274,15 @@
   <MD_LegalConstraintsOtherConstraintsObject type="object">{"default":"Pas d'autre limitation", "langfre":"Pas d'autre limitation", "langger":"Keine andere Einschr\u00E4nkung", "langeng":"No other limitation"}</MD_LegalConstraintsOtherConstraintsObject>
   <licenseObject type="object">{"default":"Pas d'autre limitation", "langfre":"Pas d'autre limitation", "langger":"Keine andere Einschr\u00E4nkung", "langeng":"No other limitation"}</licenseObject>
   <resourceTemporalDateRange type="object">{
-                  "gte": "2023-12-14T23:00:00.000Z"
+                  "gte": "2023-12-15T00:00:00.000Z"
                   
-                    ,"lte": "2024-02-14T23:00:00.000Z"
+                    ,"lte": "2024-02-15T00:00:00.000Z"
                   
                   }</resourceTemporalDateRange>
   <resourceTemporalExtentDateRange type="object">{
-                  "gte": "2023-12-14T23:00:00.000Z"
+                  "gte": "2023-12-15T00:00:00.000Z"
                   
-                    ,"lte": "2024-02-14T23:00:00.000Z"
+                    ,"lte": "2024-02-15T00:00:00.000Z"
                   
                 }</resourceTemporalExtentDateRange>
   <resourceTemporalExtentDetails type="object">{

--- a/schemas/iso19115-3.2018/src/test/resources/UpperRhineCastles-index.xml
+++ b/schemas/iso19115-3.2018/src/test/resources/UpperRhineCastles-index.xml
@@ -1,0 +1,410 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<doc>
+  <docType>metadata</docType>
+  <document />
+  <metadataIdentifier>f74f5451-b198-4edf-abdd-a6b6b7caed81</metadataIdentifier>
+  <standardNameObject type="object">{"default":"ISO 19115-3:2018", "langfre":"ISO 19115-3:2018"}</standardNameObject>
+  <standardVersionObject type="object">{"default":"1.0", "lang":"1.0"}</standardVersionObject>
+  <indexingDate>2025-04-11T17:46:21+02:00</indexingDate>
+  <dateStamp>2025-06-18T14:55:30.520183Z</dateStamp>
+  <mainLanguage>fre</mainLanguage>
+  <otherLanguage>ger</otherLanguage>
+  <otherLanguageId>DE</otherLanguageId>
+  <otherLanguage>eng</otherLanguage>
+  <otherLanguageId>EN</otherLanguageId>
+  <otherLanguage>fre</otherLanguage>
+  <otherLanguageId>FR</otherLanguageId>
+  <cl_characterSet type="object">{"key":"utf8","default":"lan:MD_CharacterSetCode--utf8--fre","langfre":"lan:MD_CharacterSetCode--utf8--fre","langger":"lan:MD_CharacterSetCode--utf8--ger","langeng":"lan:MD_CharacterSetCode--utf8--eng","langfre":"lan:MD_CharacterSetCode--utf8--fre","link":"https:\/\/standards.iso.org\/iso\/19115\/resources\/Codelists\/cat\/codelists.xml#MD_CharacterSetCode","text":"utf8"}</cl_characterSet>
+  <resourceType>dataset</resourceType>
+  <OrgObject type="object">{"default":"GeoRhena: Syst\u00E8me d'Information G\u00E9ographique du Rhin Sup\u00E9rieur", "langfre":"GeoRhena: Syst\u00E8me d'Information G\u00E9ographique du Rhin Sup\u00E9rieur", "langger":"GeoRhena: Geographische Informationssystem des Oberrheins", "langeng":"GeoRhena: Geographical Information System of the Upper Rhine"}</OrgObject>
+  <distributorOrgObject type="object">{"default":"GeoRhena: Syst\u00E8me d'Information G\u00E9ographique du Rhin Sup\u00E9rieur", "langfre":"GeoRhena: Syst\u00E8me d'Information G\u00E9ographique du Rhin Sup\u00E9rieur", "langger":"GeoRhena: Geographische Informationssystem des Oberrheins", "langeng":"GeoRhena: Geographical Information System of the Upper Rhine"}</distributorOrgObject>
+  <contact type="object">{
+      
+        "organisationObject": 
+            {"default":"GeoRhena: Syst\u00E8me d'Information G\u00E9ographique du Rhin Sup\u00E9rieur", "langfre":"GeoRhena: Syst\u00E8me d'Information G\u00E9ographique du Rhin Sup\u00E9rieur", "langger":"GeoRhena: Geographische Informationssystem des Oberrheins", "langeng":"GeoRhena: Geographical Information System of the Upper Rhine"}
+            ,
+      
+      "role":"distributor",
+      "email":"",
+      "website":"http:\/\/www.georhena.eu",
+      "logo":"",
+      "individual":"",
+      "position":"",
+      "phone":"00 33 3 89 30 63 91",
+      "address":"100, avenue d'Alsace, COLMAR, 68000, FR"
+      
+      }</contact>
+  <cl_resourceScope type="object">{"key":"dataset","default":"mcc:MD_ScopeCode--dataset--fre","langfre":"mcc:MD_ScopeCode--dataset--fre","langger":"mcc:MD_ScopeCode--dataset--ger","langeng":"mcc:MD_ScopeCode--dataset--eng","langfre":"mcc:MD_ScopeCode--dataset--fre","link":"https:\/\/standards.iso.org\/iso\/19115\/resources\/Codelists\/cat\/codelists.xml#MD_ScopeCode","text":"dataset"}</cl_resourceScope>
+  <cl_numberType type="object">{"key":"facsimile","default":"cit:CI_TelephoneTypeCode--facsimile--fre","langfre":"cit:CI_TelephoneTypeCode--facsimile--fre","langger":"cit:CI_TelephoneTypeCode--facsimile--ger","langeng":"cit:CI_TelephoneTypeCode--facsimile--eng","langfre":"cit:CI_TelephoneTypeCode--facsimile--fre","link":"https:\/\/standards.iso.org\/iso\/19115\/resources\/Codelists\/cat\/codelists.xml#CI_TelephoneTypeCode","text":"facsimile"}</cl_numberType>
+  <cl_status type="object">{"key":"completed","default":"mcc:MD_ProgressCode--completed--fre","langfre":"mcc:MD_ProgressCode--completed--fre","langger":"mcc:MD_ProgressCode--completed--ger","langeng":"mcc:MD_ProgressCode--completed--eng","langfre":"mcc:MD_ProgressCode--completed--fre","link":"https:\/\/standards.iso.org\/iso\/19115\/resources\/Codelists\/cat\/codelists.xml#MD_ProgressCode","text":"completed"}</cl_status>
+  <cl_numberType type="object">{"key":"voice","default":"cit:CI_TelephoneTypeCode--voice--fre","langfre":"cit:CI_TelephoneTypeCode--voice--fre","langger":"cit:CI_TelephoneTypeCode--voice--ger","langeng":"cit:CI_TelephoneTypeCode--voice--eng","langfre":"cit:CI_TelephoneTypeCode--voice--fre","link":"https:\/\/standards.iso.org\/iso\/19115\/resources\/Codelists\/cat\/codelists.xml#CI_TelephoneTypeCode","text":"voice"}</cl_numberType>
+  <cl_spatialRepresentationType type="object">{"key":"vector","default":"mcc:MD_SpatialRepresentationTypeCode--vector--fre","langfre":"mcc:MD_SpatialRepresentationTypeCode--vector--fre","langger":"mcc:MD_SpatialRepresentationTypeCode--vector--ger","langeng":"mcc:MD_SpatialRepresentationTypeCode--vector--eng","langfre":"mcc:MD_SpatialRepresentationTypeCode--vector--fre","link":"https:\/\/standards.iso.org\/iso\/19115\/resources\/Codelists\/cat\/codelists.xml#MD_SpatialRepresentationTypeCode","text":"vector"}</cl_spatialRepresentationType>
+  <cl_maintenanceAndUpdateFrequency type="object">{"key":"asNeeded","default":"mmi:MD_MaintenanceFrequencyCode--asNeeded--fre","langfre":"mmi:MD_MaintenanceFrequencyCode--asNeeded--fre","langger":"mmi:MD_MaintenanceFrequencyCode--asNeeded--ger","langeng":"mmi:MD_MaintenanceFrequencyCode--asNeeded--eng","langfre":"mmi:MD_MaintenanceFrequencyCode--asNeeded--fre","link":"http:\/\/standards.iso.org\/iso\/19139\/resources\/gmxCodelists.xml#MD_MaintenanceFrequencyCode"}</cl_maintenanceAndUpdateFrequency>
+  <cl_type type="object">{"key":"place","default":"mri:MD_KeywordTypeCode--place--fre","langfre":"mri:MD_KeywordTypeCode--place--fre","langger":"mri:MD_KeywordTypeCode--place--ger","langeng":"mri:MD_KeywordTypeCode--place--eng","langfre":"mri:MD_KeywordTypeCode--place--fre","link":"http:\/\/standards.iso.org\/iso\/19139\/resources\/gmxCodelists.xml#MD_KeywordTypeCode"}</cl_type>
+  <cl_type type="object">{"key":"theme","default":"mri:MD_KeywordTypeCode--theme--fre","langfre":"mri:MD_KeywordTypeCode--theme--fre","langger":"mri:MD_KeywordTypeCode--theme--ger","langeng":"mri:MD_KeywordTypeCode--theme--eng","langfre":"mri:MD_KeywordTypeCode--theme--fre","link":"http:\/\/standards.iso.org\/iso\/19139\/resources\/gmxCodelists.xml#MD_KeywordTypeCode"}</cl_type>
+  <cl_accessConstraints type="object">{"key":"otherRestrictions","default":"mco:MD_RestrictionCode--otherRestrictions--fre","langfre":"mco:MD_RestrictionCode--otherRestrictions--fre","langger":"mco:MD_RestrictionCode--otherRestrictions--ger","langeng":"mco:MD_RestrictionCode--otherRestrictions--eng","langfre":"mco:MD_RestrictionCode--otherRestrictions--fre","link":"http:\/\/standards.iso.org\/iso\/19139\/resources\/gmxCodelists.xml#MD_RestrictionCode"}</cl_accessConstraints>
+  <resourceTitleObject type="object">{"default":"Ch\u00E2teaux rh\u00E9nans", "langfre":"Ch\u00E2teaux rh\u00E9nans", "langger":"Burgen am Oberrhein", "langeng":"Castles on the Upper Rhine"}</resourceTitleObject>
+  <creationDateForResource>2024-02-15</creationDateForResource>
+  <creationYearForResource>2024</creationYearForResource>
+  <creationMonthForResource>2024-02</creationMonthForResource>
+  <publicationDateForResource>2024-03-14</publicationDateForResource>
+  <publicationYearForResource>2024</publicationYearForResource>
+  <publicationMonthForResource>2024-03</publicationMonthForResource>
+  <revisionDateForResource>2024-07-15</revisionDateForResource>
+  <revisionYearForResource>2024</revisionYearForResource>
+  <revisionMonthForResource>2024-07</revisionMonthForResource>
+  <resourceDate type="object">{"type": "creation", "date": "2024-02-14T23:00:00.000Z"}</resourceDate>
+  <resourceDate type="object">{"type": "publication", "date": "2024-03-13T23:00:00.000Z"}</resourceDate>
+  <resourceDate type="object">{"type": "revision", "date": "2024-07-14T22:00:00.000Z"}</resourceDate>
+  <resourceTemporalDateRange type="object">{
+                  "gte": "2024-02-14T23:00:00.000Z",
+                  "lte": "2024-02-14T23:00:00.000Z"
+                  }</resourceTemporalDateRange>
+  <resourceTemporalDateRange type="object">{
+                  "gte": "2024-03-13T23:00:00.000Z",
+                  "lte": "2024-03-13T23:00:00.000Z"
+                  }</resourceTemporalDateRange>
+  <resourceTemporalDateRange type="object">{
+                  "gte": "2024-07-14T22:00:00.000Z",
+                  "lte": "2024-07-14T22:00:00.000Z"
+                  }</resourceTemporalDateRange>
+  <resourceAbstractObject type="object">{"default":"Pr\u00E9sentation des ch\u00E2teaux forts du Rhin Sup\u00E9rieur selon des donn\u00E9es d\u2019accessibilit\u00E9 d\u2019itin\u00E9rance, d\u2019int\u00E9r\u00EAt touristique, de billetterie ou encore d\u2019offre de restauration. \nCette action b\u00E9n\u00E9ficie d\u2019un cofinancement de l\u2019UE dans le cadre du projet Interreg VI \u00AB Ch\u00E2teaux rh\u00E9nans \u2013 Burgen am Oberrhein \u00BB.\n\nSite web du projet \"Ch\u00E2teaux rh\u00E9nans\" : www.chateaux-rhenans.eu\/fr", "langfre":"Pr\u00E9sentation des ch\u00E2teaux forts du Rhin Sup\u00E9rieur selon des donn\u00E9es d\u2019accessibilit\u00E9 d\u2019itin\u00E9rance, d\u2019int\u00E9r\u00EAt touristique, de billetterie ou encore d\u2019offre de restauration. \nCette action b\u00E9n\u00E9ficie d\u2019un cofinancement de l\u2019UE dans le cadre du projet Interreg VI \u00AB Ch\u00E2teaux rh\u00E9nans \u2013 Burgen am Oberrhein \u00BB.\n\nSite web du projet \"Ch\u00E2teaux rh\u00E9nans\" : www.chateaux-rhenans.eu\/fr", "langger":"Vorstellung der Burgen am Oberrhein anhand von Daten zur Zug\u00E4nglichkeit der Wanderwege, zum touristischen Interesse, zum Ticketverkauf oder auch zum Gastronomieangebot. \nDiese Aktion wird von der EU im Rahmen des Interreg VI-Projekts \"Rheinische Burgen - Burgen am Oberrhein\" kofinanziert.\n\nWebsite des Projekts \"Burgen am Oberrhein\" : www.chateaux-rhenans.eu\/de", "langeng":"Presentation of the fortified castles of the Upper Rhine according to data on accessibility, itinerancy, tourist interest, ticketing and catering facilities. \nThis project is co-financed by the EU as part of the Interreg VI project \"Ch\u00E2teaux rh\u00E9nans - Burgen am Oberrhein\".\n\n\"Ch\u00E2teaux rh\u00E9nans \u2013 Burgen am Oberrhein\" project website: www.chateaux-rhenans.eu"}</resourceAbstractObject>
+  <cl_resourceCharacterSet type="object">{"key":"utf8","default":"lan:MD_CharacterSetCode--utf8--fre","langfre":"lan:MD_CharacterSetCode--utf8--fre","langger":"lan:MD_CharacterSetCode--utf8--ger","langeng":"lan:MD_CharacterSetCode--utf8--eng","langfre":"lan:MD_CharacterSetCode--utf8--fre","link":"https:\/\/standards.iso.org\/iso\/19115\/resources\/Codelists\/cat\/codelists.xml#MD_CharacterSetCode","text":"utf8"}</cl_resourceCharacterSet>
+  <OrgForResourceObject type="object">{"default":"GeoRhena", "langfre":"GeoRhena", "langger":"GeoRhena", "langeng":"GeoRhena"}</OrgForResourceObject>
+  <pointOfContactOrgForResourceObject type="object">{"default":"GeoRhena", "langfre":"GeoRhena", "langger":"GeoRhena", "langeng":"GeoRhena"}</pointOfContactOrgForResourceObject>
+  <contactForResource type="object">{
+      
+        "organisationObject": 
+            {"default":"GeoRhena", "langfre":"GeoRhena", "langger":"GeoRhena", "langeng":"GeoRhena"}
+            ,
+      
+      "role":"pointOfContact",
+      "email":"contact@georhena.eu",
+      "website":"https:\/\/www.georhena.eu\/",
+      "logo":"",
+      "individual":"GeoRhena",
+      "position":"",
+      "phone":"00 33 3 89 30 63 91",
+      "address":"100, avenue d'Alsace, COLMAR, 68000, FRANCE"
+      
+      }</contactForResource>
+  <OrgForResourceObject type="object">{"default":"Collectivit\u00E9 Europ\u00E9enne d'Alsace", "langfre":"Collectivit\u00E9 Europ\u00E9enne d'Alsace", "langger":"Collectivit\u00E9 Europ\u00E9enne d'Alsace", "langeng":"Collectivit\u00E9 Europ\u00E9enne d'Alsace"}</OrgForResourceObject>
+  <custodianOrgForResourceObject type="object">{"default":"Collectivit\u00E9 Europ\u00E9enne d'Alsace", "langfre":"Collectivit\u00E9 Europ\u00E9enne d'Alsace", "langger":"Collectivit\u00E9 Europ\u00E9enne d'Alsace", "langeng":"Collectivit\u00E9 Europ\u00E9enne d'Alsace"}</custodianOrgForResourceObject>
+  <contactForResource type="object">{
+      
+        "organisationObject": 
+            {"default":"Collectivit\u00E9 Europ\u00E9enne d'Alsace", "langfre":"Collectivit\u00E9 Europ\u00E9enne d'Alsace", "langger":"Collectivit\u00E9 Europ\u00E9enne d'Alsace", "langeng":"Collectivit\u00E9 Europ\u00E9enne d'Alsace"}
+            ,
+      
+      "role":"custodian",
+      "email":"info@chateaux-rhenans.eu",
+      "website":"https:\/\/www.alsace.eu",
+      "logo":"",
+      "individual":"",
+      "position":"",
+      "phone":"",
+      "address":""
+      
+      }</contactForResource>
+  <hasOverview>true</hasOverview>
+  <overview type="object">{
+            "url": "https:\/\/geoportal.georhena.eu\/geonetwork\/srv\/api\/records\/f74f5451-b198-4edf-abdd-a6b6b7caed81\/attachments\/chateaux_rhenans.jpeg"
+            ,
+              "nameObject":
+              
+            {"default":"chateaux_rhenans.jpeg", "langfre":"chateaux_rhenans.jpeg", "langger":"chateaux_rhenans.jpeg", "langeng":"chateaux_rhenans.jpeg"}
+            
+            }</overview>
+  <resourceLanguage>fre</resourceLanguage>
+  <tag type="object">[
+      {
+      "default":"Rhin Sup\u00E9rieur", "langfre":"Rhin Sup\u00E9rieur", "langger":"Oberrhein", "langeng":"Upper Rhine"
+      }
+      ,
+      {
+      "default":"Ch\u00E2teaux forts", "langfre":"Ch\u00E2teaux forts", "langger":"Burgen und Schl\u00F6sser", "langeng":"Fortified castles"
+      }
+      ,
+      {
+      "default":"Patrimoine castral", "langfre":"Patrimoine castral", "langger":"Kastralisches Kulturerbe", "langeng":"Castral heritage"
+      }
+      ,
+      {
+      "default":"gestion patrimoniale", "langfre":"gestion patrimoniale", "langger":"Erbherrliches Management", "langeng":"patrimonial management"
+      }
+      ,
+      {
+      "default":"tourisme", "langfre":"tourisme", "langger":"Fremdenverkehr", "langeng":"tourism"
+      }
+      ]</tag>
+  <tagNumber>5</tagNumber>
+  <isOpenData>false</isOpenData>
+  <keywordType-place type="object">[
+          {
+          "default":"Rhin Sup\u00E9rieur", "langfre":"Rhin Sup\u00E9rieur", "langger":"Oberrhein", "langeng":"Upper Rhine"
+          }
+          ]</keywordType-place>
+  <keywordType-theme type="object">[
+          {
+          "default":"Ch\u00E2teaux forts", "langfre":"Ch\u00E2teaux forts", "langger":"Burgen und Schl\u00F6sser", "langeng":"Fortified castles"
+          }
+          ,
+          {
+          "default":"Patrimoine castral", "langfre":"Patrimoine castral", "langger":"Kastralisches Kulturerbe", "langeng":"Castral heritage"
+          }
+          ,
+          {
+          "default":"gestion patrimoniale", "langfre":"gestion patrimoniale", "langger":"Erbherrliches Management", "langeng":"patrimonial management"
+          }
+          ,
+          {
+          "default":"tourisme", "langfre":"tourisme", "langger":"Fremdenverkehr", "langeng":"tourism"
+          }
+          ]</keywordType-theme>
+  <th_otherKeywords-placeNumber>1</th_otherKeywords-placeNumber>
+  <th_otherKeywords-place type="object">[
+        {
+        "default":"Rhin Sup\u00E9rieur", "langfre":"Rhin Sup\u00E9rieur", "langger":"Oberrhein", "langeng":"Upper Rhine"
+        }
+        ]</th_otherKeywords-place>
+  <th_otherKeywords-themeNumber>2</th_otherKeywords-themeNumber>
+  <th_otherKeywords-theme type="object">[
+        {
+        "default":"Ch\u00E2teaux forts", "langfre":"Ch\u00E2teaux forts", "langger":"Burgen und Schl\u00F6sser", "langeng":"Fortified castles"
+        }
+        ,
+        {
+        "default":"Patrimoine castral", "langfre":"Patrimoine castral", "langger":"Kastralisches Kulturerbe", "langeng":"Castral heritage"
+        }
+        ]</th_otherKeywords-theme>
+  <th_gemetNumber>2</th_gemetNumber>
+  <th_gemet type="object">[
+        {
+        "default":"gestion patrimoniale", "langfre":"gestion patrimoniale", "langger":"Erbherrliches Management", "langeng":"patrimonial management"
+        }
+        ,
+        {
+        "default":"tourisme", "langfre":"tourisme", "langger":"Fremdenverkehr", "langeng":"tourism"
+        }
+        ]</th_gemet>
+  <allKeywords type="object">{
+      
+        "th_otherKeywords-place": {
+        
+            "title": "otherKeywords-place",
+          
+        "theme": "place",
+        
+        "keywords": [
+        
+          {
+          "default":"Rhin Sup\u00E9rieur", "langfre":"Rhin Sup\u00E9rieur", "langger":"Oberrhein", "langeng":"Upper Rhine"
+          }
+          
+        ]}
+        ,
+        "th_otherKeywords-theme": {
+        
+            "title": "otherKeywords-theme",
+          
+        "theme": "theme",
+        
+        "keywords": [
+        
+          {
+          "default":"Ch\u00E2teaux forts", "langfre":"Ch\u00E2teaux forts", "langger":"Burgen und Schl\u00F6sser", "langeng":"Fortified castles"
+          }
+          ,
+          {
+          "default":"Patrimoine castral", "langfre":"Patrimoine castral", "langger":"Kastralisches Kulturerbe", "langeng":"Castral heritage"
+          }
+          
+        ]}
+        ,
+        "th_gemet": {
+        
+          "id": "geonetwork.thesaurus.external.theme.gemet",
+        
+            "multilingualTitle": {
+              "default":"GEMET - Concepts, version 2.4", "langfre":"GEMET - Concepts, version 2.4"
+            },
+          
+        "theme": "theme",
+        
+          "link": "https:\/\/geoportal.georhena.eu\/geonetwork\/srv\/api\/registries\/vocabularies\/external.theme.gemet",
+        
+        "keywords": [
+        
+          {
+          "default":"gestion patrimoniale", "langfre":"gestion patrimoniale", "langger":"Erbherrliches Management", "langeng":"patrimonial management"
+          }
+          ,
+          {
+          "default":"tourisme", "langfre":"tourisme", "langger":"Fremdenverkehr", "langeng":"tourism"
+          }
+          
+        ]}
+        
+      }</allKeywords>
+  <indexingErrorMsg type="object">{
+                            "string": "indexingErrorMsg-keywordNotFoundInThesaurus",
+                            "type": "warning",
+                            "values": {
+                              "keyword": "gestion patrimoniale",
+                              "thesaurus": "geonetwork.thesaurus.external.theme.gemet"
+                            }
+                          }</indexingErrorMsg>
+  <indexingErrorMsg type="object">{
+                            "string": "indexingErrorMsg-keywordNotFoundInThesaurus",
+                            "type": "warning",
+                            "values": {
+                              "keyword": "tourisme",
+                              "thesaurus": "geonetwork.thesaurus.external.theme.gemet"
+                            }
+                          }</indexingErrorMsg>
+  <cl_topic type="object">{"key":"society","default":"mri:MD_TopicCategoryCode--society--fre","langfre":"mri:MD_TopicCategoryCode--society--fre","langger":"mri:MD_TopicCategoryCode--society--ger","langeng":"mri:MD_TopicCategoryCode--society--eng","langfre":"mri:MD_TopicCategoryCode--society--fre"}</cl_topic>
+  <resolutionScaleDenominator>100000</resolutionScaleDenominator>
+  <spatialRepresentationType>vector</spatialRepresentationType>
+  <maintenance type="object">{
+            "frequency": "asNeeded"
+            
+            }</maintenance>
+  <MD_ConstraintsUseLimitationObject type="object">{"default":"Licence CC-BY - \u00A9CeA ; \u00A9GeoRhena", "langfre":"Licence CC-BY - \u00A9CeA ; \u00A9GeoRhena", "langger":"Lizenz CC-BY - \u00A9CeA ; \u00A9GeoRhena", "langeng":"Licence CC-BY - \u00A9CeA ; \u00A9GeoRhena"}</MD_ConstraintsUseLimitationObject>
+  <MD_LegalConstraintsOtherConstraintsObject type="object">{"default":"Pas d'autre limitation", "langfre":"Pas d'autre limitation", "langger":"Keine andere Einschr\u00E4nkung", "langeng":"No other limitation"}</MD_LegalConstraintsOtherConstraintsObject>
+  <licenseObject type="object">{"default":"Pas d'autre limitation", "langfre":"Pas d'autre limitation", "langger":"Keine andere Einschr\u00E4nkung", "langeng":"No other limitation"}</licenseObject>
+  <resourceTemporalDateRange type="object">{
+                  "gte": "2023-12-14T23:00:00.000Z"
+                  
+                    ,"lte": "2024-02-14T23:00:00.000Z"
+                  
+                  }</resourceTemporalDateRange>
+  <resourceTemporalExtentDateRange type="object">{
+                  "gte": "2023-12-14T23:00:00.000Z"
+                  
+                    ,"lte": "2024-02-14T23:00:00.000Z"
+                  
+                }</resourceTemporalExtentDateRange>
+  <resourceTemporalExtentDetails type="object">{
+        "start": {
+        "date": "2023-12-15"
+        },
+        "end": {
+        "date": "2024-02-15"
+        }
+        }</resourceTemporalExtentDetails>
+  <geom type="object">{"type": "Polygon","coordinates": [[[7.009277,47.346267],[8.745117,47.346267],[8.745117,49.310799],[7.009277,49.310799],[7.009277,47.346267]]]}</geom>
+  <location>48.328533,7.877197000000001</location>
+  <featureTypes type="object">[
+        
+        ]</featureTypes>
+  <lineageObject type="object">{"default":"Recensement des ch\u00E2teaux forts \u00E0 partir de donn\u00E9es collect\u00E9es aupr\u00E8s d\u2019institutions culturelles ou touristiques partenaires dans le cadre du projet Ch\u00E2teaux rh\u00E9nans.", "langfre":"Recensement des ch\u00E2teaux forts \u00E0 partir de donn\u00E9es collect\u00E9es aupr\u00E8s d\u2019institutions culturelles ou touristiques partenaires dans le cadre du projet Ch\u00E2teaux rh\u00E9nans.", "langger":"Erfassung von Burgen und Schl\u00F6ssern anhand von Daten, die bei kulturellen oder touristischen Partnerinstitutionen im Rahmen des Projekts Rheinburgen gesammelt wurden.", "langeng":"Inventory of castles based on data collected from partner cultural and tourist institutions as part of the Ch\u00E2teaux rh\u00E9nans project."}</lineageObject>
+  <format>Géodonnée au format SHP</format>
+  <format />
+  <format />
+  <format />
+  <format />
+  <OrgForDistributionObject type="object">{"default":"GeoRhena", "langfre":"GeoRhena"}</OrgForDistributionObject>
+  <publisherOrgForDistributionObject type="object">{"default":"GeoRhena", "langfre":"GeoRhena"}</publisherOrgForDistributionObject>
+  <contactForDistribution type="object">{
+      
+        "organisationObject": 
+            {"default":"GeoRhena", "langfre":"GeoRhena"}
+            ,
+      
+      "role":"publisher",
+      "email":"",
+      "website":"",
+      "logo":"",
+      "individual":"",
+      "position":"",
+      "phone":"",
+      "address":""
+      
+      }</contactForDistribution>
+  <linkUrl>https://geoportal.georhena.eu/geoserver/society/ows</linkUrl>
+  <linkProtocol>OGC:WMS</linkProtocol>
+  <linkUrlProtocolOGCWMS>https://geoportal.georhena.eu/geoserver/society/ows</linkUrlProtocolOGCWMS>
+  <link type="object">{
+            "protocol":"OGC:WMS",
+            "mimeType":"",
+            
+              "urlObject": 
+            {"default":"https:\/\/geoportal.georhena.eu\/geoserver\/society\/ows", "langfre":"https:\/\/geoportal.georhena.eu\/geoserver\/society\/ows"}
+            ,
+            
+              "nameObject": 
+            {"default":"chateaux_rhenans", "langfre":"chateaux_rhenans"}
+            ,
+            
+              "descriptionObject": 
+            {"default":"Ch\u00E2teaux rh\u00E9nans du Rhin Sup\u00E9rieur - copie", "langfre":"Ch\u00E2teaux rh\u00E9nans du Rhin Sup\u00E9rieur - copie", "langger":"Burgen am Oberrhein - kopie"}
+            ,
+            
+            "function":"",
+            "applicationProfile":"",
+            "group": 0
+            }</link>
+  <linkUrl>https://geoportal.georhena.eu/geoserver/society/ows</linkUrl>
+  <linkProtocol>OGC:WFS</linkProtocol>
+  <linkUrlProtocolOGCWFS>https://geoportal.georhena.eu/geoserver/society/ows</linkUrlProtocolOGCWFS>
+  <link type="object">{
+            "protocol":"OGC:WFS",
+            "mimeType":"",
+            
+              "urlObject": 
+            {"default":"https:\/\/geoportal.georhena.eu\/geoserver\/society\/ows", "langfre":"https:\/\/geoportal.georhena.eu\/geoserver\/society\/ows"}
+            ,
+            
+              "nameObject": 
+            {"default":"society:chateaux_rhenans", "langfre":"society:chateaux_rhenans", "langger":"society:chateaux_rhenans"}
+            ,
+            
+              "descriptionObject": 
+            {"default":"Ch\u00E2teaux rh\u00E9nans du Rhin Sup\u00E9rieur", "langfre":"Ch\u00E2teaux rh\u00E9nans du Rhin Sup\u00E9rieur", "langger":"Burgen am Oberrhein"}
+            ,
+            
+            "function":"",
+            "applicationProfile":"",
+            "group": 0
+            }</link>
+  <linkUrl>https://geoportal.georhena.eu/geoserver/society/ows?request=GetFeature&amp;service=WFS&amp;typeName=chateaux_rhenans&amp;version=1.0.0&amp;outputFormat=SHAPE-ZIP</linkUrl>
+  <linkProtocol>WWW:DOWNLOAD-1.0-ftp--download</linkProtocol>
+  <linkUrlProtocolWWWDOWNLOAD10ftpdownload>https://geoportal.georhena.eu/geoserver/society/ows?request=GetFeature&amp;service=WFS&amp;typeName=chateaux_rhenans&amp;version=1.0.0&amp;outputFormat=SHAPE-ZIP</linkUrlProtocolWWWDOWNLOAD10ftpdownload>
+  <link type="object">{
+            "protocol":"WWW:DOWNLOAD-1.0-ftp--download",
+            "mimeType":"",
+            
+              "urlObject": 
+            {"default":"https:\/\/geoportal.georhena.eu\/geoserver\/society\/ows?request=GetFeature&amp;service=WFS&amp;typeName=chateaux_rhenans&amp;version=1.0.0&amp;outputFormat=SHAPE-ZIP", "langfre":"https:\/\/geoportal.georhena.eu\/geoserver\/society\/ows?request=GetFeature&amp;service=WFS&amp;typeName=chateaux_rhenans&amp;version=1.0.0&amp;outputFormat=SHAPE-ZIP"}
+            ,
+            
+              "nameObject": 
+            {"default":"T\u00E9l\u00E9chargement du Shapefile", "langfre":"T\u00E9l\u00E9chargement du Shapefile", "langeng":"T\u00E9l\u00E9chargement du Shapefile", "langeng":"T\u00E9l\u00E9chargement du Shapefile"}
+            ,
+            
+            "function":"",
+            "applicationProfile":"",
+            "group": 0
+            }</link>
+  <linkUrl>www.chateaux-rhenans.eu</linkUrl>
+  <linkProtocol>WWW:LINK-1.0-http--link</linkProtocol>
+  <linkUrlProtocolWWWLINK10httplink>www.chateaux-rhenans.eu</linkUrlProtocolWWWLINK10httplink>
+  <link type="object">{
+            "protocol":"WWW:LINK-1.0-http--link",
+            "mimeType":"",
+            
+              "urlObject": 
+            {"default":"www.chateaux-rhenans.eu", "langfre":"www.chateaux-rhenans.eu"}
+            ,
+            
+              "nameObject": 
+            {"default":"Site internet du projet \"Ch\u00E2teaux rh\u00E9nans\"", "langfre":"Site internet du projet \"Ch\u00E2teaux rh\u00E9nans\"", "langger":"Webseite des Projekts \"Rheinburgen\".", "langeng":"\"Rhine castles\" project website"}
+            ,
+            
+            "function":"",
+            "applicationProfile":"",
+            "group": 0
+            }</link>
+  <recordGroup>f74f5451-b198-4edf-abdd-a6b6b7caed81</recordGroup>
+</doc>
+

--- a/schemas/iso19115-3.2018/src/test/resources/UpperRhineCastles-iso19115-3.2018.xml
+++ b/schemas/iso19115-3.2018/src/test/resources/UpperRhineCastles-iso19115-3.2018.xml
@@ -1,0 +1,907 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mdb:MD_Metadata xmlns:mdb="http://standards.iso.org/iso/19115/-3/mdb/2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cat="http://standards.iso.org/iso/19115/-3/cat/1.0" xmlns:gfc="http://standards.iso.org/iso/19110/gfc/1.1" xmlns:cit="http://standards.iso.org/iso/19115/-3/cit/2.0" xmlns:gcx="http://standards.iso.org/iso/19115/-3/gcx/1.0" xmlns:gex="http://standards.iso.org/iso/19115/-3/gex/1.0" xmlns:lan="http://standards.iso.org/iso/19115/-3/lan/1.0" xmlns:srv="http://standards.iso.org/iso/19115/-3/srv/2.0" xmlns:mas="http://standards.iso.org/iso/19115/-3/mas/1.0" xmlns:mcc="http://standards.iso.org/iso/19115/-3/mcc/1.0" xmlns:mco="http://standards.iso.org/iso/19115/-3/mco/1.0" xmlns:mda="http://standards.iso.org/iso/19115/-3/mda/1.0" xmlns:mds="http://standards.iso.org/iso/19115/-3/mds/2.0" xmlns:mdt="http://standards.iso.org/iso/19115/-3/mdt/2.0" xmlns:mex="http://standards.iso.org/iso/19115/-3/mex/1.0" xmlns:mmi="http://standards.iso.org/iso/19115/-3/mmi/1.0" xmlns:mpc="http://standards.iso.org/iso/19115/-3/mpc/1.0" xmlns:mrc="http://standards.iso.org/iso/19115/-3/mrc/2.0" xmlns:mrd="http://standards.iso.org/iso/19115/-3/mrd/1.0" xmlns:mri="http://standards.iso.org/iso/19115/-3/mri/1.0" xmlns:mrl="http://standards.iso.org/iso/19115/-3/mrl/2.0" xmlns:mrs="http://standards.iso.org/iso/19115/-3/mrs/1.0" xmlns:msr="http://standards.iso.org/iso/19115/-3/msr/2.0" xmlns:mdq="http://standards.iso.org/iso/19157/-2/mdq/1.0" xmlns:dqm="http://standards.iso.org/iso/19157/-2/dqm/1.0" xmlns:mac="http://standards.iso.org/iso/19115/-3/mac/2.0" xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xlink="http://www.w3.org/1999/xlink">
+  <mdb:metadataIdentifier>
+    <mcc:MD_Identifier>
+      <mcc:code>
+        <gco:CharacterString>f74f5451-b198-4edf-abdd-a6b6b7caed81</gco:CharacterString>
+      </mcc:code>
+    </mcc:MD_Identifier>
+  </mdb:metadataIdentifier>
+  <mdb:defaultLocale>
+    <lan:PT_Locale>
+      <lan:language>
+        <lan:LanguageCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#LanguageCode" codeListValue="fre">fre</lan:LanguageCode>
+      </lan:language>
+      <lan:characterEncoding>
+        <lan:MD_CharacterSetCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_CharacterSetCode" codeListValue="utf8">utf8</lan:MD_CharacterSetCode>
+      </lan:characterEncoding>
+    </lan:PT_Locale>
+  </mdb:defaultLocale>
+  <mdb:metadataScope>
+    <mdb:MD_MetadataScope>
+      <mdb:resourceScope>
+        <mcc:MD_ScopeCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_ScopeCode" codeListValue="dataset">dataset</mcc:MD_ScopeCode>
+      </mdb:resourceScope>
+    </mdb:MD_MetadataScope>
+  </mdb:metadataScope>
+  <mdb:contact>
+    <cit:CI_Responsibility>
+      <cit:role>
+        <cit:CI_RoleCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_RoleCode" codeListValue="distributor">distributor</cit:CI_RoleCode>
+      </cit:role>
+      <cit:party>
+        <cit:CI_Organisation>
+          <cit:name xsi:type="lan:PT_FreeText_PropertyType">
+            <gco:CharacterString>GeoRhena: Système d'Information Géographique du Rhin Supérieur</gco:CharacterString>
+            <lan:PT_FreeText>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#FR">GeoRhena: Système d'Information Géographique du Rhin Supérieur</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#DE">GeoRhena: Geographische Informationssystem des Oberrheins</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#EN">GeoRhena: Geographical Information System of the Upper Rhine</lan:LocalisedCharacterString>
+              </lan:textGroup>
+            </lan:PT_FreeText>
+          </cit:name>
+          <cit:contactInfo>
+            <cit:CI_Contact>
+              <cit:phone>
+                <cit:CI_Telephone>
+                  <cit:number>
+                    <gco:CharacterString>00 33 3 89 30 63 91</gco:CharacterString>
+                  </cit:number>
+                  <cit:numberType>
+                    <cit:CI_TelephoneTypeCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_TelephoneTypeCode" codeListValue="facsimile">facsimile</cit:CI_TelephoneTypeCode>
+                  </cit:numberType>
+                </cit:CI_Telephone>
+              </cit:phone>
+              <cit:address>
+                <cit:CI_Address>
+                  <cit:deliveryPoint xsi:type="gmd:PT_FreeText_PropertyType">
+                    <gco:CharacterString>100, avenue d'Alsace</gco:CharacterString>
+                    <lan:PT_FreeText>
+                      <lan:textGroup>
+                        <lan:LocalisedCharacterString locale="#FR">100, avenue d'Alsace</lan:LocalisedCharacterString>
+                      </lan:textGroup>
+                      <lan:textGroup>
+                        <lan:LocalisedCharacterString locale="#EN">100, avenue d'Alsace</lan:LocalisedCharacterString>
+                      </lan:textGroup>
+                    </lan:PT_FreeText>
+                  </cit:deliveryPoint>
+                  <cit:city>
+                    <gco:CharacterString>COLMAR</gco:CharacterString>
+                  </cit:city>
+                  <cit:postalCode>
+                    <gco:CharacterString>68000</gco:CharacterString>
+                  </cit:postalCode>
+                  <cit:country xsi:type="gmd:PT_FreeText_PropertyType">
+                    <gco:CharacterString>FR</gco:CharacterString>
+                    <lan:PT_FreeText>
+                      <lan:textGroup>
+                        <lan:LocalisedCharacterString locale="#FR">FR</lan:LocalisedCharacterString>
+                      </lan:textGroup>
+                      <lan:textGroup>
+                        <lan:LocalisedCharacterString locale="#EN">FR</lan:LocalisedCharacterString>
+                      </lan:textGroup>
+                    </lan:PT_FreeText>
+                  </cit:country>
+                </cit:CI_Address>
+              </cit:address>
+              <cit:onlineResource>
+                <cit:CI_OnlineResource>
+                  <cit:linkage>
+                    <gco:CharacterString>http://www.georhena.eu</gco:CharacterString>
+                  </cit:linkage>
+                  <cit:protocol>
+                    <gco:CharacterString>text/html</gco:CharacterString>
+                  </cit:protocol>
+                </cit:CI_OnlineResource>
+              </cit:onlineResource>
+            </cit:CI_Contact>
+          </cit:contactInfo>
+        </cit:CI_Organisation>
+      </cit:party>
+    </cit:CI_Responsibility>
+  </mdb:contact>
+  <mdb:dateInfo>
+    <cit:CI_Date>
+      <cit:date>
+        <gco:DateTime>2025-06-18T14:55:30.520183Z</gco:DateTime>
+      </cit:date>
+      <cit:dateType>
+        <cit:CI_DateTypeCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_DateTypeCode" codeListValue="revision">revision</cit:CI_DateTypeCode>
+      </cit:dateType>
+    </cit:CI_Date>
+  </mdb:dateInfo>
+  <mdb:metadataStandard>
+    <cit:CI_Citation>
+      <cit:title>
+        <gco:CharacterString>ISO 19115-3:2018</gco:CharacterString>
+      </cit:title>
+      <cit:edition>
+        <gco:CharacterString>1.0</gco:CharacterString>
+      </cit:edition>
+    </cit:CI_Citation>
+  </mdb:metadataStandard>
+  <mdb:otherLocale>
+    <lan:PT_Locale id="DE">
+      <lan:language>
+        <lan:LanguageCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#LanguageCode" codeListValue="ger">ger</lan:LanguageCode>
+      </lan:language>
+      <lan:characterEncoding>
+        <lan:MD_CharacterSetCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_CharacterSetCode" codeListValue="utf8">utf8</lan:MD_CharacterSetCode>
+      </lan:characterEncoding>
+    </lan:PT_Locale>
+  </mdb:otherLocale>
+  <mdb:otherLocale>
+    <lan:PT_Locale id="EN">
+      <lan:language>
+        <lan:LanguageCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#LanguageCode" codeListValue="eng">eng</lan:LanguageCode>
+      </lan:language>
+      <lan:characterEncoding>
+        <lan:MD_CharacterSetCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_CharacterSetCode" codeListValue="utf8">utf8</lan:MD_CharacterSetCode>
+      </lan:characterEncoding>
+    </lan:PT_Locale>
+  </mdb:otherLocale>
+  <mdb:otherLocale>
+    <lan:PT_Locale id="FR">
+      <lan:language>
+        <lan:LanguageCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#LanguageCode" codeListValue="fre">fre</lan:LanguageCode>
+      </lan:language>
+      <lan:characterEncoding>
+        <lan:MD_CharacterSetCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_CharacterSetCode" codeListValue="utf8">utf8</lan:MD_CharacterSetCode>
+      </lan:characterEncoding>
+    </lan:PT_Locale>
+  </mdb:otherLocale>
+  <mdb:identificationInfo>
+    <mri:MD_DataIdentification>
+      <mri:citation>
+        <cit:CI_Citation>
+          <cit:title xsi:type="lan:PT_FreeText_PropertyType">
+            <gco:CharacterString>Châteaux rhénans</gco:CharacterString>
+            <lan:PT_FreeText>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#FR">Châteaux rhénans</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#DE">Burgen am Oberrhein</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#EN">Castles on the Upper Rhine</lan:LocalisedCharacterString>
+              </lan:textGroup>
+            </lan:PT_FreeText>
+          </cit:title>
+          <cit:date>
+            <cit:CI_Date>
+              <cit:date>
+                <gco:Date>2024-02-15</gco:Date>
+              </cit:date>
+              <cit:dateType>
+                <cit:CI_DateTypeCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_DateTypeCode" codeListValue="creation">creation</cit:CI_DateTypeCode>
+              </cit:dateType>
+            </cit:CI_Date>
+          </cit:date>
+          <cit:date>
+            <cit:CI_Date>
+              <cit:date>
+                <gco:Date>2024-03-14</gco:Date>
+              </cit:date>
+              <cit:dateType>
+                <cit:CI_DateTypeCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_DateTypeCode" codeListValue="publication">publication</cit:CI_DateTypeCode>
+              </cit:dateType>
+            </cit:CI_Date>
+          </cit:date>
+          <cit:date>
+            <cit:CI_Date>
+              <cit:date>
+                <gco:Date>2024-07-15</gco:Date>
+              </cit:date>
+              <cit:dateType>
+                <cit:CI_DateTypeCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_DateTypeCode" codeListValue="revision">revision</cit:CI_DateTypeCode>
+              </cit:dateType>
+            </cit:CI_Date>
+          </cit:date>
+        </cit:CI_Citation>
+      </mri:citation>
+      <mri:abstract xsi:type="lan:PT_FreeText_PropertyType">
+        <gco:CharacterString>Présentation des châteaux forts du Rhin Supérieur selon des données d’accessibilité d’itinérance, d’intérêt touristique, de billetterie ou encore d’offre de restauration. 
+Cette action bénéficie d’un cofinancement de l’UE dans le cadre du projet Interreg VI « Châteaux rhénans – Burgen am Oberrhein ».
+
+Site web du projet "Châteaux rhénans" : www.chateaux-rhenans.eu/fr</gco:CharacterString>
+        <lan:PT_FreeText>
+          <lan:textGroup>
+            <lan:LocalisedCharacterString locale="#FR">Présentation des châteaux forts du Rhin Supérieur selon des données d’accessibilité d’itinérance, d’intérêt touristique, de billetterie ou encore d’offre de restauration. 
+Cette action bénéficie d’un cofinancement de l’UE dans le cadre du projet Interreg VI « Châteaux rhénans – Burgen am Oberrhein ».
+
+Site web du projet "Châteaux rhénans" : www.chateaux-rhenans.eu/fr</lan:LocalisedCharacterString>
+          </lan:textGroup>
+          <lan:textGroup>
+            <lan:LocalisedCharacterString locale="#DE">Vorstellung der Burgen am Oberrhein anhand von Daten zur Zugänglichkeit der Wanderwege, zum touristischen Interesse, zum Ticketverkauf oder auch zum Gastronomieangebot. 
+Diese Aktion wird von der EU im Rahmen des Interreg VI-Projekts "Rheinische Burgen - Burgen am Oberrhein" kofinanziert.
+
+Website des Projekts "Burgen am Oberrhein" : www.chateaux-rhenans.eu/de</lan:LocalisedCharacterString>
+          </lan:textGroup>
+          <lan:textGroup>
+            <lan:LocalisedCharacterString locale="#EN">Presentation of the fortified castles of the Upper Rhine according to data on accessibility, itinerancy, tourist interest, ticketing and catering facilities. 
+This project is co-financed by the EU as part of the Interreg VI project "Châteaux rhénans - Burgen am Oberrhein".
+
+"Châteaux rhénans – Burgen am Oberrhein" project website: www.chateaux-rhenans.eu</lan:LocalisedCharacterString>
+          </lan:textGroup>
+        </lan:PT_FreeText>
+      </mri:abstract>
+      <mri:status>
+        <mcc:MD_ProgressCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_ProgressCode" codeListValue="completed">completed</mcc:MD_ProgressCode>
+      </mri:status>
+      <mri:pointOfContact>
+        <cit:CI_Responsibility>
+          <cit:role>
+            <cit:CI_RoleCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_RoleCode" codeListValue="pointOfContact">pointOfContact</cit:CI_RoleCode>
+          </cit:role>
+          <cit:party>
+            <cit:CI_Organisation>
+              <cit:name xsi:type="lan:PT_FreeText_PropertyType">
+                <gco:CharacterString>GeoRhena</gco:CharacterString>
+                <lan:PT_FreeText>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#FR">GeoRhena</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#DE">GeoRhena</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#EN">GeoRhena</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                </lan:PT_FreeText>
+              </cit:name>
+              <cit:contactInfo>
+                <cit:CI_Contact>
+                  <cit:phone>
+                    <cit:CI_Telephone>
+                      <cit:number>
+                        <gco:CharacterString>00 33 3 89 30 63 91</gco:CharacterString>
+                      </cit:number>
+                      <cit:numberType>
+                        <cit:CI_TelephoneTypeCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_TelephoneTypeCode" codeListValue="voice">voice</cit:CI_TelephoneTypeCode>
+                      </cit:numberType>
+                    </cit:CI_Telephone>
+                  </cit:phone>
+                  <cit:address>
+                    <cit:CI_Address>
+                      <cit:deliveryPoint xsi:type="gmd:PT_FreeText_PropertyType">
+                        <gco:CharacterString>100, avenue d'Alsace</gco:CharacterString>
+                        <lan:PT_FreeText>
+                          <lan:textGroup>
+                            <lan:LocalisedCharacterString locale="#FR">100, avenue d'Alsace</lan:LocalisedCharacterString>
+                          </lan:textGroup>
+                          <lan:textGroup>
+                            <lan:LocalisedCharacterString locale="#EN">100, avenue d'Alsace</lan:LocalisedCharacterString>
+                          </lan:textGroup>
+                        </lan:PT_FreeText>
+                      </cit:deliveryPoint>
+                      <cit:city>
+                        <gco:CharacterString>COLMAR</gco:CharacterString>
+                      </cit:city>
+                      <cit:postalCode>
+                        <gco:CharacterString>68000</gco:CharacterString>
+                      </cit:postalCode>
+                      <cit:country xsi:type="gmd:PT_FreeText_PropertyType">
+                        <gco:CharacterString>FRANCE</gco:CharacterString>
+                        <lan:PT_FreeText>
+                          <lan:textGroup>
+                            <lan:LocalisedCharacterString locale="#FR">FRANCE</lan:LocalisedCharacterString>
+                          </lan:textGroup>
+                          <lan:textGroup>
+                            <lan:LocalisedCharacterString locale="#EN">FRANCE</lan:LocalisedCharacterString>
+                          </lan:textGroup>
+                        </lan:PT_FreeText>
+                      </cit:country>
+                      <cit:electronicMailAddress xsi:type="gmd:PT_FreeText_PropertyType">
+                        <gco:CharacterString>contact@georhena.eu</gco:CharacterString>
+                        <lan:PT_FreeText>
+                          <lan:textGroup>
+                            <lan:LocalisedCharacterString locale="#FR">contact@georhena.eu</lan:LocalisedCharacterString>
+                          </lan:textGroup>
+                          <lan:textGroup>
+                            <lan:LocalisedCharacterString locale="#DE">contact@georhena.eu</lan:LocalisedCharacterString>
+                          </lan:textGroup>
+                          <lan:textGroup>
+                            <lan:LocalisedCharacterString locale="#EN">contact@georhena.eu</lan:LocalisedCharacterString>
+                          </lan:textGroup>
+                        </lan:PT_FreeText>
+                      </cit:electronicMailAddress>
+                    </cit:CI_Address>
+                  </cit:address>
+                  <cit:onlineResource>
+                    <cit:CI_OnlineResource>
+                      <cit:linkage>
+                        <gco:CharacterString>https://www.georhena.eu/</gco:CharacterString>
+                      </cit:linkage>
+                      <cit:protocol>
+                        <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
+                      </cit:protocol>
+                      <cit:name gco:nilReason="missing" xsi:type="gmd:PT_FreeText_PropertyType">
+                        <gco:CharacterString />
+                      </cit:name>
+                      <cit:description gco:nilReason="missing" xsi:type="gmd:PT_FreeText_PropertyType">
+                        <gco:CharacterString />
+                      </cit:description>
+                    </cit:CI_OnlineResource>
+                  </cit:onlineResource>
+                </cit:CI_Contact>
+              </cit:contactInfo>
+              <cit:individual>
+                <cit:CI_Individual>
+                  <cit:name xsi:type="lan:PT_FreeText_PropertyType">
+                    <gco:CharacterString>GeoRhena</gco:CharacterString>
+                    <lan:PT_FreeText>
+                      <lan:textGroup>
+                        <lan:LocalisedCharacterString locale="#FR">GeoRhena</lan:LocalisedCharacterString>
+                      </lan:textGroup>
+                      <lan:textGroup>
+                        <lan:LocalisedCharacterString locale="#DE">GeoRhena</lan:LocalisedCharacterString>
+                      </lan:textGroup>
+                      <lan:textGroup>
+                        <lan:LocalisedCharacterString locale="#EN">GeoRhena</lan:LocalisedCharacterString>
+                      </lan:textGroup>
+                    </lan:PT_FreeText>
+                  </cit:name>
+                </cit:CI_Individual>
+              </cit:individual>
+            </cit:CI_Organisation>
+          </cit:party>
+        </cit:CI_Responsibility>
+      </mri:pointOfContact>
+      <mri:pointOfContact>
+        <cit:CI_Responsibility>
+          <cit:role>
+            <cit:CI_RoleCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_RoleCode" codeListValue="custodian">custodian</cit:CI_RoleCode>
+          </cit:role>
+          <cit:party>
+            <cit:CI_Organisation>
+              <cit:name xsi:type="lan:PT_FreeText_PropertyType">
+                <gco:CharacterString>Collectivité Européenne d'Alsace</gco:CharacterString>
+                <lan:PT_FreeText>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#FR">Collectivité Européenne d'Alsace</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#DE">Collectivité Européenne d'Alsace</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#EN">Collectivité Européenne d'Alsace</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                </lan:PT_FreeText>
+              </cit:name>
+              <cit:contactInfo>
+                <cit:CI_Contact>
+                  <cit:address>
+                    <cit:CI_Address>
+                      <cit:electronicMailAddress xsi:type="gmd:PT_FreeText_PropertyType">
+                        <gco:CharacterString>info@chateaux-rhenans.eu</gco:CharacterString>
+                        <lan:PT_FreeText>
+                          <lan:textGroup>
+                            <lan:LocalisedCharacterString locale="#FR">info@chateaux-rhenans.eu</lan:LocalisedCharacterString>
+                          </lan:textGroup>
+                          <lan:textGroup>
+                            <lan:LocalisedCharacterString locale="#DE">info@chateaux-rhenans.eu</lan:LocalisedCharacterString>
+                          </lan:textGroup>
+                        </lan:PT_FreeText>
+                      </cit:electronicMailAddress>
+                    </cit:CI_Address>
+                  </cit:address>
+                  <cit:onlineResource>
+                    <cit:CI_OnlineResource>
+                      <cit:linkage>
+                        <gco:CharacterString>https://www.alsace.eu</gco:CharacterString>
+                      </cit:linkage>
+                      <cit:protocol>
+                        <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
+                      </cit:protocol>
+                      <cit:name gco:nilReason="missing" xsi:type="gmd:PT_FreeText_PropertyType">
+                        <gco:CharacterString />
+                      </cit:name>
+                      <cit:description gco:nilReason="missing" xsi:type="gmd:PT_FreeText_PropertyType">
+                        <gco:CharacterString />
+                      </cit:description>
+                    </cit:CI_OnlineResource>
+                  </cit:onlineResource>
+                </cit:CI_Contact>
+              </cit:contactInfo>
+            </cit:CI_Organisation>
+          </cit:party>
+        </cit:CI_Responsibility>
+      </mri:pointOfContact>
+      <mri:spatialRepresentationType>
+        <mcc:MD_SpatialRepresentationTypeCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_SpatialRepresentationTypeCode" codeListValue="vector">vector</mcc:MD_SpatialRepresentationTypeCode>
+      </mri:spatialRepresentationType>
+      <mri:spatialResolution>
+        <mri:MD_Resolution>
+          <mri:equivalentScale>
+            <mri:MD_RepresentativeFraction>
+              <mri:denominator>
+                <gco:Integer>100000</gco:Integer>
+              </mri:denominator>
+            </mri:MD_RepresentativeFraction>
+          </mri:equivalentScale>
+        </mri:MD_Resolution>
+      </mri:spatialResolution>
+      <mri:topicCategory>
+        <mri:MD_TopicCategoryCode>society</mri:MD_TopicCategoryCode>
+      </mri:topicCategory>
+      <mri:extent>
+        <gex:EX_Extent>
+          <gex:temporalElement>
+            <gex:EX_TemporalExtent>
+              <gex:extent>
+                <TimePeriod xmlns="http://www.opengis.net/gml/3.2" gml:id="d600e429a1052958">
+                  <beginPosition>2023-12-15</beginPosition>
+                  <endPosition>2024-02-15</endPosition>
+                </TimePeriod>
+              </gex:extent>
+            </gex:EX_TemporalExtent>
+          </gex:temporalElement>
+        </gex:EX_Extent>
+      </mri:extent>
+      <mri:extent>
+        <gex:EX_Extent>
+          <gex:geographicElement>
+            <gex:EX_GeographicBoundingBox>
+              <gex:westBoundLongitude>
+                <gco:Decimal>7.009277343750001</gco:Decimal>
+              </gex:westBoundLongitude>
+              <gex:eastBoundLongitude>
+                <gco:Decimal>8.745117187500002</gco:Decimal>
+              </gex:eastBoundLongitude>
+              <gex:southBoundLatitude>
+                <gco:Decimal>47.346267182053</gco:Decimal>
+              </gex:southBoundLatitude>
+              <gex:northBoundLatitude>
+                <gco:Decimal>49.31079887964631</gco:Decimal>
+              </gex:northBoundLatitude>
+            </gex:EX_GeographicBoundingBox>
+          </gex:geographicElement>
+        </gex:EX_Extent>
+      </mri:extent>
+      <mri:resourceMaintenance>
+        <mmi:MD_MaintenanceInformation>
+          <mmi:maintenanceAndUpdateFrequency>
+            <mmi:MD_MaintenanceFrequencyCode codeListValue="asNeeded" codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_MaintenanceFrequencyCode" />
+          </mmi:maintenanceAndUpdateFrequency>
+        </mmi:MD_MaintenanceInformation>
+      </mri:resourceMaintenance>
+      <mri:graphicOverview>
+        <mcc:MD_BrowseGraphic>
+          <mcc:fileName>
+            <gco:CharacterString>https://geoportal.georhena.eu/geonetwork/srv/api/records/f74f5451-b198-4edf-abdd-a6b6b7caed81/attachments/chateaux_rhenans.jpeg</gco:CharacterString>
+          </mcc:fileName>
+          <mcc:fileDescription xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>chateaux_rhenans.jpeg</gco:CharacterString>
+            <lan:PT_FreeText>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#FR">chateaux_rhenans.jpeg</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#DE">chateaux_rhenans.jpeg</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#EN">chateaux_rhenans.jpeg</lan:LocalisedCharacterString>
+              </lan:textGroup>
+            </lan:PT_FreeText>
+          </mcc:fileDescription>
+        </mcc:MD_BrowseGraphic>
+      </mri:graphicOverview>
+      <mri:descriptiveKeywords>
+        <mri:MD_Keywords>
+          <mri:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Rhin Supérieur</gco:CharacterString>
+            <lan:PT_FreeText>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#FR">Rhin Supérieur</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#DE">Oberrhein</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#EN">Upper Rhine</lan:LocalisedCharacterString>
+              </lan:textGroup>
+            </lan:PT_FreeText>
+          </mri:keyword>
+          <mri:type>
+            <mri:MD_KeywordTypeCode codeListValue="place" codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_KeywordTypeCode" />
+          </mri:type>
+        </mri:MD_Keywords>
+      </mri:descriptiveKeywords>
+      <mri:descriptiveKeywords>
+        <mri:MD_Keywords>
+          <mri:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>gestion patrimoniale</gco:CharacterString>
+            <lan:PT_FreeText>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#FR">gestion patrimoniale</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#DE">Erbherrliches Management</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#EN">patrimonial management</lan:LocalisedCharacterString>
+              </lan:textGroup>
+            </lan:PT_FreeText>
+          </mri:keyword>
+          <mri:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>tourisme</gco:CharacterString>
+            <lan:PT_FreeText>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#FR">tourisme</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#DE">Fremdenverkehr</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#EN">tourism</lan:LocalisedCharacterString>
+              </lan:textGroup>
+            </lan:PT_FreeText>
+          </mri:keyword>
+          <mri:type>
+            <mri:MD_KeywordTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="theme" />
+          </mri:type>
+          <mri:thesaurusName>
+            <cit:CI_Citation>
+              <cit:title xsi:type="lan:PT_FreeText_PropertyType">
+                <gco:CharacterString>GEMET - Concepts, version 2.4</gco:CharacterString>
+                <lan:PT_FreeText>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#FR">GEMET - Concepts, version 2.4</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                </lan:PT_FreeText>
+              </cit:title>
+              <cit:date>
+                <cit:CI_Date>
+                  <cit:date>
+                    <gco:Date>2010-01-13</gco:Date>
+                  </cit:date>
+                  <cit:dateType>
+                    <cit:CI_DateTypeCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_DateTypeCode" codeListValue="publication">publication</cit:CI_DateTypeCode>
+                  </cit:dateType>
+                </cit:CI_Date>
+              </cit:date>
+              <cit:identifier>
+                <mcc:MD_Identifier>
+                  <mcc:code>
+                    <gcx:Anchor xlink:href="https://geoportal.georhena.eu/geonetwork/srv/api/registries/vocabularies/external.theme.gemet">geonetwork.thesaurus.external.theme.gemet</gcx:Anchor>
+                  </mcc:code>
+                </mcc:MD_Identifier>
+              </cit:identifier>
+            </cit:CI_Citation>
+          </mri:thesaurusName>
+        </mri:MD_Keywords>
+      </mri:descriptiveKeywords>
+      <mri:descriptiveKeywords>
+        <mri:MD_Keywords>
+          <mri:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Châteaux forts</gco:CharacterString>
+            <lan:PT_FreeText>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#FR">Châteaux forts</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#DE">Burgen und Schlösser</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#EN">Fortified castles</lan:LocalisedCharacterString>
+              </lan:textGroup>
+            </lan:PT_FreeText>
+          </mri:keyword>
+          <mri:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Patrimoine castral</gco:CharacterString>
+            <lan:PT_FreeText>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#FR">Patrimoine castral</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#DE">Kastralisches Kulturerbe</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#EN">Castral heritage</lan:LocalisedCharacterString>
+              </lan:textGroup>
+            </lan:PT_FreeText>
+          </mri:keyword>
+          <mri:type>
+            <mri:MD_KeywordTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="theme" />
+          </mri:type>
+        </mri:MD_Keywords>
+      </mri:descriptiveKeywords>
+      <mri:resourceConstraints>
+        <mco:MD_Constraints>
+          <mco:useLimitation xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Licence CC-BY - ©CeA ; ©GeoRhena</gco:CharacterString>
+            <lan:PT_FreeText>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#FR">Licence CC-BY - ©CeA ; ©GeoRhena</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#DE">Lizenz CC-BY - ©CeA ; ©GeoRhena</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#EN">Licence CC-BY - ©CeA ; ©GeoRhena</lan:LocalisedCharacterString>
+              </lan:textGroup>
+            </lan:PT_FreeText>
+          </mco:useLimitation>
+        </mco:MD_Constraints>
+      </mri:resourceConstraints>
+      <mri:resourceConstraints>
+        <mco:MD_LegalConstraints>
+          <mco:accessConstraints>
+            <mco:MD_RestrictionCode codeListValue="otherRestrictions" codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode" />
+          </mco:accessConstraints>
+          <mco:useConstraints>
+            <mco:MD_RestrictionCode codeListValue="otherRestrictions" codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode" />
+          </mco:useConstraints>
+          <mco:otherConstraints xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Pas d'autre limitation</gco:CharacterString>
+            <lan:PT_FreeText>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#FR">Pas d'autre limitation</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#DE">Keine andere Einschränkung</lan:LocalisedCharacterString>
+              </lan:textGroup>
+              <lan:textGroup>
+                <lan:LocalisedCharacterString locale="#EN">No other limitation</lan:LocalisedCharacterString>
+              </lan:textGroup>
+            </lan:PT_FreeText>
+          </mco:otherConstraints>
+        </mco:MD_LegalConstraints>
+      </mri:resourceConstraints>
+      <mri:defaultLocale>
+        <lan:PT_Locale>
+          <lan:language>
+            <lan:LanguageCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#LanguageCode" codeListValue="fre">fre</lan:LanguageCode>
+          </lan:language>
+          <lan:characterEncoding>
+            <lan:MD_CharacterSetCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_CharacterSetCode" codeListValue="utf8">utf8</lan:MD_CharacterSetCode>
+          </lan:characterEncoding>
+        </lan:PT_Locale>
+      </mri:defaultLocale>
+      <mri:defaultLocale>
+        <lan:PT_Locale>
+          <lan:language>
+            <lan:LanguageCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#LanguageCode" codeListValue="ger">ger</lan:LanguageCode>
+          </lan:language>
+          <lan:characterEncoding>
+            <lan:MD_CharacterSetCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_CharacterSetCode" codeListValue="utf8">utf8</lan:MD_CharacterSetCode>
+          </lan:characterEncoding>
+        </lan:PT_Locale>
+      </mri:defaultLocale>
+    </mri:MD_DataIdentification>
+  </mdb:identificationInfo>
+  <mdb:distributionInfo>
+    <mrd:MD_Distribution>
+      <mrd:distributionFormat>
+        <mrd:MD_Format>
+          <mrd:formatSpecificationCitation>
+            <cit:CI_Citation>
+              <cit:title xsi:type="lan:PT_FreeText_PropertyType">
+                <gco:CharacterString>Géodonnée au format SHP</gco:CharacterString>
+                <lan:PT_FreeText>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#FR">Géodonnée au format SHP</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#DE">GeoDatei im SHP Format</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#EN">SHP GeoData</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                </lan:PT_FreeText>
+              </cit:title>
+              <cit:date gco:nilReason="unknown" />
+              <cit:edition>
+                <gco:CharacterString>-</gco:CharacterString>
+              </cit:edition>
+            </cit:CI_Citation>
+          </mrd:formatSpecificationCitation>
+        </mrd:MD_Format>
+      </mrd:distributionFormat>
+      <mrd:distributor>
+        <mrd:MD_Distributor>
+          <mrd:distributorContact>
+            <cit:CI_Responsibility>
+              <cit:role>
+                <cit:CI_RoleCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_RoleCode" codeListValue="publisher">publisher</cit:CI_RoleCode>
+              </cit:role>
+              <cit:party>
+                <cit:CI_Organisation>
+                  <cit:name xsi:type="lan:PT_FreeText_PropertyType">
+                    <gco:CharacterString>GeoRhena</gco:CharacterString>
+                    <lan:PT_FreeText>
+                      <lan:textGroup>
+                        <lan:LocalisedCharacterString locale="#FR">GeoRhena</lan:LocalisedCharacterString>
+                      </lan:textGroup>
+                    </lan:PT_FreeText>
+                  </cit:name>
+                  <cit:contactInfo>
+                    <cit:CI_Contact>
+                      <cit:address>
+                        <cit:CI_Address>
+                          <cit:electronicMailAddress gco:nilReason="missing" xsi:type="gmd:PT_FreeText_PropertyType">
+                            <gco:CharacterString />
+                          </cit:electronicMailAddress>
+                        </cit:CI_Address>
+                      </cit:address>
+                    </cit:CI_Contact>
+                  </cit:contactInfo>
+                  <cit:individual>
+                    <cit:CI_Individual>
+                      <cit:name gco:nilReason="missing">
+                        <gco:CharacterString />
+                      </cit:name>
+                    </cit:CI_Individual>
+                  </cit:individual>
+                </cit:CI_Organisation>
+              </cit:party>
+            </cit:CI_Responsibility>
+          </mrd:distributorContact>
+        </mrd:MD_Distributor>
+      </mrd:distributor>
+      <mrd:transferOptions>
+        <mrd:MD_DigitalTransferOptions>
+          <mrd:onLine>
+            <cit:CI_OnlineResource>
+              <cit:linkage>
+                <gco:CharacterString>https://geoportal.georhena.eu/geoserver/society/ows</gco:CharacterString>
+              </cit:linkage>
+              <cit:protocol>
+                <gco:CharacterString>OGC:WMS</gco:CharacterString>
+              </cit:protocol>
+              <cit:name xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>chateaux_rhenans</gco:CharacterString>
+                <lan:PT_FreeText>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#FR">chateaux_rhenans</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#DE" />
+                  </lan:textGroup>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#EN" />
+                  </lan:textGroup>
+                </lan:PT_FreeText>
+              </cit:name>
+              <cit:description xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>Châteaux rhénans du Rhin Supérieur - copie</gco:CharacterString>
+                <lan:PT_FreeText>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#FR">Châteaux rhénans du Rhin Supérieur - copie</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#DE">Burgen am Oberrhein - kopie</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#EN" />
+                  </lan:textGroup>
+                </lan:PT_FreeText>
+              </cit:description>
+            </cit:CI_OnlineResource>
+          </mrd:onLine>
+          <mrd:onLine>
+            <cit:CI_OnlineResource>
+              <cit:linkage>
+                <gco:CharacterString>https://geoportal.georhena.eu/geoserver/society/ows</gco:CharacterString>
+              </cit:linkage>
+              <cit:protocol>
+                <gco:CharacterString>OGC:WFS</gco:CharacterString>
+              </cit:protocol>
+              <cit:name xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>society:chateaux_rhenans</gco:CharacterString>
+                <lan:PT_FreeText>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#FR">society:chateaux_rhenans</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#DE">society:chateaux_rhenans</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#EN" />
+                  </lan:textGroup>
+                </lan:PT_FreeText>
+              </cit:name>
+              <cit:description xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>Châteaux rhénans du Rhin Supérieur</gco:CharacterString>
+                <lan:PT_FreeText>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#FR">Châteaux rhénans du Rhin Supérieur</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#DE">Burgen am Oberrhein</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#EN" />
+                  </lan:textGroup>
+                </lan:PT_FreeText>
+              </cit:description>
+            </cit:CI_OnlineResource>
+          </mrd:onLine>
+          <mrd:onLine>
+            <cit:CI_OnlineResource>
+              <cit:linkage>
+                <gco:CharacterString>https://geoportal.georhena.eu/geoserver/society/ows?request=GetFeature&amp;service=WFS&amp;typeName=chateaux_rhenans&amp;version=1.0.0&amp;outputFormat=SHAPE-ZIP</gco:CharacterString>
+              </cit:linkage>
+              <cit:protocol>
+                <gco:CharacterString>WWW:DOWNLOAD-1.0-ftp--download</gco:CharacterString>
+              </cit:protocol>
+              <cit:name xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>Téléchargement du Shapefile</gco:CharacterString>
+                <lan:PT_FreeText>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#FR">Téléchargement du Shapefile</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#EN">Téléchargement du Shapefile</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#EN">Téléchargement du Shapefile</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                </lan:PT_FreeText>
+              </cit:name>
+            </cit:CI_OnlineResource>
+          </mrd:onLine>
+          <mrd:onLine>
+            <cit:CI_OnlineResource>
+              <cit:linkage>
+                <gco:CharacterString>www.chateaux-rhenans.eu</gco:CharacterString>
+              </cit:linkage>
+              <cit:protocol>
+                <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
+              </cit:protocol>
+              <cit:name xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>Site internet du projet "Châteaux rhénans"</gco:CharacterString>
+                <lan:PT_FreeText>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#FR">Site internet du projet "Châteaux rhénans"</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#DE">Webseite des Projekts "Rheinburgen".</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                  <lan:textGroup>
+                    <lan:LocalisedCharacterString locale="#EN">"Rhine castles" project website</lan:LocalisedCharacterString>
+                  </lan:textGroup>
+                </lan:PT_FreeText>
+              </cit:name>
+              <cit:description gco:nilReason="missing" xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString />
+              </cit:description>
+            </cit:CI_OnlineResource>
+          </mrd:onLine>
+        </mrd:MD_DigitalTransferOptions>
+      </mrd:transferOptions>
+    </mrd:MD_Distribution>
+  </mdb:distributionInfo>
+  <mdb:resourceLineage>
+    <mrl:LI_Lineage>
+      <mrl:statement xsi:type="lan:PT_FreeText_PropertyType">
+        <gco:CharacterString>Recensement des châteaux forts à partir de données collectées auprès d’institutions culturelles ou touristiques partenaires dans le cadre du projet Châteaux rhénans.</gco:CharacterString>
+        <lan:PT_FreeText>
+          <lan:textGroup>
+            <lan:LocalisedCharacterString locale="#FR">Recensement des châteaux forts à partir de données collectées auprès d’institutions culturelles ou touristiques partenaires dans le cadre du projet Châteaux rhénans.</lan:LocalisedCharacterString>
+          </lan:textGroup>
+          <lan:textGroup>
+            <lan:LocalisedCharacterString locale="#DE">Erfassung von Burgen und Schlössern anhand von Daten, die bei kulturellen oder touristischen Partnerinstitutionen im Rahmen des Projekts Rheinburgen gesammelt wurden.</lan:LocalisedCharacterString>
+          </lan:textGroup>
+          <lan:textGroup>
+            <lan:LocalisedCharacterString locale="#EN">Inventory of castles based on data collected from partner cultural and tourist institutions as part of the Châteaux rhénans project.</lan:LocalisedCharacterString>
+          </lan:textGroup>
+        </lan:PT_FreeText>
+      </mrl:statement>
+      <mrl:scope>
+        <mcc:MD_Scope>
+          <mcc:level>
+            <mcc:MD_ScopeCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_ScopeCode" codeListValue="dataset">dataset</mcc:MD_ScopeCode>
+          </mcc:level>
+        </mcc:MD_Scope>
+      </mrl:scope>
+    </mrl:LI_Lineage>
+  </mdb:resourceLineage>
+</mdb:MD_Metadata>
+

--- a/schemas/iso19115-3.2018/src/test/resources/UpperRhineCastles-iso19115-3.2018.xml
+++ b/schemas/iso19115-3.2018/src/test/resources/UpperRhineCastles-iso19115-3.2018.xml
@@ -664,7 +664,7 @@ This project is co-financed by the EU as part of the Interreg VI project "Châte
           </lan:characterEncoding>
         </lan:PT_Locale>
       </mri:defaultLocale>
-      <mri:defaultLocale>
+      <mri:otherLocale>
         <lan:PT_Locale>
           <lan:language>
             <lan:LanguageCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#LanguageCode" codeListValue="ger">ger</lan:LanguageCode>
@@ -673,7 +673,7 @@ This project is co-financed by the EU as part of the Interreg VI project "Châte
             <lan:MD_CharacterSetCode codeList="https://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_CharacterSetCode" codeListValue="utf8">utf8</lan:MD_CharacterSetCode>
           </lan:characterEncoding>
         </lan:PT_Locale>
-      </mri:defaultLocale>
+      </mri:otherLocale>
     </mri:MD_DataIdentification>
   </mdb:identificationInfo>
   <mdb:distributionInfo>

--- a/schemas/iso19115-3.2018/src/test/resources/UpperRhineCastles-iso19139.xml
+++ b/schemas/iso19115-3.2018/src/test/resources/UpperRhineCastles-iso19139.xml
@@ -1,0 +1,842 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<gmd:MD_Metadata xmlns:gmd="http://www.isotc211.org/2005/gmd" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:gco="http://www.isotc211.org/2005/gco" xmlns:srv="http://www.isotc211.org/2005/srv" xmlns:gmx="http://www.isotc211.org/2005/gmx" xmlns:gts="http://www.isotc211.org/2005/gts" xmlns:gsr="http://www.isotc211.org/2005/gsr" xmlns:gmi="http://www.isotc211.org/2005/gmi" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xlink="http://www.w3.org/1999/xlink" xsi:schemaLocation="http://www.isotc211.org/2005/gmd http://schemas.opengis.net/csw/2.0.2/profiles/apiso/1.0.0/apiso.xsd">
+  <gmd:fileIdentifier>
+    <gco:CharacterString>f74f5451-b198-4edf-abdd-a6b6b7caed81</gco:CharacterString>
+  </gmd:fileIdentifier>
+  <gmd:language>
+    <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="fre" />
+  </gmd:language>
+  <gmd:characterSet>
+    <gmd:MD_CharacterSetCode codeListValue="utf8" codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_CharacterSetCode" />
+  </gmd:characterSet>
+  <gmd:hierarchyLevel>
+    <gmd:MD_ScopeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_ScopeCode" codeListValue="dataset" />
+  </gmd:hierarchyLevel>
+  <gmd:contact>
+    <gmd:CI_ResponsibleParty>
+      <gmd:organisationName xsi:type="gmd:PT_FreeText_PropertyType">
+        <gco:CharacterString>GeoRhena: Système d'Information Géographique du Rhin Supérieur</gco:CharacterString>
+        <gmd:PT_FreeText>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#FR">GeoRhena: Système d'Information Géographique du Rhin Supérieur</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#DE">GeoRhena: Geographische Informationssystem des Oberrheins</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#EN">GeoRhena: Geographical Information System of the Upper Rhine</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+        </gmd:PT_FreeText>
+      </gmd:organisationName>
+      <gmd:contactInfo>
+        <gmd:CI_Contact>
+          <gmd:phone>
+            <gmd:CI_Telephone>
+              <gmd:facsimile>
+                <gco:CharacterString>00 33 3 89 30 63 91</gco:CharacterString>
+              </gmd:facsimile>
+            </gmd:CI_Telephone>
+          </gmd:phone>
+          <gmd:address>
+            <gmd:CI_Address>
+              <gmd:deliveryPoint xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>100, avenue d'Alsace</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#FR">100, avenue d'Alsace</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#EN">100, avenue d'Alsace</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </gmd:deliveryPoint>
+              <gmd:city>
+                <gco:CharacterString>COLMAR</gco:CharacterString>
+              </gmd:city>
+              <gmd:postalCode>
+                <gco:CharacterString>68000</gco:CharacterString>
+              </gmd:postalCode>
+              <gmd:country xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>FR</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#FR">FR</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#EN">FR</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </gmd:country>
+            </gmd:CI_Address>
+          </gmd:address>
+          <gmd:onlineResource>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage>
+                <gmd:URL>http://www.georhena.eu</gmd:URL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gco:CharacterString>text/html</gco:CharacterString>
+              </gmd:protocol>
+            </gmd:CI_OnlineResource>
+          </gmd:onlineResource>
+        </gmd:CI_Contact>
+      </gmd:contactInfo>
+      <gmd:role>
+        <gmd:CI_RoleCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_RoleCode" codeListValue="distributor" />
+      </gmd:role>
+    </gmd:CI_ResponsibleParty>
+  </gmd:contact>
+  <gmd:dateStamp>
+    <gco:DateTime>2025-06-18T14:55:30.520183Z</gco:DateTime>
+  </gmd:dateStamp>
+  <gmd:metadataStandardName>
+    <gco:CharacterString>ISO 19115:2003/19139</gco:CharacterString>
+  </gmd:metadataStandardName>
+  <gmd:metadataStandardVersion>
+    <gco:CharacterString>1.0</gco:CharacterString>
+  </gmd:metadataStandardVersion>
+  <gmd:locale>
+    <gmd:PT_Locale id="DE">
+      <gmd:languageCode>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="ger" />
+      </gmd:languageCode>
+      <gmd:characterEncoding>
+        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8" />
+      </gmd:characterEncoding>
+    </gmd:PT_Locale>
+  </gmd:locale>
+  <gmd:locale>
+    <gmd:PT_Locale id="EN">
+      <gmd:languageCode>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="eng" />
+      </gmd:languageCode>
+      <gmd:characterEncoding>
+        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8" />
+      </gmd:characterEncoding>
+    </gmd:PT_Locale>
+  </gmd:locale>
+  <gmd:locale>
+    <gmd:PT_Locale id="FR">
+      <gmd:languageCode>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="fre" />
+      </gmd:languageCode>
+      <gmd:characterEncoding>
+        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8" />
+      </gmd:characterEncoding>
+    </gmd:PT_Locale>
+  </gmd:locale>
+  <gmd:identificationInfo>
+    <gmd:MD_DataIdentification>
+      <gmd:citation>
+        <gmd:CI_Citation>
+          <gmd:title xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Châteaux rhénans</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Châteaux rhénans</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Burgen am Oberrhein</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">Castles on the Upper Rhine</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:title>
+          <gmd:date>
+            <gmd:CI_Date>
+              <gmd:date>
+                <gco:Date>2024-02-15</gco:Date>
+              </gmd:date>
+              <gmd:dateType>
+                <gmd:CI_DateTypeCode codeListValue="creation" codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode" />
+              </gmd:dateType>
+            </gmd:CI_Date>
+          </gmd:date>
+          <gmd:date>
+            <gmd:CI_Date>
+              <gmd:date>
+                <gco:Date>2024-03-14</gco:Date>
+              </gmd:date>
+              <gmd:dateType>
+                <gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication" />
+              </gmd:dateType>
+            </gmd:CI_Date>
+          </gmd:date>
+          <gmd:date>
+            <gmd:CI_Date>
+              <gmd:date>
+                <gco:Date>2024-07-15</gco:Date>
+              </gmd:date>
+              <gmd:dateType>
+                <gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode" codeListValue="revision" />
+              </gmd:dateType>
+            </gmd:CI_Date>
+          </gmd:date>
+        </gmd:CI_Citation>
+      </gmd:citation>
+      <gmd:abstract xsi:type="gmd:PT_FreeText_PropertyType">
+        <gco:CharacterString>Présentation des châteaux forts du Rhin Supérieur selon des données d’accessibilité d’itinérance, d’intérêt touristique, de billetterie ou encore d’offre de restauration. 
+Cette action bénéficie d’un cofinancement de l’UE dans le cadre du projet Interreg VI « Châteaux rhénans – Burgen am Oberrhein ».
+
+Site web du projet "Châteaux rhénans" : www.chateaux-rhenans.eu/fr</gco:CharacterString>
+        <gmd:PT_FreeText>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#FR">Présentation des châteaux forts du Rhin Supérieur selon des données d’accessibilité d’itinérance, d’intérêt touristique, de billetterie ou encore d’offre de restauration. 
+Cette action bénéficie d’un cofinancement de l’UE dans le cadre du projet Interreg VI « Châteaux rhénans – Burgen am Oberrhein ».
+
+Site web du projet "Châteaux rhénans" : www.chateaux-rhenans.eu/fr</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#DE">Vorstellung der Burgen am Oberrhein anhand von Daten zur Zugänglichkeit der Wanderwege, zum touristischen Interesse, zum Ticketverkauf oder auch zum Gastronomieangebot. 
+Diese Aktion wird von der EU im Rahmen des Interreg VI-Projekts "Rheinische Burgen - Burgen am Oberrhein" kofinanziert.
+
+Website des Projekts "Burgen am Oberrhein" : www.chateaux-rhenans.eu/de</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+          <gmd:textGroup>
+            <gmd:LocalisedCharacterString locale="#EN">Presentation of the fortified castles of the Upper Rhine according to data on accessibility, itinerancy, tourist interest, ticketing and catering facilities. 
+This project is co-financed by the EU as part of the Interreg VI project "Châteaux rhénans - Burgen am Oberrhein".
+
+"Châteaux rhénans – Burgen am Oberrhein" project website: www.chateaux-rhenans.eu</gmd:LocalisedCharacterString>
+          </gmd:textGroup>
+        </gmd:PT_FreeText>
+      </gmd:abstract>
+      <gmd:status>
+        <gmd:MD_ProgressCode codeListValue="completed" codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_ProgressCode" />
+      </gmd:status>
+      <gmd:pointOfContact>
+        <gmd:CI_ResponsibleParty>
+          <gmd:individualName xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>GeoRhena</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">GeoRhena</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">GeoRhena</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">GeoRhena</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:individualName>
+          <gmd:organisationName xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>GeoRhena</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">GeoRhena</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">GeoRhena</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">GeoRhena</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:organisationName>
+          <gmd:contactInfo>
+            <gmd:CI_Contact>
+              <gmd:phone>
+                <gmd:CI_Telephone>
+                  <gmd:voice>
+                    <gco:CharacterString>00 33 3 89 30 63 91</gco:CharacterString>
+                  </gmd:voice>
+                </gmd:CI_Telephone>
+              </gmd:phone>
+              <gmd:address>
+                <gmd:CI_Address>
+                  <gmd:deliveryPoint xsi:type="gmd:PT_FreeText_PropertyType">
+                    <gco:CharacterString>100, avenue d'Alsace</gco:CharacterString>
+                    <gmd:PT_FreeText>
+                      <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#FR">100, avenue d'Alsace</gmd:LocalisedCharacterString>
+                      </gmd:textGroup>
+                      <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#EN">100, avenue d'Alsace</gmd:LocalisedCharacterString>
+                      </gmd:textGroup>
+                    </gmd:PT_FreeText>
+                  </gmd:deliveryPoint>
+                  <gmd:city>
+                    <gco:CharacterString>COLMAR</gco:CharacterString>
+                  </gmd:city>
+                  <gmd:postalCode>
+                    <gco:CharacterString>68000</gco:CharacterString>
+                  </gmd:postalCode>
+                  <gmd:country xsi:type="gmd:PT_FreeText_PropertyType">
+                    <gco:CharacterString>FRANCE</gco:CharacterString>
+                    <gmd:PT_FreeText>
+                      <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#FR">FRANCE</gmd:LocalisedCharacterString>
+                      </gmd:textGroup>
+                      <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#EN">FRANCE</gmd:LocalisedCharacterString>
+                      </gmd:textGroup>
+                    </gmd:PT_FreeText>
+                  </gmd:country>
+                  <gmd:electronicMailAddress xsi:type="gmd:PT_FreeText_PropertyType">
+                    <gco:CharacterString>contact@georhena.eu</gco:CharacterString>
+                    <gmd:PT_FreeText>
+                      <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#FR">contact@georhena.eu</gmd:LocalisedCharacterString>
+                      </gmd:textGroup>
+                      <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#DE">contact@georhena.eu</gmd:LocalisedCharacterString>
+                      </gmd:textGroup>
+                      <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#EN">contact@georhena.eu</gmd:LocalisedCharacterString>
+                      </gmd:textGroup>
+                    </gmd:PT_FreeText>
+                  </gmd:electronicMailAddress>
+                </gmd:CI_Address>
+              </gmd:address>
+              <gmd:onlineResource>
+                <gmd:CI_OnlineResource>
+                  <gmd:linkage>
+                    <gmd:URL>https://www.georhena.eu/</gmd:URL>
+                  </gmd:linkage>
+                  <gmd:protocol>
+                    <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
+                  </gmd:protocol>
+                  <gmd:name gco:nilReason="missing" xsi:type="gmd:PT_FreeText_PropertyType">
+                    <gco:CharacterString />
+                  </gmd:name>
+                  <gmd:description gco:nilReason="missing" xsi:type="gmd:PT_FreeText_PropertyType">
+                    <gco:CharacterString />
+                  </gmd:description>
+                </gmd:CI_OnlineResource>
+              </gmd:onlineResource>
+            </gmd:CI_Contact>
+          </gmd:contactInfo>
+          <gmd:role>
+            <gmd:CI_RoleCode codeListValue="pointOfContact" codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_RoleCode" />
+          </gmd:role>
+        </gmd:CI_ResponsibleParty>
+      </gmd:pointOfContact>
+      <gmd:pointOfContact>
+        <gmd:CI_ResponsibleParty>
+          <gmd:organisationName xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Collectivité Européenne d'Alsace</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Collectivité Européenne d'Alsace</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Collectivité Européenne d'Alsace</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">Collectivité Européenne d'Alsace</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:organisationName>
+          <gmd:contactInfo>
+            <gmd:CI_Contact>
+              <gmd:address>
+                <gmd:CI_Address>
+                  <gmd:electronicMailAddress xsi:type="gmd:PT_FreeText_PropertyType">
+                    <gco:CharacterString>info@chateaux-rhenans.eu</gco:CharacterString>
+                    <gmd:PT_FreeText>
+                      <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#FR">info@chateaux-rhenans.eu</gmd:LocalisedCharacterString>
+                      </gmd:textGroup>
+                      <gmd:textGroup>
+                        <gmd:LocalisedCharacterString locale="#DE">info@chateaux-rhenans.eu</gmd:LocalisedCharacterString>
+                      </gmd:textGroup>
+                    </gmd:PT_FreeText>
+                  </gmd:electronicMailAddress>
+                </gmd:CI_Address>
+              </gmd:address>
+              <gmd:onlineResource>
+                <gmd:CI_OnlineResource>
+                  <gmd:linkage>
+                    <gmd:URL>https://www.alsace.eu</gmd:URL>
+                  </gmd:linkage>
+                  <gmd:protocol>
+                    <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
+                  </gmd:protocol>
+                  <gmd:name gco:nilReason="missing" xsi:type="gmd:PT_FreeText_PropertyType">
+                    <gco:CharacterString />
+                  </gmd:name>
+                  <gmd:description gco:nilReason="missing" xsi:type="gmd:PT_FreeText_PropertyType">
+                    <gco:CharacterString />
+                  </gmd:description>
+                </gmd:CI_OnlineResource>
+              </gmd:onlineResource>
+            </gmd:CI_Contact>
+          </gmd:contactInfo>
+          <gmd:role>
+            <gmd:CI_RoleCode codeListValue="custodian" codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_RoleCode" />
+          </gmd:role>
+        </gmd:CI_ResponsibleParty>
+      </gmd:pointOfContact>
+      <gmd:resourceMaintenance>
+        <gmd:MD_MaintenanceInformation>
+          <gmd:maintenanceAndUpdateFrequency>
+            <gmd:MD_MaintenanceFrequencyCode codeListValue="asNeeded" codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_MaintenanceFrequencyCode" />
+          </gmd:maintenanceAndUpdateFrequency>
+        </gmd:MD_MaintenanceInformation>
+      </gmd:resourceMaintenance>
+      <gmd:graphicOverview>
+        <gmd:MD_BrowseGraphic>
+          <gmd:fileName>
+            <gco:CharacterString>https://geoportal.georhena.eu/geonetwork/srv/api/records/f74f5451-b198-4edf-abdd-a6b6b7caed81/attachments/chateaux_rhenans.jpeg</gco:CharacterString>
+          </gmd:fileName>
+          <gmd:fileDescription xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>chateaux_rhenans.jpeg</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">chateaux_rhenans.jpeg</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">chateaux_rhenans.jpeg</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">chateaux_rhenans.jpeg</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:fileDescription>
+        </gmd:MD_BrowseGraphic>
+      </gmd:graphicOverview>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Rhin Supérieur</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Rhin Supérieur</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Oberrhein</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">Upper Rhine</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeListValue="place" codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_KeywordTypeCode" />
+          </gmd:type>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>gestion patrimoniale</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">gestion patrimoniale</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Erbherrliches Management</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">patrimonial management</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>tourisme</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">tourisme</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Fremdenverkehr</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">tourism</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="theme" />
+          </gmd:type>
+          <gmd:thesaurusName>
+            <gmd:CI_Citation>
+              <gmd:title xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>GEMET - Concepts, version 2.4</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#FR">GEMET - Concepts, version 2.4</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </gmd:title>
+              <gmd:date>
+                <gmd:CI_Date>
+                  <gmd:date>
+                    <gco:Date>2010-01-13</gco:Date>
+                  </gmd:date>
+                  <gmd:dateType>
+                    <gmd:CI_DateTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_DateTypeCode" codeListValue="publication" />
+                  </gmd:dateType>
+                </gmd:CI_Date>
+              </gmd:date>
+              <gmd:identifier>
+                <gmd:MD_Identifier>
+                  <gmd:code>
+                    <gmx:Anchor xlink:href="https://geoportal.georhena.eu/geonetwork/srv/api/registries/vocabularies/external.theme.gemet">geonetwork.thesaurus.external.theme.gemet</gmx:Anchor>
+                  </gmd:code>
+                </gmd:MD_Identifier>
+              </gmd:identifier>
+            </gmd:CI_Citation>
+          </gmd:thesaurusName>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:descriptiveKeywords>
+        <gmd:MD_Keywords>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Châteaux forts</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Châteaux forts</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Burgen und Schlösser</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">Fortified castles</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:keyword xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Patrimoine castral</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Patrimoine castral</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Kastralisches Kulturerbe</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">Castral heritage</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:keyword>
+          <gmd:type>
+            <gmd:MD_KeywordTypeCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_KeywordTypeCode" codeListValue="theme" />
+          </gmd:type>
+        </gmd:MD_Keywords>
+      </gmd:descriptiveKeywords>
+      <gmd:resourceConstraints>
+        <gmd:MD_Constraints>
+          <gmd:useLimitation xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Licence CC-BY - ©CeA ; ©GeoRhena</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Licence CC-BY - ©CeA ; ©GeoRhena</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Lizenz CC-BY - ©CeA ; ©GeoRhena</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">Licence CC-BY - ©CeA ; ©GeoRhena</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:useLimitation>
+        </gmd:MD_Constraints>
+      </gmd:resourceConstraints>
+      <gmd:resourceConstraints>
+        <gmd:MD_LegalConstraints>
+          <gmd:accessConstraints>
+            <gmd:MD_RestrictionCode codeListValue="otherRestrictions" codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode" />
+          </gmd:accessConstraints>
+          <gmd:useConstraints>
+            <gmd:MD_RestrictionCode codeListValue="otherRestrictions" codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_RestrictionCode" />
+          </gmd:useConstraints>
+          <gmd:otherConstraints xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Pas d'autre limitation</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Pas d'autre limitation</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Keine andere Einschränkung</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">No other limitation</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:otherConstraints>
+        </gmd:MD_LegalConstraints>
+      </gmd:resourceConstraints>
+      <gmd:spatialRepresentationType>
+        <gmd:MD_SpatialRepresentationTypeCode codeListValue="vector" codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_SpatialRepresentationTypeCode" />
+      </gmd:spatialRepresentationType>
+      <gmd:spatialResolution>
+        <gmd:MD_Resolution>
+          <gmd:equivalentScale>
+            <gmd:MD_RepresentativeFraction>
+              <gmd:denominator>
+                <gco:Integer>100000</gco:Integer>
+              </gmd:denominator>
+            </gmd:MD_RepresentativeFraction>
+          </gmd:equivalentScale>
+        </gmd:MD_Resolution>
+      </gmd:spatialResolution>
+      <gmd:language>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="fre" />
+      </gmd:language>
+      <gmd:language>
+        <gmd:LanguageCode codeList="http://www.loc.gov/standards/iso639-2/" codeListValue="ger" />
+      </gmd:language>
+      <gmd:characterSet>
+        <gmd:MD_CharacterSetCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_CharacterSetCode" codeListValue="utf8" />
+      </gmd:characterSet>
+      <gmd:topicCategory>
+        <gmd:MD_TopicCategoryCode>society</gmd:MD_TopicCategoryCode>
+      </gmd:topicCategory>
+      <gmd:extent>
+        <gmd:EX_Extent>
+          <gmd:temporalElement>
+            <gmd:EX_TemporalExtent>
+              <gmd:extent>
+                <gml:TimePeriod gml:id="d600e429a1052958">
+                  <gml:beginPosition>2023-12-15</gml:beginPosition>
+                  <gml:endPosition>2024-02-15</gml:endPosition>
+                </gml:TimePeriod>
+              </gmd:extent>
+            </gmd:EX_TemporalExtent>
+          </gmd:temporalElement>
+        </gmd:EX_Extent>
+      </gmd:extent>
+      <gmd:extent>
+        <gmd:EX_Extent>
+          <gmd:geographicElement>
+            <gmd:EX_GeographicBoundingBox>
+              <gmd:westBoundLongitude>
+                <gco:Decimal>7.009277343750001</gco:Decimal>
+              </gmd:westBoundLongitude>
+              <gmd:eastBoundLongitude>
+                <gco:Decimal>8.745117187500002</gco:Decimal>
+              </gmd:eastBoundLongitude>
+              <gmd:southBoundLatitude>
+                <gco:Decimal>47.346267182053</gco:Decimal>
+              </gmd:southBoundLatitude>
+              <gmd:northBoundLatitude>
+                <gco:Decimal>49.31079887964631</gco:Decimal>
+              </gmd:northBoundLatitude>
+            </gmd:EX_GeographicBoundingBox>
+          </gmd:geographicElement>
+        </gmd:EX_Extent>
+      </gmd:extent>
+    </gmd:MD_DataIdentification>
+  </gmd:identificationInfo>
+  <gmd:distributionInfo>
+    <gmd:MD_Distribution>
+      <gmd:distributionFormat xmlns:date="http://exslt.org/dates-and-times">
+        <gmd:MD_Format>
+          <gmd:name xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Géodonnée au format SHP</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Géodonnée au format SHP</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">GeoDatei im SHP Format</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">SHP GeoData</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:name>
+          <gmd:version>
+            <gco:CharacterString>-</gco:CharacterString>
+          </gmd:version>
+        </gmd:MD_Format>
+      </gmd:distributionFormat>
+      <gmd:distributor>
+        <gmd:MD_Distributor>
+          <gmd:distributorContact>
+            <gmd:CI_ResponsibleParty>
+              <gmd:individualName gco:nilReason="missing" xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString />
+              </gmd:individualName>
+              <gmd:organisationName xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>GeoRhena</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#FR">GeoRhena</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </gmd:organisationName>
+              <gmd:contactInfo>
+                <gmd:CI_Contact>
+                  <gmd:address>
+                    <gmd:CI_Address>
+                      <gmd:electronicMailAddress gco:nilReason="missing" xsi:type="gmd:PT_FreeText_PropertyType">
+                        <gco:CharacterString />
+                      </gmd:electronicMailAddress>
+                    </gmd:CI_Address>
+                  </gmd:address>
+                </gmd:CI_Contact>
+              </gmd:contactInfo>
+              <gmd:role>
+                <gmd:CI_RoleCode codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#CI_RoleCode" codeListValue="publisher" />
+              </gmd:role>
+            </gmd:CI_ResponsibleParty>
+          </gmd:distributorContact>
+        </gmd:MD_Distributor>
+      </gmd:distributor>
+      <gmd:transferOptions>
+        <gmd:MD_DigitalTransferOptions>
+          <gmd:onLine>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage>
+                <gmd:URL>https://geoportal.georhena.eu/geoserver/society/ows</gmd:URL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gco:CharacterString>OGC:WMS</gco:CharacterString>
+              </gmd:protocol>
+              <gmd:name xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>chateaux_rhenans</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#FR">chateaux_rhenans</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE" />
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#EN" />
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </gmd:name>
+              <gmd:description xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>Châteaux rhénans du Rhin Supérieur - copie</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#FR">Châteaux rhénans du Rhin Supérieur - copie</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">Burgen am Oberrhein - kopie</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#EN" />
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </gmd:description>
+            </gmd:CI_OnlineResource>
+          </gmd:onLine>
+          <gmd:onLine>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage>
+                <gmd:URL>https://geoportal.georhena.eu/geoserver/society/ows</gmd:URL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gco:CharacterString>OGC:WFS</gco:CharacterString>
+              </gmd:protocol>
+              <gmd:name xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>society:chateaux_rhenans</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#FR">society:chateaux_rhenans</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">society:chateaux_rhenans</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#EN" />
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </gmd:name>
+              <gmd:description xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>Châteaux rhénans du Rhin Supérieur</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#FR">Châteaux rhénans du Rhin Supérieur</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">Burgen am Oberrhein</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#EN" />
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </gmd:description>
+            </gmd:CI_OnlineResource>
+          </gmd:onLine>
+          <gmd:onLine>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage>
+                <gmd:URL>https://geoportal.georhena.eu/geoserver/society/ows?request=GetFeature&amp;service=WFS&amp;typeName=chateaux_rhenans&amp;version=1.0.0&amp;outputFormat=SHAPE-ZIP</gmd:URL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gco:CharacterString>WWW:DOWNLOAD-1.0-ftp--download</gco:CharacterString>
+              </gmd:protocol>
+              <gmd:name xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>Téléchargement du Shapefile</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#FR">Téléchargement du Shapefile</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#EN">Téléchargement du Shapefile</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#EN">Téléchargement du Shapefile</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </gmd:name>
+            </gmd:CI_OnlineResource>
+          </gmd:onLine>
+          <gmd:onLine>
+            <gmd:CI_OnlineResource>
+              <gmd:linkage>
+                <gmd:URL>www.chateaux-rhenans.eu</gmd:URL>
+              </gmd:linkage>
+              <gmd:protocol>
+                <gco:CharacterString>WWW:LINK-1.0-http--link</gco:CharacterString>
+              </gmd:protocol>
+              <gmd:name xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString>Site internet du projet "Châteaux rhénans"</gco:CharacterString>
+                <gmd:PT_FreeText>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#FR">Site internet du projet "Châteaux rhénans"</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#DE">Webseite des Projekts "Rheinburgen".</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                  <gmd:textGroup>
+                    <gmd:LocalisedCharacterString locale="#EN">"Rhine castles" project website</gmd:LocalisedCharacterString>
+                  </gmd:textGroup>
+                </gmd:PT_FreeText>
+              </gmd:name>
+              <gmd:description gco:nilReason="missing" xsi:type="gmd:PT_FreeText_PropertyType">
+                <gco:CharacterString />
+              </gmd:description>
+            </gmd:CI_OnlineResource>
+          </gmd:onLine>
+        </gmd:MD_DigitalTransferOptions>
+      </gmd:transferOptions>
+    </gmd:MD_Distribution>
+  </gmd:distributionInfo>
+  <gmd:dataQualityInfo>
+    <gmd:DQ_DataQuality>
+      <gmd:scope>
+        <gmd:DQ_Scope>
+          <gmd:level>
+            <gmd:MD_ScopeCode codeListValue="dataset" codeList="http://standards.iso.org/iso/19139/resources/gmxCodelists.xml#MD_ScopeCode" />
+          </gmd:level>
+        </gmd:DQ_Scope>
+      </gmd:scope>
+      <gmd:lineage>
+        <gmd:LI_Lineage>
+          <gmd:statement xsi:type="gmd:PT_FreeText_PropertyType">
+            <gco:CharacterString>Recensement des châteaux forts à partir de données collectées auprès d’institutions culturelles ou touristiques partenaires dans le cadre du projet Châteaux rhénans.</gco:CharacterString>
+            <gmd:PT_FreeText>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#FR">Recensement des châteaux forts à partir de données collectées auprès d’institutions culturelles ou touristiques partenaires dans le cadre du projet Châteaux rhénans.</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#DE">Erfassung von Burgen und Schlössern anhand von Daten, die bei kulturellen oder touristischen Partnerinstitutionen im Rahmen des Projekts Rheinburgen gesammelt wurden.</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+              <gmd:textGroup>
+                <gmd:LocalisedCharacterString locale="#EN">Inventory of castles based on data collected from partner cultural and tourist institutions as part of the Châteaux rhénans project.</gmd:LocalisedCharacterString>
+              </gmd:textGroup>
+            </gmd:PT_FreeText>
+          </gmd:statement>
+        </gmd:LI_Lineage>
+      </gmd:lineage>
+    </gmd:DQ_DataQuality>
+  </gmd:dataQualityInfo>
+</gmd:MD_Metadata>
+


### PR DESCRIPTION
When converting iso19139 to iso19115-3, identification info's locales should be allocated into default locale and other locale.

Indexation should take other locale into account.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [X] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [X] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

- `Funded by geocat.ch`

