### PR TITLE
group change will also change permissions

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/MetadataSharingApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataSharingApi.java
@@ -898,7 +898,8 @@ public class MetadataSharingApi implements ApplicationEventPublisherAware
         //old permissions
         Integer sourceUsr = metadata.getSourceInfo().getOwner();
         String metadataId = String.valueOf(metadata.getId());
-        Vector<OperationAllowedId> oldPriv = retrievePrivileges(context, metadataId, sourceUsr, oldGroup.getId());
+        Integer oldGroupId = oldGroup != null ? oldGroup.getId() : null;
+        Vector<OperationAllowedId> oldPriv = retrievePrivileges(context, metadataId, sourceUsr, oldGroupId);
 
 
         //modify the sharingResponse (current permissions from DB) with new privileges (group XFER).


### PR DESCRIPTION
<!--Include a few sentences describing the overall goals for this Pull Request-->

When you change a group owner (i.e. in the editor):

<img width="318" height="250" alt="image" src="https://github.com/user-attachments/assets/ee1eafe2-8fe8-41a4-9d51-b918128ee22a" />
  
Geonetwork does NOT change any permissions - which is inconsistent with the change owner.

This PR fixes GN so it will change the group owner as well as the permissions. 

If going from `GroupSrc` to `GroupEnd`:

* `GroupSrc` will have **NO** Permissions.
* `GroupEnd` will have the OLD `GroupSrc` permissions **ADDED** to it.

EXAMPLE:

We are moving from `group1` to `group2`:

Before (record is in `group1`):
<img width="738" height="428" alt="image" src="https://github.com/user-attachments/assets/b4fdd605-e67d-4a77-9799-71cb8000aca8" />

After.  Record is now in `group2`.  The original `group1`'s permission are ADDED to `group2`'s permissions.
 
<img width="742" height="413" alt="image" src="https://github.com/user-attachments/assets/3598d04f-4f0a-4bda-8540-355db5bda397" />



<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [x] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [x] *Build documentation* provided for development instructions in `README.md` files
- [x] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

