### PR TITLE
CSW / Fix invalid character in constraints parameters

### DIFF
--- a/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/AbstractOperation.java
+++ b/csw-server/src/main/java/org/fao/geonet/kernel/csw/services/AbstractOperation.java
@@ -280,9 +280,14 @@ public abstract class AbstractOperation {
 
         Filter filter;
         try {
+            if (StringUtils.isNotEmpty(cql)) {
+                // GeoNetwork <4.4.10 may generate CQL with &nbsp; instead of space
+                // characters. Replace them to avoid CQL parsing errors.
+                cql = cql.replace("&nbsp;", " ").replace('\u00A0', ' ');
+            }
             filter = CQL.toFilter(cql);
         } catch (CQLException e) {
-            Log.error(Geonet.CSW, "Error parsing CQL or during conversion into Filter");
+            Log.error(Geonet.CSW, "Error parsing CQL or during conversion into Filter. Error: " + e.getMessage());
             throw new NoApplicableCodeEx("Error during CQL to Filter conversion : " + e);
         }
 

--- a/web/src/main/webapp/xml/csw/harvester-csw-cql.xsl
+++ b/web/src/main/webapp/xml/csw/harvester-csw-cql.xsl
@@ -41,7 +41,7 @@
                 </xsl:call-template>
             </xsl:variable>
 
-            <xsl:if test="string($condition)"><xsl:value-of select="$condition" />&#160;</xsl:if>
+          <xsl:if test="string($condition)"><xsl:value-of select="$condition" /><xsl:text> </xsl:text></xsl:if>
 
             <xsl:call-template name="processFilter">
               <xsl:with-param name="filter" select="$filter" />


### PR DESCRIPTION
GeoNetwork <4.4.10 may generate constraints with `\u00a0` instead of space characters. Replace them to avoid CQL parsing errors to avoid error when harvesting old GeoNetwork version.

Error was reported by GeoTools parser:
```
"org.geotools.filter.text.cql2.CQLException: Lexical error at line 1, column 32.
Encountered: "\u00a0" (160), after : "" Parsing : inspireTheme <> 'buildings' And inspireTheme <>...
```

Properly use space instead of `\u00a0`.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

Funded by Ifremer
