### PR TITLE
Modify URI construction logic in ThesaurusService

### DIFF
--- a/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusService.js
+++ b/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusService.js
@@ -146,7 +146,7 @@
             thesaurus: thesaurus,
             rows: max,
             q: filter || "",
-            uri: "*" + filter + "*" || "",
+            uri: (typeSearch === "MATCH" ? filter : "*" + filter + "*") || "",
             lang: lang || "eng"
           };
           if (outputLang) {


### PR DESCRIPTION
When a thesaurus contains keys which can be contained in another, it may display the wrong key when editing a metadata.

By example, there's two thesaurus keys http://domain.com/mykey/1 and http://domain.com/mykey/12.

Depending on the order in the thesaurus, if I have the first one in my metadata record, geonetwork may answer with the second one.  

How to replicate: 
- Import this thesaurus [place-test.zip](https://github.com/user-attachments/files/25042528/place-test.zip)
- Edit/create a record and add this thesaurus with `Test 1` keyword
- Save and close
- Check value: Will be ok `Test 1` 
- Re-edit the record and go to thesaurus part
- 🚫 The value show will be `Test wrong`

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

