### PR TITLE
Fix path for encryptor.properties file

### DIFF
--- a/docs/manual/docs/maintainer-guide/updating/index.md
+++ b/docs/manual/docs/maintainer-guide/updating/index.md
@@ -6,11 +6,11 @@
 
 Since GeoNetwork 4.0.4, passwords stored in the database for the mail server, harvesters, etc. are encrypted with [Jasypt](https://www.jasypt.org/).
     
-By default, a random encryption password is generated when GeoNetwork is started, if it is not already defined, and it is stored in the data directory **`data/config/encryptor/encryptor.properties`**.
+By default, a random encryption password is generated when GeoNetwork is started, if it is not already defined, and it is stored in the data directory **`data/config/encryptor.properties`**.
 
 === "Application data directory"
 
-    If you are using the application data direcotry, the encryption password is stored in the file **`/geonetwork/WEB-INF/data/config/encryptor/encryptor.properties`**. 
+    If you are using the application data direcotry, the encryption password is stored in the file **`/geonetwork/WEB-INF/data/config/encryptor.properties`**. 
     
     !!! warning
     
@@ -18,7 +18,7 @@ By default, a random encryption password is generated when GeoNetwork is started
 
 === "External data directory"
 
-    If you have set the location of the data directory outside of the application, the file will be stored in this external location at **`data/config/encryptor/encryptor.properties`**
+    If you have set the location of the data directory outside of the application, the file will be stored in this external location at **`data/config/encryptor.properties`**
   
     Read more at [Customizing the data directory](../../install-guide/customizing-data-directory.md).
 


### PR DESCRIPTION
Making change from @ZakarFin PR https://github.com/geonetwork/doc/pull/249 to markdown

See also:

* https://github.com/geonetwork/core-geonetwork/pull/9110
* https://github.com/geonetwork/doc/pull/249 

<img width="709" height="464" alt="image" src="https://github.com/user-attachments/assets/ecbbe4b0-a03d-4233-86fc-966ab213fd19" />

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [x] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

