### PR TITLE
Fix horizontal scroll bar in WFS features table

### DIFF
--- a/web-ui/src/main/resources/catalog/components/viewer/gfi/partials/featurestables.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/gfi/partials/featurestables.html
@@ -69,6 +69,7 @@
     </h4>
     <!--    </div>-->
     <gn-features-table
+      class="gn-features-table"
       gn-features-table-loader="table.loader"
       gn-features-table-loader-map="ctrl.map"
       data-show-export="ctrl.showExport"

--- a/web-ui/src/main/resources/catalog/style/gn_viewer.less
+++ b/web-ui/src/main/resources/catalog/style/gn_viewer.less
@@ -897,6 +897,7 @@ gn-features-tables,
       }
       .fixed-table-container {
         grid-area: main;
+        overflow-x: auto;
       }
       .fixed-table-pagination {
         grid-area: footer;


### PR DESCRIPTION
The WFS features table shown in the map viewer doesn't show a horizontal scroll bar. When the feature type has many columns the layer overflow the map space. This PR fixes the issue by adding overflow-x: auto to the fixed-table-container.

Before:
<img width="1070" height="261" alt="image" src="https://github.com/user-attachments/assets/86d940bb-007a-4dc9-a26c-afe80512fbc8" />


After:
<img width="1651" height="338" alt="image" src="https://github.com/user-attachments/assets/e737d16e-937a-480a-8235-6dd004afae18" />



# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

