### PR TITLE
Harvester / CSW / Avoid using uneeded nested operator when only one logical operator is used.

### DIFF
--- a/web/src/main/webapp/xml/csw/harvester-csw-filter.xsl
+++ b/web/src/main/webapp/xml/csw/harvester-csw-filter.xsl
@@ -6,11 +6,35 @@
     version="2.0">
 
     <xsl:template match="filters">
+      <xsl:variable name="operators"
+                    select="distinct-values(filter/condition[. != ''])"/>
+      <xsl:variable name="isUsingOneLogicalOperator"
+                    select="count($operators) = 1"/>
+
       <ogc:Filter>
-         <xsl:call-template name="processFilters">
-            <xsl:with-param name="filters" select="." />
-            <xsl:with-param name="position" select="count(./filter)" />
-        </xsl:call-template>
+        <xsl:choose>
+          <xsl:when test="$isUsingOneLogicalOperator">
+            <xsl:variable name="condition">
+              <xsl:call-template name="getCondition">
+                <xsl:with-param name="condition" select="$operators[1]" />
+              </xsl:call-template>
+            </xsl:variable>
+            <xsl:element name="{$condition}" namespace="http://www.opengis.net/ogc">
+              <xsl:for-each select="filter">
+                <xsl:call-template name="processFilter">
+                  <xsl:with-param name="filter" select="current()" />
+                </xsl:call-template>
+              </xsl:for-each>
+            </xsl:element>
+
+          </xsl:when>
+          <xsl:otherwise>
+            <xsl:call-template name="processFilters">
+              <xsl:with-param name="filters" select="." />
+              <xsl:with-param name="position" select="count(./filter)" />
+            </xsl:call-template>
+          </xsl:otherwise>
+        </xsl:choose>
       </ogc:Filter>
     </xsl:template>
 


### PR DESCRIPTION

When configuring CSW criteria like

<img width="476" height="432" alt="image" src="https://github.com/user-attachments/assets/a77c016d-d52e-44c0-9a44-256a20e7d193" />

only one `Or` operator is needed:

```xml
<?xml version="1.0" encoding="UTF-8"?>
<csw:GetRecords xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:gmd="http://www.isotc211.org/2005/gmd" service="CSW" version="2.0.2" resultType="results" outputFormat="application/xml" outputSchema="http://www.isotc211.org/2005/gmd" startPosition="61" maxRecords="20">
  <csw:Query typeNames="gmd:MD_Metadata">
    <csw:ElementSetName>summary</csw:ElementSetName>
    <csw:Constraint version="1.1.0">
      <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
        <ogc:Or>
          <ogc:PropertyIsEqualTo>
            <ogc:PropertyName>Identifier</ogc:PropertyName>
            <ogc:Literal>e1b7db81-4168-492a-9f45-68cbf7b718d3</ogc:Literal>
          </ogc:PropertyIsEqualTo>
          <ogc:PropertyIsEqualTo>
            <ogc:PropertyName>Identifier</ogc:PropertyName>
            <ogc:Literal>d96b007a-4e26-4dbd-8dd5-24dbe5c9b31f</ogc:Literal>
          </ogc:PropertyIsEqualTo>
          <ogc:PropertyIsEqualTo>
..
```

instead of current 

```xml
<?xml version="1.0" encoding="UTF-8"?>
<csw:GetRecords xmlns:csw="http://www.opengis.net/cat/csw/2.0.2" xmlns:dc="http://purl.org/dc/elements/1.1/" xmlns:gmd="http://www.isotc211.org/2005/gmd" service="CSW" version="2.0.2" resultType="results" outputFormat="application/xml" outputSchema="http://www.isotc211.org/2005/gmd" startPosition="1" maxRecords="20">
  <csw:Query typeNames="gmd:MD_Metadata">
    <csw:ElementSetName>summary</csw:ElementSetName>
    <csw:Constraint version="1.1.0">
      <ogc:Filter xmlns:ogc="http://www.opengis.net/ogc">
        <ogc:Or>
          <ogc:PropertyIsEqualTo>
            <ogc:PropertyName>Identifier</ogc:PropertyName>
            <ogc:Literal>b895b6cf-80d7-4c82-8ca4-f26a682fff0b</ogc:Literal>
          </ogc:PropertyIsEqualTo>
          <ogc:Or>
            <ogc:PropertyIsEqualTo>
              <ogc:PropertyName>Identifier</ogc:PropertyName>
              <ogc:Literal>df6e5e64-f9fb-41e6-9333-855c13e4808c</ogc:Literal>
            </ogc:PropertyIsEqualTo>
            <ogc:Or>
              <ogc:PropertyIsEqualTo>
                <ogc:PropertyName>Identifier</ogc:PropertyName>
                <ogc:Literal>565db295-0d63-4e22-87e9-c812bc8db13f</ogc:Literal>
              </ogc:PropertyIsEqualTo>
              <ogc:Or>
                <ogc:PropertyIsEqualTo>
....
```

Nested operators, at some point, trigger errors on Elasticsearch side:

```
<ows:ExceptionText>java.lang.RuntimeException: co.elastic.clients.elasticsearch._types.ElasticsearchException: [es/search] failed: [x_content_parse_exception] [1:579] [bool] failed to parse field [should]</ows:ExceptionText>
```


Config for test (67 criteria):

```json
{"@id":"335535398","@type":"csw","owner":["1"],"ownerGroup":["334291911"],"ownerUser":["undefined"],"site":{"name":"EEA-BY-UUID","uuid":"8783da41-44fa-41c1-bc24-297c7624c49a","account":{"use":false,"username":[],"password":[]},"capabilitiesUrl":"https://sdi.eea.europa.eu/catalogue/srv/eng/csw","icon":"logo_eea.png","rejectDuplicateResource":false,"hopCount":"2","xpathFilter":[],"xslfilter":[],"queryScope":"local","outputSchema":"http://www.isotc211.org/2005/gmd","sortBy":"identifier:A"},"content":{"validate":"NOVALIDATION","importxslt":"none","batchEdits":"[\n  {\n    \"condition\": \"\",\n    \"xpath\": \"/gmd:identificationInfo/gmd:MD_DataIdentification\",\n    \"value\": \"<gn_add><gmd:descriptiveKeywords xmlns:gmd=\\\"http://www.isotc211.org/2005/gmd\\\" xmlns:gco=\\\"http://www.isotc211.org/2005/gco\\\" xmlns:gmx=\\\"http://www.isotc211.org/2005/gmx\\\" xmlns:xlink=\\\"http://www.w3.org/1999/xlink\\\"><gmd:MD_Keywords><gmd:keyword><gco:CharacterString>/Métropole</gco:CharacterString></gmd:keyword><gmd:keyword><gco:CharacterString>/Métropole/Manche mer du Nord</gco:CharacterString></gmd:keyword><gmd:keyword><gco:CharacterString>/Métropole/Mers Celtiques</gco:CharacterString></gmd:keyword><gmd:keyword><gco:CharacterString>/Métropole/Golfe de Gascogne</gco:CharacterString></gmd:keyword><gmd:keyword><gco:CharacterString>/Métropole/Méditerranée occidentale</gco:CharacterString></gmd:keyword><gmd:type><gmd:MD_KeywordTypeCode codeList=\\\"http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_KeywordTypeCode\\\" codeListValue=\\\"place\\\"/></gmd:type><gmd:thesaurusName><gmd:CI_Citation><gmd:title><gco:CharacterString>Sous-regions marines</gco:CharacterString></gmd:title><gmd:identifier><gmd:MD_Identifier><gmd:code><gmx:Anchor xlink:href=\\\"https://sextant.ifremer.fr/geonetwork/srv/eng/thesaurus.download?ref=local.place.dcsmm.area\\\">geonetwork.thesaurus.local.place.dcsmm.area</gmx:Anchor></gmd:code></gmd:MD_Identifier></gmd:identifier></gmd:CI_Citation></gmd:thesaurusName></gmd:MD_Keywords></gmd:descriptiveKeywords></gn_add>\"\n  },\n  {\n    \"condition\": \"count(.//gmd:fileIdentifier[*/text() = 'df6e5e64-f9fb-41e6-9333-855c13e4808c']) > 0\",\n    \"xpath\": \"/gmd:identificationInfo/gmd:MD_DataIdentification\",\n    \"value\": \"<gn_add><gmd:descriptiveKeywords xmlns:gmd=\\\"http://www.isotc211.org/2005/gmd\\\" xmlns:gco=\\\"http://www.isotc211.org/2005/gco\\\" xmlns:gmx=\\\"http://www.isotc211.org/2005/gmx\\\" xmlns:xlink=\\\"http://www.w3.org/1999/xlink\\\"><gmd:MD_Keywords><gmd:keyword><gco:CharacterString>/National</gco:CharacterString></gmd:keyword><gmd:keyword><gco:CharacterString>/Outre-mer</gco:CharacterString></gmd:keyword><gmd:keyword><gco:CharacterString>/Outre-mer/Antilles françaises</gco:CharacterString></gmd:keyword><gmd:keyword><gco:CharacterString>/Outre-mer/Guyane française</gco:CharacterString></gmd:keyword><gmd:keyword><gco:CharacterString>/Outre-mer/Océan Indien</gco:CharacterString></gmd:keyword><gmd:type><gmd:MD_KeywordTypeCode codeList=\\\"http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_KeywordTypeCode\\\" codeListValue=\\\"place\\\"/></gmd:type><gmd:thesaurusName><gmd:CI_Citation><gmd:title><gco:CharacterString>Sous-regions marines</gco:CharacterString></gmd:title><gmd:identifier><gmd:MD_Identifier><gmd:code><gmx:Anchor xlink:href=\\\"https://sextant.ifremer.fr/geonetwork/srv/eng/thesaurus.download?ref=local.place.dcsmm.area\\\">geonetwork.thesaurus.local.place.dcsmm.area</gmx:Anchor></gmd:code></gmd:MD_Identifier></gmd:identifier></gmd:CI_Citation></gmd:thesaurusName></gmd:MD_Keywords></gmd:descriptiveKeywords></gn_add>\"\n  },\n  {\n    \"condition\": \"count(.//gmd:fileIdentifier[*/text() = '6d365112-5c0a-409e-bd45-68197fe3b2e8' or */text() = '99869345-d8b0-4933-a9d0-3c9e08055c4a' or */text() = 'd1cddb75-fd90-4dc3-a17a-8c051406bf51']) > 0\",\n    \"xpath\": \"/gmd:identificationInfo/gmd:MD_DataIdentification\",\n    \"value\": \"<gn_add><gmd:descriptiveKeywords xmlns:gmd=\\\"http://www.isotc211.org/2005/gmd\\\" xmlns:gco=\\\"http://www.isotc211.org/2005/gco\\\" xmlns:gmx=\\\"http://www.isotc211.org/2005/gmx\\\" xmlns:xlink=\\\"http://www.w3.org/1999/xlink\\\"><gmd:MD_Keywords><gmd:keyword><gco:CharacterString>/Actions concrètes</gco:CharacterString></gmd:keyword><gmd:type><gmd:MD_KeywordTypeCode codeList=\\\"http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_KeywordTypeCode\\\" codeListValue=\\\"theme\\\"/></gmd:type><gmd:thesaurusName><gmd:CI_Citation><gmd:title><gco:CharacterString>Thématiques - SIMM</gco:CharacterString></gmd:title><gmd:identifier><gmd:MD_Identifier><gmd:code><gmx:Anchor xlink:href=\\\"https://sextant.ifremer.fr/geonetwork/srv/eng/thesaurus.download?ref=local.theme.simm.thematiques\\\">geonetwork.thesaurus.local.theme.simm.thematiques</gmx:Anchor></gmd:code></gmd:MD_Identifier></gmd:identifier></gmd:CI_Citation></gmd:thesaurusName></gmd:MD_Keywords></gmd:descriptiveKeywords></gn_add>\"\n  },\n  {\n    \"condition\": \"count(.//gmd:fileIdentifier[*/text() = '1fb349ec-84d9-46ee-b361-facb4e3a5251f' or */text() = '205e2db2-4e35-4b1b-bf84-271c4a82248c' or */text() = '660ce4c2-6e23-4aca-b906-0996bdcf24acf' or */text() = '670cb5a9-40b9-4b12-90e3-597de5927700' or */text() = '6d365112-5c0a-409e-bd45-68197fe3b2e8' or */text() = '99869345-d8b0-4933-a9d0-3c9e08055c4a' or */text() = 'c88e743d-e838-49e1-8c80-54f26bcf4ab8' or */text() = 'd047cdb1-a62b-4299-8469-9038519430c0' or */text() = 'd1cddb75-fd90-4dc3-a17a-8c051406bf51' or */text() = 'd96b007a-4e26-4dbd-8dd5-24dbe5c9b31f' or */text() = 'e1b7db81-4168-492a-9f45-68cbf7b718d3' or */text() = 'fe8d5d51-36ab-46d4-be61-dcfad7c308f1']) > 0\",\n    \"xpath\": \"/gmd:identificationInfo/gmd:MD_DataIdentification\",\n    \"value\": \"<gn_add><gmd:descriptiveKeywords xmlns:gmd=\\\"http://www.isotc211.org/2005/gmd\\\" xmlns:gco=\\\"http://www.isotc211.org/2005/gco\\\" xmlns:gmx=\\\"http://www.isotc211.org/2005/gmx\\\" xmlns:xlink=\\\"http://www.w3.org/1999/xlink\\\"><gmd:MD_Keywords><gmd:keyword><gco:CharacterString>/Activités et Usages/Analyse économique et sociale</gco:CharacterString></gmd:keyword><gmd:type><gmd:MD_KeywordTypeCode codeList=\\\"http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_KeywordTypeCode\\\" codeListValue=\\\"theme\\\"/></gmd:type><gmd:thesaurusName><gmd:CI_Citation><gmd:title><gco:CharacterString>Thématiques - SIMM</gco:CharacterString></gmd:title><gmd:identifier><gmd:MD_Identifier><gmd:code><gmx:Anchor xlink:href=\\\"https://sextant.ifremer.fr/geonetwork/srv/eng/thesaurus.download?ref=local.theme.simm.thematiques\\\">geonetwork.thesaurus.local.theme.simm.thematiques</gmx:Anchor></gmd:code></gmd:MD_Identifier></gmd:identifier></gmd:CI_Citation></gmd:thesaurusName></gmd:MD_Keywords></gmd:descriptiveKeywords></gn_add>\"\n  },\n  {\n    \"condition\": \"count(.//gmd:fileIdentifier[*/text() = '0ab524a2-fd09-4185-adc8-58998efe8f23' or */text() = '1c3b1860-780e-44fa-ad80-85405a0cb2a9' or */text() = '1d8c8e88-fb95-40f8-b41a-7134aaff2d8a' or */text() = '231a62c7-f2fb-4e7b-b805-4ce06f4f61db' or */text() = '6bea3720-f2dc-4e64-813c-80f89eeff019' or */text() = '6e2e8ce0-7d81-4904-bf52-e919f784ef6e' or */text() = '84b01013-692f-4342-bd75-28a0225848c2' or */text() = 'a86f0051-c971-4492-84b2-eb42aaab5fa9' or */text() = 'fc96c6c8-8832-4908-b634-522403aca882']) > 0\",\n    \"xpath\": \"/gmd:identificationInfo/gmd:MD_DataIdentification\",\n    \"value\": \"<gn_add><gmd:descriptiveKeywords xmlns:gmd=\\\"http://www.isotc211.org/2005/gmd\\\" xmlns:gco=\\\"http://www.isotc211.org/2005/gco\\\" xmlns:gmx=\\\"http://www.isotc211.org/2005/gmx\\\" xmlns:xlink=\\\"http://www.w3.org/1999/xlink\\\"><gmd:MD_Keywords><gmd:keyword><gco:CharacterString>/Activités et Usages/Industrie et énergie</gco:CharacterString></gmd:keyword><gmd:type><gmd:MD_KeywordTypeCode codeList=\\\"http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_KeywordTypeCode\\\" codeListValue=\\\"theme\\\"/></gmd:type><gmd:thesaurusName><gmd:CI_Citation><gmd:title><gco:CharacterString>Thématiques - SIMM</gco:CharacterString></gmd:title><gmd:identifier><gmd:MD_Identifier><gmd:code><gmx:Anchor xlink:href=\\\"https://sextant.ifremer.fr/geonetwork/srv/eng/thesaurus.download?ref=local.theme.simm.thematiques\\\">geonetwork.thesaurus.local.theme.simm.thematiques</gmx:Anchor></gmd:code></gmd:MD_Identifier></gmd:identifier></gmd:CI_Citation></gmd:thesaurusName></gmd:MD_Keywords></gmd:descriptiveKeywords></gn_add>\"\n  },\n  {\n    \"condition\": \"count(.//gmd:fileIdentifier[*/text() = '6b7b7f62-659f-4df7-8b54-88c5113a9400']) > 0\",\n    \"xpath\": \"/gmd:identificationInfo/gmd:MD_DataIdentification\",\n    \"value\": \"<gn_add><gmd:descriptiveKeywords xmlns:gmd=\\\"http://www.isotc211.org/2005/gmd\\\" xmlns:gco=\\\"http://www.isotc211.org/2005/gco\\\" xmlns:gmx=\\\"http://www.isotc211.org/2005/gmx\\\" xmlns:xlink=\\\"http://www.w3.org/1999/xlink\\\"><gmd:MD_Keywords><gmd:keyword><gco:CharacterString>/Activités et Usages/Loisirs</gco:CharacterString></gmd:keyword><gmd:type><gmd:MD_KeywordTypeCode codeList=\\\"http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_KeywordTypeCode\\\" codeListValue=\\\"theme\\\"/></gmd:type><gmd:thesaurusName><gmd:CI_Citation><gmd:title><gco:CharacterString>Thématiques - SIMM</gco:CharacterString></gmd:title><gmd:identifier><gmd:MD_Identifier><gmd:code><gmx:Anchor xlink:href=\\\"https://sextant.ifremer.fr/geonetwork/srv/eng/thesaurus.download?ref=local.theme.simm.thematiques\\\">geonetwork.thesaurus.local.theme.simm.thematiques</gmx:Anchor></gmd:code></gmd:MD_Identifier></gmd:identifier></gmd:CI_Citation></gmd:thesaurusName></gmd:MD_Keywords></gmd:descriptiveKeywords></gn_add>\"\n  },\n  {\n    \"condition\": \"count(.//gmd:fileIdentifier[*/text() = '6bea3720-f2dc-4e64-813c-80f89eeff019' or */text() = '6d8f11b5-d395-45fb-937e-bea2f290c447' or */text() = '84b01013-692f-4342-bd75-28a0225848c2' or */text() = 'e99610ad-8fdb-44f2-a671-ccf9ec13c252' or */text() = 'fc96c6c8-8832-4908-b634-522403aca882' or */text() = 'fff43204-793a-4a44-96f7-918672a2047d']) > 0\",\n    \"xpath\": \"/gmd:identificationInfo/gmd:MD_DataIdentification\",\n    \"value\": \"<gn_add><gmd:descriptiveKeywords xmlns:gmd=\\\"http://www.isotc211.org/2005/gmd\\\" xmlns:gco=\\\"http://www.isotc211.org/2005/gco\\\" xmlns:gmx=\\\"http://www.isotc211.org/2005/gmx\\\" xmlns:xlink=\\\"http://www.w3.org/1999/xlink\\\"><gmd:MD_Keywords><gmd:keyword><gco:CharacterString>/Activités et Usages/Pêche et Aquaculture</gco:CharacterString></gmd:keyword><gmd:type><gmd:MD_KeywordTypeCode codeList=\\\"http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_KeywordTypeCode\\\" codeListValue=\\\"theme\\\"/></gmd:type><gmd:thesaurusName><gmd:CI_Citation><gmd:title><gco:CharacterString>Thématiques - SIMM</gco:CharacterString></gmd:title><gmd:identifier><gmd:MD_Identifier><gmd:code><gmx:Anchor xlink:href=\\\"https://sextant.ifremer.fr/geonetwork/srv/eng/thesaurus.download?ref=local.theme.simm.thematiques\\\">geonetwork.thesaurus.local.theme.simm.thematiques</gmx:Anchor></gmd:code></gmd:MD_Identifier></gmd:identifier></gmd:CI_Citation></gmd:thesaurusName></gmd:MD_Keywords></gmd:descriptiveKeywords></gn_add>\"\n  },\n  {\n    \"condition\": \"count(.//gmd:fileIdentifier[*/text() = '0ab524a2-fd09-4185-adc8-58998efe8f23' or */text() = '22ad5ddf-967d-4ce7-9933-f7ac89e0b638' or */text() = '231a62c7-f2fb-4e7b-b805-4ce06f4f61db' or */text() = '60b9ba8d-f133-4143-962a-f1edb49d2e60' or */text() = '6bea3720-f2dc-4e64-813c-80f89eeff019' or */text() = '6e2e8ce0-7d81-4904-bf52-e919f784ef6e' or */text() = '84b01013-692f-4342-bd75-28a0225848c2' or */text() = '8874825e-8459-4ae3-92cd-1b5ce3d90ebf' or */text() = 'a86f0051-c971-4492-84b2-eb42aaab5fa9' or */text() = 'f7fb5360-e8e6-4a98-852c-3f56f96a361c' or */text() = 'fc96c6c8-8832-4908-b634-522403aca882']) > 0\",\n    \"xpath\": \"/gmd:identificationInfo/gmd:MD_DataIdentification\",\n    \"value\": \"<gn_add><gmd:descriptiveKeywords xmlns:gmd=\\\"http://www.isotc211.org/2005/gmd\\\" xmlns:gco=\\\"http://www.isotc211.org/2005/gco\\\" xmlns:gmx=\\\"http://www.isotc211.org/2005/gmx\\\" xmlns:xlink=\\\"http://www.w3.org/1999/xlink\\\"><gmd:MD_Keywords><gmd:keyword><gco:CharacterString>/Activités et Usages/Transport maritime et Ports</gco:CharacterString></gmd:keyword><gmd:type><gmd:MD_KeywordTypeCode codeList=\\\"http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_KeywordTypeCode\\\" codeListValue=\\\"theme\\\"/></gmd:type><gmd:thesaurusName><gmd:CI_Citation><gmd:title><gco:CharacterString>Thématiques - SIMM</gco:CharacterString></gmd:title><gmd:identifier><gmd:MD_Identifier><gmd:code><gmx:Anchor xlink:href=\\\"https://sextant.ifremer.fr/geonetwork/srv/eng/thesaurus.download?ref=local.theme.simm.thematiques\\\">geonetwork.thesaurus.local.theme.simm.thematiques</gmx:Anchor></gmd:code></gmd:MD_Identifier></gmd:identifier></gmd:CI_Citation></gmd:thesaurusName></gmd:MD_Keywords></gmd:descriptiveKeywords></gn_add>\"\n  },\n  {\n    \"condition\": \"count(.//gmd:fileIdentifier[*/text() = '1c3b1860-780e-44fa-ad80-85405a0cb2a9' or */text() = '1d8c8e88-fb95-40f8-b41a-7134aaff2d8a' or */text() = '670cb5a9-40b9-4b12-90e3-597de5927700' or */text() = 'd047cdb1-a62b-4299-8469-9038519430c0' or */text() = 'd96b007a-4e26-4dbd-8dd5-24dbe5c9b31f' or */text() = 'e1b7db81-4168-492a-9f45-68cbf7b718d3' or */text() = 'f7fb5360-e8e6-4a98-852c-3f56f96a361c']) > 0\",\n    \"xpath\": \"/gmd:identificationInfo/gmd:MD_DataIdentification\",\n    \"value\": \"<gn_add><gmd:descriptiveKeywords xmlns:gmd=\\\"http://www.isotc211.org/2005/gmd\\\" xmlns:gco=\\\"http://www.isotc211.org/2005/gco\\\" xmlns:gmx=\\\"http://www.isotc211.org/2005/gmx\\\" xmlns:xlink=\\\"http://www.w3.org/1999/xlink\\\"><gmd:MD_Keywords><gmd:keyword><gco:CharacterString>/Activités et Usages/Urbanisation et Artificialisation</gco:CharacterString></gmd:keyword><gmd:type><gmd:MD_KeywordTypeCode codeList=\\\"http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_KeywordTypeCode\\\" codeListValue=\\\"theme\\\"/></gmd:type><gmd:thesaurusName><gmd:CI_Citation><gmd:title><gco:CharacterString>Thématiques - SIMM</gco:CharacterString></gmd:title><gmd:identifier><gmd:MD_Identifier><gmd:code><gmx:Anchor xlink:href=\\\"https://sextant.ifremer.fr/geonetwork/srv/eng/thesaurus.download?ref=local.theme.simm.thematiques\\\">geonetwork.thesaurus.local.theme.simm.thematiques</gmx:Anchor></gmd:code></gmd:MD_Identifier></gmd:identifier></gmd:CI_Citation></gmd:thesaurusName></gmd:MD_Keywords></gmd:descriptiveKeywords></gn_add>\"\n  },\n  {\n    \"condition\": \"count(.//gmd:fileIdentifier[*/text() = '6e2e8ce0-7d81-4904-bf52-e919f784ef6e' or */text() = 'aa791cf1-ead5-4364-b0c3-4c54dc83c7e4']) > 0\",\n    \"xpath\": \"/gmd:identificationInfo/gmd:MD_DataIdentification\",\n    \"value\": \"<gn_add><gmd:descriptiveKeywords xmlns:gmd=\\\"http://www.isotc211.org/2005/gmd\\\" xmlns:gco=\\\"http://www.isotc211.org/2005/gco\\\" xmlns:gmx=\\\"http://www.isotc211.org/2005/gmx\\\" xmlns:xlink=\\\"http://www.w3.org/1999/xlink\\\"><gmd:MD_Keywords><gmd:keyword><gco:CharacterString>/Etat du Milieu/Bathymétrie</gco:CharacterString></gmd:keyword><gmd:type><gmd:MD_KeywordTypeCode codeList=\\\"http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_KeywordTypeCode\\\" codeListValue=\\\"theme\\\"/></gmd:type><gmd:thesaurusName><gmd:CI_Citation><gmd:title><gco:CharacterString>Thématiques - SIMM</gco:CharacterString></gmd:title><gmd:identifier><gmd:MD_Identifier><gmd:code><gmx:Anchor xlink:href=\\\"https://sextant.ifremer.fr/geonetwork/srv/eng/thesaurus.download?ref=local.theme.simm.thematiques\\\">geonetwork.thesaurus.local.theme.simm.thematiques</gmx:Anchor></gmd:code></gmd:MD_Identifier></gmd:identifier></gmd:CI_Citation></gmd:thesaurusName></gmd:MD_Keywords></gmd:descriptiveKeywords></gn_add>\"\n  },\n  {\n    \"condition\": \"count(.//gmd:fileIdentifier[*/text() = 'b895b6cf-80d7-4c82-8ca4-f26a682fff0b' or */text() = 'df6e5e64-f9fb-41e6-9333-855c13e4808c']) > 0\",\n    \"xpath\": \"/gmd:identificationInfo/gmd:MD_DataIdentification\",\n    \"value\": \"<gn_add><gmd:descriptiveKeywords xmlns:gmd=\\\"http://www.isotc211.org/2005/gmd\\\" xmlns:gco=\\\"http://www.isotc211.org/2005/gco\\\" xmlns:gmx=\\\"http://www.isotc211.org/2005/gmx\\\" xmlns:xlink=\\\"http://www.w3.org/1999/xlink\\\"><gmd:MD_Keywords><gmd:keyword><gco:CharacterString>/Etat du Milieu/Biogéochimie</gco:CharacterString></gmd:keyword><gmd:type><gmd:MD_KeywordTypeCode codeList=\\\"http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_KeywordTypeCode\\\" codeListValue=\\\"theme\\\"/></gmd:type><gmd:thesaurusName><gmd:CI_Citation><gmd:title><gco:CharacterString>Thématiques - SIMM</gco:CharacterString></gmd:title><gmd:identifier><gmd:MD_Identifier><gmd:code><gmx:Anchor xlink:href=\\\"https://sextant.ifremer.fr/geonetwork/srv/eng/thesaurus.download?ref=local.theme.simm.thematiques\\\">geonetwork.thesaurus.local.theme.simm.thematiques</gmx:Anchor></gmd:code></gmd:MD_Identifier></gmd:identifier></gmd:CI_Citation></gmd:thesaurusName></gmd:MD_Keywords></gmd:descriptiveKeywords></gn_add>\"\n  },\n  {\n    \"condition\": \"count(.//gmd:fileIdentifier[*/text() = '22ad5ddf-967d-4ce7-9933-f7ac89e0b638' or */text() = '565db295-0d63-4e22-87e9-c812bc8db13f' or */text() = '5b83a3ca-2545-4b9e-a294-e709be063059' or */text() = '70064384-f3b7-49ad-b137-bdf31af82158' or */text() = '7fc458f8-40e1-4528-87bf-62ef0896fbb3' or */text() = '84b01013-692f-4342-bd75-28a0225848c2' or */text() = '9f71b3e3-f8ec-442b-a2d5-c3c190605ac4' or */text() = 'b895b6cf-80d7-4c82-8ca4-f26a682fff0b' or */text() = 'cc8c0653-59e7-4f20-aa05-5f8ecb720fee' or */text() = 'f461f13a-038c-4e3d-bfbe-22e91389dcef']) > 0\",\n    \"xpath\": \"/gmd:identificationInfo/gmd:MD_DataIdentification\",\n    \"value\": \"<gn_add><gmd:descriptiveKeywords xmlns:gmd=\\\"http://www.isotc211.org/2005/gmd\\\" xmlns:gco=\\\"http://www.isotc211.org/2005/gco\\\" xmlns:gmx=\\\"http://www.isotc211.org/2005/gmx\\\" xmlns:xlink=\\\"http://www.w3.org/1999/xlink\\\"><gmd:MD_Keywords><gmd:keyword><gco:CharacterString>/Etat du Milieu/Espèces</gco:CharacterString></gmd:keyword><gmd:type><gmd:MD_KeywordTypeCode codeList=\\\"http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_KeywordTypeCode\\\" codeListValue=\\\"theme\\\"/></gmd:type><gmd:thesaurusName><gmd:CI_Citation><gmd:title><gco:CharacterString>Thématiques - SIMM</gco:CharacterString></gmd:title><gmd:identifier><gmd:MD_Identifier><gmd:code><gmx:Anchor xlink:href=\\\"https://sextant.ifremer.fr/geonetwork/srv/eng/thesaurus.download?ref=local.theme.simm.thematiques\\\">geonetwork.thesaurus.local.theme.simm.thematiques</gmx:Anchor></gmd:code></gmd:MD_Identifier></gmd:identifier></gmd:CI_Citation></gmd:thesaurusName></gmd:MD_Keywords></gmd:descriptiveKeywords></gn_add>\"\n  },\n  {\n    \"condition\": \"count(.//gmd:fileIdentifier[*/text() = '84b01013-692f-4342-bd75-28a0225848c2' or */text() = 'aa791cf1-ead5-4364-b0c3-4c54dc83c7e4' or */text() = 'd047cdb1-a62b-4299-8469-9038519430c0']) > 0\",\n    \"xpath\": \"/gmd:identificationInfo/gmd:MD_DataIdentification\",\n    \"value\": \"<gn_add><gmd:descriptiveKeywords xmlns:gmd=\\\"http://www.isotc211.org/2005/gmd\\\" xmlns:gco=\\\"http://www.isotc211.org/2005/gco\\\" xmlns:gmx=\\\"http://www.isotc211.org/2005/gmx\\\" xmlns:xlink=\\\"http://www.w3.org/1999/xlink\\\"><gmd:MD_Keywords><gmd:keyword><gco:CharacterString>/Etat du Milieu/Géologie</gco:CharacterString></gmd:keyword><gmd:type><gmd:MD_KeywordTypeCode codeList=\\\"http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_KeywordTypeCode\\\" codeListValue=\\\"theme\\\"/></gmd:type><gmd:thesaurusName><gmd:CI_Citation><gmd:title><gco:CharacterString>Thématiques - SIMM</gco:CharacterString></gmd:title><gmd:identifier><gmd:MD_Identifier><gmd:code><gmx:Anchor xlink:href=\\\"https://sextant.ifremer.fr/geonetwork/srv/eng/thesaurus.download?ref=local.theme.simm.thematiques\\\">geonetwork.thesaurus.local.theme.simm.thematiques</gmx:Anchor></gmd:code></gmd:MD_Identifier></gmd:identifier></gmd:CI_Citation></gmd:thesaurusName></gmd:MD_Keywords></gmd:descriptiveKeywords></gn_add>\"\n  },\n  {\n    \"condition\": \"count(.//gmd:fileIdentifier[*/text() = '0f5f5180-8546-4bc9-979f-3039e850f23a' or */text() = '22ad5ddf-967d-4ce7-9933-f7ac89e0b638' or */text() = '231a62c7-f2fb-4e7b-b805-4ce06f4f61db' or */text() = '2bf95800-8b2e-4edf-9a45-05860300f002' or */text() = '3feffd63-ab0b-4f03-84e8-b2c324c93bbe' or */text() = '49eb412e-3002-492c-8323-ab5cac07fc40' or */text() = '565db295-0d63-4e22-87e9-c812bc8db13f' or */text() = '5b3e4da9-4c14-498c-b20e-bc514470eab5' or */text() = '5b83a3ca-2545-4b9e-a294-e709be063059' or */text() = '5d2e8632-245e-41ad-9a7b-be78f4f4597d' or */text() = '60b9ba8d-f133-4143-962a-f1edb49d2e60' or */text() = '660a7b8e-27c0-4b94-b495-e2d6d98ddd42' or */text() = '6bea3720-f2dc-4e64-813c-80f89eeff019' or */text() = '6e2e8ce0-7d81-4904-bf52-e919f784ef6e' or */text() = '70064384-f3b7-49ad-b137-bdf31af82158' or */text() = '7c66cfd5-4246-4b9d-86af-624950aa49d4' or */text() = '7fc458f8-40e1-4528-87bf-62ef0896fbb3' or */text() = '8874825e-8459-4ae3-92cd-1b5ce3d90ebf' or */text() = '9f71b3e3-f8ec-442b-a2d5-c3c190605ac4' or */text() = 'aa791cf1-ead5-4364-b0c3-4c54dc83c7e4' or */text() = 'b895b6cf-80d7-4c82-8ca4-f26a682fff0b' or */text() = 'cd87cd22-0a6f-499b-9e27-9691e6e46030' or */text() = 'da521e3e-95bb-4eb3-8226-358e1171e298' or */text() = 'dfe9061b-84ad-4ef1-ba83-519ab61ebb40' or */text() = 'f626c353-fff5-410c-84f1-1cf48951f4af' or */text() = 'f97c9bdc-3bdc-45e9-8f28-e687702096d7' or */text() = 'fc018b57-05ba-4692-b96b-809983a3a983' or */text() = 'fc96c6c8-8832-4908-b634-522403aca882']) > 0\",\n    \"xpath\": \"/gmd:identificationInfo/gmd:MD_DataIdentification\",\n    \"value\": \"<gn_add><gmd:descriptiveKeywords xmlns:gmd=\\\"http://www.isotc211.org/2005/gmd\\\" xmlns:gco=\\\"http://www.isotc211.org/2005/gco\\\" xmlns:gmx=\\\"http://www.isotc211.org/2005/gmx\\\" xmlns:xlink=\\\"http://www.w3.org/1999/xlink\\\"><gmd:MD_Keywords><gmd:keyword><gco:CharacterString>/Etat du Milieu/Habitats</gco:CharacterString></gmd:keyword><gmd:type><gmd:MD_KeywordTypeCode codeList=\\\"http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_KeywordTypeCode\\\" codeListValue=\\\"theme\\\"/></gmd:type><gmd:thesaurusName><gmd:CI_Citation><gmd:title><gco:CharacterString>Thématiques - SIMM</gco:CharacterString></gmd:title><gmd:identifier><gmd:MD_Identifier><gmd:code><gmx:Anchor xlink:href=\\\"https://sextant.ifremer.fr/geonetwork/srv/eng/thesaurus.download?ref=local.theme.simm.thematiques\\\">geonetwork.thesaurus.local.theme.simm.thematiques</gmx:Anchor></gmd:code></gmd:MD_Identifier></gmd:identifier></gmd:CI_Citation></gmd:thesaurusName></gmd:MD_Keywords></gmd:descriptiveKeywords></gn_add>\"\n  },\n  {\n    \"condition\": \"count(.//gmd:fileIdentifier[*/text() = '1d8c8e88-fb95-40f8-b41a-7134aaff2d8a' or */text() = '789de867-c056-4f59-ac42-c7bbf71e662b' or */text() = '84b01013-692f-4342-bd75-28a0225848c2' or */text() = 'b895b6cf-80d7-4c82-8ca4-f26a682fff0b']) > 0\",\n    \"xpath\": \"/gmd:identificationInfo/gmd:MD_DataIdentification\",\n    \"value\": \"<gn_add><gmd:descriptiveKeywords xmlns:gmd=\\\"http://www.isotc211.org/2005/gmd\\\" xmlns:gco=\\\"http://www.isotc211.org/2005/gco\\\" xmlns:gmx=\\\"http://www.isotc211.org/2005/gmx\\\" xmlns:xlink=\\\"http://www.w3.org/1999/xlink\\\"><gmd:MD_Keywords><gmd:keyword><gco:CharacterString>/Etat du Milieu/Hydrodynamique</gco:CharacterString></gmd:keyword><gmd:type><gmd:MD_KeywordTypeCode codeList=\\\"http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_KeywordTypeCode\\\" codeListValue=\\\"theme\\\"/></gmd:type><gmd:thesaurusName><gmd:CI_Citation><gmd:title><gco:CharacterString>Thématiques - SIMM</gco:CharacterString></gmd:title><gmd:identifier><gmd:MD_Identifier><gmd:code><gmx:Anchor xlink:href=\\\"https://sextant.ifremer.fr/geonetwork/srv/eng/thesaurus.download?ref=local.theme.simm.thematiques\\\">geonetwork.thesaurus.local.theme.simm.thematiques</gmx:Anchor></gmd:code></gmd:MD_Identifier></gmd:identifier></gmd:CI_Citation></gmd:thesaurusName></gmd:MD_Keywords></gmd:descriptiveKeywords></gn_add>\"\n  },\n  {\n    \"condition\": \"count(.//gmd:fileIdentifier[*/text() = '0ab524a2-fd09-4185-adc8-58998efe8f23' or */text() = '0f5f5180-8546-4bc9-979f-3039e850f23a' or */text() = '1d8c8e88-fb95-40f8-b41a-7134aaff2d8a' or */text() = '22ad5ddf-967d-4ce7-9933-f7ac89e0b638' or */text() = '231a62c7-f2fb-4e7b-b805-4ce06f4f61db' or */text() = '2bf95800-8b2e-4edf-9a45-05860300f002' or */text() = '3feffd63-ab0b-4f03-84e8-b2c324c93bbe' or */text() = '49eb412e-3002-492c-8323-ab5cac07fc40' or */text() = '5d2e8632-245e-41ad-9a7b-be78f4f4597d' or */text() = '60b9ba8d-f133-4143-962a-f1edb49d2e60' or */text() = '660a7b8e-27c0-4b94-b495-e2d6d98ddd42' or */text() = '6b7b7f62-659f-4df7-8b54-88c5113a9400' or */text() = '6bea3720-f2dc-4e64-813c-80f89eeff019' or */text() = '6d8f11b5-d395-45fb-937e-bea2f290c447' or */text() = '6e2e8ce0-7d81-4904-bf52-e919f784ef6e' or */text() = '7c66cfd5-4246-4b9d-86af-624950aa49d4' or */text() = '8874825e-8459-4ae3-92cd-1b5ce3d90ebf' or */text() = 'a86f0051-c971-4492-84b2-eb42aaab5fa9' or */text() = 'cd87cd22-0a6f-499b-9e27-9691e6e46030' or */text() = 'df6e5e64-f9fb-41e6-9333-855c13e4808c' or */text() = 'dfe9061b-84ad-4ef1-ba83-519ab61ebb40' or */text() = 'e99610ad-8fdb-44f2-a671-ccf9ec13c252' or */text() = 'f7fb5360-e8e6-4a98-852c-3f56f96a361c' or */text() = 'fc018b57-05ba-4692-b96b-809983a3a983' or */text() = 'fc96c6c8-8832-4908-b634-522403aca882' or */text() = 'fff43204-793a-4a44-96f7-918672a2047d']) > 0\",\n    \"xpath\": \"/gmd:identificationInfo/gmd:MD_DataIdentification\",\n    \"value\": \"<gn_add><gmd:descriptiveKeywords xmlns:gmd=\\\"http://www.isotc211.org/2005/gmd\\\" xmlns:gco=\\\"http://www.isotc211.org/2005/gco\\\" xmlns:gmx=\\\"http://www.isotc211.org/2005/gmx\\\" xmlns:xlink=\\\"http://www.w3.org/1999/xlink\\\"><gmd:MD_Keywords><gmd:keyword><gco:CharacterString>/Etat du Milieu/Pollutions</gco:CharacterString></gmd:keyword><gmd:type><gmd:MD_KeywordTypeCode codeList=\\\"http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_KeywordTypeCode\\\" codeListValue=\\\"theme\\\"/></gmd:type><gmd:thesaurusName><gmd:CI_Citation><gmd:title><gco:CharacterString>Thématiques - SIMM</gco:CharacterString></gmd:title><gmd:identifier><gmd:MD_Identifier><gmd:code><gmx:Anchor xlink:href=\\\"https://sextant.ifremer.fr/geonetwork/srv/eng/thesaurus.download?ref=local.theme.simm.thematiques\\\">geonetwork.thesaurus.local.theme.simm.thematiques</gmx:Anchor></gmd:code></gmd:MD_Identifier></gmd:identifier></gmd:CI_Citation></gmd:thesaurusName></gmd:MD_Keywords></gmd:descriptiveKeywords></gn_add>\"\n  },\n  {\n    \"condition\": \"count(.//gmd:fileIdentifier[*/text() = '1ae48a16-89b7-4568-aae8-2308f254e2cf' or */text() = '1d8c8e88-fb95-40f8-b41a-7134aaff2d8a' or */text() = '205e2db2-4e35-4b1b-bf84-271c4a82248c' or */text() = '24cdf846-e0d3-4884-84c7-9930d5b29c38' or */text() = '393359a7-7ebd-4a52-80ac-1a18d5f3db9c' or */text() = '4c1baca3-6494-4463-9958-dc4d8d15bbab' or */text() = '670cb5a9-40b9-4b12-90e3-597de5927700' or */text() = '723f0742-727b-45ec-a70d-df6292b7e003' or */text() = '84d1f816-1913-45b1-94b7-a5721a18296c' or */text() = '9faa6ea1-372a-4826-a3c7-fb5b05e31c52' or */text() = 'aa791cf1-ead5-4364-b0c3-4c54dc83c7e4' or */text() = 'b895b6cf-80d7-4c82-8ca4-f26a682fff0b' or */text() = 'b95f9c1f-00b2-4eb6-b890-3f5e11bc8c7b' or */text() = 'bebe21b4-15cf-480b-80b7-b6e229676bea' or */text() = 'c88e743d-e838-49e1-8c80-54f26bcf4ab8' or */text() = 'd047cdb1-a62b-4299-8469-9038519430c0' or */text() = 'd96b007a-4e26-4dbd-8dd5-24dbe5c9b31f' or */text() = 'db4cfdd3-0687-4460-a2c7-fd10ca29c214' or */text() = 'df6e5e64-f9fb-41e6-9333-855c13e4808c' or */text() = 'e1b7db81-4168-492a-9f45-68cbf7b718d3' or */text() = 'f68623ca-c1ff-44b6-a582-14872f43fc93' or */text() = 'fe8d5d51-36ab-46d4-be61-dcfad7c308f1' or */text() = 'fee1dd1a-b65b-4d01-9f54-00c080f9e151']) > 0\",\n    \"xpath\": \"/gmd:identificationInfo/gmd:MD_DataIdentification\",\n    \"value\": \"<gn_add><gmd:descriptiveKeywords xmlns:gmd=\\\"http://www.isotc211.org/2005/gmd\\\" xmlns:gco=\\\"http://www.isotc211.org/2005/gco\\\" xmlns:gmx=\\\"http://www.isotc211.org/2005/gmx\\\" xmlns:xlink=\\\"http://www.w3.org/1999/xlink\\\"><gmd:MD_Keywords><gmd:keyword><gco:CharacterString>/Etat du Milieu/Littoral</gco:CharacterString></gmd:keyword><gmd:type><gmd:MD_KeywordTypeCode codeList=\\\"http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_KeywordTypeCode\\\" codeListValue=\\\"theme\\\"/></gmd:type><gmd:thesaurusName><gmd:CI_Citation><gmd:title><gco:CharacterString>Thématiques - SIMM</gco:CharacterString></gmd:title><gmd:identifier><gmd:MD_Identifier><gmd:code><gmx:Anchor xlink:href=\\\"https://sextant.ifremer.fr/geonetwork/srv/eng/thesaurus.download?ref=local.theme.simm.thematiques\\\">geonetwork.thesaurus.local.theme.simm.thematiques</gmx:Anchor></gmd:code></gmd:MD_Identifier></gmd:identifier></gmd:CI_Citation></gmd:thesaurusName></gmd:MD_Keywords></gmd:descriptiveKeywords></gn_add>\"\n  },\n  {\n    \"condition\": \"count(.//gmd:fileIdentifier[*/text() = '6d365112-5c0a-409e-bd45-68197fe3b2e8' or */text() = '84d1f816-1913-45b1-94b7-a5721a18296c' or */text() = '99869345-d8b0-4933-a9d0-3c9e08055c4a' or */text() = '9faa6ea1-372a-4826-a3c7-fb5b05e31c52' or */text() = 'd1cddb75-fd90-4dc3-a17a-8c051406bf51' or */text() = 'db4cfdd3-0687-4460-a2c7-fd10ca29c214' or */text() = 'df6e5e64-f9fb-41e6-9333-855c13e4808c']) > 0\",\n    \"xpath\": \"/gmd:identificationInfo/gmd:MD_DataIdentification\",\n    \"value\": \"<gn_add><gmd:descriptiveKeywords xmlns:gmd=\\\"http://www.isotc211.org/2005/gmd\\\" xmlns:gco=\\\"http://www.isotc211.org/2005/gco\\\" xmlns:gmx=\\\"http://www.isotc211.org/2005/gmx\\\" xmlns:xlink=\\\"http://www.w3.org/1999/xlink\\\"><gmd:MD_Keywords><gmd:keyword><gco:CharacterString>/Données administratives</gco:CharacterString></gmd:keyword><gmd:type><gmd:MD_KeywordTypeCode codeList=\\\"http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_KeywordTypeCode\\\" codeListValue=\\\"theme\\\"/></gmd:type><gmd:thesaurusName><gmd:CI_Citation><gmd:title><gco:CharacterString>Type de jeux de donnée - ODATIS</gco:CharacterString></gmd:title><gmd:identifier><gmd:MD_Identifier><gmd:code><gmx:Anchor xlink:href=\\\"https://sextant.ifremer.fr/geonetwork/srv/eng/thesaurus.download?ref=local.theme.type_jeux_donnee\\\">geonetwork.thesaurus.local.theme.type_jeux_donnee</gmx:Anchor></gmd:code></gmd:MD_Identifier></gmd:identifier></gmd:CI_Citation></gmd:thesaurusName></gmd:MD_Keywords></gmd:descriptiveKeywords></gn_add>\"\n  },\n  {\n    \"condition\": \"count(.//gmd:fileIdentifier[*/text() = '5b3e4da9-4c14-498c-b20e-bc514470eab5' or */text() = '723f0742-727b-45ec-a70d-df6292b7e003' or */text() = 'bebe21b4-15cf-480b-80b7-b6e229676bea' or */text() = 'f97c9bdc-3bdc-45e9-8f28-e687702096d7']) > 0\",\n    \"xpath\": \"/gmd:identificationInfo/gmd:MD_DataIdentification\",\n    \"value\": \"<gn_add><gmd:descriptiveKeywords xmlns:gmd=\\\"http://www.isotc211.org/2005/gmd\\\" xmlns:gco=\\\"http://www.isotc211.org/2005/gco\\\" xmlns:gmx=\\\"http://www.isotc211.org/2005/gmx\\\" xmlns:xlink=\\\"http://www.w3.org/1999/xlink\\\"><gmd:MD_Keywords><gmd:keyword><gco:CharacterString>/Données dérivées/Données de type modèle</gco:CharacterString></gmd:keyword><gmd:type><gmd:MD_KeywordTypeCode codeList=\\\"http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_KeywordTypeCode\\\" codeListValue=\\\"theme\\\"/></gmd:type><gmd:thesaurusName><gmd:CI_Citation><gmd:title><gco:CharacterString>Type de jeux de donnée - ODATIS</gco:CharacterString></gmd:title><gmd:identifier><gmd:MD_Identifier><gmd:code><gmx:Anchor xlink:href=\\\"https://sextant.ifremer.fr/geonetwork/srv/eng/thesaurus.download?ref=local.theme.type_jeux_donnee\\\">geonetwork.thesaurus.local.theme.type_jeux_donnee</gmx:Anchor></gmd:code></gmd:MD_Identifier></gmd:identifier></gmd:CI_Citation></gmd:thesaurusName></gmd:MD_Keywords></gmd:descriptiveKeywords></gn_add>\"\n  },\n  {\n    \"condition\": \"count(.//gmd:fileIdentifier[*/text() = '0f5f5180-8546-4bc9-979f-3039e850f23a' or */text() = '231a62c7-f2fb-4e7b-b805-4ce06f4f61db' or */text() = '2bf95800-8b2e-4edf-9a45-05860300f002' or */text() = '3feffd63-ab0b-4f03-84e8-b2c324c93bbe' or */text() = '49eb412e-3002-492c-8323-ab5cac07fc40' or */text() = '5d2e8632-245e-41ad-9a7b-be78f4f4597d' or */text() = '660a7b8e-27c0-4b94-b495-e2d6d98ddd42' or */text() = '6b7b7f62-659f-4df7-8b54-88c5113a9400' or */text() = '6bea3720-f2dc-4e64-813c-80f89eeff019' or */text() = '70064384-f3b7-49ad-b137-bdf31af82158' or */text() = '723f0742-727b-45ec-a70d-df6292b7e003' or */text() = '7c66cfd5-4246-4b9d-86af-624950aa49d4' or */text() = 'cd87cd22-0a6f-499b-9e27-9691e6e46030' or */text() = 'dfe9061b-84ad-4ef1-ba83-519ab61ebb40' or */text() = 'f7fb5360-e8e6-4a98-852c-3f56f96a361c' or */text() = 'fc018b57-05ba-4692-b96b-809983a3a983' or */text() = 'fc96c6c8-8832-4908-b634-522403aca882' or */text() = '789de867-c056-4f59-ac42-c7bbf71e662b']) > 0\",\n    \"xpath\": \"/gmd:identificationInfo/gmd:MD_DataIdentification\",\n    \"value\": \"<gn_add><gmd:descriptiveKeywords xmlns:gmd=\\\"http://www.isotc211.org/2005/gmd\\\" xmlns:gco=\\\"http://www.isotc211.org/2005/gco\\\" xmlns:gmx=\\\"http://www.isotc211.org/2005/gmx\\\" xmlns:xlink=\\\"http://www.w3.org/1999/xlink\\\"><gmd:MD_Keywords><gmd:keyword><gco:CharacterString>/Données dérivées/Indicateurs</gco:CharacterString></gmd:keyword><gmd:type><gmd:MD_KeywordTypeCode codeList=\\\"http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_KeywordTypeCode\\\" codeListValue=\\\"theme\\\"/></gmd:type><gmd:thesaurusName><gmd:CI_Citation><gmd:title><gco:CharacterString>Type de jeux de donnée - ODATIS</gco:CharacterString></gmd:title><gmd:identifier><gmd:MD_Identifier><gmd:code><gmx:Anchor xlink:href=\\\"https://sextant.ifremer.fr/geonetwork/srv/eng/thesaurus.download?ref=local.theme.type_jeux_donnee\\\">geonetwork.thesaurus.local.theme.type_jeux_donnee</gmx:Anchor></gmd:code></gmd:MD_Identifier></gmd:identifier></gmd:CI_Citation></gmd:thesaurusName></gmd:MD_Keywords></gmd:descriptiveKeywords></gn_add>\"\n  },\n  {\n    \"condition\": \"count(.//gmd:fileIdentifier[*/text() = '0ab524a2-fd09-4185-adc8-58998efe8f23' or */text() = '0f5f5180-8546-4bc9-979f-3039e850f23a' or */text() = '1ae48a16-89b7-4568-aae8-2308f254e2cf' or */text() = '1c3b1860-780e-44fa-ad80-85405a0cb2a9' or */text() = '1d8c8e88-fb95-40f8-b41a-7134aaff2d8a' or */text() = '205e2db2-4e35-4b1b-bf84-271c4a82248c' or */text() = '22ad5ddf-967d-4ce7-9933-f7ac89e0b638' or */text() = '24cdf846-e0d3-4884-84c7-9930d5b29c38' or */text() = '2bf95800-8b2e-4edf-9a45-05860300f002' or */text() = '393359a7-7ebd-4a52-80ac-1a18d5f3db9c' or */text() = '3feffd63-ab0b-4f03-84e8-b2c324c93bbe' or */text() = '49eb412e-3002-492c-8323-ab5cac07fc40' or */text() = '4c1baca3-6494-4463-9958-dc4d8d15bbab' or */text() = '565db295-0d63-4e22-87e9-c812bc8db13f' or */text() = '5b83a3ca-2545-4b9e-a294-e709be063059' or */text() = '5d2e8632-245e-41ad-9a7b-be78f4f4597d' or */text() = '60b9ba8d-f133-4143-962a-f1edb49d2e60' or */text() = '660a7b8e-27c0-4b94-b495-e2d6d98ddd42' or */text() = '670cb5a9-40b9-4b12-90e3-597de5927700' or */text() = '6d8f11b5-d395-45fb-937e-bea2f290c447' or */text() = '6e2e8ce0-7d81-4904-bf52-e919f784ef6e' or */text() = '70064384-f3b7-49ad-b137-bdf31af82158' or */text() = '7c66cfd5-4246-4b9d-86af-624950aa49d4' or */text() = '7fc458f8-40e1-4528-87bf-62ef0896fbb3' or */text() = '84b01013-692f-4342-bd75-28a0225848c2' or */text() = '8874825e-8459-4ae3-92cd-1b5ce3d90ebf' or */text() = '9f71b3e3-f8ec-442b-a2d5-c3c190605ac4' or */text() = 'a86f0051-c971-4492-84b2-eb42aaab5fa9' or */text() = 'aa791cf1-ead5-4364-b0c3-4c54dc83c7e4' or */text() = 'b895b6cf-80d7-4c82-8ca4-f26a682fff0b' or */text() = 'b95f9c1f-00b2-4eb6-b890-3f5e11bc8c7b' or */text() = 'c88e743d-e838-49e1-8c80-54f26bcf4ab8' or */text() = 'cc8c0653-59e7-4f20-aa05-5f8ecb720fee' or */text() = 'cd87cd22-0a6f-499b-9e27-9691e6e46030' or */text() = 'd047cdb1-a62b-4299-8469-9038519430c0' or */text() = 'd96b007a-4e26-4dbd-8dd5-24dbe5c9b31f' or */text() = 'da521e3e-95bb-4eb3-8226-358e1171e298' or */text() = 'df6e5e64-f9fb-41e6-9333-855c13e4808c' or */text() = 'dfe9061b-84ad-4ef1-ba83-519ab61ebb40' or */text() = 'e1b7db81-4168-492a-9f45-68cbf7b718d3' or */text() = 'e99610ad-8fdb-44f2-a671-ccf9ec13c252' or */text() = 'f461f13a-038c-4e3d-bfbe-22e91389dcef' or */text() = 'f626c353-fff5-410c-84f1-1cf48951f4af' or */text() = 'f68623ca-c1ff-44b6-a582-14872f43fc93' or */text() = 'f7fb5360-e8e6-4a98-852c-3f56f96a361c' or */text() = 'fc018b57-05ba-4692-b96b-809983a3a983' or */text() = 'fe8d5d51-36ab-46d4-be61-dcfad7c308f1' or */text() = 'fee1dd1a-b65b-4d01-9f54-00c080f9e151' or */text() = 'fff43204-793a-4a44-96f7-918672a2047d']) > 0\",\n    \"xpath\": \"/gmd:identificationInfo/gmd:MD_DataIdentification\",\n    \"value\": \"<gn_add><gmd:descriptiveKeywords xmlns:gmd=\\\"http://www.isotc211.org/2005/gmd\\\" xmlns:gco=\\\"http://www.isotc211.org/2005/gco\\\" xmlns:gmx=\\\"http://www.isotc211.org/2005/gmx\\\" xmlns:xlink=\\\"http://www.w3.org/1999/xlink\\\"><gmd:MD_Keywords><gmd:keyword><gco:CharacterString>/Données dérivées/Produits composites</gco:CharacterString></gmd:keyword><gmd:type><gmd:MD_KeywordTypeCode codeList=\\\"http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_KeywordTypeCode\\\" codeListValue=\\\"theme\\\"/></gmd:type><gmd:thesaurusName><gmd:CI_Citation><gmd:title><gco:CharacterString>Type de jeux de donnée - ODATIS</gco:CharacterString></gmd:title><gmd:identifier><gmd:MD_Identifier><gmd:code><gmx:Anchor xlink:href=\\\"https://sextant.ifremer.fr/geonetwork/srv/eng/thesaurus.download?ref=local.theme.type_jeux_donnee\\\">geonetwork.thesaurus.local.theme.type_jeux_donnee</gmx:Anchor></gmd:code></gmd:MD_Identifier></gmd:identifier></gmd:CI_Citation></gmd:thesaurusName></gmd:MD_Keywords></gmd:descriptiveKeywords></gn_add>\"\n  },\n  {\n    \"condition\": \"count(.//gmd:fileIdentifier[*/text() = '1c3b1860-780e-44fa-ad80-85405a0cb2a9' or */text() = '1fb349ec-84d9-46ee-b361-facb4e3a5251f' or */text() = '660ce4c2-6e23-4aca-b906-0996bdcf24acf' or */text() = '6d365112-5c0a-409e-bd45-68197fe3b2e8' or */text() = '84d1f816-1913-45b1-94b7-a5721a18296c' or */text() = '99869345-d8b0-4933-a9d0-3c9e08055c4a' or */text() = '9faa6ea1-372a-4826-a3c7-fb5b05e31c52' or */text() = 'd1cddb75-fd90-4dc3-a17a-8c051406bf51' or */text() = 'db4cfdd3-0687-4460-a2c7-fd10ca29c214' or */text() = 'df6e5e64-f9fb-41e6-9333-855c13e4808c']) > 0\",\n    \"xpath\": \"/gmd:identificationInfo/gmd:MD_DataIdentification\",\n    \"value\": \"<gn_add><gmd:descriptiveKeywords xmlns:gmd=\\\"http://www.isotc211.org/2005/gmd\\\" xmlns:gco=\\\"http://www.isotc211.org/2005/gco\\\" xmlns:gmx=\\\"http://www.isotc211.org/2005/gmx\\\" xmlns:xlink=\\\"http://www.w3.org/1999/xlink\\\"><gmd:MD_Keywords><gmd:keyword><gco:CharacterString>/Données dérivées/Références statistiques</gco:CharacterString></gmd:keyword><gmd:type><gmd:MD_KeywordTypeCode codeList=\\\"http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_KeywordTypeCode\\\" codeListValue=\\\"theme\\\"/></gmd:type><gmd:thesaurusName><gmd:CI_Citation><gmd:title><gco:CharacterString>Type de jeux de donnée - ODATIS</gco:CharacterString></gmd:title><gmd:identifier><gmd:MD_Identifier><gmd:code><gmx:Anchor xlink:href=\\\"https://sextant.ifremer.fr/geonetwork/srv/eng/thesaurus.download?ref=local.theme.type_jeux_donnee\\\">geonetwork.thesaurus.local.theme.type_jeux_donnee</gmx:Anchor></gmd:code></gmd:MD_Identifier></gmd:identifier></gmd:CI_Citation></gmd:thesaurusName></gmd:MD_Keywords></gmd:descriptiveKeywords></gn_add>\"\n  },\n  {\n    \"condition\": \"count(.//gmd:fileIdentifier[*/text() = '1ae48a16-89b7-4568-aae8-2308f254e2cf' or */text() = '205e2db2-4e35-4b1b-bf84-271c4a82248c' or */text() = '24cdf846-e0d3-4884-84c7-9930d5b29c38' or */text() = '393359a7-7ebd-4a52-80ac-1a18d5f3db9c' or */text() = '4c1baca3-6494-4463-9958-dc4d8d15bbab' or */text() = 'b95f9c1f-00b2-4eb6-b890-3f5e11bc8c7b' or */text() = 'c88e743d-e838-49e1-8c80-54f26bcf4ab8' or */text() = 'd047cdb1-a62b-4299-8469-9038519430c0' or */text() = 'd96b007a-4e26-4dbd-8dd5-24dbe5c9b31f' or */text() = 'e1b7db81-4168-492a-9f45-68cbf7b718d3' or */text() = 'f68623ca-c1ff-44b6-a582-14872f43fc93' or */text() = 'fe8d5d51-36ab-46d4-be61-dcfad7c308f1' or */text() = 'fee1dd1a-b65b-4d01-9f54-00c080f9e151']) > 0\",\n    \"xpath\": \"/gmd:identificationInfo/gmd:MD_DataIdentification\",\n    \"value\": \"<gn_add><gmd:descriptiveKeywords xmlns:gmd=\\\"http://www.isotc211.org/2005/gmd\\\" xmlns:gco=\\\"http://www.isotc211.org/2005/gco\\\" xmlns:gmx=\\\"http://www.isotc211.org/2005/gmx\\\" xmlns:xlink=\\\"http://www.w3.org/1999/xlink\\\"><gmd:MD_Keywords><gmd:keyword><gco:CharacterString>/Télédétection</gco:CharacterString></gmd:keyword><gmd:type><gmd:MD_KeywordTypeCode codeList=\\\"http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_KeywordTypeCode\\\" codeListValue=\\\"theme\\\"/></gmd:type><gmd:thesaurusName><gmd:CI_Citation><gmd:title><gco:CharacterString>Type de jeux de donnée - ODATIS</gco:CharacterString></gmd:title><gmd:identifier><gmd:MD_Identifier><gmd:code><gmx:Anchor xlink:href=\\\"https://sextant.ifremer.fr/geonetwork/srv/eng/thesaurus.download?ref=local.theme.type_jeux_donnee\\\">geonetwork.thesaurus.local.theme.type_jeux_donnee</gmx:Anchor></gmd:code></gmd:MD_Identifier></gmd:identifier></gmd:CI_Citation></gmd:thesaurusName></gmd:MD_Keywords></gmd:descriptiveKeywords></gn_add>\"\n  },\n  {\n    \"condition\": \"count(.//gmd:fileIdentifier[*/text() = '0f5f5180-8546-4bc9-979f-3039e850f23a' or */text() = '2bf95800-8b2e-4edf-9a45-05860300f002' or */text() = '3feffd63-ab0b-4f03-84e8-b2c324c93bbe' or */text() = '49eb412e-3002-492c-8323-ab5cac07fc40' or */text() = '5d2e8632-245e-41ad-9a7b-be78f4f4597d' or */text() = '660a7b8e-27c0-4b94-b495-e2d6d98ddd42' or */text() = '6d365112-5c0a-409e-bd45-68197fe3b2e8' or */text() = '7c66cfd5-4246-4b9d-86af-624950aa49d4' or */text() = '84d1f816-1913-45b1-94b7-a5721a18296c' or */text() = '99869345-d8b0-4933-a9d0-3c9e08055c4a' or */text() = 'cd87cd22-0a6f-499b-9e27-9691e6e46030' or */text() = 'd1cddb75-fd90-4dc3-a17a-8c051406bf51' or */text() = 'dfe9061b-84ad-4ef1-ba83-519ab61ebb40' or */text() = 'fc018b57-05ba-4692-b96b-809983a3a983']) > 0\",\n    \"xpath\": \"/gmd:identificationInfo/gmd:MD_DataIdentification\",\n    \"value\": \"<gn_add><gmd:descriptiveKeywords xmlns:gmd=\\\"http://www.isotc211.org/2005/gmd\\\" xmlns:gco=\\\"http://www.isotc211.org/2005/gco\\\" xmlns:gmx=\\\"http://www.isotc211.org/2005/gmx\\\" xmlns:xlink=\\\"http://www.w3.org/1999/xlink\\\"><gmd:MD_Keywords><gmd:keyword><gco:CharacterString>Directive Cadre Stratégie pour le Milieu Marin (DCSMM)</gco:CharacterString></gmd:keyword><gmd:type><gmd:MD_KeywordTypeCode codeList=\\\"http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_KeywordTypeCode\\\" codeListValue=\\\"theme\\\"/></gmd:type><gmd:thesaurusName><gmd:CI_Citation><gmd:title><gco:CharacterString>Cadre Réglementaire - SIMM</gco:CharacterString></gmd:title><gmd:identifier><gmd:MD_Identifier><gmd:code><gmx:Anchor xlink:href=\\\"https://sextant.ifremer.fr/geonetwork/srv/eng/thesaurus.download?ref=local.theme.simm.reglementaire\\\">geonetwork.thesaurus.local.theme.simm.reglementaire</gmx:Anchor></gmd:code></gmd:MD_Identifier></gmd:identifier></gmd:CI_Citation></gmd:thesaurusName></gmd:MD_Keywords></gmd:descriptiveKeywords></gn_add>\"\n  },\n  {\n    \"condition\": \"count(.//gmd:fileIdentifier[*/text() = '0f5f5180-8546-4bc9-979f-3039e850f23a' or */text() = '1d8c8e88-fb95-40f8-b41a-7134aaff2d8a' or */text() = '2bf95800-8b2e-4edf-9a45-05860300f002' or */text() = '3feffd63-ab0b-4f03-84e8-b2c324c93bbe' or */text() = '49eb412e-3002-492c-8323-ab5cac07fc40' or */text() = '5d2e8632-245e-41ad-9a7b-be78f4f4597d' or */text() = '660a7b8e-27c0-4b94-b495-e2d6d98ddd42' or */text() = '6b7b7f62-659f-4df7-8b54-88c5113a9400' or */text() = '7c66cfd5-4246-4b9d-86af-624950aa49d4' or */text() = 'b895b6cf-80d7-4c82-8ca4-f26a682fff0b' or */text() = 'cd87cd22-0a6f-499b-9e27-9691e6e46030' or */text() = 'dfe9061b-84ad-4ef1-ba83-519ab61ebb40' or */text() = 'fc018b57-05ba-4692-b96b-809983a3a983']) > 0\",\n    \"xpath\": \"/gmd:identificationInfo/gmd:MD_DataIdentification\",\n    \"value\": \"<gn_add><gmd:descriptiveKeywords xmlns:gmd=\\\"http://www.isotc211.org/2005/gmd\\\" xmlns:gco=\\\"http://www.isotc211.org/2005/gco\\\" xmlns:gmx=\\\"http://www.isotc211.org/2005/gmx\\\" xmlns:xlink=\\\"http://www.w3.org/1999/xlink\\\"><gmd:MD_Keywords><gmd:keyword><gco:CharacterString>Directive Cadre sur l'Eau (DCE)</gco:CharacterString></gmd:keyword><gmd:type><gmd:MD_KeywordTypeCode codeList=\\\"http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_KeywordTypeCode\\\" codeListValue=\\\"theme\\\"/></gmd:type><gmd:thesaurusName><gmd:CI_Citation><gmd:title><gco:CharacterString>Cadre Réglementaire - SIMM</gco:CharacterString></gmd:title><gmd:identifier><gmd:MD_Identifier><gmd:code><gmx:Anchor xlink:href=\\\"https://sextant.ifremer.fr/geonetwork/srv/eng/thesaurus.download?ref=local.theme.simm.reglementaire\\\">geonetwork.thesaurus.local.theme.simm.reglementaire</gmx:Anchor></gmd:code></gmd:MD_Identifier></gmd:identifier></gmd:CI_Citation></gmd:thesaurusName></gmd:MD_Keywords></gmd:descriptiveKeywords></gn_add>\"\n  },\n  {\n    \"condition\": \"count(.//gmd:fileIdentifier[*/text() = 'aa791cf1-ead5-4364-b0c3-4c54dc83c7e4']) > 0\",\n    \"xpath\": \"/gmd:identificationInfo/gmd:MD_DataIdentification\",\n    \"value\": \"<gn_add><gmd:descriptiveKeywords xmlns:gmd=\\\"http://www.isotc211.org/2005/gmd\\\" xmlns:gco=\\\"http://www.isotc211.org/2005/gco\\\" xmlns:gmx=\\\"http://www.isotc211.org/2005/gmx\\\" xmlns:xlink=\\\"http://www.w3.org/1999/xlink\\\"><gmd:MD_Keywords><gmd:keyword><gco:CharacterString>Convention sur la Diversité Biologique</gco:CharacterString></gmd:keyword><gmd:type><gmd:MD_KeywordTypeCode codeList=\\\"http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_KeywordTypeCode\\\" codeListValue=\\\"theme\\\"/></gmd:type><gmd:thesaurusName><gmd:CI_Citation><gmd:title><gco:CharacterString>Cadre Réglementaire - SIMM</gco:CharacterString></gmd:title><gmd:identifier><gmd:MD_Identifier><gmd:code><gmx:Anchor xlink:href=\\\"https://sextant.ifremer.fr/geonetwork/srv/eng/thesaurus.download?ref=local.theme.simm.reglementaire\\\">geonetwork.thesaurus.local.theme.simm.reglementaire</gmx:Anchor></gmd:code></gmd:MD_Identifier></gmd:identifier></gmd:CI_Citation></gmd:thesaurusName></gmd:MD_Keywords></gmd:descriptiveKeywords></gn_add>\"\n  },\n  {\n    \"condition\": \"count(.//gmd:fileIdentifier[*/text() = '6b7b7f62-659f-4df7-8b54-88c5113a9400' or */text() = 'f7fb5360-e8e6-4a98-852c-3f56f96a361c']) > 0\",\n    \"xpath\": \"/gmd:identificationInfo/gmd:MD_DataIdentification\",\n    \"value\": \"<gn_add><gmd:descriptiveKeywords xmlns:gmd=\\\"http://www.isotc211.org/2005/gmd\\\" xmlns:gco=\\\"http://www.isotc211.org/2005/gco\\\" xmlns:gmx=\\\"http://www.isotc211.org/2005/gmx\\\" xmlns:xlink=\\\"http://www.w3.org/1999/xlink\\\"><gmd:MD_Keywords><gmd:keyword><gco:CharacterString>Directive Eaux de baignade</gco:CharacterString></gmd:keyword><gmd:type><gmd:MD_KeywordTypeCode codeList=\\\"http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_KeywordTypeCode\\\" codeListValue=\\\"theme\\\"/></gmd:type><gmd:thesaurusName><gmd:CI_Citation><gmd:title><gco:CharacterString>Cadre Réglementaire - SIMM</gco:CharacterString></gmd:title><gmd:identifier><gmd:MD_Identifier><gmd:code><gmx:Anchor xlink:href=\\\"https://sextant.ifremer.fr/geonetwork/srv/eng/thesaurus.download?ref=local.theme.simm.reglementaire\\\">geonetwork.thesaurus.local.theme.simm.reglementaire</gmx:Anchor></gmd:code></gmd:MD_Identifier></gmd:identifier></gmd:CI_Citation></gmd:thesaurusName></gmd:MD_Keywords></gmd:descriptiveKeywords></gn_add>\"\n  },\n  {\n    \"condition\": \"count(.//gmd:fileIdentifier[*/text() = '7fc458f8-40e1-4528-87bf-62ef0896fbb3' or */text() = '9f71b3e3-f8ec-442b-a2d5-c3c190605ac4' or */text() = 'f461f13a-038c-4e3d-bfbe-22e91389dcef']) > 0\",\n    \"xpath\": \"/gmd:identificationInfo/gmd:MD_DataIdentification\",\n    \"value\": \"<gn_add><gmd:descriptiveKeywords xmlns:gmd=\\\"http://www.isotc211.org/2005/gmd\\\" xmlns:gco=\\\"http://www.isotc211.org/2005/gco\\\" xmlns:gmx=\\\"http://www.isotc211.org/2005/gmx\\\" xmlns:xlink=\\\"http://www.w3.org/1999/xlink\\\"><gmd:MD_Keywords><gmd:keyword><gco:CharacterString>Directive Habitat, Faune et Flore</gco:CharacterString></gmd:keyword><gmd:type><gmd:MD_KeywordTypeCode codeList=\\\"http://standards.iso.org/ittf/PubliclyAvailableStandards/ISO_19139_Schemas/resources/codelist/ML_gmxCodelists.xml#MD_KeywordTypeCode\\\" codeListValue=\\\"theme\\\"/></gmd:type><gmd:thesaurusName><gmd:CI_Citation><gmd:title><gco:CharacterString>Cadre Réglementaire - SIMM</gco:CharacterString></gmd:title><gmd:identifier><gmd:MD_Identifier><gmd:code><gmx:Anchor xlink:href=\\\"https://sextant.ifremer.fr/geonetwork/srv/eng/thesaurus.download?ref=local.theme.simm.reglementaire\\\">geonetwork.thesaurus.local.theme.simm.reglementaire</gmx:Anchor></gmd:code></gmd:MD_Identifier></gmd:identifier></gmd:CI_Citation></gmd:thesaurusName></gmd:MD_Keywords></gmd:descriptiveKeywords></gn_add>\"\n  }\n]","translateContent":false,"translateContentLangs":"","translateContentFields":[]},"options":{"every":"0 0 10 * * ?","oneRunOnly":false,"overrideUuid":"SKIP","status":"active"},"filters":[{"field":"Identifier","operator":"EQUAL","value":"e1b7db81-4168-492a-9f45-68cbf7b718d3","condition":[]},{"field":"Identifier","operator":"EQUAL","value":"d96b007a-4e26-4dbd-8dd5-24dbe5c9b31f","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"49eb412e-3002-492c-8323-ab5cac07fc40","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"dfe9061b-84ad-4ef1-ba83-519ab61ebb40","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"cd87cd22-0a6f-499b-9e27-9691e6e46030","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"fc018b57-05ba-4692-b96b-809983a3a983","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"2bf95800-8b2e-4edf-9a45-05860300f002","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"5d2e8632-245e-41ad-9a7b-be78f4f4597d","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"0f5f5180-8546-4bc9-979f-3039e850f23a","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"3feffd63-ab0b-4f03-84e8-b2c324c93bbe","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"660a7b8e-27c0-4b94-b495-e2d6d98ddd42","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"7c66cfd5-4246-4b9d-86af-624950aa49d4","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"6b7b7f62-659f-4df7-8b54-88c5113a9400","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"70064384-f3b7-49ad-b137-bdf31af82158","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"fff43204-793a-4a44-96f7-918672a2047d","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"6d8f11b5-d395-45fb-937e-bea2f290c447","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"723f0742-727b-45ec-a70d-df6292b7e003","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"fe8d5d51-36ab-46d4-be61-dcfad7c308f1","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"205e2db2-4e35-4b1b-bf84-271c4a82248c","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"c88e743d-e838-49e1-8c80-54f26bcf4ab8","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"fee1dd1a-b65b-4d01-9f54-00c080f9e151","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"4c1baca3-6494-4463-9958-dc4d8d15bbab","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"f68623ca-c1ff-44b6-a582-14872f43fc93","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"1ae48a16-89b7-4568-aae8-2308f254e2cf","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"6bea3720-f2dc-4e64-813c-80f89eeff019","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"231a62c7-f2fb-4e7b-b805-4ce06f4f61db","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"fc96c6c8-8832-4908-b634-522403aca882","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"7fc458f8-40e1-4528-87bf-62ef0896fbb3","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"9f71b3e3-f8ec-442b-a2d5-c3c190605ac4","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"f461f13a-038c-4e3d-bfbe-22e91389dcef","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"d047cdb1-a62b-4299-8469-9038519430c0","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"670cb5a9-40b9-4b12-90e3-597de5927700","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"aa791cf1-ead5-4364-b0c3-4c54dc83c7e4","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"9faa6ea1-372a-4826-a3c7-fb5b05e31c52","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"db4cfdd3-0687-4460-a2c7-fd10ca29c214","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"84d1f816-1913-45b1-94b7-a5721a18296c","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"660ce4c2-6e23-4aca-b906-0996bdcf24acf","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"1fb349ec-84d9-46ee-b361-facb4e3a5251f","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"393359a7-7ebd-4a52-80ac-1a18d5f3db9c","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"da521e3e-95bb-4eb3-8226-358e1171e298","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"f97c9bdc-3bdc-45e9-8f28-e687702096d7","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"f626c353-fff5-410c-84f1-1cf48951f4af","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"5b3e4da9-4c14-498c-b20e-bc514470eab5","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"7ce1666b-fcdc-4cf3-91f0-96b58ad14e99","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"60b9ba8d-f133-4143-962a-f1edb49d2e60","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"8874825e-8459-4ae3-92cd-1b5ce3d90ebf","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"e99610ad-8fdb-44f2-a671-ccf9ec13c252","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"1d8c8e88-fb95-40f8-b41a-7134aaff2d8a","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"b95f9c1f-00b2-4eb6-b890-3f5e11bc8c7b","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"0ab524a2-fd09-4185-adc8-58998efe8f23","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"a86f0051-c971-4492-84b2-eb42aaab5fa9","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"f7fb5360-e8e6-4a98-852c-3f56f96a361c","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"cc8c0653-59e7-4f20-aa05-5f8ecb720fee","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"24cdf846-e0d3-4884-84c7-9930d5b29c38","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"99869345-d8b0-4933-a9d0-3c9e08055c4a","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"d1cddb75-fd90-4dc3-a17a-8c051406bf51","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"6d365112-5c0a-409e-bd45-68197fe3b2e8","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"1c3b1860-780e-44fa-ad80-85405a0cb2a9","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"84b01013-692f-4342-bd75-28a0225848c2","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"6e2e8ce0-7d81-4904-bf52-e919f784ef6e","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"5b83a3ca-2545-4b9e-a294-e709be063059","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"bebe21b4-15cf-480b-80b7-b6e229676bea","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"22ad5ddf-967d-4ce7-9933-f7ac89e0b638","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"789de867-c056-4f59-ac42-c7bbf71e662b","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"565db295-0d63-4e22-87e9-c812bc8db13f","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"df6e5e64-f9fb-41e6-9333-855c13e4808c","condition":"OR"},{"field":"Identifier","operator":"EQUAL","value":"b895b6cf-80d7-4c82-8ca4-f26a682fff0b","condition":"OR"}],"privileges":[{"@id":"1","operation":[{"@name":"view"},{"@name":"dynamic"},{"@name":"download"}]},{"@id":"334291911","operation":[{"@name":"view"},{"@name":"dynamic"},{"@name":"download"}]}],"ifRecordExistAppendPrivileges":false,"info":{"lastRun":"2026-02-09T12:19:30.986604Z","running":false,"result":{"added":"0","atomicDatasetRecords":"0","badFormat":"0","collectionDatasetRecords":"0","datasetUuidExist":"0","privilegesAppendedOnExistingRecord":"0","doesNotValidate":"0","xpathFilterExcluded":"0","duplicatedResource":"0","fragmentsMatched":"0","fragmentsReturned":"0","fragmentsUnknownSchema":"0","incompatible":"0","recordsBuilt":"0","recordsUpdated":"0","removed":"0","serviceRecords":"0","subtemplatesAdded":"0","subtemplatesRemoved":"0","subtemplatesUpdated":"0","total":"0","unchanged":"0","unknownSchema":"0","unretrievable":"0","updated":"0","thumbnails":"0","thumbnailsFailed":"0"}}}
```



<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

Funded by Ifremer