### PR TITLE
Standard / ISO19115-3 / Indexing / Fix date parsing error on stepDateTime

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/index-fields/index.xsl
@@ -1185,13 +1185,13 @@
                       select="mrl:processStep/*[mrl:description/gco:CharacterString != '']"/>
         <xsl:for-each select="$processSteps">
           <xsl:variable name="stepDateTimeZulu"
-                        select="date-util:convertToISOZuluDateTime(normalize-space(mrl:stepDateTime))"/>
+                        select="date-util:convertToISOZuluDateTime(normalize-space(mrl:stepDateTime//gml:timePosition/text()))"/>
 
           <processSteps type="object">{
             "descriptionObject": <xsl:value-of select="gn-fn-index:add-multilingual-field(
                                 'description', mrl:description, $allLanguages, true())"/>
             <xsl:if test="$stepDateTimeZulu != ''">
-              ,"date": "<xsl:value-of select="mrl:stepDateTime//gml:timePosition/text()"/>"
+              ,"date": "<xsl:value-of select="$stepDateTimeZulu"/>"
             </xsl:if>
             ,"source": [
             <xsl:for-each select="mrl:source/*[mrl:description/gco:CharacterString != '']">


### PR DESCRIPTION
eg.

```xml
<mdb:resourceLineage>
<mrl:LI_Lineage>
 <mrl:statement gco:nilReason="missing">
    <gco:CharacterString/>
 </mrl:statement>
 <mrl:processStep>
    <mrl:LE_ProcessStep>
       <mrl:description>
          <gco:CharacterString>Step 1</gco:CharacterString>
       </mrl:description>
       <mrl:stepDateTime>
          <gml:TimeInstant gml:id="d5396339e631a1051934">
             <gml:timePosition>2026-02-06</gml:timePosition>
          </gml:TimeInstant>
       </mrl:stepDateTime>
    </mrl:LE_ProcessStep>
 </mrl:processStep>
```

Warning is raised while indexing when a process step has addition info like description text.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

Funded by Ifremer