### PR TITLE
Fix issues with metadata api view redirect

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/IMetadataUtils.java
@@ -121,7 +121,30 @@ public interface IMetadataUtils {
 
     LinkedHashMap<String, String> extractTitles(@Nonnull String id) throws Exception;
 
+    /**
+     * Build the canonical public link for a record.
+     *
+     * The result may come from the configured permalink template. If no custom
+     * template is configured, this falls back to the default record URL.
+     *
+     * @param uuid metadata UUID
+     * @param language UI language code to include in the generated URL when applicable
+     * @return canonical public link for the record
+     */
     String getPermalink(String uuid, String language);
+
+    /**
+     * Build the plain HTML record link.
+     *
+     * When DOI-first mode is enabled and a DOI exists, the DOI URL is returned.
+     * Otherwise, this returns a direct server-rendered HTML endpoint suitable for
+     * search-engine crawlers (no SPA redirect).
+     *
+     * @param uuid metadata UUID
+     * @param language UI language code to include in the generated URL when applicable
+     * @return plain HTML public link for the record
+     */
+    String getPlainHtmlUrl(String uuid, String language);
 
     String getDefaultUrl(String uuid, String language);
 

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataUtils.java
@@ -365,10 +365,10 @@ public class BaseMetadataUtils implements IMetadataUtils {
             // Get the formatter configured for *links* to records (recordLinkFormatter) from the UI configuration.
             String recordLinkFormatter = XslUtil.getUiConfigurationJsonProperty(null, "mods.search.formatter.recordLinkFormatter");
 
-            // When building the record URL, the formatter is passed as the `recordViewFormatter` query parameter
-            // because the API expects that parameter name to decide which formatter to use when displaying the record.
+            // If there is a formatter configured for links to records, add the redirectToRecordView parameter to the
+            // permalink so that the record view will be used to display the record instead of the metadata api view.
             if (StringUtils.isNotBlank(recordLinkFormatter)) {
-                uriComponentsBuilder.queryParam("recordViewFormatter", recordLinkFormatter);
+                uriComponentsBuilder.queryParam("redirectToRecordView", true);
             }
         }
 

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataUtils.java
@@ -333,11 +333,34 @@ public class BaseMetadataUtils implements IMetadataUtils {
         return null;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String getPermalink(String uuid, String language) {
-        Boolean doiIsFirst = settingManager.getValueAsBool(METADATA_URL_SITEMAPDOIFIRST, false);
+        return getPermalink(uuid, language, false);
+    }
 
-        if (Boolean.TRUE.equals(doiIsFirst)) {
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public String getPlainHtmlUrl(String uuid, String language) {
+        return getPermalink(uuid, language, true);
+    }
+
+    /**
+     * Build a record URL with optional plain HTML rendering.
+     *
+     * If DOI-first is enabled and a DOI exists, the DOI is returned immediately.
+     * Otherwise, this uses the configured permalink template when available; if not,
+     * it falls back to the default API record URL and adapts it depending on whether
+     * a plain HTML (crawler-friendly) link is requested.
+     */
+    private String getPermalink(String uuid, String language, boolean plainHtml) {
+        boolean doiIsFirst = settingManager.getValueAsBool(METADATA_URL_SITEMAPDOIFIRST, false);
+
+        if (doiIsFirst) {
             String doi = null;
             try {
                 doi = getDoi(uuid);
@@ -351,16 +374,22 @@ public class BaseMetadataUtils implements IMetadataUtils {
 
 
         String sitemapLinkUrl = settingManager.getValue(METADATA_URL_SITEMAPLINKURL);
-        String defaultLink = settingManager.getNodeURL() + "api/records/" + uuid + "?language=all";
+        String defaultLink = settingManager.getNodeURL() + "api/records/" + uuid;
         String permalink = buildUrl(uuid, language, sitemapLinkUrl);
 
         // If the permalink template has been modified use the configured permalink template
-        // otherwise use the defaultLink
+        // Otherwise, if plain html is requested, use the xsl-view formatter
+        // Otherwise, fallback to the default link
         UriComponentsBuilder uriComponentsBuilder;
         if (StringUtils.isNotEmpty(permalink) && !defaultLink.equals(permalink)) {
             uriComponentsBuilder = UriComponentsBuilder.fromUriString(permalink);
         } else {
             uriComponentsBuilder = UriComponentsBuilder.fromUriString(defaultLink);
+            if (plainHtml) {
+                uriComponentsBuilder.pathSegment("formatters", "xsl-view");
+            } else {
+                uriComponentsBuilder.queryParam("language", "all");
+            }
         }
 
         return uriComponentsBuilder.build().toString();

--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataUtils.java
@@ -361,15 +361,6 @@ public class BaseMetadataUtils implements IMetadataUtils {
             uriComponentsBuilder = UriComponentsBuilder.fromUriString(permalink);
         } else {
             uriComponentsBuilder = UriComponentsBuilder.fromUriString(defaultLink);
-
-            // Get the formatter configured for *links* to records (recordLinkFormatter) from the UI configuration.
-            String recordLinkFormatter = XslUtil.getUiConfigurationJsonProperty(null, "mods.search.formatter.recordLinkFormatter");
-
-            // If there is a formatter configured for links to records, add the redirectToRecordView parameter to the
-            // permalink so that the record view will be used to display the record instead of the metadata api view.
-            if (StringUtils.isNotBlank(recordLinkFormatter)) {
-                uriComponentsBuilder.queryParam("redirectToRecordView", true);
-            }
         }
 
         return uriComponentsBuilder.build().toString();

--- a/core/src/main/java/org/fao/geonet/util/LocalizedEmailComponent.java
+++ b/core/src/main/java/org/fao/geonet/util/LocalizedEmailComponent.java
@@ -288,7 +288,7 @@ public class LocalizedEmailComponent {
             } else {
                 // Replace the link placeholders with index field placeholder so that it isn't interpreted as a MessageFormat arg
                 if (replaceLinks) {
-                    parsedMessage = replaceLinks(parsedMessage);
+                    parsedMessage = replaceLinks(parsedMessage, locale);
                 }
                 parsedMessage = MessageFormat.format(parsedMessage, parsedLocaleEmailParameters);
             }
@@ -303,7 +303,7 @@ public class LocalizedEmailComponent {
 
         // Replace link placeholders
         if (replaceLinks) {
-            parsedMessage = replaceLinks(parsedMessage);
+            parsedMessage = replaceLinks(parsedMessage, locale);
         }
 
         // Replace index field placeholders
@@ -359,7 +359,7 @@ public class LocalizedEmailComponent {
         }
     }
 
-    private String replaceLinks(String message) {
+    private String replaceLinks(String message, Locale locale) {
         SettingManager settingManager = ApplicationContextHolder.get().getBean(SettingManager.class);
 
         // Get the formatter configured for *links* to records (recordLinkFormatter) from the UI configuration.
@@ -371,10 +371,12 @@ public class LocalizedEmailComponent {
             .fromHttpUrl(settingManager.getNodeURL())
             .pathSegment("api", "records", replaceLinksWithHtmlFormat ? "{{index:uuid}}" : "'{{index:uuid}}'");
 
-        // When building the record URL, the formatter is passed as the `recordViewFormatter` query parameter
-        // because the API expects that parameter name to decide which formatter to use when displaying the record.
+        uriComponentsBuilder.queryParam("language", locale.getISO3Language());
+
+        // If there is a formatter configured for links to records, add the redirectToRecordView parameter to the
+        // permalink so that the record view will be used to display the record instead of the metadata api view.
         if (StringUtils.isNotBlank(recordLinkFormatter)) {
-            uriComponentsBuilder.queryParam("recordViewFormatter", recordLinkFormatter);
+            uriComponentsBuilder.queryParam("redirectToRecordView", true);
         }
 
         return message.replace("{{link}}", uriComponentsBuilder.build().toString());

--- a/core/src/main/java/org/fao/geonet/util/LocalizedEmailComponent.java
+++ b/core/src/main/java/org/fao/geonet/util/LocalizedEmailComponent.java
@@ -362,9 +362,6 @@ public class LocalizedEmailComponent {
     private String replaceLinks(String message, Locale locale) {
         SettingManager settingManager = ApplicationContextHolder.get().getBean(SettingManager.class);
 
-        // Get the formatter configured for *links* to records (recordLinkFormatter) from the UI configuration.
-        String recordLinkFormatter = XslUtil.getUiConfigurationJsonProperty(null, "mods.search.formatter.recordLinkFormatter");
-
         // Build the link to replace the {{link}} placeholder
         // Add the uuid placeholder to the link in the specified format
         UriComponentsBuilder uriComponentsBuilder = UriComponentsBuilder
@@ -372,12 +369,6 @@ public class LocalizedEmailComponent {
             .pathSegment("api", "records", replaceLinksWithHtmlFormat ? "{{index:uuid}}" : "'{{index:uuid}}'");
 
         uriComponentsBuilder.queryParam("language", locale.getISO3Language());
-
-        // If there is a formatter configured for links to records, add the redirectToRecordView parameter to the
-        // permalink so that the record view will be used to display the record instead of the metadata api view.
-        if (StringUtils.isNotBlank(recordLinkFormatter)) {
-            uriComponentsBuilder.queryParam("redirectToRecordView", true);
-        }
 
         return message.replace("{{link}}", uriComponentsBuilder.build().toString());
     }

--- a/core/src/main/java/org/fao/geonet/util/XslUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/XslUtil.java
@@ -1201,11 +1201,28 @@ public final class XslUtil {
         return si.getSiteUrl() + (!baseUrl.startsWith("/") ? "/" : "") + baseUrl;
     }
 
-    public static String getPermalink(String uuid, String language) {
+    /**
+     * Return the plain HTML record link for a metadata UUID.
+     * <p>
+     * Depending on configuration, this may resolve to a DOI URL or to a direct
+     * server-rendered HTML endpoint suitable for crawlers.
+     *
+     * @param uuid metadata UUID
+     * @param language UI language code when language-specific links are enabled
+     * @return plain HTML link for the record
+     */
+    public static String getPlainHtmlUrl(String uuid, String language) {
         BaseMetadataUtils metadataUtils = ApplicationContextHolder.get().getBean(BaseMetadataUtils.class);
-        return metadataUtils.getPermalink(uuid, language);
+        return metadataUtils.getPlainHtmlUrl(uuid, language);
     }
 
+    /**
+     * Return the default UI-oriented record URL.
+     *
+     * @param uuid metadata UUID
+     * @param language UI language code or {@code all}
+     * @return default record URL
+     */
     public static String getDefaultUrl(String uuid, String language) {
         BaseMetadataUtils metadataUtils = ApplicationContextHolder.get().getBean(BaseMetadataUtils.class);
         return metadataUtils.getDefaultUrl(uuid, language);

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/eu-po-doi/base.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/eu-po-doi/base.xsl
@@ -71,7 +71,7 @@
       <eu:DOIData>
         <eu:DOI><xsl:value-of select="gn-doi:createDoi($doiServerId, $metadataUuid)"/></eu:DOI>
         <eu:DOIWebsiteLink>
-          <xsl:value-of select="util:getPermalink($metadataUuid, util:getLanguage())"/>
+          <xsl:value-of select="util:getPlainHtmlUrl($metadataUuid, util:getLanguage())"/>
         </eu:DOIWebsiteLink>
         <eu:Metadata>
           <xsl:copy-of select="$dataciteResource"/>

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataApi.java
@@ -208,7 +208,8 @@ public class MetadataApi {
         String acceptHeader = StringUtils.isBlank(request.getHeader(HttpHeaders.ACCEPT)) ? MediaType.APPLICATION_XML_VALUE : request.getHeader(HttpHeaders.ACCEPT);
         List<String> accept = Arrays.asList(acceptHeader.split(","));
 
-        String defaultFormatter = "xsl-view";
+        String formatterBasePath = metadataUuid + "/formatters/";
+        String defaultFormatterPath = formatterBasePath + "xsl-view";
         if (accept.contains(MediaType.TEXT_HTML_VALUE) || accept.contains(MediaType.APPLICATION_XHTML_XML_VALUE)) {
             // Check if the language query parameter is a real language supported by the system. If not, fallback to the request language.
             String resolvedLanguage = (StringUtils.isNotBlank(language) && languageUtils.getUiLanguages().contains(language.toLowerCase()))
@@ -216,22 +217,25 @@ public class MetadataApi {
                 : languageUtils.getIso3langCode(request.getLocales());
             // If there is a redirect to a record view formatter configured use it, otherwise fallback to the default xsl-view formatter.
             String redirect = getRecordViewFormatterRedirect(resolvedLanguage, metadataUuid, recordViewFormatter);
-            return redirect != null ? redirect : "forward:" + (metadataUuid + "/formatters/" + defaultFormatter);
+            if (StringUtils.isNotBlank(redirect)) {
+                return redirect;
+            }
+            return "forward:" + defaultFormatterPath;
         } else if (accept.contains("application/pdf")) {
-            return "forward:" + (metadataUuid + "/formatters/" + defaultFormatter);
+            return "forward:" + defaultFormatterPath;
         } else if (accept.contains(MediaType.APPLICATION_XML_VALUE)) {
-            return "forward:" + (metadataUuid + "/formatters/xml");
+            return "forward:" + (formatterBasePath + "xml");
         } else if (accept.contains(MediaType.APPLICATION_JSON_VALUE)) {
-            return "forward:" + (metadataUuid + "/formatters/json");
+            return "forward:" + (formatterBasePath + "json");
         } else if (accept.contains("application/zip")
             || accept.contains(MEF_V1_ACCEPT_TYPE)
             || accept.contains(MEF_V2_ACCEPT_TYPE)) {
-            return "forward:" + (metadataUuid + "/formatters/zip");
+            return "forward:" + (formatterBasePath + "zip");
         } else {
             // FIXME this else is never reached because any of the accepted medias match one of the previous if conditions.
             response.setHeader(HttpHeaders.ACCEPT, MediaType.APPLICATION_XHTML_XML_VALUE);
             //response.sendRedirect(metadataUuid + "/formatters/" + defaultFormatter);
-            return "forward:" + (metadataUuid + "/formatters/" + defaultFormatter);
+            return "forward:" + defaultFormatterPath;
         }
     }
 

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataApi.java
@@ -65,11 +65,11 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.support.ResourceBundleMessageSource;
 import org.springframework.http.*;
+import org.springframework.lang.NonNull;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.*;
 
-import javax.annotation.Nullable;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.nio.file.Files;
@@ -185,14 +185,15 @@ public class MetadataApi {
             required = true)
         @PathVariable
         String metadataUuid,
-        @Parameter(description = "Language used for localization of the record and response (e.g. 'eng', 'fre').",
-            required = false)
+        @Parameter(description = "Language used for localization of the record and response (e.g. 'eng', 'fre')." +
+            "If invalid or not specified, the Accept-Language header is used to determine the language.")
+        @RequestParam(required = false)
         String language,
-        @Parameter(description = "Whether to redirect to the record view page instead of directly returning the record content. " +
-            "If true, the redirection is done before checking the Accept header.",
-            required = false)
-        @RequestParam(required = false, defaultValue = "false")
-        Boolean redirectToRecordView,
+        @Parameter(description = "Formatter to use on the record view page. " +
+            "If not specified, attempts to use the default formatter from UI configuration. " +
+            "If invalid or no default is configured, no redirect to the record view page is performed.")
+        @RequestParam(required = false)
+        String recordViewFormatter,
         HttpServletResponse response,
         HttpServletRequest request
     )
@@ -204,27 +205,19 @@ public class MetadataApi {
             throw new NotAllowedException(ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_VIEW);
         }
 
-        if (redirectToRecordView) {
-            // Check if the language query parameter is a real language supported by the system. If not, fallback to the request language.
-            String resolvedLanguage = language.toLowerCase();
-            if (!languageUtils.getUiLanguages().contains(resolvedLanguage)) {
-                resolvedLanguage = languageUtils.getIso3langCode(request.getLocales());
-            }
-
-            String redirect = getRedirect(resolvedLanguage, metadataUuid);
-
-            if (redirect != null) {
-                return redirect;
-            }
-        }
-
         String acceptHeader = StringUtils.isBlank(request.getHeader(HttpHeaders.ACCEPT)) ? MediaType.APPLICATION_XML_VALUE : request.getHeader(HttpHeaders.ACCEPT);
         List<String> accept = Arrays.asList(acceptHeader.split(","));
 
         String defaultFormatter = "xsl-view";
-        if (accept.contains(MediaType.TEXT_HTML_VALUE)
-            || accept.contains(MediaType.APPLICATION_XHTML_XML_VALUE)
-            || accept.contains("application/pdf")) {
+        if (accept.contains(MediaType.TEXT_HTML_VALUE) || accept.contains(MediaType.APPLICATION_XHTML_XML_VALUE)) {
+            // Check if the language query parameter is a real language supported by the system. If not, fallback to the request language.
+            String resolvedLanguage = (StringUtils.isNotBlank(language) && languageUtils.getUiLanguages().contains(language.toLowerCase()))
+                ? language.toLowerCase()
+                : languageUtils.getIso3langCode(request.getLocales());
+            // If there is a redirect to a record view formatter configured use it, otherwise fallback to the default xsl-view formatter.
+            String redirect = getRecordViewFormatterRedirect(resolvedLanguage, metadataUuid, recordViewFormatter);
+            return redirect != null ? redirect : "forward:" + (metadataUuid + "/formatters/" + defaultFormatter);
+        } else if (accept.contains("application/pdf")) {
             return "forward:" + (metadataUuid + "/formatters/" + defaultFormatter);
         } else if (accept.contains(MediaType.APPLICATION_XML_VALUE)) {
             return "forward:" + (metadataUuid + "/formatters/xml");
@@ -906,18 +899,31 @@ public class MetadataApi {
     }
 
     /**
-     * Constructs a redirect string based on the provided formatter flag, language, and metadata UUID
+     * Constructs a redirect string based on the provided formatter flag, language, and metadata UUID.
+     * This method determines the appropriate redirect URL for a metadata record view page based on
+     * the formatter label provided, the language parameter, and the metadata UUID. If no formatter
+     * label is provided, it attempts to retrieve a default formatter from the UI configuration.
      *
-     * @param language      The language code to include in the URL
-     * @param metadataUuid  The unique identifier of the metadata record
-     * @return A redirect string if the flag is true and a valid formatter is configured, or null otherwise
+     * @param language       The language code to use in the redirect URL.
+     * @param metadataUuid   The unique identifier of the metadata record for which the redirect URL
+     *                       is being constructed.
+     * @param recordViewFormatterParam The formatter label to look for in the UI configuration. If null, the
+     *                       method attempts to retrieve a default formatter from the configuration.
+     * @return A redirect string if a valid formatter is found and configured, or null otherwise.
      */
-    private String getRedirect(String language, String metadataUuid) {
+    private String getRecordViewFormatterRedirect(@NonNull String language, String metadataUuid, String recordViewFormatterParam) {
+        // If the formatter label is not provided as a parameter, try to get it from the UI configuration
+        String recordViewFormatter = recordViewFormatterParam;
+        if (StringUtils.isBlank(recordViewFormatter)) {
+            recordViewFormatter = XslUtil.getUiConfigurationJsonProperty(null, "mods.search.formatter.recordLinkFormatter");
+            if (StringUtils.isBlank(recordViewFormatter)) {
+                // If the record link formatter is not set in the UI configuration, return null as no formatter can be applied
+                return null;
+            }
+        }
+
         // Parse the UI configuration
         JsonObject uiConfig = JsonParser.parseString(XslUtil.getUiConfiguration(null)).getAsJsonObject();
-
-        // Get the formatter label for record links from the UI configuration
-        String recordViewFormatter = XslUtil.getUiConfigurationJsonProperty(null, "mods.search.formatter.recordLinkFormatter");
 
         // Navigate through the JSON structure to retrieve the array of record view page formatters
         JsonArray formatterArray = Optional.ofNullable(uiConfig)

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataApi.java
@@ -198,8 +198,9 @@ public class MetadataApi {
         HttpServletRequest request
     )
         throws Exception {
+        AbstractMetadata metadata;
         try {
-            ApiUtils.canViewRecord(metadataUuid, request);
+            metadata = ApiUtils.canViewRecord(metadataUuid, request);
         } catch (SecurityException e) {
             Log.debug(API.LOG_MODULE_NAME, e.getMessage(), e);
             throw new NotAllowedException(ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_VIEW);
@@ -208,7 +209,8 @@ public class MetadataApi {
         String acceptHeader = StringUtils.isBlank(request.getHeader(HttpHeaders.ACCEPT)) ? MediaType.APPLICATION_XML_VALUE : request.getHeader(HttpHeaders.ACCEPT);
         List<String> accept = Arrays.asList(acceptHeader.split(","));
 
-        String formatterBasePath = metadataUuid + "/formatters/";
+        // Use the uuid from the abstract metadata instead of the path variable to address URL forwarding vulnerabilities
+        String formatterBasePath = metadata.getUuid() + "/formatters/";
         String defaultFormatterPath = formatterBasePath + "xsl-view";
         if (accept.contains(MediaType.TEXT_HTML_VALUE) || accept.contains(MediaType.APPLICATION_XHTML_XML_VALUE)) {
             // Check if the language query parameter is a real language supported by the system. If not, fallback to the request language.
@@ -216,7 +218,7 @@ public class MetadataApi {
                 ? language.toLowerCase()
                 : languageUtils.getIso3langCode(request.getLocales());
             // If there is a redirect to a record view formatter configured use it, otherwise fallback to the default xsl-view formatter.
-            String redirect = getRecordViewFormatterRedirect(resolvedLanguage, metadataUuid, recordViewFormatter);
+            String redirect = getRecordViewFormatterRedirect(resolvedLanguage, metadata.getUuid(), recordViewFormatter);
             if (StringUtils.isNotBlank(redirect)) {
                 return redirect;
             }

--- a/web/src/main/webapp/xslt/services/sitemap/sitemap.xsl
+++ b/web/src/main/webapp/xslt/services/sitemap/sitemap.xsl
@@ -120,7 +120,7 @@
                 <xsl:value-of select="concat($nodeUrl, 'api/records/', $uuid, '/formatters/xml')"/>
               </xsl:when>
               <xsl:otherwise>
-                <xsl:value-of select="util:getPermalink($uuid, $lang)"/>
+                <xsl:value-of select="util:getPlainHtmlUrl($uuid, $lang)"/>
               </xsl:otherwise>
             </xsl:choose>
           </loc>


### PR DESCRIPTION
There are a couple of issues with the metadata API view redirect introduced in #8966.

### 1. Language not preserved
  The redirect URL does not include the language, so the link always resolves to the default language.
  
  This means multilingual emails would have multiple links pointing to the same page with the default language. It would be better to have each link point to its respective language.

  This PR adds support for a language parameter and uses it in the redirect URL. If the language code is invalid, it falls back to the default language.

### 2. Formatter name in permalink
  The formatter name is currently embedded in the permalink. This creates a fragile link — if the formatter is renamed or removed, existing links will break.

  This PR removes the formatter name requirement from the URL by implementing a configuration-based lookup with backwards compatibility. When the recordViewFormatter parameter is not provided in HTML requests, the API now retrieves the default formatter from the UI configuration instead of failing or using a hardcoded default.
  
**This PR contains API changes**

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

