### PR TITLE
Add UUID display to directory entries

### DIFF
--- a/web-ui/src/main/resources/catalog/templates/editor/directory.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/directory.html
@@ -217,7 +217,7 @@
                       data-from-now=""
                     ></small>
                     <br />
-                    <small>uuid: {{md.uuid}}</small>
+                    <small><span translate>uuid</span>: {{md.uuid}}</small>
                   </div>
 
                   <div class="flex-spacer flex-grow"></div>


### PR DESCRIPTION
Displaying subtemplate uuid in "manage directory" helps management:

- during xlink's xml edition,
- when looking for subtemplate in "manage diectory".

<img width="1042" height="410" alt="display_subtemplate_uuid" src="https://github.com/user-attachments/assets/a695f1c9-1717-4d40-abc1-5d1566104730" />


# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by swisstopo`
-->

