### PR TITLE
Add scrollable dropdown for WFS format selection menu

### DIFF
--- a/web-ui/src/main/resources/catalog/components/viewer/wfs/partials/download.html
+++ b/web-ui/src/main/resources/catalog/components/viewer/wfs/partials/download.html
@@ -55,7 +55,7 @@
           <span>{{type.label}}</span>
           <span class="caret"></span>
         </button>
-        <ul class="dropdown-menu">
+        <ul class="dropdown-menu gn-wfs-formats-menu">
           <li class="dropdown-header" data-translate="">downloadAllIn</li>
           <li data-ng-repeat="f in formats | orderBy:f track by $index">
             <a
@@ -114,7 +114,7 @@
             <span>{{ftSelected.name.localPart}}</span>
             <span class="caret"></span>
           </button>
-          <ul class="dropdown-menu">
+          <ul class="dropdown-menu gn-wfs-formats-menu">
             <li data-ng-repeat="format in formats | orderBy:format">
               <a
                 data-gn-click-and-spin="downloadFeatureType(ftSelected,

--- a/web-ui/src/main/resources/catalog/style/gn_metadata.less
+++ b/web-ui/src/main/resources/catalog/style/gn_metadata.less
@@ -779,3 +779,13 @@ ul.container-list {
     height: 100%;
   }
 }
+
+.gn-wfs-formats-menu {
+  max-height: 300px;
+  overflow-y: auto;
+  background-color: @dropdown-bg;
+
+  &::-webkit-scrollbar-track {
+    background-color: @dropdown-bg;
+  }
+}


### PR DESCRIPTION
* Fix the WFS format menu for very long download format lists.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

In the Downloads sections of the metadata record view sometimes the list of formats available for download from a WFS service is very long, displaying a large dropdown menu:

<img width="1910" height="926" alt="image" src="https://github.com/user-attachments/assets/d7dce882-be35-4615-bc99-29722bf7d57a" />


After the change the dropdown max length is 300 px and has a scroll bar:

<img width="817" height="627" alt="image" src="https://github.com/user-attachments/assets/92e5812c-7e01-4828-8a51-e5e4c2067e5c" />


