### PR TITLE
Fix retrieval of remote source logos in GeoNetwork harvesters.

### DIFF
--- a/common/src/main/java/org/fao/geonet/utils/XmlRequest.java
+++ b/common/src/main/java/org/fao/geonet/utils/XmlRequest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2024 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2026 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -143,8 +143,14 @@ public class XmlRequest extends AbstractHttpRequest {
     protected final Path doExecuteLarge(HttpRequestBase httpMethod, Path outFile) throws IOException {
 
         try (ClientHttpResponse httpResponse = doExecute(httpMethod)) {
-            Files.copy(httpResponse.getBody(), outFile, StandardCopyOption.REPLACE_EXISTING);
-            return outFile;
+            if (!httpResponse.getStatusCode().isError()) {
+                Files.copy(httpResponse.getBody(), outFile, StandardCopyOption.REPLACE_EXISTING);
+                return outFile;
+            } else {
+                throw new IOException(
+                    String.format("Error retrieving the remote file: Response status: %s, URI: %s, Response Code: %s",
+                        httpResponse.getStatusText(), httpMethod.getURI(), httpResponse.getRawStatusCode()));
+            }
         } finally {
             httpMethod.releaseConnection();
 

--- a/core/src/main/java/org/fao/geonet/resources/Resources.java
+++ b/core/src/main/java/org/fao/geonet/resources/Resources.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2026 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -28,7 +28,9 @@ import com.google.common.collect.Sets;
 import com.google.common.io.Files;
 import jeeves.server.context.ServiceContext;
 
+import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.domain.Pair;
+import org.fao.geonet.exceptions.BadParameterEx;
 import org.fao.geonet.kernel.GeonetworkDataDirectory;
 import org.fao.geonet.utils.IO;
 import org.fao.geonet.utils.XmlRequest;
@@ -42,6 +44,7 @@ import java.nio.file.Path;
 import java.nio.file.attribute.FileTime;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;
 
 import javax.annotation.Nonnull;
@@ -191,11 +194,7 @@ public abstract class Resources {
             }
         }
 
-        if (property == null) {
-            return IO.toPath("resources");
-        } else {
-            return property;
-        }
+        return Objects.requireNonNullElseGet(property, () -> IO.toPath("resources"));
     }
 
     /**
@@ -275,6 +274,8 @@ public abstract class Resources {
      */
     public String copyLogo(ServiceContext context, String icon,
                          String destName) {
+        validatePath(context, locateLogosDir(context), destName);
+
         ServletContext servletContext = null;
         if (context.getServlet() != null) {
             servletContext = context.getServlet().getServletContext();
@@ -314,6 +315,7 @@ public abstract class Resources {
      * @param destName the filename prefix to copy the unknown filename to.
      */
     public void copyUnknownLogo(ServiceContext context, String destName) {
+        validatePath(context, locateLogosDir(context), destName);
         copyLogo(context, BLANK_LOGO, destName);
     }
 
@@ -351,16 +353,36 @@ public abstract class Resources {
 
     public abstract void deleteImageIfExists(final String image, final Path dir) throws IOException;
 
+    /**
+     * Verify that the final file is inside of the resourcesDir path.
+     *
+     * @param context the service context
+     * @param dir     the directory where the file should be located
+     * @param filename the name of the file
+     */
+    protected void validatePath(ServiceContext context, Path dir, String filename) {
+        if (StringUtils.isEmpty(filename)) {
+            return;
+        }
+        Path resourcesDir = locateResourcesDir(context);
+        Path finalPath = dir.resolve(filename).normalize();
+        if (!finalPath.startsWith(resourcesDir.normalize())) {
+            throw new BadParameterEx("The final file (" + finalPath
+                                               + ") is outside of the resourcesDir (" + resourcesDir + ") path.");
+        }
+    }
+
     public void createImageFromReq(ServiceContext context, final Path logoDir, final String filename,
                                    final XmlRequest req) throws IOException {
+        validatePath(context, logoDir, filename);
+
         try(ResourceHolder file = getWritableImage(context, filename, logoDir)) {
             try {
                 req.executeLarge(file.getPath());
-            } catch (IOException e) {
+            } catch (IOException | IllegalArgumentException e) {
                 file.abort();
                 throw e;
             }
-
         }
     }
 

--- a/core/src/test/java/org/fao/geonet/AbstractCoreIntegrationTest.java
+++ b/core/src/test/java/org/fao/geonet/AbstractCoreIntegrationTest.java
@@ -31,6 +31,7 @@ import jeeves.server.UserSession;
 import jeeves.server.context.ServiceContext;
 import jeeves.server.dispatchers.ServiceManager;
 import jeeves.server.sources.ServiceRequest;
+import jeeves.server.sources.http.JeevesServlet;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.AbstractMetadata;
 import org.fao.geonet.domain.ISODate;
@@ -217,6 +218,7 @@ public abstract class AbstractCoreIntegrationTest extends AbstractSpringDataTest
         context.setMaxUploadSize(100);
         context.setOutputMethod(ServiceRequest.OutputMethod.DEFAULT);
         context.setBaseUrl("geonetwork");
+        context.setServlet(new JeevesServlet());
         context.getBean(ServiceManager.class).registerContext(Geonet.CONTEXT_NAME, gc);
 
         assertDataDirInMemoryFS(context);

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/BaseGeoNetworkHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/BaseGeoNetworkHarvester.java
@@ -1,5 +1,5 @@
 //=============================================================================
-//===    Copyright (C) 2001-2025 Food and Agriculture Organization of the
+//===    Copyright (C) 2001-2026 Food and Agriculture Organization of the
 //===    United Nations (FAO-UN), United Nations World Food Programme (WFP)
 //===    and United Nations Environment Programme (UNEP)
 //===
@@ -54,7 +54,7 @@ import org.fao.geonet.utils.XmlRequest;
  * records during the harvesting process.
  *
  * @param <P> A type parameter extending BaseGeonetParams, representing the specific
- *            configuration or parameters utilized by the harvester.
+ *            configuration or parameters used by the harvester.
  */
 public abstract class BaseGeoNetworkHarvester<P extends BaseGeonetParams> {
     protected final AtomicBoolean cancelMonitor;
@@ -115,7 +115,7 @@ public abstract class BaseGeoNetworkHarvester<P extends BaseGeonetParams> {
                 Source source = remoteSources.get(sourceUuid);
 
                 if (source != null) {
-                    retrieveLogo(context, resources, params.host, sourceUuid);
+                    retrieveLogo(context, resources, params.host, source);
                 } else {
                     String sourceName = "(unknown)";
                     source = new Source(sourceUuid, sourceName, new HashMap<>(), SourceType.harvester);
@@ -134,30 +134,55 @@ public abstract class BaseGeoNetworkHarvester<P extends BaseGeonetParams> {
      * @param context the {@link ServiceContext} instance providing access to system-level resources and services
      * @param resources the {@link Resources} object used to locate and manipulate the logos directory
      * @param url the base URL from which the logo file is retrieved
-     * @param uuid the unique identifier corresponding to the logo, typically used as the logo's filename
-     * @throws MalformedURLException if the constructed URL for the logo retrieval or proxy setup is malformed
+     * @param source the metadata source from which the logo is retrieved
      */
-    protected void retrieveLogo(ServiceContext context, final Resources resources, String url, String uuid) throws MalformedURLException {
-        String logo = uuid + ".gif";
+    protected void retrieveLogo(ServiceContext context, final Resources resources, final String url, final Source source)  {
+
+        if (source.getLogo() != null) {
+            // trust the logo name
+            try {
+                createLogoImage(resources, source.getLogo(), url);
+            } catch (IOException e) {
+                context.warning(String.format("Cannot retrieve logo file from : %s", url));
+                context.warning(String.format("  (C) Logo  : %s", source.getLogo()));
+                context.warning(String.format("  (C) Excep : %s",  e.getMessage()));
+
+                resources.copyUnknownLogo(context, source.getLogo());
+            }
+        } else {
+            String[] allowedLogoFileExtensions = {".png", ".gif", ".jpg", ".jpeg"};
+
+            for (String logoFileExtension : allowedLogoFileExtensions) {
+                String logo = source.getUuid() + logoFileExtension;
+                try {
+                    createLogoImage(resources, logo, url);
+                    return;
+                } catch (IOException e) {
+                    // Ignore the exception
+                }
+            }
+
+            // No logo found, use the default logo
+            context.warning(String.format("Cannot retrieve logo file from : %s for logo '%s' with the file extensions '%s'",
+                url, source.getUuid(), String.join(",", allowedLogoFileExtensions)));
+            context.warning(String.format("Cannot retrieve logo file from : %s", url));
+            resources.copyUnknownLogo(context, source.getLogo());
+        }
+    }
+
+    private void createLogoImage(final Resources resources, final String logo, final String url) throws IOException {
+        final Path logoDir = resources.locateLogosDir(context);
+
         String baseUrl = url;
         if (!new URL(baseUrl).getPath().endsWith("/")) {
             // Needed to make it work when harvesting from a GN deployed at ROOT ("/")
             baseUrl += "/";
         }
+
         XmlRequest req = context.getBean(GeonetHttpRequestFactory.class).createXmlRequest(new URL(baseUrl));
         Lib.net.setupProxy(context, req);
         req.setAddress(req.getAddress() + "images/logos/" + logo);
 
-        final Path logoDir = resources.locateLogosDir(context);
-
-        try {
-            resources.createImageFromReq(context, logoDir, logo, req);
-        } catch (IOException e) {
-            context.warning("Cannot retrieve logo file from : " + url);
-            context.warning("  (C) Logo  : " + logo);
-            context.warning("  (C) Excep : " + e.getMessage());
-
-            resources.copyUnknownLogo(context, uuid);
-        }
+        resources.createImageFromReq(context, logoDir, logo, req);
     }
 }

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/BaseGeoNetworkHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/BaseGeoNetworkHarvester.java
@@ -34,16 +34,21 @@ import java.util.Map;
 import java.util.Set;
 import java.util.SortedSet;
 import java.util.concurrent.atomic.AtomicBoolean;
+
+import bsh.StringUtil;
 import jeeves.server.context.ServiceContext;
+import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.Logger;
 import org.fao.geonet.domain.Source;
 import org.fao.geonet.domain.SourceType;
+import org.fao.geonet.exceptions.BadParameterEx;
 import org.fao.geonet.kernel.harvest.harvester.HarvestError;
 import org.fao.geonet.kernel.harvest.harvester.RecordInfo;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.lib.Lib;
 import org.fao.geonet.repository.SourceRepository;
 import org.fao.geonet.resources.Resources;
+import org.fao.geonet.utils.FilePathChecker;
 import org.fao.geonet.utils.GeonetHttpRequestFactory;
 import org.fao.geonet.utils.XmlRequest;
 
@@ -137,36 +142,47 @@ public abstract class BaseGeoNetworkHarvester<P extends BaseGeonetParams> {
      * @param source the metadata source from which the logo is retrieved
      */
     protected void retrieveLogo(ServiceContext context, final Resources resources, final String url, final Source source)  {
+        if (StringUtils.isNotEmpty(source.getLogo())) {
+            // use the source logo name
+            String logoFileName = source.getLogo();
 
-        if (source.getLogo() != null) {
-            // trust the logo name
             try {
-                createLogoImage(resources, source.getLogo(), url);
-            } catch (IOException e) {
+                FilePathChecker.verify(logoFileName);
+
+                createLogoImage(resources, logoFileName, url);
+            } catch (IOException | BadParameterEx e) {
                 context.warning(String.format("Cannot retrieve logo file from : %s", url));
-                context.warning(String.format("  (C) Logo  : %s", source.getLogo()));
+                context.warning(String.format("  (C) Logo  : %s", logoFileName));
                 context.warning(String.format("  (C) Excep : %s",  e.getMessage()));
 
-                resources.copyUnknownLogo(context, source.getLogo());
+                resources.copyUnknownLogo(context, logoFileName);
             }
         } else {
             String[] allowedLogoFileExtensions = {".png", ".gif", ".jpg", ".jpeg"};
 
             for (String logoFileExtension : allowedLogoFileExtensions) {
-                String logo = source.getUuid() + logoFileExtension;
+                String logoFileName = source.getUuid() + logoFileExtension;
                 try {
-                    createLogoImage(resources, logo, url);
+                    FilePathChecker.verify(logoFileName);
+
+                    createLogoImage(resources, logoFileName, url);
                     return;
-                } catch (IOException e) {
+                } catch (IOException | BadParameterEx e)  {
                     // Ignore the exception
                 }
             }
 
-            // No logo found, use the default logo
-            context.warning(String.format("Cannot retrieve logo file from : %s for logo '%s' with the file extensions '%s'",
-                url, source.getUuid(), String.join(",", allowedLogoFileExtensions)));
-            context.warning(String.format("Cannot retrieve logo file from : %s", url));
-            resources.copyUnknownLogo(context, source.getLogo());
+            try {
+                // No logo found, use the default logo
+                FilePathChecker.verify(source.getLogo());
+
+                context.warning(String.format("Cannot retrieve logo file from : %s for logo '%s' with the file extensions '%s'",
+                    url, source.getUuid(), String.join(",", allowedLogoFileExtensions)));
+                context.warning(String.format("Cannot retrieve logo file from : %s", url));
+                resources.copyUnknownLogo(context, source.getLogo());
+            } catch (BadParameterEx e)  {
+                // Ignore the exception
+            }
         }
     }
 


### PR DESCRIPTION
Logo retrieval was assuming that the logos extension was `gif` only, which is not the case, `png` and `jpg` formats are allowed also.


# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
