### PR TITLE
Improve logging for harvester UUID collisions

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
@@ -213,7 +213,7 @@ public class Aligner extends BaseAligner<CswParams> {
                             addMetadata(ri, UUID.randomUUID().toString());
                             break;
                         case SKIP:
-                            log.debug("Skipping record with uuid " + ri.uuid);
+                            log.info("Skipping record with uuid " + ri.uuid);
                             result.uuidSkipped++;
                             break;
                         default:

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/database/DatabaseHarvesterAligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/database/DatabaseHarvesterAligner.java
@@ -245,7 +245,7 @@ class DatabaseHarvesterAligner extends BaseAligner<DatabaseHarvesterParams> impl
                     addMetadata(metadataElement, UUID.randomUUID().toString(), schema);
                     break;
                 case SKIP:
-                    log.debug(String.format("Skipping record with uuid %s", uuid));
+                    log.info(String.format("Skipping record with uuid %s", uuid));
                     result.uuidSkipped++;
                     break;
                 default:

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/BaseGeoNetworkAligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/BaseGeoNetworkAligner.java
@@ -258,7 +258,7 @@ public abstract class BaseGeoNetworkAligner<P extends BaseGeonetParams> extends 
                                 addMetadata(ri, localRating.equals(RatingsSetting.BASIC), UUID.randomUUID().toString());
                                 break;
                             case SKIP:
-                                log.debug("Skipping record with uuid " + ri.uuid);
+                                log.info("Skipping record with uuid " + ri.uuid);
                                 result.uuidSkipped++;
                                 break;
                             default:

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFsHarvesterFileVisitor.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/localfilesystem/LocalFsHarvesterFileVisitor.java
@@ -317,7 +317,7 @@ class LocalFsHarvesterFileVisitor extends SimpleFileVisitor<Path> {
 
                         break;
                     case SKIP:
-                        harvester.getLogger().debug("Skipping record with uuid " + metadata.getUuid());
+                        harvester.getLogger().info("Skipping record with uuid " + metadata.getUuid());
                         result.uuidSkipped++;
                         result.unchangedMetadata++;
 

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/oaipmh/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/oaipmh/Harvester.java
@@ -327,7 +327,7 @@ class Harvester extends BaseAligner<OaiPmhParams> implements IHarvester<HarvestR
                             addMetadata(t, ri, processName, processParams, newRandomUuid);
                             break;
                         case SKIP:
-                            log.debug("Skipping record with uuid " + ri.id);
+                            log.info("Skipping record with uuid " + ri.id);
                             result.uuidSkipped++;
                             break;
                         default:

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/simpleurl/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/simpleurl/Aligner.java
@@ -139,7 +139,7 @@ public class Aligner extends BaseAligner<SimpleUrlParams> {
                             addMetadata(e, UUID.randomUUID().toString());
                             break;
                         case SKIP:
-                            log.debug("Skipping record with uuid " + e.getKey());
+                            log.info("Skipping record with uuid " + e.getKey());
                             result.uuidSkipped++;
                             break;
                         default:


### PR DESCRIPTION
Currently when a UUID collision occurs during harvesting, it is handled internally according to the UUID merge policy (skip, overwrite, etc.), but without any explicit log entry.

As a result, records may be skipped, replaced, or otherwise handled without any visibility in the logs, making it difficult to understand why certain records were not created or were modified.

This PR aims to fix this issue by consistently logging info messages whenever a UUID collision occurs. This makes collision-related behavior easier to trace and debug.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
