### PR TITLE
Do not set humanized date when not set

### DIFF
--- a/web-ui/src/main/resources/catalog/components/utility/UtilityService.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityService.js
@@ -626,7 +626,7 @@
             };
           } else {
             return {
-              title: settingAllowToUseFromNow  ? fromNow : date,
+              title: settingAllowToUseFromNow ? fromNow : date,
               value: format ? parsedDate.format(format) : parsedDate.toString()
             };
           }

--- a/web-ui/src/main/resources/catalog/components/utility/UtilityService.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityService.js
@@ -594,22 +594,20 @@
     "gnGlobalSettings",
     function (gnGlobalSettings) {
       return function (date, format, contextAllowToUseFromNow) {
-        const isDateGmlFormat = /[Zz]$/.test(date);
-        const isDateTimeFormat = date.includes("T");
+        var isDateGmlFormat = /[Zz]$/.test(date);
+        var isDateTimeFormat = date.includes("T");
         var settingAllowToUseFromNow = gnGlobalSettings.gnCfg.mods.global.humanizeDates;
         var timezone = gnGlobalSettings.gnCfg.mods.global.timezone;
         var parsedDate = null;
 
         if (isDateGmlFormat) {
           parsedDate = moment(date, "YYYY-MM-DDtHH-mm-SSSZ");
-        } else if (isDateTimeFormat) {
-          parsedDate = moment(date);
         } else {
-          parsedDate = moment.utc(date); // Date only
+          parsedDate = moment(date);
         }
 
         if (parsedDate.isValid()) {
-          if (!!timezone) {
+          if (!!timezone && isDateTimeFormat) {
             parsedDate = parsedDate.tz(
               timezone === "Browser" ? moment.tz.guess() : timezone
             );
@@ -628,7 +626,7 @@
             };
           } else {
             return {
-              title: isDateTimeFormat ? parsedDate.toString() : fromNow,
+              title: settingAllowToUseFromNow  ? fromNow : date,
               value: format ? parsedDate.format(format) : parsedDate.toString()
             };
           }

--- a/web-ui/src/main/resources/catalog/components/utility/UtilityService.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityService.js
@@ -594,36 +594,41 @@
     "gnGlobalSettings",
     function (gnGlobalSettings) {
       return function (date, format, contextAllowToUseFromNow) {
-        function isDateGmlFormat(date) {
-          return date.match("[Zz]$") !== null;
-        }
-        var settingAllowToUseFromNow = gnGlobalSettings.gnCfg.mods.global.humanizeDates,
-          timezone = gnGlobalSettings.gnCfg.mods.global.timezone;
+        const isDateGmlFormat = /[Zz]$/.test(date);
+        const isDateTimeFormat = date.includes("T");
+        var settingAllowToUseFromNow = gnGlobalSettings.gnCfg.mods.global.humanizeDates;
+        var timezone = gnGlobalSettings.gnCfg.mods.global.timezone;
         var parsedDate = null;
-        if (isDateGmlFormat(date)) {
+
+        if (isDateGmlFormat) {
           parsedDate = moment(date, "YYYY-MM-DDtHH-mm-SSSZ");
-        } else {
+        } else if (isDateTimeFormat) {
           parsedDate = moment(date);
+        } else {
+          parsedDate = moment.utc(date); // Date only
         }
+
         if (parsedDate.isValid()) {
           if (!!timezone) {
             parsedDate = parsedDate.tz(
               timezone === "Browser" ? moment.tz.guess() : timezone
             );
           }
-          var fromNow = parsedDate.fromNow();
 
           if (date.length === 4) {
-            format = "YYYY";
-          }
+            format = "YYYY"; // Year only format
+          } // Otherwise defaults to the format provided as input
+
+          var fromNow = parsedDate.fromNow();
+
           if (settingAllowToUseFromNow && contextAllowToUseFromNow) {
             return {
-              value: fromNow,
-              title: format ? parsedDate.format(format) : parsedDate.toString()
+              title: format ? parsedDate.format(format) : parsedDate.toString(),
+              value: fromNow
             };
           } else {
             return {
-              title: date,
+              title: isDateTimeFormat ? parsedDate.toString() : fromNow,
               value: format ? parsedDate.format(format) : parsedDate.toString()
             };
           }

--- a/web-ui/src/main/resources/catalog/components/utility/UtilityService.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityService.js
@@ -623,7 +623,7 @@
             };
           } else {
             return {
-              title: fromNow,
+              title: date,
               value: format ? parsedDate.format(format) : parsedDate.toString()
             };
           }

--- a/web-ui/src/main/resources/catalog/components/utility/UtilityService.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityService.js
@@ -594,17 +594,10 @@
     "gnGlobalSettings",
     function (gnGlobalSettings) {
       return function (date, format, contextAllowToUseFromNow) {
-        var isDateGmlFormat = /[Zz]$/.test(date);
         var isDateTimeFormat = date.includes("T");
         var settingAllowToUseFromNow = gnGlobalSettings.gnCfg.mods.global.humanizeDates;
         var timezone = gnGlobalSettings.gnCfg.mods.global.timezone;
-        var parsedDate = null;
-
-        if (isDateGmlFormat) {
-          parsedDate = moment(date, "YYYY-MM-DDtHH-mm-SSSZ");
-        } else {
-          parsedDate = moment(date);
-        }
+        var parsedDate = moment(date);
 
         if (parsedDate.isValid()) {
           if (!!timezone && isDateTimeFormat) {


### PR DESCRIPTION
Humanized date is showed also when the setting is not set:

<img width="726" height="102" alt="image" src="https://github.com/user-attachments/assets/6bbb6262-d781-4bc0-9076-9ef6aeb0aa78" />

And is not possible to see the time in the date without checking the XML.

This change was suggested by @wangf1122 in this issue https://github.com/geonetwork/core-geonetwork/issues/8409.

This PR does the following changes:
- When the humanized dates setting is not active, the hover popup displays the date with the time, if set. Otherwise, if the date doesn't contain a time, the current behavior is kept.
- When the date doesn't contain a time, conversion to the browser's timezone it's not necessary and must be avoided.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

