### PR TITLE
Fix NPE when redirecting to portal and no accept header is set

### DIFF
--- a/core/src/main/java/org/fao/geonet/web/LocaleRedirects.java
+++ b/core/src/main/java/org/fao/geonet/web/LocaleRedirects.java
@@ -45,7 +45,6 @@ import org.springframework.web.servlet.view.RedirectView;
 import java.util.*;
 
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpSession;
 
 
 /**
@@ -113,10 +112,14 @@ public class LocaleRedirects {
                              ) throws ResourceNotFoundException {
         String lang = lang(langParam, langCookie, langHeader);
 
-        if (checkPortalExist(portal, !accept.startsWith(ACCEPT_VALUE))) {
+        // Throw exception for non-HTML requests instead of redirecting if portal is not found
+        boolean throwExceptionOnMissingPortal = accept != null && !accept.startsWith(ACCEPT_VALUE);
+
+        if (checkPortalExist(portal, throwExceptionOnMissingPortal)) {
             return redirectURL(createServiceUrl(request, _homeRedirectUrl, lang, portal));
         } else {
-            if (sourceRepository.findByType(SourceType.portal, null).size() == 0) {
+            List<Source> portals = sourceRepository.findByType(SourceType.portal, null);
+            if (portals == null || portals.isEmpty()) {
                 return redirectURL(createServiceUrl(request, _homeRedirectUrl, lang, NodeInfo.DEFAULT_NODE));
             }
             // Redirect to list of portal page if more than one or the default if only one
@@ -147,10 +150,14 @@ public class LocaleRedirects {
                                            final String langHeader) throws ResourceNotFoundException {
         String lang = lang(langParam, langCookie, langHeader);
 
-        if (checkPortalExist(portal, !accept.startsWith(ACCEPT_VALUE))) {
+        // Throw exception for non-HTML requests instead of redirecting if portal is not found
+        boolean throwExceptionOnMissingPortal = accept != null && !accept.startsWith(ACCEPT_VALUE);
+
+        if (checkPortalExist(portal, throwExceptionOnMissingPortal)) {
             return redirectURL(createServiceUrl(request, _homeRedirectUrl, lang, portal));
         } else {
-            if (sourceRepository.findByType(SourceType.subportal, null).size() == 0) {
+            List<Source> subPortals = sourceRepository.findByType(SourceType.subportal, null);
+            if (subPortals == null || subPortals.isEmpty()) {
                 return redirectURL(createServiceUrl(request, _homeRedirectUrl, lang, NodeInfo.DEFAULT_NODE));
             }
             // Redirect to list of portal page if more than one or the default if only one


### PR DESCRIPTION
Currently `LocaleRedirects` assumes the `Accept` header is always present when checking whether a missing portal should trigger a redirect or an exception

However, when the `Accept` header is missing this results in a `NullPointerException`.

This PR aims to fix this issue by safely handling a missing `Accept` header before evaluating the request type.

It also improves the portal and subportal source checks by explicitly handling null or empty repository results.

This ensures the request is handled correctly instead of failing with a `NullPointerException`.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation