### PR TITLE
Fix access to retrieve DOI servers for a metadata

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/ApiParams.java
+++ b/services/src/main/java/org/fao/geonet/api/ApiParams.java
@@ -76,6 +76,6 @@ public class ApiParams {
     public static final String API_PARAM_BUCKET_NAME = "Selection bucket name";
     public static final String API_PARAM_UPDATE_DATESTAMP = "If true updates the DateStamp (or equivalent in standards different to ISO 19139) " +
         "field in the metadata with the current timestamp";
-    public static final String API_RESPONSE_NOT_ALLOWED_METADATA_DOI = "Operation not allowed. Only administrators, the owner of the metadata " +
-        "a reviewer in the metadata group owner or the can access it";
+    public static final String API_RESPONSE_NOT_ALLOWED_METADATA_DOI = "Operation not allowed. Only administrators, the owner of the metadata, " +
+        "or a reviewer in the metadata group owner can access it.";
 }

--- a/services/src/main/java/org/fao/geonet/api/doiservers/DoiServersApi.java
+++ b/services/src/main/java/org/fao/geonet/api/doiservers/DoiServersApi.java
@@ -111,7 +111,8 @@ public class DoiServersApi {
     @PreAuthorize("hasAuthority('Editor')")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "List of all DOI servers where a metadata can be published."),
-        @ApiResponse(responseCode = "403", description = ApiParams.API_RESPONSE_NOT_ALLOWED_METADATA_DOI)
+        @ApiResponse(responseCode = "403", description = ApiParams.API_RESPONSE_NOT_ALLOWED_METADATA_DOI),
+        @ApiResponse(responseCode = "404", description = ApiParams.API_RESPONSE_RESOURCE_NOT_FOUND)
     })
     List<AnonymousDoiServer> getDoiServers(
         @Parameter(description = "Metadata UUID",
@@ -128,6 +129,11 @@ public class DoiServersApi {
         ServiceContext serviceContext = ApiUtils.createServiceContext(request);
 
         AbstractMetadata metadata = metadataUtils.findOne(metadataId);
+        if (metadata == null) {
+            throw new ResourceNotFoundException(String.format("Metadata with id '%d' not found.", metadataId))
+                .withMessageKey("exception.resourceNotFound.metadata");
+        }
+
         Integer groupOwner = metadata.getSourceInfo().getGroupOwner();
         Profile userProfile = ApiUtils.getUserSession(httpSession).getProfile();
 
@@ -341,9 +347,9 @@ public class DoiServersApi {
     }
 
     private boolean isMetadataOwnerOrReviewer(ServiceContext serviceContext, Integer metadataId,
-                                              Integer groupOwner, Profile userProfile) throws Exception{
+                                              Integer groupOwner, Profile userProfile) throws Exception {
 
-        return (userProfile == Profile.Administrator)  || accessManager.isOwner(serviceContext, String.valueOf(metadataId))
+        return (userProfile == Profile.Administrator) || accessManager.isOwner(serviceContext, String.valueOf(metadataId))
             || accessManager.isProfileOrMoreOnGroup(serviceContext, Profile.Reviewer, groupOwner);
     }
 }

--- a/services/src/test/java/org/fao/geonet/api/doiservers/DoiServersApiTest.java
+++ b/services/src/test/java/org/fao/geonet/api/doiservers/DoiServersApiTest.java
@@ -144,7 +144,7 @@ public class DoiServersApiTest extends AbstractServiceIntegrationTest {
                 .accept(MediaType.APPLICATION_JSON_VALUE))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$", hasSize(1)))
-            .andExpect(jsonPath("$[0    ].name", is(doiServerToRetrieve.get().getName())))
+            .andExpect(jsonPath("$[0].name", is(doiServerToRetrieve.get().getName())))
             .andExpect(content().contentType(API_JSON_EXPECTED_ENCODING));
     }
 
@@ -175,7 +175,7 @@ public class DoiServersApiTest extends AbstractServiceIntegrationTest {
                 .accept(MediaType.APPLICATION_JSON_VALUE))
             .andExpect(status().isOk())
             .andExpect(jsonPath("$", hasSize(1)))
-            .andExpect(jsonPath("$[0    ].name", is(doiServerToRetrieve.get().getName())))
+            .andExpect(jsonPath("$[0].name", is(doiServerToRetrieve.get().getName())))
             .andExpect(content().contentType(API_JSON_EXPECTED_ENCODING));
     }
 
@@ -239,6 +239,21 @@ public class DoiServersApiTest extends AbstractServiceIntegrationTest {
                 .session(this.mockHttpSession)
                 .accept(MediaType.APPLICATION_JSON_VALUE))
             .andExpect(status().isForbidden());
+    }
+
+    @Test
+    public void getDoiServerForMetadataNotFound() throws Exception {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
+
+        int nonExistingMetadataId = 99999;
+        assertTrue(metadataRepository.findById(nonExistingMetadataId).isEmpty());
+
+        this.mockHttpSession = loginAsAdmin();
+
+        this.mockMvc.perform(get("/srv/api/doiservers/metadata/" + nonExistingMetadataId)
+                .session(this.mockHttpSession)
+                .accept(MediaType.APPLICATION_JSON_VALUE))
+            .andExpect(status().isNotFound());
     }
 
     @Test


### PR DESCRIPTION
The service should be available for the metadata owner and reviewers of the metadata group owner, as described in https://docs.geonetwork-opensource.org/latest/user-guide/associating-resources/doi/#configuration

Currently, was only accesible for Administrators, not displaying the Create DOI option for the metadata owner or reviewers of the metadata group owner.

Related to https://github.com/geonetwork/core-geonetwork/pull/8098

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [x] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation


