### PR TITLE
API / OpenAPI endpoint return error when Accept is */*

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/OpenApiController.java
+++ b/services/src/main/java/org/fao/geonet/api/OpenApiController.java
@@ -117,12 +117,15 @@ public class OpenApiController extends AbstractOpenApiResource {
     }
 
     @Operation(hidden = true)
-    @GetMapping(value = "/{portal}/api/doc", produces = MediaType.APPLICATION_JSON_VALUE)
-    public String openapiJson(HttpServletRequest request, Locale locale)
+    @GetMapping(value = "/{portal}/api/doc",
+        produces = {MediaType.ALL_VALUE})
+    public org.springframework.http.ResponseEntity<String> openapiJson(HttpServletRequest request, Locale locale)
         throws JsonProcessingException {
         calculateServerUrl(request, locale);
         OpenAPI openAPI = this.getOpenApi(locale);
-        return new String(this.writeJsonValue(openAPI), StandardCharsets.UTF_8);
+        return org.springframework.http.ResponseEntity.ok()
+            .contentType(MediaType.APPLICATION_JSON)
+            .body(new String(this.writeJsonValue(openAPI), StandardCharsets.UTF_8));
     }
 
     @Operation(hidden = true)


### PR DESCRIPTION
Tools like scalar (https://github.com/scalar/scalar) are calling the endpoint with Accept header set to `*/*` and an error was returned

```shell
curl 'http://localhost:8080/geonetwork/srv/api/doc' -H 'Accept: */*'
> Failure

curl 'http://localhost:8080/geonetwork/srv/api/doc' -H 'Accept: application/json'
> JSON response
```


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

