### PR TITLE
Formatter / Full view missing/extra matching nodes

### DIFF
--- a/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
+++ b/web/src/main/webapp/WEB-INF/data/data/formatter/xslt/render-layout.xsl
@@ -556,11 +556,13 @@
     <xsl:param name="collapsible" as="xs:boolean" select="true()" required="no"/>
     <xsl:param name="collapsed" as="xs:boolean" select="false()" required="no"/>
 
-    <!-- Matching nodes -->
+    <xsl:variable name="xpath" select="."/>
+
+    <!-- Matching nodes (without context) -->
     <xsl:variable name="nodes">
       <saxon:call-template name="{concat('evaluate-', $schema)}">
         <xsl:with-param name="base" select="$base"/>
-        <xsl:with-param name="in" select="concat('/../', .)"/>
+        <xsl:with-param name="in" select="concat('/../', $xpath)"/>
       </saxon:call-template>
     </xsl:variable>
 
@@ -570,8 +572,28 @@
       </xsl:if>
     </xsl:variable>
 
-    <!-- The matching nodes when using evaluate loose their context, re-calculate it -->
-    <xsl:variable name="originalNodes" select="$metadata//*[some $n in $nodes/* satisfies deep-equal(., $n)]"/>
+    <!--
+    The matching nodes when using evaluate lose their context and the context may be used to get labels.
+    The base can be the root (the metadata document) or a sub element if the field is in a section with forEach.
+
+    * Use deep-equal function to find nodes which are identical to the matching nodes.
+    * Check that those identical nodes are located at the xpath location matching the requested xpath.
+     -->
+    <xsl:variable name="parentForEachSection"
+                  select="ancestor::section[@forEach][1]"/>
+
+    <xsl:variable name="fullXpath"
+                  select="if ($parentForEachSection) then concat($parentForEachSection/@forEach, '/', $xpath) else $xpath"/>
+
+    <!-- May return nodes which are identical but located at another xpath location. -->
+    <xsl:variable name="equalNodes" as="node()*"
+                  select="$metadata//*[some $nodeWithNoContext in $nodes/* satisfies deep-equal(., $nodeWithNoContext)]"/>
+
+    <!-- Filter identical nodes to keep only those located at the right xpath location.
+     XPath using * will never match path matching. Using node without context.
+    This only happens if editor configuration is using *. -->
+    <xsl:variable name="originalNodes"
+                  select="if (contains($xpath, '/*/')) then $nodes else $equalNodes[concat('/', string-join(ancestor-or-self::*/name()[. != 'root'], '/')) = $fullXpath]"/>
 
     <xsl:for-each select="$originalNodes">
       <xsl:apply-templates mode="render-field">


### PR DESCRIPTION
In https://github.com/geonetwork/core-geonetwork/pull/9000, we added a tentative fix for improving labels when translations contains labels with xpath context.

eg.
```xml
<element name="gmd:description" context="/gmd:MD_Metadata/gmd:identificationInfo/gmd:MD_DataIdentification/gmd:extent/gmd:EX_Extent/gmd:description">
    <label>Beschrijving temporele dekking</label>
    <description>temporele dekking van de data, gespecificeerd als een periode.</description>
  </element>
```

This was not working due to the formatter reading the editor config, find matching field/section to render using saxon `evaluate` function. One drawback is that when using this function, the returned node does not have its context (eg. `..` to get its parent). So the logic to get label based on xpath can't work.

To avoid this a check was made to retrieve the corresponding the original node in the document and `deep-equal` function was used for that. But we noticed some case not handled
* https://github.com/geonetwork/core-geonetwork/pull/9163 2 sections matching the xpath of the editor config (due to wrong usage of deep-equal)
* More than one node matching at different location in the document (eg. a DCAT-AP document with the same license in Catalog and DataService will display the 2 license for the service). This should only happen on custom editor view (ISO default and advanced view should probably not be affected by that case)

```xml    
<section name="serviceInformation">  
  <section xpath="/rdf:RDF/dcat:Catalog/dcat:service/dcat:DataService/dct:license"/>
```


<img width="603" height="523" alt="image" src="https://github.com/user-attachments/assets/234d6c36-687b-4321-827d-1249986cf745" />


* No matching element when using a section with a forEach attribute (eg. `dct:rights` is not rendered).

```xml
          <section name="distribution"
                   forEach="/rdf:RDF/dcat:Catalog/dcat:dataset/dcat:Dataset/dcat:distribution"
                   del=".">
            <section xpath="dcat:Distribution/dct:rights"/>
```


Note: In edit mode, unique ref in `gn:element` is used to retrieve
original node which is more reliable but can't be used in view mode.

Proposal is to find the original node using `deep-equal` and then checking using node xpath matching when the xpath does not make use of wildcard. If wildcard, then `evaluate` returned nodes are used (and may cause the label issue).




Related
* https://github.com/geonetwork/core-geonetwork/pull/9000
* https://github.com/geonetwork/core-geonetwork/pull/9163


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

