### PR TITLE
Thesaurus search cache immutable

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/AllThesaurus.java
+++ b/core/src/main/java/org/fao/geonet/kernel/AllThesaurus.java
@@ -91,7 +91,7 @@ public class AllThesaurus extends Thesaurus {
     }
 
     @VisibleForTesting
-    static String buildKeywordUri(String thesaurusKey, String uri) {
+    public static String buildKeywordUri(String thesaurusKey, String uri) {
         try {
             thesaurusKey = URLEncoder.encode(thesaurusKey, Constants.ENCODING);
 //            uri = URLEncoder.encode(uri, Constants.ENCODING);

--- a/core/src/main/java/org/fao/geonet/kernel/KeywordBean.java
+++ b/core/src/main/java/org/fao/geonet/kernel/KeywordBean.java
@@ -69,6 +69,25 @@ public class KeywordBean {
         this.isoLanguageMapper = isoLangMapper;
     }
 
+    public KeywordBean(KeywordBean other) {
+        this.values.putAll(other.values);
+        this.definitions.putAll(other.definitions);
+        this.id = other.id;
+        this.code = other.code;
+        this.coordEast = other.coordEast;
+        this.coordWest = other.coordWest;
+        this.coordSouth = other.coordSouth;
+        this.coordNorth = other.coordNorth;
+        this.thesaurusKey = other.thesaurusKey;
+        this.selected = other.selected;
+        this.thesaurusTitle = other.thesaurusTitle;
+        this.thesaurusDate = other.thesaurusDate;
+        this.downloadUrl = other.downloadUrl;
+        this.keywordUrl = other.keywordUrl;
+        this.isoLanguageMapper = other.isoLanguageMapper;
+        this.defaultLang = other.defaultLang;
+    }
+
     /**
      * Transforms a list of KeywordBean object into its iso19139 representation.
      *

--- a/core/src/main/java/org/fao/geonet/kernel/Thesaurus.java
+++ b/core/src/main/java/org/fao/geonet/kernel/Thesaurus.java
@@ -1159,7 +1159,7 @@ public class Thesaurus {
 
         KeywordBean keywordBean = keywords.get(0);
         THESAURUS_SEARCH_CACHE.put(cacheKey, keywordBean);
-        return keywordBean;
+        return new KeywordBean(keywordBean);
     }
 
     /**

--- a/core/src/main/java/org/fao/geonet/kernel/Thesaurus.java
+++ b/core/src/main/java/org/fao/geonet/kernel/Thesaurus.java
@@ -1137,7 +1137,7 @@ public class Thesaurus {
         String cacheKey = "getKeyword" + uri + String.join("", languages);
         Object cacheValue = THESAURUS_SEARCH_CACHE.getIfPresent(cacheKey);
         if (cacheValue != null) {
-            return (KeywordBean) cacheValue;
+            return new KeywordBean((KeywordBean) cacheValue);
         }
 
         List<KeywordBean> keywords;

--- a/core/src/test/java/org/fao/geonet/kernel/AbstractThesaurusBasedTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/AbstractThesaurusBasedTest.java
@@ -93,7 +93,7 @@ public abstract class AbstractThesaurusBasedTest {
 
         this.thesaurusFile = directory.resolve("testThesaurus.rdf");
         this.thesaurus = new Thesaurus(isoLangMapper, thesaurusFile.getFileName().toString(), null, null, "test", "test",
-            thesaurusFile, "http://concept", true, 0);
+            thesaurusFile, "http://concept", true, 5);
         this.thesaurus.initRepository();
     }
 

--- a/core/src/test/java/org/fao/geonet/kernel/search/KeywordsSearcherTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/search/KeywordsSearcherTest.java
@@ -56,6 +56,7 @@ public class KeywordsSearcherTest extends AbstractThesaurusBasedTest {
     private ThesaurusFinder thesaurusFinder;
     private Thesaurus thesaurusBlah;
     private Thesaurus thesaurusFoo;
+    private AllThesaurus allThesaurus;
     private int smallWords = 20;
 
     private Map<String, Thesaurus> thesaurusMap = new HashMap<>();
@@ -69,6 +70,7 @@ public class KeywordsSearcherTest extends AbstractThesaurusBasedTest {
     public synchronized void createExtraThesauri() throws Exception {
     	thesaurusBlah = createThesaurus("blah");
         thesaurusFoo = createThesaurus("foo");
+        allThesaurus = new AllThesaurus();
 
         this.thesaurusFinder = new ThesaurusFinder() {
             {
@@ -100,6 +102,9 @@ public class KeywordsSearcherTest extends AbstractThesaurusBasedTest {
                 return getThesauriMap().containsKey(name);
             }
         };
+
+        allThesaurus.init("siteUrl");
+        allThesaurus.setThesaurusFinder(thesaurusFinder);
     }
 
     private Thesaurus createThesaurus(String string) throws Exception {
@@ -173,6 +178,19 @@ public class KeywordsSearcherTest extends AbstractThesaurusBasedTest {
 
         searcher.search(null, params.toXmlParams());
         assertSearchNoContextEngLangNoSearchAllThesauri(searcher);
+    }
+
+    @Test
+    public void searchAllThesaurusFirstDoNotCorruptThesaurusCache() {
+        String thesaurusKey = "test.test.testThesaurus";
+        String uri = "http://abstract.thesaurus.test#0";
+        String allThesaurusUri = AllThesaurus.buildKeywordUri(thesaurusKey, uri);
+        allThesaurus.getKeyword(allThesaurusUri, "eng");
+
+        KeywordBean keyword = thesaurus.getKeyword(uri, "eng");
+
+        assertEquals(thesaurusKey, keyword.getThesaurusKey());
+        assertEquals(uri, keyword.getUriCode());
     }
 
     private void assertSearchNoContextEngLangNoSearchAllThesauri(KeywordsSearcher searcher) {

--- a/core/src/test/java/org/fao/geonet/kernel/search/KeywordsSearcherTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/search/KeywordsSearcherTest.java
@@ -191,6 +191,13 @@ public class KeywordsSearcherTest extends AbstractThesaurusBasedTest {
 
         assertEquals(thesaurusKey, keyword.getThesaurusKey());
         assertEquals(uri, keyword.getUriCode());
+
+        allThesaurus.getKeyword(allThesaurusUri, "eng");
+
+        keyword = thesaurus.getKeyword(uri, "eng");
+
+        assertEquals(thesaurusKey, keyword.getThesaurusKey());
+        assertEquals(uri, keyword.getUriCode());
     }
 
     private void assertSearchNoContextEngLangNoSearchAllThesauri(KeywordsSearcher searcher) {


### PR DESCRIPTION
observed: AllThesaurus delegates search to existing thesauri. Existing thesauri use their own cache. As AllThesaurus modify KeywordBean returned by delegate, it corrupts cached keyword.

solution: ensure Thesaurus getKeyword always returns a copy of the cached entry.
  

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [X] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

- `Funded by Swisstopo`

