### PR TITLE
editor, side panels, online resources, edit when no title

### DIFF
--- a/web-ui/src/main/resources/catalog/components/metadataactions/RelatedDirective.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/RelatedDirective.js
@@ -399,13 +399,14 @@
           }
 
           scope.convertLinkToEdit = function (link) {
+            var convertedNameObject = convertLangProperties(link.nameObject);
             var convertedLink = {
               id: link.url,
               idx: link.idx,
               hash: link.hash,
               url: convertLangProperties(link.urlObject),
               type: getType(link.function),
-              title: convertLangProperties(link.nameObject),
+              title: convertedNameObject ? convertedNameObject : {},
               protocol: link.protocol,
               description: convertLangProperties(link.descriptionObject),
               function: link["function"],


### PR DESCRIPTION
observed:
There is a side panel to edit online resource:
<img width="1760" height="774" alt="edit_resource_having_title" src="https://github.com/user-attachments/assets/9d77309d-2fbf-44b9-874e-936954599fef" />

When one removes the resource title (please note that md remains 'xsd valid'): 
<img width="617" height="648" alt="removing_title" src="https://github.com/user-attachments/assets/35c6b8a3-13e1-43c9-8205-7e176c6a2650" />

One can no longer use the side panel for edition:
<img width="1796" height="812" alt="edit_resource_having_no_title" src="https://github.com/user-attachments/assets/fffcc1dd-e783-452f-8617-0558064161ff" />

solution:
the fix makes the edition possible:
<img width="1742" height="786" alt="with_fix" src="https://github.com/user-attachments/assets/16abc7a4-d385-4b0b-b5cc-d147907960db" />



<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

- `Funded by Swisstopo`

