### PR TITLE
Revert attachment endpoint to manual streaming to fix JSON downloads

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/attachments/AttachmentsApi.java
@@ -52,7 +52,6 @@ import org.fao.geonet.util.FileMimetypeChecker;
 import org.fao.geonet.util.ImageUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
-import org.springframework.core.io.ByteArrayResource;
 import org.springframework.core.io.Resource;
 import org.springframework.http.*;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -72,6 +71,7 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import javax.annotation.PostConstruct;
 import javax.imageio.ImageIO;
 import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
 import java.awt.image.BufferedImage;
 import java.io.*;
 import java.net.URL;
@@ -252,12 +252,13 @@ public class AttachmentsApi {
             content = @Content(schema = @Schema(type = "string", format = "binary"))),
         @ApiResponse(responseCode = "403", description = "Operation not allowed. "
             + "User needs to be able to download the resource.")})
-    public ResponseEntity<Resource> getResource(
+    public void getResource(
         @Parameter(description = "The metadata UUID", required = true, example = "43d7c186-2187-4bcd-8843-41e575a5ef56") @PathVariable String metadataUuid,
         @Parameter(description = "The resource identifier (ie. filename)", required = true) @PathVariable String resourceId,
         @Parameter(description = "Use approved version or not", example = "true") @RequestParam(required = false, defaultValue = "true") Boolean approved,
         @Parameter(description = "Size (only applies to images). From 1px to 2048px.", example = "200") @RequestParam(required = false) Integer size,
-        @Parameter(hidden = true) HttpServletRequest request
+        @Parameter(hidden = true) HttpServletRequest request,
+        @Parameter(hidden = true) HttpServletResponse response
     ) throws Exception {
         ServiceContext context = ApiUtils.createServiceContext(request);
         ApiUtils.canViewRecord(metadataUuid, request);
@@ -267,7 +268,8 @@ public class AttachmentsApi {
         MetadataResource resourceMetadata = store.getResourceMetadata(context, metadataUuid, resourceId, approved);
 
         if (resourceMetadata == null) {
-            return ResponseEntity.status(HttpStatus.NOT_FOUND).build();
+            response.setStatus(HttpStatus.NOT_FOUND.value());
+            return;
         }
 
         String fileName = resourceMetadata.getFilename();
@@ -277,15 +279,14 @@ public class AttachmentsApi {
         String fileETag = "\"" + DigestUtils.md5Hex(fileName + fileSize + resourceMetadata.getVersion() + fileLastModifiedDate) + "\"";
 
         // Set common headers
-        HttpHeaders responseHeaders = new HttpHeaders();
-        responseHeaders.setCacheControl(CacheControl.noCache());
-        responseHeaders.setLastModified(fileLastModifiedDate);
-        responseHeaders.setETag(fileETag);
-        responseHeaders.set(HttpHeaders.ACCEPT_RANGES, "bytes");
+        response.setHeader(HttpHeaders.CACHE_CONTROL, CacheControl.noCache().getHeaderValue());
+        response.setDateHeader(HttpHeaders.LAST_MODIFIED, fileLastModifiedDate);
+        response.setHeader(HttpHeaders.ETAG, fileETag);
+        response.setHeader(HttpHeaders.ACCEPT_RANGES, "bytes");
 
         // Check if the request is not modified based on ETag or Last-Modified
-        if (new ServletWebRequest(request).checkNotModified(fileETag, fileLastModifiedDate)) {
-            return ResponseEntity.status(HttpStatus.NOT_MODIFIED).headers(responseHeaders).build();
+        if (new ServletWebRequest(request, response).checkNotModified(fileETag, fileLastModifiedDate)) {
+            return;
         }
 
         HttpRange range = null;
@@ -300,10 +301,9 @@ public class AttachmentsApi {
             }
         } catch (IllegalArgumentException e) {
             // invalid range -> 416 with real size
-            return ResponseEntity.status(HttpStatus.REQUESTED_RANGE_NOT_SATISFIABLE)
-                .header(HttpHeaders.CONTENT_RANGE, "bytes */" + fileSize)
-                .headers(responseHeaders)
-                .build();
+            response.setStatus(HttpStatus.REQUESTED_RANGE_NOT_SATISFIABLE.value());
+            response.setHeader(HttpHeaders.CONTENT_RANGE, "bytes */" + fileSize);
+            return;
         }
 
         // If the request is a range request, check the If-Range header
@@ -331,40 +331,37 @@ public class AttachmentsApi {
 
         // If the resource is an image and a size is requested, resize the image and return it
         if (fileMediaType.getType().equals("image") && size != null) {
-            Store.ResourceHolder resourceHolder = store.getResource(context, metadataUuid, resourceId, approved);
-            return serveResizedImage(resourceHolder.getResource(), fileName, responseHeaders, size);
+            try (Store.ResourceHolder resourceHolder = store.getResource(context, metadataUuid, resourceId, approved)) {
+                serveResizedImage(resourceHolder.getResource(), fileName, fileETag, size, response);
+            }
+            return;
         }
 
         // Set headers for downloads
-        responseHeaders.setContentType(fileMediaType);
-        responseHeaders.setContentDisposition(ContentDisposition.attachment().filename(fileName).build());
+        response.setContentType(fileMediaType.toString());
+        response.setHeader(HttpHeaders.CONTENT_DISPOSITION, ContentDisposition.attachment().filename(fileName).build().toString());
 
         // Get the resource or a range of it
-        Store.ResourceHolder resourceHolder;
         if (range != null) {
             // Get the range start and end
             long start = range.getRangeStart(fileSize);
             long end = range.getRangeEnd(fileSize);
             // Get the resource for the requested range
-            resourceHolder = store.getResourceWithRange(context, metadataUuid, resourceId, approved, start, end);
-            // If the resource is not a file (ie. a stream) we must serve it manually
-            if (!resourceHolder.getResource().isFile()) {
-                responseHeaders.setContentLength(end - start + 1);
-                responseHeaders.set(HttpHeaders.CONTENT_RANGE, "bytes " + start + "-" + end + "/" + fileSize);
-                return ResponseEntity.status(HttpStatus.PARTIAL_CONTENT)
-                    .headers(responseHeaders)
-                    .body(resourceHolder.getResource());
+            try (Store.ResourceHolder resourceHolder = store.getResourceWithRange(
+                context, metadataUuid, resourceId, approved, start, end)) {
+                response.setStatus(HttpStatus.PARTIAL_CONTENT.value());
+                response.setHeader(HttpHeaders.CONTENT_RANGE, "bytes " + start + "-" + end + "/" + fileSize);
+                response.setContentLengthLong(end - start + 1);
+                streamResource(resourceHolder.getResource(), response);
             }
         } else {
             // Get the full resource
-            resourceHolder = store.getResource(context, metadataUuid, resourceId, approved);
-            responseHeaders.setContentLength(fileSize);
+            try (Store.ResourceHolder resourceHolder = store.getResource(context, metadataUuid, resourceId, approved)) {
+                response.setStatus(HttpStatus.OK.value());
+                response.setContentLengthLong(fileSize);
+                streamResource(resourceHolder.getResource(), response);
+            }
         }
-
-        // If no range is requested or the resource is a file we can let Spring handle the range request
-        return ResponseEntity.ok()
-            .headers(responseHeaders)
-            .body(resourceHolder.getResource());
     }
 
 
@@ -413,12 +410,16 @@ public class AttachmentsApi {
      *
      * @param resource Resource representing the original image
      * @param originalImageName Original filename of the image
-     * @param responseHeaders HTTP headers to be set in the response
+     * @param originalETag Original resource ETag used to generate resized image ETag
      * @param size Desired size for the resized image (in pixels)
+     * @param response Current HTTP response
      * @throws IOException If an I/O error occurs while reading or writing the image
      */
-    private ResponseEntity<Resource> serveResizedImage(Resource resource,
-                                                       String originalImageName, HttpHeaders responseHeaders, int size) throws IOException {
+    private void serveResizedImage(Resource resource,
+                                   String originalImageName,
+                                   String originalETag,
+                                   int size,
+                                   HttpServletResponse response) throws IOException {
         if (size < MIN_IMAGE_SIZE || size > MAX_IMAGE_SIZE) {
             throw new IllegalArgumentException(String.format(
                 "Image can only be resized from %d to %d. You requested %d.",
@@ -436,16 +437,31 @@ public class AttachmentsApi {
             String pngFilename = originalImageName.substring(0, originalImageName.lastIndexOf('.')) + ".png";
 
             // Resized image headers
-            responseHeaders.setContentType(MediaType.IMAGE_PNG);
-            responseHeaders.setContentDisposition(ContentDisposition.attachment().filename(pngFilename).build());
-            responseHeaders.setContentLength(outputStream.size());
-            responseHeaders.setLastModified(System.currentTimeMillis());
+            response.setStatus(HttpStatus.OK.value());
+            response.setContentType(MediaType.IMAGE_PNG_VALUE);
+            response.setHeader(HttpHeaders.CONTENT_DISPOSITION,
+                ContentDisposition.attachment().filename(pngFilename).build().toString());
+            response.setContentLength(outputStream.size());
+            response.setDateHeader(HttpHeaders.LAST_MODIFIED, System.currentTimeMillis());
 
             // Generate a new ETag based on the original ETag and the size
-            String originalETag = responseHeaders.getETag();
-            responseHeaders.setETag("\"" + DigestUtils.md5Hex(originalETag + size) + "\"");
+            response.setHeader(HttpHeaders.ETAG, "\"" + DigestUtils.md5Hex(originalETag + size) + "\"");
 
-            return ResponseEntity.ok().headers(responseHeaders).body(new ByteArrayResource(outputStream.toByteArray()));
+            OutputStream servletOutput = response.getOutputStream();
+            outputStream.writeTo(servletOutput);
+            servletOutput.flush();
+        }
+    }
+
+    private void streamResource(Resource resource, HttpServletResponse response) throws IOException {
+        try (InputStream inputStream = resource.getInputStream()) {
+            OutputStream outputStream = response.getOutputStream();
+            byte[] buffer = new byte[BUFFER_SIZE];
+            int bytesRead;
+            while ((bytesRead = inputStream.read(buffer)) != -1) {
+                outputStream.write(buffer, 0, bytesRead);
+            }
+            outputStream.flush();
         }
     }
 }


### PR DESCRIPTION
Currently, the attachment download endpoint returns `ResponseEntity<Resource>`, which relies on Spring message converters to write the response.

For most file types this works fine, but when the content type is `application/json`, Spring may select Jackson instead of the resource writer and attempt to serialize the `Resource` itself rather than stream it.

This results in errors such as:
```
No serializer found for class sun.net.www.protocol.http.HttpURLConnection$HttpInputStream
```
This PR aims to fix this issue by reverting the endpoint back to a fully manual implementation using `HttpServletResponse`, bypassing Spring message conversion entirely
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

