### PR TITLE
Ger schematron diagnostics

### DIFF
--- a/core/src/main/java/org/fao/geonet/util/XslUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/XslUtil.java
@@ -941,10 +941,10 @@ public final class XslUtil {
     }
 
     /**
-     * Return 2 iso lang code from a 3 iso lang code. If any error occurs return "".
+     * Return 2 iso lang code (ISO 639-1 two-letter code) from a 3 iso lang code. If any error occurs return "".
      *
-     * @param iso3LangCode The 2 iso lang code
-     * @return The related 3 iso lang code
+     * @param iso3LangCode The 3 chars iso lang code
+     * @return The related 2 chars iso lang code
      */
     public static
     @Nonnull

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/process/languages-refactor.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/process/languages-refactor.xsl
@@ -57,14 +57,14 @@
                 select="concat('#', $previousDefaultLanguageId)"
                 as="xs:string?"/>
 
-  <!-- eg. eng,spa,ger -->
+  <!-- eg. fre,eng,spa,ger -->
   <xsl:variable name="otherLanguageIds"
                 select="tokenize(
                           replace($others, $defaultLanguage, $previousDefaultLanguage),
                           ',')"
                 as="xs:string*"/>
 
-  <!-- eg. #FR,#EN,#SP,#GE -->
+  <!-- eg. #FR,#EN,#ES,#DE -->
   <xsl:variable name="otherLanguageIdsRef" as="node()*">
     <lang><xsl:value-of select="$defaultLanguageIdRef"/></lang>
     <xsl:for-each select="$otherLanguageIds[. != 'none']">

--- a/schemas/iso19115-3.2018/src/test/java/org/fao/geonet/schema/LanguageXslProcessTest.java
+++ b/schemas/iso19115-3.2018/src/test/java/org/fao/geonet/schema/LanguageXslProcessTest.java
@@ -85,7 +85,7 @@ public class LanguageXslProcessTest extends XslProcessTest {
         params.put("defaultLanguage", "fre");
         Element resultElement = Xml.transform(inputElement, xslFile, params);
         resultString = Xml.getString(resultElement);
-        check(resultString, "fre", new String[]{}, 224, 9);
+        check(resultString, "fre", new String[]{}, 222, 8);
         assertThat(
             resultString,
             hasXPath(XPATH_MAIN_TITLE, equalTo("Modèle pour les données vecteur (multilingue)"))
@@ -186,7 +186,7 @@ public class LanguageXslProcessTest extends XslProcessTest {
         Element resultElement = Xml.transform(inputElement, xslFile, params);
         String resultString = Xml.getString(resultElement);
 
-        check(resultString, "eng", new String[]{}, 224, 9);
+        check(resultString, "eng", new String[]{}, 222, 8);
         assertThat(
             resultString,
             hasXPath(XPATH_MAIN_TITLE, equalTo("Template for Vector data (multilingual)"))

--- a/schemas/iso19115-3.2018/src/test/java/org/fao/geonet/schema/SchematronTest.java
+++ b/schemas/iso19115-3.2018/src/test/java/org/fao/geonet/schema/SchematronTest.java
@@ -76,16 +76,29 @@ public class SchematronTest {
 
 	@Test
 	public void createFreValidationReport() throws Exception {
+		createValidationReport("fre",
+				"UpperRhineCastles-schematron-rules-iso-report.xml",
+				"UpperRhineCastles-validation-report.xml");
+	}
+
+	@Test
+	public void createGerValidationReport() throws Exception {
+		createValidationReport("ger",
+				"UpperRhineCastles-schematron-rules-iso-report-with-ia-based-german.xml",
+				"UpperRhineCastles-validation-report-with-ia-based-german.xml");
+	}
+	private void createValidationReport(String languageCode, String sourceFile, String controlFile) throws Exception {
 		Path xslFile = getResource("gn-site/xslt/services/metadata/validate.xsl");
 
 		org.jdom.Namespace geonetNs = org.jdom.Namespace.getNamespace("geonet", "http://www.fao.org/geonetwork");
-        Element root = new Element("root");
+		Element root = new Element("root");
 		Element language = new Element("language");
-		language.setText("fre");
-        Element rootReport = new Element("report", geonetNs);
-        Element schematronErrors = new Element("schematronerrors", geonetNs);
-        Element report = new Element("report", geonetNs);
-		Path xmlFile = getResourceInsideSchema("UpperRhineCastles-schematron-rules-iso-report.xml");
+		language.setText(languageCode);
+		Element rootReport = new Element("report", geonetNs);
+		Element schematronErrors = new Element("schematronerrors", geonetNs);
+		Element report = new Element("report", geonetNs);
+		Path xmlFile = getResourceInsideSchema(sourceFile);
+
 		Element source = Xml.loadFile(xmlFile);
 
 		root.addContent(rootReport);
@@ -98,7 +111,7 @@ public class SchematronTest {
 
 		XMLOutputter xmlOutputter = new XMLOutputter(Format.getPrettyFormat().setLineSeparator("\n"));
 		String actual = xmlOutputter.outputString(new Document(transformed));
-		TestSupport.assertGeneratedDataByteMatchExpected("UpperRhineCastles-validation-report.xml", actual, GENERATE_EXPECTED_FILE);
+		TestSupport.assertGeneratedDataByteMatchExpected(controlFile, actual, GENERATE_EXPECTED_FILE);
 	}
 
 	private void applySchematronAndCompare(String inputFileName, String expectedFileName) throws Exception {

--- a/schemas/iso19115-3.2018/src/test/java/org/fao/geonet/schema/SchematronTest.java
+++ b/schemas/iso19115-3.2018/src/test/java/org/fao/geonet/schema/SchematronTest.java
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2001-2025 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+package org.fao.geonet.schema;
+
+import org.fao.geonet.utils.IO;
+import org.fao.geonet.utils.TransformerFactoryFactory;
+import org.fao.geonet.utils.Xml;
+import org.jdom.Document;
+import org.jdom.Element;
+import org.jdom.output.Format;
+import org.jdom.output.XMLOutputter;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.fao.geonet.schema.TestSupport.getResource;
+import static org.fao.geonet.schema.TestSupport.getResourceInsideSchema;
+
+public class SchematronTest {
+	@ClassRule
+	public static final TemporaryFolder temporaryFolder = new TemporaryFolder();
+	private static final boolean GENERATE_EXPECTED_FILE = false;
+	private static Path compiledSchematronFilePath;
+
+	@BeforeClass
+	public static void makeUtilsFnAvailable() throws IOException, URISyntaxException {
+		Path targetUtilsFnFile = temporaryFolder.getRoot().toPath().resolve("xsl/utils-fn.xsl");
+		Files.createDirectories(targetUtilsFnFile.getParent());
+		IO.copyDirectoryOrFile( getResource("gn-site/xsl/utils-fn.xsl"), targetUtilsFnFile, false);
+	}
+
+	@BeforeClass
+	public static void initSaxonAndCompileSchematron() throws Exception {
+		TransformerFactoryFactory.init("net.sf.saxon.TransformerFactoryImpl");
+		Element schematronSource = Xml.loadFile(getResourceInsideSchema("schematron/schematron-rules-iso.sch"));
+		Path schematronCompilation = getResource("gn-site/WEB-INF/classes/schematron/iso_svrl_for_xslt2.xsl");
+		Element compiledSchematron = Xml.transform(schematronSource, schematronCompilation);
+		compiledSchematronFilePath = temporaryFolder.getRoot().toPath().resolve("path/requiredtoFind/utilsfile/compiled-iso-schematron.xsl");
+		Files.createDirectories(compiledSchematronFilePath.getParent());
+		Files.write(compiledSchematronFilePath, Xml.getString(compiledSchematron).getBytes(StandardCharsets.UTF_8));
+	}
+
+	@Test
+	public void isoSchematronTest() throws Exception {
+		applySchematronAndCompare( "UpperRhineCastles-iso19115-3.2018.xml", "UpperRhineCastles-schematron-rules-iso-report.xml");
+	}
+
+	@Test
+	public void createFreValidationReport() throws Exception {
+		Path xslFile = getResource("gn-site/xslt/services/metadata/validate.xsl");
+
+		org.jdom.Namespace geonetNs = org.jdom.Namespace.getNamespace("geonet", "http://www.fao.org/geonetwork");
+        Element root = new Element("root");
+		Element language = new Element("language");
+		language.setText("fre");
+        Element rootReport = new Element("report", geonetNs);
+        Element schematronErrors = new Element("schematronerrors", geonetNs);
+        Element report = new Element("report", geonetNs);
+		Path xmlFile = getResourceInsideSchema("UpperRhineCastles-schematron-rules-iso-report.xml");
+		Element source = Xml.loadFile(xmlFile);
+
+		root.addContent(rootReport);
+		root.addContent(language);
+		rootReport.addContent(schematronErrors);
+		schematronErrors.addContent(report);
+		report.addContent(source);
+
+		Element transformed = Xml.transform(root, xslFile);
+
+		XMLOutputter xmlOutputter = new XMLOutputter(Format.getPrettyFormat().setLineSeparator("\n"));
+		String actual = xmlOutputter.outputString(new Document(transformed));
+		TestSupport.assertGeneratedDataByteMatchExpected("UpperRhineCastles-validation-report.xml", actual, GENERATE_EXPECTED_FILE);
+	}
+
+	private void applySchematronAndCompare(String inputFileName, String expectedFileName) throws Exception {
+		Path xmlFile = getResource( inputFileName);
+		Element md = Xml.loadFile(xmlFile);
+
+		Element report = Xml.transform(md, compiledSchematronFilePath, Map.of(
+				"rule", "schematron-rules-iso",
+				"thesaurusDir", getResource("gn-site/WEB-INF/data/config/codelist").toAbsolutePath().toString(),
+				"lang", "fre"
+		));
+
+		XMLOutputter xmlOutputter = new XMLOutputter(Format.getPrettyFormat().setLineSeparator("\n"));
+		String actual = xmlOutputter.outputString(new Document(report));
+		TestSupport.assertGeneratedDataByteMatchExpected(expectedFileName, actual, GENERATE_EXPECTED_FILE);
+	}
+
+}

--- a/schemas/iso19115-3.2018/src/test/java/org/fao/geonet/util/XslUtil.java
+++ b/schemas/iso19115-3.2018/src/test/java/org/fao/geonet/util/XslUtil.java
@@ -32,7 +32,7 @@ public class XslUtil {
     public static Boolean IS_INSPIRE_ENABLED = false;
 
     public static String twoCharLangCode(String iso3code) {
-        return iso3code.substring(0, 2);
+        return twoCharLangCode(iso3code, iso3code.substring(0, 2));
     }
     public static String threeCharLangCode(String iso2code) {
         return "fre";

--- a/schemas/iso19115-3.2018/src/test/resources/UpperRhineCastles-schematron-rules-iso-report-with-ia-based-german.xml
+++ b/schemas/iso19115-3.2018/src/test/resources/UpperRhineCastles-schematron-rules-iso-report-with-ia-based-german.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svrl:schematron-output xmlns:svrl="http://purl.oclc.org/dsdl/svrl" title="Règles ISO" schemaVersion="">
+  <!--
+         
+        
+         
+        
+         
+        -->
+  <svrl:ns-prefix-in-attribute-values uri="http://www.opengis.net/gml/3.2" prefix="gml" />
+  <svrl:ns-prefix-in-attribute-values uri="http://standards.iso.org/iso/19115/-3/srv/2.0" prefix="srv" />
+  <svrl:ns-prefix-in-attribute-values uri="http://standards.iso.org/iso/19115/-3/cit/2.0" prefix="cit" />
+  <svrl:ns-prefix-in-attribute-values uri="http://standards.iso.org/iso/19115/-3/gex/1.0" prefix="gex" />
+  <svrl:ns-prefix-in-attribute-values uri="http://standards.iso.org/iso/19115/-3/mco/1.0" prefix="mco" />
+  <svrl:ns-prefix-in-attribute-values uri="http://standards.iso.org/iso/19115/-3/mdb/2.0" prefix="mdb" />
+  <svrl:ns-prefix-in-attribute-values uri="http://standards.iso.org/iso/19115/-3/mex/1.0" prefix="mex" />
+  <svrl:ns-prefix-in-attribute-values uri="http://standards.iso.org/iso/19115/-3/mmi/1.0" prefix="mmi" />
+  <svrl:ns-prefix-in-attribute-values uri="http://standards.iso.org/iso/19115/-3/gmw/1.0" prefix="gmw" />
+  <svrl:ns-prefix-in-attribute-values uri="http://standards.iso.org/iso/19115/-3/mrc/2.0" prefix="mrc" />
+  <svrl:ns-prefix-in-attribute-values uri="http://standards.iso.org/iso/19115/-3/mrd/1.0" prefix="mrd" />
+  <svrl:ns-prefix-in-attribute-values uri="http://standards.iso.org/iso/19115/-3/mri/1.0" prefix="mri" />
+  <svrl:ns-prefix-in-attribute-values uri="http://standards.iso.org/iso/19115/-3/mrs/1.0" prefix="mrs" />
+  <svrl:ns-prefix-in-attribute-values uri="http://standards.iso.org/iso/19115/-3/mcc/1.0" prefix="mcc" />
+  <svrl:ns-prefix-in-attribute-values uri="http://standards.iso.org/iso/19115/-3/lan/1.0" prefix="lan" />
+  <svrl:ns-prefix-in-attribute-values uri="http://standards.iso.org/iso/19115/-3/gco/1.0" prefix="gco" />
+  <svrl:ns-prefix-in-attribute-values uri="http://www.fao.org/geonetwork" prefix="geonet" />
+  <svrl:ns-prefix-in-attribute-values uri="http://www.w3.org/1999/xlink" prefix="xlink" />
+  <svrl:ns-prefix-in-attribute-values uri="http://www.w3.org/2001/XMLSchema" prefix="xsi" />
+  <svrl:active-pattern document="" id="rule.cit.individualnameandposition" name_en="Individual MUST have a name or a position" name_fr="Une personne DOIT avoir un nom ou une fonction" name_de="Eine Person MUSS einen Namen oder eine Funktion haben" name="Une personne DOIT avoir un nom ou une fonction" />
+  <svrl:fired-rule context="//cit:CI_Individual" />
+  <svrl:successful-report ref="#_" test="$hasName or $hasPosition" location="/*[local-name()='MD_Metadata']/*[local-name()='identificationInfo']/*[local-name()='MD_DataIdentification']/*[local-name()='pointOfContact']&#xA;          [&#xA;          1&#xA;          ]&#xA;        /*[local-name()='CI_Responsibility']/*[local-name()='party']/*[local-name()='CI_Organisation']/*[local-name()='individual']/*[local-name()='CI_Individual']">
+    <svrl:text />
+    <svrl:diagnostic-reference ref="#_" diagnostic="rule.cit.individualnameandposition-success-en" xml:lang="en">Individual name is
+      "
+          GeoRhena GeoRhena GeoRhena GeoRhena
+          "
+      and position
+      "
+          
+          "
+      .</svrl:diagnostic-reference>
+    <svrl:diagnostic-reference ref="#_" diagnostic="rule.cit.individualnameandposition-success-fr" xml:lang="fr">Le nom de la personne est
+      "
+          GeoRhena GeoRhena GeoRhena GeoRhena
+          "
+      ,sa fonction
+      "
+          
+          "
+      .</svrl:diagnostic-reference>
+    <svrl:diagnostic-reference ref="#_" diagnostic="rule.cit.individualnameandposition-success-de" xml:lang="de">Der Name der Person ist
+      "
+          GeoRhena GeoRhena GeoRhena GeoRhena
+          "
+      und die Position
+      "
+
+          "
+      .</svrl:diagnostic-reference>
+  </svrl:successful-report>
+</svrl:schematron-output>
+

--- a/schemas/iso19115-3.2018/src/test/resources/UpperRhineCastles-schematron-rules-iso-report.xml
+++ b/schemas/iso19115-3.2018/src/test/resources/UpperRhineCastles-schematron-rules-iso-report.xml
@@ -1,0 +1,345 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svrl:schematron-output xmlns:svrl="http://purl.oclc.org/dsdl/svrl" title="Règles ISO" schemaVersion="">
+  <!--
+         
+        
+         
+        
+         
+        -->
+  <svrl:ns-prefix-in-attribute-values uri="http://www.opengis.net/gml/3.2" prefix="gml" />
+  <svrl:ns-prefix-in-attribute-values uri="http://standards.iso.org/iso/19115/-3/srv/2.0" prefix="srv" />
+  <svrl:ns-prefix-in-attribute-values uri="http://standards.iso.org/iso/19115/-3/cit/2.0" prefix="cit" />
+  <svrl:ns-prefix-in-attribute-values uri="http://standards.iso.org/iso/19115/-3/gex/1.0" prefix="gex" />
+  <svrl:ns-prefix-in-attribute-values uri="http://standards.iso.org/iso/19115/-3/mco/1.0" prefix="mco" />
+  <svrl:ns-prefix-in-attribute-values uri="http://standards.iso.org/iso/19115/-3/mdb/2.0" prefix="mdb" />
+  <svrl:ns-prefix-in-attribute-values uri="http://standards.iso.org/iso/19115/-3/mex/1.0" prefix="mex" />
+  <svrl:ns-prefix-in-attribute-values uri="http://standards.iso.org/iso/19115/-3/mmi/1.0" prefix="mmi" />
+  <svrl:ns-prefix-in-attribute-values uri="http://standards.iso.org/iso/19115/-3/gmw/1.0" prefix="gmw" />
+  <svrl:ns-prefix-in-attribute-values uri="http://standards.iso.org/iso/19115/-3/mrc/2.0" prefix="mrc" />
+  <svrl:ns-prefix-in-attribute-values uri="http://standards.iso.org/iso/19115/-3/mrd/1.0" prefix="mrd" />
+  <svrl:ns-prefix-in-attribute-values uri="http://standards.iso.org/iso/19115/-3/mri/1.0" prefix="mri" />
+  <svrl:ns-prefix-in-attribute-values uri="http://standards.iso.org/iso/19115/-3/mrs/1.0" prefix="mrs" />
+  <svrl:ns-prefix-in-attribute-values uri="http://standards.iso.org/iso/19115/-3/mcc/1.0" prefix="mcc" />
+  <svrl:ns-prefix-in-attribute-values uri="http://standards.iso.org/iso/19115/-3/lan/1.0" prefix="lan" />
+  <svrl:ns-prefix-in-attribute-values uri="http://standards.iso.org/iso/19115/-3/gco/1.0" prefix="gco" />
+  <svrl:ns-prefix-in-attribute-values uri="http://www.fao.org/geonetwork" prefix="geonet" />
+  <svrl:ns-prefix-in-attribute-values uri="http://www.w3.org/1999/xlink" prefix="xlink" />
+  <svrl:ns-prefix-in-attribute-values uri="http://www.w3.org/2001/XMLSchema" prefix="xsi" />
+  <svrl:active-pattern document="" id="rule.cit.individualnameandposition" name_en="Individual MUST have a name or a position" name_fr="Une personne DOIT avoir un nom ou une fonction" name="Une personne DOIT avoir un nom ou une fonction" />
+  <svrl:fired-rule context="//cit:CI_Individual" />
+  <svrl:successful-report ref="#_" test="$hasName or $hasPosition" location="/*[local-name()='MD_Metadata']/*[local-name()='identificationInfo']/*[local-name()='MD_DataIdentification']/*[local-name()='pointOfContact']&#xA;          [&#xA;          1&#xA;          ]&#xA;        /*[local-name()='CI_Responsibility']/*[local-name()='party']/*[local-name()='CI_Organisation']/*[local-name()='individual']/*[local-name()='CI_Individual']">
+    <svrl:text />
+    <svrl:diagnostic-reference ref="#_" diagnostic="rule.cit.individualnameandposition-success-en" xml:lang="en">Individual name is
+      "
+          GeoRhena GeoRhena GeoRhena GeoRhena
+          "
+      and position
+      "
+          
+          "
+      .</svrl:diagnostic-reference>
+    <svrl:diagnostic-reference ref="#_" diagnostic="rule.cit.individualnameandposition-success-fr" xml:lang="fr">Le nom de la personne est
+      "
+          GeoRhena GeoRhena GeoRhena GeoRhena
+          "
+      ,sa fonction
+      "
+          
+          "
+      .</svrl:diagnostic-reference>
+  </svrl:successful-report>
+  <svrl:fired-rule context="//cit:CI_Individual" />
+  <svrl:failed-assert ref="#_" test="$hasName or $hasPosition" location="/*[local-name()='MD_Metadata']/*[local-name()='distributionInfo']/*[local-name()='MD_Distribution']/*[local-name()='distributor']/*[local-name()='MD_Distributor']/*[local-name()='distributorContact']/*[local-name()='CI_Responsibility']/*[local-name()='party']/*[local-name()='CI_Organisation']/*[local-name()='individual']/*[local-name()='CI_Individual']">
+    <svrl:text />
+    <svrl:diagnostic-reference ref="#_" diagnostic="rule.cit.individualnameandposition-failure-en" xml:lang="en">The individual does not have a name or a
+      position.</svrl:diagnostic-reference>
+    <svrl:diagnostic-reference ref="#_" diagnostic="rule.cit.individualnameandposition-failure-fr" xml:lang="fr">Une personne n'a pas de nom ou de fonction.</svrl:diagnostic-reference>
+  </svrl:failed-assert>
+  <svrl:active-pattern document="" id="rule.cit.organisationnameandlogo" name_en="Organisation MUST have a name or a logo" name_fr="Une organisation DOIT avoir un nom ou un logo" name="Une organisation DOIT avoir un nom ou un logo" />
+  <svrl:fired-rule context="//cit:CI_Organisation" />
+  <svrl:successful-report ref="#_" test="$hasName or $hasLogo" location="/*[local-name()='MD_Metadata']/*[local-name()='contact']/*[local-name()='CI_Responsibility']/*[local-name()='party']/*[local-name()='CI_Organisation']">
+    <svrl:text />
+    <svrl:diagnostic-reference ref="#_" diagnostic="rule.cit.organisationnameandlogo-success-en" xml:lang="en">Organisation name is
+      "
+          GeoRhena: Système d'Information Géographique du Rhin Supérieur GeoRhena: Système d'Information Géographique du Rhin Supérieur GeoRhena: Geographische Informationssystem des Oberrheins GeoRhena: Geographical Information System of the Upper Rhine
+          "
+      and logo filename is
+      "
+          
+          "
+      .</svrl:diagnostic-reference>
+    <svrl:diagnostic-reference ref="#_" diagnostic="rule.cit.organisationnameandlogo-success-fr" xml:lang="fr">Le nom de l'organisation est
+      "
+          GeoRhena: Système d'Information Géographique du Rhin Supérieur GeoRhena: Système d'Information Géographique du Rhin Supérieur GeoRhena: Geographische Informationssystem des Oberrheins GeoRhena: Geographical Information System of the Upper Rhine
+          "
+      , son logo
+      "
+          
+          "
+      .</svrl:diagnostic-reference>
+  </svrl:successful-report>
+  <svrl:fired-rule context="//cit:CI_Organisation" />
+  <svrl:successful-report ref="#_" test="$hasName or $hasLogo" location="/*[local-name()='MD_Metadata']/*[local-name()='identificationInfo']/*[local-name()='MD_DataIdentification']/*[local-name()='pointOfContact']&#xA;          [&#xA;          1&#xA;          ]&#xA;        /*[local-name()='CI_Responsibility']/*[local-name()='party']/*[local-name()='CI_Organisation']">
+    <svrl:text />
+    <svrl:diagnostic-reference ref="#_" diagnostic="rule.cit.organisationnameandlogo-success-en" xml:lang="en">Organisation name is
+      "
+          GeoRhena GeoRhena GeoRhena GeoRhena
+          "
+      and logo filename is
+      "
+          
+          "
+      .</svrl:diagnostic-reference>
+    <svrl:diagnostic-reference ref="#_" diagnostic="rule.cit.organisationnameandlogo-success-fr" xml:lang="fr">Le nom de l'organisation est
+      "
+          GeoRhena GeoRhena GeoRhena GeoRhena
+          "
+      , son logo
+      "
+          
+          "
+      .</svrl:diagnostic-reference>
+  </svrl:successful-report>
+  <svrl:fired-rule context="//cit:CI_Organisation" />
+  <svrl:successful-report ref="#_" test="$hasName or $hasLogo" location="/*[local-name()='MD_Metadata']/*[local-name()='identificationInfo']/*[local-name()='MD_DataIdentification']/*[local-name()='pointOfContact']&#xA;          [&#xA;          2&#xA;          ]&#xA;        /*[local-name()='CI_Responsibility']/*[local-name()='party']/*[local-name()='CI_Organisation']">
+    <svrl:text />
+    <svrl:diagnostic-reference ref="#_" diagnostic="rule.cit.organisationnameandlogo-success-en" xml:lang="en">Organisation name is
+      "
+          Collectivité Européenne d'Alsace Collectivité Européenne d'Alsace Collectivité Européenne d'Alsace Collectivité Européenne d'Alsace
+          "
+      and logo filename is
+      "
+          
+          "
+      .</svrl:diagnostic-reference>
+    <svrl:diagnostic-reference ref="#_" diagnostic="rule.cit.organisationnameandlogo-success-fr" xml:lang="fr">Le nom de l'organisation est
+      "
+          Collectivité Européenne d'Alsace Collectivité Européenne d'Alsace Collectivité Européenne d'Alsace Collectivité Européenne d'Alsace
+          "
+      , son logo
+      "
+          
+          "
+      .</svrl:diagnostic-reference>
+  </svrl:successful-report>
+  <svrl:fired-rule context="//cit:CI_Organisation" />
+  <svrl:successful-report ref="#_" test="$hasName or $hasLogo" location="/*[local-name()='MD_Metadata']/*[local-name()='distributionInfo']/*[local-name()='MD_Distribution']/*[local-name()='distributor']/*[local-name()='MD_Distributor']/*[local-name()='distributorContact']/*[local-name()='CI_Responsibility']/*[local-name()='party']/*[local-name()='CI_Organisation']">
+    <svrl:text />
+    <svrl:diagnostic-reference ref="#_" diagnostic="rule.cit.organisationnameandlogo-success-en" xml:lang="en">Organisation name is
+      "
+          GeoRhena GeoRhena
+          "
+      and logo filename is
+      "
+          
+          "
+      .</svrl:diagnostic-reference>
+    <svrl:diagnostic-reference ref="#_" diagnostic="rule.cit.organisationnameandlogo-success-fr" xml:lang="fr">Le nom de l'organisation est
+      "
+          GeoRhena GeoRhena
+          "
+      , son logo
+      "
+          
+          "
+      .</svrl:diagnostic-reference>
+  </svrl:successful-report>
+  <svrl:active-pattern document="" id="rule.gex.extenthasoneelement" name_en="Extent MUST have one description or one geographic,&#xA;      temporal or vertical element" name_fr="Une étendue DOIT avoir une description ou un&#xA;      élément géographique, temporel ou vertical" name="Une étendue DOIT avoir une description ou un&#xA;      élément géographique, temporel ou vertical" />
+  <svrl:fired-rule context="//gex:EX_Extent" />
+  <svrl:successful-report ref="#_" test="count($temporal)" location="/*[local-name()='MD_Metadata']/*[local-name()='identificationInfo']/*[local-name()='MD_DataIdentification']/*[local-name()='extent']&#xA;          [&#xA;          1&#xA;          ]&#xA;        /*[local-name()='EX_Extent']">
+    <svrl:text />
+    <svrl:diagnostic-reference ref="#_" diagnostic="rule.gex.extenthasoneelement-temporal-success-en" xml:lang="en">The extent contains a temporal element.</svrl:diagnostic-reference>
+    <svrl:diagnostic-reference ref="#_" diagnostic="rule.gex.extenthasoneelement-temporal-success-fr" xml:lang="fr">L'étendue contient une étendue temporelle.</svrl:diagnostic-reference>
+  </svrl:successful-report>
+  <svrl:fired-rule context="//gex:EX_Extent" />
+  <svrl:successful-report ref="#_" test="count($geographicBox)" location="/*[local-name()='MD_Metadata']/*[local-name()='identificationInfo']/*[local-name()='MD_DataIdentification']/*[local-name()='extent']&#xA;          [&#xA;          2&#xA;          ]&#xA;        /*[local-name()='EX_Extent']">
+    <svrl:text />
+    <svrl:diagnostic-reference ref="#_" diagnostic="rule.gex.extenthasoneelement-box-success-en" xml:lang="en">The extent contains a bounding box element.</svrl:diagnostic-reference>
+    <svrl:diagnostic-reference ref="#_" diagnostic="rule.gex.extenthasoneelement-box-success-fr" xml:lang="fr">L'étendue contient une emprise géographique.</svrl:diagnostic-reference>
+  </svrl:successful-report>
+  <svrl:active-pattern document="" id="rule.gex.verticalhascrsorcrsid" name_en="Vertical element MUST contains a CRS or CRS&#xA;      identifier" name_fr="Une étendue verticale DOIT contenir un CRS ou un&#xA;      identifiant de CRS" name="Une étendue verticale DOIT contenir un CRS ou un&#xA;      identifiant de CRS" />
+  <svrl:active-pattern document="" id="rule.mco-releasability" name_en="Releasability MUST&#xA;      specified an addresse or a statement" name_fr="La possibilité de divulgation&#xA;      DOIT définir un destinataire ou une indication" name="La possibilité de divulgation&#xA;      DOIT définir un destinataire ou une indication" />
+  <svrl:active-pattern document="" id="rule.mco-legalconstraintdetails" name_en="Legal constraint MUST&#xA;      specified an access, use or other constraint or&#xA;      use limitation or releasability" name_fr="Une contrainte légale DOIT&#xA;      définir un type de contrainte (d'accès, d'utilisation ou autre)&#xA;      ou bien une limite d'utilisation ou une possibilité de divulgation" name="Une contrainte légale DOIT&#xA;      définir un type de contrainte (d'accès, d'utilisation ou autre)&#xA;      ou bien une limite d'utilisation ou une possibilité de divulgation" />
+  <svrl:fired-rule context="//mco:MD_LegalConstraints" />
+  <svrl:successful-report ref="#_" test="$hasDetails" location="/*[local-name()='MD_Metadata']/*[local-name()='identificationInfo']/*[local-name()='MD_DataIdentification']/*[local-name()='resourceConstraints']&#xA;          [&#xA;          2&#xA;          ]&#xA;        /*[local-name()='MD_LegalConstraints']">
+    <svrl:text />
+    <svrl:diagnostic-reference ref="#_" diagnostic="rule.mco-legalconstraintdetails-success-en" xml:lang="en">The legal constraint is complete.</svrl:diagnostic-reference>
+    <svrl:diagnostic-reference ref="#_" diagnostic="rule.mco-legalconstraintdetails-success-fr" xml:lang="fr">La contrainte légale est complète.</svrl:diagnostic-reference>
+  </svrl:successful-report>
+  <svrl:active-pattern document="" id="rule.mco-legalconstraint-other" name_en="Legal constraint defining&#xA;      other restrictions for access or use constraint MUST&#xA;      specified other constraint." name_fr="Une contrainte légale indiquant&#xA;      d'autres restrictions d'utilisation ou d'accès DOIT&#xA;      préciser ces autres restrictions" name="Une contrainte légale indiquant&#xA;      d'autres restrictions d'utilisation ou d'accès DOIT&#xA;      préciser ces autres restrictions" />
+  <svrl:fired-rule context="//mco:MD_LegalConstraints[       mco:accessConstraints/mco:MD_RestrictionCode/@codeListValue = 'otherRestrictions' or       mco:useConstraints/mco:MD_RestrictionCode/@codeListValue = 'otherRestrictions'       ]" />
+  <svrl:successful-report ref="#_" test="$hasOtherConstraints" location="/*[local-name()='MD_Metadata']/*[local-name()='identificationInfo']/*[local-name()='MD_DataIdentification']/*[local-name()='resourceConstraints']&#xA;          [&#xA;          2&#xA;          ]&#xA;        /*[local-name()='MD_LegalConstraints']">
+    <svrl:text />
+    <svrl:diagnostic-reference ref="#_" diagnostic="rule.mco-legalconstraint-other-success-en" xml:lang="en">
+      The legal constraint other constraints is
+      "
+      <gco:CharacterString xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0" xmlns:mdb="http://standards.iso.org/iso/19115/-3/mdb/2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cat="http://standards.iso.org/iso/19115/-3/cat/1.0" xmlns:gfc="http://standards.iso.org/iso/19110/gfc/1.1" xmlns:cit="http://standards.iso.org/iso/19115/-3/cit/2.0" xmlns:gcx="http://standards.iso.org/iso/19115/-3/gcx/1.0" xmlns:gex="http://standards.iso.org/iso/19115/-3/gex/1.0" xmlns:lan="http://standards.iso.org/iso/19115/-3/lan/1.0" xmlns:srv="http://standards.iso.org/iso/19115/-3/srv/2.0" xmlns:mas="http://standards.iso.org/iso/19115/-3/mas/1.0" xmlns:mcc="http://standards.iso.org/iso/19115/-3/mcc/1.0" xmlns:mco="http://standards.iso.org/iso/19115/-3/mco/1.0" xmlns:mda="http://standards.iso.org/iso/19115/-3/mda/1.0" xmlns:mds="http://standards.iso.org/iso/19115/-3/mds/2.0" xmlns:mdt="http://standards.iso.org/iso/19115/-3/mdt/2.0" xmlns:mex="http://standards.iso.org/iso/19115/-3/mex/1.0" xmlns:mmi="http://standards.iso.org/iso/19115/-3/mmi/1.0" xmlns:mpc="http://standards.iso.org/iso/19115/-3/mpc/1.0" xmlns:mrc="http://standards.iso.org/iso/19115/-3/mrc/2.0" xmlns:mrd="http://standards.iso.org/iso/19115/-3/mrd/1.0" xmlns:mri="http://standards.iso.org/iso/19115/-3/mri/1.0" xmlns:mrl="http://standards.iso.org/iso/19115/-3/mrl/2.0" xmlns:mrs="http://standards.iso.org/iso/19115/-3/mrs/1.0" xmlns:msr="http://standards.iso.org/iso/19115/-3/msr/2.0" xmlns:mdq="http://standards.iso.org/iso/19157/-2/mdq/1.0" xmlns:dqm="http://standards.iso.org/iso/19157/-2/dqm/1.0" xmlns:mac="http://standards.iso.org/iso/19115/-3/mac/2.0" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xlink="http://www.w3.org/1999/xlink">Pas d'autre limitation</gco:CharacterString>
+      <lan:PT_FreeText xmlns:lan="http://standards.iso.org/iso/19115/-3/lan/1.0" xmlns:mdb="http://standards.iso.org/iso/19115/-3/mdb/2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cat="http://standards.iso.org/iso/19115/-3/cat/1.0" xmlns:gfc="http://standards.iso.org/iso/19110/gfc/1.1" xmlns:cit="http://standards.iso.org/iso/19115/-3/cit/2.0" xmlns:gcx="http://standards.iso.org/iso/19115/-3/gcx/1.0" xmlns:gex="http://standards.iso.org/iso/19115/-3/gex/1.0" xmlns:srv="http://standards.iso.org/iso/19115/-3/srv/2.0" xmlns:mas="http://standards.iso.org/iso/19115/-3/mas/1.0" xmlns:mcc="http://standards.iso.org/iso/19115/-3/mcc/1.0" xmlns:mco="http://standards.iso.org/iso/19115/-3/mco/1.0" xmlns:mda="http://standards.iso.org/iso/19115/-3/mda/1.0" xmlns:mds="http://standards.iso.org/iso/19115/-3/mds/2.0" xmlns:mdt="http://standards.iso.org/iso/19115/-3/mdt/2.0" xmlns:mex="http://standards.iso.org/iso/19115/-3/mex/1.0" xmlns:mmi="http://standards.iso.org/iso/19115/-3/mmi/1.0" xmlns:mpc="http://standards.iso.org/iso/19115/-3/mpc/1.0" xmlns:mrc="http://standards.iso.org/iso/19115/-3/mrc/2.0" xmlns:mrd="http://standards.iso.org/iso/19115/-3/mrd/1.0" xmlns:mri="http://standards.iso.org/iso/19115/-3/mri/1.0" xmlns:mrl="http://standards.iso.org/iso/19115/-3/mrl/2.0" xmlns:mrs="http://standards.iso.org/iso/19115/-3/mrs/1.0" xmlns:msr="http://standards.iso.org/iso/19115/-3/msr/2.0" xmlns:mdq="http://standards.iso.org/iso/19157/-2/mdq/1.0" xmlns:dqm="http://standards.iso.org/iso/19157/-2/dqm/1.0" xmlns:mac="http://standards.iso.org/iso/19115/-3/mac/2.0" xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <lan:textGroup>
+          <lan:LocalisedCharacterString locale="#FR">Pas d'autre limitation</lan:LocalisedCharacterString>
+        </lan:textGroup>
+        <lan:textGroup>
+          <lan:LocalisedCharacterString locale="#DE">Keine andere Einschränkung</lan:LocalisedCharacterString>
+        </lan:textGroup>
+        <lan:textGroup>
+          <lan:LocalisedCharacterString locale="#EN">No other limitation</lan:LocalisedCharacterString>
+        </lan:textGroup>
+      </lan:PT_FreeText>
+      ".
+    </svrl:diagnostic-reference>
+    <svrl:diagnostic-reference ref="#_" diagnostic="rule.mco-legalconstraint-other-success-fr" xml:lang="fr">
+      Les autres contraintes de la contrainte légale sont
+      "
+      <gco:CharacterString xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0" xmlns:mdb="http://standards.iso.org/iso/19115/-3/mdb/2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cat="http://standards.iso.org/iso/19115/-3/cat/1.0" xmlns:gfc="http://standards.iso.org/iso/19110/gfc/1.1" xmlns:cit="http://standards.iso.org/iso/19115/-3/cit/2.0" xmlns:gcx="http://standards.iso.org/iso/19115/-3/gcx/1.0" xmlns:gex="http://standards.iso.org/iso/19115/-3/gex/1.0" xmlns:lan="http://standards.iso.org/iso/19115/-3/lan/1.0" xmlns:srv="http://standards.iso.org/iso/19115/-3/srv/2.0" xmlns:mas="http://standards.iso.org/iso/19115/-3/mas/1.0" xmlns:mcc="http://standards.iso.org/iso/19115/-3/mcc/1.0" xmlns:mco="http://standards.iso.org/iso/19115/-3/mco/1.0" xmlns:mda="http://standards.iso.org/iso/19115/-3/mda/1.0" xmlns:mds="http://standards.iso.org/iso/19115/-3/mds/2.0" xmlns:mdt="http://standards.iso.org/iso/19115/-3/mdt/2.0" xmlns:mex="http://standards.iso.org/iso/19115/-3/mex/1.0" xmlns:mmi="http://standards.iso.org/iso/19115/-3/mmi/1.0" xmlns:mpc="http://standards.iso.org/iso/19115/-3/mpc/1.0" xmlns:mrc="http://standards.iso.org/iso/19115/-3/mrc/2.0" xmlns:mrd="http://standards.iso.org/iso/19115/-3/mrd/1.0" xmlns:mri="http://standards.iso.org/iso/19115/-3/mri/1.0" xmlns:mrl="http://standards.iso.org/iso/19115/-3/mrl/2.0" xmlns:mrs="http://standards.iso.org/iso/19115/-3/mrs/1.0" xmlns:msr="http://standards.iso.org/iso/19115/-3/msr/2.0" xmlns:mdq="http://standards.iso.org/iso/19157/-2/mdq/1.0" xmlns:dqm="http://standards.iso.org/iso/19157/-2/dqm/1.0" xmlns:mac="http://standards.iso.org/iso/19115/-3/mac/2.0" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xlink="http://www.w3.org/1999/xlink">Pas d'autre limitation</gco:CharacterString>
+      <lan:PT_FreeText xmlns:lan="http://standards.iso.org/iso/19115/-3/lan/1.0" xmlns:mdb="http://standards.iso.org/iso/19115/-3/mdb/2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:cat="http://standards.iso.org/iso/19115/-3/cat/1.0" xmlns:gfc="http://standards.iso.org/iso/19110/gfc/1.1" xmlns:cit="http://standards.iso.org/iso/19115/-3/cit/2.0" xmlns:gcx="http://standards.iso.org/iso/19115/-3/gcx/1.0" xmlns:gex="http://standards.iso.org/iso/19115/-3/gex/1.0" xmlns:srv="http://standards.iso.org/iso/19115/-3/srv/2.0" xmlns:mas="http://standards.iso.org/iso/19115/-3/mas/1.0" xmlns:mcc="http://standards.iso.org/iso/19115/-3/mcc/1.0" xmlns:mco="http://standards.iso.org/iso/19115/-3/mco/1.0" xmlns:mda="http://standards.iso.org/iso/19115/-3/mda/1.0" xmlns:mds="http://standards.iso.org/iso/19115/-3/mds/2.0" xmlns:mdt="http://standards.iso.org/iso/19115/-3/mdt/2.0" xmlns:mex="http://standards.iso.org/iso/19115/-3/mex/1.0" xmlns:mmi="http://standards.iso.org/iso/19115/-3/mmi/1.0" xmlns:mpc="http://standards.iso.org/iso/19115/-3/mpc/1.0" xmlns:mrc="http://standards.iso.org/iso/19115/-3/mrc/2.0" xmlns:mrd="http://standards.iso.org/iso/19115/-3/mrd/1.0" xmlns:mri="http://standards.iso.org/iso/19115/-3/mri/1.0" xmlns:mrl="http://standards.iso.org/iso/19115/-3/mrl/2.0" xmlns:mrs="http://standards.iso.org/iso/19115/-3/mrs/1.0" xmlns:msr="http://standards.iso.org/iso/19115/-3/msr/2.0" xmlns:mdq="http://standards.iso.org/iso/19157/-2/mdq/1.0" xmlns:dqm="http://standards.iso.org/iso/19157/-2/dqm/1.0" xmlns:mac="http://standards.iso.org/iso/19115/-3/mac/2.0" xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0" xmlns:gml="http://www.opengis.net/gml/3.2" xmlns:xlink="http://www.w3.org/1999/xlink">
+        <lan:textGroup>
+          <lan:LocalisedCharacterString locale="#FR">Pas d'autre limitation</lan:LocalisedCharacterString>
+        </lan:textGroup>
+        <lan:textGroup>
+          <lan:LocalisedCharacterString locale="#DE">Keine andere Einschränkung</lan:LocalisedCharacterString>
+        </lan:textGroup>
+        <lan:textGroup>
+          <lan:LocalisedCharacterString locale="#EN">No other limitation</lan:LocalisedCharacterString>
+        </lan:textGroup>
+      </lan:PT_FreeText>
+      ".
+    </svrl:diagnostic-reference>
+  </svrl:successful-report>
+  <svrl:active-pattern document="" id="rule.mdb.root-element" name_en="Metadata document root element" name_fr="Élément racine du document" name="Élément racine du document">
+    <svrl:text>A metadata instance document conforming to
+      this specification SHALL have a root MD_Metadata element
+      defined in the http://standards.iso.org/iso/19115/-3/mdb/2.0 namespace.</svrl:text>
+    <svrl:text>Une fiche de métadonnées conforme au standard
+      ISO19115-1 DOIT avoir un élément racine MD_Metadata (défini dans l'espace
+      de nommage http://standards.iso.org/iso/19115/-3/mdb/2.0).</svrl:text>
+  </svrl:active-pattern>
+  <svrl:fired-rule context="/" />
+  <svrl:successful-report ref="#_" test="$hasOneMD_MetadataElement" location="/*[local-name()='MD_Metadata']">
+    <svrl:text />
+    <svrl:diagnostic-reference ref="#_" diagnostic="rule.mdb.root-element-success-en" xml:lang="en">Root
+      element MD_Metadata found.</svrl:diagnostic-reference>
+    <svrl:diagnostic-reference ref="#_" diagnostic="rule.mdb.root-element-success-fr" xml:lang="fr">Élément
+      racine MD_Metadata défini.</svrl:diagnostic-reference>
+  </svrl:successful-report>
+  <svrl:active-pattern document="" id="rule.mdb.defaultlocale" name_en="Default locale" name_fr="Langue du document" name="Langue du document">
+    <svrl:text>The default locale MUST be documented if
+      not defined by the encoding. The default value for the character
+      encoding is "UTF-8".</svrl:text>
+    <svrl:text>La langue doit être documentée
+      si non définie par l'encodage. L'encodage par défaut doit être "UTF-8".</svrl:text>
+  </svrl:active-pattern>
+  <svrl:fired-rule context="/mdb:MD_Metadata/mdb:defaultLocale|                        /mdb:MD_Metadata/mdb:identificationInfo/*/mri:defaultLocale" />
+  <svrl:successful-report ref="#_" test="$hasEncoding" location="/*[local-name()='MD_Metadata']/*[local-name()='defaultLocale']">
+    <svrl:text />
+    <svrl:diagnostic-reference ref="#_" diagnostic="rule.mdb.defaultlocale-success-en" xml:lang="en">The
+      characeter encoding is "
+          utf8
+          .</svrl:diagnostic-reference>
+    <svrl:diagnostic-reference ref="#_" diagnostic="rule.mdb.defaultlocale-success-fr" xml:lang="fr">L'encodage est "
+          utf8
+          .</svrl:diagnostic-reference>
+  </svrl:successful-report>
+  <svrl:fired-rule context="/mdb:MD_Metadata/mdb:defaultLocale|                        /mdb:MD_Metadata/mdb:identificationInfo/*/mri:defaultLocale" />
+  <svrl:successful-report ref="#_" test="$hasEncoding" location="/*[local-name()='MD_Metadata']/*[local-name()='identificationInfo']/*[local-name()='MD_DataIdentification']/*[local-name()='defaultLocale']">
+    <svrl:text />
+    <svrl:diagnostic-reference ref="#_" diagnostic="rule.mdb.defaultlocale-success-en" xml:lang="en">The
+      characeter encoding is "
+          utf8
+          .</svrl:diagnostic-reference>
+    <svrl:diagnostic-reference ref="#_" diagnostic="rule.mdb.defaultlocale-success-fr" xml:lang="fr">L'encodage est "
+          utf8
+          .</svrl:diagnostic-reference>
+  </svrl:successful-report>
+  <svrl:active-pattern document="" id="rule.mdb.scope-name" name_en="Metadata scope Name" name_fr="Description du domaine d'application" name="Description du domaine d'application">
+    <svrl:text>If a MD_MetadataScope element is present,
+      the name property MUST have a value if resourceScope is not equal to
+      "dataset"</svrl:text>
+    <svrl:text>Si un élément domaine d'application (MD_MetadataScope)
+      est défini, sa description (name) DOIT avoir une valeur
+      si ce domaine n'est pas "jeu de données" (ie. "dataset").</svrl:text>
+  </svrl:active-pattern>
+  <svrl:active-pattern document="" id="rule.mdb.create-date" name_en="Metadata create date" name_fr="Date de création du document" name="Date de création du document">
+    <svrl:text>A dateInfo property value with data type = "creation"
+      MUST be present in every MD_Metadata instance.</svrl:text>
+    <svrl:text>Tout document DOIT avoir une date de création
+      définie (en utilisant un élément dateInfo avec un type de date
+      "creation").</svrl:text>
+  </svrl:active-pattern>
+  <svrl:fired-rule context="mdb:MD_Metadata" />
+  <svrl:failed-assert ref="#_" test="$hasAtLeastOneCreationDate" location="/*[local-name()='MD_Metadata']">
+    <svrl:text />
+    <svrl:diagnostic-reference ref="#_" diagnostic="rule.mdb.create-date-failure-en" xml:lang="en">Specify a
+      creation date for the metadata record
+      in the metadata section.</svrl:diagnostic-reference>
+    <svrl:diagnostic-reference ref="#_" diagnostic="rule.mdb.create-date-failure-fr" xml:lang="fr">Définir
+      une date de création pour le document
+      dans la section sur les métadonnées.</svrl:diagnostic-reference>
+  </svrl:failed-assert>
+  <svrl:active-pattern document="" id="rule.mex.datatypedetails" name_en="Extended element information&#xA;      which are not codelist, enumeration or codelistElement&#xA;      MUST specified max occurence and domain value" name_fr="Un élément d'extension qui n'est&#xA;      ni une codelist, ni une énumération, ni un élément de codelist&#xA;      DOIT préciser le nombre maximum d'occurences&#xA;      ainsi que la valeur du domaine" name="Un élément d'extension qui n'est&#xA;      ni une codelist, ni une énumération, ni un élément de codelist&#xA;      DOIT préciser le nombre maximum d'occurences&#xA;      ainsi que la valeur du domaine" />
+  <svrl:active-pattern document="" id="rule.mex.conditional" name_en="Extended element information&#xA;      which are conditional MUST explained the condition" name_fr="Un élément d'extension conditionnel&#xA;      DOIT préciser les termes de la condition" name="Un élément d'extension conditionnel&#xA;      DOIT préciser les termes de la condition" />
+  <svrl:active-pattern document="" id="rule.mex.mandatorycode" name_en="Extended element information&#xA;      which are codelist, enumeration or codelistElement&#xA;      MUST specified a code and a concept name" name_fr="Un élément d'extension qui est&#xA;      une codelist, une énumération, un élément de codelist&#xA;      DOIT préciser un code et un nom de concept" name="Un élément d'extension qui est&#xA;      une codelist, une énumération, un élément de codelist&#xA;      DOIT préciser un code et un nom de concept" />
+  <svrl:active-pattern document="" id="rule.mmi-updatefrequency" name_en="Maintenance information MUST&#xA;      specified an update frequency" name_fr="L'information sur la maintenance&#xA;      DOIT définir une fréquence de mise à jour" name="L'information sur la maintenance&#xA;      DOIT définir une fréquence de mise à jour" />
+  <svrl:fired-rule context="//mmi:MD_MaintenanceInformation" />
+  <svrl:successful-report ref="#_" test="count($maintenanceAndUpdateFrequency)" location="/*[local-name()='MD_Metadata']/*[local-name()='identificationInfo']/*[local-name()='MD_DataIdentification']/*[local-name()='resourceMaintenance']/*[local-name()='MD_MaintenanceInformation']">
+    <svrl:text />
+    <svrl:diagnostic-reference ref="#_" diagnostic="rule.mmi-updatefrequency-success-en" xml:lang="en">The update frequency is "
+          asNeeded
+          ".</svrl:diagnostic-reference>
+    <svrl:diagnostic-reference ref="#_" diagnostic="rule.mmi-updatefrequency-success-fr" xml:lang="fr">La fréquence de mise à jour est "
+          asNeeded
+          ".</svrl:diagnostic-reference>
+  </svrl:successful-report>
+  <svrl:active-pattern document="" id="rule.mrc.sampledimension" name_en="Sample dimension MUST provide a max,&#xA;      a min or a mean value" name_fr="La dimension de l'échantillon DOIT préciser&#xA;      une valeur maximum, une valeur minimum ou une moyenne" name="La dimension de l'échantillon DOIT préciser&#xA;      une valeur maximum, une valeur minimum ou une moyenne" />
+  <svrl:active-pattern document="" id="rule.mrc.bandunit" name_en="Band MUST specified bounds units&#xA;      when a bound max or bound min is defined" name_fr="Une bande DOIT préciser l'unité&#xA;      lorsqu'une borne maximum ou minimum est définie" name="Une bande DOIT préciser l'unité&#xA;      lorsqu'une borne maximum ou minimum est définie" />
+  <svrl:active-pattern document="" id="rule.mrd.mediumunit" name_en="Medium having density MUST specified density&#xA;      units" name_fr="Un média précisant une densité DOIT préciser&#xA;      l'unité" name="Un média précisant une densité DOIT préciser&#xA;      l'unité" />
+  <svrl:active-pattern document="" id="rule.mri.datasetextent" name_en="Dataset extent" name_fr="Emprise du jeu de données" name="Emprise du jeu de données" />
+  <svrl:fired-rule context="/mdb:MD_Metadata[mdb:metadataScope/                           mdb:MD_MetadataScope/mdb:resourceScope/                           mcc:MD_ScopeCode/@codeListValue = 'dataset']/                           mdb:identificationInfo/mri:MD_DataIdentification" />
+  <svrl:successful-report ref="#_" test="count($geobox) &gt; 0" location="/*[local-name()='MD_Metadata']/*[local-name()='identificationInfo']/*[local-name()='MD_DataIdentification']">
+    <svrl:text />
+    <svrl:diagnostic-reference ref="#_" diagnostic="rule.mri.datasetextentbox-success-en" xml:lang="en">The
+      dataset geographic bounding box is:
+      [W:
+          7.009277343750001
+          ,
+      S:
+          47.346267182053
+          ],
+      [E:
+          8.745117187500002
+          ,
+      N:
+          49.31079887964631
+          ],
+      .</svrl:diagnostic-reference>
+    <svrl:diagnostic-reference ref="#_" diagnostic="rule.mri.datasetextentbox-success-fr" xml:lang="fr">L'emprise géographique du jeu de données est
+      [W:
+          7.009277343750001
+          ,
+      S:
+          47.346267182053
+          ],
+      [E:
+          8.745117187500002
+          ,
+      N:
+          49.31079887964631
+          ]
+      .</svrl:diagnostic-reference>
+  </svrl:successful-report>
+  <svrl:active-pattern document="" id="rule.mri.topicategoryfordsandseries" name_en="Topic category for dataset and series" name_fr="Thème principal d'un jeu de données ou d'une&#xA;      série" name="Thème principal d'un jeu de données ou d'une&#xA;      série" />
+  <svrl:fired-rule context="/mdb:MD_Metadata[mdb:metadataScope/                          mdb:MD_MetadataScope/mdb:resourceScope/                          mcc:MD_ScopeCode/@codeListValue = 'dataset' or                           mdb:metadataScope/                          mdb:MD_MetadataScope/mdb:resourceScope/                          mcc:MD_ScopeCode/@codeListValue = 'series']/                          mdb:identificationInfo/mri:MD_DataIdentification" />
+  <svrl:successful-report ref="#_" test="$hasTopics" location="/*[local-name()='MD_Metadata']/*[local-name()='identificationInfo']/*[local-name()='MD_DataIdentification']">
+    <svrl:text />
+    <svrl:diagnostic-reference ref="#_" diagnostic="rule.mri.topicategoryfordsandseries-success-en" xml:lang="en">Number of topic category identified:
+          1
+          .</svrl:diagnostic-reference>
+    <svrl:diagnostic-reference ref="#_" diagnostic="rule.mri.topicategoryfordsandseries-success-fr" xml:lang="fr">Nombre de thèmes :
+          1
+          .</svrl:diagnostic-reference>
+  </svrl:successful-report>
+  <svrl:active-pattern document="" id="rule.mri.associatedresource" name_en="Associated resource name" name_fr="Nom ou référence à une ressource associée" name="Nom ou référence à une ressource associée" />
+  <svrl:active-pattern document="" id="rule.mri.defaultlocalewhenhastext" name_en="Resource language" name_fr="Langue de la ressource" name="Langue de la ressource" />
+  <svrl:active-pattern document="" id="rule.srv.servicetaxonomy" name_en="Service taxonomy" name_fr="Taxonomie des services" name="Taxonomie des services" />
+</svrl:schematron-output>
+

--- a/schemas/iso19115-3.2018/src/test/resources/UpperRhineCastles-validation-report-with-ia-based-german.xml
+++ b/schemas/iso19115-3.2018/src/test/resources/UpperRhineCastles-validation-report-with-ia-based-german.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rules>
+  <report xmlns:gml320="http://www.opengis.net/gml">
+    <id>xsd</id>
+    <displayPriority>0</displayPriority>
+    <error>0</error>
+    <success>?</success>
+    <total>?</total>
+    <requirement>REQUIRED</requirement>
+    <patterns />
+  </report>
+  <report xmlns:gml320="http://www.opengis.net/gml">
+    <id />
+    <displayPriority />
+    <label>Règles ISO</label>
+    <error>0</error>
+    <success>1</success>
+    <total>1</total>
+    <requirement />
+    <patterns>
+      <pattern>
+        <title>Individual MUST have a name or a position</title>
+        <rules />
+      </pattern>
+    </patterns>
+  </report>
+</rules>
+

--- a/schemas/iso19115-3.2018/src/test/resources/UpperRhineCastles-validation-report-with-ia-based-german.xml
+++ b/schemas/iso19115-3.2018/src/test/resources/UpperRhineCastles-validation-report-with-ia-based-german.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rules>
-  <report xmlns:gml320="http://www.opengis.net/gml">
+  <report xmlns:gml320="http://www.opengis.net/gml" xmlns:util="java:org.fao.geonet.util.XslUtil">
     <id>xsd</id>
     <displayPriority>0</displayPriority>
     <error>0</error>
@@ -9,7 +9,7 @@
     <requirement>REQUIRED</requirement>
     <patterns />
   </report>
-  <report xmlns:gml320="http://www.opengis.net/gml">
+  <report xmlns:gml320="http://www.opengis.net/gml" xmlns:util="java:org.fao.geonet.util.XslUtil">
     <id />
     <displayPriority />
     <label>Règles ISO</label>
@@ -19,7 +19,7 @@
     <requirement />
     <patterns>
       <pattern>
-        <title>Individual MUST have a name or a position</title>
+        <title>Eine Person MUSS einen Namen oder eine Funktion haben</title>
         <rules />
       </pattern>
     </patterns>

--- a/schemas/iso19115-3.2018/src/test/resources/UpperRhineCastles-validation-report.xml
+++ b/schemas/iso19115-3.2018/src/test/resources/UpperRhineCastles-validation-report.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rules>
-  <report xmlns:gml320="http://www.opengis.net/gml">
+  <report xmlns:gml320="http://www.opengis.net/gml" xmlns:util="java:org.fao.geonet.util.XslUtil">
     <id>xsd</id>
     <displayPriority>0</displayPriority>
     <error>0</error>
@@ -9,7 +9,7 @@
     <requirement>REQUIRED</requirement>
     <patterns />
   </report>
-  <report xmlns:gml320="http://www.opengis.net/gml">
+  <report xmlns:gml320="http://www.opengis.net/gml" xmlns:util="java:org.fao.geonet.util.XslUtil">
     <id />
     <displayPriority />
     <label>Règles ISO</label>

--- a/schemas/iso19115-3.2018/src/test/resources/UpperRhineCastles-validation-report.xml
+++ b/schemas/iso19115-3.2018/src/test/resources/UpperRhineCastles-validation-report.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<rules>
+  <report xmlns:gml320="http://www.opengis.net/gml">
+    <id>xsd</id>
+    <displayPriority>0</displayPriority>
+    <error>0</error>
+    <success>?</success>
+    <total>?</total>
+    <requirement>REQUIRED</requirement>
+    <patterns />
+  </report>
+  <report xmlns:gml320="http://www.opengis.net/gml">
+    <id />
+    <displayPriority />
+    <label>Règles ISO</label>
+    <error>2</error>
+    <success>15</success>
+    <total>17</total>
+    <requirement />
+    <patterns>
+      <pattern>
+        <title>Une personne DOIT avoir un nom ou une fonction</title>
+        <rules />
+      </pattern>
+      <pattern>
+        <title>Une organisation DOIT avoir un nom ou un logo</title>
+        <rules />
+      </pattern>
+      <pattern>
+        <title>Une étendue DOIT avoir une description ou un
+      élément géographique, temporel ou vertical</title>
+        <rules />
+      </pattern>
+      <pattern>
+        <title>Une étendue verticale DOIT contenir un CRS ou un
+      identifiant de CRS</title>
+        <rules />
+      </pattern>
+      <pattern>
+        <title>La possibilité de divulgation
+      DOIT définir un destinataire ou une indication</title>
+        <rules />
+      </pattern>
+      <pattern>
+        <title>Une contrainte légale DOIT
+      définir un type de contrainte (d'accès, d'utilisation ou autre)
+      ou bien une limite d'utilisation ou une possibilité de divulgation</title>
+        <rules />
+      </pattern>
+      <pattern>
+        <title>Une contrainte légale indiquant
+      d'autres restrictions d'utilisation ou d'accès DOIT
+      préciser ces autres restrictions</title>
+        <rules />
+      </pattern>
+      <pattern>
+        <title>Élément racine du document</title>
+        <rules />
+      </pattern>
+      <pattern>
+        <title>Langue du document</title>
+        <rules />
+      </pattern>
+      <pattern>
+        <title>Description du domaine d'application</title>
+        <rules />
+      </pattern>
+      <pattern>
+        <title>Date de création du document</title>
+        <rules />
+      </pattern>
+      <pattern>
+        <title>Un élément d'extension qui n'est
+      ni une codelist, ni une énumération, ni un élément de codelist
+      DOIT préciser le nombre maximum d'occurences
+      ainsi que la valeur du domaine</title>
+        <rules />
+      </pattern>
+      <pattern>
+        <title>Un élément d'extension conditionnel
+      DOIT préciser les termes de la condition</title>
+        <rules />
+      </pattern>
+      <pattern>
+        <title>Un élément d'extension qui est
+      une codelist, une énumération, un élément de codelist
+      DOIT préciser un code et un nom de concept</title>
+        <rules />
+      </pattern>
+      <pattern>
+        <title>L'information sur la maintenance
+      DOIT définir une fréquence de mise à jour</title>
+        <rules />
+      </pattern>
+      <pattern>
+        <title>La dimension de l'échantillon DOIT préciser
+      une valeur maximum, une valeur minimum ou une moyenne</title>
+        <rules />
+      </pattern>
+      <pattern>
+        <title>Une bande DOIT préciser l'unité
+      lorsqu'une borne maximum ou minimum est définie</title>
+        <rules />
+      </pattern>
+      <pattern>
+        <title>Un média précisant une densité DOIT préciser
+      l'unité</title>
+        <rules />
+      </pattern>
+      <pattern>
+        <title>Emprise du jeu de données</title>
+        <rules />
+      </pattern>
+      <pattern>
+        <title>Thème principal d'un jeu de données ou d'une
+      série</title>
+        <rules />
+      </pattern>
+      <pattern>
+        <title>Nom ou référence à une ressource associée</title>
+        <rules />
+      </pattern>
+      <pattern>
+        <title>Langue de la ressource</title>
+        <rules />
+      </pattern>
+      <pattern>
+        <title>Taxonomie des services</title>
+        <rules />
+      </pattern>
+    </patterns>
+  </report>
+</rules>
+

--- a/web/src/main/webapp/xslt/services/metadata/validate.xsl
+++ b/web/src/main/webapp/xslt/services/metadata/validate.xsl
@@ -27,6 +27,7 @@
                 xmlns:sch="http://www.ascc.net/xml/schematron"
                 xmlns:gml="http://www.opengis.net/gml/3.2"
                 xmlns:gml320="http://www.opengis.net/gml"
+                xmlns:util="java:org.fao.geonet.util.XslUtil"
                 xmlns:gmd="http://www.isotc211.org/2005/gmd"
                 xmlns:srv="http://www.isotc211.org/2005/srv"
                 xmlns:gco="http://www.isotc211.org/2005/gco"
@@ -37,9 +38,7 @@
   <xsl:include href="validate-fn.xsl"/>
   <xsl:param name="rootTag" select="'rules'"/>
 
-  <!-- Retrieve GUI language first 2 letters
-  for multilingual schematron using xml:lang attribute. -->
-  <xsl:variable name="language" select="substring(/root/language, 1, 2)"/>
+  <xsl:variable name="language" select="util:twoCharLangCode(/root/language)"/>
   <xsl:variable name="metadataSchema" select="/root/schema"/>
 
   <xsl:template match="/">


### PR DESCRIPTION
It can occur that schematron are amended to embed foreign language (such as german) diagnosis. In this case, editor ui validation windows should use them when ui language matches.

<img width="551" height="702" alt="ger-diagnosis" src="https://github.com/user-attachments/assets/c6c6bf1d-0f29-44fc-bcfd-47cdd332ad6f" />


To allow it, in validation.xsl, "ger" 3 letters language code has to be converted to "de" 2 letters language code (and not into "ge" ;-)).

Please note that this pr does NOT come with german schematron diagnosis.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [X] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

- `Funded by Swisstopo`

