### PR TITLE
Fix typo in github QA workflow

### DIFF
--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -67,7 +67,7 @@ jobs:
     - name: Test with maven
       run: |
         mvn -B resources:resources@copy-index-schema-to-source -f web
-        mvn -B -ntp -V -fae verify -Drelesae -Pit
+        mvn -B -ntp -V -fae verify -Drelease -Pit
     - name: Check for uncommitted changes such as formatting changes
       run: |
         if [[ -n "$(git status -s)" ]]; then


### PR DESCRIPTION
Fix typo in `mvn verify` command.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
