### PR TITLE
Fix ISO-19139 URN fileIdentifier modified when converted to DCAT

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/dcat/dcat-core.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/dcat/dcat-core.xsl
@@ -283,7 +283,7 @@
                   select="*/mcc:codeSpace/*/text()"/>
     <xsl:variable name="isUrn"
                   as="xs:boolean"
-                  select="starts-with($codeSpace, 'urn:')"/>
+                  select="$codeSpace = 'urn' or starts-with($codeSpace, 'urn:')"/>
     <xsl:variable name="separator"
                   as="xs:string"
                   select="if ($isUrn) then ':' else '/'"/>


### PR DESCRIPTION
Fix https://github.com/geonetwork/core-geonetwork/issues/9170

This is a quick fix for the inconsistency between the way the ISO-19139 to ISO-19115-3.2018 converter extracts a `codeSpace` from the original `fileIdentifier` (in [convert/ISO19139/mapping/core.xsl](https://github.com/geonetwork/core-geonetwork/blob/main/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/ISO19139/mapping/core.xsl#L55)) and the way the DCAT* formatters put the metadata `identifier` back together (in [formatter/dcat/dcat-core.xsl](https://github.com/geonetwork/core-geonetwork/blob/4.4.6/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/dcat/dcat-core.xsl#L221)).

Example:
```
ISO-19139 original:
  fileIdentifier = urn:isogeo:metadata:uuid:e9dc2a55-5783-481e-8582-aca1461bda5b
ISO-19115-3 intermediate:
  MD_Identifier
    code = isogeo:metadata:uuid:e9dc2a55-5783-481e-8582-aca1461bda5b
    codeSpace = urn
DCAT* output (before fix):
  isPrimaryTopicOf
    identifier = urn/isogeo:metadata:uuid:e9dc2a55-5783-481e-8582-aca1461bda5b
DCAT* output (after fix):
  isPrimaryTopicOf
    identifier = urn:isogeo:metadata:uuid:e9dc2a55-5783-481e-8582-aca1461bda5b
```

The fix treats "urn" as a URN `codeSpace`, so it ends up being concatenated to `code` with the proper ':' separator instead of '/'.

The proper fix is not obvious since parsing rules for URNs depend on the URN namespace (NID), so in the example above we'd have to know what the "isogeo" parsing rules are to extract the full `codeSpace` from `fileIdentifier`. There is no guarantee that the last ':' can be treated as the `code`/`codeSpace` separator since ':' is also a valid character for the NSS part of the URN.

While not addressing the root cause, this quick fix is low-risk and solves the inconsistency, at least until a proper fix is attempted.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
