### PR TITLE
Improve privileges panel UI for record privilege groups

### DIFF
--- a/docs/manual/docs/user-guide/publishing/managing-privileges.md
+++ b/docs/manual/docs/user-guide/publishing/managing-privileges.md
@@ -5,8 +5,14 @@ To manage privileges to your metadata record and any attached data, you will nee
 For example, you can specify that the metadata and related services are visible to all (Internet users) or just to internal users only (Intranet). Privileges are assigned on a per group basis. Depending on the user profile (Guest, Registered User, Editor, Admin etc.) access to these functions may differ on a per user basis.
 
 !!! Note
-  
-    [System Privilege Groups](../../administrator-guide/managing-users-and-groups/creating-group.md#3-system-privilege-group) are special groups which cannot have privileges set for specific metadata records.
+
+    The privileges panel uses colour coding to identify different group types:
+
+    - **Blue rows** — [Reserved groups](../../administrator-guide/managing-users-and-groups/creating-group.md) (All, Intranet, Guest). Only Administrators and Reviewers can edit these privileges.
+    - **Yellow rows** — [Record Privilege Groups](../../administrator-guide/managing-users-and-groups/creating-group.md#2-record-privilege-group). These groups can be assigned privileges on specific records but cannot own metadata.
+    - **No highlight** — Standard [Workspace Groups](../../administrator-guide/managing-users-and-groups/creating-group.md#1-workspace-group).
+
+    [System Privilege Groups](../../administrator-guide/managing-users-and-groups/creating-group.md#3-system-privilege-group) are not shown in the panel, as privileges for specific metadata records cannot be assigned to them.
 
 ## Assigning privileges
 

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataSharingApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataSharingApi.java
@@ -764,6 +764,7 @@ public class MetadataSharingApi implements ApplicationEventPublisherAware
                 GroupPrivilege groupPrivilege = new GroupPrivilege();
                 groupPrivilege.setGroup(g.getId());
                 groupPrivilege.setReserved(g.isReserved());
+                groupPrivilege.setRecordPrivilege(g.getType() == GroupType.RecordPrivilege);
                 // TODO: Restrict to user group only in response depending on settings?
                 groupPrivilege.setUserGroup(userGroups.contains(g.getId()));
 
@@ -908,6 +909,7 @@ public class MetadataSharingApi implements ApplicationEventPublisherAware
                     result.setGroup(x.getGroup());
                     result.setReserved(x.isReserved());
                     result.setRestricted(x.isRestricted());
+                    result.setRecordPrivilege(x.isRecordPrivilege());
                     result.setUserGroup(x.isUserGroup());
                     result.setUserProfile(x.getUserProfiles());
                     result.setOperations(new HashMap<>(x.getOperations()));
@@ -1065,6 +1067,7 @@ public class MetadataSharingApi implements ApplicationEventPublisherAware
             GroupPrivilege groupPrivilege = new GroupPrivilege();
             groupPrivilege.setGroup(g.getId());
             groupPrivilege.setReserved(g.isReserved());
+            groupPrivilege.setRecordPrivilege(g.getType() == GroupType.RecordPrivilege);
             // Restrict changing privileges for groups with a minimum profile for setting privileges set
             groupPrivilege.setRestricted(!canUserChangePrivilegesForGroup(context, g));
             groupPrivilege.setUserGroup(userGroups.contains(g.getId()));

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataSharingApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataSharingApi.java
@@ -99,8 +99,7 @@ import static org.springframework.data.jpa.domain.Specification.where;
 @PreAuthorize("hasAuthority('Editor')")
 @Controller("recordSharing")
 @ReadWriteController
-public class MetadataSharingApi implements ApplicationEventPublisherAware
-{
+public class MetadataSharingApi implements ApplicationEventPublisherAware {
     private static final String DEFAULT_PUBLICATION_TYPE_NAME = "default";
 
     /**
@@ -366,7 +365,6 @@ public class MetadataSharingApi implements ApplicationEventPublisherAware
         boolean skipAllReservedGroup = !accessManager.hasReviewPermission(context, Integer.toString(metadata.getId()));
 
 
-
         List<Operation> operationList = operationRepository.findAll();
         Map<String, Integer> operationMap = new HashMap<>(operationList.size());
         for (Operation o : operationList) {
@@ -412,7 +410,7 @@ public class MetadataSharingApi implements ApplicationEventPublisherAware
         @Parameter(
             description = "Publication type",
             required = false)
-        @RequestParam(required = false)  String publicationType,
+        @RequestParam(required = false) String publicationType,
         @Parameter(hidden = true)
         HttpSession session,
         HttpServletRequest request
@@ -428,7 +426,7 @@ public class MetadataSharingApi implements ApplicationEventPublisherAware
         java.util.Optional<PublicationOption> publicationOption = publicationConfig.getPublicationOptionConfiguration(publicationTypeToUse);
         if (publicationOption.isPresent()) {
             Set<Integer> metadataProcessed = metadataProcessingReport.getMetadata();
-            for(Integer metadataId: metadataProcessed) {
+            for (Integer metadataId : metadataProcessed) {
                 publicationConfig.processMetadata(serviceContext, publicationOption.get(),
                     metadataId, true);
             }
@@ -477,7 +475,7 @@ public class MetadataSharingApi implements ApplicationEventPublisherAware
         java.util.Optional<PublicationOption> publicationOption = publicationConfig.getPublicationOptionConfiguration(publicationTypeToUse);
         if (publicationOption.isPresent()) {
             Set<Integer> metadataProcessed = metadataProcessingReport.getMetadata();
-            for(Integer metadataId: metadataProcessed) {
+            for (Integer metadataId : metadataProcessed) {
                 publicationConfig.processMetadata(serviceContext, publicationOption.get(),
                     metadataId, false);
             }
@@ -581,7 +579,7 @@ public class MetadataSharingApi implements ApplicationEventPublisherAware
             List<Integer> excludeFromDelete = new ArrayList<>();
 
             // Exclude deleting privileges for groups in which the user does not have the minimum profile for privileges
-            for (Group group: groupRepository.findByMinimumProfileForPrivilegesNotNull()) {
+            for (Group group : groupRepository.findByMinimumProfileForPrivilegesNotNull()) {
                 if (!canUserChangePrivilegesForGroup(context, group)) {
                     excludeFromDelete.add(group.getId());
                 }
@@ -605,7 +603,7 @@ public class MetadataSharingApi implements ApplicationEventPublisherAware
                     // Never set editing for reserved group or any privileges for system groups
                     if (
                         groupIsType(groupId, GroupType.SystemPrivilege, locale) ||
-                        (opId == ReservedOperation.editing.getId() && ReservedGroup.isReserved(groupId))
+                            (opId == ReservedOperation.editing.getId() && ReservedGroup.isReserved(groupId))
                     ) {
                         continue;
                     }
@@ -654,7 +652,7 @@ public class MetadataSharingApi implements ApplicationEventPublisherAware
                     privileges.stream().filter(p -> p.getGroup() == ReservedGroup.all.getId()).findFirst();
 
                 // If we cannot find it then default to before value so that it will fail the next condition.
-                boolean publishedAfter = allGroupOpsAfter.isPresent()?allGroupOpsAfter.get().getOperations().getOrDefault(ReservedOperation.view.name(), publishedBefore):publishedBefore;
+                boolean publishedAfter = allGroupOpsAfter.isPresent() ? allGroupOpsAfter.get().getOperations().getOrDefault(ReservedOperation.view.name(), publishedBefore) : publishedBefore;
 
                 if (publishedBefore != publishedAfter) {
                     MetadataPublicationNotificationInfo metadataNotificationInfo = new MetadataPublicationNotificationInfo();
@@ -870,7 +868,7 @@ public class MetadataSharingApi implements ApplicationEventPublisherAware
         List<Integer> allMetadataIds = this.metadataUtils.findAllIdsBy(
             MetadataSpecs.hasMetadataUuid(metadata.getUuid()));
 
-        if(!allMetadataIds.isEmpty()) {
+        if (!allMetadataIds.isEmpty()) {
             for (Integer mdId : allMetadataIds) {
                 AbstractMetadata md = metadataUtils.findOne(mdId);
                 if (md != null) {
@@ -904,18 +902,18 @@ public class MetadataSharingApi implements ApplicationEventPublisherAware
         originalSharingResponse.setGroupOwner(sharingResponse.getGroupOwner());
         originalSharingResponse.setOwner(sharingResponse.getOwner());
         var copyPrivs = sharingResponse.getPrivileges().stream()
-                .map(x-> {
-                    var result = new GroupPrivilege();
-                    result.setGroup(x.getGroup());
-                    result.setReserved(x.isReserved());
-                    result.setRestricted(x.isRestricted());
-                    result.setRecordPrivilege(x.isRecordPrivilege());
-                    result.setUserGroup(x.isUserGroup());
-                    result.setUserProfile(x.getUserProfiles());
-                    result.setOperations(new HashMap<>(x.getOperations()));
-                    return result;
-                })
-                .collect(Collectors.toList());
+            .map(x -> {
+                var result = new GroupPrivilege();
+                result.setGroup(x.getGroup());
+                result.setReserved(x.isReserved());
+                result.setRestricted(x.isRestricted());
+                result.setRecordPrivilege(x.isRecordPrivilege());
+                result.setUserGroup(x.isUserGroup());
+                result.setUserProfile(x.getUserProfiles());
+                result.setOperations(new HashMap<>(x.getOperations()));
+                return result;
+            })
+            .collect(Collectors.toList());
         originalSharingResponse.setPrivileges(copyPrivs);
 
 
@@ -927,15 +925,15 @@ public class MetadataSharingApi implements ApplicationEventPublisherAware
 
 
         //modify the sharingResponse (current permissions from DB) with new privileges (group XFER).
-        for(var groupPriv : sharingResponse.getPrivileges()) {
+        for (var groupPriv : sharingResponse.getPrivileges()) {
             if (Objects.equals(groupPriv.getGroup(), previousGroup)) {
                 //old group: permissions - remove them (set all false)
-                var ops=groupPriv.getOperations();
+                var ops = groupPriv.getOperations();
                 ops.replaceAll((o, v) -> false);
             } else if (Objects.equals(groupPriv.getGroup(), groupIdentifier)) {
                 //new group: permissions - ADD the old groups permissions
-                var ops=groupPriv.getOperations();
-                for(var addOp : oldPriv) {
+                var ops = groupPriv.getOperations();
+                for (var addOp : oldPriv) {
                     var opName = ReservedOperation.lookup(addOp.getOperationId());
                     ops.put(opName.toString(), true);
                 }
@@ -987,7 +985,7 @@ public class MetadataSharingApi implements ApplicationEventPublisherAware
             request,
             metadataListToNotifyPublication,
             notifyByEmail
-            );
+        );
 
         if (notifyByEmail && !metadataListToNotifyPublication.isEmpty()) {
             metadataPublicationMailNotifier.notifyPublication(feedbackLocales,
@@ -995,14 +993,13 @@ public class MetadataSharingApi implements ApplicationEventPublisherAware
         }
 
 
-
         dataManager.indexMetadata(String.valueOf(metadata.getId()), true);
 
         //publish group change
         new RecordGroupOwnerChangeEvent(metadata.getId(),
-                                        ApiUtils.getUserSession(request.getSession()).getUserIdAsInt(),
-                                        ObjectJSONUtils.convertObjectInJsonObject(oldGroup, RecordGroupOwnerChangeEvent.FIELD),
-                                        ObjectJSONUtils.convertObjectInJsonObject(group.get(), RecordGroupOwnerChangeEvent.FIELD)).publish(appContext);
+            ApiUtils.getUserSession(request.getSession()).getUserIdAsInt(),
+            ObjectJSONUtils.convertObjectInJsonObject(oldGroup, RecordGroupOwnerChangeEvent.FIELD),
+            ObjectJSONUtils.convertObjectInJsonObject(group.get(), RecordGroupOwnerChangeEvent.FIELD)).publish(appContext);
 
         //publish permissions change
         new RecordPrivilegesChangeEvent(metadata.getId(),
@@ -1401,7 +1398,7 @@ public class MetadataSharingApi implements ApplicationEventPublisherAware
      * @throws Exception
      */
     private void shareMetadataWithReservedGroup(String metadataUuid, boolean publish, String publicationType,
-                                           HttpSession session, HttpServletRequest request) throws Exception {
+                                                HttpSession session, HttpServletRequest request) throws Exception {
         AbstractMetadata metadata = ApiUtils.canEditRecord(metadataUuid, request);
         ApplicationContext appContext = ApplicationContextHolder.get();
         ServiceContext context = ApiUtils.createServiceContext(request);
@@ -1719,8 +1716,8 @@ public class MetadataSharingApi implements ApplicationEventPublisherAware
      * @return List of privilege changes for the reserved groups.
      */
     private List<PrivilegeStatusChange> reservedGroupsPrivilegesStatusChanges(SharingResponse sharingBefore,
-                                                                             List<GroupOperations> newPrivileges,
-                                                                             boolean merge) {
+                                                                              List<GroupOperations> newPrivileges,
+                                                                              boolean merge) {
 
         List<PrivilegeStatusChange> privilegeStatuses = new ArrayList<>();
         for (GroupPrivilege g : sharingBefore.getPrivileges()) {
@@ -1755,9 +1752,9 @@ public class MetadataSharingApi implements ApplicationEventPublisherAware
      * Checks if the given group is of type Workspace.
      *
      * @param groupId the identifier of the group to check
-     * @param locale the locale to use for error messages
+     * @param locale  the locale to use for error messages
      * @throws ResourceNotFoundException if the group is not found
-     * @throws IllegalArgumentException if the group is not of type Workspace
+     * @throws IllegalArgumentException  if the group is not of type Workspace
      */
     private void checkGroupIsWorkspace(Integer groupId, Locale locale) throws ResourceNotFoundException {
         if (!groupIsType(groupId, GroupType.Workspace, locale)) {
@@ -1769,9 +1766,9 @@ public class MetadataSharingApi implements ApplicationEventPublisherAware
     /**
      * Checks if the given group is of the specified type.
      *
-     * @param groupId the identifier of the group to check
+     * @param groupId   the identifier of the group to check
      * @param groupType the type to check against
-     * @param locale the locale to use for error messages
+     * @param locale    the locale to use for error messages
      * @return true if the group is of the specified type, false otherwise
      * @throws ResourceNotFoundException if the group is not found
      */
@@ -1785,7 +1782,7 @@ public class MetadataSharingApi implements ApplicationEventPublisherAware
     }
 
     /**
-     * Class to track the privileges status changes on the reserved groups operations.
+     * Class to track the privilege status changes on the reserved groups operations.
      */
     private class PrivilegeStatusChange {
         private boolean publishedBefore;

--- a/services/src/main/java/org/fao/geonet/api/records/model/GroupPrivilege.java
+++ b/services/src/main/java/org/fao/geonet/api/records/model/GroupPrivilege.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2026 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -27,7 +27,9 @@ import org.fao.geonet.domain.Profile;
 import java.util.List;
 
 /**
- * Created by francois on 16/06/16.
+ * The GroupPrivilege class represents a set of privileges associated with a group.
+ * It extends the functionality provided by the {@link GroupOperations} class, adding more
+ * specific fields and methods related to group privileges.
  */
 public class GroupPrivilege extends GroupOperations {
     private List<Profile> userProfiles;
@@ -60,9 +62,13 @@ public class GroupPrivilege extends GroupOperations {
         this.reserved = reserved;
     }
 
-    public boolean isRestricted() { return restricted; }
+    public boolean isRestricted() {
+        return restricted;
+    }
 
-    public void setRestricted(boolean restricted) { this.restricted = restricted; }
+    public void setRestricted(boolean restricted) {
+        this.restricted = restricted;
+    }
 
     public boolean isRecordPrivilege() {
         return recordPrivilege;

--- a/services/src/main/java/org/fao/geonet/api/records/model/GroupPrivilege.java
+++ b/services/src/main/java/org/fao/geonet/api/records/model/GroupPrivilege.java
@@ -34,6 +34,7 @@ public class GroupPrivilege extends GroupOperations {
     private boolean userGroup;
     private boolean reserved;
     private boolean restricted;
+    private boolean recordPrivilege;
 
     public List<Profile> getUserProfiles() {
         return userProfiles;
@@ -62,4 +63,12 @@ public class GroupPrivilege extends GroupOperations {
     public boolean isRestricted() { return restricted; }
 
     public void setRestricted(boolean restricted) { this.restricted = restricted; }
+
+    public boolean isRecordPrivilege() {
+        return recordPrivilege;
+    }
+
+    public void setRecordPrivilege(boolean recordPrivilege) {
+        this.recordPrivilege = recordPrivilege;
+    }
 }

--- a/services/src/test/java/org/fao/geonet/api/records/MetadataSharingApiTest.java
+++ b/services/src/test/java/org/fao/geonet/api/records/MetadataSharingApiTest.java
@@ -26,8 +26,11 @@ package org.fao.geonet.api.records;
 import com.google.gson.Gson;
 import jeeves.server.context.ServiceContext;
 import org.fao.geonet.api.records.model.GroupOperations;
+import org.fao.geonet.api.records.model.GroupPrivilege;
 import org.fao.geonet.api.records.model.SharingParameter;
+import org.fao.geonet.api.records.model.SharingResponse;
 import org.fao.geonet.domain.Group;
+import org.fao.geonet.domain.GroupType;
 import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.OperationAllowed;
 import org.fao.geonet.domain.Profile;
@@ -56,6 +59,7 @@ import java.util.Map;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
@@ -285,6 +289,49 @@ public class MetadataSharingApiTest extends AbstractServiceIntegrationTest {
         List<OperationAllowed> metadataOperations = operationAllowedRepository.findAllById_MetadataId(metadataId);
         boolean hasReservedGroupPrivileges = metadataOperations.stream().anyMatch(op -> ReservedGroup.isReserved(op.getId().getGroupId()));
         assertFalse(hasReservedGroupPrivileges);
+    }
+
+    @Test
+    public void sharingResponseIncludesRecordPrivilegeFlag() throws Exception {
+        MockMvc mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
+        MockHttpSession mockHttpSession = loginAs(editorUser);
+
+        Group recordPrivilegeGroup = _groupRepo.save(new Group()
+            .setName("record-privilege-test-group")
+            .setType(GroupType.RecordPrivilege));
+        int recordPrivilegeGroupId = recordPrivilegeGroup.getId();
+
+        Group systemPrivilegeGroup = _groupRepo.save(new Group()
+            .setName("system-privilege-test-group")
+            .setType(GroupType.SystemPrivilege));
+        int systemPrivilegeGroupId = systemPrivilegeGroup.getId();
+
+        String responseBody = mockMvc.perform(get("/srv/api/records/" + metadataUuid + "/sharing")
+                .session(mockHttpSession)
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andReturn()
+            .getResponse()
+            .getContentAsString();
+
+        Gson gson = new Gson();
+        SharingResponse sharingResponse = gson.fromJson(responseBody, SharingResponse.class);
+
+        java.util.Optional<GroupPrivilege> recordPrivGroup = sharingResponse.getPrivileges().stream()
+            .filter(p -> p.getGroup() == recordPrivilegeGroupId)
+            .findFirst();
+        assertTrue("RecordPrivilege group should appear in sharing response", recordPrivGroup.isPresent());
+        assertTrue("RecordPrivilege group should have recordPrivilege=true", recordPrivGroup.get().isRecordPrivilege());
+
+        java.util.Optional<GroupPrivilege> workspaceGroup = sharingResponse.getPrivileges().stream()
+            .filter(p -> p.getGroup() == SAMPLE_GROUP_ID)
+            .findFirst();
+        assertTrue("Workspace group should appear in sharing response", workspaceGroup.isPresent());
+        assertFalse("Workspace group should have recordPrivilege=false", workspaceGroup.get().isRecordPrivilege());
+
+        boolean systemGroupPresent = sharingResponse.getPrivileges().stream()
+            .anyMatch(p -> p.getGroup() == systemPrivilegeGroupId);
+        assertFalse("SystemPrivilege group should be excluded from sharing response", systemGroupPresent);
     }
 
     private SharingParameter createPrivilegesRequest(boolean addPublicationPrivileges) {

--- a/web-ui/src/main/resources/catalog/components/common/share/partials/panel.html
+++ b/web-ui/src/main/resources/catalog/components/common/share/partials/panel.html
@@ -27,11 +27,11 @@
   <div class="col-md-8 text-right text-muted">
     <div class="legend">
       <div class="legend-item">
-        <span class="legend-box bg-info-subtle"></span>
+        <span class="legend-box gn-legend-info"></span>
         <span>{{'reservedGroup' | translate}}</span>
       </div>
       <div class="legend-item">
-        <span class="legend-box bg-warning-subtle"></span>
+        <span class="legend-box gn-legend-warning"></span>
         <span>{{'recordPrivilegeGroup' | translate}}</span>
       </div>
     </div>

--- a/web-ui/src/main/resources/catalog/components/common/share/partials/panel.html
+++ b/web-ui/src/main/resources/catalog/components/common/share/partials/panel.html
@@ -30,7 +30,8 @@
         <span class="gn-legend-box gn-legend-info"></span>
         <span>{{'reservedGroup' | translate}}</span>
       </div>
-      <div class="gn-legend-item">
+      <div class="gn-legend-item"
+           ng-if="(privileges | filter:{recordPrivilege: true}).length > 0">
         <span class="gn-legend-box gn-legend-warning"></span>
         <span>{{'recordPrivilegeGroup' | translate}}</span>
       </div>

--- a/web-ui/src/main/resources/catalog/components/common/share/partials/panel.html
+++ b/web-ui/src/main/resources/catalog/components/common/share/partials/panel.html
@@ -116,7 +116,7 @@
           data-ng-repeat="g in privileges | filter:{reserved: false} | filter:pFilterFn | orderBy:sortGroups:sorter.reverse"
           data-ng-show="(onlyUserGroup == true && g.userGroup == true) ||
                        onlyUserGroup == false"
-          data-ng-class="g.restricted ? 'warning' : ''"
+          data-ng-class="g.recordPrivilege ? 'warning' : ''"
         >
           <td><strong>{{::('group-' + g.group) | translate}}</strong></td>
           <td data-ng-repeat="key in ::operations" class="text-center">

--- a/web-ui/src/main/resources/catalog/components/common/share/partials/panel.html
+++ b/web-ui/src/main/resources/catalog/components/common/share/partials/panel.html
@@ -10,16 +10,32 @@
   privilegesBatchAlert
 </p>
 
-<!--Search inpup-->
-<div class="col-md-4 input-group input-group-sm gn-searchgroup-input">
-  <span class="input-group-addon" translate>filter</span>
-  <input
-    type="text"
-    class="form-control input-sm"
-    ng-model="pFilter"
-    ng-model-options="{debounce: 300}"
-    placeholder="{{'filterGroup' | translate}}"
-  />
+<!--Search and legend-->
+<div class="row">
+  <div class="col-md-4 gn-nopadding-left">
+    <div class="input-group input-group-sm gn-searchgroup-input">
+      <span class="input-group-addon" translate>filter</span>
+      <input
+        type="text"
+        class="form-control input-sm"
+        ng-model="pFilter"
+        ng-model-options="{debounce: 300}"
+        placeholder="{{'filterGroup' | translate}}"
+      />
+    </div>
+  </div>
+  <div class="col-md-8 text-right text-muted">
+    <div class="legend">
+      <div class="legend-item">
+        <span class="legend-box bg-info-subtle"></span>
+        <span>{{'reservedGroup' | translate}}</span>
+      </div>
+      <div class="legend-item">
+        <span class="legend-box bg-warning-subtle"></span>
+        <span>{{'recordPrivilegeGroup' | translate}}</span>
+      </div>
+    </div>
+  </div>
 </div>
 
 <!-- TODO: simplify layout if only one group -->

--- a/web-ui/src/main/resources/catalog/components/common/share/partials/panel.html
+++ b/web-ui/src/main/resources/catalog/components/common/share/partials/panel.html
@@ -30,8 +30,10 @@
         <span class="gn-legend-box gn-legend-info"></span>
         <span>{{'reservedGroup' | translate}}</span>
       </div>
-      <div class="gn-legend-item"
-           ng-if="(privileges | filter:{recordPrivilege: true}).length > 0">
+      <div
+        class="gn-legend-item"
+        data-ng-if="(privileges | filter:{reserved: false} | filter:{recordPrivilege: true}).length > 0"
+      >
         <span class="gn-legend-box gn-legend-warning"></span>
         <span>{{'recordPrivilegeGroup' | translate}}</span>
       </div>

--- a/web-ui/src/main/resources/catalog/components/common/share/partials/panel.html
+++ b/web-ui/src/main/resources/catalog/components/common/share/partials/panel.html
@@ -25,13 +25,13 @@
     </div>
   </div>
   <div class="col-md-8 text-right text-muted">
-    <div class="legend">
-      <div class="legend-item">
-        <span class="legend-box gn-legend-info"></span>
+    <div class="gn-legend">
+      <div class="gn-legend-item">
+        <span class="gn-legend-box gn-legend-info"></span>
         <span>{{'reservedGroup' | translate}}</span>
       </div>
-      <div class="legend-item">
-        <span class="legend-box gn-legend-warning"></span>
+      <div class="gn-legend-item">
+        <span class="gn-legend-box gn-legend-warning"></span>
         <span>{{'recordPrivilegeGroup' | translate}}</span>
       </div>
     </div>

--- a/web-ui/src/main/resources/catalog/locales/en-core.json
+++ b/web-ui/src/main/resources/catalog/locales/en-core.json
@@ -373,6 +373,8 @@
     "createChild": "Create a child",
     "privileges": "Privileges",
     "whoCanAccess": "Who has access",
+    "reservedGroup": "Reserved Group",
+    "recordPrivilegeGroup": "Record Privilege Group",
     "actions" : "Actions",
     "reset" : "Reset",
     "stop": "Stop",

--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -218,19 +218,19 @@ a {
   word-wrap: break-word;
 }
 
-.legend {
+.gn-legend {
   display: inline-flex;
   gap: 15px;
   align-items: center;
 }
 
-.legend-item {
+.gn-legend-item {
   display: inline-flex;
   align-items: center;
   gap: 6px;
 }
 
-.legend-box {
+.gn-legend-box {
   width: 14px;
   height: 14px;
   display: inline-block;

--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -217,6 +217,35 @@ div[gn-transfer-ownership] * .list-group {
 a {
   word-wrap: break-word;
 }
+
+.legend {
+  display: inline-flex;
+  gap: 15px;
+  align-items: center;
+}
+
+.legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.legend-box {
+  width: 14px;
+  height: 14px;
+  display: inline-block;
+  border: 1px solid rgba(0, 0, 0, 0.1);
+  border-radius: 3px;
+}
+
+.bg-info-subtle {
+  background-color: @state-info-bg !important;
+}
+
+.bg-warning-subtle {
+  background-color: @state-warning-bg !important;
+}
+
 .gn-break {
   word-wrap: break-word;
   word-break: break-word;

--- a/web-ui/src/main/resources/catalog/style/gn.less
+++ b/web-ui/src/main/resources/catalog/style/gn.less
@@ -238,11 +238,11 @@ a {
   border-radius: 3px;
 }
 
-.bg-info-subtle {
+.gn-legend-info {
   background-color: @state-info-bg !important;
 }
 
-.bg-warning-subtle {
+.gn-legend-warning {
   background-color: @state-warning-bg !important;
 }
 


### PR DESCRIPTION
#8741 introduced "Record Privilege Groups" which cannot own metadata but privileges for a record can be assigned to them.

Currently it is hard to identify the "Record Privilege Groups" in the privileges panel. System groups are blue and groups that the user cannot set privileges for are yellow and the checkboxes are disabled.

This PR aims to fix this issue by changing "Record Privilege Groups" to the yellow style:
<img width="768" height="536" alt="image" src="https://github.com/user-attachments/assets/e2d6b94d-64d1-4f85-9708-773fed530b35" />

The disabled checkboxes should be enough to show the user they cannot set privileges for a group

Additionally I added a legend for the colors to help the users understand what they mean:
<img width="769" height="536" alt="image" src="https://github.com/user-attachments/assets/4253413c-e716-4576-aeab-9a8cf4ec2299" />


  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [x] *API Changes* are identified in commit messages
- [x] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [x] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

