### PR TITLE
Fix creating a new setting in Java code

### DIFF
--- a/domain/src/main/java/org/fao/geonet/entitylistener/SettingValueSetter.java
+++ b/domain/src/main/java/org/fao/geonet/entitylistener/SettingValueSetter.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2021 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2026 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -29,8 +29,24 @@ import org.jasypt.encryption.pbe.StandardPBEStringEncryptor;
 import org.springframework.beans.factory.annotation.Autowired;
 
 /**
- * Handler for database events to manage encrypt/decrypt of encrypted settings.
+ * JPA entity listener that keeps {@link Setting#getValue()} (transient) and
+ * {@link Setting#getStoredValue()} (persisted column) in sync, handling encryption
+ * transparently.
  *
+ * <p>The {@code value} field is transient and not managed by Hibernate, so this listener
+ * bridges the gap between the in-memory representation and the database column:</p>
+ * <ul>
+ *   <li><b>PrePersist</b>: copies {@code value} → {@code storedValue}, encrypting if needed.
+ *       Skipped when {@code value} is null/empty to preserve any {@code storedValue} set
+ *       directly via {@link Setting#setStoredValue(String)}.</li>
+ *   <li><b>PreUpdate</b>: re-encrypts {@code value} into {@code storedValue} for encrypted
+ *       settings only. Non-encrypted settings are not handled here because
+ *       {@link Setting#setValue(String)} already calls {@link Setting#setStoredValue(String)}
+ *       as a side effect, which is what triggers Hibernate's dirty detection on the
+ *       persistent field.</li>
+ *   <li><b>PostLoad / PostUpdate</b>: populates the transient {@code value} from
+ *       {@code storedValue}, decrypting if needed.</li>
+ * </ul>
  */
 public class SettingValueSetter implements GeonetworkEntityListener<Setting> {
     @Autowired
@@ -44,8 +60,12 @@ public class SettingValueSetter implements GeonetworkEntityListener<Setting> {
     @Override
     public void handleEvent(final PersistentEventType type, final Setting entity) {
         if ((type == PersistentEventType.PrePersist)) {
-            if (entity.isEncrypted() && StringUtils.isNotEmpty(entity.getValue())) {
-                entity.setStoredValue(this.encryptor.encrypt(entity.getValue()));
+            if (entity.isEncrypted()) {
+                if (StringUtils.isNotEmpty(entity.getValue())) {
+                    entity.setStoredValue(this.encryptor.encrypt(entity.getValue()));
+                } else if (StringUtils.isNotEmpty(entity.getStoredValue())) {
+                    entity.setStoredValue(this.encryptor.encrypt(entity.getStoredValue()));
+                }
             } else if (StringUtils.isNotEmpty(entity.getValue())) {
                 entity.setStoredValue(entity.getValue());
             }
@@ -54,7 +74,7 @@ public class SettingValueSetter implements GeonetworkEntityListener<Setting> {
                 entity.setStoredValue(this.encryptor.encrypt(entity.getValue()));
             }
 
-        } else if ((type == PersistentEventType.PostLoad) ||  (type == PersistentEventType.PostUpdate)) {
+        } else if ((type == PersistentEventType.PostPersist) || (type == PersistentEventType.PostLoad) || (type == PersistentEventType.PostUpdate)) {
             if (entity.isEncrypted() && StringUtils.isNotEmpty(entity.getStoredValue())) {
                 try {
                     entity.setValue(this.encryptor.decrypt(entity.getStoredValue()));

--- a/domain/src/main/java/org/fao/geonet/entitylistener/SettingValueSetter.java
+++ b/domain/src/main/java/org/fao/geonet/entitylistener/SettingValueSetter.java
@@ -46,7 +46,7 @@ public class SettingValueSetter implements GeonetworkEntityListener<Setting> {
         if ((type == PersistentEventType.PrePersist)) {
             if (entity.isEncrypted() && StringUtils.isNotEmpty(entity.getValue())) {
                 entity.setStoredValue(this.encryptor.encrypt(entity.getValue()));
-            } else {
+            } else if (StringUtils.isNotEmpty(entity.getValue())) {
                 entity.setStoredValue(entity.getValue());
             }
         } else if (type == PersistentEventType.PreUpdate) {

--- a/domain/src/test/java/org/fao/geonet/repository/SettingRepositoryTest.java
+++ b/domain/src/test/java/org/fao/geonet/repository/SettingRepositoryTest.java
@@ -1,3 +1,26 @@
+/*
+ * Copyright (C) 2001-2026 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
 package org.fao.geonet.repository;
 
 import org.fao.geonet.domain.Setting;
@@ -11,6 +34,9 @@ import java.util.Optional;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
+/**
+ * Test {@link org.fao.geonet.repository.SettingRepository}
+ */
 public class SettingRepositoryTest extends AbstractSpringDataTest {
     @Autowired
     private EntityManager em;
@@ -20,20 +46,29 @@ public class SettingRepositoryTest extends AbstractSpringDataTest {
 
     @Test
     public void testCreateASetting() {
-        Setting setting = newSetting("test", SettingDataType.STRING, "testValue", 1, false);
+        Setting setting = newSetting("test", SettingDataType.STRING, "testValue", 1, false, false);
         save(setting);
 
         Optional<Setting> savedSetting = repo.findById("test");
 
         assertTrue(savedSetting.isPresent());
-        assertEquals(setting.getName(), savedSetting.get().getName());
-        assertEquals(setting.getValue(), savedSetting.get().getValue());
-        assertEquals(setting.getDataType(), savedSetting.get().getDataType());
+        checkSettingValues(setting, savedSetting.get());
+    }
+
+    @Test
+    public void testCreateASettingEncrypted() {
+        Setting setting = newSetting("test", SettingDataType.STRING, "testValue", 1, false, true);
+        save(setting);
+
+        Optional<Setting> savedSetting = repo.findById("test");
+        assertTrue(savedSetting.isPresent());
+
+        checkSettingValues(setting, savedSetting.get());
     }
 
     @Test
     public void testUpdateASetting() {
-        Setting setting = newSetting("test", SettingDataType.STRING, "testValue", 1, false);
+        Setting setting = newSetting("test", SettingDataType.STRING, "testValue", 1, false, false);
         save(setting);
 
         Optional<Setting> savedSettingOpt = repo.findById("test");
@@ -43,19 +78,15 @@ public class SettingRepositoryTest extends AbstractSpringDataTest {
         savedSetting.setValue("newValue");
         save(savedSetting);
 
-        savedSettingOpt = repo.findById("test");
-        assertTrue(savedSettingOpt.isPresent());
+        Optional<Setting> savedSettingUpdated = repo.findById("test");
+        assertTrue(savedSettingUpdated.isPresent());
 
-        Setting savedSettingUpdated = savedSettingOpt.get();
-
-        assertEquals(savedSetting.getName(), savedSettingUpdated.getName());
-        assertEquals(savedSetting.getValue(), savedSettingUpdated.getValue());
-        assertEquals(savedSetting.getDataType(), savedSettingUpdated.getDataType());
+        checkSettingValues(savedSetting, savedSettingUpdated.get());
     }
 
     @Test
     public void testUpdateASettingToEmptyValue() {
-        Setting setting = newSetting("test", SettingDataType.STRING, "testValue", 1, false);
+        Setting setting = newSetting("test", SettingDataType.STRING, "testValue", 1, false, false);
         save(setting);
 
         Optional<Setting> savedSettingOpt = repo.findById("test");
@@ -65,23 +96,77 @@ public class SettingRepositoryTest extends AbstractSpringDataTest {
         savedSetting.setValue("");
         save(savedSetting);
 
-        savedSettingOpt = repo.findById("test");
+        Optional<Setting> savedSettingUpdated = repo.findById("test");
+        assertTrue(savedSettingUpdated.isPresent());
+
+        checkSettingValues(savedSetting, savedSettingUpdated.get());
+    }
+
+    @Test
+    public void testUpdateASettingEncryptedValue() {
+        Setting setting = newSetting("test", SettingDataType.STRING, "testValue", 1, false, true);
+        save(setting);
+
+        Optional<Setting> savedSettingOpt = repo.findById("test");
         assertTrue(savedSettingOpt.isPresent());
 
-        Setting savedSettingUpdated = savedSettingOpt.get();
+        Setting savedSetting = savedSettingOpt.get();
+        savedSetting.setValue("newValue");
+        save(savedSetting);
 
-        assertEquals(savedSetting.getName(), savedSettingUpdated.getName());
-        assertEquals(savedSetting.getValue(), savedSettingUpdated.getValue());
-        assertEquals(savedSetting.getDataType(), savedSettingUpdated.getDataType());
+        Optional<Setting> savedSettingUpdated = repo.findById("test");
+        assertTrue(savedSettingUpdated.isPresent());
+
+        checkSettingValues(savedSetting, savedSettingUpdated.get());
     }
-    
-    private Setting newSetting(String key, SettingDataType type, String value, int position, boolean internal) {
+
+    @Test
+    public void testUpdateASettingEncryptedEmptyValue() {
+        Setting setting = newSetting("test", SettingDataType.STRING, "testValue", 1, false, true);
+        save(setting);
+
+        Optional<Setting> savedSettingOpt = repo.findById("test");
+        assertTrue(savedSettingOpt.isPresent());
+
+        Setting savedSetting = savedSettingOpt.get();
+        savedSetting.setValue("");
+        save(savedSetting);
+
+        Optional<Setting> savedSettingUpdated = repo.findById("test");
+        assertTrue(savedSettingUpdated.isPresent());
+
+        checkSettingValues(savedSetting, savedSettingUpdated.get());
+    }
+
+    @Test
+    public void testCreateASettingUsingStoredValueDirectly() {
+        Setting setting = new Setting();
+        setting.setDataType(SettingDataType.STRING);
+        setting.setName("test");
+        setting.setPosition(1);
+        setting.setInternal(false);
+        // Set storedValue directly without going through setValue(), leaving the transient
+        // value field null. Before the fix, PrePersist would overwrite storedValue with
+        // null because it entered the else branch unconditionally.
+        setting.setStoredValue("directValue");
+        save(setting);
+
+        Optional<Setting> savedSetting = repo.findById("test");
+
+        assertTrue(savedSetting.isPresent());
+        assertEquals("directValue", savedSetting.get().getValue());
+    }
+
+
+    private Setting newSetting(String key, SettingDataType type, String value,
+                               int position, boolean internal, boolean encrypted) {
         Setting setting = new Setting();
         setting.setDataType(type);
         setting.setName(key);
         setting.setPosition(position);
         setting.setValue(value);
         setting.setInternal(internal);
+        setting.setEncrypted(encrypted);
 
         return setting;
     }
@@ -92,6 +177,14 @@ public class SettingRepositoryTest extends AbstractSpringDataTest {
         em.flush();
         // Empties 1st level cache, so find method retrieves the data from the database and listener PostLoad event is triggered
         em.clear();
+    }
+
+    private void checkSettingValues(Setting expected, Setting actual) {
+        assertEquals(expected.getName(), actual.getName());
+        assertEquals(expected.getValue(), actual.getValue());
+        assertEquals(expected.getDataType(), actual.getDataType());
+        assertEquals(expected.isInternal(), actual.isInternal());
+        assertEquals(expected.isEncrypted(), actual.isEncrypted());
     }
 
 }

--- a/domain/src/test/java/org/fao/geonet/repository/SettingRepositoryTest.java
+++ b/domain/src/test/java/org/fao/geonet/repository/SettingRepositoryTest.java
@@ -1,0 +1,97 @@
+package org.fao.geonet.repository;
+
+import org.fao.geonet.domain.Setting;
+import org.fao.geonet.domain.SettingDataType;
+import org.junit.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import javax.persistence.EntityManager;
+import java.util.Optional;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class SettingRepositoryTest extends AbstractSpringDataTest {
+    @Autowired
+    private EntityManager em;
+
+    @Autowired
+    private SettingRepository repo;
+
+    @Test
+    public void testCreateASetting() {
+        Setting setting = newSetting("test", SettingDataType.STRING, "testValue", 1, false);
+        save(setting);
+
+        Optional<Setting> savedSetting = repo.findById("test");
+
+        assertTrue(savedSetting.isPresent());
+        assertEquals(setting.getName(), savedSetting.get().getName());
+        assertEquals(setting.getValue(), savedSetting.get().getValue());
+        assertEquals(setting.getDataType(), savedSetting.get().getDataType());
+    }
+
+    @Test
+    public void testUpdateASetting() {
+        Setting setting = newSetting("test", SettingDataType.STRING, "testValue", 1, false);
+        save(setting);
+
+        Optional<Setting> savedSettingOpt = repo.findById("test");
+        assertTrue(savedSettingOpt.isPresent());
+
+        Setting savedSetting = savedSettingOpt.get();
+        savedSetting.setValue("newValue");
+        save(savedSetting);
+
+        savedSettingOpt = repo.findById("test");
+        assertTrue(savedSettingOpt.isPresent());
+
+        Setting savedSettingUpdated = savedSettingOpt.get();
+
+        assertEquals(savedSetting.getName(), savedSettingUpdated.getName());
+        assertEquals(savedSetting.getValue(), savedSettingUpdated.getValue());
+        assertEquals(savedSetting.getDataType(), savedSettingUpdated.getDataType());
+    }
+
+    @Test
+    public void testUpdateASettingToEmptyValue() {
+        Setting setting = newSetting("test", SettingDataType.STRING, "testValue", 1, false);
+        save(setting);
+
+        Optional<Setting> savedSettingOpt = repo.findById("test");
+        assertTrue(savedSettingOpt.isPresent());
+
+        Setting savedSetting = savedSettingOpt.get();
+        savedSetting.setValue("");
+        save(savedSetting);
+
+        savedSettingOpt = repo.findById("test");
+        assertTrue(savedSettingOpt.isPresent());
+
+        Setting savedSettingUpdated = savedSettingOpt.get();
+
+        assertEquals(savedSetting.getName(), savedSettingUpdated.getName());
+        assertEquals(savedSetting.getValue(), savedSettingUpdated.getValue());
+        assertEquals(savedSetting.getDataType(), savedSettingUpdated.getDataType());
+    }
+    
+    private Setting newSetting(String key, SettingDataType type, String value, int position, boolean internal) {
+        Setting setting = new Setting();
+        setting.setDataType(type);
+        setting.setName(key);
+        setting.setPosition(position);
+        setting.setValue(value);
+        setting.setInternal(internal);
+
+        return setting;
+    }
+
+    private void save(Setting setting) {
+        repo.save(setting);
+        // Ensures that the data is persisted in the database
+        em.flush();
+        // Empties 1st level cache, so find method retrieves the data from the database and listener PostLoad event is triggered
+        em.clear();
+    }
+
+}


### PR DESCRIPTION
This is not a typical scenario, as in Geonetwork, new settins are not created in the Java code, but are simply read from the database and updated.

Some metadata schemas or custom modules add new settings when the application is started up, like:

https://github.com/metadata101/iso19139.ca.HNAP/blob/4.4.x/src/main/java/ca/gc/schemas/iso19139hnap/init/SchemaInitializerSettings.java

Without this change the settings were added, but the values were stored as `null`. With the fix, the correct values are stored in the database when creating new settings in the Java code.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [X] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

