### PR TITLE
Fix OSM background map image not displayed in metadata full view

### DIFF
--- a/web/src/main/webResources/WEB-INF/config.properties
+++ b/web/src/main/webResources/WEB-INF/config.properties
@@ -58,7 +58,7 @@ urlChecker.UserAgent=GeoNetwork Link Checker
 
 thesaurus.cache.maxsize=400000
 
-map.bbox.background.service=https://ows.terrestris.de/osm/service?SERVICE=WMS&amp;REQUEST=GetMap&amp;VERSION=1.1.0&amp;LAYERS=OSM-WMS&amp;STYLES=default&amp;SRS={srs}&amp;BBOX={minx},{miny},{maxx},{maxy}&amp;WIDTH={width}&amp;HEIGHT={height}&amp;FORMAT=image/png
+map.bbox.background.service=https://ows.terrestris.de/osm/service?SERVICE=WMS&REQUEST=GetMap&VERSION=1.1.0&LAYERS=OSM-WMS&STYLES=default&SRS={srs}&BBOX={minx},{miny},{maxx},{maxy}&WIDTH={width}&HEIGHT={height}&FORMAT=image/png
 
 # Set to false to enable the services to draw map extents (region.getmap and {metadatauuid}/extents.png) accepting
 # urls for map services to provide the background layers. Otherwise the only allowed options are from the settings


### PR DESCRIPTION
The background map in the metadata full view displays an empty background map image:

<img width="951" height="771" alt="Empty background map" src="https://github.com/user-attachments/assets/33314e3e-15b0-41c7-a579-448474ec0822" />

It's due to the encoded `&` char in the URL defined in the `config.properties` file. This used to work fine, it is quite an old change, see https://github.com/geonetwork/core-geonetwork/commit/7b718414f60461656783cb805492479e0f1c6fff

But it is causing issues in recent versions. It is unclear what has caused this. This fix remove the encoding of the `&` char in the URL and solves the problem:

<img width="738" height="693" alt="Screenshot 2026-04-22 at 09 01 49" src="https://github.com/user-attachments/assets/8a596dd3-7394-4198-b165-9154d1dc8a65" />

It happens also in 4.2.x version, maybe related to some `ImageIO` update due to Geotools upgrades.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation



