### PR TITLE
Standard / ISO19115-3 / Metadata linkage readonly for multilingual records

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/layout-custom-fields.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/layout-custom-fields.xsl
@@ -21,7 +21,7 @@
   <!-- Readonly elements -->
   <xsl:template mode="mode-iso19115-3.2018"
                 match="mdb:metadataIdentifier/mcc:MD_Identifier/mcc:code|
-                             mdb:metadataLinkage/*[cit:function/*/@codeListValue = 'completeMetadata']/cit:linkage[not(lan:PT_FreeText)]|
+                             mdb:metadataLinkage/*[cit:function/*/@codeListValue = 'completeMetadata']/cit:linkage|
                              mdb:dateInfo/cit:CI_Date[cit:dateType/cit:CI_DateTypeCode = 'revision']/cit:date|
                              mdb:dateInfo/cit:CI_Date[cit:dateType/cit:CI_DateTypeCode = 'revision']/cit:dateType"
                 priority="2000">

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/update-fixed-info.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/update-fixed-info.xsl
@@ -209,9 +209,16 @@
 
             <xsl:copy>
               <cit:CI_OnlineResource>
-                <cit:linkage>
-                  <gco:CharacterString><xsl:value-of select="if ($isPermalink) then $permalink else */cit:linkage/gco:CharacterString"/></gco:CharacterString>
-                </cit:linkage>
+                <xsl:choose>
+                  <xsl:when test="$isPermalink">
+                    <cit:linkage>
+                      <gco:CharacterString><xsl:value-of select="$permalink"/></gco:CharacterString>
+                    </cit:linkage>
+                  </xsl:when>
+                  <xsl:otherwise>
+                    <xsl:apply-templates select="*/cit:linkage"/>
+                  </xsl:otherwise>
+                </xsl:choose>
                 <xsl:apply-templates select="*/* except */cit:linkage"/>
               </cit:CI_OnlineResource>
             </xsl:copy>


### PR DESCRIPTION
Follow up of https://github.com/geonetwork/core-geonetwork/pull/9167.

https://github.com/geonetwork/core-geonetwork/commit/6c3535f3250eb8ac1668cbad9202c151e496d6a2 reported an issue for multilingual record.

Make the metadata linkage readonly (completeMetadata) also if record is multilingual.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

