### PR TITLE
Sort geographic extent autocomplete suggestions alphabetically

### DIFF
--- a/web-ui/src/main/resources/catalog/components/utility/UtilityService.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityService.js
@@ -552,6 +552,9 @@
                 });
                 country.name = country.label[lang] || country.label[defaultLang];
               });
+              data.sort(function (a, b) {
+                return (a.name || "").localeCompare(b.name || "");
+              });
               defer.resolve(data);
             });
 


### PR DESCRIPTION
## Summary

- Sort region entries alphabetically by display name in `gnRegionService.loadRegion()` using `localeCompare()`
- Fixes the metadata editor region picker and the search form multi-select, both of which consume this service method
- Sorting is locale-aware so accented characters (e.g. "Île-de-France") sort correctly across all UI languages

## Before

<img width="1136" height="631" alt="image" src="https://github.com/user-attachments/assets/466f7b19-bb4a-4808-8ad7-08d623218ba5" />

## After

<img width="1025" height="529" alt="image" src="https://github.com/user-attachments/assets/12919d2d-4932-449d-b6c2-56152bedb4af" />


## Test plan

- [ ] Open a metadata record in the editor, navigate to the geographic extent section and select a region group with many entries (e.g. "Nederland")
- [ ] Confirm the autocomplete dropdown lists entries in A–Z order
- [ ] Type a partial name and confirm filtering still works correctly
- [ ] Select a region and confirm the bounding box updates as before