### PR TITLE
Add helper text for static page link

### DIFF
--- a/web-ui/src/main/resources/catalog/locales/en-v4.json
+++ b/web-ui/src/main/resources/catalog/locales/en-v4.json
@@ -429,6 +429,7 @@
   "staticPageStatus-GROUPS": "Visible to users belonging to the groups",
   "staticPageStatus-PUBLIC": "Visible to everyone",
   "pageLink": "Link",
+  "pageLink-help": "URL can contain the following variables between '{' and '}': <ul><li><strong>uuid</strong> for the current metadata uuid</li><li><strong>id</strong> for the current metadata id</li></ul>",
   "pageSection-help": "Currently, the default UI view only supports TOP and FOOTER values. Custom UI views can make use of additional values.",
   "application/vnd.geo+json": "GeoJSON",
   "application/json": "JSON",

--- a/web-ui/src/main/resources/catalog/templates/admin/settings/static-pages.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/settings/static-pages.html
@@ -190,6 +190,10 @@
                 data-ng-model="staticPageSelected.link"
               />
             </div>
+
+            <div class="col-sm-9 col-sm-offset-3">
+              <p class="help-block ng-scope" data-translate="">pageLink-help</p>
+            </div>
           </div>
 
           <!-- Upload panel -->


### PR DESCRIPTION
Currently there is no helper text for the static page link. This means users adding a static page link do not know about the available `{uuid}` and `{id}` replacements.

This PR aims to fix this issue my implementing the missing helper text:

<img width="584" height="124" alt="image" src="https://github.com/user-attachments/assets/82ca26f3-f4bc-479e-8ead-69ce55a0f25c" />
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

