### PR TITLE
Add new static page status so that administrators respect the group restriction

### DIFF
--- a/docs/manual/docs/customizing-application/adding-static-pages.md
+++ b/docs/manual/docs/customizing-application/adding-static-pages.md
@@ -34,7 +34,11 @@ To add new static pages go to **Admin Console** -->  **Settings** -->  **Static 
     - **Visible only to the administrator**
     - **Visible to logged users**
     - **Visible to users belonging to groups**
+    - **Visible to users belonging to groups and to administrators**
     - **Visible to every one**
+
+  When using one of the group-based visibility options, select one or more values in the **Groups** field.
+  Administrators can still see all configured static pages in the administration screen so they can manage pages even when a page is not publicly visible.
 
   ![](img/add-static-page.png)
 

--- a/domain/src/main/java/org/fao/geonet/domain/page/Page.java
+++ b/domain/src/main/java/org/fao/geonet/domain/page/Page.java
@@ -86,7 +86,7 @@ public class Page extends GeonetEntity implements Serializable {
     }
 
     public enum PageStatus {
-        PUBLIC, PUBLIC_ONLY, GROUPS, PRIVATE, HIDDEN;
+        PUBLIC, PUBLIC_ONLY, GROUPS, GROUPS_AND_ADMIN, PRIVATE, HIDDEN;
     }
 
     public enum PageFormat {

--- a/services/src/main/java/org/fao/geonet/api/groups/GroupsApi.java
+++ b/services/src/main/java/org/fao/geonet/api/groups/GroupsApi.java
@@ -83,6 +83,7 @@ import java.nio.file.attribute.FileTime;
 import java.sql.SQLException;
 import java.util.*;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 import static org.springframework.data.jpa.domain.Specification.where;
 
@@ -619,10 +620,11 @@ public class GroupsApi {
                 ));
             }
 
-            List<Page> staticPages = pageRepository.findPageByStatus(Page.PageStatus.GROUPS);
             List<Page> staticPagesAssignedToGroup =
-                staticPages.stream().filter(p ->
-                    !p.getGroups().stream().filter(g -> g.getId() == groupIdentifier).collect(Collectors.toList()).isEmpty())
+                Stream.of(Page.PageStatus.GROUPS, Page.PageStatus.GROUPS_AND_ADMIN)
+                    .flatMap(status -> pageRepository.findPageByStatus(status).stream())
+                    .filter(p -> p.getGroups().stream()
+                        .anyMatch(g -> Objects.equals(g.getId(), groupIdentifier)))
                     .collect(Collectors.toList());
 
             if (!staticPagesAssignedToGroup.isEmpty()) {

--- a/services/src/main/java/org/fao/geonet/api/pages/PagesAPI.java
+++ b/services/src/main/java/org/fao/geonet/api/pages/PagesAPI.java
@@ -59,7 +59,6 @@ import org.springframework.web.multipart.MultipartFile;
 
 import javax.servlet.http.HttpServletResponse;
 import javax.servlet.http.HttpSession;
-import javax.validation.constraints.Email;
 import javax.validation.constraints.NotNull;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;

--- a/services/src/main/java/org/fao/geonet/api/pages/PagesAPI.java
+++ b/services/src/main/java/org/fao/geonet/api/pages/PagesAPI.java
@@ -204,7 +204,7 @@ public class PagesAPI {
             if (status != null) {
                 newPage.setStatus(status);
 
-                if (status == Page.PageStatus.GROUPS && CollectionUtils.isNotEmpty(groups)) {
+                if ((status == Page.PageStatus.GROUPS || status == Page.PageStatus.GROUPS_AND_ADMIN) && CollectionUtils.isNotEmpty(groups)) {
                     Set<Group> pageGroups = new LinkedHashSet<>();
                     for (String groupName : groups) {
                         Group group = groupRepository.findByName(groupName);
@@ -308,7 +308,7 @@ public class PagesAPI {
             pageToUpdate.setIcon(newIcon);
 
             pageToUpdate.getGroups().clear();
-            if (pageToUpdate.getStatus() == Page.PageStatus.GROUPS) {
+            if (pageToUpdate.getStatus() == Page.PageStatus.GROUPS || pageToUpdate.getStatus() == Page.PageStatus.GROUPS_AND_ADMIN) {
                 pageToUpdate.getGroups().addAll(_groups);
             }
 
@@ -409,9 +409,7 @@ public class PagesAPI {
         }
 
         final UserSession us = ApiUtils.getUserSession(session);
-        if (page.get().getStatus().equals(Page.PageStatus.HIDDEN) && us.getProfile() != Profile.Administrator) {
-            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
-        } else if ((page.get().getStatus().equals(Page.PageStatus.PRIVATE) || page.get().getStatus().equals(Page.PageStatus.GROUPS)) && (us.getProfile() == null || us.getProfile() == Profile.Guest)) {
+        if (!canAccessPage(us, page.get())) {
             return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
         } else {
             String content;
@@ -442,9 +440,15 @@ public class PagesAPI {
         @RequestParam(value = "language", required = false) final String language,
         @RequestParam(value = "section", required = false) final Page.PageSection section,
         @RequestParam(value = "format", required = false) final Page.PageFormat format,
+        @Parameter(description = "Whether to include all pages regardless of the permissions (only for administrators)")
+        @RequestParam(value = "includeAll", required = false, defaultValue = "false") final boolean includeAll,
         @Parameter(hidden = true) final HttpSession session) {
 
         final UserSession us = ApiUtils.getUserSession(session);
+
+        if (includeAll && us.getProfile() != Profile.Administrator) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
 
         List<Page> unfilteredResult;
 
@@ -457,11 +461,7 @@ public class PagesAPI {
         final List<org.fao.geonet.api.pages.PageProperties> filteredResult = new ArrayList<>();
 
         for (final Page page : unfilteredResult) {
-            if (page.getStatus().equals(Page.PageStatus.HIDDEN) && us.getProfile() == Profile.Administrator
-                || page.getStatus().equals(Page.PageStatus.PRIVATE) && us.getProfile() != null && us.getProfile() != Profile.Guest
-                || page.getStatus().equals(Page.PageStatus.GROUPS) && us.getProfile() != null && us.getProfile() != Profile.Guest && checkGroupPermission(us, page)
-                || page.getStatus().equals(Page.PageStatus.PUBLIC)
-                || page.getStatus().equals(Page.PageStatus.PUBLIC_ONLY) && !us.isAuthenticated()) {
+            if (includeAll || canAccessPage(us, page)) {
                 if (section == null) {
                     filteredResult.add(new PageProperties(page));
                 } else {
@@ -566,13 +566,43 @@ public class PagesAPI {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         } else {
             final UserSession us = ApiUtils.getUserSession(session);
-            if (page.getStatus().equals(Page.PageStatus.HIDDEN) && us.getProfile() != Profile.Administrator) {
-                return new ResponseEntity<>(HttpStatus.FORBIDDEN);
-            } else if ((page.getStatus().equals(Page.PageStatus.PRIVATE) || page.getStatus().equals(Page.PageStatus.GROUPS)) && (us.getProfile() == null || us.getProfile() == Profile.Guest)) {
+            if (!canAccessPage(us, page)) {
                 return new ResponseEntity<>(HttpStatus.FORBIDDEN);
             } else {
                 return new ResponseEntity<>(new PageProperties(page), HttpStatus.OK);
             }
+        }
+    }
+
+    /**
+     * Check if the user has permissions to access the page based on the page status and user profile.
+     *
+     * @param us   Current User Session
+     * @param page static page object
+     * @return permission granted
+     */
+    private boolean canAccessPage(UserSession us, Page page) {
+        Profile profile = us.getProfile();
+
+        boolean isAdmin = profile == Profile.Administrator;
+        boolean isLoggedIn = profile != null && profile != Profile.Guest;
+        boolean hasGroupAccess = isLoggedIn && checkGroupPermission(us, page);
+
+        switch (page.getStatus()) {
+            case HIDDEN:
+                return isAdmin;
+            case PRIVATE:
+                return isLoggedIn;
+            case GROUPS:
+                return hasGroupAccess;
+            case GROUPS_AND_ADMIN:
+                return isAdmin || hasGroupAccess;
+            case PUBLIC:
+                return true;
+            case PUBLIC_ONLY:
+                return !us.isAuthenticated();
+            default:
+                return false;
         }
     }
 
@@ -644,18 +674,17 @@ public class PagesAPI {
 
 
     /**
-     * Check is the user is in designated group to access the static page when page permission level is set to GROUP
+     * Check if the user belongs to one of the groups assigned to the static page.
+     *
      * @param us Current User Session
      * @param page static page object
-     * @return permission granted
+     * @return permission granted by group membership
      */
     private boolean checkGroupPermission (UserSession us, Page page) {
         boolean isGranted = false;
         String currentUserId = us.getUserId();
 
-        if (us.getProfile() == Profile.Administrator) {
-            isGranted = true;
-        } else if (page.getStatus().equals(Page.PageStatus.GROUPS) && StringUtils.isNotEmpty(currentUserId)) {
+        if (StringUtils.isNotEmpty(currentUserId)) {
             List<UserGroup> userGroups = userGroupRepository.findAll(UserGroupSpecs.hasUserId(Integer.parseInt(currentUserId)));
 
             Set<Group> accessingGroups = page.getGroups();

--- a/services/src/test/java/org/fao/geonet/api/groups/GroupsApiTest.java
+++ b/services/src/test/java/org/fao/geonet/api/groups/GroupsApiTest.java
@@ -30,7 +30,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.UUID;
 import org.apache.commons.lang3.StringUtils;

--- a/services/src/test/java/org/fao/geonet/api/groups/GroupsApiTest.java
+++ b/services/src/test/java/org/fao/geonet/api/groups/GroupsApiTest.java
@@ -25,8 +25,14 @@ package org.fao.geonet.api.groups;
 import com.google.common.collect.Lists;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.UUID;
 import org.apache.commons.lang3.StringUtils;
 import org.fao.geonet.api.FieldNameExclusionStrategy;
 import org.fao.geonet.api.JsonFieldNamingStrategy;
@@ -34,6 +40,9 @@ import org.fao.geonet.domain.Group;
 import org.fao.geonet.domain.Profile;
 import org.fao.geonet.domain.User;
 import org.fao.geonet.domain.UserGroup;
+import org.fao.geonet.domain.page.Page;
+import org.fao.geonet.domain.page.PageIdentity;
+import org.fao.geonet.repository.page.PageRepository;
 import org.fao.geonet.services.AbstractServiceIntegrationTest;
 import org.junit.Assert;
 import org.junit.Before;
@@ -68,6 +77,9 @@ public class GroupsApiTest extends AbstractServiceIntegrationTest {
     private MockMvc mockMvc;
 
     private MockHttpSession mockHttpSession;
+
+    @Autowired
+    private PageRepository pageRepository;
 
     @Before
     public void setUp() {
@@ -196,6 +208,22 @@ public class GroupsApiTest extends AbstractServiceIntegrationTest {
                 .accept(MediaType.parseMediaType("application/json")))
             .andExpect(status().is(404))
             .andExpect(content().contentType(API_JSON_EXPECTED_ENCODING));
+    }
+
+    @Test
+    public void deleteGroupAssignedToGroupsStaticPageIsRejected() throws Exception {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
+        this.mockHttpSession = loginAsAdmin();
+
+        assertDeleteGroupAssignedToStaticPageIsRejected(Page.PageStatus.GROUPS);
+    }
+
+    @Test
+    public void deleteGroupAssignedToGroupsAndAdminStaticPageIsRejected() throws Exception {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
+        this.mockHttpSession = loginAsAdmin();
+
+        assertDeleteGroupAssignedToStaticPageIsRejected(Page.PageStatus.GROUPS_AND_ADMIN);
     }
 
     @Test
@@ -448,6 +476,34 @@ public class GroupsApiTest extends AbstractServiceIntegrationTest {
     /**
      * Create sample data for the tests.
      */
+    private void assertDeleteGroupAssignedToStaticPageIsRejected(Page.PageStatus statusToTest) throws Exception {
+        String pageId = "delete-group-" + statusToTest.name().toLowerCase() + "-" + UUID.randomUUID().toString().substring(0, 8);
+
+        Group groupToDelete = new Group();
+        groupToDelete.setName("page-group-" + UUID.randomUUID().toString().replace("-", "").substring(0, 12));
+        groupToDelete = _groupRepo.saveAndFlush(groupToDelete);
+
+        Page page = new Page(
+            new PageIdentity("eng", pageId),
+            "<p>Protected content</p>".getBytes(StandardCharsets.UTF_8),
+            "../api/pages/eng/" + pageId + "/content",
+            Page.PageFormat.HTML,
+            new ArrayList<>(),
+            statusToTest,
+            "Delete group " + statusToTest.name().toLowerCase(),
+            null,
+            new LinkedHashSet<>(Collections.singleton(groupToDelete)));
+        pageRepository.saveAndFlush(page);
+
+        this.mockMvc.perform(delete("/srv/api/groups/" + groupToDelete.getId())
+                .session(this.mockHttpSession)
+                .accept(MediaType.parseMediaType("application/json")))
+            .andExpect(status().is(403))
+            .andExpect(jsonPath("$.message", is(String.format(
+                "Group %s is associated with '%s' static page(s). Please remove the static page(s) associated with that group first.",
+                groupToDelete.getName(), page.getLabel()))));
+    }
+
     private void createTestData() {
         Group sampleGroup = _groupRepo.findByName("sample");
 

--- a/services/src/test/java/org/fao/geonet/api/pages/PagesApiTest.java
+++ b/services/src/test/java/org/fao/geonet/api/pages/PagesApiTest.java
@@ -52,6 +52,7 @@ import java.util.Optional;
 import java.util.UUID;
 
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.not;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
@@ -153,12 +154,51 @@ public class PagesApiTest extends AbstractServiceIntegrationTest {
     }
 
     @Test
-    public void groupsAndAdminPagesAreVisibleToAdminsAndAssignedGroupMembers() throws Exception {
+    public void groupsAndAdminPagesAreListedForAdminsAndAssignedGroupMembers() throws Exception {
+        final String language = "eng";
+        final String pageId = "groups-and-admin-list-" + UUID.randomUUID().toString().substring(0, 8);
+        final Group sampleGroup = _groupRepo.findByName("sample");
+        Assert.assertNotNull(sampleGroup);
+
+        final User nonGroupMember = createAuthenticatedUser("page-non-group-member-" + UUID.randomUUID());
+        final User groupMember = createUserInGroup("page-group-member-" + UUID.randomUUID(), sampleGroup);
+        pageRepository.saveAndFlush(createPage(language, pageId, Page.PageStatus.GROUPS_AND_ADMIN, sampleGroup));
+
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
+
+        this.mockMvc.perform(get("/srv/api/pages")
+                .session(loginAsAnonymous())
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().string(not(containsString("\"pageId\":\"" + pageId + "\""))));
+
+        this.mockMvc.perform(get("/srv/api/pages")
+                .session(loginAs(nonGroupMember))
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().string(not(containsString("\"pageId\":\"" + pageId + "\""))));
+
+        this.mockMvc.perform(get("/srv/api/pages")
+                .session(loginAs(groupMember))
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().string(containsString("\"pageId\":\"" + pageId + "\"")));
+
+        this.mockMvc.perform(get("/srv/api/pages")
+                .session(loginAsAdmin())
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().string(containsString("\"pageId\":\"" + pageId + "\"")));
+    }
+
+    @Test
+    public void groupsAndAdminPageDetailsAreVisibleToAdminsAndAssignedGroupMembers() throws Exception {
         final String language = "eng";
         final String pageId = "groups-and-admin-access-" + UUID.randomUUID().toString().substring(0, 8);
         final Group sampleGroup = _groupRepo.findByName("sample");
         Assert.assertNotNull(sampleGroup);
 
+        final User nonGroupMember = createAuthenticatedUser("page-non-group-member-" + UUID.randomUUID());
         final User groupMember = createUserInGroup("page-group-member-" + UUID.randomUUID(), sampleGroup);
         pageRepository.saveAndFlush(createPage(language, pageId, Page.PageStatus.GROUPS_AND_ADMIN, sampleGroup));
 
@@ -170,16 +210,9 @@ public class PagesApiTest extends AbstractServiceIntegrationTest {
             .andExpect(status().isForbidden());
 
         this.mockMvc.perform(get("/srv/api/pages/" + language + "/" + pageId)
-                .session(loginAs(groupMember))
+                .session(loginAs(nonGroupMember))
                 .accept(MediaType.APPLICATION_JSON))
-            .andExpect(status().isOk())
-            .andExpect(content().string(containsString("\"pageId\":\"" + pageId + "\"")));
-
-        this.mockMvc.perform(get("/srv/api/pages/" + language + "/" + pageId + "/content")
-                .session(loginAs(groupMember))
-                .accept(MediaType.TEXT_HTML))
-            .andExpect(status().isOk())
-            .andExpect(content().string("<p>Restricted content</p>"));
+            .andExpect(status().isForbidden());
 
         this.mockMvc.perform(get("/srv/api/pages/" + language + "/" + pageId)
                 .session(loginAsAdmin())
@@ -187,11 +220,47 @@ public class PagesApiTest extends AbstractServiceIntegrationTest {
             .andExpect(status().isOk())
             .andExpect(content().string(containsString("\"pageId\":\"" + pageId + "\"")));
 
-        this.mockMvc.perform(get("/srv/api/pages")
+        this.mockMvc.perform(get("/srv/api/pages/" + language + "/" + pageId)
                 .session(loginAs(groupMember))
                 .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isOk())
             .andExpect(content().string(containsString("\"pageId\":\"" + pageId + "\"")));
+    }
+
+    @Test
+    public void groupsAndAdminPageContentIsVisibleToAdminsAndAssignedGroupMembers() throws Exception {
+        final String language = "eng";
+        final String pageId = "groups-and-admin-content-" + UUID.randomUUID().toString().substring(0, 8);
+        final Group sampleGroup = _groupRepo.findByName("sample");
+        Assert.assertNotNull(sampleGroup);
+
+        final User nonGroupMember = createAuthenticatedUser("page-non-group-member-" + UUID.randomUUID());
+        final User groupMember = createUserInGroup("page-group-member-" + UUID.randomUUID(), sampleGroup);
+        pageRepository.saveAndFlush(createPage(language, pageId, Page.PageStatus.GROUPS_AND_ADMIN, sampleGroup));
+
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
+
+        this.mockMvc.perform(get("/srv/api/pages/" + language + "/" + pageId + "/content")
+                .session(loginAsAnonymous())
+                .accept(MediaType.TEXT_HTML))
+            .andExpect(status().isForbidden());
+
+        this.mockMvc.perform(get("/srv/api/pages/" + language + "/" + pageId + "/content")
+                .session(loginAs(nonGroupMember))
+                .accept(MediaType.TEXT_HTML))
+            .andExpect(status().isForbidden());
+
+        this.mockMvc.perform(get("/srv/api/pages/" + language + "/" + pageId + "/content")
+                .session(loginAs(groupMember))
+                .accept(MediaType.TEXT_HTML))
+            .andExpect(status().isOk())
+            .andExpect(content().string("<p>Restricted content</p>"));
+
+        this.mockMvc.perform(get("/srv/api/pages/" + language + "/" + pageId + "/content")
+                .session(loginAsAdmin())
+                .accept(MediaType.TEXT_HTML))
+            .andExpect(status().isOk())
+            .andExpect(content().string("<p>Restricted content</p>"));
     }
 
     @Test
@@ -230,13 +299,18 @@ public class PagesApiTest extends AbstractServiceIntegrationTest {
             new LinkedHashSet<>(Collections.singleton(group)));
     }
 
-    private User createUserInGroup(String username, Group group) {
+    private User createAuthenticatedUser(String username) {
         User user = new User();
         user.setUsername(username);
         user.setProfile(Profile.Editor);
         user.setEnabled(true);
         user.getEmailAddresses().add(username + "@example.com");
         _userRepo.save(user);
+        return user;
+    }
+
+    private User createUserInGroup(String username, Group group) {
+        User user = createAuthenticatedUser(username);
         _userGroupRepo.save(new UserGroup().setGroup(group).setProfile(Profile.Editor).setUser(user));
         return user;
     }

--- a/services/src/test/java/org/fao/geonet/api/pages/PagesApiTest.java
+++ b/services/src/test/java/org/fao/geonet/api/pages/PagesApiTest.java
@@ -25,6 +25,10 @@ package org.fao.geonet.api.pages;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import org.fao.geonet.api.JsonFieldNamingStrategy;
+import org.fao.geonet.domain.Group;
+import org.fao.geonet.domain.Profile;
+import org.fao.geonet.domain.User;
+import org.fao.geonet.domain.UserGroup;
 import org.fao.geonet.domain.page.Page;
 import org.fao.geonet.domain.page.PageIdentity;
 import org.fao.geonet.repository.page.PageRepository;
@@ -40,11 +44,18 @@ import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilde
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.context.WebApplicationContext;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.Optional;
+import java.util.UUID;
 
+import static org.hamcrest.Matchers.containsString;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 public class PagesApiTest extends AbstractServiceIntegrationTest {
@@ -139,5 +150,94 @@ public class PagesApiTest extends AbstractServiceIntegrationTest {
             .andExpect(status().is(HttpStatus.OK.value()));
         this.mockMvc.perform(deletePageBuilder)
             .andExpect(status().is(HttpStatus.NOT_FOUND.value()));
+    }
+
+    @Test
+    public void groupsAndAdminPagesAreVisibleToAdminsAndAssignedGroupMembers() throws Exception {
+        final String language = "eng";
+        final String pageId = "groups-and-admin-access-" + UUID.randomUUID().toString().substring(0, 8);
+        final Group sampleGroup = _groupRepo.findByName("sample");
+        Assert.assertNotNull(sampleGroup);
+
+        final User groupMember = createUserInGroup("page-group-member-" + UUID.randomUUID(), sampleGroup);
+        pageRepository.saveAndFlush(createPage(language, pageId, Page.PageStatus.GROUPS_AND_ADMIN, sampleGroup));
+
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
+
+        this.mockMvc.perform(get("/srv/api/pages/" + language + "/" + pageId)
+                .session(loginAsAnonymous())
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isForbidden());
+
+        this.mockMvc.perform(get("/srv/api/pages/" + language + "/" + pageId)
+                .session(loginAs(groupMember))
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().string(containsString("\"pageId\":\"" + pageId + "\"")));
+
+        this.mockMvc.perform(get("/srv/api/pages/" + language + "/" + pageId + "/content")
+                .session(loginAs(groupMember))
+                .accept(MediaType.TEXT_HTML))
+            .andExpect(status().isOk())
+            .andExpect(content().string("<p>Restricted content</p>"));
+
+        this.mockMvc.perform(get("/srv/api/pages/" + language + "/" + pageId)
+                .session(loginAsAdmin())
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().string(containsString("\"pageId\":\"" + pageId + "\"")));
+
+        this.mockMvc.perform(get("/srv/api/pages")
+                .session(loginAs(groupMember))
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().string(containsString("\"pageId\":\"" + pageId + "\"")));
+    }
+
+    @Test
+    public void includeAllPagesRequiresAdministratorPrivileges() throws Exception {
+        final String pageId = "groups-and-admin-listing-" + UUID.randomUUID().toString().substring(0, 8);
+        final Group sampleGroup = _groupRepo.findByName("sample");
+        Assert.assertNotNull(sampleGroup);
+
+        final User groupMember = createUserInGroup("page-include-all-member-" + UUID.randomUUID(), sampleGroup);
+        pageRepository.saveAndFlush(createPage("eng", pageId, Page.PageStatus.GROUPS_AND_ADMIN, sampleGroup));
+
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
+
+        this.mockMvc.perform(get("/srv/api/pages?includeAll=true")
+                .session(loginAs(groupMember))
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isForbidden());
+
+        this.mockMvc.perform(get("/srv/api/pages?includeAll=true")
+                .session(loginAsAdmin())
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isOk())
+            .andExpect(content().string(containsString("\"pageId\":\"" + pageId + "\"")));
+    }
+
+    private Page createPage(String language, String pageId, Page.PageStatus status, Group group) {
+        return new Page(
+            new PageIdentity(language, pageId),
+            "<p>Restricted content</p>".getBytes(StandardCharsets.UTF_8),
+            "../api/pages/" + language + "/" + pageId + "/content",
+            Page.PageFormat.HTML,
+            new ArrayList<>(),
+            status,
+            pageId,
+            null,
+            new LinkedHashSet<>(Collections.singleton(group)));
+    }
+
+    private User createUserInGroup(String username, Group group) {
+        User user = new User();
+        user.setUsername(username);
+        user.setProfile(Profile.Editor);
+        user.setEnabled(true);
+        user.getEmailAddresses().add(username + "@example.com");
+        _userRepo.save(user);
+        _userGroupRepo.save(new UserGroup().setGroup(group).setProfile(Profile.Editor).setUser(user));
+        return user;
     }
 }

--- a/web-ui/src/main/resources/catalog/js/admin/StaticPagesController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/StaticPagesController.js
@@ -82,7 +82,7 @@
 
       function loadStaticPages() {
         $scope.staticPageSelected = null;
-        $http.get("../api/pages").then(function (r) {
+        $http.get("../api/pages?includeAll=true").then(function (r) {
           $scope.staticPages = r.data;
         });
       }
@@ -182,7 +182,9 @@
       $scope.selectStaticPage = function (v) {
         $scope.isUpdate = true;
         $scope.staticPageSelected = v;
-        $scope.isGroupEnabled = $scope.staticPageSelected.status == "GROUPS";
+        $scope.isGroupEnabled =
+          $scope.staticPageSelected.status == "GROUPS" ||
+          $scope.staticPageSelected.status == "GROUPS_AND_ADMIN";
 
         var link =
           "api/pages/" +
@@ -258,7 +260,10 @@
         }
       };
       $scope.updateGroupSelection = function () {
-        if ($scope.staticPageSelected.status === "GROUPS") {
+        if (
+          $scope.staticPageSelected.status === "GROUPS" ||
+          $scope.staticPageSelected.status === "GROUPS_AND_ADMIN"
+        ) {
           $scope.isGroupEnabled = true;
         } else {
           $scope.isGroupEnabled = false;

--- a/web-ui/src/main/resources/catalog/locales/en-v4.json
+++ b/web-ui/src/main/resources/catalog/locales/en-v4.json
@@ -427,6 +427,7 @@
   "staticPageStatus-HIDDEN": "Visible only to the administrator",
   "staticPageStatus-PRIVATE": "Visible to logged users",
   "staticPageStatus-GROUPS": "Visible to users belonging to the groups",
+  "staticPageStatus-GROUPS_AND_ADMIN": "Visible to users belonging to the groups and to administrators",
   "staticPageStatus-PUBLIC": "Visible to everyone",
   "pageLink": "Link",
   "pageSection-help": "Currently, the default UI view only supports TOP and FOOTER values. Custom UI views can make use of additional values.",

--- a/web-ui/src/main/resources/catalog/templates/admin/settings/static-pages.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/settings/static-pages.html
@@ -313,6 +313,9 @@
                   {{'staticPageStatus-PRIVATE' | translate }}
                 </option>
                 <option value="GROUPS">{{'staticPageStatus-GROUPS' | translate }}</option>
+                <option value="GROUPS_AND_ADMIN">
+                  {{'staticPageStatus-GROUPS_AND_ADMIN' | translate }}
+                </option>
                 <option value="PUBLIC">{{'staticPageStatus-PUBLIC' | translate }}</option>
               </select>
             </div>


### PR DESCRIPTION
Currently, static pages can be restricted to specific groups, but administrators are always allowed to access them even when they are not part of those groups.

This means there is currently no way to hide a static page or menu item from an administrator who is not in the configured group.

This PR aims to fix this issue by splitting the GROUPS status into two separate statuses:
- GROUPS: only users in the configured groups can access the page
- GROUPS_AND_ADMIN: users in the configured groups or administrators can access the page

This makes the behaviour explicit and allows static pages to either include or exclude administrators from group-based access, depending on the selected status.

Administrators can still see all static pages in the settings, even if they cannot access them directly, so they can configure them.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [X] *API Changes* are identified in commit messages
- [X] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [X] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
