### PR TITLE
Metadata import / help text for the category field

### DIFF
--- a/web-ui/src/main/resources/catalog/locales/en-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/en-editor.json
@@ -33,6 +33,7 @@
     "applySuggestion": "Apply suggestion",
     "assignToCatalog": "Assign to current catalog",
     "assignToCategory": "Assign to category",
+    "assignToCategory-help": "This value is not used when importing metadata in MEF (ZIP) format, as the value defined in the ZIP file is used instead.",
     "assignToGroup": "Assign to group",
     "associationType": "Association type",
     "chooseContactRole": "Choose contact role",

--- a/web-ui/src/main/resources/catalog/templates/editor/import.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/import.html
@@ -460,6 +460,8 @@
                   name="category"
                   class="form-control hidden"
                 />
+
+                <p class="help-block" data-translate="">assignToCategory-help</p>
               </div>
             </div>
 


### PR DESCRIPTION
The category field in the import metadata page it is not used when importing MEF files. Add a help text to clarify the usage.

<img width="797" height="949" alt="image" src="https://github.com/user-attachments/assets/88aa8443-638b-49d1-974c-3da8805880d1" />


# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

