### PR TITLE
Metadata editor / fix generate thumbnail from metadata layer when the map background layer is a WMTS layer

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/map/print/PrintDirective.js
+++ b/web-ui/src/main/resources/catalog/components/common/map/print/PrintDirective.js
@@ -33,7 +33,8 @@
     "$window",
     "$translate",
     "$document",
-    function ($scope, $http, $window, $translate, $document) {
+    "gnGlobalSettings",
+    function ($scope, $http, $window, $translate, $document, gnGlobalSettings) {
       var waitclass = "ga-print-wait";
       var bodyEl = angular.element($document[0].body);
       bodyEl.removeClass(waitclass);
@@ -546,26 +547,56 @@
             });
             return enc;
           },
-          WMTS: function (layer, config) {
+          WMTS: function (layer, config, proj) {
             var enc = $scope.encoders.layers["Layer"].call(this, layer);
             var source = layer.getSource();
             var tileGrid = source.getTileGrid();
+            var matrixSet = source.getMatrixSet();
+            var matrixIds = new Array(tileGrid.getResolutions().length);
+            var layerUrl = layer.get("url");
+            for (var z = 0; z < tileGrid.getResolutions().length; ++z) {
+              var mSize =
+                ol.extent.getWidth(proj.getExtent()) /
+                tileGrid.getTileSize(z) /
+                tileGrid.getResolutions()[z];
+              matrixIds[z] = {
+                identifier: tileGrid.getMatrixIds()[z],
+                resolution: tileGrid.getResolutions()[z],
+                tileSize: [tileGrid.getTileSize(z), tileGrid.getTileSize(z)],
+                topLeftCorner: tileGrid.getOrigin(z),
+                matrixSize: [mSize, mSize]
+              };
+            }
+
+            // workaround for Mapfish v2.1.2 with REST and matrixIds
+            if (matrixIds.length > 0) {
+              if (/{style}/gi.test(decodeURI(layerUrl))) {
+                layerUrl = encodeURI(
+                  decodeURI(layerUrl).replace(/{style}/gi, source.getStyle())
+                );
+              }
+              if (/layer/gi.test(decodeURI(layerUrl))) {
+                layerUrl = encodeURI(
+                  decodeURI(layerUrl).replace(/{layer}/gi, source.getLayer())
+                );
+              }
+            }
+
+            layerUrl = gnGlobalSettings.getNonProxifiedUrl(layerUrl);
+
             angular.extend(enc, {
               type: "WMTS",
-              baseURL: location.protocol + "//wmts.geo.admin.ch", // FIXME
-              layer: config.serverLayerName,
-              maxExtent: layer.getExtent(),
-              tileOrigin: tileGrid.getOrigin(),
-              tileSize: [tileGrid.getTileSize(), tileGrid.getTileSize()],
-              resolutions: tileGrid.getResolutions(),
-              zoomOffset: tileGrid.getMinZoom(),
-              version: "1.0.0",
-              requestEncoding: "REST",
-              formatSuffix: config.format || "jpeg",
-              style: "default",
-              dimensions: ["TIME"],
-              params: { TIME: source.getDimensions().Time },
-              matrixSet: "21781" // FIXME
+              baseURL: layerUrl,
+              layer: source.getLayer(),
+              version: source.getVersion(),
+              requestEncoding: source.getRequestEncoding() || "KVP",
+              // Dimensions is not a mandatory parameter
+              // but it is required by Mapfish v2.1.2 if requestEncoding is REST
+              dimensions: [],
+              format: source.getFormat(),
+              style: source.getStyle(),
+              matrixSet: matrixSet,
+              matrixIds: matrixIds
             });
 
             return enc;


### PR DESCRIPTION
When configuring a WTMS map background layer an error occurs generating the thumbnail of a metadata with a map layer.

http://localhost:8080/geonetwork/srv/api/records/f5a3e80e-8d60-4e06-ab6e-eb45dc5ef560/attachments/print-thumbnail?jsonConfig={%22layout%22:%22overviewPrintTemplate%22,%22srs%22:%22EPSG:28992%22,%22units%22:%22m%22,%22rotation%22:0,%22lang%22:%22dut%22,%22dpi%22:%22127%22,%22outputFormat%22:%22png%22,%22layers%22:[{%22opacity%22:1,%22type%22:%22WMTS%22,%22baseURL%22:%22http://wmts.geo.admin.ch%22,%22maxExtent%22:[-285401,22598,595401,903401],%22tileSize%22:[null,null],%22resolutions%22:[3440.64,1720.32,860.16,430.08,215.04,107.52,53.76,26.88,13.44,6.72,3.36,1.68,0.84,0.42,0.21],%22zoomOffset%22:0,%22version%22:%221.0.0%22,%22requestEncoding%22:%22REST%22,%22formatSuffix%22:%22jpeg%22,%22style%22:%22default%22,%22dimensions%22:[%22TIME%22],%22params%22:{},%22matrixSet%22:%2221781%22},{%22opacity%22:1,%22type%22:%22WMS%22,%22baseURL%22:%22https://services.geodataoverijssel.nl/geoserver/B22_wegen/wms%22,%22layers%22:[%22B22_Rotondes_in_provinciale_wegen%22],%22styles%22:[%22%22],%22format%22:%22image/png%22,%22customParams%22:{%22EXCEPTIONS%22:%22XML%22,%22TRANSPARENT%22:%22true%22,%22CRS%22:%22EPSG:28992%22},%22singleTile%22:true}],%22pages%22:[{%22title%22:%22%22,%22center%22:[233300.26503093337,493898.61395412975],%22scale%22:%22781250.0%22,%22dataOwner%22:%22%C2%A9+%22,%22rotation%22:0,%22langdut%22:true}],%22hasNoTitle%22:true}&rotationAngle=0


```json
{
    "message": "attribute [spec.layers[0].layer] missing",
    "code": "runtime_exception",
    "description": null
}
```


The code had hardcoded values for the layer URL and projection. 

- https://github.com/geonetwork/core-geonetwork/blob/0456f357cc27f3c835bffd5db5172196407d4687/web-ui/src/main/resources/catalog/components/common/map/print/PrintDirective.js#L555

- https://github.com/geonetwork/core-geonetwork/blob/0456f357cc27f3c835bffd5db5172196407d4687/web-ui/src/main/resources/catalog/components/common/map/print/PrintDirective.js#L568


Apart of this, there is a similar code with some unclear differences:

https://github.com/geonetwork/core-geonetwork/blob/0456f357cc27f3c835bffd5db5172196407d4687/web-ui/src/main/resources/catalog/components/common/map/print/PrintMapService.js#L149-L413

@fxprunayre do you know the reason for this kind of duplication? It seems like the `GaPrintDirectiveController` could  use `gnPrint`, but it's not the case. And with the code differences, there are quite chances to break some stuff


# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
