### PR TITLE
Fix history is not updated when removing all privileges

### DIFF
--- a/services/pom.xml
+++ b/services/pom.xml
@@ -137,6 +137,12 @@
       <classifier>tests</classifier>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>gn-listeners</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>com.google.code.gson</groupId>

--- a/services/src/main/java/org/fao/geonet/api/records/MetadataSharingApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/MetadataSharingApi.java
@@ -594,6 +594,7 @@ public class MetadataSharingApi implements ApplicationEventPublisherAware {
 
             if (sharing.isClear()) {
                 metadataOperations.deleteMetadataOper(String.valueOf(metadata.getId()), excludeFromDelete);
+                sharingChanges = true;
             }
 
             for (GroupOperations p : privileges) {

--- a/services/src/test/java/org/fao/geonet/api/records/MetadataSharingApiTest.java
+++ b/services/src/test/java/org/fao/geonet/api/records/MetadataSharingApiTest.java
@@ -38,13 +38,19 @@ import org.fao.geonet.domain.ReservedGroup;
 import org.fao.geonet.domain.ReservedOperation;
 import org.fao.geonet.domain.User;
 import org.fao.geonet.domain.UserGroup;
+import org.fao.geonet.domain.MetadataStatus;
+import org.fao.geonet.domain.StatusValue;
+import org.fao.geonet.kernel.setting.SettingManager;
+import org.fao.geonet.kernel.setting.Settings;
 import org.fao.geonet.repository.MetadataRepository;
+import org.fao.geonet.repository.MetadataStatusRepository;
 import org.fao.geonet.repository.OperationAllowedRepository;
 import org.fao.geonet.repository.UserRepositoryTest;
 import org.fao.geonet.services.AbstractServiceIntegrationTest;
 import org.junit.Before;
 import org.junit.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Sort;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpSession;
 import org.springframework.test.web.servlet.MockMvc;
@@ -78,6 +84,12 @@ public class MetadataSharingApiTest extends AbstractServiceIntegrationTest {
     @Autowired
     private OperationAllowedRepository operationAllowedRepository;
 
+    @Autowired
+    private MetadataStatusRepository metadataStatusRepository;
+
+    @Autowired
+    private SettingManager settingManager;
+
     private User editorUser;
     private User reviewerUser;
     private int metadataId;
@@ -88,6 +100,7 @@ public class MetadataSharingApiTest extends AbstractServiceIntegrationTest {
     public void setUp() throws Exception {
         this.context = createServiceContext();
         createTestData();
+        settingManager.setValue(Settings.METADATA_HISTORY_ENABLED, true);
     }
 
     @Test
@@ -332,6 +345,48 @@ public class MetadataSharingApiTest extends AbstractServiceIntegrationTest {
         boolean systemGroupPresent = sharingResponse.getPrivileges().stream()
             .anyMatch(p -> p.getGroup() == systemPrivilegeGroupId);
         assertFalse("SystemPrivilege group should be excluded from sharing response", systemGroupPresent);
+    }
+
+    @Test
+    public void settingPrivilegesToNoneCreatesPrivilegesHistoryStatusEntry() throws Exception {
+        MockMvc mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
+        MockHttpSession mockHttpSession = loginAs(editorUser);
+
+        SharingParameter addPrivilegesRequest = createPrivilegesRequest(false);
+        Gson gson = new Gson();
+
+        // Precondition: record has at least one privilege before setting privileges to none.
+        mockMvc.perform(put("/srv/api/records/" + metadataUuid + "/sharing")
+                .session(mockHttpSession)
+                .content(gson.toJson(addPrivilegesRequest))
+                .contentType(API_JSON_EXPECTED_ENCODING)
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNoContent());
+
+        long historyEventsBefore = metadataStatusRepository.findAllByMetadataId(metadataId, Sort.unsorted()).stream()
+            .map(MetadataStatus::getStatusValue)
+            .map(StatusValue::getId)
+            .filter(id -> id.equals(StatusValue.Events.RECORDPRIVILEGESCHANGE.getId()))
+            .count();
+
+        SharingParameter clearPrivilegesRequest = new SharingParameter();
+        clearPrivilegesRequest.setClear(true);
+        clearPrivilegesRequest.setPrivileges(new ArrayList<>());
+
+        mockMvc.perform(put("/srv/api/records/" + metadataUuid + "/sharing")
+                .session(mockHttpSession)
+                .content(gson.toJson(clearPrivilegesRequest))
+                .contentType(API_JSON_EXPECTED_ENCODING)
+                .accept(MediaType.APPLICATION_JSON))
+            .andExpect(status().isNoContent());
+
+        long historyEventsAfter = metadataStatusRepository.findAllByMetadataId(metadataId, Sort.unsorted()).stream()
+            .map(MetadataStatus::getStatusValue)
+            .map(StatusValue::getId)
+            .filter(id -> id.equals(StatusValue.Events.RECORDPRIVILEGESCHANGE.getId()))
+            .count();
+
+        assertEquals(historyEventsBefore + 1, historyEventsAfter);
     }
 
     private SharingParameter createPrivilegesRequest(boolean addPublicationPrivileges) {

--- a/services/src/test/resources/services-web-test-context.xml
+++ b/services/src/test/resources/services-web-test-context.xml
@@ -2,9 +2,11 @@
 <beans xmlns="http://www.springframework.org/schema/beans"
        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
        xmlns:mvc="http://www.springframework.org/schema/mvc"
+       xmlns:context="http://www.springframework.org/schema/context"
        xsi:schemaLocation="http://www.springframework.org/schema/beans http://www.springframework.org/schema/beans/spring-beans.xsd
-       http://www.springframework.org/schema/mvc  http://www.springframework.org/schema/mvc/spring-mvc.xsd">
+       http://www.springframework.org/schema/mvc  http://www.springframework.org/schema/mvc/spring-mvc.xsd http://www.springframework.org/schema/context https://www.springframework.org/schema/context/spring-context.xsd">
 
+  <context:component-scan base-package="org.fao.geonet.listener"/>
 
   <bean id="cnManager"
         class="org.springframework.web.accept.ContentNegotiationManagerFactoryBean">


### PR DESCRIPTION
Currently when removing all the privileges of a record, the event is not emitted so nothing is saved in the history.

All privilege changes should be logged in the history so we can track why a record may be no longer visible.

This PR aims to fix this issue by updating the "none selected" path so the event is emitted. Then we will see the privilege in the history.
  
# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
