### PR TITLE
Fix add to user selection for logged users

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/savedselections/SavedSelectionsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/common/savedselections/SavedSelectionsDirective.js
@@ -320,7 +320,7 @@
           }
 
           return $http
-            .put("../api/userselections/" + selection.id, null, {
+            .put("../api/userselections/" + selection.id + "/items", null, {
               params: {
                 userIdentifier: this.userId,
                 uuid: uuid


### PR DESCRIPTION

Adding a metadata to a user selection for logged users is not working:

<img width="699" height="216" alt="image" src="https://github.com/user-attachments/assets/832a3fb8-18a3-4f3c-9bf4-b1583e1bebdf" />

Related to #8864 changes.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation