### PR TITLE
Record history / Fix view and restore buttons not showing

### DIFF
--- a/web-ui/src/main/resources/catalog/components/history/GnHistoryDirective.js
+++ b/web-ui/src/main/resources/catalog/components/history/GnHistoryDirective.js
@@ -122,6 +122,17 @@
     }
   ]);
 
+  /**
+   * @ngdoc directive
+   * @name gnRecordHistoryStep
+   * @attr {Object} gnRecordHistoryStep - The history step object to display.
+   * @attr {boolean} [noTitle] - When true, hides the record title link.
+   * @attr {boolean} [noSourceViewOption] - When true, hides the "View previous
+   *   version" and "View changed version" buttons.
+   * @attr {boolean} [noRecoverOption] - When true, hides the "Restore" button.
+   * @attr {boolean} [allowRemoval] - When true, shows the remove step button
+   *   (restricted to administrators).
+   */
   module.directive("gnRecordHistoryStep", [
     "gnDoiService",
     "gnRecordHistoryService",
@@ -134,8 +145,8 @@
         scope: {
           h: "=gnRecordHistoryStep",
           noTitle: "@noTitle",
-          noSourceViewOption: "@noTitle",
-          noRecoverOption: "@noTitle",
+          noSourceViewOption: "@noSourceViewOption",
+          noRecoverOption: "@noRecoverOption",
           allowRemoval: "=allowRemoval"
         },
         templateUrl: "../../catalog/components/history/partials/historyStep.html",


### PR DESCRIPTION
## What does this fix?

The **View previous version**, **View changed version**, and **Restore** buttons in the record history panel in the metadata record view were never visible, making the content audit log introduced in #4817 essentially inaccessible from the UI.

## Root cause

In `GnHistoryDirective.js`, the `gnRecordHistoryStep` directive defines three scope properties:

```javascript
noTitle: "@noTitle",
noSourceViewOption: "@noTitle",   // bug: should be "@noSourceViewOption"
noRecoverOption: "@noTitle",      // bug: should be "@noRecoverOption"
```

`noSourceViewOption` and `noRecoverOption` were both bound to the `noTitle` HTML attribute instead of their own. Since `recordHistory.html` passes `data-no-title="true"`, both properties evaluated to `true`, causing `data-ng-hide="noSourceViewOption"` and `data-ng-hide="noRecoverOption"` in the template to permanently hide the buttons.

The bug was introduced in #4817 (November 2020).

## Fix

Bind each scope property to its own attribute:

```javascript
noSourceViewOption: "@noSourceViewOption",
noRecoverOption: "@noRecoverOption",
```

The directive is used in two places (`recordHistory.html` and `history.html`). Neither passes `data-no-source-view-option` or `data-no-recover-option`, so both attributes correctly default to `undefined` (falsy) and the buttons are now shown.

Added ngdoc documentation for all directive attributes.

History panel after the change:
<img width="471" height="411" alt="image" src="https://github.com/user-attachments/assets/d23a574e-8994-40a1-8b71-54963360718a" />


## Related issue

Identified while investigating #9274.