### PR TITLE
Anonymous access does not seem to work for OIDC auth

### DIFF
--- a/web/src/main/webapp/WEB-INF/config-security/config-security-openidconnect.xml
+++ b/web/src/main/webapp/WEB-INF/config-security/config-security-openidconnect.xml
@@ -171,6 +171,11 @@
     <constructor-arg ref="geonetworkCsrfSecurityRequestMatcher" />
   </bean>
 
+  <bean id="grantViewMdAuthorityFilter" class="org.fao.geonet.security.GrantViewMdAuthorityFilter">
+    <constructor-arg ref="securityContextRepository"/>
+  </bean>
+
+
   <util:list id="openidConnectFilterChanFiltersExclusive">
 
     <ref bean="securityContextPersistenceFilter"/>
@@ -186,6 +191,7 @@
 
     <ref bean="requestCacheFilter"/>
     <ref bean="anonymousFilter"/>
+    <ref bean="grantViewMdAuthorityFilter"/>
     <ref bean="sessionMgmtFilter"/>
     <ref bean="exceptionTranslationFilter"/>
     <ref bean="filterSecurityInterceptor"/>


### PR DESCRIPTION
<!--Include a few sentences describing the overall goals for this Pull Request-->

For OIDC (`config-security-openidconnect.xml`), the new `org.fao.geonet.security.GrantViewMdAuthorityFilter` is not present.  This adds it in.

I expect there are other security configurations that don't have this included.

Fixes #9277

<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [x] *API Changes* are identified in commit messages
- [x] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [x] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [x] *Build documentation* provided for development instructions in `README.md` files
- [x] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

