### PR TITLE
Fix remove user selection is using the wrong api

### DIFF
--- a/web-ui/src/main/resources/catalog/components/common/savedselections/SavedSelectionsDirective.js
+++ b/web-ui/src/main/resources/catalog/components/common/savedselections/SavedSelectionsDirective.js
@@ -339,7 +339,7 @@
         var ctrl = this;
         if (selection.id > -1) {
           return $http
-            .delete("../api/userselections/" + selection.id, {
+            .delete("../api/userselections/" + selection.id + "/items", {
               params: {
                 userIdentifier: this.userId,
                 uuid: uuid


### PR DESCRIPTION
Following #9273 there are still issues with the user selection caused by #8864 

When we try to remove a user selection from the UI, the deleteUserSelection endpoint is called instead of deleteUserSelectionRecords.

This endpoint is restricted to UserAdmin, so nothing happens when non-admin users try to remove a selection.

When a UserAdmin or higher removes a selection, the endpoint is called successfully. However, this endpoint removes all records for all users for that selection type, and then removes the selection type from the database.

For example, if an admin adds two records to their watchlist and then removes one, the entire watchlist selection is removed for all users. The watchlist type itself no longer exists, so the next time anyone tries to add something to their watchlist, the option is no longer available.
<img width="177" height="146" alt="image" src="https://github.com/user-attachments/assets/1c16da11-3431-4142-b43b-f6fb1d73e8fc" />

This PR aims to fix this issue by calling deleteUserSelectionRecords when removing a selection from the UI, so only the selected record is removed from the current user's selection.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation