### PR TITLE
Hide confirm delete modal of static pages after success

### DIFF
--- a/web-ui/src/main/resources/catalog/js/admin/StaticPagesController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/StaticPagesController.js
@@ -291,6 +291,7 @@
               });
 
               loadStaticPages();
+              $("#gn-confirm-remove-static-page").modal("hide");
             },
             function (data) {
               $rootScope.$broadcast("StatusUpdated", {


### PR DESCRIPTION
It fixes bug reported [here](https://github.com/geonetwork/core-geonetwork/issues/9279)

The confirm popup that is shown on static page deletion does not disappear on deletion. This fixes this by reverting the action of `deleteStaticPageConfig()` 


# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation


