### PR TITLE
Harvester / Simple URL / OGC API Processes support

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/simpleurl/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/simpleurl/Harvester.java
@@ -23,10 +23,18 @@
 
 package org.fao.geonet.kernel.harvest.harvester.simpleurl;
 
+import com.fasterxml.jackson.core.JsonPointer;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ValueNode;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.io.CharStreams;
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.spi.json.JacksonJsonNodeJsonProvider;
+import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
 import jeeves.server.context.ServiceContext;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.StringUtils;
@@ -60,6 +68,8 @@ import java.net.URL;
 import java.nio.file.Path;
 import java.util.*;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 
 import static org.fao.geonet.utils.Xml.isRDFLike;
 import static org.fao.geonet.utils.Xml.isXMLLike;
@@ -154,9 +164,24 @@ class Harvester implements IHarvester<HarvestResult> {
                 }
             }
             try {
-                List<String> listOfUrlForPages = buildListOfUrl(params, numberOfRecordsToHarvest);
+                List<String> listOfUrlForPages = new ArrayList<>();
+
+                boolean isCrawlerMode = StringUtils.isNotEmpty(params.urlCrawlerPath);
+                if (StringUtils.isNotEmpty(params.urlCrawlerPath)) {
+                    if (type == SimpleUrlResourceType.XML
+                        || type == SimpleUrlResourceType.RDFXML) {
+                        listOfUrlForPages = findAllUrlsInXml(params.urlCrawlerPath, xmlObj);
+                    } else {
+                        listOfUrlForPages = findAllUrlsInJson(params.urlCrawlerPath, jsonObj);
+                    }
+                } else if (StringUtils.isEmpty(params.pageSizeParam)) {
+                    listOfUrlForPages.add(params.url);
+                } else {
+                    listOfUrlForPages = buildListOfUrl(params, numberOfRecordsToHarvest);
+                }
+
                 for (int i = 0; i < listOfUrlForPages.size(); i++) {
-                    if (i != 0) {
+                    if (i != 0 || isCrawlerMode) {
                         content = retrieveUrl(listOfUrlForPages.get(i));
                         if (type == SimpleUrlResourceType.XML) {
                             xmlObj = Xml.loadString(content, false);
@@ -164,24 +189,21 @@ class Harvester implements IHarvester<HarvestResult> {
                             jsonObj = objectMapper.readTree(content);
                         }
                     }
-                    if (StringUtils.isNotEmpty(params.loopElement)
-                        || type == SimpleUrlResourceType.RDFXML) {
-                        Map<String, Element> uuids = new HashMap<>();
-                        try {
-                            if (type == SimpleUrlResourceType.XML) {
-                                collectRecordsFromXml(xmlObj, uuids, aligner);
-                            } else if (type == SimpleUrlResourceType.RDFXML) {
-                                collectRecordsFromRdf(xmlObj, uuids, aligner);
-                            } else if (type == SimpleUrlResourceType.JSON) {
-                                collectRecordsFromJson(jsonObj, uuids, aligner);
-                            }
-                            aligner.align(uuids, errors);
-                            listOfUuids.addAll(uuids.keySet());
-                        } catch (Exception e) {
-                            errors.add(new HarvestError(this.context, e));
-                            log.error(String.format("Failed to collect record in response at path %s. Error is: %s",
-                                params.loopElement, e.getMessage()));
+                    Map<String, Element> uuids = new HashMap<>();
+                    try {
+                        if (type == SimpleUrlResourceType.XML) {
+                            collectRecordsFromXml(xmlObj, uuids, aligner);
+                        } else if (type == SimpleUrlResourceType.RDFXML) {
+                            collectRecordsFromRdf(xmlObj, uuids, aligner);
+                        } else if (type == SimpleUrlResourceType.JSON) {
+                            collectRecordsFromJson(jsonObj, uuids, aligner);
                         }
+                        aligner.align(uuids, errors);
+                        listOfUuids.addAll(uuids.keySet());
+                    } catch (Exception e) {
+                        errors.add(new HarvestError(this.context, e));
+                        log.error(String.format("Failed to collect record in response at path %s. Error is: %s",
+                            params.loopElement, e.getMessage()));
                     }
                 }
             } catch (Exception t) {
@@ -209,7 +231,12 @@ class Harvester implements IHarvester<HarvestResult> {
     private void collectRecordsFromJson(JsonNode jsonObj,
                                         Map<String, Element> uuids,
                                         Aligner aligner) {
-        JsonNode nodes = jsonObj.at(params.loopElement);
+        JsonNode nodes = null;
+        if (StringUtils.isEmpty(params.loopElement)) {
+            nodes = new ArrayNode(JsonNodeFactory.instance).add(jsonObj);
+        } else {
+            nodes = jsonObj.at(params.loopElement);
+        }
         log.debug(String.format("%d records found in JSON response.", nodes.size()));
 
         nodes.forEach(jsonRecord -> {
@@ -309,13 +336,44 @@ class Harvester implements IHarvester<HarvestResult> {
         return uuid;
     }
 
+    private List<String> findAllUrlsInXml(String urlCrawlerPath, Element xmlObj) {
+        List<String> urlList = new ArrayList<>();
+        try {
+            List list = Xml.selectNodes(xmlObj, urlCrawlerPath, xmlObj.getAdditionalNamespaces());
+            for (int i = 0; i < list.size(); i++) {
+                String url = getXmlElementTextValue(list.get(i));
+                if (url != null) {
+                    urlList.add(url);
+                }
+            }
+        } catch (JDOMException e) {
+            log.error(String.format("Failed to extract URL list from XML document. Error is %s.",
+                e.getMessage()));
+        }
+        return urlList;
+    }
+
+    private List<String> findAllUrlsInJson(String urlCrawlerPath, JsonNode jsonObj) {
+        List <String> urlList = new ArrayList<>();
+        JsonPath path = JsonPath.compile(urlCrawlerPath);
+        Configuration configuration = Configuration.defaultConfiguration()
+            .jsonProvider(new JacksonJsonNodeJsonProvider())
+            .mappingProvider(new JacksonMappingProvider());
+
+        ArrayNode nodes = path.read(jsonObj, configuration);
+
+        log.debug(String.format("%d URL found in JSON response.", nodes.size()));
+        for (JsonNode node : nodes) {
+            if (node.isTextual()) {
+                urlList.add(node.asText());
+            }
+        }
+        return urlList;
+    }
+
     @VisibleForTesting
     protected List<String> buildListOfUrl(SimpleUrlParams params, int numberOfRecordsToHarvest) {
         List<String> urlList = new ArrayList<>();
-        if (StringUtils.isEmpty(params.pageSizeParam)) {
-            urlList.add(params.url);
-            return urlList;
-        }
 
         int numberOfRecordsPerPage = -1;
         final String pageSizeParamValue = params.url.replaceAll(".*[?&]" + params.pageSizeParam + "=([0-9]+).*", "$1");

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/simpleurl/SimpleUrlHarvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/simpleurl/SimpleUrlHarvester.java
@@ -55,6 +55,7 @@ public class SimpleUrlHarvester extends AbstractHarvester<HarvestResult, SimpleU
         harvesterSettingsManager.add("id:" + siteId, "loopElement", params.loopElement);
         harvesterSettingsManager.add("id:" + siteId, "numberOfRecordPath", params.numberOfRecordPath);
         harvesterSettingsManager.add("id:" + siteId, "recordIdPath", params.recordIdPath);
+        harvesterSettingsManager.add("id:" + siteId, "urlCrawlerPath", params.urlCrawlerPath);
         harvesterSettingsManager.add("id:" + siteId, "pageFromParam", params.pageFromParam);
         harvesterSettingsManager.add("id:" + siteId, "pageSizeParam", params.pageSizeParam);
         harvesterSettingsManager.add("id:" + siteId, "toISOConversion", params.toISOConversion);

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/simpleurl/SimpleUrlParams.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/simpleurl/SimpleUrlParams.java
@@ -35,6 +35,7 @@ public class SimpleUrlParams extends AbstractParams {
     public String loopElement;
     public String numberOfRecordPath;
     public String recordIdPath;
+    public String urlCrawlerPath;
     public String pageSizeParam;
     public String pageFromParam;
     public String toISOConversion;
@@ -56,6 +57,7 @@ public class SimpleUrlParams extends AbstractParams {
         loopElement = Util.getParam(site, "loopElement", "");
         numberOfRecordPath = Util.getParam(site, "numberOfRecordPath", "");
         recordIdPath = Util.getParam(site, "recordIdPath", "");
+        urlCrawlerPath = Util.getParam(site, "urlCrawlerPath", "");
         pageSizeParam = Util.getParam(site, "pageSizeParam", "");
         pageFromParam = Util.getParam(site, "pageFromParam", "");
         toISOConversion = Util.getParam(site, "toISOConversion", "");
@@ -74,6 +76,7 @@ public class SimpleUrlParams extends AbstractParams {
         loopElement = Util.getParam(site, "loopElement", "");
         numberOfRecordPath = Util.getParam(site, "numberOfRecordPath", "");
         recordIdPath = Util.getParam(site, "recordIdPath", "");
+        urlCrawlerPath = Util.getParam(site, "urlCrawlerPath", "");
         pageSizeParam = Util.getParam(site, "pageSizeParam", "");
         pageFromParam = Util.getParam(site, "pageFromParam", "");
         toISOConversion = Util.getParam(site, "toISOConversion", "");
@@ -93,6 +96,7 @@ public class SimpleUrlParams extends AbstractParams {
         copy.icon = icon;
         copy.loopElement = loopElement;
         copy.numberOfRecordPath = numberOfRecordPath;
+        copy.urlCrawlerPath = urlCrawlerPath;
         copy.pageSizeParam = pageSizeParam;
         copy.pageFromParam = pageFromParam;
         copy.recordIdPath = recordIdPath;

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/fromOGCAPIProcesses.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/convert/fromOGCAPIProcesses.xsl
@@ -1,0 +1,393 @@
+<xsl:stylesheet version="2.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform"
+                xmlns:gco="http://standards.iso.org/iso/19115/-3/gco/1.0"
+                xmlns:mrd="http://standards.iso.org/iso/19115/-3/mrd/1.0"
+                xmlns:mrc="http://standards.iso.org/iso/19115/-3/mrc/2.0"
+                xmlns:lan="http://standards.iso.org/iso/19115/-3/lan/1.0"
+                xmlns:gfc="http://standards.iso.org/iso/19110/gfc/1.1"
+                xmlns:gcx="http://standards.iso.org/iso/19115/-3/gcx/1.0"
+                xmlns:cat="http://standards.iso.org/iso/19115/-3/cat/1.0"
+                xmlns:mdb="http://standards.iso.org/iso/19115/-3/mdb/2.0"
+                xmlns:cit="http://standards.iso.org/iso/19115/-3/cit/2.0"
+                xmlns:mcc="http://standards.iso.org/iso/19115/-3/mcc/1.0"
+                xmlns:mri="http://standards.iso.org/iso/19115/-3/mri/1.0"
+                xmlns:mrl="http://standards.iso.org/iso/19115/-3/mrl/2.0"
+                xmlns:xlink="http://www.w3.org/1999/xlink"
+                xmlns:util="java:org.fao.geonet.util.XslUtil"
+                exclude-result-prefixes="#all">
+  <!--
+  Convert OGC API Processes metadata to ISO 19115-3.2018 XML format.
+  -->
+
+  <xsl:import href="ISO19139/utility/create19115-3Namespaces.xsl"/>
+
+  <xsl:output method="xml" indent="yes"/>
+
+  <xsl:strip-space elements="*"/>
+
+  <xsl:template match="/record">
+    <mdb:MD_Metadata>
+      <xsl:call-template name="add-iso19115-3.2018-namespaces"/>
+      <mdb:metadataIdentifier>
+        <mcc:MD_Identifier>
+          <mcc:code>
+            <gco:CharacterString>
+              <xsl:value-of select="util:md5Hex(apiUrl)"/>
+            </gco:CharacterString>
+          </mcc:code>
+        </mcc:MD_Identifier>
+      </mdb:metadataIdentifier>
+      <mdb:defaultLocale>
+        <lan:PT_Locale>
+          <lan:language>
+            <lan:LanguageCode codeList="codeListLocation#LanguageCode"
+                              codeListValue="eng"/>
+          </lan:language>
+          <lan:characterEncoding>
+            <lan:MD_CharacterSetCode codeList="codeListLocation#MD_CharacterSetCode"
+                                     codeListValue="utf8"/>
+          </lan:characterEncoding>
+        </lan:PT_Locale>
+      </mdb:defaultLocale>
+
+      <mdb:metadataScope>
+        <mdb:MD_MetadataScope>
+          <mdb:resourceScope>
+            <mcc:MD_ScopeCode
+              codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_ScopeCode"
+              codeListValue="service"/>
+          </mdb:resourceScope>
+          <mdb:name>
+            <gco:CharacterString>OGC API Process</gco:CharacterString>
+          </mdb:name>
+        </mdb:MD_MetadataScope>
+      </mdb:metadataScope>
+
+      <mdb:contact>
+        <cit:CI_Responsibility>
+          <cit:role>
+            <cit:CI_RoleCode codeList="codeListLocation#CI_RoleCode" codeListValue="publisher"/>
+          </cit:role>
+          <cit:party>
+            <cit:CI_Organisation>
+              <cit:name>
+                <gco:CharacterString>
+                  <xsl:value-of select="nodeUrl"/>
+                </gco:CharacterString>
+              </cit:name>
+            </cit:CI_Organisation>
+          </cit:party>
+        </cit:CI_Responsibility>
+      </mdb:contact>
+
+
+      <xsl:call-template name="build-date">
+        <xsl:with-param name="tag" select="'mdb:dateInfo'"/>
+        <xsl:with-param name="value" select="format-date(current-date(), '[Y0001]-[M01]-[D01]')"/>
+      </xsl:call-template>
+
+      <mdb:metadataStandard>
+        <cit:CI_Citation>
+          <cit:title>
+            <gco:CharacterString>ISO 19115-3</gco:CharacterString>
+          </cit:title>
+        </cit:CI_Citation>
+      </mdb:metadataStandard>
+
+      <mdb:identificationInfo>
+        <mri:MD_DataIdentification>
+          <mri:citation>
+            <cit:CI_Citation>
+              <cit:title>
+                <gco:CharacterString>
+                  <xsl:value-of select="title"/>
+                </gco:CharacterString>
+              </cit:title>
+
+              <xsl:call-template name="build-date">
+                <xsl:with-param name="tag" select="'cit:date'"/>
+                <xsl:with-param name="value" select="format-date(current-date(), '[Y0001]-[M01]-[D01]')"/>
+              </xsl:call-template>
+
+              <cit:edition>
+                <gco:CharacterString>
+                  <xsl:value-of select="version"/>
+                </gco:CharacterString>
+              </cit:edition>
+              <cit:identifier>
+                <mcc:MD_Identifier>
+                  <mcc:code gco:nilReason="missing">
+                    <gcx:Anchor xlink:href="{apiUrl}">
+                      <xsl:value-of select="id"/>
+                    </gcx:Anchor>
+                  </mcc:code>
+                </mcc:MD_Identifier>
+              </cit:identifier>
+            </cit:CI_Citation>
+          </mri:citation>
+
+          <mri:abstract>
+            <gco:CharacterString>
+              <xsl:value-of select="description"/>
+            </gco:CharacterString>
+          </mri:abstract>
+
+          <xsl:if test="nodeUrl">
+            <mri:pointOfContact>
+              <cit:CI_Responsibility>
+                <cit:role>
+                  <cit:CI_RoleCode codeList="codeListLocation#CI_RoleCode" codeListValue="resourceProvider"/>
+                </cit:role>
+                <cit:party>
+                  <cit:CI_Organisation>
+                    <cit:name>
+                      <gco:CharacterString>
+                        <xsl:value-of select="nodeUrl"/>
+                      </gco:CharacterString>
+                    </cit:name>
+                  </cit:CI_Organisation>
+                </cit:party>
+              </cit:CI_Responsibility>
+            </mri:pointOfContact>
+          </xsl:if>
+
+          <xsl:variable name="keywords"
+                        select=".//keywords|use_case"/>
+          <xsl:if test="count($keywords) > 0">
+            <mri:descriptiveKeywords>
+              <mri:MD_Keywords>
+                <xsl:for-each select="$keywords">
+                  <mri:keyword>
+                    <gco:CharacterString>
+                      <xsl:value-of select="."/>
+                    </gco:CharacterString>
+                  </mri:keyword>
+                </xsl:for-each>
+                <mri:type>
+                  <mri:MD_KeywordTypeCode codeListValue="theme"
+                                          codeList="./resources/codeList.xml#MD_KeywordTypeCode"/>
+                </mri:type>
+              </mri:MD_Keywords>
+            </mri:descriptiveKeywords>
+          </xsl:if>
+
+
+          <mri:defaultLocale>
+            <lan:PT_Locale>
+              <lan:language>
+                <lan:LanguageCode codeList="codeListLocation#LanguageCode"
+                                  codeListValue="eng"/>
+              </lan:language>
+              <lan:characterEncoding>
+                <lan:MD_CharacterSetCode codeList="codeListLocation#MD_CharacterSetCode"
+                                         codeListValue="utf8"/>
+              </lan:characterEncoding>
+            </lan:PT_Locale>
+          </mri:defaultLocale>
+
+          <xsl:if test="example or jobControlOptions">
+            <mri:supplementalInformation>
+              <gco:CharacterString>
+                <xsl:if test="example">
+                  # Example:
+                  <xsl:for-each select="example/*">
+                    ##
+                    <xsl:value-of select="name()"/>
+
+                    <xsl:for-each select="*">
+                      * <xsl:value-of select="name()"/>:
+                      <xsl:value-of select="."/>
+                    </xsl:for-each>
+                  </xsl:for-each>
+                </xsl:if>
+
+                <xsl:text>
+
+
+                </xsl:text>
+
+                <xsl:if test="jobControlOptions">
+                  # Execution modes:
+                  <xsl:for-each select="jobControlOptions">
+                    *
+                    <xsl:value-of select="."/>
+                  </xsl:for-each>
+                </xsl:if>
+              </gco:CharacterString>
+            </mri:supplementalInformation>
+          </xsl:if>
+        </mri:MD_DataIdentification>
+      </mdb:identificationInfo>
+
+      <xsl:if test="inputs or outputs">
+        <mdb:contentInfo>
+          <mrc:MD_FeatureCatalogue>
+            <mrc:featureCatalogue>
+              <gfc:FC_FeatureCatalogue>
+                <cat:name>
+                  <gco:CharacterString>Process parameters</gco:CharacterString>
+                </cat:name>
+                <cat:versionNumber>
+                  <gco:CharacterString>
+                    <xsl:value-of select="version"/>
+                  </gco:CharacterString>
+                </cat:versionNumber>
+
+                <xsl:for-each select="inputs|outputs">
+                  <gfc:featureType>
+                    <gfc:FC_FeatureType>
+                      <gfc:typeName>
+                        <xsl:value-of select="name()"/>
+                      </gfc:typeName>
+                      <xsl:for-each select="*">
+                        <gfc:carrierOfCharacteristics>
+                          <gfc:FC_FeatureAttribute>
+                            <gfc:memberName>
+                              <xsl:value-of select="title"/>
+                            </gfc:memberName>
+                            <gfc:definition>
+                              <gco:CharacterString>
+                                <xsl:value-of select="description"/>
+                              </gco:CharacterString>
+                            </gfc:definition>
+                            <gfc:cardinality>
+                              <gco:CharacterString>
+                                <xsl:if test="minOccurs">
+                                  <xsl:value-of select="concat(minOccurs, '..', maxOccurs)"/>
+                                </xsl:if>
+                              </gco:CharacterString>
+                            </gfc:cardinality>
+                            <gfc:code>
+                              <gco:CharacterString>
+                                <xsl:value-of select="name()"/>
+                              </gco:CharacterString>
+                            </gfc:code>
+                            <gfc:valueType>
+                              <gco:TypeName>
+                                <gco:aName>
+                                  <gco:CharacterString>
+                                    <xsl:value-of select="schema/type"/>
+                                    <xsl:if test="schema/contentMediaType">
+                                      <xsl:value-of select="concat(' (', schema/contentMediaType, ')')"/>
+                                    </xsl:if>
+                                  </gco:CharacterString>
+                                </gco:aName>
+                              </gco:TypeName>
+                            </gfc:valueType>
+                          </gfc:FC_FeatureAttribute>
+                        </gfc:carrierOfCharacteristics>
+                      </xsl:for-each>
+                      <gfc:featureCatalogue/>
+                    </gfc:FC_FeatureType>
+                  </gfc:featureType>
+                </xsl:for-each>
+              </gfc:FC_FeatureCatalogue>
+            </mrc:featureCatalogue>
+          </mrc:MD_FeatureCatalogue>
+        </mdb:contentInfo>
+      </xsl:if>
+
+      <mdb:distributionInfo>
+        <mrd:MD_Distribution>
+          <mrd:distributionFormat>
+            <mrd:MD_Format>
+              <mrd:formatSpecificationCitation>
+                <cit:CI_Citation>
+                  <cit:title>
+                    <gco:CharacterString>
+                      OGC API Processes
+                    </gco:CharacterString>
+                  </cit:title>
+                </cit:CI_Citation>
+              </mrd:formatSpecificationCitation>
+            </mrd:MD_Format>
+          </mrd:distributionFormat>
+
+          <mrd:transferOptions>
+            <mrd:MD_DigitalTransferOptions>
+              <!--
+                <links>
+                  <hreflang>en-US</hreflang>
+                  <rel>http://www.opengis.net/def/rel/ogc/1.0/execute</rel>
+                  <href>https://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/heat4advanced/execution?f=json</href>
+                  <type>application/json</type>
+                  <title>Execution for this process as JSON</title>
+                </links>
+              -->
+              <xsl:for-each select="links">
+                <mrd:onLine>
+                  <cit:CI_OnlineResource>
+                    <cit:linkage>
+                      <gco:CharacterString>
+                        <xsl:value-of select="href"/>
+                      </gco:CharacterString>
+                    </cit:linkage>
+                    <cit:protocol>
+                      <gco:CharacterString>
+                        <xsl:value-of select="type"/>
+                      </gco:CharacterString>
+                    </cit:protocol>
+                    <cit:name>
+                      <gco:CharacterString>
+                        <xsl:value-of select="title"/>
+                      </gco:CharacterString>
+                    </cit:name>
+                    <cit:description>
+                      <gco:CharacterString>
+                        <xsl:value-of select="description"/>
+                      </gco:CharacterString>
+                    </cit:description>
+                    <cit:function>
+                      <cit:CI_OnLineFunctionCode
+                        codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#CI_OnLineFunctionCode"
+                        codeListValue="information"/>
+                    </cit:function>
+                  </cit:CI_OnlineResource>
+                </mrd:onLine>
+              </xsl:for-each>
+            </mrd:MD_DigitalTransferOptions>
+          </mrd:transferOptions>
+        </mrd:MD_Distribution>
+      </mdb:distributionInfo>
+
+      <mdb:resourceLineage>
+        <mrl:LI_Lineage>
+          <mrl:statement>
+            <gco:CharacterString>
+
+            </gco:CharacterString>
+          </mrl:statement>
+          <mrl:scope>
+            <mcc:MD_Scope>
+              <mcc:level>
+                <mcc:MD_ScopeCode
+                  codeList="http://standards.iso.org/iso/19115/resources/Codelists/cat/codelists.xml#MD_ScopeCode"
+                  codeListValue="service"/>
+              </mcc:level>
+            </mcc:MD_Scope>
+          </mrl:scope>
+        </mrl:LI_Lineage>
+      </mdb:resourceLineage>
+    </mdb:MD_Metadata>
+  </xsl:template>
+
+  <xsl:template name="build-date">
+    <xsl:param name="tag"/>
+    <xsl:param name="value"/>
+
+    <xsl:variable name="type"
+                  select="'publication'"/>
+    <xsl:element name="{$tag}">
+      <cit:CI_Date>
+        <cit:date>
+          <gco:DateTime>
+            <xsl:value-of select="$value"/>
+          </gco:DateTime>
+        </cit:date>
+        <cit:dateType>
+          <cit:CI_DateTypeCode codeList="codeListLocation#CI_DateTypeCode" codeListValue="{$type}"/>
+        </cit:dateType>
+      </cit:CI_Date>
+    </xsl:element>
+  </xsl:template>
+</xsl:stylesheet>

--- a/web-ui/src/main/resources/catalog/js/admin/HarvestSettingsController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/HarvestSettingsController.js
@@ -674,6 +674,7 @@
           defaultValues: {
             loopElement: "",
             numberOfRecordPath: "",
+            urlCrawlerPath: "",
             pageSizeParam: "",
             pageFromParam: "",
             recordIdPath: "",
@@ -684,6 +685,7 @@
           defaultValues: {
             loopElement: "/datasets",
             numberOfRecordPath: "/total_count",
+            urlCrawlerPath: "",
             pageSizeParam: "limit",
             pageFromParam: "offset",
             recordIdPath: "/dataset/dataset_id",
@@ -694,16 +696,29 @@
           defaultValues: {
             loopElement: "/collections",
             numberOfRecordPath: "",
+            urlCrawlerPath: "",
             pageSizeParam: "limit",
             pageFromParam: "page",
             recordIdPath: "/id",
             toISOConversion: "schema:iso19115-3.2018:convert/stac-to-iso19115-3"
           }
         },
+        "OGC API Processes": {
+          defaultValues: {
+            loopElement: ".",
+            numberOfRecordPath: "",
+            urlCrawlerPath: "$..links[?(@.title == 'Process description as JSON')].href",
+            pageSizeParam: "",
+            pageFromParam: "",
+            recordIdPath: "/id",
+            toISOConversion: "schema:iso19115-3.2018:convert/fromOGCAPIProcesses"
+          }
+        },
         "XML (ISO19115-3)": {
           defaultValues: {
             loopElement: ".",
             numberOfRecordPath: "",
+            urlCrawlerPath: "",
             pageSizeParam: "",
             pageFromParam: "",
             recordIdPath: "mdb:metadataIdentifier/*/mcc:code/*/text()",
@@ -714,6 +729,7 @@
           defaultValues: {
             loopElement: ".//csw:SearchResults/*",
             numberOfRecordPath: "",
+            urlCrawlerPath: "",
             pageSizeParam: "",
             pageFromParam: "",
             recordIdPath: "gmd:fileIdentifier/*/text()",

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -312,6 +312,8 @@
     "simpleurl-configHelper-help": "Depending on the target URL and the type of documents to harvest each configuration illustrate of to configure the harvester to extract the metadata records from the remote document.",
     "simpleurl-loopElementHelp": "For each element, one metadata record is created. For JSON document, points to a property. For XML document, points using XPath. eg. '.' if the element at the root of the XML document is a metadata document like 'mdb:MD_Metadata'.",
     "simpleurl-pagination": "Pagination parameters (optional)",
+    "urlCrawlerPath": "JSON path or XPath pointing to element containing URL pointing to the documents to harvest",
+    "simpleurl-urlCrawlerPathHelp": "eg. `$..links[?(@.title == 'Process description as JSON')].href` for an OGC API Process landing page and harvesting all links with title 'Process description as JSON'.",
     "numberOfRecordPath": "Element for the number of records to collect",
     "simpleurl-numberOfRecordPathHelp": "JSON property or XPath to the element containing the number of records to collect. This information is used to compute the number of pages in case pagination is needed to collect all records.",
     "recordIdPath": "Element for the UUID of each record",

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/simpleurl.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/simpleurl.html
@@ -122,6 +122,22 @@
       <p class="help-block" data-translate="">simpleurl-recordIdPathHelp</p>
     </div>
 
+    <div id="gn-harvest-settings-urlCrawlerPath-row">
+      <label
+        id="gn-harvest-settings-urlCrawlerPath-label"
+        class="control-label"
+        data-translate=""
+        >urlCrawlerPath</label
+      >
+      <input
+        id="gn-harvest-settings-urlCrawlerPath-input"
+        type="text"
+        class="form-control"
+        data-ng-model="harvesterSelected.site.urlCrawlerPath"
+      />
+      <p class="help-block" data-translate="">simpleurl-urlCrawlerPathHelp</p>
+    </div>
+
     <div>
       <label class="control-label">
         <input

--- a/web-ui/src/main/resources/catalog/templates/admin/harvest/type/simpleurl.js
+++ b/web-ui/src/main/resources/catalog/templates/admin/harvest/type/simpleurl.js
@@ -22,6 +22,7 @@ var gnHarvestersimpleurl = {
         "apiKey" : "",
         "loopElement" : "",
         "numberOfRecordPath": "",
+        "urlCrawlerPath": "",
         "pageSizeParam": "",
         "pageFromParam": "",
         "recordIdPath": "",
@@ -94,6 +95,7 @@ var gnHarvestersimpleurl = {
       + '    <loopElement>' + h.site.loopElement + '</loopElement>'
       + '    <numberOfRecordPath>' + h.site.numberOfRecordPath + '</numberOfRecordPath>'
       + '    <recordIdPath>' + h.site.recordIdPath + '</recordIdPath>'
+      + '    <urlCrawlerPath>' + h.site.urlCrawlerPath + '</urlCrawlerPath>'
       + '    <pageFromParam>' + h.site.pageFromParam + '</pageFromParam>'
       + '    <pageSizeParam>' + h.site.pageSizeParam + '</pageSizeParam>'
       + '    <toISOConversion>' + h.site.toISOConversion + '</toISOConversion>'

--- a/web/src/main/webapp/xsl/xml/harvesting/simpleurl.xsl
+++ b/web/src/main/webapp/xsl/xml/harvesting/simpleurl.xsl
@@ -25,6 +25,9 @@
     <recordIdPath>
       <xsl:value-of select="recordIdPath/value"/>
     </recordIdPath>
+    <urlCrawlerPath>
+      <xsl:value-of select="urlCrawlerPath/value"/>
+    </urlCrawlerPath>
     <pageSizeParam>
       <xsl:value-of select="pageSizeParam/value"/>
     </pageSizeParam>


### PR DESCRIPTION
Convert an OGC API Process description into an ISO19115-3 record.

The goal is to be able to browse and search for processes in the catalogue.

<img width="804" height="409" alt="image" src="https://github.com/user-attachments/assets/bd5c75f2-db08-44e3-a7fa-7459d3f65d9a" />



eg. https://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/heat1advanced?f=json

## Harvesting

Harvester configuration for testing:

<img width="487" height="959" alt="image" src="https://github.com/user-attachments/assets/08ab86ab-cdfa-481a-8e3d-b69bafa89ed2" />


```json
{"@id":"335539320","@type":"simpleurl","owner":["1"],"ownerGroup":["4"],"ownerUser":["undefined"],"site":{"name":"OOGCAPIProcesses","uuid":"93f377b5-6e8e-45ed-bada-1d3fb3ed8bb8","account":{"use":false,"username":[],"password":[]},"url":"https://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/barplot-trend-results?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/check-names?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/clean-catchment-geometry?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/combine-eurostat-data?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/corine-stats-real-areas-europe?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/corine-stats-real-areas-finland?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/filter-clip-clean-extent?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/heat1?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/heat1advanced?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/heat2?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/heat2advanced?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/heat3?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/heat3advanced?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/heat4?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/heat4advanced?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/heat5?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/heat5advanced?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/hello-world?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/malta-groundwater?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/map-shapefile-points?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/map-trends-static?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/match-data?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/mean-by-group?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/mitgcm-prep?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/mitgcm-resultplot?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/mitgcm-run-model?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/multidetect-and-clean?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/netcdf-assessment-area?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/netcdf-extract-fb-data?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/netcdf-join-dataframes?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/netcdf-logger-extract?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/netcdf-scatter-datax-vs-datay?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/netcdf-scatter-plot?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/netcdf-tile-plot?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/owt-classification?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/peri-conv?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/points-att-polygon?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/pred-extract?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/process-create-visualizations?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/process-dasymetric-refinement?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/process-interpolate-lau?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/process-interpolate-subbasins?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/retrieve-biodiversity-data?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/riverload-plot?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/riverload?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/syke-corine-stats-real-areas?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/tordera-gloria-connection?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/tordera-gloria?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/trend-analysis-mk?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/ts-selection-interpolation?f=json\nhttps://aquainfra.ogc.igb-berlin.de/pygeoapi/processes/weighting-functions?f=json","icon":"blank.png","loopElement":".","numberOfRecordPath":"/total_count","recordIdPath":"/id","pageSizeParam":"limit","pageFromParam":"offset","toISOConversion":"schema:iso19115-3.2018:convert/fromOGCAPIProcesses"},"content":{"validate":"NOVALIDATION","importxslt":"none","batchEdits":"[]","translateContent":false,"translateContentLangs":"","translateContentFields":[]},"options":{"every":"0 0 0 ? * *","oneRunOnly":false,"overrideUuid":"SKIP","status":"active"},"privileges":[{"@id":"1","operation":[{"@name":"view"},{"@name":"dynamic"},{"@name":"download"}]}],"ifRecordExistAppendPrivileges":false,"info":{"lastRun":"2026-05-20T08:20:22.338085Z","running":false,"result":{"added":"50","atomicDatasetRecords":"0","badFormat":"0","collectionDatasetRecords":"0","datasetUuidExist":"0","privilegesAppendedOnExistingRecord":"0","doesNotValidate":"0","xpathFilterExcluded":"0","duplicatedResource":"0","fragmentsMatched":"0","fragmentsReturned":"0","fragmentsUnknownSchema":"0","incompatible":"0","recordsBuilt":"0","recordsUpdated":"0","removed":"0","serviceRecords":"0","subtemplatesAdded":"0","subtemplatesRemoved":"0","subtemplatesUpdated":"0","total":"51","unchanged":"0","unknownSchema":"0","unretrievable":"0","updated":"1","thumbnails":"0","thumbnailsFailed":"0"}}}
```

## Process details

Main information and links

<img width="744" height="797" alt="image" src="https://github.com/user-attachments/assets/a42ad7a1-a2d1-4a30-b6c3-d0982a9a0042" />


Inputs and outputs described in data model

<img width="939" height="763" alt="image" src="https://github.com/user-attachments/assets/813bcfe6-0120-445c-a5a7-9fc086733f54" />






<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

