### PR TITLE
GN4 harvester / ignore unknown fields when deserializing sources and groups

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/v4/client/GeoNetwork4ApiClient.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/v4/client/GeoNetwork4ApiClient.java
@@ -26,6 +26,7 @@ package org.fao.geonet.kernel.harvest.harvester.geonet.v4.client;
 import javax.annotation.Nullable;
 import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.google.common.base.Function;
@@ -99,6 +100,7 @@ public class GeoNetwork4ApiClient {
         String sourcesJson = retrieveUrl(addUrlSlash(serverUrl) + "api/sources", user, password);
 
         ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         List<Source> sourceList
             = objectMapper.readValue(sourcesJson, new TypeReference<>() { });
 
@@ -122,6 +124,7 @@ public class GeoNetwork4ApiClient {
         String groupsJson = retrieveUrl(addUrlSlash(serverUrl) + "api/groups", user, password);
 
         ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
         return objectMapper.readValue(groupsJson, new TypeReference<>() { });
     }
 

--- a/harvesters/src/test/java/org/fao/geonet/kernel/harvest/harvester/geonet/v4/client/GeoNetworkApiClientTest.java
+++ b/harvesters/src/test/java/org/fao/geonet/kernel/harvest/harvester/geonet/v4/client/GeoNetworkApiClientTest.java
@@ -26,8 +26,10 @@ package org.fao.geonet.kernel.harvest.harvester.geonet.v4.client;
 import com.fasterxml.jackson.core.Version;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.module.SimpleModule;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -35,6 +37,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
+import org.apache.http.client.methods.HttpUriRequest;
 import org.fao.geonet.domain.Group;
 import org.fao.geonet.domain.Source;
 import org.fao.geonet.exceptions.BadParameterEx;
@@ -42,10 +45,16 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.http.client.ClientHttpResponse;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 /**
@@ -270,5 +279,35 @@ public class GeoNetworkApiClientTest {
         } catch (URISyntaxException | IOException ex) {
             fail("Error retrieving sources");
         }
+    }
+
+    @Test
+    public void testRetrieveSourcesIgnoresUnknownFields() throws URISyntaxException, IOException {
+        String sourcesJson = "[{\"uuid\":\"abc-123\",\"name\":\"test-source\",\"datahubEnabled\":true,\"futureUnknownField\":\"value\"}]";
+
+        GeoNetwork4ApiClient client = spy(new GeoNetwork4ApiClient());
+        ClientHttpResponse mockResponse = mock(ClientHttpResponse.class);
+        doReturn(new ByteArrayInputStream(sourcesJson.getBytes(StandardCharsets.UTF_8))).when(mockResponse).getBody();
+        doReturn(mockResponse).when(client).doExecute(any(HttpUriRequest.class), anyString(), anyString());
+
+        Map<String, Source> sources = client.retrieveSources("http://localhost:8080/geonetwork", "", "");
+
+        assertEquals(1, sources.size());
+        assertEquals("test-source", sources.get("abc-123").getName());
+    }
+
+    @Test
+    public void testRetrieveGroupsIgnoresUnknownFields() throws URISyntaxException, IOException {
+        String groupsJson = "[{\"id\":1,\"name\":\"test-group\",\"futureUnknownField\":\"value\"}]";
+
+        GeoNetwork4ApiClient client = spy(new GeoNetwork4ApiClient());
+        ClientHttpResponse mockResponse = mock(ClientHttpResponse.class);
+        doReturn(new ByteArrayInputStream(groupsJson.getBytes(StandardCharsets.UTF_8))).when(mockResponse).getBody();
+        doReturn(mockResponse).when(client).doExecute(any(HttpUriRequest.class), anyString(), anyString());
+
+        List<Group> groups = client.retrieveGroups("http://localhost:8080/geonetwork", "", "");
+
+        assertEquals(1, groups.size());
+        assertEquals("test-group", groups.get(0).getName());
     }
 }


### PR DESCRIPTION
## What

When harvesting a GeoNetwork 4 instance running a newer version, `/api/sources` and `/api/groups` responses may contain fields that don't exist in the local `Source`/`Group` domain classes (e.g. `datahubEnabled`). Jackson's default `ObjectMapper` fails hard on unknown properties, aborting the harvest with:

```
Unrecognized field "datahubEnabled" (class org.fao.geonet.domain.Source), not marked as ignorable
```

## Fix

Configure the `ObjectMapper` in `GeoNetwork4ApiClient.retrieveSources()` and `retrieveGroups()` with `FAIL_ON_UNKNOWN_PROPERTIES = false` so unknown fields from newer remote instances are silently ignored.

## Tests

Added two regression tests that spy on `GeoNetwork4ApiClient`, stub `doExecute()` to return a JSON payload with unknown fields, and verify the client deserializes successfully without throwing.