### PR TITLE
Use version 2.4.3 of markdown-page-generator-plugin plugin, compatible with Java 8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,6 +242,11 @@
           <version>3.3.0</version>
         </plugin>
         <plugin>
+          <groupId>com.ruleoftech</groupId>
+          <artifactId>markdown-page-generator-plugin</artifactId>
+          <version>2.4.3</version>
+        </plugin>
+        <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-antrun-plugin</artifactId>
           <version>3.0.0</version>


### PR DESCRIPTION
markdown-page-generator-plugin plugin doesn't define the version. It seems using latest version, that is not compatible with Java 8, required for GeoNetwork 4.2.x.

This causes issues with the build. See for example: https://github.com/geonetwork/core-geonetwork/actions/runs/26638638669/job/78798008533


# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [X] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

