### PR TITLE
Elasticsearch / Proxy / More robust aggregations processing

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/es/EsHTTPProxy.java
+++ b/services/src/main/java/org/fao/geonet/api/es/EsHTTPProxy.java
@@ -475,7 +475,17 @@ public class EsHTTPProxy {
 
         JsonNode queryNode = esQuery.get("query");
 
-        // If no "query", create a bool { must: match_all, filter: nodeFilter }
+
+        // Replace any "global" aggregation with a "filter" aggregation scoped to
+        // the ACL filter.
+        // Must run after nodeFilter is built, before any branch exits early via return.
+        for (String aggsKey : new String[]{"aggs", "aggregations"}) {
+            JsonNode aggsNode = esQuery.get(aggsKey);
+            if (aggsNode != null && aggsNode.isObject()) {
+                replaceGlobalAggregations((ObjectNode) aggsNode, nodeFilter);
+            }
+        }
+        // Defensive: if no "query", create a bool { must: match_all, filter: nodeFilter }
         if (queryNode == null || queryNode.isNull()
             || (queryNode.isObject() && queryNode.isEmpty())) {
             ObjectNode boolNode = objectMapper.createObjectNode();
@@ -533,6 +543,30 @@ public class EsHTTPProxy {
         ((ObjectNode) queryNode).removeAll();
         ((ObjectNode) queryNode).set("bool", objectNodeBool);
     }
+
+    private void replaceGlobalAggregations(ObjectNode aggsNode, JsonNode aclFilter) {
+        aggsNode.fields().forEachRemaining(entry -> {
+            JsonNode aggDef = entry.getValue();
+            if (!aggDef.isObject()) {
+                return;
+            }
+            ObjectNode aggDefObj = (ObjectNode) aggDef;
+            if (aggDefObj.has("global")) {
+                // "global" ignores the query scope; swap it for a filter-scoped bucket.
+                aggDefObj.remove("global");
+                aggDefObj.set("filter", aclFilter);
+            }
+            // Recurse into nested sub-aggregations.
+            for (String subKey : new String[]{"aggs", "aggregations"}) {
+                JsonNode sub = aggDefObj.get(subKey);
+                if (sub != null && sub.isObject()) {
+                    replaceGlobalAggregations((ObjectNode) sub, aclFilter);
+                }
+            }
+        });
+    }
+
+
 
     private void insertFilter(ObjectNode objectNode, JsonNode nodeFilter) {
         JsonNode filter = objectNode.get("filter");

--- a/services/src/test/java/org/fao/geonet/api/es/EsHTTPProxyTest.java
+++ b/services/src/test/java/org/fao/geonet/api/es/EsHTTPProxyTest.java
@@ -198,6 +198,37 @@ public class EsHTTPProxyTest {
         assertTrue("filter must reference *:* permission", filterNode.toString().contains("*:*"));
     }
 
+    @Test
+    public void testAddFilterToQueryReplacesGlobalAggregation() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectNode body = (ObjectNode) mapper.readTree(
+            "{\"size\":0,\"aggs\":{\"leak\":{\"global\":{},\"aggs\":{\"titles\":{\"terms\":{\"field\":\"resourceTitle.keyword\"}}}}}}");
+
+        invokeAddFilterToQuery(body, mapper);
+
+        assertAclFilterPresent(body, "global agg: query must still be injected");
+
+        JsonNode leakAgg = body.path("aggs").path("leak");
+        assertFalse("global key must be removed", leakAgg.has("global"));
+        assertNotNull("filter key must replace global", leakAgg.get("filter"));
+        assertTrue("replacement filter must reference *:* permission",
+            leakAgg.get("filter").toString().contains("*:*"));
+        assertNotNull("nested sub-aggs must be preserved", leakAgg.get("aggs"));
+    }
+
+    @Test
+    public void testAddFilterToQueryReplacesGlobalAggregationUsingAggregationsKey() throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        ObjectNode body = (ObjectNode) mapper.readTree(
+            "{\"size\":0,\"aggregations\":{\"g\":{\"global\":{}}}}");
+
+        invokeAddFilterToQuery(body, mapper);
+
+        JsonNode gAgg = body.path("aggregations").path("g");
+        assertFalse("global key must be removed (aggregations key variant)", gAgg.has("global"));
+        assertNotNull("filter key must replace global (aggregations key variant)", gAgg.get("filter"));
+    }
+
     private void invokeAddFilterToQuery(ObjectNode body, ObjectMapper mapper) throws Exception {
         ServiceContext context = new ServiceContext("default", applicationContext, new HashMap<>(), null);
         UserSession userSession = spy(new UserSession());


### PR DESCRIPTION
This change includes a more robust aggregations processing in the Elasticseach proxy.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [X] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
