### PR TITLE
GeoNetwork4 harvester / fix NPE when dateStamp is absent from search response

### DIFF
--- a/common/src/main/java/org/fao/geonet/utils/Log.java
+++ b/common/src/main/java/org/fao/geonet/utils/Log.java
@@ -178,6 +178,10 @@ public final class Log {
         LogManager.getLogger(module).warn(message, e);
     }
 
+    public static void warning(String module, String message, Object... objects) {
+        LogManager.getLogger(module).warn(message, objects);
+    }
+
 
     //---------------------------------------------------------------------------
 
@@ -275,7 +279,7 @@ public final class Log {
 
             @Override
             public void warning(String message, Object... object) {
-
+                Log.warning(module, message, object);
             }
 
             public void error(String message) {

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/v4/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/v4/Harvester.java
@@ -226,7 +226,7 @@ class Harvester extends BaseGeoNetworkHarvester<GeonetParams> implements IHarves
                 malformedRecordIds.add(md.getUuid() != null ? md.getUuid() : SearchResponseDeserializer.UNKNOWN_ID);
                 HarvestError harvestError = new HarvestError(context, e);
                 harvestError.setDescription("Malformed element '"
-                    + md.toString() + "'");
+                    + md + "'");
                 harvestError
                     .setHint("It seems that there was some malformed element. Check with your administrator.");
                 this.errors.add(harvestError);
@@ -250,9 +250,8 @@ class Harvester extends BaseGeoNetworkHarvester<GeonetParams> implements IHarves
         }
 
         String ids = String.join(", ", unparseableRecordIds);
-        String message = "Skipped " + unparseableRecordIds.size()
-            + " record(s) that could not be parsed from the search response of " + params.getName()
-            + ". Document id(s): " + ids;
+        String message = String.format("Skipped %d record(s) that could not be parsed from the search response of %s. Document id(s): %s",
+            unparseableRecordIds.size(), params.getName(), ids);
         log.warning(message);
 
         HarvestError harvestError = new HarvestError(context, new Exception(message));
@@ -278,8 +277,8 @@ class Harvester extends BaseGeoNetworkHarvester<GeonetParams> implements IHarves
 
             String queryBody = s.createElasticsearchQuery();
             if (log.isDebugEnabled()) {
-                log.debug("GeoNetwork 4 harvester sending search request to "
-                    + getServerUrl() + "/api/search/records/_search\nRequest body:\n" + queryBody);
+                log.debug(String.format("GeoNetwork 4 harvester sending search request to %s/api/search/records/_search%nRequest body:%n %s",
+                    getServerUrl(), queryBody));
             }
             return geoNetworkApiClient.query(getServerUrl(), queryBody, username, password);
         } catch (Exception ex) {

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/v4/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/v4/Harvester.java
@@ -25,6 +25,7 @@ package org.fao.geonet.kernel.harvest.harvester.geonet.v4;
 
 import com.google.common.collect.Lists;
 
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -47,6 +48,7 @@ import org.fao.geonet.kernel.harvest.harvester.RecordInfo;
 import org.fao.geonet.kernel.harvest.harvester.geonet.BaseGeoNetworkHarvester;
 import org.fao.geonet.kernel.harvest.harvester.geonet.v4.client.GeoNetwork4ApiClient;
 import org.fao.geonet.kernel.harvest.harvester.geonet.v4.client.SearchResponse;
+import org.fao.geonet.kernel.harvest.harvester.geonet.v4.client.SearchResponseDeserializer;
 import org.fao.geonet.kernel.harvest.harvester.geonet.v4.client.SearchResponseHit;
 
 /**
@@ -119,6 +121,13 @@ class Harvester extends BaseGeoNetworkHarvester<GeonetParams> implements IHarves
             searches.add(Search.createEmptySearch(1, 2));
         }
 
+        // Records that could not be turned into something harvestable. They are skipped so a single
+        // bad record never aborts the whole harvest, and reported afterwards so they are not lost.
+        // unparseableRecordIds: failed while parsing the search response JSON (stage 1).
+        // malformedRecordIds: parsed but failed while building the record info (stage 2).
+        List<String> unparseableRecordIds = new ArrayList<>();
+        List<String> malformedRecordIds = new ArrayList<>();
+
         int pageSize = 30;
         for (Search s : searches) {
             if (cancelMonitor.get()) {
@@ -136,7 +145,8 @@ class Harvester extends BaseGeoNetworkHarvester<GeonetParams> implements IHarves
                     SearchResponse searchResponse = doSearch(s);
                     resultCount = searchResponse.getTotal();
 
-                    records.addAll(processSearchResult(searchResponse.getHits()));
+                    records.addAll(processSearchResult(searchResponse.getHits(), malformedRecordIds));
+                    unparseableRecordIds.addAll(searchResponse.getFailedHits());
                 } catch (Exception t) {
                     error = true;
                     log.error("Unknown error trying to harvest");
@@ -151,13 +161,23 @@ class Harvester extends BaseGeoNetworkHarvester<GeonetParams> implements IHarves
                     errors.add(new HarvestError(context, t));
                 }
 
+                // Always advance the page cursor, even when some hits were skipped, so that the loop
+                // terminates once the remote total (resultCount) has been paged through.
                 from = from + pageSize;
                 s.setRange(from, pageSize);
 
             }
         }
 
+        // Report skipped records (logged in the harvester log and added to the harvester history).
+        reportSkippedRecords(unparseableRecordIds);
+        int badRecords = unparseableRecordIds.size() + malformedRecordIds.size();
+
         log.info("Total records processed from this search :" + records.size());
+        if (badRecords > 0) {
+            log.warning("Skipped " + badRecords
+                + " record(s) that could not be harvested from " + params.getName() + ".");
+        }
 
         //--- align local node
         HarvestResult result = new HarvestResult();
@@ -180,10 +200,14 @@ class Harvester extends BaseGeoNetworkHarvester<GeonetParams> implements IHarves
             log.warning("Due to previous errors the align process has not been called");
         }
 
+        // Account for the records skipped while parsing the search response or building the record
+        // info so the harvest report totals reconcile (they are surfaced under badFormat).
+        result.badFormat += badRecords;
+
         return result;
     }
 
-    private Set<RecordInfo> processSearchResult(Set<SearchResponseHit> searchHits) {
+    private Set<RecordInfo> processSearchResult(Set<SearchResponseHit> searchHits, List<String> malformedRecordIds) {
         Set<RecordInfo> records = new HashSet<>(searchHits.size());
 
         for (SearchResponseHit md : searchHits) {
@@ -199,6 +223,7 @@ class Harvester extends BaseGeoNetworkHarvester<GeonetParams> implements IHarves
                 records.add(new RecordInfo(uuid, changeDate, schema, source));
 
             } catch (Exception e) {
+                malformedRecordIds.add(md.getUuid() != null ? md.getUuid() : SearchResponseDeserializer.UNKNOWN_ID);
                 HarvestError harvestError = new HarvestError(context, e);
                 harvestError.setDescription("Malformed element '"
                     + md.toString() + "'");
@@ -209,6 +234,32 @@ class Harvester extends BaseGeoNetworkHarvester<GeonetParams> implements IHarves
 
         }
         return records;
+    }
+
+    /**
+     * Reports the records that could not be parsed from the search response. A summary is written to
+     * the harvester log and a {@link HarvestError} is added to the harvester history so the skipped
+     * documents are visible to the administrator instead of being silently dropped.
+     *
+     * @param unparseableRecordIds the identifiers (or {@code "unknown"} when not extractable) of the
+     *                             records skipped while parsing the search response
+     */
+    private void reportSkippedRecords(List<String> unparseableRecordIds) {
+        if (unparseableRecordIds.isEmpty()) {
+            return;
+        }
+
+        String ids = String.join(", ", unparseableRecordIds);
+        String message = "Skipped " + unparseableRecordIds.size()
+            + " record(s) that could not be parsed from the search response of " + params.getName()
+            + ". Document id(s): " + ids;
+        log.warning(message);
+
+        HarvestError harvestError = new HarvestError(context, new Exception(message));
+        harvestError.setDescription(message);
+        harvestError.setHint("These records were skipped so the harvest could continue. "
+            + "Check the identified records on the remote catalog.");
+        this.errors.add(harvestError);
     }
 
 
@@ -226,6 +277,10 @@ class Harvester extends BaseGeoNetworkHarvester<GeonetParams> implements IHarves
             }
 
             String queryBody = s.createElasticsearchQuery();
+            if (log.isDebugEnabled()) {
+                log.debug("GeoNetwork 4 harvester sending search request to "
+                    + getServerUrl() + "/api/search/records/_search\nRequest body:\n" + queryBody);
+            }
             return geoNetworkApiClient.query(getServerUrl(), queryBody, username, password);
         } catch (Exception ex) {
             log.error(ex.getMessage(), ex);

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/v4/Harvester.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/v4/Harvester.java
@@ -103,7 +103,7 @@ class Harvester extends BaseGeoNetworkHarvester<GeonetParams> implements IHarves
 
         //--- retrieve info on categories and groups
 
-        log.info("Retrieving information from : " + params.host);
+        log.info("Retrieving information from : {}", params.host);
 
         String serverUrl = getServerUrl();
         Map<String, Source> sources = geoNetworkApiClient.retrieveSources(serverUrl, username, password);
@@ -133,12 +133,12 @@ class Harvester extends BaseGeoNetworkHarvester<GeonetParams> implements IHarves
             if (cancelMonitor.get()) {
                 return new HarvestResult();
             }
-            log.info(String.format("Processing search with these parameters %s", s.toString()));
+            log.info("Processing search with these parameters {}", s);
             int from = 0;
             s.setRange(from, pageSize);
 
             long resultCount = Integer.MAX_VALUE;
-            log.info("Searching on : " + params.getName());
+            log.info("Searching on : {}", params.getName());
 
             while (from < resultCount && !error) {
                 try {
@@ -173,10 +173,9 @@ class Harvester extends BaseGeoNetworkHarvester<GeonetParams> implements IHarves
         reportSkippedRecords(unparseableRecordIds);
         int badRecords = unparseableRecordIds.size() + malformedRecordIds.size();
 
-        log.info("Total records processed from this search :" + records.size());
+        log.info("Total records processed from this search : {}", records.size());
         if (badRecords > 0) {
-            log.warning("Skipped " + badRecords
-                + " record(s) that could not be harvested from " + params.getName() + ".");
+            log.warning("Skipped {} record(s) that could not be harvested from {}.", badRecords, params.getName());
         }
 
         //--- align local node
@@ -277,8 +276,7 @@ class Harvester extends BaseGeoNetworkHarvester<GeonetParams> implements IHarves
 
             String queryBody = s.createElasticsearchQuery();
             if (log.isDebugEnabled()) {
-                log.debug(String.format("GeoNetwork 4 harvester sending search request to %s/api/search/records/_search%nRequest body:%n %s",
-                    getServerUrl(), queryBody));
+                log.debug("GeoNetwork 4 harvester sending search request to {}/api/search/records/_search\nRequest body:\n{}", getServerUrl(), queryBody);
             }
             return geoNetworkApiClient.query(getServerUrl(), queryBody, username, password);
         } catch (Exception ex) {

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/v4/client/SearchResponse.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/v4/client/SearchResponse.java
@@ -23,6 +23,8 @@
 
 package org.fao.geonet.kernel.harvest.harvester.geonet.v4.client;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -33,16 +35,30 @@ import java.util.Set;
 public class SearchResponse {
     private final long total;
     private final Set<SearchResponseHit> hits;
+    private final List<String> failedHits;
 
     /**
-     * Constructs a new SearchResponse instance.
+     * Constructs a new SearchResponse instance with no failed hits.
      *
      * @param total the total number of search hits returned
      * @param hits  a set of individual search result hits
      */
     public SearchResponse(long total, Set<SearchResponseHit> hits) {
+        this(total, hits, Collections.<String>emptyList());
+    }
+
+    /**
+     * Constructs a new SearchResponse instance.
+     *
+     * @param total      the total number of search hits returned
+     * @param hits       a set of individual search result hits that could be parsed
+     * @param failedHits the identifiers (or {@code "unknown"} when not extractable) of the hits that
+     *                   could not be parsed and were skipped
+     */
+    public SearchResponse(long total, Set<SearchResponseHit> hits, List<String> failedHits) {
         this.total = total;
         this.hits = hits;
+        this.failedHits = failedHits;
     }
 
     public long getTotal() {
@@ -51,5 +67,15 @@ public class SearchResponse {
 
     public Set<SearchResponseHit> getHits() {
         return hits;
+    }
+
+    /**
+     * Returns the identifiers of the hits that could not be parsed from the search response and were
+     * therefore skipped. The list is empty when every hit was parsed successfully.
+     *
+     * @return the list of skipped hit identifiers (never {@code null})
+     */
+    public List<String> getFailedHits() {
+        return failedHits;
     }
 }

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/v4/client/SearchResponseDeserializer.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/v4/client/SearchResponseDeserializer.java
@@ -93,9 +93,10 @@ public class SearchResponseDeserializer extends StdDeserializer<SearchResponse> 
         Set<SearchResponseHit> searchResponseHits = new HashSet<>();
         node.get(HITS).get(HITS).forEach(hitNode -> {
             String uuid = hitNode.get(ID).asText();
-            String schema = hitNode.get(SOURCE).get(DOCUMENT_STANDARD).asText();
-            String changeDate = hitNode.get(SOURCE).get(DATE_STAMP).asText();
-            String source = hitNode.get(SOURCE).get(SOURCE_CATALOGUE).asText();
+            String schema = hitNode.path(SOURCE).path(DOCUMENT_STANDARD).asText();
+            // null signals RecordInfo to set dateWasNull=true and always harvest the record
+            String changeDate = hitNode.path(SOURCE).path(DATE_STAMP).asText(null);
+            String source = hitNode.path(SOURCE).path(SOURCE_CATALOGUE).asText();
             SearchResponseHit searchResponseHit = new SearchResponseHit(uuid, schema, changeDate, source);
             searchResponseHits.add(searchResponseHit);
         });

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/v4/client/SearchResponseDeserializer.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/v4/client/SearchResponseDeserializer.java
@@ -29,8 +29,13 @@ import com.fasterxml.jackson.databind.DeserializationContext;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
+import org.apache.commons.lang.StringUtils;
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.utils.Log;
 
 /**
  * A custom deserializer for parsing JSON responses into instances of {@link SearchResponse}.
@@ -74,6 +79,7 @@ public class SearchResponseDeserializer extends StdDeserializer<SearchResponse> 
     public static final String DATE_STAMP = "dateStamp";
     public static final String SOURCE_CATALOGUE = "sourceCatalogue";
     public static final String ID = "_id";
+    public static final String UNKNOWN_ID = "unknown";
 
     public SearchResponseDeserializer() {
         this(null);
@@ -91,16 +97,31 @@ public class SearchResponseDeserializer extends StdDeserializer<SearchResponse> 
         long total = node.get(HITS).get(TOTAL).get(VALUE).asLong();
 
         Set<SearchResponseHit> searchResponseHits = new HashSet<>();
+        List<String> failedHits = new ArrayList<>();
         node.get(HITS).get(HITS).forEach(hitNode -> {
-            String uuid = hitNode.get(ID).asText();
-            String schema = hitNode.path(SOURCE).path(DOCUMENT_STANDARD).asText();
-            // null signals RecordInfo to set dateWasNull=true and always harvest the record
-            String changeDate = hitNode.path(SOURCE).path(DATE_STAMP).asText(null);
-            String source = hitNode.path(SOURCE).path(SOURCE_CATALOGUE).asText();
-            SearchResponseHit searchResponseHit = new SearchResponseHit(uuid, schema, changeDate, source);
-            searchResponseHits.add(searchResponseHit);
+            // Parse each hit defensively so a single malformed record does not abort the whole page
+            // (and therefore the whole harvest). Failures are collected and reported by the harvester.
+            String uuid = hitNode.path(ID).asText(null);
+            try {
+                if (StringUtils.isBlank(uuid)) {
+                    // Without a uuid the record cannot be harvested, treat it as a failed hit.
+                    Log.warning(Geonet.HARVESTER,
+                        "Skipping search hit without a usable '" + ID + "': " + hitNode);
+                    failedHits.add(UNKNOWN_ID);
+                    return;
+                }
+                String schema = hitNode.path(SOURCE).path(DOCUMENT_STANDARD).asText();
+                // null signals RecordInfo to set dateWasNull=true and always harvest the record
+                String changeDate = hitNode.path(SOURCE).path(DATE_STAMP).asText(null);
+                String source = hitNode.path(SOURCE).path(SOURCE_CATALOGUE).asText();
+                searchResponseHits.add(new SearchResponseHit(uuid, schema, changeDate, source));
+            } catch (Exception e) {
+                Log.warning(Geonet.HARVESTER,
+                    "Skipping malformed search hit with " + ID + " '" + uuid + "': " + e.getMessage(), e);
+                failedHits.add(StringUtils.isBlank(uuid) ? UNKNOWN_ID : uuid);
+            }
         });
 
-        return new SearchResponse(total, searchResponseHits);
+        return new SearchResponse(total, searchResponseHits, failedHits);
     }
 }

--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/v4/client/SearchResponseHit.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/geonet/v4/client/SearchResponseHit.java
@@ -65,4 +65,12 @@ public class SearchResponseHit {
         this.changeDate = changeDate;
         this.source = source;
     }
+
+    @Override
+    public String toString() {
+        return "uuid=" + uuid
+            + ", schema=" + schema
+            + ", changeDate=" + changeDate
+            + ", source=" + source;
+    }
 }

--- a/harvesters/src/test/java/org/fao/geonet/kernel/harvest/harvester/geonet/v4/client/SearchResponseDeserializerTest.java
+++ b/harvesters/src/test/java/org/fao/geonet/kernel/harvest/harvester/geonet/v4/client/SearchResponseDeserializerTest.java
@@ -1,0 +1,163 @@
+//=============================================================================
+//===	Copyright (C) 2001-2026 Food and Agriculture Organization of the
+//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
+//===	and United Nations Environment Programme (UNEP)
+//===
+//===	This program is free software; you can redistribute it and/or modify
+//===	it under the terms of the GNU General Public License as published by
+//===	the Free Software Foundation; either version 2 of the License, or (at
+//===	your option) any later version.
+//===
+//===	This program is distributed in the hope that it will be useful, but
+//===	WITHOUT ANY WARRANTY; without even the implied warranty of
+//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//===	General Public License for more details.
+//===
+//===	You should have received a copy of the GNU General Public License
+//===	along with this program; if not, write to the Free Software
+//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+//===
+//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+//===	Rome - Italy. email: geonetwork@osgeo.org
+//==============================================================================
+
+package org.fao.geonet.kernel.harvest.harvester.geonet.v4.client;
+
+import com.fasterxml.jackson.core.Version;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+import java.io.IOException;
+import java.util.UUID;
+import org.junit.Before;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class SearchResponseDeserializerTest {
+
+    private ObjectMapper mapper;
+
+    @Before
+    public void setUp() {
+        mapper = new ObjectMapper();
+        SimpleModule module = new SimpleModule(
+            "SearchResponseDeserializer", new Version(1, 0, 0, null, null, null));
+        module.addDeserializer(SearchResponse.class, new SearchResponseDeserializer());
+        mapper.registerModule(module);
+    }
+
+    @Test
+    public void deserialize_fullRecord() throws IOException {
+        String uuid = UUID.randomUUID().toString();
+        String catalogueUuid = UUID.randomUUID().toString();
+        String json = "{\n" +
+            "  \"hits\": {\n" +
+            "    \"total\": {\"value\": 1},\n" +
+            "    \"hits\": [{\n" +
+            "      \"_id\": \"" + uuid + "\",\n" +
+            "      \"_source\": {\n" +
+            "        \"documentStandard\": \"iso19139\",\n" +
+            "        \"dateStamp\": \"2021-05-12T09:53:28.000Z\",\n" +
+            "        \"sourceCatalogue\": \"" + catalogueUuid + "\"\n" +
+            "      }\n" +
+            "    }]\n" +
+            "  }\n" +
+            "}";
+
+        SearchResponse response = mapper.readValue(json, SearchResponse.class);
+
+        assertEquals(1, response.getTotal());
+        assertEquals(1, response.getHits().size());
+
+        SearchResponseHit hit = response.getHits().iterator().next();
+        assertEquals(uuid, hit.getUuid());
+        assertEquals("iso19139", hit.getSchema());
+        assertEquals("2021-05-12T09:53:28.000Z", hit.getChangeDate());
+        assertEquals(catalogueUuid, hit.getSource());
+    }
+
+    @Test
+    public void deserialize_missingDateStamp_changeDateIsNull() throws IOException {
+        String uuid = UUID.randomUUID().toString();
+        String catalogueUuid = UUID.randomUUID().toString();
+        String json = "{\n" +
+            "  \"hits\": {\n" +
+            "    \"total\": {\"value\": 1},\n" +
+            "    \"hits\": [{\n" +
+            "      \"_id\": \"" + uuid + "\",\n" +
+            "      \"_source\": {\n" +
+            "        \"documentStandard\": \"iso19139\",\n" +
+            "        \"sourceCatalogue\": \"" + catalogueUuid + "\"\n" +
+            "      }\n" +
+            "    }]\n" +
+            "  }\n" +
+            "}";
+
+        SearchResponse response = mapper.readValue(json, SearchResponse.class);
+
+        assertEquals(1, response.getTotal());
+        SearchResponseHit hit = response.getHits().iterator().next();
+        assertEquals(uuid, hit.getUuid());
+        assertEquals("iso19139", hit.getSchema());
+        assertNull(hit.getChangeDate());
+        assertEquals(catalogueUuid, hit.getSource());
+    }
+
+    @Test
+    public void deserialize_mixedRecords_someWithoutDateStamp() throws IOException {
+        String uuidWithDate = UUID.randomUUID().toString();
+        String uuidWithoutDate = UUID.randomUUID().toString();
+        String catalogueUuid = UUID.randomUUID().toString();
+        String json = "{\n" +
+            "  \"hits\": {\n" +
+            "    \"total\": {\"value\": 2},\n" +
+            "    \"hits\": [\n" +
+            "      {\n" +
+            "        \"_id\": \"" + uuidWithDate + "\",\n" +
+            "        \"_source\": {\n" +
+            "          \"documentStandard\": \"iso19139\",\n" +
+            "          \"dateStamp\": \"2024-01-15T10:00:00.000Z\",\n" +
+            "          \"sourceCatalogue\": \"" + catalogueUuid + "\"\n" +
+            "        }\n" +
+            "      },\n" +
+            "      {\n" +
+            "        \"_id\": \"" + uuidWithoutDate + "\",\n" +
+            "        \"_source\": {\n" +
+            "          \"documentStandard\": \"iso19139\",\n" +
+            "          \"sourceCatalogue\": \"" + catalogueUuid + "\"\n" +
+            "        }\n" +
+            "      }\n" +
+            "    ]\n" +
+            "  }\n" +
+            "}";
+
+        SearchResponse response = mapper.readValue(json, SearchResponse.class);
+
+        assertEquals(2, response.getTotal());
+        assertEquals(2, response.getHits().size());
+
+        SearchResponseHit withDate = response.getHits().stream()
+            .filter(h -> h.getUuid().equals(uuidWithDate)).findFirst().orElseThrow(AssertionError::new);
+        SearchResponseHit withoutDate = response.getHits().stream()
+            .filter(h -> h.getUuid().equals(uuidWithoutDate)).findFirst().orElseThrow(AssertionError::new);
+
+        assertEquals("2024-01-15T10:00:00.000Z", withDate.getChangeDate());
+        assertNull(withoutDate.getChangeDate());
+    }
+
+    @Test
+    public void deserialize_emptyHits() throws IOException {
+        String json = "{\n" +
+            "  \"hits\": {\n" +
+            "    \"total\": {\"value\": 0},\n" +
+            "    \"hits\": []\n" +
+            "  }\n" +
+            "}";
+
+        SearchResponse response = mapper.readValue(json, SearchResponse.class);
+
+        assertEquals(0, response.getTotal());
+        assertEquals(0, response.getHits().size());
+    }
+}

--- a/harvesters/src/test/java/org/fao/geonet/kernel/harvest/harvester/geonet/v4/client/SearchResponseDeserializerTest.java
+++ b/harvesters/src/test/java/org/fao/geonet/kernel/harvest/harvester/geonet/v4/client/SearchResponseDeserializerTest.java
@@ -147,6 +147,46 @@ public class SearchResponseDeserializerTest {
     }
 
     @Test
+    public void deserialize_malformedHit_isSkippedAndReported() throws IOException {
+        String goodUuid = UUID.randomUUID().toString();
+        String catalogueUuid = UUID.randomUUID().toString();
+        // The second hit has no "_id" so it cannot be harvested: it must be skipped and reported,
+        // not abort parsing of the whole page (which previously aborted the whole harvest).
+        String json = "{\n" +
+            "  \"hits\": {\n" +
+            "    \"total\": {\"value\": 2},\n" +
+            "    \"hits\": [\n" +
+            "      {\n" +
+            "        \"_id\": \"" + goodUuid + "\",\n" +
+            "        \"_source\": {\n" +
+            "          \"documentStandard\": \"iso19139\",\n" +
+            "          \"dateStamp\": \"2024-01-15T10:00:00.000Z\",\n" +
+            "          \"sourceCatalogue\": \"" + catalogueUuid + "\"\n" +
+            "        }\n" +
+            "      },\n" +
+            "      {\n" +
+            "        \"_source\": {\n" +
+            "          \"documentStandard\": \"iso19139\",\n" +
+            "          \"sourceCatalogue\": \"" + catalogueUuid + "\"\n" +
+            "        }\n" +
+            "      }\n" +
+            "    ]\n" +
+            "  }\n" +
+            "}";
+
+        SearchResponse response = mapper.readValue(json, SearchResponse.class);
+
+        // The total still reflects the remote count, but only the parseable hit is returned.
+        assertEquals(2, response.getTotal());
+        assertEquals(1, response.getHits().size());
+        assertEquals(goodUuid, response.getHits().iterator().next().getUuid());
+
+        // The skipped hit is reported so the harvester can surface it.
+        assertEquals(1, response.getFailedHits().size());
+        assertEquals(SearchResponseDeserializer.UNKNOWN_ID, response.getFailedHits().get(0));
+    }
+
+    @Test
     public void deserialize_emptyHits() throws IOException {
         String json = "{\n" +
             "  \"hits\": {\n" +


### PR DESCRIPTION
## Summary

Makes the GeoNetwork 4 harvester resilient to bad records and adds request-body logging for troubleshooting.

### Fix NPE when `dateStamp` is absent

- `SearchResponseDeserializer` called `hitNode.get("_source").get("dateStamp").asText()`, which throws `NullPointerException` when `dateStamp` is absent from `_source`.
- Some remote catalogs contain records whose `gmd:dateStamp` holds an invalid value (e.g. `--`); the iso19139 indexer rejects it and never emits the field.
- Uses Jackson's `path()` instead of `get()` for `_source` sub-fields, and `asText(null)` for `dateStamp` so `RecordInfo` receives `null`, triggers its `dateWasNull` fallback, and always harvests the record.

### Make record handling resilient

- The deserializer parsed every hit eagerly, so a single unparseable hit (for example one missing `_id`) aborted the whole page. That put the harvest in an error state and skipped alignment of every other record.
- Each hit is now parsed defensively: `_id` is read with `path(...).asText(null)`, a blank uuid or any per-hit error is treated as a failed hit, and parsing continues with the remaining hits.
- Skipped records are reported in the harvester log and history (as a `HarvestError`) and counted under `badFormat`, so the result totals reconcile and nothing is silently dropped.
- The pagination cursor still advances unconditionally, so the loop always terminates; and a skipped record no longer puts the harvest in an error state, so alignment runs as usual.

### Log the search request body at DEBUG

- The harvester logs the Elasticsearch search request URL and body at DEBUG level, mirroring what the CSW harvester already does, to ease troubleshooting.

## Test plan

- [x] New unit tests in `SearchResponseDeserializerTest` cover: full record, missing `dateStamp`, mixed records (some with / without), empty result set, and a response mixing a valid hit with an unparseable one
- [x] All v4 harvester unit tests pass (`mvn -pl harvesters test -Dtest='...geonet.v4.**'`)

