### PR TITLE
Fix Dublin Core keywords indexing error

### DIFF
--- a/schemas/dublin-core/src/main/plugin/dublin-core/index-fields/index.xsl
+++ b/schemas/dublin-core/src/main/plugin/dublin-core/index-fields/index.xsl
@@ -186,9 +186,7 @@
               <xsl:for-each select="$keywords">
                 <keyword>
                   <values>
-                    <value>
-                      "default": <xsl:value-of select="concat($doubleQuote, util:escapeForJson(.), $doubleQuote)"/>
-                    </value>
+                    <value><xsl:value-of select="concat($doubleQuote, 'default', $doubleQuote, ':' , $doubleQuote, util:escapeForJson(.), $doubleQuote)"/></value>
                   </values>
                 </keyword>
               </xsl:for-each>


### PR DESCRIPTION
Error:

```
Error on line 406 of index-utils.xsl:
  XPTY0004: A sequence of more than one item is not allowed as the first argument of
  normalize-space() (""defaul...", ""Antarctic ecosystem"")
2026-06-10T11:27:02,449 ERROR [geonetwork.index] - Indexing stylesheet contains errors: A sequence of more than one item is not allowed as the first argument of normalize-space() (""defaul...", ""Antarctic ecosystem"")
  Marking the metadata as _indexingError=1 in index
```

Related to https://github.com/geonetwork/core-geonetwork/pull/8994

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation