### PR TITLE
Fix PT_FreeText handling in eu-geodcat-ap-semiceu/view.xsl

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/eu-geodcat-ap-semiceu/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/eu-geodcat-ap-semiceu/view.xsl
@@ -201,7 +201,7 @@
   <xsl:param name="locale-preferred-lang">eng</xsl:param>
 
   <xsl:variable name="locale-preferred-id"
-                select="//gmd:PT_Locale[gmd:languageCode/gmd:LanguageCode/@codeListValue = $locale-preferred-lang]/@id"/>
+                select="root(.)//gmd:PT_Locale[*[self::gmd:languageCode|self::gmd:language]/gmd:LanguageCode/@codeListValue = $locale-preferred-lang]/@id"/>
 
 
   <!-- Parameter $include-deprecated -->
@@ -1048,8 +1048,13 @@
       </dct:conformsTo>
       <!-- Metadata language -->
       <xsl:if test="$ormlang != ''">
+        <xsl:variable name="ormlang-alpha3">
+          <xsl:call-template name="NormalizeLanguageToAlpha3">
+            <xsl:with-param name="lang" select="$ormlang"/>
+          </xsl:call-template>
+        </xsl:variable>
         <dct:language>
-          <dct:LinguisticSystem rdf:about="{concat($oplang,translate($ormlang,$lowercase,$uppercase))}"/>
+          <dct:LinguisticSystem rdf:about="{concat($oplang,translate($ormlang-alpha3,$lowercase,$uppercase))}"/>
         </dct:language>
       </xsl:if>
       <!-- Metadata date -->
@@ -1268,8 +1273,13 @@
         <xsl:choose>
           <xsl:when test="$orrlang[1]">
             <xsl:for-each select="$orrlang">
+            <xsl:variable name="orrlang-item-alpha3">
+              <xsl:call-template name="NormalizeLanguageToAlpha3">
+                <xsl:with-param name="lang" select="."/>
+              </xsl:call-template>
+            </xsl:variable>
             <dct:language>
-                <dct:LinguisticSystem rdf:about="{concat($oplang,translate(.,$lowercase,$uppercase))}"/>
+                <dct:LinguisticSystem rdf:about="{concat($oplang,translate($orrlang-item-alpha3,$lowercase,$uppercase))}"/>
             </dct:language>
             </xsl:for-each>
           </xsl:when>
@@ -1400,7 +1410,7 @@
           <xsl:variable name="Title">
             <xsl:for-each select="gmd:name">
               <dct:title xml:lang="{$MetadataLanguage}">
-                <xsl:value-of select="normalize-space(gco:CharacterString)"/>
+                <xsl:value-of select="normalize-space(*[self::gco:CharacterString|self::gmx:Anchor])"/>
               </dct:title>
               <xsl:call-template name="LocalisedString">
                 <xsl:with-param name="term">dct:title</xsl:with-param>
@@ -1411,7 +1421,7 @@
           <xsl:variable name="Description">
             <xsl:for-each select="gmd:description">
               <dct:description xml:lang="{$MetadataLanguage}">
-                <xsl:value-of select="*"/>
+                <xsl:value-of select="normalize-space(*[self::gco:CharacterString|self::gmx:Anchor])"/>
               </dct:description>
               <xsl:call-template name="LocalisedString">
                 <xsl:with-param name="term">dct:description</xsl:with-param>
@@ -2810,6 +2820,40 @@
     </xsl:choose>
   </xsl:template>
 
+  <!-- Normalize a language value to its ISO 639-2/B alpha-3 code.
+       Source records sometimes use the full language name (e.g. "Dansk",
+       "Danish") in gmd:LanguageCode instead of the standard alpha-3 code
+       ("dan"), which is a data quality issue but one that this template
+       defends against so that emitted dct:language URIs remain valid
+       Publications Office NAL identifiers rather than malformed ones like
+       ".../language/DANSK". The input is assumed to already be lowercased. -->
+  <xsl:template name="NormalizeLanguageToAlpha3">
+    <xsl:param name="lang"/>
+    <xsl:choose>
+      <xsl:when test="$lang = 'dansk' or $lang = 'danish'">
+        <xsl:text>dan</xsl:text>
+      </xsl:when>
+      <xsl:when test="$lang = 'engelsk' or $lang = 'english'">
+        <xsl:text>eng</xsl:text>
+      </xsl:when>
+      <xsl:when test="$lang = 'tysk' or $lang = 'german' or $lang = 'deutsch'">
+        <xsl:text>ger</xsl:text>
+      </xsl:when>
+      <xsl:when test="$lang = 'svensk' or $lang = 'swedish'">
+        <xsl:text>swe</xsl:text>
+      </xsl:when>
+      <xsl:when test="$lang = 'norsk' or $lang = 'norwegian'">
+        <xsl:text>nor</xsl:text>
+      </xsl:when>
+      <xsl:when test="$lang = 'fransk' or $lang = 'french'">
+        <xsl:text>fre</xsl:text>
+      </xsl:when>
+      <xsl:otherwise>
+        <xsl:value-of select="$lang"/>
+      </xsl:otherwise>
+    </xsl:choose>
+  </xsl:template>
+
   <!-- Constraints related to access and use -->
 
   <xsl:template mode="iso19139-to-dcatap" name="ConstraintsRelatedToAccessAndUse" match="gmd:identificationInfo[1]/*/gmd:resourceConstraints/*">
@@ -4182,15 +4226,40 @@
 
   <xsl:template name="LocalisedString">
     <xsl:param name="term"/>
+    <xsl:variable name="primaryValue" select="normalize-space(*[self::gco:CharacterString|self::gmx:Anchor])"/>
     <xsl:for-each select="gmd:PT_FreeText/*/gmd:LocalisedCharacterString">
       <xsl:variable name="value" select="normalize-space(.)"/>
-      <xsl:if test="$value != ''">
+      <xsl:if test="$value != '' and not($primaryValue != '' and $value = $primaryValue)">
         <xsl:variable name="locale-id" select="substring-after(@locale, '#')"/>
-        <xsl:variable name="lang-alpha3" select="//gmd:PT_Locale[@id = $locale-id]/gmd:languageCode/gmd:LanguageCode/@codeListValue"/>
+        <xsl:variable name="lang-alpha3" select="root(.)//gmd:PT_Locale[@id = $locale-id]/*[self::gmd:languageCode|self::gmd:language]/gmd:LanguageCode/@codeListValue"/>
+        <xsl:variable name="lang-alpha2-from-lookup">
+          <xsl:if test="$lang-alpha3 != ''">
+            <xsl:call-template name="Alpha3-to-Alpha2">
+                <xsl:with-param name="lang" select="$lang-alpha3"/>
+            </xsl:call-template>
+          </xsl:if>
+        </xsl:variable>
+        <!-- Fallback: if the PT_Locale lookup fails to resolve a language (e.g. because
+             gmd:otherLocale/gmd:defaultLocale does not define a PT_Locale for this
+             locale-id, which happens when GeoNetwork's ISO 19115-3 to ISO 19139
+             conversion drops the defaultLocale), fall back to using locale-id itself.
+             The locale-id (taken from @locale="#XX") is in practice almost always
+             already a valid ISO 639-1 alpha-2 code (e.g. "DA", "EN"), so lowercasing
+             it directly is a reasonable last resort. -->
         <xsl:variable name="lang-alpha2">
-          <xsl:call-template name="Alpha3-to-Alpha2">
-              <xsl:with-param name="lang" select="$lang-alpha3"/>
-          </xsl:call-template>
+          <xsl:choose>
+            <xsl:when test="$lang-alpha2-from-lookup != ''">
+              <xsl:value-of select="$lang-alpha2-from-lookup"/>
+            </xsl:when>
+            <xsl:when test="string-length($locale-id) = 2">
+              <xsl:value-of select="translate($locale-id,$uppercase,$lowercase)"/>
+            </xsl:when>
+            <xsl:otherwise>
+              <xsl:call-template name="Alpha3-to-Alpha2">
+                <xsl:with-param name="lang" select="translate($locale-id,$uppercase,$lowercase)"/>
+              </xsl:call-template>
+            </xsl:otherwise>
+          </xsl:choose>
         </xsl:variable>
         <xsl:element name="{$term}">
           <xsl:attribute name="xml:lang"><xsl:value-of select="$lang-alpha2"/></xsl:attribute>

--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/eu-geodcat-ap-semiceu/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/eu-geodcat-ap-semiceu/view.xsl
@@ -84,7 +84,7 @@
         xmlns:xlink  = "http://www.w3.org/1999/xlink"
         xmlns:xsi    = "http://www.w3.org/2001/XMLSchema-instance"
         xmlns:xsl    = "http://www.w3.org/1999/XSL/Transform"
-        xmlns:xs="http://www.w3.org/2001/XMLSchema"
+												   
         exclude-result-prefixes="earl gco gmd gml gmx i i-gp srv xlink xsi xsl wdrs"
         version="2.0">
 
@@ -454,7 +454,7 @@
                               gmd:identifier/*"/>
 
       <xsl:variable name="uriIdentifiers"
-                    as="node()*">
+>
         <xsl:for-each select="$identifiers">
           <xsl:variable name="rURI"
                         select="if (gmd:codeSpace)
@@ -1353,7 +1353,7 @@
           <xsl:variable name="Title">
             <xsl:for-each select="gmd:name">
               <dct:title xml:lang="{$MetadataLanguage}">
-                <xsl:value-of select="normalize-space(*)"/>
+                <xsl:value-of select="normalize-space(*[self::gco:CharacterString|self::gmx:Anchor])"/>
               </dct:title>
               <xsl:call-template name="LocalisedString">
                 <xsl:with-param name="term">dct:title</xsl:with-param>
@@ -1364,7 +1364,7 @@
           <xsl:variable name="Description">
             <xsl:for-each select="gmd:description">
               <dct:description xml:lang="{$MetadataLanguage}">
-                <xsl:value-of select="normalize-space(*)"/>
+                <xsl:value-of select="normalize-space(*[self::gco:CharacterString|self::gmx:Anchor])"/>
               </dct:description>
               <xsl:call-template name="LocalisedString">
                 <xsl:with-param name="term">dct:description</xsl:with-param>
@@ -1387,10 +1387,10 @@
 
           <xsl:variable name="TitleOrDescriptionOrPlaceholder">
             <xsl:choose>
-              <xsl:when test="normalize-space(gmd:name/*) != ''">
-                <xsl:value-of select="normalize-space(gmd:name/*)"/>
+              <xsl:when test="normalize-space(gmd:name/*[self::gco:CharacterString|self::gmx:Anchor]) != ''">
+                <xsl:value-of select="normalize-space(gmd:name/*[self::gco:CharacterString|self::gmx:Anchor])"/>
               </xsl:when>
-              <xsl:when test="normalize-space(gmd:description/*) != ''">
+              <xsl:when test="normalize-space(gmd:description/*[self::gco:CharacterString|self::gmx:Anchor]) != ''">
                 <xsl:value-of select="normalize-space(gmd:description)"/>
               </xsl:when>
               <xsl:otherwise>
@@ -1633,7 +1633,7 @@
     </xsl:param>
 
     <xsl:param name="IndividualName">
-      <xsl:value-of select="normalize-space(gmd:individualName/*)"/>
+      <xsl:value-of select="normalize-space(gmd:individualName/*[self::gco:CharacterString|self::gmx:Anchor])"/>
     </xsl:param>
 
     <xsl:param name="IndividualName-FOAF">
@@ -1700,13 +1700,13 @@
     </xsl:param>
 
     <xsl:param name="Email">
-      <xsl:for-each select="gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:electronicMailAddress/*[normalize-space() != '']">
+      <xsl:for-each select="gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:electronicMailAddress/gco:CharacterString[normalize-space() != '']">
         <foaf:mbox rdf:resource="mailto:{normalize-space(.)}"/>
       </xsl:for-each>
     </xsl:param>
 
     <xsl:param name="Email-vCard">
-      <xsl:for-each select="gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:electronicMailAddress/*[normalize-space() != '']">
+      <xsl:for-each select="gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address/gmd:electronicMailAddress/gco:CharacterString[normalize-space() != '']">
         <vcard:hasEmail rdf:resource="mailto:{normalize-space(.)}"/>
       </xsl:for-each>
     </xsl:param>
@@ -4010,7 +4010,7 @@
       </xsl:when>
       <xsl:otherwise>
         <xsl:choose>
-          <xsl:when test="$code castable as xs:double and $code = number($code) and (translate($codespace,$uppercase,$lowercase) = 'epsg' or starts-with(translate($codespace,$uppercase,$lowercase),translate($EpsgSrsBaseUrn,$uppercase,$lowercase)))">
+          <xsl:when test="number($code) = number($code) and (translate($codespace,$uppercase,$lowercase) = 'epsg' or starts-with(translate($codespace,$uppercase,$lowercase),translate($EpsgSrsBaseUrn,$uppercase,$lowercase)))">
             <geodcatap:referenceSystem>
               <rdf:Description rdf:about="{$EpsgSrsBaseUri}/{$code}">
                 <rdf:type rdf:resource="{$dct}Standard"/>
@@ -4109,6 +4109,7 @@
 
   <xsl:template name="LocalisedString">
     <xsl:param name="term"/>
+    <xsl:variable name="primaryValue" select="normalize-space(*[self::gco:CharacterString|self::gmx:Anchor])"/>
     <xsl:for-each select="gmd:PT_FreeText/*/gmd:LocalisedCharacterString">
       <xsl:variable name="value" select="normalize-space(.)"/>
       <xsl:variable name="langs">
@@ -4116,7 +4117,7 @@
           <xsl:with-param name="lang" select="translate(translate(@locale, $uppercase, $lowercase), '#', '')"/>
         </xsl:call-template>
       </xsl:variable>
-      <xsl:if test="$value != ''">
+      <xsl:if test="$value != '' and not($primaryValue != '' and $value = $primaryValue)">
         <xsl:element name="{$term}">
           <xsl:attribute name="xml:lang"><xsl:value-of select="$langs"/></xsl:attribute>
           <xsl:value-of select="$value"/>

--- a/schemas/iso19139/src/main/plugin/iso19139/formatter/eu-geodcat-ap-semiceu/view.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/formatter/eu-geodcat-ap-semiceu/view.xsl
@@ -52,41 +52,42 @@
 -->
 
 <xsl:transform
-        xmlns:adms   = "http://www.w3.org/ns/adms#"
-        xmlns:cnt    = "http://www.w3.org/2011/content#"
-        xmlns:dc     = "http://purl.org/dc/elements/1.1/"
-        xmlns:dcat   = "http://www.w3.org/ns/dcat#"
-        xmlns:dct    = "http://purl.org/dc/terms/"
-        xmlns:dctype = "http://purl.org/dc/dcmitype/"
-        xmlns:dqv    = "http://www.w3.org/ns/dqv#"
-        xmlns:earl   = "http://www.w3.org/ns/earl#"
-        xmlns:foaf   = "http://xmlns.com/foaf/0.1/"
-        xmlns:gco    = "http://www.isotc211.org/2005/gco"
-        xmlns:geodcatap = "http://data.europa.eu/930/"
-        xmlns:gmd    = "http://www.isotc211.org/2005/gmd"
-        xmlns:gml    = "http://www.opengis.net/gml"
-        xmlns:gmx    = "http://www.isotc211.org/2005/gmx"
-        xmlns:gsp    = "http://www.opengis.net/ont/geosparql#"
-        xmlns:i      = "http://inspire.ec.europa.eu/schemas/common/1.0"
-        xmlns:i-gp   = "http://inspire.ec.europa.eu/schemas/geoportal/1.0"
-        xmlns:locn   = "http://www.w3.org/ns/locn#"
-        xmlns:owl    = "http://www.w3.org/2002/07/owl#"
-        xmlns:org    = "http://www.w3.org/ns/org#"
-        xmlns:prov   = "http://www.w3.org/ns/prov#"
-        xmlns:rdf    = "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-        xmlns:rdfs   = "http://www.w3.org/2000/01/rdf-schema#"
-        xmlns:schema = "http://schema.org/"
-        xmlns:sdmx-attribute = "http://purl.org/linked-data/sdmx/2009/attribute#"
-        xmlns:skos   = "http://www.w3.org/2004/02/skos/core#"
-        xmlns:srv    = "http://www.isotc211.org/2005/srv"
-        xmlns:vcard  = "http://www.w3.org/2006/vcard/ns#"
-        xmlns:wdrs   = "http://www.w3.org/2007/05/powder-s#"
-        xmlns:xlink  = "http://www.w3.org/1999/xlink"
-        xmlns:xsi    = "http://www.w3.org/2001/XMLSchema-instance"
-        xmlns:xsl    = "http://www.w3.org/1999/XSL/Transform"
-												   
-        exclude-result-prefixes="earl gco gmd gml gmx i i-gp srv xlink xsi xsl wdrs"
-        version="2.0">
+  xmlns:adms   = "http://www.w3.org/ns/adms#"
+  xmlns:cnt    = "http://www.w3.org/2011/content#"
+  xmlns:dc     = "http://purl.org/dc/elements/1.1/"
+  xmlns:dcat   = "http://www.w3.org/ns/dcat#"
+  xmlns:dcatap = "http://data.europa.eu/r5r/"
+  xmlns:dct    = "http://purl.org/dc/terms/"
+  xmlns:dctype = "http://purl.org/dc/dcmitype/"
+  xmlns:dqv    = "http://www.w3.org/ns/dqv#"
+  xmlns:earl   = "http://www.w3.org/ns/earl#"
+  xmlns:foaf   = "http://xmlns.com/foaf/0.1/"
+  xmlns:gco    = "http://www.isotc211.org/2005/gco"
+  xmlns:geodcatap = "http://data.europa.eu/930/"
+  xmlns:gmd    = "http://www.isotc211.org/2005/gmd"
+  xmlns:gml    = "http://www.opengis.net/gml"
+  xmlns:gmx    = "http://www.isotc211.org/2005/gmx"
+  xmlns:gsp    = "http://www.opengis.net/ont/geosparql#"
+  xmlns:i      = "http://inspire.ec.europa.eu/schemas/common/1.0"
+  xmlns:i-gp   = "http://inspire.ec.europa.eu/schemas/geoportal/1.0"
+  xmlns:locn   = "http://www.w3.org/ns/locn#"
+  xmlns:owl    = "http://www.w3.org/2002/07/owl#"
+  xmlns:org    = "http://www.w3.org/ns/org#"
+  xmlns:prov   = "http://www.w3.org/ns/prov#"
+  xmlns:rdf    = "http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+  xmlns:rdfs   = "http://www.w3.org/2000/01/rdf-schema#"
+  xmlns:schema = "http://schema.org/"
+  xmlns:sdmx-attribute = "http://purl.org/linked-data/sdmx/2009/attribute#"
+  xmlns:skos   = "http://www.w3.org/2004/02/skos/core#"
+  xmlns:srv    = "http://www.isotc211.org/2005/srv"
+  xmlns:vcard  = "http://www.w3.org/2006/vcard/ns#"
+  xmlns:wdrs   = "http://www.w3.org/2007/05/powder-s#"
+  xmlns:xlink  = "http://www.w3.org/1999/xlink"
+  xmlns:xs     = "http://www.w3.org/2001/XMLSchema"
+  xmlns:xsi    = "http://www.w3.org/2001/XMLSchema-instance"
+  xmlns:xsl    = "http://www.w3.org/1999/XSL/Transform"
+  exclude-result-prefixes="#all"
+  version="2.0">
 
   <xsl:output method="xml"
               indent="yes"
@@ -190,12 +191,24 @@
     </xsl:choose>
   </xsl:variable>
 
+
+<!-- Parameter $locale-preferred-lang -->
+<!--
+  This parameter specifies the preferred language for localized text.
+  Must be a valid gmd:locale//gmd:LanguageCode/@codeListValue, or empty.
+-->
+
+  <xsl:param name="locale-preferred-lang">eng</xsl:param>
+
+  <xsl:variable name="locale-preferred-id"
+                select="//gmd:PT_Locale[gmd:languageCode/gmd:LanguageCode/@codeListValue = $locale-preferred-lang]/@id"/>
+
+
   <!-- Parameter $include-deprecated -->
   <!--
     This parameter specifies whether deprecated mappings must ("yes") or must not
     ("no") be included in the output.
   -->
-
   <!-- Uncomment to include deprecated mappings from the output -->
 
   <xsl:param name="include-deprecated">yes</xsl:param>
@@ -409,6 +422,27 @@
 
   <!--
 
+    Helper Functions
+    ================
+
+  -->
+
+  <!--
+    Function to extract text content from ISO 19139 multilingual elements.
+    Handles three patterns:
+    1. gmx:Anchor - returns the text content
+    2. gco:CharacterString - returns the text content
+    3. gmd:PT_FreeText with LocalisedCharacterStrings - returns preferred localized text if available, otherwise first available
+  -->
+
+  <!--
+    Function to normalize a decimal number represented as string.
+    Makes sure the normalized output can be parsed as decimal while preserving input precision.
+    See https://github.com/SEMICeu/iso-19139-to-dcat-ap/issues/112 for context.
+  -->
+
+<!--
+
     Master template
     ===============
 
@@ -453,8 +487,7 @@
                     select="gmd:identificationInfo/*/gmd:citation/*/
                               gmd:identifier/*"/>
 
-      <xsl:variable name="uriIdentifiers"
->
+      <xsl:variable name="uriIdentifiers">
         <xsl:for-each select="$identifiers">
           <xsl:variable name="rURI"
                         select="if (gmd:codeSpace)
@@ -590,17 +623,22 @@
     </xsl:param>
 
     <!-- Resource language: corresponding Alpha-2 codes -->
-
     <xsl:param name="orrlang">
       <xsl:choose>
-        <xsl:when test="gmd:identificationInfo/*/gmd:language/gmd:LanguageCode/@codeListValue != ''">
-          <xsl:value-of select="translate(gmd:identificationInfo/*/gmd:language/gmd:LanguageCode/@codeListValue,$uppercase,$lowercase)"/>
+        <xsl:when test="gmd:identificationInfo/*/gmd:language[1]/gmd:LanguageCode/@codeListValue">
+          <xsl:for-each select="gmd:identificationInfo/*/gmd:language/gmd:LanguageCode/@codeListValue">
+            <xsl:value-of select="translate(.,$uppercase,$lowercase)"/>
+          </xsl:for-each>
         </xsl:when>
-        <xsl:when test="gmd:identificationInfo/*/gmd:language/gmd:LanguageCode != ''">
-          <xsl:value-of select="translate(gmd:identificationInfo/*/gmd:language/gmd:LanguageCode,$uppercase,$lowercase)"/>
+        <xsl:when test="gmd:identificationInfo/*/gmd:language[1]/gmd:LanguageCode">
+          <xsl:for-each select="gmd:identificationInfo/*/gmd:language/gmd:LanguageCode">
+            <xsl:value-of select="translate(.,$uppercase,$lowercase)"/>
+          </xsl:for-each>
         </xsl:when>
-        <xsl:when test="gmd:identificationInfo/*/gmd:language/gco:CharacterString != ''">
-          <xsl:value-of select="translate(gmd:identificationInfo/*/gmd:language/gco:CharacterString,$uppercase,$lowercase)"/>
+        <xsl:when test="gmd:identificationInfo/*/gmd:language[1]/gco:CharacterString">
+          <xsl:for-each select="gmd:identificationInfo/*/gmd:language/gco:CharacterString">
+            <xsl:value-of select="translate(.,$uppercase,$lowercase)"/>
+          </xsl:for-each>
         </xsl:when>
       </xsl:choose>
     </xsl:param>
@@ -705,7 +743,9 @@
         </xsl:otherwise>
       </xsl:choose>
     </xsl:param>
-
+    <xsl:param name="ServiceCategory">
+      <xsl:value-of select="gmd:identificationInfo/*/gmd:descriptiveKeywords/gmd:MD_Keywords/gmd:keyword/gmx:Anchor[starts-with(@xlink:href, $SpatialDataServiceCategoryCodelistUri)]/@xlink:href"/>
+    </xsl:param>
     <xsl:param name="ServiceType">
       <xsl:value-of select="gmd:identificationInfo/*/srv:serviceType/gco:LocalName"/>
     </xsl:param>
@@ -732,10 +772,21 @@
     <xsl:param name="ResourceAbstract">
       <xsl:for-each select="gmd:identificationInfo[1]/*/gmd:abstract">
         <dct:description xml:lang="{$MetadataLanguage}">
-          <xsl:value-of select="normalize-space(gco:CharacterString)"/>
+          <xsl:value-of select="gco:CharacterString"/>
         </dct:description>
         <xsl:call-template name="LocalisedString">
           <xsl:with-param name="term">dct:description</xsl:with-param>
+        </xsl:call-template>
+      </xsl:for-each>
+    </xsl:param>
+
+    <xsl:param name="ResourcePurpose">
+      <xsl:for-each select="gmd:identificationInfo[1]/*/gmd:purpose">
+        <geodcatap:purpose xml:lang="{$MetadataLanguage}">
+          <xsl:value-of select="normalize-space(gco:CharacterString)"/>
+        </geodcatap:purpose>
+        <xsl:call-template name="LocalisedString">
+          <xsl:with-param name="term">geodcatap:purpose</xsl:with-param>
         </xsl:call-template>
       </xsl:for-each>
     </xsl:param>
@@ -748,7 +799,7 @@
       <xsl:for-each select="gmd:dataQualityInfo/*/gmd:lineage/*/gmd:statement">
         <dct:provenance>
           <dct:ProvenanceStatement>
-            <dct:description xml:lang="{$MetadataLanguage}"><xsl:value-of select="normalize-space(gco:CharacterString)"/></dct:description>
+            <dct:description xml:lang="{$MetadataLanguage}"><xsl:value-of select="gco:CharacterString"/></dct:description>
             <xsl:call-template name="LocalisedString">
               <xsl:with-param name="term">dct:description</xsl:with-param>
             </xsl:call-template>
@@ -771,19 +822,6 @@
       </xsl:choose>
     </xsl:param>
 
-    <xsl:param name="UniqueResourceIdentifier">
-      <xsl:for-each select="gmd:identificationInfo[1]/*/gmd:citation/*/gmd:identifier/*">
-        <xsl:choose>
-          <xsl:when test="gmd:codeSpace/gco:CharacterString/text() != ''">
-            <xsl:value-of select="concat(gmd:codeSpace/gco:CharacterString/text(),gmd:code/gco:CharacterString/text())"/>
-          </xsl:when>
-          <xsl:otherwise>
-            <xsl:value-of select="gmd:code/gco:CharacterString/text()"/>
-          </xsl:otherwise>
-        </xsl:choose>
-      </xsl:for-each>
-    </xsl:param>
-
     <xsl:param name="ConstraintsRelatedToAccessAndUse">
       <xsl:apply-templates mode="iso19139-to-dcatap"
                            select="gmd:identificationInfo[1]/*/gmd:resourceConstraints/*">
@@ -799,7 +837,7 @@
               <dct:title xml:lang="{$MetadataLanguage}">
                 <xsl:value-of select="gmd:title/gco:CharacterString"/>
               </dct:title>
-              <xsl:apply-templates select="gmd:date/gmd:CI_Date"/>
+              <xsl:apply-templates mode="iso19139-to-dcatap" select="gmd:date/gmd:CI_Date"/>
             </xsl:variable>
             <xsl:variable name="degree">
               <xsl:choose>
@@ -902,7 +940,7 @@
         <xsl:variable name="explanation">
           <xsl:for-each select="../../gmd:explanation">
             <dct:description xml:lang="{$MetadataLanguage}">
-              <xsl:value-of select="normalize-space(gco:CharacterString)"/>
+              <xsl:value-of select="gco:CharacterString"/>
             </dct:description>
             <xsl:call-template name="LocalisedString">
               <xsl:with-param name="term">dct:description</xsl:with-param>
@@ -1035,7 +1073,8 @@
           </xsl:apply-templates>
         </xsl:for-each>
         <!-- Old version
-                <xsl:apply-templates select="gmd:contact/gmd:CI_ResponsibleParty">
+                <xsl:apply-templates mode="iso19139-to-dcatap"
+                select="gmd:contact/gmd:CI_ResponsibleParty">
                   <xsl:with-param name="MetadataLanguage" select="$MetadataLanguage"/>
                 </xsl:apply-templates>
         -->
@@ -1183,59 +1222,56 @@
       -->
       <xsl:copy-of select="$ResourceTitle"/>
       <!--
-            <dct:description xml:lang="{$MetadataLanguage}">
-              <xsl:value-of select="normalize-space($ResourceAbstract)"/>
-            </dct:description>
+      <dct:description xml:lang="{$MetadataLanguage}">
+        <xsl:value-of select="$ResourceAbstract"/>
+      </dct:description>
       -->
       <xsl:copy-of select="$ResourceAbstract"/>
+      <xsl:copy-of select="$ResourcePurpose"/>
       <!-- Maintenance information (tentative) -->
       <xsl:for-each select="gmd:identificationInfo/*/gmd:resourceMaintenance">
-        <xsl:apply-templates mode="iso19139-to-dcatap"
-                             select="gmd:MD_MaintenanceInformation/gmd:maintenanceAndUpdateFrequency/gmd:MD_MaintenanceFrequencyCode"/>
+        <xsl:apply-templates mode="iso19139-to-dcatap" select="gmd:MD_MaintenanceInformation/gmd:maintenanceAndUpdateFrequency/gmd:MD_MaintenanceFrequencyCode"/>
       </xsl:for-each>
       <!-- Topic category -->
       <xsl:if test="$profile = $extended">
-        <xsl:apply-templates mode="iso19139-to-dcatap"
-                             select="gmd:identificationInfo/*/gmd:topicCategory">
+        <xsl:apply-templates mode="iso19139-to-dcatap" select="gmd:identificationInfo/*/gmd:topicCategory">
           <xsl:with-param name="MetadataLanguage" select="$MetadataLanguage"/>
         </xsl:apply-templates>
       </xsl:if>
       <!-- Keyword -->
-      <xsl:apply-templates mode="iso19139-to-dcatap"
-                           select="gmd:identificationInfo/*/gmd:descriptiveKeywords/gmd:MD_Keywords">
+      <xsl:apply-templates mode="iso19139-to-dcatap" select="gmd:identificationInfo/*/gmd:descriptiveKeywords/gmd:MD_Keywords">
         <xsl:with-param name="MetadataLanguage" select="$MetadataLanguage"/>
         <xsl:with-param name="ResourceType" select="$ResourceType"/>
-        <xsl:with-param name="ServiceType" select="$ServiceType"/>
       </xsl:apply-templates>
       <!-- Identifier, 0..1 -->
       <!--
-            <xsl:apply-templates select="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:identifier/*">
+            <xsl:apply-templates mode="iso19139-to-dcatap" select="gmd:identificationInfo/gmd:MD_DataIdentification/gmd:citation/gmd:CI_Citation/gmd:identifier/*">
               <xsl:with-param name="MetadataLanguage" select="$MetadataLanguage"/>
             </xsl:apply-templates>
       -->
       <!-- Resource locators -->
       <!--
-            <xsl:apply-templates select="gmd:distributionInfo/*/gmd:transferOptions/*/gmd:onLine/*/gmd:linkage">
+            <xsl:apply-templates mode="iso19139-to-dcatap" select="gmd:distributionInfo/*/gmd:transferOptions/*/gmd:onLine/*/gmd:linkage">
               <xsl:with-param name="ResourceType" select="$ResourceType"/>
               <xsl:with-param name="MetadataLanguage" select="$MetadataLanguage"/>
             </xsl:apply-templates>
       -->
       <!-- Unique Resource Identifier -->
-      <xsl:apply-templates mode="iso19139-to-dcatap"
-                           select="gmd:identificationInfo/*/gmd:citation/*/gmd:identifier/*"/>
+      <xsl:apply-templates mode="iso19139-to-dcatap" select="gmd:identificationInfo/*/gmd:citation/*/gmd:identifier/*"/>
       <!-- Coupled resources -->
-      <xsl:apply-templates mode="iso19139-to-dcatap"
-                           select="gmd:identificationInfo[1]/*/srv:operatesOn">
+      <xsl:apply-templates mode="iso19139-to-dcatap" select="gmd:identificationInfo[1]/*/srv:operatesOn">
         <xsl:with-param name="ResourceType" select="$ResourceType"/>
         <xsl:with-param name="MetadataLanguage" select="$MetadataLanguage"/>
       </xsl:apply-templates>
       <!-- Resource Language -->
       <xsl:if test="$ResourceType = 'dataset' or $ResourceType = 'series'">
         <xsl:choose>
-          <xsl:when test="$orrlang != ''">
+          <xsl:when test="$orrlang[1]">
+            <xsl:for-each select="$orrlang">
             <dct:language>
-              <dct:LinguisticSystem rdf:about="{concat($oplang,translate($orrlang,$lowercase,$uppercase))}"/>
+                <dct:LinguisticSystem rdf:about="{concat($oplang,translate(.,$lowercase,$uppercase))}"/>
             </dct:language>
+            </xsl:for-each>
           </xsl:when>
           <xsl:otherwise>
             <!-- To be decided (when the resource language is not specified, it defaults to the metadata language): -->
@@ -1255,33 +1291,33 @@
       <xsl:if test="$ResourceType = 'service'">
         <!-- Replaced by param $ServiceType -->
         <!--
-                <xsl:apply-templates select="gmd:identificationInfo/*/srv:serviceType">
+                <xsl:apply-templates mode="iso19139-to-dcatap" select="gmd:identificationInfo/*/srv:serviceType">
                   <xsl:with-param name="MetadataLanguage" select="$MetadataLanguage"/>
                 </xsl:apply-templates>
         -->
+        <xsl:if test="$ServiceCategory != ''">
+           <geodcatap:serviceCategory rdf:resource="{$ServiceCategory}"/>
+        </xsl:if>
         <geodcatap:serviceType rdf:resource="{$SpatialDataServiceTypeCodelistUri}/{$ServiceType}"/>
       </xsl:if>
       <!-- Spatial extent -->
       <!--
-            <xsl:apply-templates select="gmd:identificationInfo[1]/*/*[self::gmd:extent|self::srv:extent]/*/gmd:geographicElement/gmd:EX_GeographicBoundingBox"/>
+            <xsl:apply-templates mode="iso19139-to-dcatap" select="gmd:identificationInfo[1]/*/*[self::gmd:extent|self::srv:extent]/*/gmd:geographicElement/gmd:EX_GeographicBoundingBox"/>
       -->
-      <xsl:apply-templates mode="iso19139-to-dcatap"
-                           select="gmd:identificationInfo[1]/*/*[self::gmd:extent|self::srv:extent]/*/gmd:geographicElement">
+      <xsl:apply-templates mode="iso19139-to-dcatap" select="gmd:identificationInfo[1]/*/*[self::gmd:extent|self::srv:extent]/*/gmd:geographicElement">
         <xsl:with-param name="MetadataLanguage" select="$MetadataLanguage"/>
       </xsl:apply-templates>
       <!-- Temporal extent -->
-      <xsl:apply-templates mode="iso19139-to-dcatap"
-                           select="gmd:identificationInfo/*/gmd:extent/gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent"/>
+      <xsl:apply-templates mode="iso19139-to-dcatap" select="gmd:identificationInfo/*/gmd:extent/gmd:EX_Extent/gmd:temporalElement/gmd:EX_TemporalExtent"/>
       <!-- Creation date, publication date, date of last revision -->
-      <xsl:apply-templates mode="iso19139-to-dcatap"
-                           select="gmd:identificationInfo/*/gmd:citation/gmd:CI_Citation"/>
+      <xsl:apply-templates mode="iso19139-to-dcatap" select="gmd:identificationInfo/*/gmd:citation/gmd:CI_Citation"/>
       <!-- Lineage -->
       <xsl:if test="$ResourceType != 'service' and $Lineage != ''">
         <!--
                 <dct:provenance>
                   <dct:ProvenanceStatement>
                     <rdfs:label xml:lang="{$MetadataLanguage}">
-                      <xsl:value-of select="normalize-space($Lineage)"/>
+                      <xsl:value-of select="$Lineage"/>
                     </rdfs:label>
                   </dct:ProvenanceStatement>
                 </dct:provenance>
@@ -1293,8 +1329,7 @@
       <!--
             <xsl:if test="$profile = $extended">
       -->
-      <xsl:apply-templates mode="iso19139-to-dcatap"
-                           select="gmd:referenceSystemInfo/gmd:MD_ReferenceSystem/gmd:referenceSystemIdentifier/gmd:RS_Identifier">
+      <xsl:apply-templates mode="iso19139-to-dcatap" select="gmd:referenceSystemInfo/gmd:MD_ReferenceSystem/gmd:referenceSystemIdentifier/gmd:RS_Identifier">
         <xsl:with-param name="MetadataLanguage" select="$MetadataLanguage"/>
       </xsl:apply-templates>
       <!--
@@ -1305,8 +1340,7 @@
       <!--
             <xsl:if test="$profile = $extended">
       -->
-      <xsl:apply-templates mode="iso19139-to-dcatap"
-                           select="gmd:identificationInfo/*/gmd:spatialResolution/gmd:MD_Resolution"/>
+      <xsl:apply-templates mode="iso19139-to-dcatap" select="gmd:identificationInfo/*/gmd:spatialResolution/gmd:MD_Resolution"/>
       <!--
             </xsl:if>
       -->
@@ -1320,8 +1354,7 @@
       </xsl:if>
 
       <!-- Conformity -->
-      <xsl:apply-templates mode="iso19139-to-dcatap"
-                           select="gmd:dataQualityInfo/*/gmd:report/*/gmd:result/*/gmd:specification/gmd:CI_Citation">
+      <xsl:apply-templates mode="iso19139-to-dcatap" select="gmd:dataQualityInfo/*/gmd:report/*/gmd:result/*/gmd:specification/gmd:CI_Citation">
         <xsl:with-param name="ResourceUri" select="$ResourceUri"/>
         <xsl:with-param name="MetadataLanguage" select="$MetadataLanguage"/>
         <xsl:with-param name="Conformity" select="$Conformity"/>
@@ -1329,18 +1362,32 @@
 
       <!-- Spatial representation type -->
       <xsl:variable name="SpatialRepresentationType">
-        <xsl:apply-templates mode="iso19139-to-dcatap"
-                             select="gmd:identificationInfo/*/gmd:spatialRepresentationType/gmd:MD_SpatialRepresentationTypeCode"/>
+        <xsl:apply-templates mode="iso19139-to-dcatap" select="gmd:identificationInfo/*/gmd:spatialRepresentationType/gmd:MD_SpatialRepresentationTypeCode"/>
       </xsl:variable>
 
       <xsl:for-each select="gmd:distributionInfo/gmd:MD_Distribution">
         <!-- Encoding -->
-        <xsl:variable name="Encoding">
-          <xsl:apply-templates mode="iso19139-to-dcatap"
-                               select="gmd:distributionFormat/gmd:MD_Format/gmd:name/*"/>
+        <xsl:variable name="DistributionFormat">
+          <xsl:apply-templates mode="iso19139-to-dcatap" select="gmd:distributionFormat/gmd:MD_Format/gmd:name/*"/>
         </xsl:variable>
-        <!-- Resource locators (access / download URLs) -->
-        <xsl:for-each select="gmd:transferOptions/*/gmd:onLine/*">
+<!-- Resource locators (access / download URLs) -->
+        <xsl:for-each select="(gmd:transferOptions | gmd:distributor/gmd:MD_Distributor/gmd:distributorTransferOptions)/*/gmd:onLine/*">
+
+          <xsl:variable name="DistributorFormat">
+            <xsl:if test="../../../../gmd:distributorFormat">
+              <xsl:apply-templates mode="iso19139-to-dcatap" select="../../../../gmd:distributorFormat/gmd:MD_Format/gmd:name/*"/>
+            </xsl:if>
+          </xsl:variable>
+          <xsl:variable name="Encoding">
+            <xsl:choose>
+              <xsl:when test="$DistributorFormat != ''">
+                <xsl:copy-of select="$DistributorFormat"/>
+              </xsl:when>
+              <xsl:otherwise>
+                <xsl:copy-of select="$DistributionFormat"/>
+              </xsl:otherwise>
+            </xsl:choose>
+          </xsl:variable>
 
           <xsl:variable name="url" select="gmd:linkage/gmd:URL"/>
 
@@ -1353,7 +1400,7 @@
           <xsl:variable name="Title">
             <xsl:for-each select="gmd:name">
               <dct:title xml:lang="{$MetadataLanguage}">
-                <xsl:value-of select="normalize-space(*[self::gco:CharacterString|self::gmx:Anchor])"/>
+                <xsl:value-of select="normalize-space(gco:CharacterString)"/>
               </dct:title>
               <xsl:call-template name="LocalisedString">
                 <xsl:with-param name="term">dct:title</xsl:with-param>
@@ -1364,7 +1411,7 @@
           <xsl:variable name="Description">
             <xsl:for-each select="gmd:description">
               <dct:description xml:lang="{$MetadataLanguage}">
-                <xsl:value-of select="normalize-space(*[self::gco:CharacterString|self::gmx:Anchor])"/>
+                <xsl:value-of select="*"/>
               </dct:description>
               <xsl:call-template name="LocalisedString">
                 <xsl:with-param name="term">dct:description</xsl:with-param>
@@ -1396,6 +1443,14 @@
               <xsl:otherwise>
                 <xsl:text>N/A</xsl:text>
               </xsl:otherwise>
+            </xsl:choose>
+          </xsl:variable>
+
+          <xsl:variable name="FileSize">
+            <xsl:choose>
+              <xsl:when test="../../gmd:transferSize/gco:Real != ''">
+                <dcat:byteSize rdf:datatype="{$xsd}nonNegativeInteger"><xsl:value-of select="format-number(round(../../gmd:transferSize/gco:Real * 1000000), '#')"/></dcat:byteSize>
+              </xsl:when>
             </xsl:choose>
           </xsl:variable>
 
@@ -1467,6 +1522,8 @@
                       <xsl:if test="$profile = $extended">
                         <xsl:copy-of select="$SpatialRepresentationType"/>
                       </xsl:if>
+<!-- File size -->
+                      <xsl:copy-of select="$FileSize"/>
                       <!-- Encoding -->
                       <xsl:copy-of select="$Encoding"/>
                       <!-- Resource character encoding -->
@@ -1503,14 +1560,13 @@
       </xsl:for-each>
       <!-- Responsible organisation -->
       <xsl:for-each select="gmd:identificationInfo/*/gmd:pointOfContact">
-        <xsl:apply-templates mode="iso19139-to-dcatap"
-                             select="gmd:CI_ResponsibleParty">
+        <xsl:apply-templates mode="iso19139-to-dcatap" select="gmd:CI_ResponsibleParty">
           <xsl:with-param name="MetadataLanguage" select="$MetadataLanguage"/>
           <xsl:with-param name="ResourceType" select="$ResourceType"/>
         </xsl:apply-templates>
       </xsl:for-each>
       <!--
-            <xsl:apply-templates select="gmd:identificationInfo/*/gmd:pointOfContact/gmd:CI_ResponsibleParty">
+            <xsl:apply-templates mode="iso19139-to-dcatap" select="gmd:identificationInfo/*/gmd:pointOfContact/gmd:CI_ResponsibleParty">
               <xsl:with-param name="MetadataLanguage" select="$MetadataLanguage"/>
               <xsl:with-param name="ResourceType" select="$ResourceType"/>
             </xsl:apply-templates>
@@ -1582,8 +1638,14 @@
     <xsl:param name="code">
       <xsl:value-of select="gmd:code/gco:CharacterString"/>
     </xsl:param>
+    <xsl:param name="anchor">
+      <xsl:value-of select="gmd:code/gmx:Anchor"/>
+    </xsl:param>
     <xsl:param name="id">
       <xsl:choose>
+        <xsl:when test="$anchor != ''">
+          <xsl:value-of select="$anchor"/>
+        </xsl:when>
         <xsl:when test="$ns != ''">
           <xsl:choose>
             <xsl:when test="substring($ns,string-length($ns),1) = '/'">
@@ -1614,7 +1676,7 @@
 
   <!-- Responsible Organisation -->
   <!--
-    <xsl:template name="ResponsibleOrganisation" match="gmd:identificationInfo/*/gmd:pointOfContact/gmd:CI_ResponsibleParty">
+    <xsl:template mode="iso19139-to-dcatap" name="ResponsibleOrganisation" match="gmd:identificationInfo/*/gmd:pointOfContact/gmd:CI_ResponsibleParty">
   -->
   <xsl:template mode="iso19139-to-dcatap" name="ResponsibleOrganisation" match="gmd:CI_ResponsibleParty">
     <xsl:param name="MetadataLanguage"/>
@@ -1638,7 +1700,7 @@
 
     <xsl:param name="IndividualName-FOAF">
       <xsl:for-each select="gmd:individualName">
-        <foaf:name xml:lang="{$MetadataLanguage}"><xsl:value-of select="normalize-space(*[self::gco:CharacterString|gmx:Anchor])"/></foaf:name>
+        <foaf:name xml:lang="{$MetadataLanguage}"><xsl:value-of select="normalize-space(*[self::gco:CharacterString|self::gmx:Anchor])"/></foaf:name>
         <xsl:call-template name="LocalisedString">
           <xsl:with-param name="term">foaf:name</xsl:with-param>
         </xsl:call-template>
@@ -1647,7 +1709,7 @@
 
     <xsl:param name="IndividualName-vCard">
       <xsl:for-each select="gmd:individualName">
-        <vcard:fn xml:lang="{$MetadataLanguage}"><xsl:value-of select="normalize-space(*[self::gco:CharacterString|gmx:Anchor])"/></vcard:fn>
+        <vcard:fn xml:lang="{$MetadataLanguage}"><xsl:value-of select="normalize-space(*[self::gco:CharacterString|self::gmx:Anchor])"/></vcard:fn>
         <xsl:call-template name="LocalisedString">
           <xsl:with-param name="term">vcard:fn</xsl:with-param>
         </xsl:call-template>
@@ -1670,11 +1732,11 @@
     </xsl:param>
 
     <xsl:param name="OrganisationName">
-      <xsl:value-of select="string-join(gmd:organisationName/*[self::gco:CharacterString|gmx:Anchor], '')"/>
+      <xsl:value-of select="string-join(gmd:organisationName/*[self::gco:CharacterString|self::gmx:Anchor], '')"/>
     </xsl:param>
     <xsl:param name="OrganisationName-FOAF">
       <xsl:for-each select="gmd:organisationName">
-        <foaf:name xml:lang="{$MetadataLanguage}"><xsl:value-of select="normalize-space(*[self::gco:CharacterString|gmx:Anchor])"/></foaf:name>
+        <foaf:name xml:lang="{$MetadataLanguage}"><xsl:value-of select="normalize-space(*[self::gco:CharacterString|self::gmx:Anchor])"/></foaf:name>
         <xsl:call-template name="LocalisedString">
           <xsl:with-param name="term">foaf:name</xsl:with-param>
         </xsl:call-template>
@@ -1683,7 +1745,7 @@
 
     <xsl:param name="OrganisationName-vCard">
       <xsl:for-each select="gmd:organisationName">
-        <vcard:organization-name xml:lang="{$MetadataLanguage}"><xsl:value-of select="normalize-space(*[self::gco:CharacterString|gmx:Anchor])"/></vcard:organization-name>
+        <vcard:organization-name xml:lang="{$MetadataLanguage}"><xsl:value-of select="normalize-space(*[self::gco:CharacterString|self::gmx:Anchor])"/></vcard:organization-name>
         <xsl:call-template name="LocalisedString">
           <xsl:with-param name="term">vcard:organization-name</xsl:with-param>
         </xsl:call-template>
@@ -1692,7 +1754,7 @@
 
     <xsl:param name="OrganisationNameAsIndividualName-vCard">
       <xsl:for-each select="gmd:organisationName">
-        <vcard:fn xml:lang="{$MetadataLanguage}"><xsl:value-of select="normalize-space(*[self::gco:CharacterString|gmx:Anchor])"/></vcard:fn>
+        <vcard:fn xml:lang="{$MetadataLanguage}"><xsl:value-of select="normalize-space(*[self::gco:CharacterString|self::gmx:Anchor])"/></vcard:fn>
         <xsl:call-template name="LocalisedString">
           <xsl:with-param name="term">vcard:fn</xsl:with-param>
         </xsl:call-template>
@@ -1737,10 +1799,10 @@
     <xsl:param name="Address">
       <xsl:for-each select="gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address">
         <xsl:variable name="deliveryPoint" select="normalize-space(string-join(gmd:deliveryPoint/*, ' '))"/>
-        <xsl:variable name="city" select="normalize-space(gmd:city/*)"/>
-        <xsl:variable name="administrativeArea" select="normalize-space(gmd:administrativeArea/*)"/>
-        <xsl:variable name="postalCode" select="normalize-space(gmd:postalCode/*)"/>
-        <xsl:variable name="country" select="normalize-space(gmd:country/*)"/>
+        <xsl:variable name="city" select="normalize-space(gmd:city/*[self::gco:CharacterString|self::gmx:Anchor])"/>
+        <xsl:variable name="administrativeArea" select="normalize-space(gmd:administrativeArea/*[self::gco:CharacterString|self::gmx:Anchor])"/>
+        <xsl:variable name="postalCode" select="normalize-space(gmd:postalCode/*[self::gco:CharacterString|self::gmx:Anchor])"/>
+        <xsl:variable name="country" select="normalize-space(gmd:country/*[self::gco:CharacterString|self::gmx:Anchor])"/>
         <xsl:if test="$deliveryPoint != '' or $city != '' or $administrativeArea != '' or $postalCode != '' or $country != ''">
           <locn:address>
             <locn:Address>
@@ -1768,10 +1830,10 @@
     <xsl:param name="Address-vCard">
       <xsl:for-each select="gmd:contactInfo/gmd:CI_Contact/gmd:address/gmd:CI_Address">
         <xsl:variable name="deliveryPoint" select="normalize-space(string-join(gmd:deliveryPoint/*, ' '))"/>
-        <xsl:variable name="city" select="normalize-space(gmd:city/*)"/>
-        <xsl:variable name="administrativeArea" select="normalize-space(gmd:administrativeArea/*)"/>
-        <xsl:variable name="postalCode" select="normalize-space(gmd:postalCode/*)"/>
-        <xsl:variable name="country" select="normalize-space(gmd:country/*)"/>
+        <xsl:variable name="city" select="normalize-space(gmd:city/*[self::gco:CharacterString|self::gmx:Anchor])"/>
+        <xsl:variable name="administrativeArea" select="normalize-space(gmd:administrativeArea/*[self::gco:CharacterString|self::gmx:Anchor])"/>
+        <xsl:variable name="postalCode" select="normalize-space(gmd:postalCode/*[self::gco:CharacterString|self::gmx:Anchor])"/>
+        <xsl:variable name="country" select="normalize-space(gmd:country/*[self::gco:CharacterString|self::gmx:Anchor])"/>
         <xsl:if test="$deliveryPoint != '' or $city != '' or $administrativeArea != '' or $postalCode != '' or $country != ''">
           <vcard:hasAddress>
             <vcard:Address>
@@ -2093,7 +2155,7 @@
 
   <!-- Metadata point of contact -->
   <!--
-    <xsl:template name="MetadataPointOfContact" match="gmd:contact/gmd:CI_ResponsibleParty">
+    <xsl:template mode="iso19139-to-dcatap" name="MetadataPointOfContact" match="gmd:contact/gmd:CI_ResponsibleParty">
       <xsl:param name="MetadataLanguage"/>
       <xsl:param name="ResponsiblePartyRole">
         <xsl:value-of select="concat($ResponsiblePartyRoleCodelistUri,'/','pointOfContact')"/>
@@ -2128,7 +2190,7 @@
   -->
   <!-- Resource locator -->
   <!-- Old version, applied to the resource (not to the resource distribution)
-    <xsl:template name="ResourceLocator" match="gmd:distributionInfo/*/gmd:transferOptions/*/gmd:onLine/*/gmd:linkage">
+    <xsl:template mode="iso19139-to-dcatap" name="ResourceLocator" match="gmd:distributionInfo/*/gmd:transferOptions/*/gmd:onLine/*/gmd:linkage">
       <xsl:param name="ResourceType"/>
       <xsl:choose>
         <xsl:when test="$ResourceType = 'dataset' or $ResourceType = 'series'">
@@ -2267,7 +2329,7 @@
   <!-- Spatial data service type -->
   <!-- Replaced by param $ServiceType -->
   <!--
-    <xsl:template match="gmd:identificationInfo/*/srv:serviceType">
+    <xsl:template mode="iso19139-to-dcatap" match="gmd:identificationInfo/*/srv:serviceType">
       <dct:type rdf:resource="{$SpatialDataServiceTypeCodelistUri}/{gco:LocalName}"/>
     </xsl:template>
   -->
@@ -2298,15 +2360,14 @@
             </dct:title>
       -->
       <xsl:copy-of select="$specTitle"/>
-      <xsl:apply-templates mode="iso19139-to-dcatap"
-                           select="gmd:date/gmd:CI_Date"/>
+      <xsl:apply-templates mode="iso19139-to-dcatap" select="gmd:date/gmd:CI_Date"/>
     </xsl:variable>
     <!--
         <xsl:variable name="specinfo">
           <dct:title xml:lang="{$MetadataLanguage}">
             <xsl:value-of select="gmd:title/gco:CharacterString"/>
           </dct:title>
-          <xsl:apply-templates select="gmd:date/gmd:CI_Date"/>
+          <xsl:apply-templates mode="iso19139-to-dcatap" select="gmd:date/gmd:CI_Date"/>
         </xsl:variable>
     -->
     <!--
@@ -2427,12 +2488,10 @@
                   <rdfs:label xml:lang="{$MetadataLanguage}"><xsl:value-of select="gco:CharacterString"/></rdfs:label>
                 </xsl:for-each>
     -->
-    <xsl:apply-templates mode="iso19139-to-dcatap"
-                         select="gmd:EX_GeographicDescription/gmd:geographicIdentifier/*">
+    <xsl:apply-templates mode="iso19139-to-dcatap" select="gmd:EX_GeographicDescription/gmd:geographicIdentifier/*">
       <xsl:with-param name="MetadataLanguage" select="$MetadataLanguage"/>
     </xsl:apply-templates>
-    <xsl:apply-templates mode="iso19139-to-dcatap"
-                         select="gmd:EX_GeographicBoundingBox"/>
+    <xsl:apply-templates mode="iso19139-to-dcatap" select="gmd:EX_GeographicBoundingBox"/>
     <!--
               </dct:Location>
             </dct:spatial>
@@ -2481,7 +2540,7 @@
                         <xsl:if test="$GeoCode != ''">
                           <rdfs:label xml:lang="{$MetadataLanguage}"><xsl:value-of select="$GeoCode"/></rdfs:label>
                         </xsl:if>
-                        <xsl:apply-templates select="gmd:EX_GeographicBoundingBox"/>
+                        <xsl:apply-templates mode="iso19139-to-dcatap" select="gmd:EX_GeographicBoundingBox"/>
                       </dct:Location>
                     </dct:spatial>
                   </xsl:when>
@@ -2517,8 +2576,7 @@
                 <dct:title xml:lang="{$MetadataLanguage}">
                   <xsl:value-of select="gmd:title/*[self::gco:CharacterString|self::gmx:Anchor]"/>
                 </dct:title>
-                <xsl:apply-templates mode="iso19139-to-dcatap"
-                                     select="gmd:date/gmd:CI_Date"/>
+                <xsl:apply-templates mode="iso19139-to-dcatap" select="gmd:date/gmd:CI_Date"/>
               </skos:ConceptScheme>
             </skos:inScheme>
           </xsl:for-each>
@@ -2533,13 +2591,14 @@
   <!-- Geographic bounding box -->
 
   <!--
-    <xsl:template name="GeographicBoundingBox" match="gmd:identificationInfo[1]/*/*[self::gmd:extent|self::srv:extent]/*/gmd:geographicElement/gmd:EX_GeographicBoundingBox">
+    <xsl:template mode="iso19139-to-dcatap" name="GeographicBoundingBox" match="gmd:identificationInfo[1]/*/*[self::gmd:extent|self::srv:extent]/*/gmd:geographicElement/gmd:EX_GeographicBoundingBox">
   -->
-  <xsl:template mode="iso19139-to-dcatap" name="GeographicBoundingBox" match="gmd:EX_GeographicBoundingBox">
-    <xsl:param name="north" select="gmd:northBoundLatitude/gco:Decimal"/>
-    <xsl:param name="east"  select="gmd:eastBoundLongitude/gco:Decimal"/>
-    <xsl:param name="south" select="gmd:southBoundLatitude/gco:Decimal"/>
-    <xsl:param name="west"  select="gmd:westBoundLongitude/gco:Decimal"/>
+  <xsl:template name="GeographicBoundingBox" match="gmd:EX_GeographicBoundingBox"
+                mode="iso19139-to-dcatap">
+    <xsl:param name="north" select="format-number(gmd:northBoundLatitude/gco:Decimal, '0.0######')"/>
+    <xsl:param name="east"  select="format-number(gmd:eastBoundLongitude/gco:Decimal, '0.0######')"/>
+    <xsl:param name="south" select="format-number(gmd:southBoundLatitude/gco:Decimal, '0.0######')"/>
+    <xsl:param name="west"  select="format-number(gmd:westBoundLongitude/gco:Decimal, '0.0######')"/>
 
     <!-- Bbox as a dct:Box -->
     <!-- Need to check whether this is correct - in particular, the "projection" parameter -->
@@ -2686,8 +2745,7 @@
   <!-- Dates of publication, last revision, creation -->
 
   <xsl:template mode="iso19139-to-dcatap" name="ResourceDates" match="gmd:identificationInfo/*/gmd:citation/gmd:CI_Citation">
-    <xsl:apply-templates mode="iso19139-to-dcatap"
-                         select="gmd:date/gmd:CI_Date"/>
+    <xsl:apply-templates mode="iso19139-to-dcatap" select="gmd:date/gmd:CI_Date"/>
   </xsl:template>
 
   <!-- Generic date template -->
@@ -2696,7 +2754,7 @@
     <xsl:param name="date">
       <xsl:choose>
         <xsl:when test="gmd:date/gco:Date">
-      <xsl:value-of select="normalize-space(gmd:date/gco:Date)"/>
+          <xsl:value-of select="normalize-space(gmd:date/gco:Date)"/>
         </xsl:when>
         <xsl:when test="gmd:date/gco:DateTime">
           <xsl:value-of select="normalize-space(gmd:date/gco:DateTime)"/>
@@ -2734,7 +2792,7 @@
 
   <!-- Generic date data type template -->
 
-  <xsl:template name="DateDataType">
+  <xsl:template  name="DateDataType">
     <xsl:param name="date"/>
     <xsl:choose>
       <xsl:when test="string-length($date) = 4">
@@ -2961,7 +3019,6 @@
   <xsl:template mode="iso19139-to-dcatap" name="Keyword" match="gmd:identificationInfo/*/gmd:descriptiveKeywords/gmd:MD_Keywords">
     <xsl:param name="MetadataLanguage"/>
     <xsl:param name="ResourceType"/>
-    <xsl:param name="ServiceType"/>
     <xsl:param name="OriginatingControlledVocabularyURI" select="normalize-space(gmd:thesaurusName/gmd:CI_Citation/gmd:title/gmx:Anchor/@xlink:href)"/>
     <xsl:param name="OriginatingControlledVocabulary">
       <!--
@@ -2969,7 +3026,7 @@
               <dct:title xml:lang="{$MetadataLanguage}">
                 <xsl:value-of select="gmd:title/gco:CharacterString"/>
               </dct:title>
-              <xsl:apply-templates select="gmd:date/gmd:CI_Date"/>
+              <xsl:apply-templates mode="iso19139-to-dcatap" select="gmd:date/gmd:CI_Date"/>
             </xsl:for-each>
       -->
       <xsl:for-each select="gmd:thesaurusName/gmd:CI_Citation">
@@ -2982,8 +3039,7 @@
           </xsl:call-template>
         </xsl:for-each>
         <xsl:if test="$profile = $extended">
-          <xsl:apply-templates mode="iso19139-to-dcatap"
-                               select="gmd:date/gmd:CI_Date"/>
+          <xsl:apply-templates mode="iso19139-to-dcatap" select="gmd:date/gmd:CI_Date"/>
         </xsl:if>
       </xsl:for-each>
     </xsl:param>
@@ -3120,34 +3176,38 @@
             </xsl:when>
             <!-- In case the concept's URI is provided -->
             <xsl:when test="gmx:Anchor/@xlink:href">
+
               <xsl:choose>
-                <xsl:when test="$ResourceType != 'service'">
-                  <dcat:theme rdf:resource="{gmx:Anchor/@xlink:href}"/>
-                  <!--
-                                    <skos:Concept rdf:about="{gmx:Anchor/@xlink:href}">
-                                      <skos:prefLabel xml:lang="{$MetadataLanguage}">
-                                        <xsl:value-of select="gmx:Anchor"/>
-                                      </skos:prefLabel>
-                                      <skos:inScheme>
-                                        <skos:ConceptScheme>
-                                          <xsl:copy-of select="$OriginatingControlledVocabulary"/>
-                                        </skos:ConceptScheme>
-                                      </skos:inScheme>
-                                    </skos:Concept>
-                  -->
+                <!-- HVD applicable legislation -->
+                <xsl:when test="gmx:Anchor/@xlink:href = 'http://data.europa.eu/eli/reg_impl/2023/138/oj'">
+                  <dcatap:applicableLegislation rdf:resource="{gmx:Anchor/@xlink:href}"/>
                 </xsl:when>
+
+                <!-- HVD Category -->
+                <xsl:when test="../gmd:thesaurusName/gmd:CI_Citation/gmd:title/gmx:Anchor/@xlink:href = 'http://data.europa.eu/bna/asd487ae75'">
+                  <dcatap:hvdCategory rdf:resource="{gmx:Anchor/@xlink:href}"/>
+                </xsl:when>
+
+                <!-- Regular dcat:theme -->
                 <xsl:otherwise>
-                  <!-- Mapping moved to core profile for compliance with DCAT-AP 2 -->
-                  <!-- Mapping added for compliance with DCAT-AP 2 -->
-                  <dcat:theme rdf:resource="{gmx:Anchor/@xlink:href}"/>
-                  <xsl:if test="$profile = $extended">
-                    <!-- DEPRECATED: Mapping kept for backward compatibility with GeoDCAT-AP v1.* -->
-                    <xsl:if test="$include-deprecated = 'yes'">
+                    <xsl:if test="not(starts-with(gmx:Anchor/@xlink:href, $SpatialDataServiceCategoryCodelistUri))">
+                      <dcat:theme rdf:resource="{gmx:Anchor/@xlink:href}"/>
+                    </xsl:if>
+                </xsl:otherwise>
+              </xsl:choose>
+
+              <xsl:if test="$ResourceType = 'service'">
+                <!-- Mapping moved to core profile for compliance with DCAT-AP 2 -->
+                <!-- Mapping added for compliance with DCAT-AP 2 -->
+                <xsl:if test="$profile = $extended">
+                  <!-- DEPRECATED: Mapping kept for backward compatibility with GeoDCAT-AP v1.* -->
+                <xsl:if test="$include-deprecated = 'yes'">
+                  <xsl:if test="not(starts-with(gmx:Anchor/@xlink:href, $SpatialDataServiceCategoryCodelistUri))">
                       <dct:subject rdf:resource="{gmx:Anchor/@xlink:href}"/>
                     </xsl:if>
                   </xsl:if>
-                </xsl:otherwise>
-              </xsl:choose>
+                </xsl:if>
+              </xsl:if>
             </xsl:when>
           </xsl:choose>
         </xsl:otherwise>
@@ -3395,7 +3455,8 @@
 
   <!-- Encoding -->
 
-  <xsl:template mode="iso19139-to-dcatap" name="Encoding" match="gmd:distributionFormat/gmd:MD_Format/gmd:name/*">
+  <xsl:template mode="iso19139-to-dcatap" name="Encoding"
+                match="gmd:distributionFormat/gmd:MD_Format/gmd:name/*|gmd:distributorFormat/gmd:MD_Format/gmd:name/*">
     <xsl:param name="format-label">
       <xsl:value-of select="normalize-space(.)"/>
     </xsl:param>
@@ -3872,6 +3933,10 @@
             -->
             <xsl:value-of select="concat($opfq,'BIWEEKLY')"/>
           </xsl:when>
+          <xsl:when test="@codeListValue = 'semimonthly'">
+            <!--  A mapping is missing in Dublin Core -->
+            <xsl:value-of select="concat($opfq,'MONTHLY_2')"/>
+          </xsl:when>
           <xsl:when test="@codeListValue = 'monthly'">
             <!--  DC Freq voc
                         <xsl:value-of select="concat($cldFrequency,'monthly')"/>
@@ -3895,6 +3960,14 @@
                         <xsl:value-of select="concat($cldFrequency,'annual')"/>
             -->
             <xsl:value-of select="concat($opfq,'ANNUAL')"/>
+          </xsl:when>
+          <xsl:when test="@codeListValue = 'biennially'">
+            <!--  A mapping is missing in Dublin Core -->
+            <xsl:value-of select="concat($opfq,'BIENNIAL')"/>
+          </xsl:when>
+          <xsl:when test="@codeListValue = 'periodic'">
+            <!--  A mapping is missing in Dublin Core -->
+            <xsl:value-of select="concat($opfq,'OTHER')"/>
           </xsl:when>
           <xsl:when test="@codeListValue = 'asNeeded'">
             <!--  A mapping is missing in Dublin Core -->
@@ -3931,10 +4004,10 @@
 
   <xsl:template mode="iso19139-to-dcatap" name="ReferenceSystem" match="gmd:referenceSystemInfo/gmd:MD_ReferenceSystem/gmd:referenceSystemIdentifier/gmd:RS_Identifier">
     <xsl:param name="MetadataLanguage"/>
-    <xsl:param name="code" select="gmd:code/*[self::gco:CharacterString|gmx:Anchor]"/>
+    <xsl:param name="code" select="gmd:code/*[self::gco:CharacterString|self::gmx:Anchor]"/>
     <xsl:param name="link" select="gmd:code/gmx:Anchor/@xlink:href"/>
-    <xsl:param name="codespace" select="gmd:codeSpace/*[self::gco:CharacterString|gmx:Anchor]"/>
-    <xsl:param name="version" select="gmd:version/*[self::gco:CharacterString|gmx:Anchor]"/>
+    <xsl:param name="codespace" select="gmd:codeSpace/*[self::gco:CharacterString|self::gmx:Anchor]"/>
+    <xsl:param name="version" select="gmd:version/*[self::gco:CharacterString|self::gmx:Anchor]"/>
     <xsl:param name="version-statement">
       <xsl:if test="$profile = $extended">
         <xsl:if test="$version != ''">
@@ -4109,17 +4182,18 @@
 
   <xsl:template name="LocalisedString">
     <xsl:param name="term"/>
-    <xsl:variable name="primaryValue" select="normalize-space(*[self::gco:CharacterString|self::gmx:Anchor])"/>
     <xsl:for-each select="gmd:PT_FreeText/*/gmd:LocalisedCharacterString">
       <xsl:variable name="value" select="normalize-space(.)"/>
-      <xsl:variable name="langs">
-        <xsl:call-template name="Alpha3-to-Alpha2">
-          <xsl:with-param name="lang" select="translate(translate(@locale, $uppercase, $lowercase), '#', '')"/>
-        </xsl:call-template>
-      </xsl:variable>
-      <xsl:if test="$value != '' and not($primaryValue != '' and $value = $primaryValue)">
+      <xsl:if test="$value != ''">
+        <xsl:variable name="locale-id" select="substring-after(@locale, '#')"/>
+        <xsl:variable name="lang-alpha3" select="//gmd:PT_Locale[@id = $locale-id]/gmd:languageCode/gmd:LanguageCode/@codeListValue"/>
+        <xsl:variable name="lang-alpha2">
+          <xsl:call-template name="Alpha3-to-Alpha2">
+              <xsl:with-param name="lang" select="$lang-alpha3"/>
+          </xsl:call-template>
+        </xsl:variable>
         <xsl:element name="{$term}">
-          <xsl:attribute name="xml:lang"><xsl:value-of select="$langs"/></xsl:attribute>
+          <xsl:attribute name="xml:lang"><xsl:value-of select="$lang-alpha2"/></xsl:attribute>
           <xsl:value-of select="$value"/>
         </xsl:element>
       </xsl:if>


### PR DESCRIPTION
Attempt to serve ISO 19139 records via CSW with outputSchema=http://data.europa.eu/930/#semiceu fails with either:

	•	Failed to compile stylesheet. 1 error detected. — at startup/first use
	•	net.sf.saxon.trans.XPathException: A sequence of more than one item is not allowed as the first argument of normalize-space() — at runtime

The root cause is that many ISO 19139 records use xsi:type="gmd:PT_FreeText_PropertyType" on text fields such as individualName, name, description and electronicMailAddress. This means these elements have multiple child nodes — both a gco:CharacterString and a gmd:PT_FreeText element — rather than a single child.

Additionally, the LocalisedString template emitted duplicate language-tagged literals when a PT_FreeText locale value was identical to the primary gco:CharacterString value.

Changes:

- Remove xmlns:xs namespace declaration — no longer needed after removing castable as xs:double
- Remove as="node()*" type annotation on $uriIdentifiers variable — Saxon 9.1 Basic does not support type annotations on variables
- Replace $code castable as xs:double with number($code) = number($code) — Saxon 9.1 Basic does not support the castable as operator
- Fix normalize-space(gmd:individualName/*) → normalize-space(gmd:individualName/*[self::gco:CharacterString|self::gmx:Anchor]) — prevents XPTY0004 error when individualName has xsi:type="PT_FreeText_PropertyType" with multiple child nodes
- Fix normalize-space(*) on gmd:name and gmd:description in distribution resources — same PT_FreeText issue
- Fix electronicMailAddress/* → electronicMailAddress/gco:CharacterString — prevents email concatenation when PT_FreeText children are present
- Fix LocalisedString template — added duplicate filtering so PT_FreeText localisations that are identical to the primary gco:CharacterString value are not emitted twice

Tested against https://data.europa.eu/mqa/shacl-validator-ui/data-provision

Response with current XSLT:
https://geodata-info.dk/srv/dan/csw?service=CSW&version=2.0.2&request=GetRecordById&outputSchema=http://data.europa.eu/930/%23semiceu&elementsetname=full&id=4aaf72e6-b4eb-4c4f-a472-d8639f60710f&resulttype=results&constraintlanguage=FILTER&constraint_language_version=1.1.0&namespace=xmlns(gmd=http%3A%2F%2Fwww.isotc211.org%2F2005%2Fgmd)&typenames=gmd:MD_Metadata&constraint=%3Cogc%3AFilter%20xmlns%3Acsw%3D%22http%3A%2F%2Fwww.opengis.net%2Fcat%2Fcsw%2F2.0.2%22%20xmlns%3Aogc%3D%22http%3A%2F%2Fwww.opengis.net%2Fogc%22%3E%3C%2Fogc%3AFilter%3E

Response with fixed XSLT:
https://test.geodata-info.dk/srv/dan/csw?service=CSW&version=2.0.2&request=GetRecordById&outputSchema=http://data.europa.eu/930/%23semiceu&elementsetname=full&id=4aaf72e6-b4eb-4c4f-a472-d8639f60710f&resulttype=results&constraintlanguage=FILTER&constraint_language_version=1.1.0&namespace=xmlns(gmd=http%3A%2F%2Fwww.isotc211.org%2F2005%2Fgmd)&typenames=gmd:MD_Metadata&constraint=%3Cogc%3AFilter%20xmlns%3Acsw%3D%22http%3A%2F%2Fwww.opengis.net%2Fcat%2Fcsw%2F2.0.2%22%20xmlns%3Aogc%3D%22http%3A%2F%2Fwww.opengis.net%2Fogc%22%3E%3C%2Fogc%3AFilter%3E