### PR TITLE
Validate inline UI configuration before initialization

### DIFF
--- a/core/src/main/java/org/fao/geonet/util/XslUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/XslUtil.java
@@ -25,6 +25,8 @@ package org.fao.geonet.util;
 
 import co.elastic.clients.elasticsearch.core.search.Hit;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.cache.Cache;
@@ -407,6 +409,39 @@ public final class XslUtil {
         } catch (Exception e) {
             return "";
         }
+    }
+
+    /**
+     * Build a JavaScript expression for an optional inline UI configuration.
+     *
+     * Returns a {@code JSON.parse(...)} call when the value is a JSON object,
+     * or an empty string otherwise so the caller can fall back to a default.
+     */
+    public static String toUiConfigArg(String config) {
+        if (StringUtils.isBlank(config)) {
+            return "";
+        }
+        try {
+            ObjectMapper mapper = new ObjectMapper()
+                .enable(DeserializationFeature.FAIL_ON_TRAILING_TOKENS);
+            JsonNode node = mapper.readTree(config);
+            if (node == null || !node.isObject()) {
+                return "";
+            }
+            String literal = mapper.writeValueAsString(mapper.writeValueAsString(node));
+            return "JSON.parse(" + escapeForScriptContext(literal) + ")";
+        } catch (JsonProcessingException e) {
+            return "";
+        }
+    }
+
+    private static String escapeForScriptContext(String value) {
+        return value
+            .replace("&", "\\u0026")
+            .replace("<", "\\u003c")
+            .replace(">", "\\u003e")
+            .replace(String.valueOf((char) 0x2028), "\\u2028")
+            .replace(String.valueOf((char) 0x2029), "\\u2029");
     }
 
     /**

--- a/core/src/test/java/org/fao/geonet/util/XslUtilTest.java
+++ b/core/src/test/java/org/fao/geonet/util/XslUtilTest.java
@@ -26,6 +26,8 @@ package org.fao.geonet.util;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 public class XslUtilTest {
 
@@ -90,6 +92,62 @@ public class XslUtilTest {
         String text = XslUtil.html2textNormalized(html);
 
         assertEquals(expectedText, text);
+    }
+
+    @Test
+    public void testToUiConfigArgValidObject() {
+        String result = XslUtil.toUiConfigArg("{\"a\":1}");
+        assertTrue(result.startsWith("JSON.parse("));
+        assertTrue(result.contains("a"));
+    }
+
+    @Test
+    public void testToUiConfigArgCodeInjectionPayload() {
+        assertEquals("", XslUtil.toUiConfigArg("(alert(1),{})"));
+    }
+
+    @Test
+    public void testToUiConfigArgScriptBreakout() {
+        String result = XslUtil.toUiConfigArg("{\"x\":\"</script>\"}");
+        assertFalse(result.isEmpty());
+        assertFalse(result.contains("</script>"));
+    }
+
+    @Test
+    public void testToUiConfigArgArrayReturnsEmpty() {
+        assertEquals("", XslUtil.toUiConfigArg("[1,2]"));
+    }
+
+    @Test
+    public void testToUiConfigArgStringReturnsEmpty() {
+        assertEquals("", XslUtil.toUiConfigArg("\"5\""));
+    }
+
+    @Test
+    public void testToUiConfigArgBooleanReturnsEmpty() {
+        assertEquals("", XslUtil.toUiConfigArg("true"));
+    }
+
+    @Test
+    public void testToUiConfigArgTrailingTokensReturnsEmpty() {
+        assertEquals("", XslUtil.toUiConfigArg("{}whatever"));
+    }
+
+    @Test
+    public void testToUiConfigArgBlankReturnsEmpty() {
+        assertEquals("", XslUtil.toUiConfigArg(""));
+        assertEquals("", XslUtil.toUiConfigArg("   "));
+        assertEquals("", XslUtil.toUiConfigArg(null));
+    }
+
+    @Test
+    public void testToUiConfigArgLineSeparatorEscaped() {
+        String lineSep = String.valueOf((char) 0x2028);
+        String input = "{\"k\":\"val" + lineSep + "ue\"}";
+        String result = XslUtil.toUiConfigArg(input);
+        assertFalse(result.isEmpty());
+        assertFalse(result.contains(lineSep));
+        assertTrue(result.contains("\\u2028"));
     }
 
 }

--- a/schemas/iso19115-3.2018/src/test/java/org/fao/geonet/util/XslUtil.java
+++ b/schemas/iso19115-3.2018/src/test/java/org/fao/geonet/util/XslUtil.java
@@ -201,4 +201,6 @@ public class XslUtil {
     public static String getDefaultLangCode() {
         return "eng";
     }
+
+    public static String toUiConfigArg(String config)  { return config; }
 }

--- a/web/src/main/webapp/xslt/base-layout-cssjs-loader.xsl
+++ b/web/src/main/webapp/xslt/base-layout-cssjs-loader.xsl
@@ -281,9 +281,9 @@
     <link rel="stylesheet" href="{$uiResourcesPath}lib/d3_timeseries/nv.d3.min.css"/>
 
     <xsl:variable name="appConfig"
-                  select="util:getUiConfiguration(/root/request/ui)"/>
+                  select="util:toUiConfigArg(util:getUiConfiguration(/root/request/ui))"/>
     <xsl:variable name="urlAppConfig"
-                  select="/root/request/uiconfig"/>
+                  select="util:toUiConfigArg(/root/request/uiconfig)"/>
 
     <script type="text/javascript">
       var module = angular.module('<xsl:value-of select="$angularApp"/>');


### PR DESCRIPTION
The uiconfig request parameter and the stored UI configuration are now parsed as JSON objects and emitted via `JSON.parse()`, falling back to the default configuration when the value is not a JSON object.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [x] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

