### PR TITLE
Editor / Associated resource / More consistent search (and support uuid)

### DIFF
--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -2375,13 +2375,7 @@
                   if (scope.searchObj.any == "") {
                     scope.$broadcast("resetSearch");
                   } else {
-                    var addWildcard =
-                      scope.searchObj.any.indexOf('"') === -1 &&
-                      scope.searchObj.any.indexOf("*") === -1 &&
-                      scope.searchObj.any.indexOf("q(") !== 0;
-                    scope.searchObj.params.any = addWildcard
-                      ? "*" + scope.searchObj.any + "*"
-                      : scope.searchObj.any;
+                    scope.searchObj.params.any = scope.searchObj.any;
                   }
                 };
 


### PR DESCRIPTION
The `gnLinkToSibling` search panel was not supported search by UUID. It was related to some logic to make LIKE query using "*" (made long time ago https://github.com/geonetwork/core-geonetwork/commit/86c853c42d3bf2e938f66bedebdc57780a8551f6).

There is no such logic for other related types (parent, services, sources, ...) and current search configuration made with `queryBase` configuration option works fine for text and uuid search.

Removing this wildcard search which is not really needed and make the search consistent with other types and the main search.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

Funded by https://metadata.vlaanderen.be/