### PR TITLE
ISO19139 / Distribution format should not be multilingual

### DIFF
--- a/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/config-editor.xml
@@ -427,6 +427,7 @@
       <name>gmd:userDefinedMaintenanceFrequency</name>
       <name>gmd:distance</name>
       <name>gmd:geometricObjectCount</name>
+      <name ancestor="gmd:MD_Format">gmd:name</name>
       <name>srv:name</name>
       <name>srv:invocationName</name>
       <name>srv:serviceTypeVersion</name>
@@ -512,7 +513,7 @@
         <col/>
       </header>
       <row>
-        <col xpath="gmd:name"/>
+        <col xpath="gmd:name" multilingual="false"/>
         <col xpath="gmd:version"/>
         <col del=".."/>
       </row>

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout.xsl
@@ -247,8 +247,30 @@
 
     <xsl:variable name="elementName" select="name()"/>
 
+    <!-- In table mode, the context is lost; the parent element is called ‘col’.
+
+        This does not match the multilingual exclusion settings: <name ancestor="gmd:MD_Format">gmd:name</name>
+
+         In this case, we set the `multilingual=false` attribute in the table configuration. For example, for `gmd:name` in the distribution formats:
+
+         <table for="gmd:MD_Format">
+          <header>
+            <col label="gmd:name"/>
+            <col label="gmd:version"/>
+            <col/>
+          </header>
+          <row>
+            <col xpath="gmd:name" multilingual="false"/>
+            <col xpath="gmd:version" />
+            <col del=".."/>
+          </row>
+        </table>
+
+        This allows the ‘gmd:name’ element to be managed in a multilingual manner within other elements, such as online resources.
+    -->
     <xsl:variable name="excluded"
-                  select="gn-fn-iso19139:isNotMultilingualField(., $editorConfig)"/>
+                  select="(gn-fn-iso19139:isNotMultilingualField(., $editorConfig) or ((name(..) = 'col') and ../@multilingual = 'false'))"/>
+
 
     <xsl:variable name="hasPTFreeText"
                   select="count(gmd:PT_FreeText) > 0"/>

--- a/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
+++ b/web/src/main/webapp/xslt/ui-metadata/form-builder.xsl
@@ -1847,6 +1847,12 @@
           <row>
             <xsl:for-each select="col">
               <col>
+                <!-- Copy the multilingual attribute if defined -->
+                <xsl:variable name="multilingual" select="@multilingual" />
+                <xsl:if test="string($multilingual)">
+                  <xsl:attribute name="multilingual" select="$multilingual" />
+                </xsl:if>
+
                 <xsl:choose>
                   <xsl:when test="@use != ''">
                     <xsl:copy-of select="@use|directiveAttributes"/>


### PR DESCRIPTION
Updates in the metadata editor to display the distribution format name as non multilingual in table mode and in form mode.

The search indexing and metadata page treated the field as non-multilingual, but the metadata editor did not.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation