### PR TITLE
Record page / Series member ordered by last date

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/search/EsSearchManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/EsSearchManager.java
@@ -146,7 +146,7 @@ public class EsSearchManager implements ISearchManager {
             // Elasticsearch scripted field to get the first overview url. Scripted fields must return single values.
             .put("overview", "return params['_source'].overview == null ? [] : params['_source'].overview.stream().map(f -> f.url).findFirst().orElse('');")
             .put("overview_data", "return params['_source'].overview == null ? [] : params['_source'].overview.stream().map(f -> f.data).filter(Objects::nonNull).findFirst().orElse('');")
-            .put("lastResourceDate", "return params['_source'].resourceDate == null ? null : params['_source'].resourceDate.stream().map(d -> d.date).filter(date -> date != null).max(String::compareTo).orElse(null);")
+            .put("lastResourceDate", "return params['_source'].resourceDate == null ? '' : params['_source'].resourceDate.stream().map(d -> d.date).filter(date -> date != null).max(String::compareTo).orElse('');")
             .build();
     }
 

--- a/core/src/main/java/org/fao/geonet/kernel/search/EsSearchManager.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/EsSearchManager.java
@@ -146,6 +146,7 @@ public class EsSearchManager implements ISearchManager {
             // Elasticsearch scripted field to get the first overview url. Scripted fields must return single values.
             .put("overview", "return params['_source'].overview == null ? [] : params['_source'].overview.stream().map(f -> f.url).findFirst().orElse('');")
             .put("overview_data", "return params['_source'].overview == null ? [] : params['_source'].overview.stream().map(f -> f.data).filter(Objects::nonNull).findFirst().orElse('');")
+            .put("lastResourceDate", "return params['_source'].resourceDate == null ? null : params['_source'].resourceDate.stream().map(d -> d.date).filter(date -> date != null).max(String::compareTo).orElse(null);")
             .build();
     }
 

--- a/web-ui/src/main/resources/catalog/components/metadataactions/RelatedDirective.js
+++ b/web-ui/src/main/resources/catalog/components/metadataactions/RelatedDirective.js
@@ -48,6 +48,34 @@
     "$http",
     "$q",
     function ($http, $q) {
+      this.sortByField = function (records, sortBy) {
+        if (!sortBy || !records) {
+          return records;
+        }
+
+        var descOrder = sortBy.startsWith("-");
+        var sortField = descOrder ? sortBy.substring(1) : sortBy;
+        records.sort(function (a, b) {
+          var aProperty = a[sortField] || (a.properties && a.properties[sortField]);
+          var bProperty = b[sortField] || (b.properties && b.properties[sortField]);
+
+          if (!aProperty && !bProperty) {
+            return 0;
+          }
+          if (!aProperty) {
+            return 1;
+          }
+          if (!bProperty) {
+            return -1;
+          }
+
+          var comparison = String(aProperty).localeCompare(String(bProperty));
+          return descOrder ? -comparison : comparison;
+        });
+
+        return records;
+      };
+
       this.get = function (uuidOrId, types, approved) {
         var canceller = $q.defer();
         var request = $http({
@@ -962,7 +990,8 @@
   ]);
 
   module.directive("gnRelatedWithStats", [
-    function () {
+    "gnRelatedService",
+    function (gnRelatedService) {
       return {
         restrict: "A",
         templateUrl: function (elem, attrs) {
@@ -1025,11 +1054,7 @@
           }
 
           function sort() {
-            if (scope.sortBy) {
-              scope.displayedRecords.sort(function (a, b) {
-                return a[scope.sortBy] && a[scope.sortBy].localeCompare(b[scope.sortBy]);
-              });
-            }
+            gnRelatedService.sortByField(scope.displayedRecords, scope.sortBy);
           }
 
           function reset() {
@@ -1196,8 +1221,9 @@
 
   module.directive("gnRecordsTable", [
     "Metadata",
+    "gnConfigService",
     "gnRelatedService",
-    function (Metadata, gnRelatedService) {
+    function (Metadata, gnConfigService, gnRelatedService) {
       return {
         restrict: "A",
         templateUrl: function (elem, attrs) {
@@ -1214,6 +1240,7 @@
           // * links by type eg. link:OGC
           columns: "@",
           labels: "@",
+          sortBy: "@",
           agg: "="
         },
         link: function (scope, element, attrs, controller) {
@@ -1262,10 +1289,7 @@
           });
 
           function sort() {
-            scope.displayedRecords.sort(function (a, b) {
-              var sortBy = scope.columnsConfig[0];
-              return a[sortBy] && a[sortBy].localeCompare(b[sortBy]);
-            });
+            gnRelatedService.sortByField(scope.displayedRecords, scope.sortBy);
           }
 
           function reset() {

--- a/web-ui/src/main/resources/catalog/views/default/templates/recordView/type-series.html
+++ b/web-ui/src/main/resources/catalog/views/default/templates/recordView/type-series.html
@@ -55,7 +55,7 @@
           ? mdView.current.record.related.aggregations_children
           :mdView.current.record.related.aggregations_siblings"
       data-type="'blocks'"
-      data-sort-by="resourceTitle"
+      data-sort-by="-lastResourceDate"
       data-title="{{'seriesComposedOf' | translate}}"
     ></div>
 
@@ -69,6 +69,7 @@
           :mdView.current.record.related.aggregations_siblings"
       labels="{{::viewConfig.collectionTableConfig.labels}}"
       columns="{{::viewConfig.collectionTableConfig.columns}}"
+      data-sort-by="-lastResourceDate"
     ></div>
   </div>
 </div>


### PR DESCRIPTION
Was sort by title but the main idea here is to easily identify the most recent child of the series.

Before:


<img width="854" height="252" alt="Screenshot From 2026-06-17 13-35-55" src="https://github.com/user-attachments/assets/2cb0f1a6-c668-4eb0-85bc-97ff7fae0eb1" />


After:

<img width="854" height="252" alt="image" src="https://github.com/user-attachments/assets/97c13f1c-d9b7-4122-a09e-92ed2d196812" />


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

Funded by https://metadata.vlaanderen.be/