### PR TITLE
UI / Fix signin form action when signinAPI or signinUrl missing from auth config

### DIFF
--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -1890,9 +1890,14 @@
 
       // login url and form action with hash reference to the current page
       $scope.signInFormLinkWithHash =
-        $scope.gnCfg.mods.authentication.signinUrl + "#" + $location.url();
+        ($scope.gnCfg.mods.authentication.signinUrl ||
+          "../../{{node}}/{{lang}}/catalog.signin") +
+        "#" +
+        $location.url();
       $scope.signInFormActionWithHash =
-        $scope.gnCfg.mods.authentication.signinAPI + "#" + $location.url();
+        ($scope.gnCfg.mods.authentication.signinAPI || "../../signin") +
+        "#" +
+        $location.url();
 
       // when the login input have focus, do not close the dropdown/popup
       $scope.focusLoginPopup = function () {


### PR DESCRIPTION
## Summary

When a custom UI configuration overrides the `authentication` block without including `signinAPI`
or `signinUrl`, the `signInFormActionWithHash` and `signInFormLinkWithHash` scope variables in
`GnCatController` were set to strings starting with `"undefined"`, producing a broken `action`
attribute on the `catalog.signin` login form. The form would POST back to itself, silently failing
with no error message shown to the user.

This was observed on a deployment where the Dutch view's custom UI configuration defined
`authentication` with only `enabled`, `signinUrl`, and `signoutUrl`, omitting `signinAPI`. The
shallow merge in an older compiled bundle had discarded the code default; but even with a correct
build, the code was not defensive against partial overrides.

The fix adds fallbacks to the built-in defaults for both values, matching the resilience of the
original hardcoded approach that existed before commit `242c73b61a`.

## Changes

- `CatController.js`: add `|| "../../signin"` fallback for `signinAPI` and
  `|| "../../{{node}}/{{lang}}/catalog.signin"` fallback for `signinUrl` when computing
  `signInFormActionWithHash` and `signInFormLinkWithHash`.

## Test plan

- Open `catalog.signin` with a UI configuration that has an `authentication` block missing
  `signinAPI` and verify the login form submits to `/signin` correctly.
- Open `catalog.signin` with the default UI configuration and verify no regression.
- Open `catalog.signin` with a GN5 `signinAPI` URL configured and verify it is still used.