### PR TITLE
Metadata editor / add a configuration to define mandatory keywords from a thesaurus

### DIFF
--- a/docs/manual/docs/customizing-application/editor-ui/creating-custom-editor.md
+++ b/docs/manual/docs/customizing-application/editor-ui/creating-custom-editor.md
@@ -334,6 +334,18 @@ e.g. only 2 INSPIRE themes:
 </thesaurusList>
 ```
 
+The `<thesaurus>` element supports the following attributes:
+
+| Attribute | Description |
+|-----------|-------------|
+| `key` | (Required) The thesaurus identifier (e.g. `external.theme.httpinspireeceuropaeutheme-theme`). |
+| `maxtags` | Maximum number of keywords that can be selected. Unlimited if not set. |
+| `orderById` | When `true`, keywords are ordered by their identifier instead of by label. Defaults to `false`. |
+| `fieldset` | When `false`, the widget is rendered as a simple field instead of being boxed in a fieldset. |
+| `browsable` | When `false`, the keyword browse/tree control is hidden and keywords can only be searched. Defaults to `true`. |
+| `transformations` | Comma-separated list of allowed encodings for the keywords (see `convert/thesaurus-transformation.xsl`). Falls back to the `defaultTransformation` defined on `<thesaurusList>` when empty. |
+| `mandatory` | When `true`, the field is flagged as required in the editor (displays the required indicator). Note this is a visual indicator only; it does not enforce keyword selection on save. Defaults to `false`. |
+
 ## Configuring the side panel {#creating-custom-editor-sidePanel}
 
 The side panel is configured by adding `<text>` elements or `<directive>` elements to the `<sidePanel>` element within a `<view>`.

--- a/schemas/config-editor.xsd
+++ b/schemas/config-editor.xsd
@@ -1022,6 +1022,7 @@ Conversion are defined in `convert/thesaurus-transformation.xsl`.
             <xs:attribute name="fieldset" type="xs:string" use="optional" fixed="false"/>
             <xs:attribute name="browsable" type="xs:string" use="optional" fixed="false"/>
             <xs:attribute name="transformations" type="xs:string" use="optional"/>
+            <xs:attribute name="mandatory" type="xs:string" use="optional" default="false"/>
           </xs:complexType>
         </xs:element>
       </xs:sequence>

--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/layout-custom-fields-keywords.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/layout/layout-custom-fields-keywords.xsl
@@ -261,6 +261,7 @@
              data-max-tags="{$maxTags}"
              data-browsable="{not($thesaurusConfig/@browsable)
                               or $thesaurusConfig/@browsable != 'false'}"
+             data-required="{if ($thesaurusConfig/@mandatory = 'true') then 'true' else 'false'}"
              data-order-by-id="{$orderById}"
              data-lang="{$metadataOtherLanguagesAsJson}"
              data-textgroup-only="false">

--- a/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields-keywords.xsl
+++ b/schemas/iso19139/src/main/plugin/iso19139/layout/layout-custom-fields-keywords.xsl
@@ -299,6 +299,7 @@
              data-max-tags="{$maxTags}"
              data-browsable="{not($thesaurusConfig/@browsable)
                               or $thesaurusConfig/@browsable != 'false'}"
+             data-required="{if ($thesaurusConfig/@mandatory = 'true') then 'true' else 'false'}"
              data-order-by-id="{$orderById}"
              data-lang="{$metadataOtherLanguagesAsJson}"
              data-textgroup-only="false">


### PR DESCRIPTION
The directive `gnKeywordSelector` has the `required` attribute to display the field as mandatory, but it was not used.

This change request adds an attribute in the `thesaurus` element of the metadata editor configuration to allow to define a thesaurus as mandatory:

```xml
<thesaurus 
  key="local.theme.pg-privacy" fieldset="false" maxtags="1"  transformations="to-iso19139-keyword"
  mandatory="true" />
```

<img width="928" height="143" alt="image" src="https://github.com/user-attachments/assets/058fdd8f-e041-48d4-8632-518ac7db8a64" />


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
