### PR TITLE
Index / add Swedish (swe) to Elasticsearch records mapping

### DIFF
--- a/web/src/main/webResources/WEB-INF/data/config/index/records.json
+++ b/web/src/main/webResources/WEB-INF/data/config/index/records.json
@@ -1129,6 +1129,10 @@
                 "type": "keyword",
                 "copy_to": ["any.langpor", "organisationName.langpor"]
               },
+              "langswe": {
+                "type": "keyword",
+                "copy_to": ["any.langswe", "organisationName.langswe"]
+              },
               "link": {
                 "type": "keyword"
               }
@@ -1335,6 +1339,17 @@
                   }
                 }
               },
+              "langswe": {
+                "type": "text",
+                "analyzer": "swedish",
+                "copy_to": ["any.langswe"],
+                "fields": {
+                  "keyword": {
+                    "type": "keyword",
+                    "ignore_above": ${es.index.ignore_above}
+                  }
+                }
+              },
               "link": {
                 "type": "keyword"
               }
@@ -1452,6 +1467,10 @@
               "langpor": {
                 "type": "keyword",
                 "copy_to": ["any.langpor"]
+              },
+              "langswe": {
+                "type": "keyword",
+                "copy_to": ["any.langswe"]
               },
               "text": {
                 "type": "keyword"
@@ -1688,6 +1707,10 @@
           "langpor": {
             "type": "text",
             "analyzer": "portuguese"
+          },
+          "langswe": {
+            "type": "text",
+            "analyzer": "swedish"
           }
         }
       },
@@ -1756,6 +1779,10 @@
           "langpor": {
             "type": "keyword",
             "copy_to": ["any.langpor"]
+          },
+          "langswe": {
+            "type": "keyword",
+            "copy_to": ["any.langswe"]
           },
           "link": {
             "type": "keyword"
@@ -2317,6 +2344,9 @@
             "type": "keyword"
           },
           "langpor": {
+            "type": "keyword"
+          },
+          "langswe": {
             "type": "keyword"
           }
         }


### PR DESCRIPTION
## What this does

Adds Swedish (`swe`) to the Elasticsearch index mapping template `records.json`.

Swedish is registered as a supported UI language in `CatController.js`, but it was the only such language with no explicit field definitions in `records.json`. When the UI was switched to Swedish, facet aggregations ran against `langswe` fields that Elasticsearch had created through dynamic mapping as `text` fields. Text fields can't be aggregated, so the request failed with HTTP 400 and the search page displayed an error:

```
illegal_argument_exception: Text fields are not optimised for operations
that require per-document field data like aggregations and sorting.
Please use a keyword field instead. Alternatively, set fielddata=true
on [tag.langswe].
```

`langswe` is now added to every relevant section, mirroring the existing languages:

- `keyword` for the aggregatable fields and their dynamic templates (`organisationName`, `tag` / `th_*`, `any`)
- `text` with the built-in `swedish` analyzer for the full-text fields (`*Object` template and `any`)

This matches how `german`, `danish`, `italian`, `spanish`, `romanian` and `portuguese` are handled (built-in language analyzer; only `english`/`french` use custom `_rebuilt` analyzers).

## Verification

Tested against Elasticsearch 8.19:

- Confirmed the built-in `swedish` analyzer exists and stems/stops correctly.
- A `keyword`-mapped `tag.langswe` field aggregates correctly.
- A dynamically-mapped (text) `tag.langswe` reproduces the reported 400.
- A `text` field with `analyzer: swedish` is accepted.

Existing indexes need to be rebuilt for the new mapping to take effect.

Closes #9243