### PR TITLE
[Backport 4.2.x] Fix delete users with metadata user feedback entries associated (#9334)

### DIFF
--- a/domain/src/main/java/org/fao/geonet/repository/userfeedback/UserFeedbackRepository.java
+++ b/domain/src/main/java/org/fao/geonet/repository/userfeedback/UserFeedbackRepository.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2026 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -28,7 +28,6 @@ import java.util.UUID;
 import org.fao.geonet.domain.userfeedback.UserFeedback;
 import org.fao.geonet.domain.userfeedback.UserFeedback.UserRatingStatus;
 import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
@@ -110,4 +109,14 @@ public interface UserFeedbackRepository extends JpaRepository<UserFeedback, UUID
      * @return the user feedback
      */
     UserFeedback findByUuidAndStatus(String uuid, UserRatingStatus status);
+
+    @Modifying(clearAutomatically = true)
+    @Transactional
+    @Query("update GUF_UserFeedback uf set uf.authorId = null where uf.authorId.id = ?1")
+    int nullifyAuthor(int userId);
+
+    @Modifying(clearAutomatically = true)
+    @Transactional
+    @Query("update GUF_UserFeedback uf set uf.approver = null where uf.approver.id = ?1")
+    int nullifyApprover(int userId);
 }

--- a/services/src/main/java/org/fao/geonet/api/users/UsersApi.java
+++ b/services/src/main/java/org/fao/geonet/api/users/UsersApi.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2025 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2026 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -27,7 +27,6 @@ import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
-import java.util.regex.Pattern;
 import jeeves.server.UserSession;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
@@ -51,6 +50,7 @@ import org.fao.geonet.repository.*;
 import org.fao.geonet.repository.specification.MetadataSpecs;
 import org.fao.geonet.repository.specification.UserGroupSpecs;
 import org.fao.geonet.repository.specification.UserSpecs;
+import org.fao.geonet.repository.userfeedback.UserFeedbackRepository;
 import org.fao.geonet.util.PasswordUtil;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.jpa.domain.Specification;
@@ -74,6 +74,7 @@ import java.net.URL;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.*;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import static org.fao.geonet.kernel.setting.Settings.SYSTEM_SECURITY_PASSWORD_ALLOWADMINRESET;
@@ -124,6 +125,9 @@ public class UsersApi {
     @Autowired(required=false)
     SecurityProviderConfiguration securityProviderConfiguration;
 
+    @Autowired
+    UserFeedbackRepository userFeedbackRepository;
+
     private BufferedImage pixel;
 
     public UsersApi() {
@@ -133,8 +137,7 @@ public class UsersApi {
 
 
     @io.swagger.v3.oas.annotations.Operation(
-        summary = "Get users",
-        description = "")
+        summary = "Get users")
     @RequestMapping(
         produces = MediaType.APPLICATION_JSON_VALUE,
         method = RequestMethod.GET)
@@ -178,8 +181,7 @@ public class UsersApi {
 
 
     @io.swagger.v3.oas.annotations.Operation(
-        summary = "Get user",
-        description = "")
+        summary = "Get user")
     @RequestMapping(
         value = "/{userIdentifier}",
         produces = MediaType.APPLICATION_JSON_VALUE,
@@ -228,8 +230,7 @@ public class UsersApi {
     }
 
     @io.swagger.v3.oas.annotations.Operation(
-        summary = "Get user identicon",
-        description = "")
+        summary = "Get user identicon")
     @RequestMapping(
         value = "/{userIdentifier}.png",
         produces = MediaType.IMAGE_PNG_VALUE,
@@ -314,7 +315,7 @@ public class UsersApi {
 
 
         if (myProfile == Profile.UserAdmin) {
-            final Integer iMyUserId = Integer.parseInt(myUserId);
+            final int iMyUserId = Integer.parseInt(myUserId);
             final List<Integer> groupIdsSessionUser = userGroupRepository
                 .findGroupIds(where(hasUserId(iMyUserId)));
 
@@ -353,6 +354,8 @@ public class UsersApi {
             Arrays.asList(userIdentifier));
 
         userSavedSelectionRepository.deleteAllByUser(userIdentifier);
+        userFeedbackRepository.nullifyAuthor(userIdentifier);
+        userFeedbackRepository.nullifyApprover(userIdentifier);
 
         try {
             userRepository.deleteById(userIdentifier);
@@ -364,8 +367,7 @@ public class UsersApi {
     }
 
     @io.swagger.v3.oas.annotations.Operation(
-        summary = "Check if a user property already exist",
-        description = ""
+        summary = "Check if a user property already exist"
         //       authorizations = {
         //           @Authorization(value = "basicAuth")
         //      })
@@ -503,7 +505,7 @@ public class UsersApi {
         user = userRepository.save(user);
         setUserGroups(user, groups);
 
-        return new ResponseEntity(HttpStatus.NO_CONTENT);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
     @io.swagger.v3.oas.annotations.Operation(
@@ -719,7 +721,7 @@ public class UsersApi {
         user.get().getSecurity().getSecurityNotifications().remove(UserSecurityNotification.UPDATE_HASH_REQUIRED);
         userRepository.save(user.get());
 
-        return new ResponseEntity(HttpStatus.NO_CONTENT);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
     @io.swagger.v3.oas.annotations.Operation(

--- a/services/src/test/java/org/fao/geonet/api/users/UsersApiTest.java
+++ b/services/src/test/java/org/fao/geonet/api/users/UsersApiTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2025 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2026 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.lang.StringUtils;
 import org.fao.geonet.api.users.model.PasswordResetDto;
@@ -38,6 +39,8 @@ import org.fao.geonet.domain.Group;
 import org.fao.geonet.domain.Profile;
 import org.fao.geonet.domain.User;
 import org.fao.geonet.domain.UserGroup;
+import org.fao.geonet.domain.userfeedback.UserFeedback;
+import org.fao.geonet.repository.userfeedback.UserFeedbackRepository;
 import org.fao.geonet.services.AbstractServiceIntegrationTest;
 import org.junit.Assert;
 import org.junit.Before;
@@ -70,6 +73,9 @@ public class UsersApiTest extends AbstractServiceIntegrationTest {
     private WebApplicationContext wac;
 
     private MockMvc mockMvc;
+
+    @Autowired
+    private UserFeedbackRepository userFeedbackRepository;
 
     private MockHttpSession mockHttpSession;
 
@@ -135,6 +141,59 @@ public class UsersApiTest extends AbstractServiceIntegrationTest {
             .andExpect(jsonPath("$", hasSize(1)))
             .andExpect(jsonPath("$[0].id.groupId", is(sampleGroup.getId())))
             .andExpect(content().contentType(API_JSON_EXPECTED_ENCODING));
+    }
+
+    @Test
+    public void deleteUserWithFeedback() throws Exception {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(this.wac).build();
+        this.mockHttpSession = loginAsAdmin();
+
+        // 1. Create a user to delete
+        User userToDelete = new User()
+            .setUsername("user-with-feedback")
+            .setProfile(Profile.Editor)
+            .setEnabled(true);
+        userToDelete.getSecurity().setPassword("Password123!");
+        userToDelete = _userRepo.save(userToDelete);
+
+        // 2. Create feedback entries
+        UserFeedback feedback1 = new UserFeedback();
+        feedback1.setUuid(UUID.randomUUID().toString());
+        feedback1.setAuthorId(userToDelete);
+        feedback1.setCommentText("Feedback from author");
+        feedback1.setStatus(UserFeedback.UserRatingStatus.PUBLISHED);
+        userFeedbackRepository.save(feedback1);
+
+        UserFeedback feedback2 = new UserFeedback();
+        feedback2.setUuid(UUID.randomUUID().toString());
+        feedback2.setApprover(userToDelete);
+        feedback2.setCommentText("Feedback to be approved");
+        feedback2.setStatus(UserFeedback.UserRatingStatus.PUBLISHED);
+        userFeedbackRepository.save(feedback2);
+
+        // 3. Delete the user
+        this.mockMvc.perform(delete("/srv/api/users/" + userToDelete.getId())
+                .session(this.mockHttpSession)
+                .accept(MediaType.parseMediaType("application/json")))
+            .andExpect(status().is(204));
+
+        // 4. Verify user is deleted
+        Assert.assertFalse(_userRepo.findById(userToDelete.getId()).isPresent());
+
+        // Flush and clear the persistence context so the assertions below read
+        // from the database instead of returning the stale managed instances
+        // cached before the nullify bulk updates ran.
+        _entityManager.flush();
+        _entityManager.clear();
+
+        // 5. Verify feedback entries still exist and author/approver are null
+        UserFeedback updatedFeedback1 = userFeedbackRepository.findByUuid(feedback1.getUuid());
+        Assert.assertNotNull(updatedFeedback1);
+        Assert.assertNull(updatedFeedback1.getAuthorId());
+
+        UserFeedback updatedFeedback2 = userFeedbackRepository.findByUuid(feedback2.getUuid());
+        Assert.assertNotNull(updatedFeedback2);
+        Assert.assertNull(updatedFeedback2.getApprover());
     }
 
     @Test


### PR DESCRIPTION
Manual backport of #9334 to the `4.2.x` branch (the automated backport failed due to conflicts).

## Conflicts resolved

All conflicts were in `services/.../UsersApi.java`. The `4.2.x` branch does not have `UserAuditableService` (introduced later on `main`), and the squash-merged PR carried along unrelated audit-logging blocks plus an import refactor. I kept the `4.2.x` structure and grafted on only the actual fix:

- Added the `userFeedbackRepository` autowired field and the two `nullify` calls in `deleteUser`.
- Left out the `UserAuditable` / `auditDelete` / `auditSave` blocks (not present in `4.2.x`).
- Restored the `java.util.*` and `web.bind.annotation.*` wildcard imports the PR had expanded, since `main`'s explicit import list omitted `java.util.Arrays`, which is still used by `4.2.x`'s `deleteUser`.

The repository changes (`nullifyAuthor` / `nullifyApprover` with `clearAutomatically = true`) and the new `deleteUserWithFeedback` test applied cleanly.

## Verification

Built with Java 8 (the JDK used for `4.2.x`). `UsersApiTest` passes via failsafe (`-Pit`): 29 tests, 0 failures, including the new `deleteUserWithFeedback`.