### PR TITLE
User management / User edit should enable the Save button when selecting the 'Is Administrator' checkbox

### DIFF
--- a/web-ui/src/main/resources/catalog/templates/admin/usergroup/users.html
+++ b/web-ui/src/main/resources/catalog/templates/admin/usergroup/users.html
@@ -543,7 +543,7 @@
                 <input
                   type="checkbox"
                   data-ng-checked="userSelected.profile == 'Administrator'"
-                  data-ng-click="setUserProfile(true)"
+                  data-ng-click="setUserProfile(true); gnUserEdit.profile.$setDirty()"
                   data-ng-show="user.isAdministratorOrMore()"
                   data-ng-disabled="!isUserGroupUpdateEnabled"
                 />


### PR DESCRIPTION
Currently, editing a user and selecting / un-selecting the option `Is Administrator` does not enable the `Save` button, unless other fields are edited.

With this fix, the `Save` button is enabled when selecting / un-selecting the option `Is Administrator` (when all other mandatory fields are filled).

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation