### PR TITLE
OAI-PMH / Apply privileges filter on ListRecords, ListIdentifiers and GetRecord

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/oaipmh/Lib.java
+++ b/core/src/main/java/org/fao/geonet/kernel/oaipmh/Lib.java
@@ -28,6 +28,7 @@ import co.elastic.clients.elasticsearch.core.search.Hit;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -36,7 +37,10 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import jeeves.constants.Jeeves;
 import jeeves.server.context.ServiceContext;
+import org.fao.geonet.NodeInfo;
 import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.kernel.search.EsFilterBuilder;
+import org.fao.geonet.kernel.search.EsQueryFilterUtils;
 import org.fao.geonet.kernel.search.EsSearchManager;
 import static org.fao.geonet.kernel.search.EsSearchManager.FIELDLIST_CORE;
 import org.fao.geonet.utils.Log;
@@ -109,8 +113,16 @@ public class Lib {
 
     public static List<Integer> search(ServiceContext context, Element params) throws Exception {
         EsSearchManager searchMan = context.getBean(EsSearchManager.class);
+        ObjectMapper objectMapper = new ObjectMapper();
+        String permissionsFilter = EsFilterBuilder.build(
+            context, "metadata", false, context.getBean(NodeInfo.class));
 
         JsonNode esJsonQuery = createSearchQuery(params);
+        JsonNode queryStringFilter = EsQueryFilterUtils.buildQueryStringFilter(objectMapper, permissionsFilter);
+        ObjectNode wrappedSearchRequest = objectMapper.createObjectNode();
+        wrappedSearchRequest.set("query", esJsonQuery);
+        EsQueryFilterUtils.addFilterToQuery(objectMapper, wrappedSearchRequest, queryStringFilter);
+        esJsonQuery = wrappedSearchRequest.get("query");
 
         // Get results count
         SearchResponse queryResult = searchMan.query(
@@ -127,7 +139,6 @@ public class Lib {
 
         List<Integer> result;
 
-        ObjectMapper objectMapper = new ObjectMapper();
         result = ((List<Hit>) queryResult.hits().hits())
             .stream()
             .map(h -> Integer.parseInt(objectMapper.convertValue(h.source(), Map.class)

--- a/core/src/main/java/org/fao/geonet/kernel/oaipmh/services/GetRecord.java
+++ b/core/src/main/java/org/fao/geonet/kernel/oaipmh/services/GetRecord.java
@@ -35,6 +35,8 @@ import org.fao.geonet.domain.ISODate;
 import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.MetadataCategory;
 import org.fao.geonet.domain.MetadataDataInfo;
+import org.fao.geonet.domain.ReservedOperation;
+import org.fao.geonet.exceptions.OperationNotAllowedEx;
 import org.fao.geonet.kernel.SchemaManager;
 import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.kernel.oaipmh.Lib;
@@ -52,6 +54,7 @@ import org.fao.oaipmh.responses.Record;
 import org.jdom.Attribute;
 import org.jdom.Element;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.security.access.AccessDeniedException;
 
 import jeeves.server.context.ServiceContext;
 
@@ -65,8 +68,20 @@ public class GetRecord implements OaiPmhService {
         SchemaManager sm = gc.getBean(SchemaManager.class);
 
         AbstractMetadata metadata = context.getBean(IMetadataUtils.class).findOne(spec);
+
         if (metadata == null)
             throw new IdDoesNotExistException(spec.toString());
+
+        try {
+            org.fao.geonet.lib.Lib.resource.checkPrivilege(
+                context, String.valueOf(metadata.getId()), ReservedOperation.view);
+        } catch (AccessDeniedException | OperationNotAllowedEx e) {
+            // The record exists but the caller is not allowed to view it. Report
+            // it as non-existent so a restricted record cannot be distinguished
+            // from an unknown one, and so ListRecords skips it instead of aborting
+            // the whole response. Any other error propagates unchanged.
+            throw new IdDoesNotExistException(metadata.getUuid());
+        }
 
         String uuid = metadata.getUuid();
         final MetadataDataInfo dataInfo = metadata.getDataInfo();

--- a/core/src/main/java/org/fao/geonet/kernel/search/EsQueryFilterUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/search/EsQueryFilterUtils.java
@@ -1,0 +1,144 @@
+/*
+ * Copyright (C) 2001-2026 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+package org.fao.geonet.kernel.search;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.JsonNodeFactory;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+
+public final class EsQueryFilterUtils {
+    private EsQueryFilterUtils() {
+    }
+
+    public static JsonNode buildQueryStringFilter(ObjectMapper objectMapper, String query) {
+        ObjectNode queryStringNode = objectMapper.createObjectNode();
+        queryStringNode.put("query", query);
+        ObjectNode nodeFilter = objectMapper.createObjectNode();
+        nodeFilter.set("query_string", queryStringNode);
+        return nodeFilter;
+    }
+
+    public static void addFilterToQuery(ObjectMapper objectMapper, JsonNode esQuery, JsonNode nodeFilter) {
+        JsonNode queryNode = esQuery.get("query");
+
+        // Replace any "global" aggregation with a "filter" aggregation scoped to
+        // the ACL filter.
+        // Must run after nodeFilter is built, before any branch exits early via return.
+        for (String aggsKey : new String[]{"aggs", "aggregations"}) {
+            JsonNode aggsNode = esQuery.get(aggsKey);
+            if (aggsNode != null && aggsNode.isObject()) {
+                replaceGlobalAggregations((ObjectNode) aggsNode, nodeFilter);
+            }
+        }
+
+        // Defensive: if no "query", create a bool { must: match_all, filter: nodeFilter }
+        if (queryNode == null || queryNode.isNull()
+            || (queryNode.isObject() && queryNode.isEmpty())) {
+            ObjectNode boolNode = objectMapper.createObjectNode();
+            ObjectNode matchAll = objectMapper.createObjectNode();
+            matchAll.putObject("match_all");
+            boolNode.set("must", matchAll);
+            boolNode.set("filter", nodeFilter);
+            ((ObjectNode) esQuery).set("query", objectMapper.createObjectNode().set("bool", boolNode));
+            return;
+        }
+
+        // Try to find the boolean node where to insert the filter.
+        // Prefer function_score.query.bool if present because function_score
+        // needs the filter to be applied to the inner query used for scoring.
+        JsonNode functionScoreNode = queryNode.get("function_score");
+        if (functionScoreNode != null && functionScoreNode.isObject()) {
+            JsonNode innerQuery = functionScoreNode.get("query");
+            if (innerQuery == null || innerQuery.isNull()) {
+                ObjectNode boolNode = objectMapper.createObjectNode();
+                boolNode.set("filter", nodeFilter);
+                ((ObjectNode) functionScoreNode).set("query", objectMapper.createObjectNode().set("bool", boolNode));
+                return;
+            }
+
+            JsonNode innerBool = innerQuery.get("bool");
+            if (innerBool != null && innerBool.isObject()) {
+                insertFilter((ObjectNode) innerBool, nodeFilter);
+                return;
+            }
+
+            // innerQuery exists but isn't a bool -> wrap it into a bool { must: <old>, filter: <new> }
+            ObjectNode newBool = objectMapper.createObjectNode();
+            newBool.set("must", innerQuery.deepCopy());
+            newBool.set("filter", nodeFilter);
+            ((ObjectNode) functionScoreNode).set("query", objectMapper.createObjectNode().set("bool", newBool));
+            return;
+        }
+
+        // Top-level bool
+        JsonNode boolNode = queryNode.get("bool");
+        if (boolNode != null && boolNode.isObject()) {
+            insertFilter((ObjectNode) boolNode, nodeFilter);
+            return;
+        }
+
+        // Other query shapes: wrap existing query into a bool { must: <existing query>, filter: nodeFilter }
+        ObjectNode objectNodeBool = objectMapper.createObjectNode();
+        objectNodeBool.set("must", queryNode.deepCopy());
+        objectNodeBool.set("filter", nodeFilter);
+        ((ObjectNode) esQuery).set("query", objectMapper.createObjectNode().set("bool", objectNodeBool));
+    }
+
+    private static void replaceGlobalAggregations(ObjectNode aggsNode, JsonNode aclFilter) {
+        aggsNode.fields().forEachRemaining(entry -> {
+            JsonNode aggDef = entry.getValue();
+            if (!aggDef.isObject()) {
+                return;
+            }
+            ObjectNode aggDefObj = (ObjectNode) aggDef;
+            if (aggDefObj.has("global")) {
+                // "global" ignores the query scope; swap it for a filter-scoped bucket.
+                aggDefObj.remove("global");
+                aggDefObj.set("filter", aclFilter);
+            }
+            // Recurse into nested sub-aggregations.
+            for (String subKey : new String[]{"aggs", "aggregations"}) {
+                JsonNode sub = aggDefObj.get(subKey);
+                if (sub != null && sub.isObject()) {
+                    replaceGlobalAggregations((ObjectNode) sub, aclFilter);
+                }
+            }
+        });
+    }
+
+    private static void insertFilter(ObjectNode objectNode, JsonNode nodeFilter) {
+        JsonNode filter = objectNode.get("filter");
+        if (filter == null || filter.isNull() || (filter.isObject() && filter.isEmpty())) {
+            objectNode.set("filter", nodeFilter);
+        } else if (filter.isArray()) {
+            ((ArrayNode) filter).add(nodeFilter);
+        } else {
+            ArrayNode arr = JsonNodeFactory.instance.arrayNode();
+            arr.add(filter);
+            arr.add(nodeFilter);
+            objectNode.set("filter", arr);
+        }
+    }
+}

--- a/core/src/test/java/org/fao/geonet/kernel/oaipmh/LibTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/oaipmh/LibTest.java
@@ -26,9 +26,10 @@ package org.fao.geonet.kernel.oaipmh;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.fao.geonet.kernel.search.EsQueryFilterUtils;
 import org.fao.geonet.schema.iso19139.ISO19139SchemaPlugin;
 import org.jdom.Element;
-import org.jsoup.select.Elements;
 import org.junit.Test;
 
 import static org.junit.Assert.assertEquals;
@@ -262,6 +263,43 @@ public class LibTest {
             assertEquals(searchQueryExpected, searchQuery);
         } catch (Exception ex) {
             fail("Error creating OAIMPH search query");
+        }
+    }
+
+    @Test
+    public void testAddFilterToQuery() {
+        Element params = new Element("params");
+        ObjectMapper objectMapper = new ObjectMapper();
+
+        try {
+            String queryExpected = "{" +
+                "    \"bool\": {" +
+                "      \"must\": [" +
+                "        {" +
+                "          \"terms\": {" +
+                "            \"isTemplate\": [\"n\"]" +
+                "          }" +
+                "        }" +
+                "      ]," +
+                "      \"filter\": {" +
+                "        \"query_string\": {" +
+                "          \"query\": \"op0:(1)\"" +
+                "        }" +
+                "      }" +
+                "    }" +
+                "}";
+
+            JsonNode searchQueryExpected = objectMapper.readTree(queryExpected);
+            JsonNode searchQuery = Lib.createSearchQuery(params);
+            ObjectNode wrappedSearchRequest = objectMapper.createObjectNode();
+            wrappedSearchRequest.set("query", searchQuery);
+            EsQueryFilterUtils.addFilterToQuery(
+                objectMapper,
+                wrappedSearchRequest,
+                EsQueryFilterUtils.buildQueryStringFilter(objectMapper, "op0:(1)"));
+            assertEquals(searchQueryExpected, wrappedSearchRequest.get("query"));
+        } catch (Exception ex) {
+            fail("Error adding ACL filter to OAIPMH search query");
         }
     }
 }

--- a/core/src/test/java/org/fao/geonet/kernel/oaipmh/services/GetRecordTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/oaipmh/services/GetRecordTest.java
@@ -1,0 +1,120 @@
+//=============================================================================
+//===	Copyright (C) 2001-2026 Food and Agriculture Organization of the
+//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
+//===	and United Nations Environment Programme (UNEP)
+//===
+//===	This program is free software; you can redistribute it and/or modify
+//===	it under the terms of the GNU General Public License as published by
+//===	the Free Software Foundation; either version 2 of the License, or (at
+//===	your option) any later version.
+//===
+//===	This program is distributed in the hope that it will be useful, but
+//===	WITHOUT ANY WARRANTY; without even the implied warranty of
+//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//===	General Public License for more details.
+//===
+//===	You should have received a copy of the GNU General Public License
+//===	along with this program; if not, write to the Free Software
+//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+//===
+//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+//===	Rome - Italy. email: geonetwork@osgeo.org
+//==============================================================================
+
+package org.fao.geonet.kernel.oaipmh.services;
+
+import jeeves.server.UserSession;
+import jeeves.server.context.ServiceContext;
+import org.fao.geonet.GeonetContext;
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.domain.AbstractMetadata;
+import org.fao.geonet.kernel.AccessManager;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
+import org.fao.oaipmh.exceptions.IdDoesNotExistException;
+import org.junit.Test;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Access control tests for {@link GetRecord#buildRecordStat}.
+ *
+ * A record the caller is not allowed to view must be reported as
+ * {@code idDoesNotExist} (so it is indistinguishable from an unknown record and
+ * {@code ListRecords} can skip it), while an unrelated failure during the
+ * privilege check must keep propagating rather than being turned into a denial.
+ */
+public class GetRecordTest {
+
+    private static final String PREFIX = "iso19139";
+
+    /**
+     * A {@link ServiceContext} whose metadata lookup returns a single record and
+     * whose {@link AccessManager} and authentication state are those provided.
+     */
+    @SuppressWarnings("unchecked")
+    private ServiceContext mockContext(AccessManager accessManager, boolean authenticated) throws Exception {
+        ServiceContext context = mock(ServiceContext.class);
+
+        GeonetContext gc = mock(GeonetContext.class);
+        when(context.getHandlerContext(Geonet.CONTEXT_NAME)).thenReturn(gc);
+
+        AbstractMetadata metadata = mock(AbstractMetadata.class);
+        when(metadata.getId()).thenReturn(1);
+        when(metadata.getUuid()).thenReturn("restricted-uuid");
+
+        IMetadataUtils metadataUtils = mock(IMetadataUtils.class);
+        when(metadataUtils.findOne(any(Specification.class))).thenReturn(metadata);
+
+        when(context.getBean(IMetadataUtils.class)).thenReturn(metadataUtils);
+        when(context.getBean(AccessManager.class)).thenReturn(accessManager);
+
+        UserSession session = mock(UserSession.class);
+        when(session.isAuthenticated()).thenReturn(authenticated);
+        when(context.getUserSession()).thenReturn(session);
+
+        return context;
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void anonymousCallerWithoutViewPrivilegeGetsIdDoesNotExist() throws Exception {
+        AccessManager accessManager = mock(AccessManager.class);
+        when(accessManager.getOperations(any(), any(), any())).thenReturn(Collections.emptySet());
+
+        ServiceContext context = mockContext(accessManager, false);
+
+        assertThrows(IdDoesNotExistException.class, () ->
+            GetRecord.buildRecordStat(context, mock(Specification.class), PREFIX));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void authenticatedCallerWithoutViewPrivilegeGetsIdDoesNotExist() throws Exception {
+        AccessManager accessManager = mock(AccessManager.class);
+        when(accessManager.getOperations(any(), any(), any())).thenReturn(Collections.emptySet());
+
+        ServiceContext context = mockContext(accessManager, true);
+
+        assertThrows(IdDoesNotExistException.class, () ->
+            GetRecord.buildRecordStat(context, mock(Specification.class), PREFIX));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void unexpectedErrorDuringPrivilegeCheckIsNotMaskedAsIdDoesNotExist() throws Exception {
+        AccessManager accessManager = mock(AccessManager.class);
+        when(accessManager.getOperations(any(), any(), any()))
+            .thenThrow(new IllegalStateException("boom"));
+
+        ServiceContext context = mockContext(accessManager, false);
+
+        assertThrows(IllegalStateException.class, () ->
+            GetRecord.buildRecordStat(context, mock(Specification.class), PREFIX));
+    }
+}

--- a/services/src/main/java/org/fao/geonet/api/es/EsHTTPProxy.java
+++ b/services/src/main/java/org/fao/geonet/api/es/EsHTTPProxy.java
@@ -31,7 +31,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.MappingIterator;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.Sets;
 import com.jayway.jsonpath.DocumentContext;
@@ -67,6 +66,7 @@ import org.fao.geonet.kernel.schema.MetadataOperationFilterType;
 import org.fao.geonet.kernel.schema.MetadataSchema;
 import org.fao.geonet.kernel.schema.MetadataSchemaOperationFilter;
 import org.fao.geonet.kernel.search.EsFilterBuilder;
+import org.fao.geonet.kernel.search.EsQueryFilterUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -465,122 +465,13 @@ public class EsHTTPProxy {
                                   ObjectMapper objectMapper,
                                   JsonNode esQuery) throws Exception {
 
-        // Build filter node
         String esFilter = buildQueryFilter(context,
             "",
             esQuery.toString().contains("\"draft\":")
                 || esQuery.toString().contains("+draft:")
                 || esQuery.toString().contains("-draft:"));
         JsonNode nodeFilter = objectMapper.readTree(esFilter);
-
-        JsonNode queryNode = esQuery.get("query");
-
-
-        // Replace any "global" aggregation with a "filter" aggregation scoped to
-        // the ACL filter.
-        // Must run after nodeFilter is built, before any branch exits early via return.
-        for (String aggsKey : new String[]{"aggs", "aggregations"}) {
-            JsonNode aggsNode = esQuery.get(aggsKey);
-            if (aggsNode != null && aggsNode.isObject()) {
-                replaceGlobalAggregations((ObjectNode) aggsNode, nodeFilter);
-            }
-        }
-        // Defensive: if no "query", create a bool { must: match_all, filter: nodeFilter }
-        if (queryNode == null || queryNode.isNull()
-            || (queryNode.isObject() && queryNode.isEmpty())) {
-            ObjectNode boolNode = objectMapper.createObjectNode();
-            // prefer must = match_all object (same shape as existing code)
-            ObjectNode matchAll = objectMapper.createObjectNode();
-            matchAll.putObject("match_all");
-            boolNode.set("must", matchAll);
-            boolNode.set("filter", nodeFilter);
-            ((ObjectNode) esQuery).set("query", objectMapper.createObjectNode().set("bool", boolNode));
-            return;
-        }
-
-        // Try to find the boolean node where to insert the filter.
-        // Prefer function_score.query.bool if present because function_score
-        // needs the filter to be applied to the inner query used for scoring.
-        JsonNode functionScoreNode = queryNode.get("function_score");
-        if (functionScoreNode != null && functionScoreNode.isObject()) {
-            JsonNode innerQuery = functionScoreNode.get("query");
-            if (innerQuery == null || innerQuery.isNull()) {
-                // create function_score.query.bool with only the filter
-                ObjectNode boolNode = objectMapper.createObjectNode();
-                boolNode.set("filter", nodeFilter);
-                ((ObjectNode) functionScoreNode).set("query", objectMapper.createObjectNode().set("bool", boolNode));
-                return;
-            }
-
-            JsonNode innerBool = innerQuery.get("bool");
-            if (innerBool != null && innerBool.isObject()) {
-                insertFilter((ObjectNode) innerBool, nodeFilter);
-                return;
-            }
-
-            // innerQuery exists but isn't a bool -> wrap it into a bool { must: <old>, filter: <new> }
-            ObjectNode newBool = objectMapper.createObjectNode();
-            newBool.set("must", innerQuery.deepCopy());
-            newBool.set("filter", nodeFilter);
-            ((ObjectNode) functionScoreNode).set("query", objectMapper.createObjectNode().set("bool", newBool));
-            return;
-        }
-
-        // Top-level bool
-        JsonNode boolNode = queryNode.get("bool");
-        if (boolNode != null && boolNode.isObject()) {
-            insertFilter((ObjectNode) boolNode, nodeFilter);
-            return;
-        }
-
-        // Other query shapes: wrap existing query into a bool { must: <existing query>, filter: nodeFilter }
-        ObjectNode copy = queryNode.deepCopy();
-        ObjectNode objectNodeBool = objectMapper.createObjectNode();
-        objectNodeBool.set("must", copy);
-        objectNodeBool.set("filter", nodeFilter);
-
-        // Replace the existing "query" content with the new bool
-        ((ObjectNode) queryNode).removeAll();
-        ((ObjectNode) queryNode).set("bool", objectNodeBool);
-    }
-
-    private void replaceGlobalAggregations(ObjectNode aggsNode, JsonNode aclFilter) {
-        aggsNode.fields().forEachRemaining(entry -> {
-            JsonNode aggDef = entry.getValue();
-            if (!aggDef.isObject()) {
-                return;
-            }
-            ObjectNode aggDefObj = (ObjectNode) aggDef;
-            if (aggDefObj.has("global")) {
-                // "global" ignores the query scope; swap it for a filter-scoped bucket.
-                aggDefObj.remove("global");
-                aggDefObj.set("filter", aclFilter);
-            }
-            // Recurse into nested sub-aggregations.
-            for (String subKey : new String[]{"aggs", "aggregations"}) {
-                JsonNode sub = aggDefObj.get(subKey);
-                if (sub != null && sub.isObject()) {
-                    replaceGlobalAggregations((ObjectNode) sub, aclFilter);
-                }
-            }
-        });
-    }
-
-
-
-    private void insertFilter(ObjectNode objectNode, JsonNode nodeFilter) {
-        JsonNode filter = objectNode.get("filter");
-        if (filter == null || filter.isNull() || (filter.isObject() && filter.isEmpty())) {
-            objectNode.set("filter", nodeFilter);
-        } else if (filter.isArray()) {
-            ((ArrayNode) filter).add(nodeFilter);
-        } else {
-            // existing filter is an object (or other non-array) -> convert to array preserving both
-            ArrayNode arr = JsonNodeFactory.instance.arrayNode();
-            arr.add(filter);
-            arr.add(nodeFilter);
-            objectNode.set("filter", arr);
-        }
+        EsQueryFilterUtils.addFilterToQuery(objectMapper, esQuery, nodeFilter);
     }
 
     /**


### PR DESCRIPTION
## Overview

Align the OAI-PMH endpoint with the search and CSW endpoints by applying the standard privileges filter when listing and retrieving records.

- `ListRecords` and `ListIdentifiers` build the query with `EsFilterBuilder` — the same `op0`/owner filter already used by search and CSW — so results are scoped to what the caller may view.
- `GetRecord` checks the `view` privilege and returns `idDoesNotExist` for records the caller may not view, in line with the OAI-PMH error model. `ListRecords` skips those records through its existing `idDoesNotExist` handling.
- The query filter-insertion logic is extracted from `EsHTTPProxy` into a small `EsQueryFilterUtils` helper and reused, so both endpoints share one implementation.

## Notes

- OAI-PMH no longer returns draft/working copies (the filter adds `draft:n OR draft:e`), consistent with search and CSW.
- Adds unit tests covering the `GetRecord` privilege handling and the query filter builder; these do not require a running Elasticsearch.

## Backport

Please backport to `4.2.x`.
