### PR TITLE
MSearch / Fix invalid query

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/es/EsHTTPProxy.java
+++ b/services/src/main/java/org/fao/geonet/api/es/EsHTTPProxy.java
@@ -434,9 +434,11 @@ public class EsHTTPProxy {
             JsonNode node = (JsonNode) mappingIterator.nextValue();
             boolean isMultiSearchHeader = isMultiSearch && requestLineNumber % 2 == 0;
             if (isMultiSearchHeader) {
-                if (node.isObject()) {
-                    ((ObjectNode) node).put("index", defaultIndex);
+                if (!node.isObject()) {
+                    throw new IllegalArgumentException(
+                        "Invalid _msearch request: expected a JSON object for the header at line " + requestLineNumber);
                 }
+                ((ObjectNode) node).put("index", defaultIndex);
             } else {
                 enrichSearchRequestNode(context, session, objectMapper, node, selectionBucket);
             }

--- a/services/src/main/java/org/fao/geonet/api/es/EsHTTPProxy.java
+++ b/services/src/main/java/org/fao/geonet/api/es/EsHTTPProxy.java
@@ -411,41 +411,62 @@ public class EsHTTPProxy {
         if (SEARCH_ENDPOINT.equals(endPoint) || MULTISEARCH_ENDPOINT.equals(endPoint)) {
             UserSession session = context.getUserSession();
             ObjectMapper objectMapper = new ObjectMapper();
-
-            // multisearch support
-            final MappingIterator<Object> mappingIterator = objectMapper.readerFor(JsonNode.class).readValues(body);
-            StringBuilder requestBody = new StringBuilder();
-            while (mappingIterator.hasNextValue()) {
-                JsonNode node = (JsonNode) mappingIterator.nextValue();
-                final JsonNode indexNode = node.get("index");
-                if (indexNode != null) {
-                    ((ObjectNode) node).put("index", defaultIndex);
-                } else {
-                    addFilterToQuery(context, objectMapper, node);
-                    if (selectionBucket != null) {
-                        // Multisearch are not supposed to work with a bucket.
-                        // Only one request is store in session
-                        session.setProperty(Geonet.Session.SEARCH_REQUEST + selectionBucket, node);
-                    }
-                    final JsonNode sourceNode = node.get("_source");
-                    if (sourceNode != null) {
-                        if (sourceNode.isArray()) {
-                            addRequiredField((ArrayNode) sourceNode);
-                        } else {
-                            final JsonNode sourceIncludes = sourceNode.get("includes");
-                            if (sourceIncludes != null && sourceIncludes.isArray()) {
-                                addRequiredField((ArrayNode) sourceIncludes);
-                            }
-                        }
-                    }
-                }
-                requestBody.append(node).append(System.lineSeparator());
-            }
+            String requestBody = buildSearchRequestBody(context, session, objectMapper, body, endPoint, selectionBucket);
             handleRequest(context, httpSession, request, response, url, endPoint,
-                requestBody.toString(), true, selectionBucket, relatedTypes);
+                requestBody, true, selectionBucket, relatedTypes);
         } else {
             handleRequest(context, httpSession, request, response, url, endPoint,
                 body, true, selectionBucket, relatedTypes);
+        }
+    }
+
+    private String buildSearchRequestBody(ServiceContext context,
+                                          UserSession session,
+                                          ObjectMapper objectMapper,
+                                          String body,
+                                          String endPoint,
+                                          String selectionBucket) throws Exception {
+        boolean isMultiSearch = MULTISEARCH_ENDPOINT.equals(endPoint);
+        final MappingIterator<Object> mappingIterator = objectMapper.readerFor(JsonNode.class).readValues(body);
+        StringBuilder requestBody = new StringBuilder();
+        int requestLineNumber = 0;
+        while (mappingIterator.hasNextValue()) {
+            JsonNode node = (JsonNode) mappingIterator.nextValue();
+            boolean isMultiSearchHeader = isMultiSearch && requestLineNumber % 2 == 0;
+            if (isMultiSearchHeader) {
+                if (node.isObject()) {
+                    ((ObjectNode) node).put("index", defaultIndex);
+                }
+            } else {
+                enrichSearchRequestNode(context, session, objectMapper, node, selectionBucket);
+            }
+            requestLineNumber++;
+            requestBody.append(node).append(System.lineSeparator());
+        }
+        return requestBody.toString();
+    }
+
+    private void enrichSearchRequestNode(ServiceContext context,
+                                         UserSession session,
+                                         ObjectMapper objectMapper,
+                                         JsonNode node,
+                                         String selectionBucket) throws Exception {
+        addFilterToQuery(context, objectMapper, node);
+        if (selectionBucket != null) {
+            // Multisearch are not supposed to work with a bucket.
+            // Only one request is store in session
+            session.setProperty(Geonet.Session.SEARCH_REQUEST + selectionBucket, node);
+        }
+        final JsonNode sourceNode = node.get("_source");
+        if (sourceNode != null) {
+            if (sourceNode.isArray()) {
+                addRequiredField((ArrayNode) sourceNode);
+            } else {
+                final JsonNode sourceIncludes = sourceNode.get("includes");
+                if (sourceIncludes != null && sourceIncludes.isArray()) {
+                    addRequiredField((ArrayNode) sourceIncludes);
+                }
+            }
         }
     }
 

--- a/services/src/test/java/org/fao/geonet/api/es/EsHTTPProxyTest.java
+++ b/services/src/test/java/org/fao/geonet/api/es/EsHTTPProxyTest.java
@@ -229,6 +229,33 @@ public class EsHTTPProxyTest {
         assertNotNull("filter key must replace global (aggregations key variant)", gAgg.get("filter"));
     }
 
+    @Test
+    public void testMSearchAppliesDefaultIndexOnlyToHeaderAndFilterOnlyToSearchRequest() throws Exception {
+        setPrivateField("defaultIndex", "gn-records");
+        ServiceContext context = new ServiceContext("default", applicationContext, new HashMap<>(), null);
+        UserSession userSession = spy(new UserSession());
+        when(userSession.getProfile()).thenReturn(Profile.Administrator);
+        context.setUserSession(userSession);
+
+        ObjectMapper mapper = new ObjectMapper();
+        String msearchBody = "{\"index\":\"external-index\"}\n"
+            + "{\"query\":{\"match_all\":{}}}\n";
+        String rewrittenBody = invokeBuildSearchRequestBody(context, userSession, mapper, msearchBody, "_msearch", null);
+
+        String[] lines = rewrittenBody.split("\\R");
+        assertTrue("Expected header + request NDJSON lines", lines.length >= 2);
+
+        JsonNode headerNode = mapper.readTree(lines[0]);
+        JsonNode searchNode = mapper.readTree(lines[1]);
+
+        assertEquals("gn-records", headerNode.path("index").asText());
+        assertFalse("Header must not be rewritten into a query payload", headerNode.has("query"));
+        assertFalse("Header must not receive ACL filter", headerNode.toString().contains("*:*"));
+
+        assertTrue("Search request must receive ACL filter",
+            searchNode.path("query").path("bool").path("filter").toString().contains("*:*"));
+    }
+
     private void invokeAddFilterToQuery(ObjectNode body, ObjectMapper mapper) throws Exception {
         ServiceContext context = new ServiceContext("default", applicationContext, new HashMap<>(), null);
         UserSession userSession = spy(new UserSession());
@@ -242,6 +269,31 @@ public class EsHTTPProxyTest {
         method.setAccessible(true);
         method.invoke(esHTTPProxy, context, mapper, body);
     }
+
+    private String invokeBuildSearchRequestBody(ServiceContext context,
+                                                UserSession session,
+                                                ObjectMapper mapper,
+                                                String body,
+                                                String endPoint,
+                                                String selectionBucket) throws Exception {
+        Method method = EsHTTPProxy.class.getDeclaredMethod("buildSearchRequestBody",
+            ServiceContext.class,
+            UserSession.class,
+            ObjectMapper.class,
+            String.class,
+            String.class,
+            String.class);
+        method.setAccessible(true);
+        return (String) method.invoke(esHTTPProxy, context, session, mapper, body, endPoint, selectionBucket);
+    }
+
+    private void setPrivateField(String fieldName, Object value) throws Exception {
+        java.lang.reflect.Field field = EsHTTPProxy.class.getDeclaredField(fieldName);
+        field.setAccessible(true);
+        field.set(esHTTPProxy, value);
+    }
+
+
 
     private void assertAclFilterPresent(ObjectNode body, String caseLabel) {
         JsonNode queryNode = body.get("query");

--- a/services/src/test/java/org/fao/geonet/api/es/EsHTTPProxyTest.java
+++ b/services/src/test/java/org/fao/geonet/api/es/EsHTTPProxyTest.java
@@ -256,6 +256,112 @@ public class EsHTTPProxyTest {
             searchNode.path("query").path("bool").path("filter").toString().contains("*:*"));
     }
 
+    /**
+     * Reproduces the reported bug: third-party clients may send a _msearch header that omits
+     * the "index" field entirely (relying on the URL path's default index instead). The old
+     * content-sniffing implementation (checking for an "index" key to decide header vs. body)
+     * misclassified this as a search body and corrupted it with an ACL filter, producing an
+     * invalid request. The position-based implementation must still recognise it as the header.
+     */
+    @Test
+    public void testMSearchAppliesDefaultIndexToHeaderMissingIndexField() throws Exception {
+        setPrivateField("defaultIndex", "gn-records");
+        ServiceContext context = new ServiceContext("default", applicationContext, new HashMap<>(), null);
+        UserSession userSession = spy(new UserSession());
+        when(userSession.getProfile()).thenReturn(Profile.Administrator);
+        context.setUserSession(userSession);
+
+        ObjectMapper mapper = new ObjectMapper();
+        String msearchBody = "{\"search_type\":\"query_then_fetch\"}\n"
+            + "{\"query\":{\"match_all\":{}}}\n";
+        String rewrittenBody = invokeBuildSearchRequestBody(context, userSession, mapper, msearchBody, "_msearch", null);
+
+        String[] lines = rewrittenBody.split("\\R");
+        assertEquals("Expected exactly one header + one request line", 2, lines.length);
+
+        JsonNode headerNode = mapper.readTree(lines[0]);
+        JsonNode searchNode = mapper.readTree(lines[1]);
+
+        assertEquals("Header without an index field must still get the default index",
+            "gn-records", headerNode.path("index").asText());
+        assertEquals("Other header fields must be preserved",
+            "query_then_fetch", headerNode.path("search_type").asText());
+        assertFalse("Header must not receive ACL filter", headerNode.toString().contains("*:*"));
+
+        assertTrue("Search request must receive ACL filter",
+            searchNode.path("query").path("bool").path("filter").toString().contains("*:*"));
+    }
+
+    /**
+     * A _msearch body can contain several header/body pairs. The header/body alternation must
+     * be tracked by line position across the whole request, not just for the first pair.
+     */
+    @Test
+    public void testMSearchHandlesMultipleRequestPairs() throws Exception {
+        setPrivateField("defaultIndex", "gn-records");
+        ServiceContext context = new ServiceContext("default", applicationContext, new HashMap<>(), null);
+        UserSession userSession = spy(new UserSession());
+        when(userSession.getProfile()).thenReturn(Profile.Administrator);
+        context.setUserSession(userSession);
+
+        ObjectMapper mapper = new ObjectMapper();
+        String msearchBody = "{}\n"
+            + "{\"query\":{\"match_all\":{}}}\n"
+            + "{\"index\":\"external-index\"}\n"
+            + "{\"query\":{\"term\":{\"field\":\"value\"}}}\n";
+        String rewrittenBody = invokeBuildSearchRequestBody(context, userSession, mapper, msearchBody, "_msearch", null);
+
+        String[] lines = rewrittenBody.split("\\R");
+        assertEquals("Expected two header + request pairs", 4, lines.length);
+
+        JsonNode header1 = mapper.readTree(lines[0]);
+        JsonNode search1 = mapper.readTree(lines[1]);
+        JsonNode header2 = mapper.readTree(lines[2]);
+        JsonNode search2 = mapper.readTree(lines[3]);
+
+        assertEquals("gn-records", header1.path("index").asText());
+        assertTrue("First search request must receive ACL filter",
+            search1.path("query").path("bool").path("filter").toString().contains("*:*"));
+
+        assertEquals("Second header's index must also be forced to the default index, " +
+            "overriding any client-supplied value", "gn-records", header2.path("index").asText());
+        assertTrue("Second search request must receive ACL filter",
+            search2.path("query").path("bool").path("filter").toString().contains("*:*"));
+    }
+
+    /**
+     * A _msearch header line must be a JSON object. A malformed header (e.g. a bare JSON null)
+     * cannot carry an "index" override, so it can't be used to bypass the default index, but it
+     * must still be rejected clearly by the proxy rather than silently forwarded to Elasticsearch.
+     *
+     * Note: the header must be a JSON scalar such as "null" here, not "[]". A top-level JSON
+     * array is special-cased by Jackson's ObjectReader#readValues(String): it is treated as the
+     * single root value to unwrap into a sequence of its own elements, rather than as one NDJSON
+     * line among several root-level values. An empty array therefore makes hasNextValue() return
+     * false immediately, silently skipping the rest of the request body (and this test) instead
+     * of reaching the code under test.
+     */
+    @Test
+    public void testMSearchRejectsNonObjectHeader() throws Exception {
+        setPrivateField("defaultIndex", "gn-records");
+        ServiceContext context = new ServiceContext("default", applicationContext, new HashMap<>(), null);
+        UserSession userSession = spy(new UserSession());
+        when(userSession.getProfile()).thenReturn(Profile.Administrator);
+        context.setUserSession(userSession);
+
+        ObjectMapper mapper = new ObjectMapper();
+        String msearchBody = "null\n"
+            + "{\"query\":{\"match_all\":{}}}\n";
+
+        try {
+            invokeBuildSearchRequestBody(context, userSession, mapper, msearchBody, "_msearch", null);
+            fail("Expected an exception for a non-object _msearch header");
+        } catch (java.lang.reflect.InvocationTargetException e) {
+            assertTrue("Cause must be an IllegalArgumentException",
+                e.getCause() instanceof IllegalArgumentException);
+        }
+    }
+
     private void invokeAddFilterToQuery(ObjectNode body, ObjectMapper mapper) throws Exception {
         ServiceContext context = new ServiceContext("default", applicationContext, new HashMap<>(), null);
         UserSession userSession = spy(new UserSession());


### PR DESCRIPTION
Invalid query detected when using third party apps relying on `_msearch` endpoint.

eg.
```bash
curl 'http://localhost:8080/geonetwork/mapstore/api/search/records/_msearch?' \
  -H 'accept: application/json' \
  -H 'content-type: application/x-ndjson' \
  --data-raw $'{"preference":"cardQuickFilter_2"}\n{"query":{"bool":{"must":[{"bool":{"must":[{"query_string":{"query":"+(resourceType:application) -(th_infraSIG.default:Reporting_INSPIRE) -(cl_status.key:obsolete)"}}]}}]}},"size":0,"_source":{"includes":["*"],"excludes":[]},"aggs":{"th_Themes_geoportail_wallon_hierarchy.default":{"terms":{"field":"th_Themes_geoportail_wallon_hierarchy.default","size":100,"order":{"_count":"desc"}}}}}\n'
```


Follow up of https://github.com/geonetwork/core-geonetwork/pull/9302

`_msearch` request is NDJSON and contains 
```
header\n
body\n
header\n
body\n
```
See https://www.elastic.co/docs/api/doc/elasticsearch/operation/operation-msearch#operation-msearch-body-application-json

Ensure header has index set and process body like searchRequest.


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

Funded by Service Public de Wallonie