### PR TITLE
Bump Jackson to 2.21.4 LTS and manage it with the Jackson BOM [4.2.x]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1125,11 +1125,6 @@
         <version>${spring.jpa.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.fasterxml.jackson.datatype</groupId>
-        <artifactId>jackson-datatype-hibernate5</artifactId>
-        <version>${jackson.version}</version>
-      </dependency>
-      <dependency>
         <groupId>edu.ucar</groupId>
         <artifactId>netcdf</artifactId>
         <version>4.3.23</version>
@@ -1161,20 +1156,15 @@
         <artifactId>flying-saucer-pdf-openpdf</artifactId>
         <version>${flying-saucer}</version>
       </dependency>
+      <!-- Manages all Jackson artifacts, including jackson-annotations,
+           which since 2.20 is released without the patch digit and can no
+           longer share a single version property with the other modules. -->
       <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-databind</artifactId>
+        <groupId>com.fasterxml.jackson</groupId>
+        <artifactId>jackson-bom</artifactId>
         <version>${jackson.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-core</artifactId>
-        <version>${jackson.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>com.fasterxml.jackson.core</groupId>
-        <artifactId>jackson-annotations</artifactId>
-        <version>${jackson.version}</version>
+        <type>pom</type>
+        <scope>import</scope>
       </dependency>
       <dependency>
         <groupId>javax.xml.bind</groupId>
@@ -1642,7 +1632,7 @@
     <node.version>v8.11.1</node.version>
     <npm.version>5.8.0</npm.version>
     <xmlunit.version>2.1.1</xmlunit.version>
-    <jackson.version>2.16.2</jackson.version>
+    <jackson.version>2.21.4</jackson.version>
     <flying-saucer>9.1.22</flying-saucer>
     <camel.version>2.25.1</camel.version>
     <log4j2.version>2.24.3</log4j2.version>


### PR DESCRIPTION
## What

- Replaces the individually managed `jackson-core`, `jackson-databind`, `jackson-annotations` and `jackson-datatype-hibernate5` entries in `dependencyManagement` with a single `com.fasterxml.jackson:jackson-bom` import, still driven by the `jackson.version` property.
- Bumps `jackson.version` from 2.16.2 to 2.21.4.

## Why the BOM

Since Jackson 2.20, `jackson-annotations` is released without the patch digit (versions are `2.20`, `2.21`, `2.22`), so a single shared version property can no longer address all Jackson artifacts. The BOM maps every artifact to its correct version and also keeps transitive Jackson modules pulled in by other dependencies aligned with the core version. This is the same restructuring proposed for `main` in #9361.

## Why 2.21.4 and not 2.22.0

2.21 is the current Jackson LTS line, with patch releases planned until January 2028, while 2.22 is a regular release with a shorter lifespan. For a maintenance branch like 4.2.x the LTS line is the better fit: we keep receiving fixes without taking further minor version jumps. To be clear, with the BOM in place 2.22.0 would resolve fine too, so staying on LTS is a deliberate choice rather than a technical limitation.

## Compatibility checks done

- `mvn clean install -DskipTests` passes locally with a Java 8 JDK (the same version the 4.2.x CI uses).
- The effective POM resolves `jackson-annotations` to 2.21 and the other Jackson artifacts to 2.21.4.
- `jackson-datatype-hibernate5` 2.21.4 is still compiled for Java 8 and built against Hibernate 5 (provided scope). The JDK 17 requirement mentioned in the Jackson release notes only applies to the new Hibernate 7 module.
- Release notes review from 2.17 to 2.21 shows few behavior changes. The notable ones: stricter coercion of stringified numbers with leading zeroes (2.17), unpaired tilde in `JsonPointer` no longer acts as an escape (2.19), parser close now clears the current token, and missing non-optional `@JacksonInject` values throw an exception (2.20). None of them look relevant to how GeoNetwork uses Jackson, but they are worth keeping in mind while testing.