### PR TITLE
Bump actions/cache from 4 to 5

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -30,7 +30,7 @@ jobs:
           distribution: 'temurin'
           cache: 'maven'
       - name: Cache SonarCloud packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.sonar/cache
           key: ${{ runner.os }}-sonar


### PR DESCRIPTION
Manual backport of #9326 to `4.2.x` (automatic backport failed due to a merge commit in the original PR that `git cherry-pick` can't handle without `-m`).

Same one-line change: `actions/cache@v4` -> `actions/cache@v5` in `.github/workflows/sonarcloud.yml`.