### PR TITLE
Bump advanced-security/maven-dependency-submission-action from 4 to 5 (backport #9325)

### DIFF
--- a/.github/workflows/mvn-dep-tree.yml
+++ b/.github/workflows/mvn-dep-tree.yml
@@ -30,4 +30,4 @@ jobs:
           cache: maven
 
       - name: Submit Dependency Snapshot
-        uses: advanced-security/maven-dependency-submission-action@v4
+        uses: advanced-security/maven-dependency-submission-action@v5


### PR DESCRIPTION
Manual backport of #9325 to `4.2.x`.

The automated backport failed because the bot's GitHub App token lacks the `workflows` permission needed to push changes to `.github/workflows/*`:

```
remote rejected: refusing to allow a GitHub App to create or update workflow `.github/workflows/mvn-dep-tree.yml` without `workflows` permission
```

Cherry-picked commit fa0090a3fb2434611495d3201c4754aa8399d88a cleanly, no conflicts.