### PR TITLE
Bump org.postgresql:postgresql from 42.7.3 to 42.7.11 (#9387)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1614,7 +1614,7 @@
     of Postgres is used and update pg.version if needed. -->
     <geotools.version>28.6.1</geotools.version>
     <jts.version>1.19.0</jts.version>
-    <pg.version>42.3.10</pg.version>
+    <pg.version>42.7.11</pg.version>
 
     <spring.version>5.3.39</spring.version>
     <spring.security.version>5.7.14</spring.security.version>


### PR DESCRIPTION
Backport of #9387 to `4.2.x`.

The automated backport failed because `4.2.x` pins `pg.version` at `42.3.10` (compared to `42.7.3` on `main`), so the cherry-pick couldn't apply cleanly. Resolved by bumping `pg.version` straight to `42.7.11`, keeping `4.2.x`'s own `geotools.version`/`jts.version` untouched.

Verified the driver still supports Java 8 (which `4.2.x` targets) and compiled the `domain` module under JDK 8 with the new version.