### PR TITLE
Bump actions/checkout from 3.1.0 to 7.0.0 (backport #9393)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -38,7 +38,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v7.0.0
       with:
         show-progress: 'false'
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout GeoNetwork
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0
       - name: Install Python

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -15,7 +15,7 @@ jobs:
           - os: ubuntu-24.04
             jdk: 8
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7.0.0
       with:
         # 500 commits, set to 0 to get all
         fetch-depth: 500
@@ -48,7 +48,7 @@ jobs:
   QA:
     runs-on: ubuntu-24.04
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v7.0.0
       with:
         # 500 commits, set to 0 to get all
         fetch-depth: 500

--- a/.github/workflows/mvn-dep-tree.yml
+++ b/.github/workflows/mvn-dep-tree.yml
@@ -15,7 +15,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7.0.0
         with:
           show-progress: 'false'
 

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -13,7 +13,7 @@ jobs:
     # https://github.community/t/how-to-detect-a-pull-request-from-a-fork/18363/4
     if: github.event.pull_request.head.repo.fork != true
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7.0.0
         with:
           fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of analysis
           submodules: 'recursive'


### PR DESCRIPTION
Manual backport of #9393 to `4.2.x`.

The automatic backport failed with a modify/delete conflict: `.github/workflows/scorecard.yml` does not exist on `4.2.x`, while the original commit modified it. Since that workflow is not present on this branch, the change to `scorecard.yml` was dropped and the `actions/checkout` bump to `v7.0.0` was applied to the remaining 5 workflow files.