### PR TITLE
Bump actions/setup-java from 4.2.1 to 5.4.0 (backport #9394)

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,7 +43,7 @@ jobs:
         show-progress: 'false'
 
     - name: Setup Java JDK
-      uses: actions/setup-java@v4.2.1
+      uses: actions/setup-java@v5.4.0
       with:
         java-version: 8
         # Java distribution. See the list of supported distributions in README file

--- a/.github/workflows/linux.yml
+++ b/.github/workflows/linux.yml
@@ -22,7 +22,7 @@ jobs:
         submodules: 'recursive'
         show-progress: 'false'
     - name: Set up JDK
-      uses: actions/setup-java@v4.2.1
+      uses: actions/setup-java@v5.4.0
       with:
         distribution: 'temurin'
         java-version: ${{ matrix.jdk }}
@@ -55,7 +55,7 @@ jobs:
         submodules: 'recursive'
         show-progress: 'false'
     - name: Set up JDK
-      uses: actions/setup-java@v4.2.1
+      uses: actions/setup-java@v5.4.0
       with:
         distribution: 'temurin'
         java-version: 8

--- a/.github/workflows/mvn-dep-tree.yml
+++ b/.github/workflows/mvn-dep-tree.yml
@@ -20,7 +20,7 @@ jobs:
           show-progress: 'false'
 
       - name: Setup Java JDK
-        uses: actions/setup-java@v4.2.1
+        uses: actions/setup-java@v5.4.0
         with:
           java-version: 8
           # Java distribution. See the list of supported distributions in README file

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -24,7 +24,7 @@ jobs:
       # So, first install JDK 8, build GeoNetwork, then install JDK21
       # and run SonarQube:
       - name: Set up JDK 8
-        uses: actions/setup-java@v4.2.1
+        uses: actions/setup-java@v5.4.0
         with:
           java-version: 8
           distribution: 'temurin'
@@ -39,7 +39,7 @@ jobs:
         run: mvn -B package -DskipTests
 
       - name: Set up JDK 21 # Sonarcloud analyzer needs at least JDK 17
-        uses: actions/setup-java@v4.2.1
+        uses: actions/setup-java@v5.4.0
         with:
           distribution: 'temurin'
           java-version: '21'


### PR DESCRIPTION
Manual backport of #9394 to `4.2.x`.

The automated backport failed with a conflict in `.github/workflows/sonarcloud.yml`. On `4.2.x` the first Java step is `Set up JDK 8` (with a comment explaining the JDK 8 build / JDK 21 SonarQube split), while on `main` it is `Set up JDK 11`, so the dependabot hunk did not apply. Resolved by keeping the `4.2.x` step/comment and applying only the version bump.

Bumps `actions/setup-java` from `v4.2.1` to `v5.4.0` across:
- `.github/workflows/codeql-analysis.yml`
- `.github/workflows/linux.yml`
- `.github/workflows/mvn-dep-tree.yml`
- `.github/workflows/sonarcloud.yml`