### PR TITLE
fix: CSW harvester NullPointerException when RecordInfo schema is null

### DIFF
--- a/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
+++ b/harvesters/src/main/java/org/fao/geonet/kernel/harvest/harvester/csw/Aligner.java
@@ -466,7 +466,7 @@ public class Aligner extends BaseAligner<CswParams> {
             updateSchema = !newSchema.equals(schema);
             schema = newSchema;
         } else {
-            if (!ri.schema.equals(schema)) {
+            if (!schema.equals(ri.schema)) {
                 log.warning("  - Detected schema '" + schema + "' is different from the one of the metadata in the catalog '" + ri.schema + "'. Using the detected one.");
                 updateSchema = true;
             }


### PR DESCRIPTION
## Summary

Fixes #9351. Reverses the schema comparison in the CSW harvester's `Aligner.updatingLocalMetadata` so it no longer throws a `NullPointerException` when a catalog record's `RecordInfo.schema` is null.

## Why this matters

After upgrading from 4.4.9 to 4.4.11, CSW harvesters stop updating records already present in the catalog (inserts still work), and the harvest log shows every update failing with:

```
java.lang.NullPointerException
  at org.fao.geonet.kernel.harvest.harvester.csw.Aligner.updatingLocalMetadata(Aligner.java:469)
```

As the reporter (@mleistner-bgr) traced, this comes from #9052, which added the schema-change check `if (!ri.schema.equals(schema))`. When the local record's `RecordInfo.schema` (`ri.schema`) is null, calling `.equals()` on it throws, and the update path dies.

The `schema` operand is the freshly autodetected schema from `dataMan.autodetectSchema(md, ...)`, which throws rather than returns null when no schema matches, so it is always non-null here. Making it the receiver is both null-safe and semantically correct: when the stored record has no schema, the detected schema differs, `updateSchema` becomes `true`, and the record's schema id is corrected on save. That matches the intent of #9052 instead of crashing.

```java
-            if (!ri.schema.equals(schema)) {
+            if (!schema.equals(ri.schema)) {
```

## Testing

No automated test is included in this PR. The change is a one-line null-safety reversal in the `else` branch of `updatingLocalMetadata`; the behavior for two non-null unequal schemas is identical (the warning still fires and `updateSchema` is set), and the previously-crashing null case now completes. The existing harvester test suite continues to exercise the insert and update paths. The same `!ri.schema.equals(...)` pattern exists in the `geonet`, `sftp`, and `webdav` aligners; I kept this PR scoped to the CSW aligner reported in #9351, and can open follow-ups for the others if you'd like them addressed the same way.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chunks
- [x] *Clean commit messages*, longer verbose messages are encouraged
