### PR TITLE
[Backport 4.2.x] Escape HTML content (#9385)

### DIFF
--- a/web-ui/src/main/resources/catalog/components/usersearches/UserSearchesDirective.js
+++ b/web-ui/src/main/resources/catalog/components/usersearches/UserSearchesDirective.js
@@ -586,7 +586,7 @@
                           ' fa-fw" title="' +
                           $filter("translate")("featuredsearch") +
                           '"></span>' +
-                          row.label
+                          gnUtilityService.escapeHtml(row.label)
                         );
                       }
                     },

--- a/web-ui/src/main/resources/catalog/components/utility/UtilityService.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityService.js
@@ -450,7 +450,8 @@
           .replace(/</g, "&lt;")
           .replace(/>/g, "&gt;")
           .replace(/"/g, "&quot;")
-          .replace(/'/g, "&#39;");
+          .replace(/'/g, "&#39;")
+          .replace(/=/g, "&#x3D;");
       };
 
       /**

--- a/web-ui/src/main/resources/catalog/components/utility/UtilityService.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityService.js
@@ -437,6 +437,23 @@
       };
 
       /**
+       * Escape HTML special characters in a string, so it can be safely inserted as text
+       * (e.g. into an HTML attribute value or as element content) when building HTML
+       * fragments by string concatenation, such as in bootstrap-table `formatter` functions.
+       * @param {string} str
+       * @return {string} the escaped string, or an empty string if str is falsy.
+       */
+      var escapeHtml = function (str) {
+        if (!str) return "";
+        return String(str)
+          .replace(/&/g, "&amp;")
+          .replace(/</g, "&lt;")
+          .replace(/>/g, "&gt;")
+          .replace(/"/g, "&quot;")
+          .replace(/'/g, "&#39;");
+      };
+
+      /**
        * Sort an array of elements with translations labels, using the provided language.
        *
        */
@@ -469,7 +486,8 @@
         displayPermalink: displayPermalink,
         openModal: openModal,
         goBack: goBack,
-        sortByTranslation: sortByTranslation
+        sortByTranslation: sortByTranslation,
+        escapeHtml: escapeHtml
       };
     }
   ]);

--- a/web-ui/src/main/resources/catalog/components/viewer/gfi/FeaturesLoader.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/gfi/FeaturesLoader.js
@@ -24,7 +24,9 @@
 (function () {
   goog.provide("gn_featurestable_loader");
 
-  var module = angular.module("gn_featurestable_loader", []);
+  goog.require("gn_utility_service");
+
+  var module = angular.module("gn_featurestable_loader", ["gn_utility_service"]);
 
   var linkTpl =
     '<span class="fa-stack">' +

--- a/web-ui/src/main/resources/catalog/components/viewer/gfi/FeaturesLoader.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/gfi/FeaturesLoader.js
@@ -197,7 +197,8 @@
   };
 
   geonetwork.GnFeaturesGFILoader.prototype.formatUrlValues_ = function (url) {
-    return '<a href="' + url + '" target="_blank">' + linkTpl + "</a>";
+    var escapeHtml = this.$injector.get("gnUtilityService").escapeHtml;
+    return '<a href="' + escapeHtml(url) + '" target="_blank">' + linkTpl + "</a>";
   };
 
   geonetwork.GnFeaturesGFILoader.prototype.getBsTableConfig = function () {

--- a/web-ui/src/main/resources/catalog/components/viewer/gfi/GetFeatureInfoDirective.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/gfi/GetFeatureInfoDirective.js
@@ -24,7 +24,7 @@
 (function () {
   goog.provide("gn_gfi_directive");
 
-  var module = angular.module("gn_gfi_directive", ["angular.filter"]);
+  var module = angular.module("gn_gfi_directive", ["angular.filter", "ngSanitize"]);
 
   var gfiTemplateURL = "../../catalog/components/viewer/gfi/partials/gfi-popup.html";
 
@@ -32,7 +32,8 @@
 
   module.directive("gnVectorFeatureToolTip", [
     "gnDebounce",
-    function (gnDebounce) {
+    "$sanitize",
+    function (gnDebounce, $sanitize) {
       return {
         restrict: "A",
         scope: {
@@ -82,7 +83,7 @@
               });
               tooltipContent += "</ul>";
               info.popover("hide");
-              info.data("bs.popover").options.content = tooltipContent;
+              info.data("bs.popover").options.content = $sanitize(tooltipContent);
               info.popover("show");
             } else {
               info.popover("hide");

--- a/web-ui/src/main/resources/catalog/js/admin/DashboardRecordLinkController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/DashboardRecordLinkController.js
@@ -42,6 +42,7 @@
     "gnHumanizeTimeService",
     "$window",
     "getBsTableLang",
+    "gnUtilityService",
     function (
       $scope,
       $routeParams,
@@ -53,7 +54,8 @@
       $compile,
       gnHumanizeTimeService,
       $window,
-      getBsTableLang
+      getBsTableLang,
+      gnUtilityService
     ) {
       $scope.filter = {};
       $scope.selections = [];
@@ -61,6 +63,8 @@
       $scope.selectionFilter = "";
       $scope.groupLinkFilter = null;
       $scope.groupOwnerIdFilter = null;
+
+      var escapeHtml = gnUtilityService.escapeHtml;
 
       $http.get("../api/selections").then(function (r) {
         Object.keys(r.data).map(function (k) {
@@ -220,7 +224,7 @@
                   "<div><i class='fa fa-fw fa-2x " +
                   _class +
                   "'><p class='hidden'>" +
-                  _key +
+                  escapeHtml(_key) +
                   "</p></i></div>"
                 );
               }.bind(this)
@@ -233,7 +237,10 @@
               filterControl: "input",
               filterControlPlaceholder: "",
               formatter: function (val, row) {
-                return "<a href='" + row.url + "' target='_blank'>" + row.url + "</a>";
+                var escapedUrl = escapeHtml(row.url);
+                return (
+                  "<a href='" + escapedUrl + "' target='_blank'>" + escapedUrl + "</a>"
+                );
               }.bind(this)
             },
             {
@@ -248,7 +255,13 @@
                     null,
                     true
                   );
-                  return '<div title="' + date.title + '">' + date.value + "</div>";
+                  return (
+                    '<div title="' +
+                    escapeHtml(date.title) +
+                    '">' +
+                    escapeHtml(date.value) +
+                    "</div>"
+                  );
                 } else {
                   return "";
                 }
@@ -262,9 +275,9 @@
               formatter: function (val, row) {
                 if (row.linkStatus && row.linkStatus[0]) {
                   return (
-                    row.linkStatus[0].statusValue +
+                    escapeHtml(row.linkStatus[0].statusValue) +
                     (row.linkStatus[0].statusInfo != ""
-                      ? ": " + row.linkStatus[0].statusInfo
+                      ? ": " + escapeHtml(row.linkStatus[0].statusInfo)
                       : "")
                   );
                 } else {
@@ -283,11 +296,12 @@
                 var ulElem = "<ul>";
                 for (var i = 0; i < row.records.length; i++) {
                   var record = row.records[i];
+                  var escapedUuid = escapeHtml(record.metadataUuid);
                   var aElem =
                     "<li><a href='catalog.search#/metadata/" +
-                    record.metadataUuid +
+                    escapedUuid +
                     "' target='_blank'>" +
-                    record.metadataUuid +
+                    escapedUuid +
                     "</a></li>";
                   ulElem = ulElem + aElem;
                 }
@@ -301,7 +315,7 @@
                 var key = row.url;
                 return (
                   '<a class="btn btn-xs btn-block btn-default" data-job-key="' +
-                  key +
+                  escapeHtml(key) +
                   '"><icon class="fa fa-fw fa-play"></icon></a>'
                 );
               }.bind(this)

--- a/web-ui/src/main/resources/catalog/js/admin/DashboardWfsIndexingController.js
+++ b/web-ui/src/main/resources/catalog/js/admin/DashboardWfsIndexingController.js
@@ -24,7 +24,12 @@
 (function () {
   goog.provide("gn_dashboard_wfs_indexing_controller");
 
-  var module = angular.module("gn_dashboard_wfs_indexing_controller", ["bsTable"]);
+  goog.require("gn_utility_service");
+
+  var module = angular.module("gn_dashboard_wfs_indexing_controller", [
+    "bsTable",
+    "gn_utility_service"
+  ]);
 
   module.controller("GnDashboardWfsIndexingController", [
     "$q",
@@ -40,6 +45,7 @@
     "wfsFilterService",
     "gnHumanizeTimeService",
     "Metadata",
+    "gnUtilityService",
     function (
       $q,
       $scope,
@@ -53,7 +59,8 @@
       gnLangs,
       wfsFilterService,
       gnHumanizeTimeService,
-      Metadata
+      Metadata,
+      gnUtilityService
     ) {
       // this returns a valid xx_XX language code based on available locales in bootstrap-table
       // if none found, return 'en'
@@ -70,6 +77,8 @@
         });
         return lang;
       }
+
+      var escapeHtml = gnUtilityService.escapeHtml;
 
       var defaultStrategy = "";
 
@@ -342,12 +351,13 @@
                 field: "mdUuid",
                 title: $translate.instant("wfsIndexingMetadata"),
                 formatter: function (value, row) {
+                  var escapedUuid = escapeHtml(row.mdUuid);
                   return row.mdUuid
                     ? '<div data-md-uuid="' +
-                        row.mdUuid +
+                        escapedUuid +
                         '">' +
                         '  <a class="md-title" style="display: none" href="catalog.search#/metadata/' +
-                        row.mdUuid +
+                        escapedUuid +
                         '">' +
                         "    <span>" +
                         $translate.instant("recordWithNoTitle") +
@@ -357,7 +367,7 @@
                         '  <i class="fa fa-spinner fa-spin"></i>' +
                         "</div>" +
                         "<code>" +
-                        row.mdUuid +
+                        escapedUuid +
                         "</code>"
                     : // '<a href="catalog.search#/metadata/' + row.mdUuid + '">' + row.mdUuid + '</a>' :
                       '<span class="text-muted">' +
@@ -370,20 +380,20 @@
                 field: "url",
                 title: $translate.instant("wfsurl"),
                 formatter: function (value, row) {
-                  var wfsUrl = row.url; // TODO: transform to getcapabilities
+                  var escapedUrl = escapeHtml(row.url); // TODO: transform to getcapabilities
                   var label = $translate.instant("wfsIndexingFeatureType");
                   return (
                     '<a href="' +
-                    row.url +
+                    escapedUrl +
                     '">' +
-                    row.url +
+                    escapedUrl +
                     '</a> - <a href="' +
-                    wfsUrl +
+                    escapedUrl +
                     '">GetCapabilities</a><br>' +
                     "<span>" +
                     label +
                     "</span>: <code>" +
-                    row.featureType +
+                    escapeHtml(row.featureType) +
                     "<code>"
                   );
                 },
@@ -404,7 +414,13 @@
                 formatter: function (value, row) {
                   if (value) {
                     var date = gnHumanizeTimeService(value, null, true);
-                    return '<div title="' + date.title + '">' + date.value + "</div>";
+                    return (
+                      '<div title="' +
+                      escapeHtml(date.title) +
+                      '">' +
+                      escapeHtml(date.value) +
+                      "</div>"
+                    );
                   } else {
                     return null;
                   }
@@ -419,9 +435,9 @@
                     $scope.getLabelClass(row.status) +
                     '" ' +
                     'title="' +
-                    (row.error || "") +
+                    escapeHtml(row.error || "") +
                     '">' +
-                    row.status +
+                    escapeHtml(row.status) +
                     "</span>"
                   );
                 },
@@ -435,7 +451,7 @@
                     var cronLabel = $translate.instant("cron-" + value);
                     return (
                       '<span title="' +
-                      (cronLabel || value) +
+                      escapeHtml(cronLabel || value) +
                       '">' +
                       $translate.instant("yes") +
                       "</span>"
@@ -450,7 +466,7 @@
                 field: "cronScheduleProducerId",
                 title: "",
                 formatter: function (value, row, index) {
-                  var key = row.url + "#" + row.featureType;
+                  var key = escapeHtml(row.url + "#" + row.featureType);
                   var labelEdit = $translate.instant("wfsIndexingEditSchedule");
                   var labelNow = $translate.instant("wfsIndexingTrigger");
                   var labelDelete = $translate.instant("wfsDeleteWfsIndexing");


### PR DESCRIPTION
Backport of #9385 to `4.2.x`.

The automatic backport failed with a conflict in `DashboardRecordLinkController.js` (the `4.2.x` version of that file predates some scope variables added later on `main`). Resolved manually, keeping only the `escapeHtml` addition and dropping the unrelated context lines that don't apply to this branch; the rest of the commits cherry-picked cleanly.