### PR TITLE
Formatter limits

### DIFF
--- a/common/src/main/java/net/sf/saxon/PatchedConfiguration.java
+++ b/common/src/main/java/net/sf/saxon/PatchedConfiguration.java
@@ -1,0 +1,71 @@
+//=============================================================================
+//===	Copyright (C) 2001-2026 Food and Agriculture Organization of the
+//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
+//===	and United Nations Environment Programme (UNEP)
+//===
+//===	This library is free software; you can redistribute it and/or
+//===	modify it under the terms of the GNU Lesser General Public
+//===	License as published by the Free Software Foundation; either
+//===	version 2.1 of the License, or (at your option) any later version.
+//===
+//===	This library is distributed in the hope that it will be useful,
+//===	but WITHOUT ANY WARRANTY; without even the implied warranty of
+//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//===	Lesser General Public License for more details.
+//===
+//===	You should have received a copy of the GNU Lesser General Public
+//===	License along with this library; if not, write to the Free Software
+//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+//===
+//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+//===	Rome - Italy. email: geonetwork@osgeo.org
+//==============================================================================
+
+package net.sf.saxon;
+
+import net.sf.saxon.expr.XPathContext;
+import net.sf.saxon.functions.StandardFunction;
+import net.sf.saxon.functions.SystemFunction;
+import net.sf.saxon.functions.VendorFunctionLibrary;
+import net.sf.saxon.pattern.NodeKindTest;
+import net.sf.saxon.type.BuiltInAtomicType;
+import net.sf.saxon.type.Type;
+import net.sf.saxon.value.Value;
+
+public class PatchedConfiguration extends Configuration {
+
+    private DisabledVendorFunctionLibrary disabledVendorFunctionLibrary;
+    private XPathContext disabledConversionContext;
+
+    public PatchedConfiguration(Configuration c) {
+        c.copyTo(this);
+        init();
+    }
+
+    public VendorFunctionLibrary getVendorFunctionLibrary() {
+        if (disabledVendorFunctionLibrary == null) {
+            disabledVendorFunctionLibrary = new DisabledVendorFunctionLibrary();
+        }
+        return disabledVendorFunctionLibrary;
+    }
+
+    private class DisabledVendorFunctionLibrary extends VendorFunctionLibrary {
+        protected void init() {
+            super.init();
+            //override
+            StandardFunction.Entry e = this.register("evaluate", DisabledEvaluate.class, 0, 1, 10, Type.ITEM_TYPE, 57344);
+            StandardFunction.arg(e, 0, BuiltInAtomicType.STRING, 16384, (Value)null);
+            e = this.register("evaluate-node", DisabledEvaluate.class, 3, 1, 1, Type.ITEM_TYPE, 57344);
+            StandardFunction.arg(e, 0, Type.NODE_TYPE, 16384, (Value)null);
+            e = this.register("eval", DisabledEvaluate.class, 2, 1, 10, Type.ITEM_TYPE, 57344);
+            StandardFunction.arg(e, 0, BuiltInAtomicType.ANY_ATOMIC, 16384, (Value)null);
+            e = this.register("expression", DisabledEvaluate.class, 1, 1, 2, BuiltInAtomicType.ANY_ATOMIC, 16384);
+            StandardFunction.arg(e, 0, BuiltInAtomicType.STRING, 16384, (Value)null);
+            StandardFunction.arg(e, 1, NodeKindTest.ELEMENT, 16384, (Value)null);
+        }
+
+    }
+
+    private class DisabledEvaluate extends SystemFunction {
+    }
+}

--- a/common/src/main/java/org/fao/geonet/utils/TransformerFactoryFactory.java
+++ b/common/src/main/java/org/fao/geonet/utils/TransformerFactoryFactory.java
@@ -44,12 +44,15 @@ public class TransformerFactoryFactory {
     public static final String TRANSFORMER_PATH = "/WEB-INF/classes/META-INF/services/" + SYSTEM_PROPERTY_NAME;
 
     private static TransformerFactory factory;
+    private static String currentImplementationName;
 
-    public static void init(String implementationName) {
+    public static synchronized void init(String implementationName) {
         debug("Implementation name: " + implementationName);
         if (implementationName != null && implementationName.length() > 0) {
+            currentImplementationName = implementationName;
             factory = TransformerFactory.newInstance(implementationName, null);
         } else {
+            currentImplementationName = null;
             factory = TransformerFactory.newInstance();
         }
     }
@@ -64,6 +67,14 @@ public class TransformerFactoryFactory {
             + " produces transformer implementation "
             + factory.newTransformer().getClass().getName());
         return factory;
+    }
+
+    public static synchronized TransformerFactory newTransformerFactory() {
+        if (currentImplementationName != null) {
+            return TransformerFactory.newInstance(currentImplementationName, null);
+        } else {
+            return TransformerFactory.newInstance();
+        }
     }
 
     // used for JUnit testing into Eclipse (which selects an incompatible TransformerFactory)

--- a/common/src/main/java/org/fao/geonet/utils/Xml.java
+++ b/common/src/main/java/org/fao/geonet/utils/Xml.java
@@ -96,6 +96,9 @@ import static org.fao.geonet.Constants.ENCODING;
  * General class of useful static methods.
  */
 public final class Xml {
+    public static Path webappDir;
+    public static Path thesauriDir;
+    public static Path schemaPluginsDir;
 
     public static final Namespace xsiNS = Namespace.getNamespace("xsi", XMLConstants.W3C_XML_SCHEMA_INSTANCE_NS_URI);
     public static final NioPathAwareEntityResolver PATH_RESOLVER = new NioPathAwareEntityResolver();

--- a/common/src/main/java/org/fao/geonet/utils/Xml.java
+++ b/common/src/main/java/org/fao/geonet/utils/Xml.java
@@ -431,68 +431,7 @@ public final class Xml {
     }
 
 
-    /**
-     * Transforms an xml tree putting the result to a stream  - no parameters.
-     */
-    public static void transform(Element xml, String styleSheetPath, Result result) throws Exception {
-        transform(xml, IO.toPath(styleSheetPath), result, null);
-    }
-
-
-    public static Element transformWithXmlParam(Element xml, String styleSheetPath, String xmlParamName, String xmlParam) throws Exception {
-        JDOMResult resXml = new JDOMResult();
-
-        File styleSheet = new File(styleSheetPath);
-        Source srcSheet = new StreamSource(styleSheet);
-        transformWithXmlParam(xml, srcSheet, resXml, xmlParamName, xmlParam);
-
-        return (Element) resXml.getDocument().getRootElement().detach();
-    }
-
-    /**
-     * Transforms an xml tree putting the result to a stream. Sends xml snippet as parameter.
-     */
-    public static void transformWithXmlParam(Element xml, Source xslt, Result result,
-                                             String xmlParamName, String xmlParam) throws Exception {
-        Source srcXml = new JDOMSource(new Document((Element) xml.detach()));
-
-        // Dear old saxon likes to yell loudly about each and every XSLT 1.0
-        // stylesheet so switch it off but trap any exceptions because this
-        // code is run on transformers other than saxon
-        TransformerFactory transFact;
-        transFact = TransformerFactoryFactory.getTransformerFactory();
-
-        try {
-            transFact.setAttribute(FeatureKeys.VERSION_WARNING, false);
-            transFact.setAttribute(FeatureKeys.LINE_NUMBERING, true);
-            transFact.setAttribute(FeatureKeys.PRE_EVALUATE_DOC_FUNCTION, true);
-            transFact.setAttribute(FeatureKeys.RECOVERY_POLICY, Configuration.RECOVER_SILENTLY);
-            transFact.setAttribute(FeatureKeys.TREE_MODEL, SAXON_TREE_MODEL);
-            // Add the following to get timing info on xslt transformations
-            //transFact.setAttribute(FeatureKeys.TIMING,true);
-        } catch (IllegalArgumentException e) {
-            Log.warning(Log.ENGINE, "WARNING: transformerfactory doesnt like saxon attributes!", e);
-        } finally {
-            Transformer t = transFact.newTransformer(xslt);
-            if (xmlParam != null) {
-                t.setParameter(xmlParamName, new StreamSource(new StringReader(xmlParam)));
-            }
-            t.transform(srcXml, result);
-        }
-    }
-
     //--------------------------------------------------------------------------
-
-    protected static Path resolvePath(Source s) throws URISyntaxException {
-        Path f;
-        final String systemId = s.getSystemId().replaceAll("%5C", "/");
-        try {
-            f = IO.toPath(new URI(systemId));
-        } catch (FileSystemNotFoundException e) {
-            f = IO.toPath(systemId);
-        }
-        return f;
-    }
 
     /**
      * Transforms an xml tree putting the result to a stream with optional parameters.
@@ -501,46 +440,14 @@ public final class Xml {
      * The preferred method is to define it using xsl:output.
      */
     public static void
-    transform(Element xml, Path styleSheetPath, Result result, Map<String, Object> params) throws Exception {
+    transform(Element xml, Path styleSheetPath, Result result, Map<String, Object> params) throws TransformerException, IOException {
         NioPathHolder.setBase(styleSheetPath);
-        Source srcXml = new JDOMSource(new Document((Element) xml.detach()));
-        try (InputStream in = IO.newInputStream(styleSheetPath)) {
-            Source srcSheet = new StreamSource(in, styleSheetPath.toUri().toASCIIString());
 
-            // Dear old saxon likes to yell loudly about each and every XSLT 1.0
-            // stylesheet so switch it off but trap any exceptions because this
-            // code is run on transformers other than saxon
-            TransformerFactory transFact = TransformerFactoryFactory.getTransformerFactory();
-            transFact.setURIResolver(new JeevesURIResolver());
-            try {
-                transFact.setAttribute(FeatureKeys.VERSION_WARNING, false);
-                transFact.setAttribute(FeatureKeys.LINE_NUMBERING, true);
-                transFact.setAttribute(FeatureKeys.PRE_EVALUATE_DOC_FUNCTION, false);
-                transFact.setAttribute(FeatureKeys.RECOVERY_POLICY, Configuration.RECOVER_SILENTLY);
-                transFact.setAttribute(FeatureKeys.TREE_MODEL, SAXON_TREE_MODEL);
-
-                // Add the following to get timing info on xslt transformations
-                //transFact.setAttribute(FeatureKeys.TIMING,true);
-            } catch (IllegalArgumentException e) {
-                Log.warning(Log.ENGINE, "WARNING: transformerfactory doesnt like saxon attributes!", e);
-            } finally {
-                transFact.setURIResolver(new JeevesURIResolver());
-                Transformer t = transFact.newTransformer(srcSheet);
-                if (params != null) {
-                    for (Map.Entry<String, Object> param : params.entrySet()) {
-                        t.setParameter(param.getKey(), param.getValue());
-                    }
-
-                    if (params.containsKey("geonet-force-xml")) {
-                        ((Controller) t).setOutputProperty("indent", "yes");
-                        ((Controller) t).setOutputProperty("method", "xml");
-                        ((Controller) t).setOutputProperty("{http://saxon.sf.net/}indent-spaces", "2");
-                    }
-                }
-
-                t.transform(srcXml, result);
-            }
-        }
+        XmlTransformer.createWithJeevesUIResolver()
+            .withExtraProperties(FeatureKeys.PRE_EVALUATE_DOC_FUNCTION, false)
+            .withExtraProperties(FeatureKeys.TREE_MODEL, SAXON_TREE_MODEL)
+            .withTransformerParameters(params)
+            .transform(xml, styleSheetPath, result);
     }
 
     //--------------------------------------------------------------------------
@@ -563,7 +470,7 @@ public final class Xml {
      * stylesheet on disk)
      */
 
-    public static Path transformFOP(Path uploadDir, Element xml, String styleSheetPath)
+    public static Path transformFOP(Path uploadDir, Element xml, Path styleSheetPath)
         throws Exception {
         Path file = uploadDir.resolve(UUID.randomUUID().toString() + ".pdf");
 
@@ -578,34 +485,12 @@ public final class Xml {
              OutputStream bufferedOut = new BufferedOutputStream(out)) {
             // Step 3: Construct fop with desired output format
             Fop fop = fopFactory.newFop(MimeConstants.MIME_PDF, bufferedOut);
+            // Resulting SAX events (the generated FO) must be piped through to FOP
+            Result res = new SAXResult(fop.getDefaultHandler());
 
-            // Step 4: Setup JAXP using identity transformer
-            TransformerFactory factory = TransformerFactoryFactory.getTransformerFactory();
-            factory.setURIResolver(new JeevesURIResolver());
-            Source xslt = new StreamSource(new File(styleSheetPath));
-            try {
-                factory.setAttribute(FeatureKeys.VERSION_WARNING, false);
-                factory.setAttribute(FeatureKeys.LINE_NUMBERING, true);
-                factory.setAttribute(FeatureKeys.RECOVERY_POLICY, Configuration.RECOVER_SILENTLY);
-            } catch (IllegalArgumentException e) {
-                Log.warning(Log.ENGINE, "WARNING: transformerfactory doesnt like saxon attributes!", e);
-            } finally {
-                Transformer transformer = factory.newTransformer(xslt);
-
-                // Step 5: Setup input and output for XSLT transformation
-                // Setup input stream
-                Source src = new JDOMSource(new Document((Element) xml.detach()));
-
-                // Resulting SAX events (the generated FO) must be piped through to
-                // FOP
-                Result res = new SAXResult(fop.getDefaultHandler());
-
-                // Step 6: Start XSLT transformation and FOP processing
-                transformer.transform(src, res);
-            }
-
+            XmlTransformer.createWithJeevesUIResolver()
+                .transform(xml, styleSheetPath, res);
         }
-
 
         return file;
     }
@@ -1213,66 +1098,5 @@ public final class Xml {
             retBool = firstTag.matches("<.*:(rdf|catalog|catalogrecord)\\n?");
         }
         return retBool;
-    }
-
-
-    private static class JeevesURIResolver implements URIResolver {
-
-        /**
-         *
-         * @param href
-         * @param base
-         * @return
-         * @throws TransformerException
-         */
-        public Source resolve(String href, String base) throws TransformerException {
-            Resolver resolver = ResolverWrapper.getInstance();
-            CatalogResolver catResolver = resolver.getCatalogResolver();
-            if (Log.isDebugEnabled(Log.XML_RESOLVER)) {
-                Log.debug(Log.XML_RESOLVER, "Trying to resolve " + href + ":" + base);
-            }
-            Source s = catResolver.resolve(href, base);
-
-            boolean isFile;
-            try {
-                final Path file = IO.toPath(new URI(s.getSystemId()));
-                isFile = Files.isRegularFile(file);
-            } catch (Exception e) {
-                isFile = false;
-            }
-
-            // If resolver has a blank XSL file use it to replace
-            // resolved file that doesn't exist...
-            String blankXSLFile = resolver.getBlankXSLFile();
-            if (blankXSLFile != null && s.getSystemId().endsWith(".xsl") && !isFile) {
-                try {
-                    if (Log.isDebugEnabled(Log.XML_RESOLVER)) {
-                        Log.debug(Log.XML_RESOLVER, "  Check if exist " + s.getSystemId());
-                    }
-
-                    Path f;
-                    f = resolvePath(s);
-                    if (Log.isDebugEnabled(Log.XML_RESOLVER))
-                        Log.debug(Log.XML_RESOLVER, "Check on " + f + " exists returned: " + Files.exists(f));
-                    // If the resolved resource does not exist, set it to blank file path to not trigger FileNotFound Exception
-
-                    if (!Files.exists(f)) {
-                        if (Log.isDebugEnabled(Log.XML_RESOLVER)) {
-                            Log.debug(Log.XML_RESOLVER, "  Resolved resource " + s.getSystemId() + " does not exist. blankXSLFile returned instead.");
-                        }
-                        s.setSystemId(blankXSLFile);
-                    } else {
-                        s.setSystemId(f.toUri().toASCIIString());
-                    }
-                } catch (URISyntaxException e) {
-                    Log.warning(Log.XML_RESOLVER, "URI syntax problem: " + e.getMessage(), e);
-                }
-            }
-
-            if (Log.isDebugEnabled(Log.XML_RESOLVER) && s != null) {
-                Log.debug(Log.XML_RESOLVER, "Resolved as " + s.getSystemId());
-            }
-            return s;
-        }
     }
 }

--- a/common/src/main/java/org/fao/geonet/utils/XmlTransformer.java
+++ b/common/src/main/java/org/fao/geonet/utils/XmlTransformer.java
@@ -23,38 +23,52 @@
 
 package org.fao.geonet.utils;
 
-import net.sf.saxon.Configuration;
-import net.sf.saxon.Controller;
-import net.sf.saxon.FeatureKeys;
+import net.sf.saxon.*;
+import net.sf.saxon.expr.Expression;
+import net.sf.saxon.expr.StaticContext;
+import net.sf.saxon.functions.FunctionLibrary;
+import net.sf.saxon.om.StructuredQName;
 import org.apache.xml.resolver.tools.CatalogResolver;
+import net.sf.saxon.expr.XPathContext;
+import net.sf.saxon.om.SequenceIterator;
+import net.sf.saxon.trans.UnparsedTextURIResolver;
+import net.sf.saxon.trans.XPathException;
 import org.jdom.Document;
 import org.jdom.Element;
 import org.jdom.transform.JDOMSource;
 
+import javax.xml.XMLConstants;
 import javax.xml.transform.*;
 import javax.xml.transform.stream.StreamSource;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Reader;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 public class XmlTransformer {
     private TransformerFactory factory;
+    private TransformerFactory untrustredFactory;
     private Map<String, Object> properties = new HashMap<>();
     private Map<String, Object> transformerParameters = null;
+    private final boolean useSaxonParser;
 
     private XmlTransformer() throws TransformerConfigurationException {
-        factory = TransformerFactoryFactory.getTransformerFactory();
+        factory = TransformerFactoryFactory.newTransformerFactory();
+        untrustredFactory = TransformerFactoryFactory.newTransformerFactory();
+        useSaxonParser = factory instanceof TransformerFactoryImpl;
     }
 
     public static XmlTransformer createWithJeevesUIResolver() throws TransformerConfigurationException {
         XmlTransformer t = new XmlTransformer();
-        t.factory.setURIResolver(new JeevesURIResolver());
+        t.factory.setURIResolver(new JeevesURIResolver(false));
+        t.untrustredFactory.setURIResolver(new JeevesURIResolver(true));
         return t;
     }
 
@@ -69,20 +83,32 @@ public class XmlTransformer {
     }
 
     public void transform(Element xml, Path sourcePath, Result result) throws TransformerException, IOException {
+        boolean isUntrusted = Files.exists(sourcePath.getParent().resolve("untrusted_formatter_bundle"));
+        final TransformerFactory _factory = isUntrusted ? untrustredFactory : this.factory;
         try {
-            initialiseCommonConfiguration(factory);
-            properties.entrySet().forEach(e -> factory.setAttribute(e.getKey(), e.getValue()));
+            initialiseCommonConfiguration(_factory);
+            if (isUntrusted) {
+                initialiseUntrustedFormatterBundle(_factory);
+            }
+            properties.entrySet().forEach(e -> _factory.setAttribute(e.getKey(), e.getValue()));
         } catch (IllegalArgumentException e) {
             Log.warning(Log.ENGINE, "WARNING: transformerfactory does not like saxon attributes!", e);
         } finally {
             try (InputStream in = IO.newInputStream(sourcePath)) {
                 Source source = new StreamSource(in, sourcePath.toUri().toASCIIString());
-
-                Transformer t = factory.newTransformer(source);
+                Transformer t = _factory.newTransformer(source);
                 if (transformerParameters != null) {
                     initialiseTransformerParameters(t);
                 }
                 Source srcXml = new JDOMSource(new Document((Element) xml.detach()));
+                if (useSaxonParser && isUntrusted) {
+                    ((Controller) t).setUnparsedTextURIResolver(new UnparsedTextURIResolver() {
+                        @Override
+                        public Reader resolve(URI uri, String s, Configuration configuration) throws XPathException {
+                            throw new XPathException("Unparsed Text URI resolution not supported");
+                        }
+                    });
+                }
                 t.transform(srcXml, result);
             }
         }
@@ -98,7 +124,7 @@ public class XmlTransformer {
         }
     }
 
-    private void initialiseCommonConfiguration(TransformerFactory factory) throws TransformerConfigurationException {
+    private void initialiseCommonConfiguration(TransformerFactory factory) {
         factory.setAttribute(FeatureKeys.VERSION_WARNING, false);
         factory.setAttribute(FeatureKeys.LINE_NUMBERING, true);
         // Dear old saxon likes to yell loudly about each and every XSLT 1.0
@@ -110,7 +136,34 @@ public class XmlTransformer {
         //transFact.setAttribute(FeatureKeys.TIMING,true);
     }
 
+    private void initialiseUntrustedFormatterBundle(TransformerFactory factory) throws TransformerConfigurationException {
+        TransformerFactoryImpl transformerFactory = (TransformerFactoryImpl) factory;
+        PatchedConfiguration patchedConfiguration = new PatchedConfiguration(transformerFactory.getConfiguration());
+        transformerFactory.setConfiguration(patchedConfiguration);
+
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        if (AllowlistedFunctionLibrary.ALLOW_LIST.isEmpty()) {
+            factory.setAttribute(FeatureKeys.ALLOW_EXTERNAL_FUNCTIONS, false);
+        } else {
+            // custom whitelist
+            factory.setAttribute(FeatureKeys.ALLOW_EXTERNAL_FUNCTIONS, true);
+            patchedConfiguration.setExtensionBinder("java", new AllowlistedFunctionLibrary(patchedConfiguration.getExtensionBinder("java")));
+        }
+        factory.setAttribute(FeatureKeys.COLLECTION_URI_RESOLVER, new CollectionURIResolver() {
+            @Override
+            public SequenceIterator resolve(String s, String s1, XPathContext xPathContext) throws XPathException {
+                throw new XPathException("Collection URI resolution not supported");
+            }
+        });
+    }
+
     private static class JeevesURIResolver implements URIResolver {
+        private final boolean isUntrusted;
+
+        public JeevesURIResolver(boolean isUntrusted) {
+            this.isUntrusted = isUntrusted;
+        }
+
         public Source resolve(String href, String base) throws TransformerException {
             Resolver resolver = ResolverWrapper.getInstance();
             CatalogResolver catResolver = resolver.getCatalogResolver();
@@ -120,11 +173,22 @@ public class XmlTransformer {
             Source s = catResolver.resolve(href, base);
 
             boolean isFile;
+            Path file;
             try {
-                final Path file = IO.toPath(new URI(s.getSystemId()));
+                file = IO.toPath(new URI(s.getSystemId()));
                 isFile = Files.isRegularFile(file);
             } catch (Exception e) {
+                file = null;
                 isFile = false;
+            }
+
+            if (isFile && isUntrusted) {
+                boolean isOutsideWebappDir = isFileOutsideDir(file, Xml.webappDir);
+                boolean isOutsideSchemaPluginsDir = isFileOutsideDir(file, Xml.schemaPluginsDir);
+                boolean isOutsideThesauriDir = isFileOutsideDir(file, Xml.thesauriDir);
+                if (isOutsideWebappDir && isOutsideSchemaPluginsDir && isOutsideThesauriDir) {
+                    throw new XPathException("File " + file + " is not in webapp or schemaPlugins or thesauri directory");
+                }
             }
 
             // If resolver has a blank XSL file use it to replace
@@ -161,6 +225,14 @@ public class XmlTransformer {
             return s;
         }
 
+        private static boolean isFileOutsideDir(Path file, Path dir) {
+            try {
+                return dir.relativize(file).toString().contains("..");
+            } catch (RuntimeException e) {
+                return true;
+            }
+        }
+
         private Path resolvePath(Source s) throws URISyntaxException {
             Path f;
             final String systemId = s.getSystemId().replaceAll("%5C", "/");
@@ -170,6 +242,38 @@ public class XmlTransformer {
                 f = IO.toPath(systemId);
             }
             return f;
+        }
+    }
+
+    public static class AllowlistedFunctionLibrary implements FunctionLibrary {
+        private final FunctionLibrary delegate;
+        private static final List<String> ALLOW_LIST = List.of("org.fao.geonet.util.XslUtil", "org.fao.geonet.api.records.MetadataUtils", "org.fao.geonet.api.records.formatters.SchemaLocalizations");
+
+        public AllowlistedFunctionLibrary(FunctionLibrary delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public boolean isAvailable(StructuredQName structuredQName, int i) {
+            if (ALLOW_LIST.stream().filter(s -> structuredQName.getNamespaceURI().contains(s)).findFirst().isPresent()) {
+                return delegate.isAvailable(structuredQName, i);
+            } else {
+                return false;
+            }
+        }
+
+        @Override
+        public Expression bind(StructuredQName structuredQName, Expression[] expressions, StaticContext staticContext) throws XPathException {
+            if (ALLOW_LIST.stream().filter(s -> structuredQName.getNamespaceURI().contains(s)).findFirst().isPresent()) {
+                return delegate.bind(structuredQName, expressions, staticContext);
+            } else {
+                return null;
+            }
+        }
+
+        @Override
+        public FunctionLibrary copy() {
+            return delegate.copy();
         }
     }
 }

--- a/common/src/main/java/org/fao/geonet/utils/XmlTransformer.java
+++ b/common/src/main/java/org/fao/geonet/utils/XmlTransformer.java
@@ -1,0 +1,175 @@
+//=============================================================================
+//===	Copyright (C) 2001-2026 Food and Agriculture Organization of the
+//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
+//===	and United Nations Environment Programme (UNEP)
+//===
+//===	This library is free software; you can redistribute it and/or
+//===	modify it under the terms of the GNU Lesser General Public
+//===	License as published by the Free Software Foundation; either
+//===	version 2.1 of the License, or (at your option) any later version.
+//===
+//===	This library is distributed in the hope that it will be useful,
+//===	but WITHOUT ANY WARRANTY; without even the implied warranty of
+//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+//===	Lesser General Public License for more details.
+//===
+//===	You should have received a copy of the GNU Lesser General Public
+//===	License along with this library; if not, write to the Free Software
+//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA  02110-1301  USA
+//===
+//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+//===	Rome - Italy. email: geonetwork@osgeo.org
+//==============================================================================
+
+package org.fao.geonet.utils;
+
+import net.sf.saxon.Configuration;
+import net.sf.saxon.Controller;
+import net.sf.saxon.FeatureKeys;
+import org.apache.xml.resolver.tools.CatalogResolver;
+import org.jdom.Document;
+import org.jdom.Element;
+import org.jdom.transform.JDOMSource;
+
+import javax.xml.transform.*;
+import javax.xml.transform.stream.StreamSource;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.file.FileSystemNotFoundException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.Map;
+
+public class XmlTransformer {
+    private TransformerFactory factory;
+    private Map<String, Object> properties = new HashMap<>();
+    private Map<String, Object> transformerParameters = null;
+
+    private XmlTransformer() throws TransformerConfigurationException {
+        factory = TransformerFactoryFactory.getTransformerFactory();
+    }
+
+    public static XmlTransformer createWithJeevesUIResolver() throws TransformerConfigurationException {
+        XmlTransformer t = new XmlTransformer();
+        t.factory.setURIResolver(new JeevesURIResolver());
+        return t;
+    }
+
+    public XmlTransformer withExtraProperties(String key, Object value) {
+        properties.put(key, value);
+        return this;
+    }
+
+    public XmlTransformer withTransformerParameters(Map<String, Object> params) {
+        this.transformerParameters = params;
+        return this;
+    }
+
+    public void transform(Element xml, Path sourcePath, Result result) throws TransformerException, IOException {
+        try {
+            initialiseCommonConfiguration(factory);
+            properties.entrySet().forEach(e -> factory.setAttribute(e.getKey(), e.getValue()));
+        } catch (IllegalArgumentException e) {
+            Log.warning(Log.ENGINE, "WARNING: transformerfactory does not like saxon attributes!", e);
+        } finally {
+            try (InputStream in = IO.newInputStream(sourcePath)) {
+                Source source = new StreamSource(in, sourcePath.toUri().toASCIIString());
+
+                Transformer t = factory.newTransformer(source);
+                if (transformerParameters != null) {
+                    initialiseTransformerParameters(t);
+                }
+                Source srcXml = new JDOMSource(new Document((Element) xml.detach()));
+                t.transform(srcXml, result);
+            }
+        }
+    }
+
+    private void initialiseTransformerParameters(Transformer t) {
+        transformerParameters.entrySet().forEach(e -> t.setParameter(e.getKey(), e.getValue()));
+
+        if (transformerParameters.containsKey("geonet-force-xml")) {
+            ((Controller) t).setOutputProperty("indent", "yes");
+            ((Controller) t).setOutputProperty("method", "xml");
+            ((Controller) t).setOutputProperty("{http://saxon.sf.net/}indent-spaces", "2");
+        }
+    }
+
+    private void initialiseCommonConfiguration(TransformerFactory factory) throws TransformerConfigurationException {
+        factory.setAttribute(FeatureKeys.VERSION_WARNING, false);
+        factory.setAttribute(FeatureKeys.LINE_NUMBERING, true);
+        // Dear old saxon likes to yell loudly about each and every XSLT 1.0
+        // stylesheet so switch it off but trap any exceptions because this
+        // code is run on transformers other than saxon
+        factory.setAttribute(FeatureKeys.RECOVERY_POLICY, Configuration.RECOVER_SILENTLY);
+
+        // Add the following to get timing info on xslt transformations
+        //transFact.setAttribute(FeatureKeys.TIMING,true);
+    }
+
+    private static class JeevesURIResolver implements URIResolver {
+        public Source resolve(String href, String base) throws TransformerException {
+            Resolver resolver = ResolverWrapper.getInstance();
+            CatalogResolver catResolver = resolver.getCatalogResolver();
+            if (Log.isDebugEnabled(Log.XML_RESOLVER)) {
+                Log.debug(Log.XML_RESOLVER, "Trying to resolve " + href + ":" + base);
+            }
+            Source s = catResolver.resolve(href, base);
+
+            boolean isFile;
+            try {
+                final Path file = IO.toPath(new URI(s.getSystemId()));
+                isFile = Files.isRegularFile(file);
+            } catch (Exception e) {
+                isFile = false;
+            }
+
+            // If resolver has a blank XSL file use it to replace
+            // resolved file that doesn't exist...
+            String blankXSLFile = resolver.getBlankXSLFile();
+            if (blankXSLFile != null && s.getSystemId().endsWith(".xsl") && !isFile) {
+                try {
+                    if (Log.isDebugEnabled(Log.XML_RESOLVER)) {
+                        Log.debug(Log.XML_RESOLVER, "  Check if exist " + s.getSystemId());
+                    }
+
+                    Path f;
+                    f = resolvePath(s);
+                    if (Log.isDebugEnabled(Log.XML_RESOLVER))
+                        Log.debug(Log.XML_RESOLVER, "Check on " + f + " exists returned: " + Files.exists(f));
+                    // If the resolved resource does not exist, set it to blank file path to not trigger FileNotFound Exception
+
+                    if (!Files.exists(f)) {
+                        if (Log.isDebugEnabled(Log.XML_RESOLVER)) {
+                            Log.debug(Log.XML_RESOLVER, "  Resolved resource " + s.getSystemId() + " does not exist. blankXSLFile returned instead.");
+                        }
+                        s.setSystemId(blankXSLFile);
+                    } else {
+                        s.setSystemId(f.toUri().toASCIIString());
+                    }
+                } catch (URISyntaxException e) {
+                    Log.warning(Log.XML_RESOLVER, "URI syntax problem: " + e.getMessage(), e);
+                }
+            }
+
+            if (Log.isDebugEnabled(Log.XML_RESOLVER) && s != null) {
+                Log.debug(Log.XML_RESOLVER, "Resolved as " + s.getSystemId());
+            }
+            return s;
+        }
+
+        private Path resolvePath(Source s) throws URISyntaxException {
+            Path f;
+            final String systemId = s.getSystemId().replaceAll("%5C", "/");
+            try {
+                f = IO.toPath(new URI(systemId));
+            } catch (FileSystemNotFoundException e) {
+                f = IO.toPath(systemId);
+            }
+            return f;
+        }
+    }
+}

--- a/common/src/main/java/org/fao/geonet/utils/XmlTransformer.java
+++ b/common/src/main/java/org/fao/geonet/utils/XmlTransformer.java
@@ -51,6 +51,7 @@ import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 public class XmlTransformer {
     private TransformerFactory factory;
@@ -142,7 +143,7 @@ public class XmlTransformer {
         transformerFactory.setConfiguration(patchedConfiguration);
 
         factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
-        if (AllowlistedFunctionLibrary.ALLOW_LIST.isEmpty()) {
+        if (AllowlistedFunctionLibrary.ALLOW_LIST != null && AllowlistedFunctionLibrary.ALLOW_LIST.isEmpty()) {
             factory.setAttribute(FeatureKeys.ALLOW_EXTERNAL_FUNCTIONS, false);
         } else {
             // custom whitelist
@@ -247,7 +248,93 @@ public class XmlTransformer {
 
     public static class AllowlistedFunctionLibrary implements FunctionLibrary {
         private final FunctionLibrary delegate;
-        private static final List<String> ALLOW_LIST = List.of("org.fao.geonet.util.XslUtil", "org.fao.geonet.api.records.MetadataUtils", "org.fao.geonet.api.records.formatters.SchemaLocalizations");
+        private static final Set<String> ALLOW_LIST = Set.of(
+            "{java:org.fao.geonet.util.XslUtil}parseGml",
+            "{java:org.fao.geonet.util.XslUtil}gmlToGeoJson",
+            "{java:org.fao.geonet.util.XslUtil}addToList",
+            "{java:org.fao.geonet.util.XslUtil}toMultiPolygon",
+            "{java:org.fao.geonet.util.XslUtil}clean",
+            "{java:org.fao.geonet.util.XslUtil}countryMatch",
+            "{java:org.fao.geonet.util.XslUtil}replace",
+            "{java:org.fao.geonet.util.XslUtil}isCasEnabled",
+            "{java:org.fao.geonet.util.XslUtil}getConfigValue",
+            "{java:org.fao.geonet.util.XslUtil}getBuildNumber",
+            "{java:org.fao.geonet.util.XslUtil}getUiConfiguration",
+            "{java:org.fao.geonet.util.XslUtil}getUiConfigurationJsonProperty",
+            "{java:org.fao.geonet.util.XslUtil}toUiConfigArg",
+            "{java:org.fao.geonet.util.XslUtil}escapeForScriptContext",
+            "{java:org.fao.geonet.util.XslUtil}getSettingValue",
+            "{java:org.fao.geonet.util.XslUtil}getNodeName",
+            "{java:org.fao.geonet.util.XslUtil}getNodeId",
+            "{java:org.fao.geonet.util.XslUtil}getNodeLogo",
+            "{java:org.fao.geonet.util.XslUtil}getDiscoveryServiceUuid",
+            "{java:org.fao.geonet.util.XslUtil}getSource",
+            "{java:org.fao.geonet.util.XslUtil}getJsonSettingValue",
+            "{java:org.fao.geonet.util.XslUtil}isAuthenticated",
+            "{java:org.fao.geonet.util.XslUtil}isDisableLoginForm",
+            "{java:org.fao.geonet.util.XslUtil}isShowLoginAsLink",
+            "{java:org.fao.geonet.util.XslUtil}isUserProfileUpdateEnabled",
+            "{java:org.fao.geonet.util.XslUtil}isUserGroupUpdateEnabled",
+            "{java:org.fao.geonet.util.XslUtil}getSecurityProvider",
+            "{java:org.fao.geonet.util.XslUtil}getResourceContainerDescription",
+            "{java:org.fao.geonet.util.XslUtil}getResourceManagementExternalProperties",
+            "{java:org.fao.geonet.util.XslUtil}isAccessibleService",
+            "{java:org.fao.geonet.util.XslUtil}takeUntil",
+            "{java:org.fao.geonet.util.XslUtil}xmlToJson",
+            "{java:org.fao.geonet.util.XslUtil}htmlElement2textReplacer",
+            "{java:org.fao.geonet.util.XslUtil}html2text",
+            "{java:org.fao.geonet.util.XslUtil}html2textNormalized",
+            "{java:org.fao.geonet.util.XslUtil}toWktCoords",
+            "{java:org.fao.geonet.util.XslUtil}posListToWktCoords",
+            "{java:org.fao.geonet.util.XslUtil}wktGeomToBbox",
+            "{java:org.fao.geonet.util.XslUtil}geoJsonGeomToBbox",
+            "{java:org.fao.geonet.util.XslUtil}getIndexField",
+            "{java:org.fao.geonet.util.XslUtil}getIndexFieldById",
+            "{java:org.fao.geonet.util.XslUtil}getCodelistTranslation",
+            "{java:org.fao.geonet.util.XslUtil}iso639_2B_to_iso639_2T",
+            "{java:org.fao.geonet.util.XslUtil}iso639_2T_to_iso639_2B",
+            "{java:org.fao.geonet.util.XslUtil}twoCharLangCode",
+            "{java:org.fao.geonet.util.XslUtil}threeCharLangCode",
+            "{java:org.fao.geonet.util.XslUtil}match",
+            "{java:org.fao.geonet.util.XslUtil}setNoScript",
+            "{java:org.fao.geonet.util.XslUtil}allowScripting",
+            "{java:org.fao.geonet.util.XslUtil}getUserDetails",
+            "{java:org.fao.geonet.util.XslUtil}reprojectCoords",
+            "{java:org.fao.geonet.util.XslUtil}geomToBbox",
+            "{java:org.fao.geonet.util.XslUtil}getRecord",
+            "{java:org.fao.geonet.util.XslUtil}evaluate",
+            "{java:org.fao.geonet.util.XslUtil}getSiteUrl",
+            "{java:org.fao.geonet.util.XslUtil}getPermalink",
+            "{java:org.fao.geonet.util.XslUtil}getDefaultUrl",
+            "{java:org.fao.geonet.util.XslUtil}getDefaultLangCode",
+            "{java:org.fao.geonet.util.XslUtil}getLanguage",
+            "{java:org.fao.geonet.util.XslUtil}encodeForJavaScript",
+            "{java:org.fao.geonet.util.XslUtil}encodeForHTML",
+            "{java:org.fao.geonet.util.XslUtil}md5Hex",
+            "{java:org.fao.geonet.util.XslUtil}encodeForURL",
+            "{java:org.fao.geonet.util.XslUtil}decodeURLParameter",
+            "{java:org.fao.geonet.util.XslUtil}randomId",
+            "{java:org.fao.geonet.util.XslUtil}getMax",
+            "{java:org.fao.geonet.util.XslUtil}getThesaurusDir",
+            "{java:org.fao.geonet.util.XslUtil}getThesaurusIdByTitle",
+            "{java:org.fao.geonet.util.XslUtil}getThesaurusTitleByKey",
+            "{java:org.fao.geonet.util.XslUtil}getThesaurusUriByKey",
+            "{java:org.fao.geonet.util.XslUtil}getIsoLanguageLabel",
+            "{java:org.fao.geonet.util.XslUtil}getKeywordHierarchy",
+            "{java:org.fao.geonet.util.XslUtil}getKeywordValueByUri",
+            "{java:org.fao.geonet.util.XslUtil}getKeywordUri",
+            "{java:org.fao.geonet.util.XslUtil}buildRecordLink",
+            "{java:org.fao.geonet.util.XslUtil}escapeForJson",
+            "{java:org.fao.geonet.util.XslUtil}escapeForEcmaScript",
+            "{java:org.fao.geonet.util.XslUtil}getWebAnalyticsService",
+            "{java:org.fao.geonet.util.XslUtil}getWebAnalyticsJavascriptCode",
+            "{java:org.fao.geonet.api.records.MetadataUtils}getAssociatedAsXml",
+            "{java:org.fao.geonet.api.records.MetadataUtils}isMetadataFieldValueExistingInOtherRecords",
+            "{java:org.fao.geonet.api.records.formatters.SchemaLocalizations}create",
+            "{java:org.fao.geonet.api.records.formatters.SchemaLocalizations}codelist-value-label",
+            "{java:org.fao.geonet.api.records.formatters.SchemaLocalizations}codelist-value-desc",
+            "{java:org.fao.geonet.api.records.formatters.SchemaLocalizations}nodeDesc",
+            "{java:org.fao.geonet.api.records.formatters.SchemaLocalizations}nodeLabel");
 
         public AllowlistedFunctionLibrary(FunctionLibrary delegate) {
             this.delegate = delegate;
@@ -255,7 +342,7 @@ public class XmlTransformer {
 
         @Override
         public boolean isAvailable(StructuredQName structuredQName, int i) {
-            if (ALLOW_LIST.stream().filter(s -> structuredQName.getNamespaceURI().contains(s)).findFirst().isPresent()) {
+            if (ALLOW_LIST.contains(structuredQName.getClarkName())) {
                 return delegate.isAvailable(structuredQName, i);
             } else {
                 return false;
@@ -264,7 +351,7 @@ public class XmlTransformer {
 
         @Override
         public Expression bind(StructuredQName structuredQName, Expression[] expressions, StaticContext staticContext) throws XPathException {
-            if (ALLOW_LIST.stream().filter(s -> structuredQName.getNamespaceURI().contains(s)).findFirst().isPresent()) {
+            if (ALLOW_LIST.contains(structuredQName.getClarkName())) {
                 return delegate.bind(structuredQName, expressions, staticContext);
             } else {
                 return null;

--- a/core/src/main/java/jeeves/server/dispatchers/ServiceManager.java
+++ b/core/src/main/java/jeeves/server/dispatchers/ServiceManager.java
@@ -706,7 +706,7 @@ public class ServiceManager {
                             Path file;
                             try {
                                 //--- first we do the transformation
-                                file = Xml.transformFOP(dataDirectory.getUploadDir(), rootElem, styleSheet.toString());
+                                file = Xml.transformFOP(dataDirectory.getUploadDir(), rootElem, styleSheet);
                             } finally {
                                 timerContext.stop();
                             }

--- a/core/src/main/java/org/fao/geonet/kernel/GeonetworkDataDirectory.java
+++ b/core/src/main/java/org/fao/geonet/kernel/GeonetworkDataDirectory.java
@@ -31,6 +31,7 @@ import org.fao.geonet.exceptions.BadParameterEx;
 import org.fao.geonet.utils.FilePathChecker;
 import org.fao.geonet.utils.IO;
 import org.fao.geonet.utils.Log;
+import org.fao.geonet.utils.Xml;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationEvent;
@@ -830,6 +831,9 @@ public class GeonetworkDataDirectory {
         public GeonetworkDataDirectoryInitializedEvent(ApplicationContext context, GeonetworkDataDirectory dataDirectory) {
             super(dataDirectory);
             this.applicationContext = context;
+            Xml.webappDir = dataDirectory.getWebappDir();
+            Xml.schemaPluginsDir = dataDirectory.getSchemaPluginsDir();
+            Xml.thesauriDir = dataDirectory.getThesauriDir();
         }
 
         public ApplicationContext getApplicationContext() {

--- a/core/src/test/java/org/fao/geonet/kernel/XmlSerializerIntegrationTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/XmlSerializerIntegrationTest.java
@@ -139,6 +139,7 @@ public class XmlSerializerIntegrationTest extends AbstractCoreIntegrationTest {
 
     @Test
     public void testInternalSelectHidingWithheldSettingsDisabled() throws Exception {
+        loginAsAnonymous();
         setSchemaFilters(false, true);
         assertHiddenElements(false, false);
     }

--- a/schemas/iso19115-3.2018/src/test/resources/UpperRhineCastles-validation-report-with-ia-based-german.xml
+++ b/schemas/iso19115-3.2018/src/test/resources/UpperRhineCastles-validation-report-with-ia-based-german.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rules>
-  <report xmlns:gml320="http://www.opengis.net/gml" xmlns:util="java:org.fao.geonet.util.XslUtil">
+  <report xmlns:util="java:org.fao.geonet.util.XslUtil" xmlns:gml320="http://www.opengis.net/gml">
     <id>xsd</id>
     <displayPriority>0</displayPriority>
     <error>0</error>
@@ -9,7 +9,7 @@
     <requirement>REQUIRED</requirement>
     <patterns />
   </report>
-  <report xmlns:gml320="http://www.opengis.net/gml" xmlns:util="java:org.fao.geonet.util.XslUtil">
+  <report xmlns:util="java:org.fao.geonet.util.XslUtil" xmlns:gml320="http://www.opengis.net/gml">
     <id />
     <displayPriority />
     <label>Règles ISO</label>

--- a/schemas/iso19115-3.2018/src/test/resources/UpperRhineCastles-validation-report.xml
+++ b/schemas/iso19115-3.2018/src/test/resources/UpperRhineCastles-validation-report.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <rules>
-  <report xmlns:gml320="http://www.opengis.net/gml" xmlns:util="java:org.fao.geonet.util.XslUtil">
+  <report xmlns:util="java:org.fao.geonet.util.XslUtil" xmlns:gml320="http://www.opengis.net/gml">
     <id>xsd</id>
     <displayPriority>0</displayPriority>
     <error>0</error>
@@ -9,7 +9,7 @@
     <requirement>REQUIRED</requirement>
     <patterns />
   </report>
-  <report xmlns:gml320="http://www.opengis.net/gml" xmlns:util="java:org.fao.geonet.util.XslUtil">
+  <report xmlns:util="java:org.fao.geonet.util.XslUtil" xmlns:gml320="http://www.opengis.net/gml">
     <id />
     <displayPriority />
     <label>Règles ISO</label>

--- a/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterAdminApi.java
+++ b/services/src/main/java/org/fao/geonet/api/records/formatters/FormatterAdminApi.java
@@ -63,10 +63,7 @@ import java.io.IOException;
 import java.io.PrintStream;
 import java.io.Serializable;
 import java.net.URLEncoder;
-import java.nio.file.DirectoryStream;
-import java.nio.file.FileSystem;
-import java.nio.file.Files;
-import java.nio.file.Path;
+import java.nio.file.*;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
@@ -501,6 +498,11 @@ public class FormatterAdminApi extends AbstractFormatService {
 
         Path formatDir = getAndVerifyFormatDir(
             dataDirectory, Params.ID, formatter, schemaDir);
+        Path markerFilePath = formatDir.resolve("untrusted_formatter_bundle");
+        if (!Files.exists(markerFilePath)) {
+            Files.createFile(markerFilePath);
+        }
+
 
         FilePathChecker.verify(file);
         Path toUpdate = formatDir.resolve(file);
@@ -564,6 +566,11 @@ public class FormatterAdminApi extends AbstractFormatService {
                 out.println("but it is recommended to always have the default language localization");
                 out.println("(unless language is fixed in the config.properties)");
             }
+        }
+
+        Path markerFilePath = file.resolve("untrusted_formatter_bundle");
+        if (!Files.exists(markerFilePath)) {
+            Files.createFile(markerFilePath);
         }
     }
 

--- a/services/src/main/java/org/fao/geonet/guiapi/search/XsltResponseWriter.java
+++ b/services/src/main/java/org/fao/geonet/guiapi/search/XsltResponseWriter.java
@@ -116,7 +116,7 @@ public class XsltResponseWriter {
 
     public void asPdf(HttpServletResponse response, String fileName) throws Exception {
         GeonetworkDataDirectory dataDirectory = ApplicationContextHolder.get().getBean(GeonetworkDataDirectory.class);
-        Path file = Xml.transformFOP(dataDirectory.getUploadDir(), xml, xsl.toString());
+        Path file = Xml.transformFOP(dataDirectory.getUploadDir(), xml, xsl);
         try {
             response.setContentType("application/pdf");
             response.addHeader("Content-Disposition", "attachment; filename=" + fileName);


### PR DESCRIPTION
Add limitation to formatters.
These limitations are only added when a formatter is modified inside geonetwork.

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

- `Funded by Swisstopo`

