### PR TITLE
Fix language selector for multilingual metadata static page

### DIFF
--- a/web-ui/src/main/resources/catalog/js/GnLandingPageLib.js
+++ b/web-ui/src/main/resources/catalog/js/GnLandingPageLib.js
@@ -22,6 +22,7 @@
  */
 (function () {
   var gnLandingPage = {};
+  window.gnLandingPage = gnLandingPage;
   gnLandingPage.displayLanguage = function (lang, target) {
     target.parentElement.parentElement.querySelectorAll("li").forEach(function (li) {
       li.classList.remove("active");


### PR DESCRIPTION
An error ocurred when the page was loaded and the language selector didn´t work: 

http://localhost:8080/geonetwork/srv/api/records/a16a0a9f-5821-4698-a1bb-0a0859cc5b44/formatters/xsl-view?language=all

```
xsl-view?language=all:136 Uncaught ReferenceError: gnLandingPage is not defined
    at HTMLAnchorElement.onclick (xsl-view?language=all:136:120)
    at window.onload (xsl-view?language=all:131:85)
```

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
