### PR TITLE
Pass metadataId to schematron

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/AbstractSchematronValidator.java
+++ b/core/src/main/java/org/fao/geonet/kernel/AbstractSchematronValidator.java
@@ -70,6 +70,7 @@ public class AbstractSchematronValidator {
             params.put("lang", lang);
             params.put("rule", ruleId);
             params.put("thesaurusDir", thesaurusManager.getThesauriDirectory().toString());
+            params.put("metadataId", metadataId);
 
             Path file = schemaDir.resolve(SCHEMATRON_DIR).resolve(schematron.getFile());
             Element xmlReport = Xml.transform(md, file, params);

--- a/core/src/main/java/org/fao/geonet/kernel/SchematronValidatorExternalMd.java
+++ b/core/src/main/java/org/fao/geonet/kernel/SchematronValidatorExternalMd.java
@@ -57,6 +57,9 @@ public class SchematronValidatorExternalMd extends AbstractSchematronValidator {
             List<ApplicableSchematron> applicableSchematron = getApplicableSchematronList(md, metadataSchema, groupOwnerId);
 
             for (ApplicableSchematron applicable : applicableSchematron) {
+                // Pass -1 as metadataId for external validation since the metadata is not in the database.
+                // Schematron rules can reference the metadataId parameter, but attempting to look up metadata
+                // using -1 will return empty results.
                 runSchematron(lang, schemaDir, validations, schemaTronXmlOut, -1, md, applicable);
             }
         } catch (Throwable e) {

--- a/core/src/test/java/org/fao/geonet/kernel/AbstractSchematronValidatorTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/AbstractSchematronValidatorTest.java
@@ -37,6 +37,7 @@ import org.fao.geonet.exceptions.LocalizedRuntimeException;
 import org.fao.geonet.exceptions.ResourceNotFoundEx;
 import org.fao.geonet.utils.Xml;
 import org.jdom.Element;
+import org.mockito.ArgumentCaptor;
 import org.mockito.MockedStatic;
 import org.mockito.Mockito;
 
@@ -44,8 +45,10 @@ import org.junit.Test;
 import org.springframework.context.ConfigurableApplicationContext;
 
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.ResourceBundle;
 
 import static org.junit.Assert.assertEquals;
@@ -125,6 +128,53 @@ public class AbstractSchematronValidatorTest {
             assertNotNull("schematronVerificationError element should exist", errorReport);
             assertEquals(errorMessage, errorReport.getText());
             assertEquals(MetadataValidationStatus.NEVER_CALCULATED, validations.get(0).getStatus());
+        }
+    }
+
+    @Test
+    public void testRunSchematronPassesMetadataIdParam() throws Exception {
+        ConfigurableApplicationContext mockContext = Mockito.mock(ConfigurableApplicationContext.class);
+        try (MockedStatic<ApplicationContextHolder> mockedHolder = Mockito.mockStatic(ApplicationContextHolder.class);
+             MockedStatic<Xml> mockedXml = Mockito.mockStatic(Xml.class)) {
+
+            mockedHolder.when(ApplicationContextHolder::get).thenReturn(mockContext);
+            ThesaurusManager mockThesaurusManager = Mockito.mock(ThesaurusManager.class);
+            Mockito.when(mockContext.getBean(ThesaurusManager.class)).thenReturn(mockThesaurusManager);
+
+            Path thesaurusDir = Paths.get("/thesaurus");
+            Mockito.when(mockThesaurusManager.getThesauriDirectory()).thenReturn(thesaurusDir);
+
+            // Capture the params passed to Xml.transform
+            @SuppressWarnings("unchecked")
+            ArgumentCaptor<Map<String, Object>> paramsCaptor = ArgumentCaptor.forClass(Map.class);
+            mockedXml.when(() -> Xml.transform(Mockito.any(), Mockito.any(Path.class), paramsCaptor.capture()))
+                .thenReturn(new Element("output"));
+
+            AbstractSchematronValidator validator = new AbstractSchematronValidator();
+            int expectedMetadataId = 42;
+            Path schemaDir = Mockito.mock(Path.class);
+            Path schematronFile = Mockito.mock(Path.class);
+            Mockito.when(schemaDir.resolve(Mockito.anyString())).thenReturn(schematronFile);
+            Mockito.when(schematronFile.resolve(Mockito.anyString())).thenReturn(schematronFile);
+
+            List<MetadataValidation> validations = new ArrayList<>();
+            Element schemaTronXmlOut = new Element("schemaTronXmlOut");
+            Element md = new Element("metadata");
+            ApplicableSchematron applicable = Mockito.mock(ApplicableSchematron.class);
+
+            Schematron schematron = new Schematron();
+            schematron.setSchemaName("testSchemaName");
+            schematron.setFile("schematron-rules-test.xsl");
+
+            Mockito.when(applicable.getSchematron()).thenReturn(schematron);
+            Mockito.when(applicable.getRequirement()).thenReturn(SchematronRequirement.REQUIRED);
+
+            validator.runSchematron("eng", schemaDir, validations, schemaTronXmlOut, expectedMetadataId, md, applicable);
+
+            Map<String, Object> capturedParams = paramsCaptor.getValue();
+            assertNotNull("params map should not be null", capturedParams);
+            assertEquals("metadataId should be passed to the schematron XSL transform",
+                expectedMetadataId, capturedParams.get("metadataId"));
         }
     }
 }

--- a/docs/manual/docs/customizing-application/implementing-a-schema-plugin.md
+++ b/docs/manual/docs/customizing-application/implementing-a-schema-plugin.md
@@ -1220,6 +1220,17 @@ As for most of GeoNetwork, the output of this rule can be localized to different
 </strings>
 ```
 
+##### Available parameters in schematron rules
+
+When GeoNetwork executes a compiled schematron, the following parameters are automatically passed to the XSL and can be referenced inside `<sch:rule>` blocks using `$paramName`:
+
+| Parameter       | Type    | Description                                                                 |
+|-----------------|---------|-----------------------------------------------------------------------------|
+| `lang`          | string  | The two or three letter language code of the current user session (e.g. `eng`). Use this to return localised messages. |
+| `rule`          | string  | The file name of the compiled schematron XSL (e.g. `schematron-rules-iso.xsl`). |
+| `thesaurusDir`  | string  | Absolute path to the GeoNetwork thesaurus directory. Useful for rules that need to validate against controlled vocabularies. |
+| `metadataId`    | integer | The internal database identifier of the metadata record being validated. Useful for rules that need to look up related information. |
+
 Procedure for adding schematron rules, working within the schematrons directory:
 
 1.  Place your schematron rules in 'rules'. Naming convention is 'schematron-rules-<suffix>.sch' eg. `schematron-rules-iso-mcp.sch`. Place localized strings for the rule assertions into 'rules/loc/<language_prefix>'.

--- a/docs/manual/docs/customizing-application/implementing-a-schema-plugin.md
+++ b/docs/manual/docs/customizing-application/implementing-a-schema-plugin.md
@@ -1229,7 +1229,7 @@ When GeoNetwork executes a compiled schematron, the following parameters are aut
 | `lang`          | string  | The two or three letter language code of the current user session (e.g. `eng`). Use this to return localised messages. |
 | `rule`          | string  | The file name of the compiled schematron XSL (e.g. `schematron-rules-iso.xsl`). |
 | `thesaurusDir`  | string  | Absolute path to the GeoNetwork thesaurus directory. Useful for rules that need to validate against controlled vocabularies. |
-| `metadataId`    | integer | The internal database identifier of the metadata record being validated. Useful for rules that need to look up related information. |
+| `metadataId`    | integer | The internal database identifier of the metadata record being validated. Useful for rules that need to look up related information. **Note:** When validating external metadata (metadata not saved to the database), this parameter is set to `-1`. Attempts to query the database using this value will return empty results. |
 
 Procedure for adding schematron rules, working within the schematrons directory:
 

--- a/web/src/main/webapp/WEB-INF/classes/schematron/iso_svrl_for_xslt2.xsl
+++ b/web/src/main/webapp/WEB-INF/classes/schematron/iso_svrl_for_xslt2.xsl
@@ -210,6 +210,7 @@
     <axsl:param name="lang"/>
     <axsl:param name="thesaurusDir"/>
     <axsl:param name="rule"/>
+    <axsl:param name="metadataId"/>
 
     <!-- Retrieve localisation entries (one file specific to the rule, the other file is shared by all schematron). Fallback language is English. -->
     <axsl:variable name="loc">

--- a/web/src/test/java/org/fao/geonet/kernel/schema/AbstractSchematronTest.java
+++ b/web/src/test/java/org/fao/geonet/kernel/schema/AbstractSchematronTest.java
@@ -115,6 +115,7 @@ public class AbstractSchematronTest {
             params.put("lang", "eng");
             params.put("thesaurusDir", THESAURUS_DIR.toAbsolutePath().toString().replace("\\", "/"));
             params.put("rule", ruleName + ".xsl");
+            params.put("metadataId", "0");
 
             Path outputFile = temporaryFolder.getRoot().toPath().resolve("path/requiredtoFind/utilsfile/" + ruleName + ".xsl");
             Files.createDirectories(outputFile.getParent());


### PR DESCRIPTION
Schematron validations currently receive a limited set of parameters from the validation pipeline. Custom schematron rules may require additional metadata context to perform validation reliably, but the metadata ID is not currently available to them.

This PR aims to fix this issue by passing `metadataId` from `AbstractSchematronValidator` to the generated schematron XSLT as a parameter.

This provides schematron implementations with a reliable way to identify the exact metadata record being validated and supports custom validation use cases that need access to record-specific context. In our case, this is used to distinguish between approved metadata and working copies when validating associated resources.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [x] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [x] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation


