### PR TITLE
Fix issues with openapi spec

### DIFF
--- a/services/src/main/java/org/fao/geonet/api/doiservers/DoiServersApi.java
+++ b/services/src/main/java/org/fao/geonet/api/doiservers/DoiServersApi.java
@@ -277,8 +277,7 @@ public class DoiServersApi {
     }
 
     @io.swagger.v3.oas.annotations.Operation(
-        summary = "Remove a DOI server",
-        operationId = "deleteDoiServer"
+        summary = "Remove a DOI server"
     )
     @DeleteMapping(
         value = "/{doiServerId}",

--- a/services/src/main/java/org/fao/geonet/api/doiservers/DoiServersApi.java
+++ b/services/src/main/java/org/fao/geonet/api/doiservers/DoiServersApi.java
@@ -277,7 +277,8 @@ public class DoiServersApi {
     }
 
     @io.swagger.v3.oas.annotations.Operation(
-        summary = "Remove a DOI server"
+        summary = "Remove a DOI server",
+        operationId = "deleteDoiServer"
     )
     @DeleteMapping(
         value = "/{doiServerId}",
@@ -291,7 +292,7 @@ public class DoiServersApi {
         @ApiResponse(responseCode = "403", description = ApiParams.API_RESPONSE_NOT_ALLOWED_ONLY_ADMIN)
     })
     @ResponseStatus(HttpStatus.NO_CONTENT)
-    public void deleteMapserver(
+    public void deleteDoiServer(
         @Parameter(description = API_PARAM_DOISERVER_IDENTIFIER,
             required = true
         )

--- a/services/src/main/java/org/fao/geonet/api/harvesting/HarvestersApi.java
+++ b/services/src/main/java/org/fao/geonet/api/harvesting/HarvestersApi.java
@@ -218,7 +218,6 @@ public class HarvestersApi {
         value = "/properties/{property}",
         method = RequestMethod.GET
     )
-    @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("hasAuthority('UserAdmin')")
     @ApiResponses(value = {
         @ApiResponse(responseCode = "200", description = "Property does not exist."),

--- a/services/src/main/java/org/fao/geonet/api/harvesting/HarvestersApi.java
+++ b/services/src/main/java/org/fao/geonet/api/harvesting/HarvestersApi.java
@@ -41,14 +41,12 @@ import org.fao.geonet.domain.Source;
 import org.fao.geonet.kernel.DataManager;
 import org.fao.geonet.kernel.datamanager.IMetadataManager;
 import org.fao.geonet.kernel.datamanager.IMetadataUtils;
-import org.fao.geonet.kernel.harvest.Common;
 import org.fao.geonet.kernel.harvest.HarvestManager;
 import org.fao.geonet.kernel.harvest.harvester.AbstractHarvester;
 import org.fao.geonet.repository.HarvestHistoryRepository;
 import org.fao.geonet.repository.SourceRepository;
 import org.jdom.Element;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
@@ -106,7 +104,7 @@ public class HarvestersApi {
         @ApiResponse(responseCode = "403", description = ApiParams.API_RESPONSE_NOT_ALLOWED_ONLY_USER_ADMIN)
     })
     @ResponseBody
-    public HttpEntity<HttpStatus> assignHarvestedRecordToSource(
+    public ResponseEntity<Void> assignHarvestedRecordToSource(
         @Parameter(
             description = "The harvester UUID"
         )
@@ -170,7 +168,7 @@ public class HarvestersApi {
         history.setParams(harvester.getParams().getNodeElement());
         historyRepository.save(history);
 
-        return new HttpEntity<>(HttpStatus.NO_CONTENT);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
 
@@ -182,7 +180,6 @@ public class HarvestersApi {
             value = "/{harvesterUuid}/reindex",
             method = RequestMethod.POST
     )
-    @ResponseStatus(value = HttpStatus.OK)
     @PreAuthorize("hasAuthority('UserAdmin')")
     @ApiResponses(value = {
             @ApiResponse(responseCode = "204", description = "Reindexing was successful"),
@@ -190,7 +187,7 @@ public class HarvestersApi {
             @ApiResponse(responseCode = "404", description = ApiParams.API_RESPONSE_RESOURCE_NOT_FOUND),
             @ApiResponse(responseCode = "403", description = ApiParams.API_RESPONSE_NOT_ALLOWED_ONLY_USER_ADMIN)
     })
-    public ResponseEntity<HttpStatus> reindexHarvester(
+    public ResponseEntity<Void> reindexHarvester(
             @Parameter(
                     description = "The harvester UUID"
             )
@@ -228,7 +225,7 @@ public class HarvestersApi {
         @ApiResponse(responseCode = "404", description = "A property with that value already exist."),
         @ApiResponse(responseCode = "403", description = ApiParams.API_RESPONSE_NOT_ALLOWED_ONLY_USER_ADMIN)
     })
-    public ResponseEntity<HttpStatus> checkHarvesterPropertyExist(
+    public ResponseEntity<Void> checkHarvesterPropertyExist(
         @Parameter(
             description = "The harvester property to check"
         )

--- a/services/src/main/java/org/fao/geonet/api/mapservers/MapServersApi.java
+++ b/services/src/main/java/org/fao/geonet/api/mapservers/MapServersApi.java
@@ -315,7 +315,8 @@ public class MapServersApi {
 
 
     @io.swagger.v3.oas.annotations.Operation(
-        summary = "Remove a mapserver"
+        summary = "Remove a mapserver",
+        operationId = "deleteMapserver"
         //       authorizations = {
         //           @Authorization(value = "basicAuth")
         //      })

--- a/services/src/main/java/org/fao/geonet/api/mapservers/MapServersApi.java
+++ b/services/src/main/java/org/fao/geonet/api/mapservers/MapServersApi.java
@@ -315,8 +315,7 @@ public class MapServersApi {
 
 
     @io.swagger.v3.oas.annotations.Operation(
-        summary = "Remove a mapserver",
-        operationId = "deleteMapserver"
+        summary = "Remove a mapserver"
         //       authorizations = {
         //           @Authorization(value = "basicAuth")
         //      })

--- a/services/src/main/java/org/fao/geonet/api/users/UsersApi.java
+++ b/services/src/main/java/org/fao/geonet/api/users/UsersApi.java
@@ -422,7 +422,7 @@ public class UsersApi {
         @ApiResponse(responseCode = "404", description = "A property with that value already exist."),
         @ApiResponse(responseCode = "403", description = ApiParams.API_RESPONSE_NOT_ALLOWED_ONLY_USER_ADMIN)
     })
-    public ResponseEntity<HttpStatus> checkUserPropertyExist(
+    public ResponseEntity<Void> checkUserPropertyExist(
         @Parameter(
             description = "The user property to check"
         )


### PR DESCRIPTION
Some API endpoints currently use `HttpStatus` as their response body type even though they do not return a response body. This causes OpenAPI to interpret `HttpStatus` as response content and generate an enum schema containing the possible status values.

The harvester reindex endpoint is also currently documented with both `200` and `204` success responses, even though it returns `204`.

In addition, the DOI server and mapserver delete endpoints currently have conflicting generated operation IDs. This causes the generated `_1` suffix to switch between the endpoints depending on their order in the OpenAPI specification, resulting in unstable generated client method names.

This PR aims to fix these issues by:

- Replacing `ResponseEntity<HttpStatus>` and `HttpEntity<HttpStatus>` with `ResponseEntity<Void>` for endpoints that do not return a response body. The response status continues to be set through the `ResponseEntity`, while `Void` correctly indicates to OpenAPI that the response does not contain content.
- Removing `@ResponseStatus(HttpStatus.OK)` from the harvester reindex endpoint so that `204` is the only documented success response.
- Adding explicit `deleteDoiServer` and `deleteMapserver` operation IDs to prevent conflicts and keep the generated method names stable.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

