### PR TITLE
Map viewer / Fix export feature table with links

### DIFF
--- a/web-ui/src/main/resources/catalog/components/viewer/gfi/FeaturesTable.js
+++ b/web-ui/src/main/resources/catalog/components/viewer/gfi/FeaturesTable.js
@@ -194,7 +194,7 @@
                   if (cell.is("th")) {
                     return cell.find(".th-inner").text();
                   } else if (cell.is("td") && cell.children("a").length > 0) {
-                    return cell.find("a").context.innerHTML.match(/href="([^"]*)/)[1];
+                    return cell.find("a").attr("href");
                   }
                   return htmlData;
                 }


### PR DESCRIPTION
Test case:

1) Add the layer `Faites un zoom avant pour obtenir des données détaillées sur les terres humides` from https://maps-cartes.ec.gc.ca/arcgis/services/CWS_SCF/INTHC/MapServer/WMSServer

2) Click on a feature of the map and in the feature info table, click the export button.

  - Without the fix the following error occurs:

```
FeaturesTable.js:197 Uncaught TypeError: Cannot read properties of undefined (reading 'innerHTML')
    at Object.onCellHtmlData (FeaturesTable.js:197:50)
    at z (tableExport.min.js?v…0744eebf5d77a:7:461)
    at tableExport.min.js?v…744eebf5d77a:17:242
```

  - With the fix, no error and the features are exported.


# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

