### PR TITLE
[Backport 4.2.x] OAI-PMH / Check view privilege on GetRecord (#9364)

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/oaipmh/services/GetRecord.java
+++ b/core/src/main/java/org/fao/geonet/kernel/oaipmh/services/GetRecord.java
@@ -34,6 +34,8 @@ import org.fao.geonet.domain.ISODate;
 import org.fao.geonet.domain.Metadata;
 import org.fao.geonet.domain.MetadataCategory;
 import org.fao.geonet.domain.MetadataDataInfo;
+import org.fao.geonet.domain.ReservedOperation;
+import org.fao.geonet.exceptions.OperationNotAllowedEx;
 import org.fao.geonet.kernel.SchemaManager;
 import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.kernel.oaipmh.Lib;
@@ -51,6 +53,7 @@ import org.fao.oaipmh.responses.Record;
 import org.jdom.Attribute;
 import org.jdom.Element;
 import org.springframework.data.jpa.domain.Specification;
+import org.springframework.security.access.AccessDeniedException;
 
 import jeeves.server.context.ServiceContext;
 
@@ -64,8 +67,20 @@ public class GetRecord implements OaiPmhService {
         SchemaManager sm = gc.getBean(SchemaManager.class);
 
         AbstractMetadata metadata = context.getBean(IMetadataUtils.class).findOne(spec);
+
         if (metadata == null)
             throw new IdDoesNotExistException(spec.toString());
+
+        try {
+            org.fao.geonet.lib.Lib.resource.checkPrivilege(
+                context, String.valueOf(metadata.getId()), ReservedOperation.view);
+        } catch (AccessDeniedException | OperationNotAllowedEx e) {
+            // The record exists but the caller is not allowed to view it. Report
+            // it as non-existent so a restricted record cannot be distinguished
+            // from an unknown one, and so ListRecords skips it instead of aborting
+            // the whole response. Any other error propagates unchanged.
+            throw new IdDoesNotExistException(metadata.getUuid());
+        }
 
         String uuid = metadata.getUuid();
         final MetadataDataInfo dataInfo = metadata.getDataInfo();

--- a/core/src/test/java/org/fao/geonet/kernel/oaipmh/services/GetRecordTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/oaipmh/services/GetRecordTest.java
@@ -1,0 +1,120 @@
+//=============================================================================
+//===	Copyright (C) 2001-2026 Food and Agriculture Organization of the
+//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
+//===	and United Nations Environment Programme (UNEP)
+//===
+//===	This program is free software; you can redistribute it and/or modify
+//===	it under the terms of the GNU General Public License as published by
+//===	the Free Software Foundation; either version 2 of the License, or (at
+//===	your option) any later version.
+//===
+//===	This program is distributed in the hope that it will be useful, but
+//===	WITHOUT ANY WARRANTY; without even the implied warranty of
+//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//===	General Public License for more details.
+//===
+//===	You should have received a copy of the GNU General Public License
+//===	along with this program; if not, write to the Free Software
+//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+//===
+//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+//===	Rome - Italy. email: geonetwork@osgeo.org
+//==============================================================================
+
+package org.fao.geonet.kernel.oaipmh.services;
+
+import jeeves.server.UserSession;
+import jeeves.server.context.ServiceContext;
+import org.fao.geonet.GeonetContext;
+import org.fao.geonet.constants.Geonet;
+import org.fao.geonet.domain.AbstractMetadata;
+import org.fao.geonet.kernel.AccessManager;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
+import org.fao.oaipmh.exceptions.IdDoesNotExistException;
+import org.junit.Test;
+import org.springframework.data.jpa.domain.Specification;
+
+import java.util.Collections;
+
+import static org.junit.Assert.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Access control tests for {@link GetRecord#buildRecordStat}.
+ *
+ * A record the caller is not allowed to view must be reported as
+ * {@code idDoesNotExist} (so it is indistinguishable from an unknown record and
+ * {@code ListRecords} can skip it), while an unrelated failure during the
+ * privilege check must keep propagating rather than being turned into a denial.
+ */
+public class GetRecordTest {
+
+    private static final String PREFIX = "iso19139";
+
+    /**
+     * A {@link ServiceContext} whose metadata lookup returns a single record and
+     * whose {@link AccessManager} and authentication state are those provided.
+     */
+    @SuppressWarnings("unchecked")
+    private ServiceContext mockContext(AccessManager accessManager, boolean authenticated) throws Exception {
+        ServiceContext context = mock(ServiceContext.class);
+
+        GeonetContext gc = mock(GeonetContext.class);
+        when(context.getHandlerContext(Geonet.CONTEXT_NAME)).thenReturn(gc);
+
+        AbstractMetadata metadata = mock(AbstractMetadata.class);
+        when(metadata.getId()).thenReturn(1);
+        when(metadata.getUuid()).thenReturn("restricted-uuid");
+
+        IMetadataUtils metadataUtils = mock(IMetadataUtils.class);
+        when(metadataUtils.findOne(any(Specification.class))).thenReturn(metadata);
+
+        when(context.getBean(IMetadataUtils.class)).thenReturn(metadataUtils);
+        when(context.getBean(AccessManager.class)).thenReturn(accessManager);
+
+        UserSession session = mock(UserSession.class);
+        when(session.isAuthenticated()).thenReturn(authenticated);
+        when(context.getUserSession()).thenReturn(session);
+
+        return context;
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void anonymousCallerWithoutViewPrivilegeGetsIdDoesNotExist() throws Exception {
+        AccessManager accessManager = mock(AccessManager.class);
+        when(accessManager.getOperations(any(), any(), any())).thenReturn(Collections.emptySet());
+
+        ServiceContext context = mockContext(accessManager, false);
+
+        assertThrows(IdDoesNotExistException.class, () ->
+            GetRecord.buildRecordStat(context, mock(Specification.class), PREFIX));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void authenticatedCallerWithoutViewPrivilegeGetsIdDoesNotExist() throws Exception {
+        AccessManager accessManager = mock(AccessManager.class);
+        when(accessManager.getOperations(any(), any(), any())).thenReturn(Collections.emptySet());
+
+        ServiceContext context = mockContext(accessManager, true);
+
+        assertThrows(IdDoesNotExistException.class, () ->
+            GetRecord.buildRecordStat(context, mock(Specification.class), PREFIX));
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    public void unexpectedErrorDuringPrivilegeCheckIsNotMaskedAsIdDoesNotExist() throws Exception {
+        AccessManager accessManager = mock(AccessManager.class);
+        when(accessManager.getOperations(any(), any(), any()))
+            .thenThrow(new IllegalStateException("boom"));
+
+        ServiceContext context = mockContext(accessManager, false);
+
+        assertThrows(IllegalStateException.class, () ->
+            GetRecord.buildRecordStat(context, mock(Specification.class), PREFIX));
+    }
+}


### PR DESCRIPTION
Backport of #9364 to `4.2.x`.

Only the `GetRecord` change from the original PR applies to this branch. `GetRecord` now checks the `view` privilege for the requested record and returns `idDoesNotExist` otherwise, following the OAI-PMH error model. This aligns `GetRecord` with the search and CSW endpoints.

The `ListRecords` / `ListIdentifiers` filter, the `EsQueryFilterUtils` helper and the `EsHTTPProxy` refactor from #9364 are not included here: they build on the OAI-PMH Elasticsearch / Spring MVC work (#8841), which is not present on `4.2.x`.

Includes a unit test covering the `GetRecord` privilege handling; it does not require a running Elasticsearch.