### PR TITLE
API / Feedback improvements

### DIFF
--- a/domain/src/main/java/org/fao/geonet/repository/userfeedback/UserFeedbackRepository.java
+++ b/domain/src/main/java/org/fao/geonet/repository/userfeedback/UserFeedbackRepository.java
@@ -66,6 +66,14 @@ public interface UserFeedbackRepository extends JpaRepository<UserFeedback, UUID
     List<UserFeedback> findByMetadata_UuidAndStatusOrderByCreationDateDesc(String metadataUuid, UserRatingStatus status, Pageable p);
 
     /**
+     * Find child feedback entries for a parent feedback uuid.
+     *
+     * @param parentUuid the parent feedback uuid
+     * @return the list
+     */
+    List<UserFeedback> findByParent_Uuid(String parentUuid);
+
+    /**
      * Find by metadata uuid order by date desc.
      *
      * @param metadataUuid the metadata uuid

--- a/services/src/main/java/org/fao/geonet/api/userfeedback/UserFeedbackAPI.java
+++ b/services/src/main/java/org/fao/geonet/api/userfeedback/UserFeedbackAPI.java
@@ -209,9 +209,7 @@ public class UserFeedbackAPI {
         try {
             Log.debug("org.fao.geonet.api.userfeedback.UserFeedback", "getMetadataUserComments");
 
-            // Check permission for metadata
-            final AbstractMetadata metadata = ApiUtils.canViewRecord(metadataUuid, request);
-
+            ApiUtils.canViewRecord(metadataUuid, request);
             final UserSession session = ApiUtils.getUserSession(httpSession);
 
             boolean published = true; // Takes only published comments
@@ -276,7 +274,7 @@ public class UserFeedbackAPI {
 
         // showing not published comments only to logged users (maybe better
         // restrict to Reviewers)
-        if (session != null && session.isAuthenticated()) {
+        if (session.isAuthenticated()) {
             published = false;
         }
 
@@ -289,11 +287,7 @@ public class UserFeedbackAPI {
         }
 
         // Check permission for metadata
-        final AbstractMetadata metadata = ApiUtils.canViewRecord(userfeedback.getMetadata().getUuid(), request);
-        if (metadata == null) {
-            printOutputMessage(response, HttpStatus.FORBIDDEN, ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_VIEW);
-            return null;
-        }
+        ApiUtils.canViewRecord(userfeedback.getMetadata().getUuid(), request);
 
         return dto;
     }
@@ -404,13 +398,13 @@ public class UserFeedbackAPI {
 
             // showing not published comments only to logged users (maybe better
             // restrict to Reviewers)
-            if (session != null && session.isAuthenticated()) {
+            if (session.isAuthenticated()) {
                 published = false;
             }
 
             List<UserFeedback> listUserfeedback = null;
 
-            if (metadataUuid == null || metadataUuid.equals("")) {
+            if (metadataUuid == null || metadataUuid.isEmpty()) {
                 listUserfeedback = userFeedbackService.retrieveUserFeedback(size, published);
             } else {
                 listUserfeedback = userFeedbackService.retrieveUserFeedbackForMetadata(metadataUuid, size, published);
@@ -518,7 +512,7 @@ public class UserFeedbackAPI {
                     String catalogueName = settingManager.getValue(SYSTEM_SITE_NAME_PATH);
                     String title = XslUtil.getIndexField(null, userFeedbackDto.getMetadataUUID(), "resourceTitleObject", "");
 
-                    if (toAddress.size() > 0) {
+                    if (!toAddress.isEmpty()) {
                         try {
                             Locale[] feedbackLocales = feedbackLanguages.getLocales(locale);
 
@@ -704,22 +698,6 @@ public class UserFeedbackAPI {
             settingManager
         );
         return new ResponseEntity<>(HttpStatus.CREATED);
-    }
-
-    /**
-     * Prints the output message.
-     *
-     * @param response the response
-     * @param code     the code
-     * @param message  the message
-     * @throws IOException Signals that an I/O exception has occurred.
-     */
-    private void printOutputMessage(final HttpServletResponse response, final HttpStatus code, final String message) throws IOException {
-        response.setStatus(code.value());
-        final PrintWriter out = response.getWriter();
-        response.setContentType("text/html");
-        out.println(message);
-        response.flushBuffer();
     }
 
     /**

--- a/services/src/main/java/org/fao/geonet/api/userfeedback/UserFeedbackAPI.java
+++ b/services/src/main/java/org/fao/geonet/api/userfeedback/UserFeedbackAPI.java
@@ -211,10 +211,6 @@ public class UserFeedbackAPI {
 
             // Check permission for metadata
             final AbstractMetadata metadata = ApiUtils.canViewRecord(metadataUuid, request);
-            if (metadata == null) {
-                printOutputMessage(response, HttpStatus.FORBIDDEN, ApiParams.API_RESPONSE_NOT_ALLOWED_CAN_VIEW);
-                return null;
-            }
 
             final UserSession session = ApiUtils.getUserSession(httpSession);
 
@@ -222,7 +218,7 @@ public class UserFeedbackAPI {
 
             // showing not published comments only to logged users (maybe better
             // restrict to Reviewers)
-            if (session != null && session.isAuthenticated()) {
+            if (session.isAuthenticated()) {
                 published = false;
             }
 

--- a/services/src/main/java/org/fao/geonet/api/userfeedback/UserFeedbackUtils.java
+++ b/services/src/main/java/org/fao/geonet/api/userfeedback/UserFeedbackUtils.java
@@ -218,7 +218,7 @@ public class UserFeedbackUtils {
         ISODate maxDate = null; // LAST COMMENT DATE
         RatingAverage v = null;
 
-        if (list.size() > 0) {
+        if (!list.isEmpty()) {
             Map<Integer, Integer> ratingAverages = new HashMap<>();
             RatingCriteriaRepository criteriaRepository = ApplicationContextHolder.get().getBean(RatingCriteriaRepository.class);
             List<RatingCriteria> criteriaList = criteriaRepository.findAll();
@@ -231,7 +231,7 @@ public class UserFeedbackUtils {
                     maxDate = new ISODate(userFeedback.getCreationDate().getTime());
                 }
 
-                if (userFeedback.getDetailedRatingList() != null && userFeedback.getDetailedRatingList().size() > 0) {
+                if (userFeedback.getDetailedRatingList() != null && !userFeedback.getDetailedRatingList().isEmpty()) {
 
                     for (final Rating rating : userFeedback.getDetailedRatingList()) {
                         Integer criteriaId = rating.getCategory().getId();
@@ -242,9 +242,10 @@ public class UserFeedbackUtils {
                                 ratingAverages.get(criteriaId) == null
                                     ? value
                                     : (ratingAverages.get(criteriaId) + value) / 2);
-                        }
-                        if (criteriaId.equals(AVERAGE_ID)) {
-                            ratingCount++;
+
+                            if (criteriaId.equals(AVERAGE_ID)) {
+                                ratingCount++;
+                            }
                         }
                     }
 
@@ -288,6 +289,7 @@ public class UserFeedbackUtils {
          * @param ratingAverages    the average for all rating categories
          * @param userfeedbackCount the userfeedback count
          * @param lastComment       the last comment
+         * @param ratingCount       the rating count
          */
         public RatingAverage(Map<Integer, Integer> ratingAverages, int userfeedbackCount, String lastComment, int ratingCount) {
             this.ratingAverages = ratingAverages;

--- a/services/src/main/java/org/fao/geonet/api/userfeedback/service/UserFeedbackDatabaseService.java
+++ b/services/src/main/java/org/fao/geonet/api/userfeedback/service/UserFeedbackDatabaseService.java
@@ -39,6 +39,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 
@@ -94,21 +95,32 @@ public class UserFeedbackDatabaseService implements IUserFeedbackService {
      * removeUserFeedback(java.lang.String)
      */
     @Override
+    @Transactional
     public void removeUserFeedback(String feedbackUuid, String ip) throws Exception {
         final UserFeedback userFeedback = userFeedbackRepository.findByUuid(feedbackUuid);
         final Metadata metadata = userFeedback.getMetadata();
 
-        userFeedbackRepository.delete(userFeedback);
+        deleteUserFeedbackWithChildren(userFeedback);
 
         // Then update global metadata rating
         List<UserFeedback> listFeedbacks = retrieveUserFeedbackForMetadata(metadata.getUuid(), -1, true);
         Integer average = 0;
-        if (listFeedbacks.size() > 0) {
+        if (!listFeedbacks.isEmpty()) {
             UserFeedbackUtils.RatingAverage averageRating = new UserFeedbackUtils()
                 .getAverage(listFeedbacks);
             average = averageRating.getRatingAverages().get(AVERAGE_ID);
         }
         dataManager.rateMetadata(metadata.getId(), ip, average);
+    }
+
+    private void deleteUserFeedbackWithChildren(UserFeedback userFeedback) {
+        List<UserFeedback> childFeedbacks = userFeedbackRepository.findByParent_Uuid(userFeedback.getUuid());
+
+        for (UserFeedback childFeedback : childFeedbacks) {
+            deleteUserFeedbackWithChildren(childFeedback);
+        }
+
+        userFeedbackRepository.delete(userFeedback);
     }
 
     /*

--- a/services/src/test/java/org/fao/geonet/api/userfeedback/service/UserFeedbackDatabaseServiceTest.java
+++ b/services/src/test/java/org/fao/geonet/api/userfeedback/service/UserFeedbackDatabaseServiceTest.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright (C) 2001-2026 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+package org.fao.geonet.api.userfeedback.service;
+
+import org.fao.geonet.domain.Metadata;
+import org.fao.geonet.domain.userfeedback.UserFeedback;
+import org.fao.geonet.domain.userfeedback.UserFeedback.UserRatingStatus;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
+import org.fao.geonet.repository.MetadataRepository;
+import org.fao.geonet.repository.UserRepository;
+import org.fao.geonet.repository.userfeedback.RatingRepository;
+import org.fao.geonet.repository.userfeedback.UserFeedbackRepository;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class UserFeedbackDatabaseServiceTest {
+
+    @Mock
+    private IMetadataUtils dataManager;
+
+    @Mock
+    private MetadataRepository metadataRepository;
+
+    @Mock
+    private RatingRepository ratingRepository;
+
+    @Mock
+    private UserFeedbackRepository userFeedbackRepository;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @InjectMocks
+    private UserFeedbackDatabaseService service = new UserFeedbackDatabaseService();
+
+    @Before
+    public void setUp() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    @Test
+    public void removeUserFeedbackDeletesChildrenBeforeParent() throws Exception {
+        Metadata metadata = new Metadata();
+        metadata.setId(12);
+        metadata.setUuid("metadata-uuid");
+
+        UserFeedback parent = new UserFeedback();
+        parent.setUuid("parent");
+        parent.setMetadata(metadata);
+
+        UserFeedback child = new UserFeedback();
+        child.setUuid("child");
+        child.setMetadata(metadata);
+
+        UserFeedback grandChild = new UserFeedback();
+        grandChild.setUuid("grand-child");
+        grandChild.setMetadata(metadata);
+
+        when(userFeedbackRepository.findByUuid("parent")).thenReturn(parent);
+        when(userFeedbackRepository.findByParent_Uuid("parent")).thenReturn(Collections.singletonList(child));
+        when(userFeedbackRepository.findByParent_Uuid("child")).thenReturn(Collections.singletonList(grandChild));
+        when(userFeedbackRepository.findByParent_Uuid("grand-child")).thenReturn(Collections.emptyList());
+        when(userFeedbackRepository.findByMetadata_UuidAndStatusOrderByCreationDateDesc(
+            eq("metadata-uuid"), eq(UserRatingStatus.PUBLISHED), isNull()))
+            .thenReturn(Collections.emptyList());
+
+        service.removeUserFeedback("parent", "127.0.0.1");
+
+        org.mockito.InOrder inOrder = inOrder(userFeedbackRepository);
+        inOrder.verify(userFeedbackRepository).findByUuid("parent");
+        inOrder.verify(userFeedbackRepository).findByParent_Uuid("parent");
+        inOrder.verify(userFeedbackRepository).findByParent_Uuid("child");
+        inOrder.verify(userFeedbackRepository).findByParent_Uuid("grand-child");
+        inOrder.verify(userFeedbackRepository).delete(grandChild);
+        inOrder.verify(userFeedbackRepository).delete(child);
+        inOrder.verify(userFeedbackRepository).delete(parent);
+        inOrder.verify(userFeedbackRepository).findByMetadata_UuidAndStatusOrderByCreationDateDesc(
+            "metadata-uuid", UserRatingStatus.PUBLISHED, null);
+
+        verify(dataManager).rateMetadata(12, "127.0.0.1", 0);
+    }
+}

--- a/services/src/test/java/org/fao/geonet/api/userfeedback/service/UserFeedbackDatabaseServiceTest.java
+++ b/services/src/test/java/org/fao/geonet/api/userfeedback/service/UserFeedbackDatabaseServiceTest.java
@@ -62,7 +62,7 @@ public class UserFeedbackDatabaseServiceTest {
     private UserRepository userRepository;
 
     @InjectMocks
-    private UserFeedbackDatabaseService service = new UserFeedbackDatabaseService();
+    private UserFeedbackDatabaseService service;
 
     @Before
     public void setUp() {


### PR DESCRIPTION
Removing feedback with child return an error. The record reviews may have a parentUuid set but the API was failing with "could not execute batch; SQL [delete from GUF_UserFeedbacks where uuid=?];". When removing a feedback, remove all children too.

Average was computed with rating > 0, but `ratingCount` property was considering null or 0 rating. Do not count rating if null or 0. The API return 2 infos:
* `ratingCount` - number of rating > 0
* `userfeedbackCount` - number of reviews (with rating or not)


<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

Funded by Ifremer