### PR TITLE
Documentation / Search statistics / Mark setting as not functional

### DIFF
--- a/docs/manual/docs/administrator-guide/configuring-the-catalog/system-configuration.md
+++ b/docs/manual/docs/administrator-guide/configuring-the-catalog/system-configuration.md
@@ -175,9 +175,18 @@ For each metadata schema, the catalog has an XSL transformation (`update-fixed-i
 
 ## Search Statistics {#search_stats_config}
 
-Enables/disables search statistics capture. Search statistics are stored in the database and can be queried using the `Search Statistics` page.
+!!! warning "Not currently functional"
 
-There is very little compute overhead involved in storing search statistics as they are written to the database in a background thread. However database storage for a very busy site must be carefully planned.
+    This setting has no effect. Search statistics capture was removed when the catalog migrated from Lucene to Elasticsearch, with the intention of rebuilding it on top of Elasticsearch and Kibana. That work has not been completed, so enabling this option does not collect any data and there is no `Search Statistics` page to query.
+
+    See [issue #4499](https://github.com/geonetwork/core-geonetwork/issues/4499) for the current status.
+
+    To collect usage statistics in the meantime, configure a web analytics service using ```WEB-INF/config.properties```:
+
+    ```properties
+    analytics.web.service=matomo
+    analytics.web.jscode=<tracking code provided by the analytics service>
+    ```
 
 ## Open Archive Initiative (OAI-PMH) Provider
 

--- a/docs/manual/docs/maintainer-guide/production-use/index.md
+++ b/docs/manual/docs/maintainer-guide/production-use/index.md
@@ -37,7 +37,7 @@ GeoNetwork is a memory-intensive application. Consider providing at least 2 GB, 
 
 ## Scaling
 
-GeoNetwork currently has limitations when deployed in a load-balanced/failover configuration. The search index is stored in memory and will not reflect changes made to records on other nodes. One option to work around this is a master-minion model: modifications are made on the master, and minions harvest from the master at regular intervals. Each minion will have its own local database. Typical aspects stored in the database, like groups, settings, user feedback, and search statistics, will not be synchronised between nodes. The data folder can be shared between nodes using a network share.
+GeoNetwork currently has limitations when deployed in a load-balanced/failover configuration. The search index is stored in memory and will not reflect changes made to records on other nodes. One option to work around this is a master-minion model: modifications are made on the master, and minions harvest from the master at regular intervals. Each minion will have its own local database. Typical aspects stored in the database, like groups, settings, and user feedback, will not be synchronised between nodes. The data folder can be shared between nodes using a network share.
 
 ## GeoNetwork and Docker
 


### PR DESCRIPTION
## Summary

The `Search Statistics` section of the administrator guide still describes the GeoNetwork 3.x behaviour:

> Enables/disables search statistics capture. Search statistics are stored in the database and can be queried using the `Search Statistics` page.

Neither statement is true in version 4. Search statistics capture was dropped during the migration from Lucene to Elasticsearch and was never reimplemented, and there is no `Search Statistics` page.

The setting `system/searchStats/enable` is still inserted at install and still rendered in `Admin console` --> `Settings`, but `SettingInfo.isSearchStatsEnabled()` has no callers and `SearcherLogger.logSearch()` only throws `NotImplementedException`. Enabling the option collects nothing.

This came up via a user who found the checkbox, read the manual, and went looking for the database table holding the data.

## Changes

- `administrator-guide/configuring-the-catalog/system-configuration.md`: replace the section with a warning stating the actual status, link to #4499, and point at the web analytics settings as the available alternative. The `search_stats_config` anchor is preserved.
- `maintainer-guide/production-use/index.md`: drop search statistics from the list of database-backed data that is not synchronised between nodes, for the same reason.

Documentation only, no functional change.

## Notes

This addresses the documentation half of #4499. The other suggestion in that issue, hiding or labelling the setting in the settings UI, is left for discussion there since the key presumably wants to stay in the database as the anchor for an eventual Elasticsearch implementation.

The rendering of the new admonition, including the anchor and the nested code block, was checked against Python-Markdown with the extensions configured in `mkdocs.yml`.

Refs #4499