### PR TITLE
Documentation / Search statistics / Mark setting as not functional (4.2.x)

### DIFF
--- a/docs/manual/docs/administrator-guide/configuring-the-catalog/system-configuration.md
+++ b/docs/manual/docs/administrator-guide/configuring-the-catalog/system-configuration.md
@@ -175,9 +175,11 @@ For each metadata schema, the catalog has an XSL transformation (`update-fixed-i
 
 ## Search Statistics {#search_stats_config}
 
-Enables/disables search statistics capture. Search statistics are stored in the database and can be queried using the `Search Statistics` page.
+!!! warning "Not currently functional"
 
-There is very little compute overhead involved in storing search statistics as they are written to the database in a background thread. However database storage for a very busy site must be carefully planned.
+    This setting has no effect. Search statistics capture was removed when the catalog migrated from Lucene to Elasticsearch, with the intention of rebuilding it on top of Elasticsearch and Kibana. That work has not been completed, so enabling this option does not collect any data and there is no `Search Statistics` page to query.
+
+    See [issue #4499](https://github.com/geonetwork/core-geonetwork/issues/4499) for the current status.
 
 ## Open Archive Initiative (OAI-PMH) Provider
 

--- a/docs/manual/docs/maintainer-guide/production-use/index.md
+++ b/docs/manual/docs/maintainer-guide/production-use/index.md
@@ -37,7 +37,7 @@ GeoNetwork is a memory intensive application. Consider to provide at least 2GB, 
 
 ## Scaling
 
-GeoNetwork currently has challenges to be set up in a load balanced/fail over configuration. The search index is stored in memory and will not be aware of changes on records done in other nodes. An option to optimise this is introducing a master-minion model; modifications are done in master, minion harvest master at intervals. Each minion will have a local database. Typical aspects stored in the database, like groups, settings, user feedback and search statistics will not be synchronised between nodes. The data folder can be shared between nodes by using a network share.
+GeoNetwork currently has challenges to be set up in a load balanced/fail over configuration. The search index is stored in memory and will not be aware of changes on records done in other nodes. An option to optimise this is introducing a master-minion model; modifications are done in master, minion harvest master at intervals. Each minion will have a local database. Typical aspects stored in the database, like groups, settings and user feedback will not be synchronised between nodes. The data folder can be shared between nodes by using a network share.
 
 ## GeoNetwork and Docker
 


### PR DESCRIPTION
Backport of #9452 to `4.2.x`.

## Summary

The `Search Statistics` section of the administrator guide still describes the GeoNetwork 3.x behaviour:

> Enables/disables search statistics capture. Search statistics are stored in the database and can be queried using the `Search Statistics` page.

Neither statement is true. Verified on this branch: `SearcherLogger.logSearch()` only throws `NotImplementedException` (`SearcherLogger.java:71`), and `SettingInfo.isSearchStatsEnabled()` (`SettingInfo.java:76`) has no callers, while the setting is still inserted at install (`data-db-default.sql:627`) and rendered in `Admin console` --> `Settings`. Enabling the option collects nothing.

## Changes

- `administrator-guide/configuring-the-catalog/system-configuration.md`: replace the section with a warning stating the actual status and a link to #4499. The `search_stats_config` anchor is preserved.
- `maintainer-guide/production-use/index.md`: drop search statistics from the list of database-backed data that is not synchronised between nodes.

Documentation only, no functional change.

## Difference from the main branch PR

#9452 also points readers at the `analytics.web.*` settings as an alternative way to collect usage statistics. Those settings were introduced in 4.4.5 and do not exist in 4.2.x, so that paragraph is omitted here. The wording of the `production-use` sentence also differs slightly between branches, so the change was applied to the 4.2.x phrasing rather than cherry-picked.

Refs #4499