### PR TITLE
Metadata selection export to PDF: Fix cover and intro pages

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1262,7 +1262,7 @@
       <dependency>
         <groupId>org.apache.pdfbox</groupId>
         <artifactId>pdfbox</artifactId>
-        <version>2.0.24</version>
+        <version>${pdfbox.version}</version>
       </dependency>
       <dependency>
         <groupId>org.jasypt</groupId>
@@ -1703,6 +1703,10 @@
     <wro.version>1.10.1</wro.version>
     <wro.debug>true</wro.debug>
     <fop.version>2.11</fop.version>
+    <!-- Must track the pdfbox version that fop-pdf-images:${fop.version} itself depends on
+         (see its POM), otherwise fox:external-document/PDF embedding fails at runtime with
+         NoClassDefFoundError masked as "java.io.IOException: closed". -->
+    <pdfbox.version>3.0.3</pdfbox.version>
     <xmlunit.version>2.10.0</xmlunit.version>
     <jackson.version>2.22.0</jackson.version>
     <flying-saucer>9.1.22</flying-saucer>

--- a/web/src/main/webapp/xslt/services/pdf/portal-present-fop.xsl
+++ b/web/src/main/webapp/xslt/services/pdf/portal-present-fop.xsl
@@ -37,7 +37,7 @@
              xmlns:fox="http://xmlgraphics.apache.org/fop/extensions">
       <xsl:call-template name="fop-master"/>
 
-      <xsl:if test="string($env/system/system/metadata/pdfReport/coverPdf)">
+      <xsl:if test="string($env/system/metadata/pdfReport/coverPdf)">
         <fox:external-document content-type="pdf" src="{$env/system/metadata/pdfReport/coverPdf}" />
       </xsl:if>
 


### PR DESCRIPTION
Cover and intro PDF pages are not included in the metadata selection PDF. 

Test case:

1) Copy to the images folder 2 PDF files: cover.pdf and intro.pdf
2) Configure the files in the Admin console > Settings > Metadata 
3) Export a metadata selection --> PDF doesn't include the cover and intro pages

With the fix, the export includes the cover and intro pages.

Probably related to the FOP upgrade in https://github.com/geonetwork/core-geonetwork/pull/9299

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation