### PR TITLE
[Backport 4.2.x] Metadata selection export to PDF: Fix cover and intro pages (#9456)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1194,7 +1194,7 @@
       <dependency>
         <groupId>org.apache.pdfbox</groupId>
         <artifactId>pdfbox</artifactId>
-        <version>2.0.24</version>
+        <version>${pdfbox.version}</version>
       </dependency>
       <dependency>
         <groupId>org.jasypt</groupId>
@@ -1629,6 +1629,10 @@
     <wro.version>1.7.9</wro.version>
     <wro.debug>true</wro.debug>
     <fop.version>2.11</fop.version>
+    <!-- Must track the pdfbox version that fop-pdf-images:${fop.version} itself depends on
+         (see its POM), otherwise fox:external-document/PDF embedding fails at runtime with
+         NoClassDefFoundError masked as "java.io.IOException: closed". -->
+    <pdfbox.version>3.0.3</pdfbox.version>
     <node.version>v8.11.1</node.version>
     <npm.version>5.8.0</npm.version>
     <xmlunit.version>2.1.1</xmlunit.version>

--- a/web/src/main/webapp/xslt/services/pdf/portal-present-fop.xsl
+++ b/web/src/main/webapp/xslt/services/pdf/portal-present-fop.xsl
@@ -37,7 +37,7 @@
              xmlns:fox="http://xmlgraphics.apache.org/fop/extensions">
       <xsl:call-template name="fop-master"/>
 
-      <xsl:if test="string($env/system/system/metadata/pdfReport/coverPdf)">
+      <xsl:if test="string($env/system/metadata/pdfReport/coverPdf)">
         <fox:external-document content-type="pdf" src="{$env/system/metadata/pdfReport/coverPdf}" />
       </xsl:if>
 


### PR DESCRIPTION
Backport of #9456 to `4.2.x`.

The automatic backport failed: `pom.xml` conflicts because 4.2.x has different neighbouring properties (`node.version`, `npm.version` and older `xmlunit`/`jackson` versions). Resolved by hand, the new `pdfbox.version` property goes right after `fop.version`. The XSLT hunk applies cleanly.

Tested on 4.2.x with JDK 8 and Elasticsearch 7.17.15, cover and intro PDFs configured in Admin console > Settings > Metadata:

- Before: the export fails with HTTP 400 and `NullPointerException at ExternalDocumentLayoutManager.createPage`, same as on main.
- After: export returns a PDF with the cover page first, then the TOC, then the intro page, then the records.