### PR TITLE
Upgrade MapFish to version 2.3.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -887,7 +887,7 @@
       <dependency>
         <groupId>org.mapfish.print</groupId>
         <artifactId>print-lib</artifactId>
-        <version>2.3.5</version>
+        <version>2.3.6</version>
         <exclusions>
           <exclusion>
             <groupId>log4j</groupId>


### PR DESCRIPTION
MapFish 2.3.6 uses pdfbox 3.0.3 the same as in GeoNetwork. The version 2.3.5 used pdfbox 2.0.x and was causing the following error when creating a thumbnail from a WMS service in the metadata editor, due to API changes in pdfbox:

```
Caused by: java.lang.NoSuchMethodError: 'org.apache.pdfbox.pdmodel.PDDocument org.apache.pdfbox.pdmodel.PDDocument.load(java.io.File)'
    at org.mapfish.print.output.FileCachingJaiMosaicOutputFactory$ImageOutputScalable.createImages(FileCachingJaiMosaicOutputFactory.java:143)
    at org.mapfish.print.output.FileCachingJaiMosaicOutputFactory$ImageOutputScalable.print(FileCachingJaiMosaicOutputFactory.java:89)
    at org.fao.geonet.kernel.thumbnail.ThumbnailMaker.generateThumbnail(ThumbnailMaker.java:169)
    at org.fao.geonet.api.records.attachments.AttachmentsActionsApi.saveThumbnail(AttachmentsActionsApi.java:131)
```

Test case:

1) Create an ISO19139 metadata and add a WMS layer
2) Generate a thumbnail from the view service

  - Without the fix: an error is reported in the console, no thumbnail is created.
  - With the fix: the thumbnail is created.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
