### PR TITLE
Metadata editor / Online resources / Fix mimeTypeStrategy parameter when adding a new online resource

### DIFF
--- a/docs/manual/docs/user-guide/associating-resources/linking-panel-configuration.md
+++ b/docs/manual/docs/user-guide/associating-resources/linking-panel-configuration.md
@@ -20,7 +20,8 @@ For distribution, configuration has the following properties:
 * `icon` is the icon class.
 * `fileStoreFilter` is a regular expression to filter files available in the metadata store
 * `process` is the XSL process to be applied when the resource is added
-* `fields` defines the fields to populate for the resource and their properties (eg. visible or not, multilingual or not, default value)
+* `fields` defines the fields to populate for the resource and their properties (eg. visible or not, multilingual or not, default value). Some entries are options passed to the
+  process rather than inputs shown to the user, see [MIME type encoding](#mime-type-encoding)
 
 Example:
 
@@ -50,7 +51,43 @@ Example:
       },
 ```
 
+### MIME type encoding
 
+When a distribution type declares a `mimeType` field, the editor shows an input for the resource
+MIME type. `mimeTypeStrategy` controls how the `onlinesrc-add` process encodes it in the record.
+
+With `"mimeTypeStrategy": {"value": "mimeType"}` the protocol element carries the MIME type in a
+`type` attribute, using `gmx:MimeFileType` in ISO19139 and `gcx:MimeFileType` in ISO19115-3:
+
+```xml
+<gmd:protocol>
+  <gmx:MimeFileType type="image/tiff">WWW:DOWNLOAD-1.0-http--download</gmx:MimeFileType>
+</gmd:protocol>
+```
+
+With `"mimeTypeStrategy": {"value": "protocol"}` the MIME type is appended to the protocol,
+separated by a colon:
+
+```xml
+<gmd:protocol>
+  <gco:CharacterString>WWW:DOWNLOAD-1.0-http--download:image/tiff</gco:CharacterString>
+</gmd:protocol>
+```
+
+`mimeTypeStrategy` is an option passed to the process rather than a field the user fills in, so
+it only takes a `value`:
+
+```json
+        "fields": {
+          "url": {"isMultilingual": false},
+          "protocol": {"isMultilingual": false},
+          "mimeType": {"isMultilingual": false},
+          "mimeTypeStrategy": {"value": "mimeType"}
+        }
+```
+
+If `mimeTypeStrategy` is declared without a `value`, `mimeType` is used. If it is not declared at
+all, the process default applies and the MIME type is appended to the protocol.
 
 ## Associated resources
 

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -1184,7 +1184,6 @@
                       url: fields.url,
                       protocol: linkToEdit.protocol,
                       mimeType: linkToEdit.mimeType,
-                      mimeTypeStrategy: "mimeType",
                       name: fields.name,
                       desc: fields.desc,
                       applicationProfile: linkToEdit.applicationProfile,
@@ -1198,7 +1197,6 @@
                     scope.params.linkType = typeConfig;
                     scope.params.protocol = null;
                     scope.params.mimeType = "";
-                    scope.params.mimeTypeStrategy = "mimeType";
                     scope.params.name = "";
                     scope.params.desc = "";
                     initMultilingualFields();
@@ -1383,6 +1381,15 @@
                     processParams[key] = scope.params[key];
                   }
                 });
+
+                // mimeTypeStrategy is a configuration option and not a user input.
+                // Take it from the link type configuration rather than from the form
+                // state, which is reset on protocol change and may be turned into a
+                // multilingual object on a multilingual record.
+                var mimeTypeStrategy = scope.params.linkType.fields.mimeTypeStrategy;
+                if (angular.isDefined(mimeTypeStrategy)) {
+                  processParams.mimeTypeStrategy = mimeTypeStrategy.value || "mimeType";
+                }
 
                 if (scope.isEditing) {
                   processParams.updateKey = scope.editingKey;
@@ -1799,7 +1806,7 @@
                 if (newValue !== oldValue) {
                   scope.config.multilingualFields = [];
                   angular.forEach(newValue.fields, function (f, k) {
-                    if (f.isMultilingual !== false) {
+                    if (scope.isMdMultilingual && f.isMultilingual !== false) {
                       scope.config.multilingualFields.push(k);
                     }
                   });

--- a/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
+++ b/web-ui/src/main/resources/catalog/components/edit/onlinesrc/OnlineSrcDirective.js
@@ -1198,7 +1198,7 @@
                     scope.params.linkType = typeConfig;
                     scope.params.protocol = null;
                     scope.params.mimeType = "";
-                    scope.mimeTypeStrategy = "mimeType";
+                    scope.params.mimeTypeStrategy = "mimeType";
                     scope.params.name = "";
                     scope.params.desc = "";
                     initMultilingualFields();


### PR DESCRIPTION
`mimeTypeStrategy` was not set in `scope.params` causing this parameter to be ignored when adding a new online resource. Editing an online resource it was correctly set in `scope.params`


To test this fix:

1) Edit ISO19139 https://github.com/geonetwork/core-geonetwork/blob/96e39152e85ad8b1a87fa38002e7b852ae580393/schemas/iso19139/src/main/plugin/iso19139/config/associated-panel/default.json#L11-L17

And add:

```json
"mimeType": {
  "isMultilingual": false,
  "tooltip": "gmx:MimeFileType"
},
"mimeTypeStrategy": {
  "value": "mimeType"
},
```

2) Create a new metadata and add an online resource.

  - Without the fix: creating a new online resource, displays the field Format (mimeType). Fill it and save the online resource. **Edit it and the Format field is empty**.
  - With the fix: creating a new online resource, displays the field Format (mimeType). Fill it and save the online resource. **Edit it and the Format field is filled correctly**.
  

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation