### PR TITLE
Record page / Fix wrong display of parent metadata link for series metadata

### DIFF
--- a/web-ui/src/main/resources/catalog/components/utility/partials/mosaic.html
+++ b/web-ui/src/main/resources/catalog/components/utility/partials/mosaic.html
@@ -1,4 +1,4 @@
-<div class="gallery">
+<div class="gallery gn-record-mosaic">
   <div data-ng-repeat="i in images">
     <img data-ng-src="{{i.data || (i.url | thumbnailUrlSize: imageSize)}}" />
   </div>

--- a/web-ui/src/main/resources/catalog/style/gn_metadata.less
+++ b/web-ui/src/main/resources/catalog/style/gn_metadata.less
@@ -702,7 +702,7 @@ ul.container-list {
     margin-left: -4px;
   }
 
-  .gn-md-view .gallery {
+  .gn-md-view .gn-record-mosaic {
     border: 1px solid #ccc;
     padding: 4px 4px 0px 0px;
     width: 33%;

--- a/web-ui/src/main/resources/catalog/views/default/less/gn_result_default.less
+++ b/web-ui/src/main/resources/catalog/views/default/less/gn_result_default.less
@@ -170,7 +170,9 @@
       color: #fff;
       background-color: #333 !important;
     }
-    .gallery {
+    // excludes the record-view mosaic (data-gn-record-mosaic), which needs to
+    // keep its own floated width/height from gn_metadata.less .gn-record-mosaic
+    .gallery:not(.gn-record-mosaic) {
       width: 100%;
       margin-top: 15px;
       margin-bottom: 15px;


### PR DESCRIPTION
Test case

1) Create a dataset metadata with hierarchy level **series** and title **Ice series 1**
2) Create a dataset metadata with hierarchy level **dataset** and title  **Ice dataset 1** and link it to the series created in 1) --> Record page is displayed correctly

<img width="1300" height="380" alt="image" src="https://github.com/user-attachments/assets/77db7e73-bfab-4728-a953-c6d28ffae794" />


2) Create a dataset metadata with hierarchy level **series** and title  **Ice series 2** and link it to the series created in 1) --> Record page is NOT displayed correctly

<img width="1178" height="412" alt="image" src="https://github.com/user-attachments/assets/ee6de044-4a3b-4c81-b5ab-2ca32e8ee30b" />


With the fix it shows up properly:

<img width="1155" height="448" alt="image" src="https://github.com/user-attachments/assets/5f393c4c-cd0a-42f1-acc4-0151adb4d52b" />

### Root cause

Two unrelated LESS rules both nested under .gn-md-view were targeting the same generic `.gallery` class:

- [web-ui/src/main/resources/catalog/style/gn_metadata.less:705](https://github.com/geonetwork/core-geonetwork/blob/81ee6d5c61a1014f55a2e910347e8dd2fe6a2051/web-ui/src/main/resources/catalog/style/gn_metadata.less#L705) — `.gn-md-view `.gallery — meant to float the series/service thumbnail mosaic (data-gn-record-mosaic, shown above the "Member of" link) at `width: 33%; height: 300px; float: right`.
- [web-ui/src/main/resources/catalog/views/default/less/gn_result_default.less:173](https://github.com/geonetwork/core-geonetwork/blob/81ee6d5c61a1014f55a2e910347e8dd2fe6a2051/web-ui/src/main/resources/catalog/views/default/less/gn_result_default.less#L173) — `.gn-md-view .gn-card .gallery `— meant for a different gallery (search-result card thumbnails), setting `width: 100%; height: auto`.

Because the record-view page wraps the title block in `.gn-card`, the 3-class selector beat the 2-class one on width/height, but not on float (which it never set). The mosaic ended up `float: right` and `width: 100%` with `height: auto`. 

When the mosaic had no images (as in the **Ice series 2** series record), it collapsed to a full-width, zero-height float sitting right where the "Member of" link text starts — leaving 0px on that first line, so "Ice" broke after "I" and the rest wrapped to the next line. This only happens for `series/service` records, since the mosaic markup is only rendered for those resource types — matching exactly why the dataset page never showed the bug.

### Fix:

- mosaic.html — give the mosaic wrapper its own `gn-record-mosaic` class alongside gallery.
- gn_metadata.less — retarget the float/33%/300px rule to `.gn-md-view .gn-record-mosaic`.
- gn_result_default.less — exclude the mosaic from the card-gallery rule via `.gallery:not(.gn-record-mosaic)`.

This decouples the two independent "gallery" use cases so neither can leak into the other; the search-result card gallery is untouched, and the record-view mosaic keeps its intended float layout, which no longer squeezes the adjacent link text.

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

