### PR TITLE
Normalize organisation name value for ISO19110 metadata.

### DIFF
--- a/web/src/main/webapp/xslt/common/index-utils.xsl
+++ b/web/src/main/webapp/xslt/common/index-utils.xsl
@@ -313,9 +313,9 @@
             <!-- Index each values in a field. -->
             <xsl:for-each select="distinct-values($element[. != ''])">
               <value><xsl:value-of select="concat($doubleQuote, 'default', $doubleQuote, ':',
-                                           $doubleQuote, util:escapeForJson(.), $doubleQuote)"/></value>
+                                           $doubleQuote, util:escapeForJson(normalize-space(.)), $doubleQuote)"/></value>
               <value><xsl:value-of select="concat($doubleQuote, 'lang', $mainLanguage, $doubleQuote, ':',
-                                           $doubleQuote, util:escapeForJson(.), $doubleQuote)"/></value>
+                                           $doubleQuote, util:escapeForJson(normalize-space(.)), $doubleQuote)"/></value>
             </xsl:for-each>
           </xsl:otherwise>
         </xsl:choose>


### PR DESCRIPTION
If not normalized, `add-multilingual-field` receives in `elements` the `gmd:organisationName` node and `util:escapeForJson(.)` was adding a breakline for the child `gco:CharacterString`. This caused the organisation name facet in the search to display a prefix `OrgForResourceObject.default -` in the organsation name


<img width="1341" height="632" alt="image" src="https://github.com/user-attachments/assets/eba81dfa-78c7-40b7-b846-b1dc268a7b22" />

Test case: 

1) Create and iso19110 metadata and define the contact organisation name
2) Go to the search page and check the organisation name facet:

  - Without the fix: the facet value shows a prefix `OrgForResourceObject.default -`
  - With the fix: the facet value shows only the organisation name.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
