### PR TITLE
Fix StackOverflowError adding gfc:FC_AssociationRole and similar feature catalogue elements

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/EditLib.java
+++ b/core/src/main/java/org/fao/geonet/kernel/EditLib.java
@@ -1041,16 +1041,22 @@ public class EditLib {
 
     private void fillElement(MetadataSchema schema, SchemaSuggestions sugg, Element parent, Element element) throws Exception {
         String parentName = parent.getQualifiedName();
-        fillElement(schema, sugg, parentName, element);
+        fillElement(schema, sugg, parentName, element, Collections.emptySet());
     }
 
     /**
-     * @param schema     The metadata schema
-     * @param sugg       The suggestion configuration for the schema
-     * @param parentName The name of the parent
-     * @param element    The element to fill
+     * @param schema           The metadata schema
+     * @param sugg             The suggestion configuration for the schema
+     * @param parentName       The name of the parent
+     * @param element          The element to fill
+     * @param ancestorTypes    Names of the types of the ancestors of this element that are
+     *                         currently being auto-expanded, used to detect and stop
+     *                         self-referencing / mutually recursive type definitions
+     *                         (eg. gfc feature catalogue types) which would otherwise cause
+     *                         infinite recursion / StackOverflowError.
      */
-    private void fillElement(MetadataSchema schema, SchemaSuggestions sugg, String parentName, Element element) throws Exception {
+    private void fillElement(MetadataSchema schema, SchemaSuggestions sugg, String parentName, Element element,
+                              Set<String> ancestorTypes) throws Exception {
         String elemName = element.getQualifiedName();
         SchemaPlugin plugin = schema.getSchemaPlugin();
         boolean isISOPlugin = plugin instanceof ISOPlugin;
@@ -1069,6 +1075,19 @@ public class EditLib {
         }
 
         MetadataType type = schema.getTypeInfo(schema.getElementType(elemName, parentName));
+
+        // Track the chain of types being auto-expanded on this branch so that
+        // self-referencing / mutually recursive type definitions (eg. gfc feature
+        // catalogue FC_AssociationRole <-> FC_FeatureAssociation) stop expanding
+        // instead of recursing until the stack overflows.
+        if (ancestorTypes.contains(type.getName())) {
+            LOGGER_FILL_ELEMENT.warn("#### Recursive type definition detected for type '{}' while filling element '{}'. " +
+                "Stopping automatic expansion to avoid infinite recursion.", type.getName(), elemName);
+            return;
+        }
+        Set<String> typesInPath = new HashSet<>(ancestorTypes);
+        typesInPath.add(type.getName());
+
         boolean hasSuggestion = sugg.hasSuggestion(elemName, type.getElementList());
 //        List<String> elementSuggestion = sugg.getSuggestedElements(elemName);
 //        boolean hasSuggestion = elementSuggestion.size() != 0;
@@ -1164,7 +1183,7 @@ public class EditLib {
                         }
 
                         // Continue ....
-                        fillElement(schema, sugg, element, child);
+                        fillElement(schema, sugg, element.getQualifiedName(), child, typesInPath);
                     } else {
                         // Logging some cases to avoid
                         if (LOGGER_FILL_ELEMENT.isDebugEnabled()) {

--- a/core/src/test/java/org/fao/geonet/kernel/EditLibIntegrationTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/EditLibIntegrationTest.java
@@ -774,6 +774,31 @@ public class EditLibIntegrationTest extends AbstractCoreIntegrationTest {
         assertEquals(att, Xml.selectString(metadataElement, attXPath, Arrays.asList(GMD, GCO)));
     }
 
+    /**
+     * gfc:FC_AssociationRole and gfc:FC_FeatureAssociation mutually reference each other's
+     * property types (FC_AssociationRole -> relation -> FC_FeatureAssociation -> roleName ->
+     * FC_AssociationRole -> ...), causing EditLib.fillElement() to recurse infinitely
+     * (StackOverflowError / Saxon "Too many nested function calls") when a user picks
+     * "Association role" (or "Binding", "Bound association role", "Bound feature attribute")
+     * from the "Property description" dropdown when editing a feature catalogue record.
+     */
+    @Test
+    public void testAddElement_FeatureCatalogueAssociationRoleDoesNotRecurseInfinitely() throws Exception {
+        MetadataSchema schema = _schemaManager.getSchema("iso19115-3.2018");
+        Namespace gfc = Namespace.getNamespace("gfc", "http://standards.iso.org/iso/19110/gfc/1.1");
+
+        EditLib editLib = new EditLib(_schemaManager);
+
+        final Element featureType = new Element("FC_FeatureType", gfc);
+        Element carrierOfCharacteristics = editLib.addElement(schema, featureType, "gfc:carrierOfCharacteristics");
+
+        Element associationRole = new Element("FC_AssociationRole", gfc);
+        carrierOfCharacteristics.addContent(associationRole);
+        editLib.fillElement(schema.getName(), carrierOfCharacteristics, associationRole);
+
+        assertEquals("FC_AssociationRole", associationRole.getName());
+    }
+
 
     @Test
     public void testAddElementFromXpath_Extent() throws Exception {


### PR DESCRIPTION
gfc:FC_AssociationRole_Type and gfc:FC_FeatureAssociation_Type mutually reference each other's PropertyType wrappers, so EditLib.fillElement() recursed forever trying to auto-fill mandatory children, overflowing the stack (surfaced as a Saxon "Too many nested function calls" error). This also affected FC_Binding, FC_BoundAssociationRole and FC_BoundFeatureAttribute for the same reason.

Track the chain of ancestor type names being auto-expanded and stop recursing once a type reappears on the current branch, leaving that element as an empty stub instead of expanding it infinitely.

Test case:

1) Create a Feature catalog metadata (ISO19115-3.2018) 
2) Add an Attribute element --> it works

<img width="250" height="263" alt="image" src="https://github.com/user-attachments/assets/a5bf8cc9-e1ca-44fb-b3b8-a259b6c4eb0f" />

2) Add an Association role:

  - Without the fix fails with:

```json
  {
      "message": "Handler dispatch failed; nested exception is java.lang.StackOverflowError",
      "code": "runtime_exception",
      "description": null
  }
```

The editor is unusable, needs to be reloaded, adding new Elements produces the following error:

```json
{
    "message": "Template dispatch- has not been defined",
    "code": "runtime_exception",
    "description": null
} 
```

  - With the fix: it works.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [X] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
