### PR TITLE
Fix static page link uuid/id injection

### DIFF
--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -2527,14 +2527,8 @@
     function () {
       return function (url, context) {
         return url
-          .replace(
-            /{uuid}/g,
-            (context && context.currentRecord && context.currentRecord.uuid) || ""
-          )
-          .replace(
-            /{id}/g,
-            (context && context.currentRecord && context.currentRecord.id) || ""
-          );
+          .replace(/{uuid}/g, (context && context.uuid) || "")
+          .replace(/{id}/g, (context && context.id) || "");
       };
     }
   ]);


### PR DESCRIPTION
#9415 accidentally changed the uuid/id injection to use the wrong object. The initial code changed from `$scope.uuid` to `$scope.currentRecord.uuid` however this was later reverted and the template was not updated.

This causes the links to be injected with an empty uuid/id: `id=&lang=...`

This PR aims to fix this issue by reverting the template to use `$scope.uuid` and `$scope.id`.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

