### PR TITLE
Fix attachments endpoint

### DIFF
--- a/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
+++ b/core/src/main/java/org/fao/geonet/api/records/attachments/AbstractStore.java
@@ -37,7 +37,6 @@ import org.fao.geonet.domain.MetadataResource;
 import org.fao.geonet.domain.MetadataResourceVisibility;
 import org.fao.geonet.kernel.AccessManager;
 import org.fao.geonet.kernel.datamanager.IMetadataUtils;
-import org.fao.geonet.repository.MetadataDraftRepository;
 import org.fao.geonet.repository.MetadataRepository;
 import org.fao.geonet.util.LimitedInputStream;
 import org.slf4j.Logger;
@@ -172,18 +171,14 @@ public abstract class AbstractStore implements Store {
     }
 
     /**
-     * Returns {@code true} when an approved copy of the record exists, i.e. the record is not a
-     * draft (see issue #9433). The internal metadata id is resolved from the draft table when a
-     * draft/working copy exists, otherwise from the approved metadata table, and its draft state
-     * is evaluated with {@link IMetadataUtils#isMetadataDraft(int)} (which returns {@code true}
-     * when the record is a draft).
+     * Returns {@code true} when an approved copy of the record exists, i.e. an entry exists in the
+     * {@code Metadata} table for this UUID and it is not itself a draft (see issue #9433).
+     * The draft state is evaluated with {@link IMetadataUtils#isMetadataDraft(int)} (which returns
+     * {@code true} when the record is a draft).
      */
     protected static boolean approvedCopyExists(String metadataUuid) throws Exception {
         final ApplicationContext appContext = ApplicationContextHolder.get();
-        AbstractMetadata metadata = appContext.getBean(MetadataDraftRepository.class).findOneByUuid(metadataUuid);
-        if (metadata == null) {
-            metadata = appContext.getBean(MetadataRepository.class).findOneByUuid(metadataUuid);
-        }
+        AbstractMetadata metadata = appContext.getBean(MetadataRepository.class).findOneByUuid(metadataUuid);
         if (metadata == null) {
             return false;
         }

--- a/core/src/test/java/org/fao/geonet/api/records/attachments/AbstractStoreApprovedResolutionTest.java
+++ b/core/src/test/java/org/fao/geonet/api/records/attachments/AbstractStoreApprovedResolutionTest.java
@@ -40,29 +40,34 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 /**
- * Unit tests for the approved-version resolution used by the attachments store (issue #9433).
+ * Unit tests for the approved-version resolution used by the attachments store (issues #9433, #9473).
  *
  * <p>The {@code approved} flag reported for a resource must reflect whether an approved copy of the
  * record actually exists (i.e. the resolved record is not a draft), not merely the {@code approved}
- * request parameter. The internal id is taken from the draft table when a draft/working copy
- * exists, otherwise from the approved metadata table, and its draft state is evaluated with
- * {@link IMetadataUtils#isMetadataDraft(int)}. These tests cover the decision in isolation;
- * {@link FilesystemStoreTest} covers the end-to-end store behaviour.</p>
+ * request parameter. The internal id is always taken from the approved metadata table: a
+ * {@code MetadataDraft} row can only exist alongside a {@code Metadata} row for the same UUID (its
+ * {@code approvedVersion} association is a mandatory foreign key), so looking up the approved table
+ * directly still resolves the approved record even while a working copy is being edited (#9473). Its
+ * draft state is evaluated with {@link IMetadataUtils#isMetadataDraft(int)}. These tests cover the
+ * decision in isolation; {@link FilesystemStoreTest} covers the end-to-end store behaviour.</p>
  *
  * <p>{@link Proxy}-backed beans and a real {@link StaticApplicationContext} are used instead of
  * Mockito so the test has no bytecode-instrumentation dependency.</p>
  */
 public class AbstractStoreApprovedResolutionTest {
 
-    // Approved record: present in the approved table (id 1), not a draft.
+    // Approved record, never edited since: present in the approved table (id 1), not a draft.
     private static final String APPROVED_UUID = "approved-uuid";
     private static final int APPROVED_ID = 1;
-    // Working copy: present in the draft table (id 2), is a draft.
-    private static final String DRAFT_TABLE_UUID = "draft-table-uuid";
-    private static final int DRAFT_TABLE_ID = 2;
-    // New, never-approved record: present in the approved table (id 3) but with draft state.
+    // Approved record currently being edited: present in the approved table (id 2, not a draft) AND
+    // in the draft table (id 3, a working copy) at the same time. This is the scenario #9473 fixes:
+    // an approved copy must still be reported as existing while a working copy is being edited.
+    private static final String WORKING_COPY_UUID = "working-copy-uuid";
+    private static final int WORKING_COPY_APPROVED_ID = 2;
+    private static final int WORKING_COPY_DRAFT_ID = 3;
+    // New, never-approved record: present in the approved table (id 4) but with draft state.
     private static final String DRAFT_STATUS_UUID = "draft-status-uuid";
-    private static final int DRAFT_STATUS_ID = 3;
+    private static final int DRAFT_STATUS_ID = 4;
     // Unknown record: absent from both tables.
     private static final String MISSING_UUID = "missing-uuid";
 
@@ -70,7 +75,7 @@ public class AbstractStoreApprovedResolutionTest {
     public void setUp() {
         MetadataDraftRepository draftRepository = proxy(MetadataDraftRepository.class, (proxy, method, args) -> {
             if ("findOneByUuid".equals(method.getName())) {
-                return DRAFT_TABLE_UUID.equals(args[0]) ? (MetadataDraft) new MetadataDraft().setId(DRAFT_TABLE_ID) : null;
+                return WORKING_COPY_UUID.equals(args[0]) ? (MetadataDraft) new MetadataDraft().setId(WORKING_COPY_DRAFT_ID) : null;
             }
             return objectMethodDefault(proxy, method, args);
         });
@@ -79,6 +84,9 @@ public class AbstractStoreApprovedResolutionTest {
             if ("findOneByUuid".equals(method.getName())) {
                 if (APPROVED_UUID.equals(args[0])) {
                     return (Metadata) new Metadata().setId(APPROVED_ID);
+                }
+                if (WORKING_COPY_UUID.equals(args[0])) {
+                    return (Metadata) new Metadata().setId(WORKING_COPY_APPROVED_ID);
                 }
                 if (DRAFT_STATUS_UUID.equals(args[0])) {
                     return (Metadata) new Metadata().setId(DRAFT_STATUS_ID);
@@ -91,8 +99,8 @@ public class AbstractStoreApprovedResolutionTest {
         IMetadataUtils metadataUtils = proxy(IMetadataUtils.class, (proxy, method, args) -> {
             if ("isMetadataDraft".equals(method.getName())) {
                 int id = (Integer) args[0];
-                // The working copy and the never-approved record are drafts; the approved one is not.
-                return id == DRAFT_TABLE_ID || id == DRAFT_STATUS_ID;
+                // The working copy and the never-approved record are drafts; the approved ones are not.
+                return id == WORKING_COPY_DRAFT_ID || id == DRAFT_STATUS_ID;
             }
             return objectMethodDefault(proxy, method, args);
         });
@@ -116,10 +124,11 @@ public class AbstractStoreApprovedResolutionTest {
     }
 
     @Test
-    public void noApprovedCopyWhenOnlyAWorkingCopyExists() throws Exception {
-        // The id is taken from the draft table first; that draft is not approved.
-        assertFalse("A working copy resolved from the draft table is a draft, so no approved copy",
-            AbstractStore.approvedCopyExists(DRAFT_TABLE_UUID));
+    public void approvedCopyExistsWhenWorkingCopyCoexistsWithApprovedRecord() throws Exception {
+        // Regression test for #9473: a working copy being edited must not hide the approved
+        // record that is still present in the approved table under the same UUID.
+        assertTrue("An approved record still has an approved copy while a working copy is being edited",
+            AbstractStore.approvedCopyExists(WORKING_COPY_UUID));
     }
 
     @Test
@@ -139,8 +148,8 @@ public class AbstractStoreApprovedResolutionTest {
     public void resolveApprovedIsTrueOnlyWhenApprovedCopyExists() throws Exception {
         assertTrue("approved=true must be honoured when an approved copy exists",
             AbstractStore.resolveApproved(APPROVED_UUID, true));
-        assertFalse("approved=true must NOT be honoured for a draft/working copy (#9433)",
-            AbstractStore.resolveApproved(DRAFT_TABLE_UUID, true));
+        assertTrue("approved=true must be honoured for an approved record even while a working copy exists (#9473)",
+            AbstractStore.resolveApproved(WORKING_COPY_UUID, true));
         assertFalse("approved=true must NOT be honoured for a never-approved record (#9433)",
             AbstractStore.resolveApproved(DRAFT_STATUS_UUID, true));
     }


### PR DESCRIPTION
#9443 introduced a new method `approvedCopyExists` to check if the requested version exists. The logic seems to have a bug though as it first checks the working copy repository. So if there is a working copy `approvedCopyExists` always returns false even if there is an approved copy as well.

This PR aims to fix this issue by instead checking the regular metadata repository first as this is where the approved copy would be.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [x] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

