### PR TITLE
Fix UI prevents invalid template publication

### DIFF
--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -2220,6 +2220,16 @@
         return gnConfig["metadata.workflow.allowPublishNonApprovedMd"];
       };
 
+      // Whether the metadata type requires validation before it can be
+      // published. This mirrors the backend MetadataType.requiresValidation
+      // logic: templates and sub-templates are incomplete by design and are
+      // therefore never validated, so they must not be blocked from being
+      // published because they are "invalid". Only normal
+      // records (isTemplate === "n") require validation.
+      $scope.metadataTypeRequiresValidation = function (md) {
+        return !md.isTemplate || md.isTemplate === "n";
+      };
+
       $scope.getPublicationOptionClass = function (
         md,
         user,
@@ -2251,7 +2261,7 @@
       ) {
         var publicationOptionTitle = "";
         if (!md.isPublished(pubOption)) {
-          if (md.isValid()) {
+          if (!$scope.metadataTypeRequiresValidation(md) || md.isValid()) {
             publicationOptionTitle = "mdvalid";
           } else {
             if (


### PR DESCRIPTION
The UI was missed when invalid templates became publishable in #9422

<img width="334" height="98" alt="image" src="https://github.com/user-attachments/assets/02551969-3a72-4479-9d16-d6c9d6178700" />

This PR aims to fix this issue by enabling the option when the record is a template.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [ ] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [ ] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

