### PR TITLE
Index status / Report unreadable cluster health responses

### DIFF
--- a/index/src/main/java/org/fao/geonet/index/es/EsRestClient.java
+++ b/index/src/main/java/org/fao/geonet/index/es/EsRestClient.java
@@ -41,6 +41,8 @@ import co.elastic.clients.json.JsonData;
 import co.elastic.clients.json.JsonpMapper;
 import co.elastic.clients.json.jackson.JacksonJsonpMapper;
 import co.elastic.clients.transport.ElasticsearchTransport;
+import co.elastic.clients.transport.TransportException;
+import co.elastic.clients.transport.Version;
 import co.elastic.clients.transport.rest_client.RestClientTransport;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -60,6 +62,8 @@ import org.apache.http.impl.nio.client.HttpAsyncClientBuilder;
 import org.apache.http.nio.conn.SchemeIOSessionStrategy;
 import org.apache.http.nio.conn.ssl.SSLIOSessionStrategy;
 import org.apache.http.ssl.SSLContextBuilder;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
 import org.elasticsearch.client.RestClientBuilder;
 import org.fao.geonet.utils.Log;
@@ -85,6 +89,10 @@ public class EsRestClient implements InitializingBean {
     private ElasticsearchClient client;
 
     private ElasticsearchAsyncClient asyncClient;
+
+    private RestClient restClient;
+
+    private boolean healthDecodeFailureReported = false;
 
 
     private String serverUrl;
@@ -176,7 +184,7 @@ public class EsRestClient implements InitializingBean {
                 }
             }
 
-            RestClient restClient = builder.build();
+            restClient = builder.build();
 
             ElasticsearchTransport transport = new RestClientTransport(restClient, new JacksonJsonpMapper());
 
@@ -527,9 +535,53 @@ public class EsRestClient implements InitializingBean {
 
     // TODO: check index exist too
     public String getServerStatus() throws IOException {
+        try {
+            HealthResponse response = client.cluster().health();
+            return response.status().toString();
+        } catch (TransportException e) {
+            // The typed client only decodes the health response of the server version it is built for.
+            // Any other version may return a response with missing or unknown properties, so read the
+            // status with the low level client which does not check the response against a model.
+            logHealthDecodeFailure(e);
+            try {
+                return getServerStatusUsingLowLevelClient();
+            } catch (Exception fallbackException) {
+                e.addSuppressed(fallbackException);
+                throw e;
+            }
+        }
+    }
 
-        HealthResponse response = client.cluster().health();
-        return response.status().toString();
+    /**
+     * Read the cluster status from the raw <code>_cluster/health</code> response.
+     */
+    private String getServerStatusUsingLowLevelClient() throws IOException {
+        Response response = restClient.performRequest(new Request("GET", "/_cluster/health"));
+        JsonNode status = new ObjectMapper().readTree(response.getEntity().getContent()).get("status");
+        if (status == null) {
+            throw new IOException(String.format(
+                "No status property found in the cluster health response from %s.", serverUrl));
+        }
+        return status.asText();
+    }
+
+    /**
+     * The status is checked on a regular basis, so only report the decoding error once.
+     * It is reported as an error because the default log configuration only reports
+     * errors for the index.
+     */
+    private void logHealthDecodeFailure(TransportException e) {
+        String message = String.format(
+            "Failed to decode the cluster health response returned by %s using the Elasticsearch client %s. "
+                + "Check that the index server version is compatible with this GeoNetwork version. "
+                + "Reading the cluster status using the low level client. Error is %s.",
+            serverUrl, Version.VERSION, e.getMessage());
+        if (healthDecodeFailureReported) {
+            Log.debug("geonetwork.index", message);
+        } else {
+            healthDecodeFailureReported = true;
+            Log.error("geonetwork.index", message);
+        }
     }
 
     public String getServerVersion() throws IOException, ElasticsearchException {

--- a/index/src/main/java/org/fao/geonet/index/es/EsServerStatusChecker.java
+++ b/index/src/main/java/org/fao/geonet/index/es/EsServerStatusChecker.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2026 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -22,6 +22,8 @@
  */
 package org.fao.geonet.index.es;
 
+import co.elastic.clients.transport.TransportException;
+import co.elastic.clients.transport.Version;
 import org.fao.geonet.index.IServerStatusChecker;
 import org.fao.geonet.index.State;
 import org.fao.geonet.index.Status;
@@ -69,6 +71,11 @@ public class EsServerStatusChecker
             } else {
                 this.status.setState(State.RED, "Index is down");
             }
+        } catch (TransportException e) {
+            this.status.setState(State.RED, String.format(
+                "Unable to read the status of the index at %s. The response can not be decoded by the Elasticsearch "
+                    + "client %s. Check that the index server version is compatible with this GeoNetwork version. "
+                    + "Error is %s", client.getServerUrl(), Version.VERSION, e.getMessage()));
         } catch (Exception e) {
             this.status.setState(State.UNINITIALIZED, String.format(
                 "Unable to revive connection to %s. Error is %s", client.getServerUrl(), e.getMessage()));

--- a/index/src/main/java/org/fao/geonet/index/es/EsServerStatusChecker.java
+++ b/index/src/main/java/org/fao/geonet/index/es/EsServerStatusChecker.java
@@ -27,6 +27,7 @@ import co.elastic.clients.transport.Version;
 import org.fao.geonet.index.IServerStatusChecker;
 import org.fao.geonet.index.State;
 import org.fao.geonet.index.Status;
+import org.fao.geonet.utils.Log;
 import org.quartz.JobExecutionContext;
 import org.quartz.JobExecutionException;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,10 +37,14 @@ public class EsServerStatusChecker
     extends QuartzJobBean
     implements IServerStatusChecker {
 
+    private static final String LOGGER = "geonetwork.index";
+
     @Autowired
     private Status status;
 
     private boolean indexChecked = false;
+
+    private boolean versionChecked = false;
 
     public EsServerStatusChecker() {
     }
@@ -62,6 +67,7 @@ public class EsServerStatusChecker
         String status = null;
         try {
             status = client.getServerStatus();
+            checkServerVersion();
             if ("green".equalsIgnoreCase(status)) {
                 this.status.setState(State.GREEN, "Index up and running. All green.");
                 checkIndexState();
@@ -81,6 +87,49 @@ public class EsServerStatusChecker
                 "Unable to revive connection to %s. Error is %s", client.getServerUrl(), e.getMessage()));
         }
         return this.status;
+    }
+
+    /**
+     * Report once the version of the index server when it is not the version of the client
+     * GeoNetwork is built with. The check is only made when the server can be reached, and
+     * is retried on the next run when the version can not be read.
+     */
+    private void checkServerVersion() {
+        if (versionChecked) {
+            return;
+        }
+        String serverVersion;
+        try {
+            serverVersion = client.getServerVersion();
+        } catch (Exception e) {
+            Log.debug(LOGGER, String.format(
+                "Unable to read the version of the index server at %s. Error is %s",
+                client.getServerUrl(), e.getMessage()));
+            return;
+        }
+        versionChecked = true;
+
+        String message = versionMismatchMessage(client.getServerUrl(), serverVersion);
+        if (message != null) {
+            Log.error(LOGGER, message);
+        }
+    }
+
+    /**
+     * @return the message to report when the index server is not a version supported
+     * by the Elasticsearch client this GeoNetwork is built with, null when it is
+     * supported or when the version can not be parsed.
+     */
+    static String versionMismatchMessage(String serverUrl, String serverVersion) {
+        Version server = Version.parse(serverVersion);
+        if (server == null || server.major() == Version.VERSION.major()) {
+            return null;
+        }
+        return String.format(
+            "Index server at %s is Elasticsearch %s but this GeoNetwork version is built with the Elasticsearch "
+                + "client %s. Only Elasticsearch %d.x is supported, check the installation guide. "
+                + "Running another version leads to errors which are not always reported as a version issue.",
+            serverUrl, serverVersion, Version.VERSION, Version.VERSION.major());
     }
 
     @Override

--- a/index/src/test/java/org/fao/geonet/index/es/EsServerStatusCheckerTest.java
+++ b/index/src/test/java/org/fao/geonet/index/es/EsServerStatusCheckerTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) 2001-2026 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+package org.fao.geonet.index.es;
+
+import co.elastic.clients.transport.TransportException;
+import co.elastic.clients.transport.http.TransportHttpClient;
+import co.elastic.clients.util.BinaryData;
+import org.fao.geonet.index.State;
+import org.fao.geonet.index.Status;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.net.ConnectException;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class EsServerStatusCheckerTest {
+
+    private static final String SERVER_URL = "http://localhost:9200";
+
+    @Test
+    public void serverStatusIsReported() {
+        Status status = check(new EsRestClientStub("green", null));
+        assertEquals(State.GREEN, status.getState());
+
+        status = check(new EsRestClientStub("yellow", null));
+        assertEquals(State.YELLOW, status.getState());
+
+        status = check(new EsRestClientStub("red", null));
+        assertEquals(State.RED, status.getState());
+    }
+
+    @Test
+    public void connectionFailureIsReportedAsUninitialized() {
+        Status status = check(new EsRestClientStub(null, new ConnectException("Connection refused")));
+
+        assertEquals(State.UNINITIALIZED, status.getState());
+        assertTrue(status.getMessage(), status.getMessage().startsWith("Unable to revive connection to " + SERVER_URL));
+    }
+
+    /**
+     * A response which the client can not decode is not a connectivity problem, it usually means
+     * that the server version is not the one the client is built for.
+     */
+    @Test
+    public void decodingFailureIsReportedAsVersionIssue() {
+        Status status = check(new EsRestClientStub(null, transportException()));
+
+        assertEquals(State.RED, status.getState());
+        assertTrue(status.getMessage(), status.getMessage().contains("can not be decoded"));
+        assertTrue(status.getMessage(), status.getMessage().contains("index server version is compatible"));
+    }
+
+    private Status check(EsRestClient client) {
+        EsServerStatusChecker checker = new EsServerStatusChecker();
+        checker.setStatus(new Status("index"));
+        checker.client = client;
+        return checker.checkState();
+    }
+
+    private TransportException transportException() {
+        return new TransportException(new ResponseStub(), "Failed to decode response", "es/cluster.health");
+    }
+
+    /**
+     * Returns the configured status or throws the configured error.
+     */
+    private static class EsRestClientStub extends EsRestClient {
+        private final String serverStatus;
+        private final IOException error;
+
+        EsRestClientStub(String serverStatus, IOException error) {
+            this.serverStatus = serverStatus;
+            this.error = error;
+            setServerUrl(SERVER_URL);
+        }
+
+        @Override
+        public String getServerStatus() throws IOException {
+            if (error != null) {
+                throw error;
+            }
+            return serverStatus;
+        }
+    }
+
+    /**
+     * Minimal response required to build a {@link TransportException}.
+     */
+    private static class ResponseStub implements TransportHttpClient.Response {
+        @Override
+        public TransportHttpClient.Node node() {
+            return new TransportHttpClient.Node(SERVER_URL);
+        }
+
+        @Override
+        public int statusCode() {
+            return 200;
+        }
+
+        @Override
+        public String header(String name) {
+            return null;
+        }
+
+        @Override
+        public List<String> headers(String name) {
+            return Collections.emptyList();
+        }
+
+        @Override
+        public BinaryData body() {
+            return null;
+        }
+
+        @Override
+        public Object originalResponse() {
+            return null;
+        }
+
+        @Override
+        public void close() {
+        }
+    }
+}

--- a/index/src/test/java/org/fao/geonet/index/es/EsServerStatusCheckerTest.java
+++ b/index/src/test/java/org/fao/geonet/index/es/EsServerStatusCheckerTest.java
@@ -23,6 +23,7 @@
 package org.fao.geonet.index.es;
 
 import co.elastic.clients.transport.TransportException;
+import co.elastic.clients.transport.Version;
 import co.elastic.clients.transport.http.TransportHttpClient;
 import co.elastic.clients.util.BinaryData;
 import org.fao.geonet.index.State;
@@ -35,6 +36,8 @@ import java.util.Collections;
 import java.util.List;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 public class EsServerStatusCheckerTest {
@@ -74,6 +77,61 @@ public class EsServerStatusCheckerTest {
         assertTrue(status.getMessage(), status.getMessage().contains("index server version is compatible"));
     }
 
+    @Test
+    public void versionOfTheServerIsReportedWhenItIsNotTheVersionOfTheClient() {
+        String message = EsServerStatusChecker.versionMismatchMessage(SERVER_URL, "7.17.15");
+
+        assertNotNull(message);
+        assertTrue(message, message.contains("7.17.15"));
+        assertTrue(message, message.contains(Version.VERSION.toString()));
+    }
+
+    @Test
+    public void versionOfTheServerIsNotReportedWhenItIsSupported() {
+        assertNull(EsServerStatusChecker.versionMismatchMessage(SERVER_URL, Version.VERSION.toString()));
+        assertNull(EsServerStatusChecker.versionMismatchMessage(SERVER_URL,
+            Version.VERSION.major() + ".0.0"));
+    }
+
+    @Test
+    public void versionOfTheServerIsNotReportedWhenItCanNotBeRead() {
+        assertNull(EsServerStatusChecker.versionMismatchMessage(SERVER_URL, "unknown"));
+    }
+
+    /**
+     * The check runs every few seconds, the version of the server is only read once.
+     */
+    @Test
+    public void versionOfTheServerIsOnlyReadOnce() {
+        EsRestClientStub client = new EsRestClientStub("green", null);
+        EsServerStatusChecker checker = new EsServerStatusChecker();
+        checker.setStatus(new Status("index"));
+        checker.client = client;
+
+        checker.checkState();
+        checker.checkState();
+        checker.checkState();
+
+        assertEquals(1, client.serverVersionReads);
+    }
+
+    /**
+     * A server which can not be reached is checked again on the next run.
+     */
+    @Test
+    public void versionOfTheServerIsReadAgainWhenItCanNotBeRead() {
+        EsRestClientStub client = new EsRestClientStub("green", null);
+        client.serverVersionError = new IOException("Connection refused");
+        EsServerStatusChecker checker = new EsServerStatusChecker();
+        checker.setStatus(new Status("index"));
+        checker.client = client;
+
+        checker.checkState();
+        checker.checkState();
+
+        assertEquals(2, client.serverVersionReads);
+    }
+
     private Status check(EsRestClient client) {
         EsServerStatusChecker checker = new EsServerStatusChecker();
         checker.setStatus(new Status("index"));
@@ -92,6 +150,9 @@ public class EsServerStatusCheckerTest {
         private final String serverStatus;
         private final IOException error;
 
+        private IOException serverVersionError;
+        private int serverVersionReads = 0;
+
         EsRestClientStub(String serverStatus, IOException error) {
             this.serverStatus = serverStatus;
             this.error = error;
@@ -104,6 +165,15 @@ public class EsServerStatusCheckerTest {
                 throw error;
             }
             return serverStatus;
+        }
+
+        @Override
+        public String getServerVersion() throws IOException {
+            serverVersionReads++;
+            if (serverVersionError != null) {
+                throw serverVersionError;
+            }
+            return Version.VERSION.toString();
         }
     }
 


### PR DESCRIPTION
## Index status / Report unreadable cluster health responses

Follow up of #9477.

### Problem

`EsServerStatusChecker` reads the cluster health through the typed Elasticsearch client:

```java
HealthResponse response = client.cluster().health();
```

The typed client only decodes the health response of the server version it is built for. The client bundled since 4.4.10 (8.19.13) has `unassigned_primary_shards` as a **required** property of the health response, and that property was only added to `_cluster/health` in Elasticsearch 8.16. Against an older server the call fails with:

```
node: http://host:9200/, status: 200, [es/cluster.health] Failed to decode response
```

The request succeeded (`status: 200`), only the decoding failed, but the single `catch (Exception e)` in the checker turns everything into:

```
uninitialized
Unable to revive connection to http://host:9200. Error is ...
```

So the catalogue permanently displays a connection banner while the server is reachable. The message sends the administrator looking at the network, the firewall and CORS instead of at the version of the index server.

### Reading the cluster health (first commit)

* `EsRestClient.getServerStatus()` falls back to a low level `GET /_cluster/health` when the typed client can not decode the response, and reads the `status` property from the raw JSON. The reported state then matches the state of the cluster. The fallback uses the same `RestClient` instance that backs the typed transport, so the `es.username` / `es.password` credentials and the https settings are the ones already configured.
* The decoding error is reported once, since the check runs every five seconds by default (`es.index.checker.interval`), and the message names the client version and points at the compatibility of the index server. It is logged as an error because the default log configuration only logs errors for `geonetwork.index`.
* If the fallback fails too, `EsServerStatusChecker` reports the decoding failure separately from a connection failure, again pointing at the version of the index server. The original error is kept as a suppressed exception.

This does not add support for unsupported Elasticsearch versions, it only makes the index status and the log say what is actually wrong.

### Reporting the version of the index server (second commit)

The version of the server is only visible in the site information page, so nothing tells an administrator that the server is not the one this GeoNetwork is built for. `EsServerStatusChecker` now compares the major version of the server with the version of the client once the server can be reached, and reports a difference once:

```
ERROR [geonetwork.index] - Index server at http://localhost:9200 is Elasticsearch 7.17.15 but this GeoNetwork
version is built with the Elasticsearch client 8.19.13. Only Elasticsearch 8.x is supported, check the
installation guide. Running another version leads to errors which are not always reported as a version issue.
```

The version is read again on the next run when the server can not be reached, so a catalogue started before its index server still reports it. Nothing is logged when the versions match, and the state of the index is not changed by this check.

### Tests

`EsServerStatusCheckerTest` covers the status branches (the cluster status is reported as is, a connection failure is still reported as `uninitialized` with the "Unable to revive connection" message, a response the client can not decode is reported with a message pointing at the server version) and the version check (reported for another major version, silent for the version of the client and for a version which can not be parsed, read once, read again when the server can not be reached).

The `index` module had no test sources yet, `junit` is inherited from the root pom so no dependency change was needed.

### Verified against Elasticsearch 7.17.15

Before, the home page shows the banner of #9477 and `/api/site/index/status` returns:

```json
{"id":"index","state":{"id":"uninitialized", ...},
 "message":"Unable to revive connection to http://localhost:9200. Error is node: http://localhost:9200/, status: 200, [es/cluster.health] Failed to decode response"}
```

![Home page before the change](https://raw.githubusercontent.com/GeoCat/core-geonetwork/screenshots-issue-9477/before-banner.png)

After, no banner and the real state of the cluster:

```json
{"id":"index","state":{"id":"yellow", ...},"message":"Index status is yellow. Check index server log."}
```

with a single line in the log:

```
ERROR [geonetwork.index] - Failed to decode the cluster health response returned by http://localhost:9200 using the
Elasticsearch client 8.19.13. Check that the index server version is compatible with this GeoNetwork version.
Reading the cluster status using the low level client. Error is node: http://localhost:9200/, status: 200,
[es/cluster.health] Failed to decode response.
```

![Home page after the change](https://raw.githubusercontent.com/GeoCat/core-geonetwork/screenshots-issue-9477/after-banner.png)

Searching still fails on that server, with the error of the incompatibility that is really there (`No mapping found for [createDate] in order to sort on`), instead of a connection error on the home page.

The version check was verified the same way: against 7.17.15 the message above is logged once at startup, against 8.19.13 nothing is logged.

Checked with and without credentials on a 7.17.15 server with `xpack.security.enabled=true`: the fallback authenticates like any other call, and a missing password is still reported as before, `missing authentication credentials for REST request [/_cluster/health]`.

### Checklist

* [x] `mvn -pl index test` passes (8 tests)
* [x] No new checkstyle violations in the module
