### PR TITLE
Add missing groups api error message translations

### DIFF
--- a/core/src/test/resources/org/fao/geonet/api/Messages.properties
+++ b/core/src/test/resources/org/fao/geonet/api/Messages.properties
@@ -143,6 +143,7 @@ metadata_unpublished_record_text=<li>The metadata <a href="{{link}}">{{index:res
 metadata_approved_published_record_text=<li>The metadata <a href="{{link}}">{{index:resourceTitleObject}}</a> has been published as a new version.</li>
 
 api.groups.group_not_found=Group with ID ''{0}'' not found in this catalog.
+api.groups.system_group_has_minimum_profile=Group ''{0}'' cannot be a system privilege group because it has a minimum profile for privileges. Remove the minimum profile for privileges to make it a system group.
 user_watchlist_subject=%s / %s updates in your watch list since %s
 user_watchlist_message_record=<li><a href="{{link}}">{{index:resourceTitleObject}}</a></li>
 user_watchlist_message=The following records have been updated:\n\

--- a/core/src/test/resources/org/fao/geonet/api/Messages_fre.properties
+++ b/core/src/test/resources/org/fao/geonet/api/Messages_fre.properties
@@ -144,6 +144,7 @@ metadata_unpublished_record_text=<li>La métadonnée <a href="{{link}}">{{index:
 metadata_approved_published_record_text=<li>Une nouvelle version de la métadonnée <a href="{{link}}">{{index:resourceTitleObject}}</a> a été publiée.</li>
 
 api.groups.group_not_found=Le groupe avec l''identifiant ''{0}'' n''a pas été trouvé dans le catalogue.
+api.groups.system_group_has_minimum_profile=Le groupe ''{0}'' ne peut pas être un groupe de privilèges système car il a un profil minimum pour les privilèges. Supprimez le profil minimum pour les privilèges afin d'en faire un groupe système.
 user_watchlist_subject=%s / %s mises à jour dans vos fiches surveillées %s
 user_watchlist_message_record=<li><a href="{{link}}">{{index:resourceTitleObject}}</a></li>
 user_watchlist_message=Les fiches suivantes ont été mises à jour :\n\

--- a/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages.properties
+++ b/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages.properties
@@ -154,6 +154,7 @@ api.groups.unset_workspace.owns_metadata=Group ''{0}'' owns metadata. To change 
 api.groups.set_system.has_privileges=Group ''{0}'' has privileges set. To change the group to a system group you should remove the privileges first.
 api.groups.set_system.invalid_profile=Group ''{0}'' has users assigned with profiles other than ''Registered User''. To change the group to a system group you should remove the users or change their profiles first.
 api.groups.delete.owns_metadata=Group ''{0}'' owns metadata. To remove the group you should transfer first the metadata to another group.
+api.groups.system_group_has_minimum_profile=Group ''{0}'' cannot be a system privilege group because it has a minimum profile for privileges. Remove the minimum profile for privileges to make it a system group.
 api.users.invalid_profile_for_system_group=Invalid profile for system group ''{0}''. Users can only be assigned the ''Registered User'' profile for system groups.
 user_watchlist_subject=%s / %s updates in your watch list since %s
 user_watchlist_message_record=<li><a href="{{link}}">{{index:resourceTitleObject}}</a></li>

--- a/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages_fre.properties
+++ b/web/src/main/webapp/WEB-INF/classes/org/fao/geonet/api/Messages_fre.properties
@@ -144,6 +144,7 @@ metadata_unpublished_record_text=<li>La métadonnée <a href="{{link}}">{{index:
 metadata_approved_published_record_text=<li>Une nouvelle version de la métadonnée <a href="{{link}}">{{index:resourceTitleObject}}</a> a été publiée.</li>
 
 api.groups.group_not_found=Le groupe avec l''identifiant ''{0}'' n''a pas été trouvé dans le catalogue.
+api.groups.system_group_has_minimum_profile=Le groupe ''{0}'' ne peut pas être un groupe de privilèges système car il a un profil minimum pour les privilèges. Supprimez le profil minimum pour les privilèges afin d'en faire un groupe système.
 user_watchlist_subject=%s / %s mises à jour dans vos fiches surveillées %s
 user_watchlist_message_record=<li><a href="{{link}}">{{index:resourceTitleObject}}</a></li>
 user_watchlist_message=Les fiches suivantes ont été mises à jour :\n\


### PR DESCRIPTION
#8741 implemented a new message key `api.groups.system_group_has_minimum_profile` in the GroupsApi but the messages were never implemented.

This PR aims to fix the issue by adding the translations for that key.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
