### PR TITLE
Improve schematron validation error in harvesters, where file name is…

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataValidator.java
+++ b/core/src/main/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataValidator.java
@@ -28,6 +28,7 @@ import static org.fao.geonet.kernel.setting.Settings.SYSTEM_METADATA_VALIDATION_
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -48,6 +49,7 @@ import org.fao.geonet.kernel.SchematronValidator;
 import org.fao.geonet.kernel.SchematronValidatorExternalMd;
 import org.fao.geonet.kernel.datamanager.IMetadataManager;
 import org.fao.geonet.kernel.datamanager.IMetadataSchemaUtils;
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
 import org.fao.geonet.kernel.setting.SettingManager;
 import org.fao.geonet.repository.MetadataValidationRepository;
 import org.fao.geonet.utils.Log;
@@ -88,6 +90,9 @@ public class BaseMetadataValidator implements org.fao.geonet.kernel.datamanager.
     @Lazy
     private SettingManager settingManager;
 
+    @Autowired
+    private IMetadataUtils metadataUtils;
+
     private IMetadataManager metadataManager;
 
     @Override
@@ -109,7 +114,7 @@ public class BaseMetadataValidator implements org.fao.geonet.kernel.datamanager.
         XmlErrorHandler eh = new XmlErrorHandler();
         Element xsdErrors = validateInfo(schema, xml, eh);
         if (xsdErrors != null) {
-            if (!fileName.equals(" ")) {
+            if (!StringUtils.isBlank(fileName)) {
                 throw new XSDValidationErrorEx("XSD Validation error(s):\n" + Xml.getString(xsdErrors) + "(in " + fileName + "): ", xsdErrors);
             } else {
                 throw new XSDValidationErrorEx("XSD Validation error(s):\n" + Xml.getString(xsdErrors), xsdErrors);
@@ -122,9 +127,9 @@ public class BaseMetadataValidator implements org.fao.geonet.kernel.datamanager.
 
         Element schemaTronReport = doSchemaTronForEditor(schema, xml, context.getLanguage(), groupOwner);
         xml.detach();
-        if (schemaTronReport != null && schemaTronReport.getContent().size() > 0) {
+        if (schemaTronReport != null && !schemaTronReport.getContent().isEmpty()) {
 
-            List<Namespace> theNSs = new ArrayList<Namespace>();
+            List<Namespace> theNSs = new ArrayList<>();
             theNSs.add(Namespace.getNamespace("geonet", "http://www.fao.org/geonetwork"));
             theNSs.add(Namespace.getNamespace("svrl", "http://purl.oclc.org/dsdl/svrl"));
 
@@ -185,8 +190,7 @@ public class BaseMetadataValidator implements org.fao.geonet.kernel.datamanager.
                     }
                 }
 
-                throw new SchematronValidationErrorEx(
-                    "Schematron errors detected for file '" + fileName + "' - " + errorReport, schemaTronReport);
+                throw new SchematronValidationErrorEx(buildSchematronValidationErrorMessage(context, fileName, schema, xml, errorReport.toString()), schemaTronReport);
             }
         }
 
@@ -198,7 +202,7 @@ public class BaseMetadataValidator implements org.fao.geonet.kernel.datamanager.
         // --- we must skip this phase
 
         Namespace ns = md.getNamespace();
-        if (ns != Namespace.NO_NAMESPACE && (md.getNamespacePrefix().equals(""))) {
+        if (ns != Namespace.NO_NAMESPACE && (md.getNamespacePrefix().isEmpty())) {
             // --- set prefix for iso19139 metadata
 
             ns = Namespace.getNamespace("gmd", md.getNamespace().getURI());
@@ -251,7 +255,7 @@ public class BaseMetadataValidator implements org.fao.geonet.kernel.datamanager.
         String schemaLoc = md.getAttributeValue("schemaLocation", Namespaces.XSI);
         LOGGER.debug("Extracted schemaLocation of {}", schemaLoc);
         boolean noChoiceButToUseSchemaLocation = schema == null;
-        boolean isSchemaLocationDefinedInMd = schemaLoc != null && !"".equals(schemaLoc);
+        boolean isSchemaLocationDefinedInMd = schemaLoc != null && !schemaLoc.isEmpty();
 
         if (noChoiceButToUseSchemaLocation || isSchemaLocationDefinedInMd) {
             return Xml.validateInfo(md, eh, schema);
@@ -385,7 +389,7 @@ public class BaseMetadataValidator implements org.fao.geonet.kernel.datamanager.
         Element xsdErrors = getXSDXmlReport(schema, md, false);
 
         int xsdErrorCount = 0;
-        if (xsdErrors != null && xsdErrors.getContent().size() > 0) {
+        if (xsdErrors != null && !xsdErrors.getContent().isEmpty()) {
             xsdErrorCount = xsdErrors.getContent().size();
         }
         if (xsdErrorCount > 0) {
@@ -409,7 +413,7 @@ public class BaseMetadataValidator implements org.fao.geonet.kernel.datamanager.
             // Apply custom schematron rules
             Element schemaTronReport = applyCustomSchematronRules(schema, metadataId, md, lang, validations);
             if (schemaTronReport != null) {
-                List<Namespace> theNSs = new ArrayList<Namespace>();
+                List<Namespace> theNSs = new ArrayList<>();
                 theNSs.add(Namespace.getNamespace("geonet", "http://www.fao.org/geonetwork"));
                 theNSs.add(Namespace.getNamespace("svrl", "http://purl.oclc.org/dsdl/svrl"));
 
@@ -608,4 +612,37 @@ public class BaseMetadataValidator implements org.fao.geonet.kernel.datamanager.
             return false;
         }
     };
+
+    private String buildSchematronValidationErrorMessage(ServiceContext context, String fileName, String schema, Element xml, String errorReport) {
+        if (!StringUtils.isBlank(fileName)) {
+            return String.format("Schematron errors detected for metadata in file '%s' - %s", fileName, errorReport);
+        } else {
+            String metadataUuid;
+            String metadataTitle;
+
+            try {
+                metadataUuid = metadataUtils.extractUUID(schema, xml);
+                metadataTitle = extractMetadataTitle(metadataUtils.extractTitles(schema, xml), context.getLanguage());
+            } catch(Exception ex) {
+                return String.format("Schematron errors detected - %s", errorReport);
+            }
+
+            return String.format("Schematron errors detected for metadata with UUID '%s' / %s - %s", metadataUuid, metadataTitle, errorReport);
+        }
+    }
+
+    private String extractMetadataTitle(LinkedHashMap<String, String> metadataTitles, String language) {
+        String metadataTitle = metadataTitles.get(language);
+
+        if (metadataTitle == null) {
+            Map.Entry<String, String> first = metadataTitles.entrySet().stream().findFirst().orElse(null);
+            if (first != null) {
+                metadataTitle = first.getValue();
+            } else {
+                metadataTitle = "";
+            }
+        }
+
+        return metadataTitle;
+    }
 }

--- a/core/src/test/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataValidatorMethodsTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/datamanager/base/BaseMetadataValidatorMethodsTest.java
@@ -1,0 +1,121 @@
+//=============================================================================
+//===	Copyright (C) 2001-2026 Food and Agriculture Organization of the
+//===	United Nations (FAO-UN), United Nations World Food Programme (WFP)
+//===	and United Nations Environment Programme (UNEP)
+//===
+//===	This program is free software; you can redistribute it and/or modify
+//===	it under the terms of the GNU General Public License as published by
+//===	the Free Software Foundation; either version 2 of the License, or (at
+//===	your option) any later version.
+//===
+//===	This program is distributed in the hope that it will be useful, but
+//===	WITHOUT ANY WARRANTY; without even the implied warranty of
+//===	MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+//===	General Public License for more details.
+//===
+//===	You should have received a copy of the GNU General Public License
+//===	along with this program; if not, write to the Free Software
+//===	Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+//===
+//===	Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+//===	Rome - Italy. email: geonetwork@osgeo.org
+//==============================================================================
+
+package org.fao.geonet.kernel.datamanager.base;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.LinkedHashMap;
+
+import org.fao.geonet.kernel.datamanager.IMetadataUtils;
+import org.jdom.Element;
+import org.junit.Before;
+import org.junit.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import jeeves.server.context.ServiceContext;
+
+public class BaseMetadataValidatorMethodsTest {
+
+    private BaseMetadataValidator validator;
+    private IMetadataUtils metadataUtils;
+    private ServiceContext context;
+
+    @Before
+    public void setUp() {
+        validator = new BaseMetadataValidator();
+        metadataUtils = mock(IMetadataUtils.class);
+        context = mock(ServiceContext.class);
+        ReflectionTestUtils.setField(validator, "metadataUtils", metadataUtils);
+    }
+
+    @Test
+    public void testExtractMetadataTitle_LanguageExists() {
+        LinkedHashMap<String, String> titles = new LinkedHashMap<>();
+        titles.put("eng", "English Title");
+        titles.put("fra", "French Title");
+
+        String result = (String) ReflectionTestUtils.invokeMethod(validator, "extractMetadataTitle", titles, "eng");
+        assertEquals("English Title", result);
+    }
+
+    @Test
+    public void testExtractMetadataTitle_LanguageDoesNotExist_ReturnsFirstValue() {
+        LinkedHashMap<String, String> titles = new LinkedHashMap<>();
+        titles.put("eng", "English Title");
+        titles.put("fra", "French Title");
+
+        String result = (String) ReflectionTestUtils.invokeMethod(validator, "extractMetadataTitle", titles, "ger");
+        assertEquals("English Title", result);
+    }
+
+    @Test
+    public void testExtractMetadataTitle_EmptyMap_ReturnsEmptyString() {
+        LinkedHashMap<String, String> titles = new LinkedHashMap<>();
+
+        String result = (String) ReflectionTestUtils.invokeMethod(validator, "extractMetadataTitle", titles, "eng");
+        assertEquals("", result);
+    }
+
+    @Test
+    public void testBuildSchematronValidationErrorMessage_WithFileName() {
+        String errorReport = "Some error";
+        String result = (String) ReflectionTestUtils.invokeMethod(validator, "buildSchematronValidationErrorMessage",
+                context, "file.xml", "iso19139", new Element("root"), errorReport);
+        assertEquals("Schematron errors detected for metadata in file 'file.xml' - Some error", result);
+    }
+
+    @Test
+    public void testBuildSchematronValidationErrorMessage_WithoutFileName_Success() throws Exception {
+        String schema = "iso19139";
+        Element xml = new Element("root");
+        String errorReport = "Some error";
+        String lang = "eng";
+        String uuid = "uuid-123";
+        LinkedHashMap<String, String> titles = new LinkedHashMap<>();
+        titles.put("eng", "Title");
+
+        when(context.getLanguage()).thenReturn(lang);
+        when(metadataUtils.extractUUID(schema, xml)).thenReturn(uuid);
+        when(metadataUtils.extractTitles(schema, xml)).thenReturn(titles);
+
+        String result = (String) ReflectionTestUtils.invokeMethod(validator, "buildSchematronValidationErrorMessage",
+                context, null, schema, xml, errorReport);
+        assertEquals("Schematron errors detected for metadata with UUID 'uuid-123' / Title - Some error", result);
+    }
+
+    @Test
+    public void testBuildSchematronValidationErrorMessage_WithoutFileName_Exception() throws Exception {
+        String schema = "iso19139";
+        Element xml = new Element("root");
+        String errorReport = "Some error";
+
+        when(metadataUtils.extractUUID(schema, xml)).thenThrow(new RuntimeException("Error"));
+
+        String result = (String) ReflectionTestUtils.invokeMethod(validator, "buildSchematronValidationErrorMessage",
+                context, "", schema, xml, errorReport);
+        assertEquals("Schematron errors detected - Some error", result);
+    }
+}


### PR DESCRIPTION
When harvesting there are errors like the following

```
2026-08-08T13:38:30,683 ERROR [geonetwork.harvester] - Cannot validate XML from file /home/site/geonetwork/data/harvester/gishub/multi-survey-rpas-pix4d.xml, ignoring. Error was: Schematron errors detected for file ' ' - schematron-rules-common:
Value is required for Reference System - Code
, schematron-rules-common:.....
```

See: 

```
Error was: Schematron errors detected for file ' ' 
```

Updated the external validation to report instead the metadata UUID / title if the filename is not available.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [X] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
