### PR TITLE
Avoid unnecessary group type warnings in getOrCreateGroup

### DIFF
--- a/core/src/main/java/org/fao/geonet/kernel/security/BaseUserUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/BaseUserUtils.java
@@ -22,11 +22,13 @@
  */
 package org.fao.geonet.kernel.security;
 
+import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.Group;
 import org.fao.geonet.domain.GroupType;
 import org.fao.geonet.domain.Language;
 import org.fao.geonet.repository.GroupRepository;
 import org.fao.geonet.repository.LanguageRepository;
+import org.fao.geonet.utils.Log;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 
@@ -88,8 +90,9 @@ public class BaseUserUtils {
 
         if (group != null && group.getType() != null && newGroupType != null && !group.getType().equals(newGroupType)) {
             // Log a warning if the existing group's type differs from the requested type
-            System.out.println("Warning: Group '" + groupName + "' exists with type '" + group.getType() +
-                "', but requested type is '" + newGroupType + "'. Using existing group type.");
+            Log.warning(Geonet.SECURITY,
+                "Group '{}' exists with type '{}', but requested type is '{}'. Using existing group type.",
+                groupName, group.getType(), newGroupType);
         } else if (group == null) {
             group = new Group();
             group.setName(groupName);

--- a/core/src/main/java/org/fao/geonet/kernel/security/BaseUserUtils.java
+++ b/core/src/main/java/org/fao/geonet/kernel/security/BaseUserUtils.java
@@ -86,7 +86,7 @@ public class BaseUserUtils {
     public Group getOrCreateGroup(String groupName, GroupType newGroupType) {
         Group group = groupRepository.findByName(groupName);
 
-        if (group != null && group.getType() != null && !group.getType().equals(newGroupType)) {
+        if (group != null && group.getType() != null && newGroupType != null && !group.getType().equals(newGroupType)) {
             // Log a warning if the existing group's type differs from the requested type
             System.out.println("Warning: Group '" + groupName + "' exists with type '" + group.getType() +
                 "', but requested type is '" + newGroupType + "'. Using existing group type.");

--- a/core/src/test/java/org/fao/geonet/kernel/security/BaseUserUtilsTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/security/BaseUserUtilsTest.java
@@ -1,24 +1,23 @@
 package org.fao.geonet.kernel.security;
 
+import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.Group;
 import org.fao.geonet.domain.GroupType;
 import org.fao.geonet.domain.Language;
 import org.fao.geonet.repository.GroupRepository;
 import org.fao.geonet.repository.LanguageRepository;
+import org.fao.geonet.utils.Log;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
 import org.mockito.junit.MockitoJUnitRunner;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
 import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -75,12 +74,13 @@ public class BaseUserUtilsTest {
 
         when(groupRepository.findByName(groupName)).thenReturn(existingGroup);
 
-        String output = captureStdOut(() -> {
+        try (MockedStatic<Log> logMock = mockStatic(Log.class)) {
             Group result = baseUserUtils.getOrCreateGroup(groupName); // no type requested
             assertEquals(existingGroup, result);
-        });
 
-        assertFalse(output.contains("Using existing group type."));
+            logMock.verifyNoInteractions();
+        }
+
         verify(groupRepository, never()).save(any(Group.class));
     }
 
@@ -95,26 +95,18 @@ public class BaseUserUtilsTest {
 
         when(groupRepository.findByName(groupName)).thenReturn(existingGroup);
 
-        String output = captureStdOut(() -> {
+        try (MockedStatic<Log> logMock = mockStatic(Log.class)) {
             Group result = baseUserUtils.getOrCreateGroup(groupName, requestedType);
             assertEquals(existingGroup, result);
-        });
 
-        assertTrue(output.contains("Warning: Group '" + groupName + "' exists with type '" + existingType +
-            "', but requested type is '" + requestedType + "'. Using existing group type."));
-        verify(groupRepository, never()).save(any(Group.class));
-    }
-
-    private String captureStdOut(Runnable action) {
-        PrintStream originalOut = System.out;
-        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-        try {
-            System.setOut(new PrintStream(outputStream));
-            action.run();
-        } finally {
-            System.setOut(originalOut);
+            logMock.verify(() -> Log.warning(
+                Geonet.SECURITY,
+                "Group '{}' exists with type '{}', but requested type is '{}'. Using existing group type.",
+                groupName, existingType, requestedType
+            ));
         }
-        return outputStream.toString();
+
+        verify(groupRepository, never()).save(any(Group.class));
     }
 
     @Test

--- a/core/src/test/java/org/fao/geonet/kernel/security/BaseUserUtilsTest.java
+++ b/core/src/test/java/org/fao/geonet/kernel/security/BaseUserUtilsTest.java
@@ -11,10 +11,14 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.MockitoJUnitRunner;
 
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
 import java.util.Collections;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.*;
 
@@ -63,6 +67,24 @@ public class BaseUserUtilsTest {
     }
 
     @Test
+    public void getOrCreateGroup_noWarningWhenRequestedTypeIsNull() {
+        String groupName = "ExistingTypedGroup";
+        Group existingGroup = new Group();
+        existingGroup.setName(groupName);
+        existingGroup.setType(GroupType.Workspace);
+
+        when(groupRepository.findByName(groupName)).thenReturn(existingGroup);
+
+        String output = captureStdOut(() -> {
+            Group result = baseUserUtils.getOrCreateGroup(groupName); // no type requested
+            assertEquals(existingGroup, result);
+        });
+
+        assertFalse(output.contains("Using existing group type."));
+        verify(groupRepository, never()).save(any(Group.class));
+    }
+
+    @Test
     public void getOrCreateGroup_logsWarningWhenGroupTypeDiffers() {
         String groupName = "MismatchedGroup";
         GroupType existingType = GroupType.SystemPrivilege;
@@ -73,10 +95,26 @@ public class BaseUserUtilsTest {
 
         when(groupRepository.findByName(groupName)).thenReturn(existingGroup);
 
-        Group result = baseUserUtils.getOrCreateGroup(groupName, requestedType);
+        String output = captureStdOut(() -> {
+            Group result = baseUserUtils.getOrCreateGroup(groupName, requestedType);
+            assertEquals(existingGroup, result);
+        });
 
-        assertEquals(existingGroup, result);
+        assertTrue(output.contains("Warning: Group '" + groupName + "' exists with type '" + existingType +
+            "', but requested type is '" + requestedType + "'. Using existing group type."));
         verify(groupRepository, never()).save(any(Group.class));
+    }
+
+    private String captureStdOut(Runnable action) {
+        PrintStream originalOut = System.out;
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        try {
+            System.setOut(new PrintStream(outputStream));
+            action.run();
+        } finally {
+            System.setOut(originalOut);
+        }
+        return outputStream.toString();
     }
 
     @Test


### PR DESCRIPTION
Currently, `BaseUserUtils#getOrCreateGroup` logs a warning when an existing group has a type, even when no group type was explicitly requested.

```
Warning: Group 'a' exists with type 'Workspace', but requested type is 'null'. Using existing group type.
```

This creates unnecessary warning noise during normal flows. A warning is only useful when a caller explicitly requests a group type that conflicts with the existing group’s type.

This PR aims to fix this issue by only logging a warning when an explicitly requested type differs from the existing group’s type. It also adds test coverage to verify the warning behaviour.

<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [X] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
