### PR TITLE
DCAT formatter / Fix dcat:distribution for associated service when the service metadata has no online resource

### DIFF
--- a/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/dcat/dcat-core-resource.xsl
+++ b/schemas/iso19115-3.2018/src/main/plugin/iso19115-3.2018/formatter/dcat/dcat-core-resource.xsl
@@ -133,83 +133,92 @@
         </xsl:when>
         <xsl:when test="local-name() = 'services'">
 
+          <!-- Prefer a link that is not purely informational (e.g. skip a
+          "more information" page or data quality report) so the distribution
+          points to the actual service endpoint. Fall back to the first link
+          if no other kind is available, so a distribution is still produced. -->
+          <xsl:variable name="nonInformationalLinks"
+                        select="root/link[not(function = ('information', 'dataQualityReport'))]"/>
+
           <xsl:variable name="mainLink"
-                        select="(root/link[not(function = ('information', 'dataQualityReport'))])[1]"/>
+                        select="if ($nonInformationalLinks) then $nonInformationalLinks[1] else root/link[1]"/>
 
           <xsl:variable name="serviceUri"
-                        select="if (root/resourceIdentifier) then concat(root/resourceIdentifier[1]/codeSpace, root/resourceIdentifier[1]/code) else ." />
+                        select="if (root/resourceIdentifier) then concat(root/resourceIdentifier[1]/codeSpace, root/resourceIdentifier[1]/code) else $mainLink/urlObject/default" />
 
-          <xsl:choose>
-            <!-- Only record with resourceType is service are mapped to a distribution.
-            Other related services which can be software, applications are mapped to foaf:page -->
-            <xsl:when test="root/resourceType = 'service'">
-              <dcat:distribution>
-                <dcat:Distribution>
-                  <xsl:for-each select="$mainLink/urlObject/default">
-                    <dcat:accessURL rdf:resource="{.}"/>
-                    <dcat:accessService rdf:resource="{$serviceUri}"/>
-                  </xsl:for-each>
+          <xsl:if test="$mainLink">
+            <xsl:choose>
+              <!-- Only record with resourceType is service are mapped to a distribution.
+              Other related services which can be software, applications are mapped to foaf:page -->
+              <xsl:when test="root/resourceType = 'service'">
+                <dcat:distribution>
+                  <dcat:Distribution>
+                    <xsl:for-each select="$mainLink/urlObject/default">
+                      <dcat:accessURL rdf:resource="{.}"/>
+                      <dcat:accessService rdf:resource="{$serviceUri}"/>
+                    </xsl:for-each>
 
-                  <xsl:call-template name="rdf-index-field-localised">
-                    <xsl:with-param name="nodeName" select="'dct:title'"/>
-                    <xsl:with-param name="field" select="root/resourceTitleObject"/>
-                  </xsl:call-template>
+                    <xsl:call-template name="rdf-index-field-localised">
+                      <xsl:with-param name="nodeName" select="'dct:title'"/>
+                      <xsl:with-param name="field" select="root/resourceTitleObject"/>
+                    </xsl:call-template>
 
-                  <xsl:call-template name="rdf-index-field-localised">
-                    <xsl:with-param name="nodeName" select="'dct:description'"/>
-                    <xsl:with-param name="field" select="root/resourceAbstractObject"/>
-                  </xsl:call-template>
-                  <!--
-                   RDF Property:	dcterms:issued
-                   Definition:	Date of formal issuance (e.g., publication) of the distribution.
-                  -->
-                  <xsl:for-each select="$metadata//mrd:MD_Distributor/mrd:distributionOrderProcess/*/mrd:plannedAvailableDateTime|
+                    <xsl:call-template name="rdf-index-field-localised">
+                      <xsl:with-param name="nodeName" select="'dct:description'"/>
+                      <xsl:with-param name="field" select="root/resourceAbstractObject"/>
+                    </xsl:call-template>
+                    <!--
+                     RDF Property:	dcterms:issued
+                     Definition:	Date of formal issuance (e.g., publication) of the distribution.
+                    -->
+                    <xsl:for-each select="$metadata//mrd:MD_Distributor/mrd:distributionOrderProcess/*/mrd:plannedAvailableDateTime|
                                                $metadata/mdb:identificationInfo/*/mri:citation/*/cit:date/*[cit:dateType/*/@codeListValue = 'publication']">
-                    <xsl:apply-templates mode="iso19115-3-to-dcat"
-                                         select=".">
-                      <xsl:with-param name="dateType" select="'publication'"/>
-                    </xsl:apply-templates>
-                  </xsl:for-each>
+                      <xsl:apply-templates mode="iso19115-3-to-dcat"
+                                           select=".">
+                        <xsl:with-param name="dateType" select="'publication'"/>
+                      </xsl:apply-templates>
+                    </xsl:for-each>
 
-                  <!--
-                  RDF Property:	dcterms:modified
-                  Definition:	Most recent date on which the distribution was changed, updated or modified.
-                  Range:	rdfs:Literal encoded using the relevant ISO 8601 Date and Time compliant string [DATETIME] and typed using the appropriate XML Schema datatype [XMLSCHEMA11-2] (xsd:gYear, xsd:gYearMonth, xsd:date, or xsd:dateTime).
-                  -->
-                  <xsl:for-each select="$metadata//mrd:MD_Distributor/mrd:distributionOrderProcess/*/mrd:plannedAvailableDateTime|
+                    <!--
+                    RDF Property:	dcterms:modified
+                    Definition:	Most recent date on which the distribution was changed, updated or modified.
+                    Range:	rdfs:Literal encoded using the relevant ISO 8601 Date and Time compliant string [DATETIME] and typed using the appropriate XML Schema datatype [XMLSCHEMA11-2] (xsd:gYear, xsd:gYearMonth, xsd:date, or xsd:dateTime).
+                    -->
+                    <xsl:for-each select="$metadata//mrd:MD_Distributor/mrd:distributionOrderProcess/*/mrd:plannedAvailableDateTime|
                                                $metadata/mdb:identificationInfo/*/mri:citation/*/cit:date/*[cit:dateType/*/@codeListValue = 'revision']">
+                      <xsl:apply-templates mode="iso19115-3-to-dcat"
+                                           select=".">
+                        <xsl:with-param name="dateType" select="'revision'"/>
+                      </xsl:apply-templates>
+                    </xsl:for-each>
+
                     <xsl:apply-templates mode="iso19115-3-to-dcat"
-                                         select=".">
-                      <xsl:with-param name="dateType" select="'revision'"/>
-                    </xsl:apply-templates>
-                  </xsl:for-each>
+                                         select="$metadata/mdb:identificationInfo/*/mri:resourceConstraints/*[mco:useConstraints]"/>
+                    <xsl:apply-templates mode="iso19115-3-to-dcat"
+                                         select="$metadata/mdb:identificationInfo/*/mri:resourceConstraints/*[mco:accessConstraints]"/>
 
-                  <xsl:apply-templates mode="iso19115-3-to-dcat"
-                                       select="$metadata/mdb:identificationInfo/*/mri:resourceConstraints/*[mco:useConstraints]"/>
-                  <xsl:apply-templates mode="iso19115-3-to-dcat"
-                                       select="$metadata/mdb:identificationInfo/*/mri:resourceConstraints/*[mco:accessConstraints]"/>
+                    <xsl:apply-templates mode="iso19115-3-to-dcat"
+                                         select="$metadata/mdb:identificationInfo/*/mri:defaultLocale"/>
 
-                  <xsl:apply-templates mode="iso19115-3-to-dcat"
-                                       select="$metadata/mdb:identificationInfo/*/mri:defaultLocale"/>
+                    <xsl:apply-templates mode="iso19115-3-to-dcat"
+                                         select="$legislations"/>
 
-                  <xsl:apply-templates mode="iso19115-3-to-dcat"
-                                       select="$legislations"/>
-
-                  <xsl:call-template name="rdf-format-as-mediatype">
-                    <xsl:with-param name="format" select="$mainLink/protocol"/>
-                  </xsl:call-template>
-                </dcat:Distribution>
-              </dcat:distribution>
-            </xsl:when>
-            <xsl:otherwise>
-              <foaf:page>
-                <foaf:Document rdf:about="{$mainLink/urlObject/default}">
-                  <dct:title><xsl:value-of select="root/resourceTitleObject/default"/></dct:title>
-                  <dct:description xml:lang="fre"><xsl:value-of select="root/resourceAbstractObject/default"/></dct:description>
-                </foaf:Document>
-              </foaf:page>
-            </xsl:otherwise>
-          </xsl:choose>
+                    <xsl:call-template name="rdf-format-as-mediatype">
+                      <xsl:with-param name="format" select="$mainLink/protocol"/>
+                    </xsl:call-template>
+                  </dcat:Distribution>
+                </dcat:distribution>
+              </xsl:when>
+              <xsl:otherwise>
+                <foaf:page>
+                  <foaf:Document rdf:about="{$mainLink/urlObject/default}">
+                    <dct:title><xsl:value-of select="root/resourceTitleObject/default"/></dct:title>
+                    <dct:description xml:lang="fre"><xsl:value-of select="root/resourceAbstractObject/default"/></dct:description>
+                  </foaf:Document>
+                </foaf:page>
+              </xsl:otherwise>
+            </xsl:choose>
+          </xsl:if>
         </xsl:when>
         <xsl:otherwise>
           <!-- TODO: other type of relations -->


### PR DESCRIPTION
Changes:

- If no online resource in the service metadata, skip the `dcat:distribution` element
- Fallback to the first online resource in the service metadata if no informative links are available.
- If no resource identifier in the service metadata, use the online resource URL for `dcat:accessService`.


Test case:

1) Create a service metadata without no distributions or a distribution with `function=information`
2) Create a dataset metadata and link it to the service metadata.
3) Request the DCAT document of the dataset metadata: http://localhost:8080/geonetwork/srv/api/records/UUID/formatters/dcat

  - Without the fix: An error page is returned. In the log:

   ```
  Aug 14 10:12:23 su0001t01 metadateneditor[841296]: Error at xsl:call-template on line 198 of dcat-core-resource.xsl:
  Aug 14 10:12:23 su0001t01 metadateneditor[841296]:  XTTE0570: An empty sequence is not allowed as the value of parameter $format
  Aug 14 10:12:23 su0001t01 metadateneditor[841296]: 2026-08-14T10:12:23,404 ERROR [geonetwork] - An empty sequence is not allowed as the value of parameter $format
  ```

  - With the fix: The DCAT document is returned. If the service metadata has no distributions, the DCAT document has no distribution related to the service metadata. If the service metadata has distributions, the first one is used in the DCAT document.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

