### PR TITLE
Resource size label

### DIFF
--- a/docs/manual/docs/administrator-guide/configuring-the-catalog/user-interface-configuration.md
+++ b/docs/manual/docs/administrator-guide/configuring-the-catalog/user-interface-configuration.md
@@ -272,6 +272,7 @@ This section defines the configuration for the map shown when editing a record. 
 -   **Application URL**: This is the URL to the editor application and can generally be left as the default.
 -   **Only my records**: If this checkbox is enabled then the "Only my records" checkbox in the editor dashboard will be checked by default.
 -   **Display filters in dashboard**: If enabled, the currently selected facets will be shown above the search results in both the editor dashboard the batch editor page.
+-   **Display file size in the file store**: If enabled, display the size of each uploaded file in the metadata editor's online resources file store panel.
 -   **Fluid container for the Editor**: If enabled, the editor application will have a full width container. If disabled it will have a fixed width and centered container.
 -   **New metadata page layout**: Choose from the options for the layout of the `add new metadata` page. The default is `Horizontal` but a vertical layout can be chosen, or a custom layout based on a supplied template.
 -   **Editor page indent type**: Choose from the options for the indent style when editing a record. The default is for minimal indents, select `Colored indents` to use the style shown below:

--- a/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
+++ b/web-ui/src/main/resources/catalog/components/admin/uiconfig/partials/uiconfig.html
@@ -820,7 +820,7 @@
                 <!-- boolean -->
                 <div
                   class="row"
-                  data-ng-switch-when="is3DModeAllowed|isVegaEnabled|isSaveMapInCatalogAllowed|isAccessible|isExportMapAsImageEnabled|useOSM|isUserRecordsOnly|isFilterTagsDisplayed|isFilterTagsDisplayedInSearch|autoFitOnLayer|showSocialBarInFooter|isSocialbarEnabled|isDefaultContactViewEnabled|isLogoInHeader|isHeaderFixed|fluidLayout|fluidHeaderLayout|fluidEditorLayout|showGNName|humanizeDates|sortKeywordsAlphabetically|showMosaic|showMaps|showApplicationInfoAndLinksInFooter|showBatchDropdown|moreLikeThisSameType|allowRemoteRecordLink|singleTileWMS|showSearch|hotkeys"
+                  data-ng-switch-when="is3DModeAllowed|isVegaEnabled|isSaveMapInCatalogAllowed|isAccessible|isExportMapAsImageEnabled|useOSM|isUserRecordsOnly|isFilterTagsDisplayed|isFilterTagsDisplayedInSearch|autoFitOnLayer|showSocialBarInFooter|isSocialbarEnabled|isDefaultContactViewEnabled|isLogoInHeader|isHeaderFixed|fluidLayout|fluidHeaderLayout|fluidEditorLayout|showGNName|humanizeDates|sortKeywordsAlphabetically|showMosaic|showMaps|showApplicationInfoAndLinksInFooter|showBatchDropdown|moreLikeThisSameType|allowRemoteRecordLink|singleTileWMS|showSearch|hotkeys|showFileStoreSize"
                   data-ng-switch-when-separator="|"
                 >
                   <div class="col-lg-5 gn-nopadding-left">

--- a/web-ui/src/main/resources/catalog/components/filestore/FileStoreDirective.js
+++ b/web-ui/src/main/resources/catalog/components/filestore/FileStoreDirective.js
@@ -25,6 +25,16 @@
   goog.provide("gn_filestore_directive");
 
   /**
+   * Convert a size in bytes into a human readable string (eg. '1.2 MB').
+   */
+  var humanizeDataSize = function (bytes) {
+    if (bytes === 0) return "0 Bytes";
+    var sizes = ["Bytes", "KB", "MB", "GB", "TB"];
+    var i = Math.floor(Math.log(bytes) / Math.log(1024)); // Determine the index for sizes
+    return parseFloat((bytes / Math.pow(1024, i)).toFixed(2)) + " " + sizes[i]; // Format size
+  };
+
+  /**
    */
   angular
     .module("gn_filestore_directive", ["blueimp.fileupload"])
@@ -112,13 +122,6 @@
                 unregisterWatch();
               }
             });
-
-            var humanizeDataSize = function (bytes) {
-              if (bytes === 0) return "0 Bytes";
-              var sizes = ["Bytes", "KB", "MB", "GB", "TB"];
-              var i = Math.floor(Math.log(bytes) / Math.log(1024)); // Determine the index for sizes
-              return parseFloat((bytes / Math.pow(1024, i)).toFixed(2)) + " " + sizes[i]; // Format size
-            };
 
             // Function to remove files from scope.queue that match data.files by $$hashKey
             var removeUploadedFilesFromQueue = function (data) {
@@ -308,13 +311,15 @@
       "$translate",
       "$rootScope",
       "$parse",
+      "gnGlobalSettings",
       function (
         gnfilestoreService,
         gnOnlinesrc,
         gnCurrentEdit,
         $translate,
         $rootScope,
-        $parse
+        $parse,
+        gnGlobalSettings
       ) {
         return {
           restrict: "A",
@@ -347,6 +352,9 @@
             scope.selectOptions = { current: undefined };
             scope.metadataResources = [];
             scope.editingResource = false;
+            scope.showFileStoreSize =
+              gnGlobalSettings.gnCfg.mods.editor.showFileStoreSize;
+            scope.humanizeFileSize = humanizeDataSize;
 
             function updateVisibilityEditingPanel(index, editing) {
               if (editing) {

--- a/web-ui/src/main/resources/catalog/components/filestore/FileStoreDirective.js
+++ b/web-ui/src/main/resources/catalog/components/filestore/FileStoreDirective.js
@@ -30,7 +30,12 @@
   var humanizeDataSize = function (bytes) {
     var numericBytes = Number(bytes);
 
-    if (bytes === null || angular.isUndefined(bytes) || !isFinite(numericBytes) || numericBytes < 0) {
+    if (
+      bytes === null ||
+      angular.isUndefined(bytes) ||
+      !isFinite(numericBytes) ||
+      numericBytes < 0
+    ) {
       return null;
     }
 

--- a/web-ui/src/main/resources/catalog/components/filestore/FileStoreDirective.js
+++ b/web-ui/src/main/resources/catalog/components/filestore/FileStoreDirective.js
@@ -28,10 +28,16 @@
    * Convert a size in bytes into a human readable string (eg. '1.2 MB').
    */
   var humanizeDataSize = function (bytes) {
-    if (bytes === 0) return "0 Bytes";
+    var numericBytes = Number(bytes);
+
+    if (bytes === null || angular.isUndefined(bytes) || !isFinite(numericBytes) || numericBytes < 0) {
+      return null;
+    }
+
+    if (numericBytes === 0) return "0 Bytes";
     var sizes = ["Bytes", "KB", "MB", "GB", "TB"];
-    var i = Math.floor(Math.log(bytes) / Math.log(1024)); // Determine the index for sizes
-    return parseFloat((bytes / Math.pow(1024, i)).toFixed(2)) + " " + sizes[i]; // Format size
+    var i = Math.floor(Math.log(numericBytes) / Math.log(1024)); // Determine the index for sizes
+    return parseFloat((numericBytes / Math.pow(1024, i)).toFixed(2)) + " " + sizes[i]; // Format size
   };
 
   /**
@@ -355,13 +361,18 @@
             scope.showFileStoreSize =
               gnGlobalSettings.gnCfg.mods.editor.showFileStoreSize;
             scope.humanizeFileSize = humanizeDataSize;
+            scope.hasFileSize = function (size) {
+              return humanizeDataSize(size) !== null;
+            };
 
             function updateVisibilityEditingPanel(index, editing) {
               if (editing) {
                 $("#resource_" + index).addClass("hidden");
+                $("#resource_size_" + index).addClass("hidden");
                 $("#resource_edit_" + index).removeClass("hidden");
               } else {
                 $("#resource_" + index).removeClass("hidden");
+                $("#resource_size_" + index).removeClass("hidden");
                 $("#resource_edit_" + index).addClass("hidden");
               }
             }

--- a/web-ui/src/main/resources/catalog/components/filestore/partials/filestore.html
+++ b/web-ui/src/main/resources/catalog/components/filestore/partials/filestore.html
@@ -48,6 +48,9 @@
             >
               {{r.id.split('/').splice(2).join('/') | decodeURIComponent}}
             </a>
+            <span data-ng-if="showFileStoreSize" class="text-muted"
+              >({{humanizeFileSize(r.size)}})</span
+            >
 
             <div id="resource_edit_{{$index}}" class="hidden">
               <input

--- a/web-ui/src/main/resources/catalog/components/filestore/partials/filestore.html
+++ b/web-ui/src/main/resources/catalog/components/filestore/partials/filestore.html
@@ -48,7 +48,10 @@
             >
               {{r.id.split('/').splice(2).join('/') | decodeURIComponent}}
             </a>
-            <span data-ng-if="showFileStoreSize" class="text-muted"
+            <span
+              data-ng-if="showFileStoreSize && hasFileSize(r.size)"
+              class="text-muted"
+              id="resource_size_{{$index}}"
               >({{humanizeFileSize(r.size)}})</span
             >
 

--- a/web-ui/src/main/resources/catalog/js/CatController.js
+++ b/web-ui/src/main/resources/catalog/js/CatController.js
@@ -1010,6 +1010,7 @@
             isUserRecordsOnly: false,
             minUserProfileToCreateTemplate: "",
             isFilterTagsDisplayed: false,
+            showFileStoreSize: true,
             fluidEditorLayout: true,
             createPageTpl: "../../catalog/templates/editor/new-metadata-horizontal.html",
             editorIndentType: "",

--- a/web-ui/src/main/resources/catalog/locales/en-admin.json
+++ b/web-ui/src/main/resources/catalog/locales/en-admin.json
@@ -1239,6 +1239,8 @@
     "ui-isUserRecordsOnly-help": "If enabled, the checkbox \"Only my records\" will be checked by default in the editor dashboard",
     "ui-isFilterTagsDisplayed": "Display filter tags in dashboard",
     "ui-isFilterTagsDisplayed-help": "If enabled, display the list of filters applied in the dashboard and the batch editor dashboard",
+    "ui-showFileStoreSize": "Display file size in the file store",
+    "ui-showFileStoreSize-help": "If enabled, display the size of each uploaded file in the metadata editor's online resources file store panel",
     "ui-isFilterTagsDisplayedInSearch": "Display filter tags in the search results",
     "ui-isFilterTagsDisplayedInSearch-help": "If enabled, display the list of filters applied in the search results page",
     "ui-searchMapPlacement": "Search result map placement",


### PR DESCRIPTION
The metadata editor's online resources file store currently displays uploaded files without their file sizes.

This makes it difficult for users to identify files and understand how much storage they use.

This PR aims to fix this issue by displaying each file's size in a human-readable format and adding a UI setting that allows administrators to disable the label if needed.
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [X] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

