### PR TITLE
Offer the option to completely replace a record when overwriting on import

### DIFF
--- a/docs/manual/docs/user-guide/describing-information/importing-metadata.md
+++ b/docs/manual/docs/user-guide/describing-information/importing-metadata.md
@@ -32,6 +32,12 @@ The user should have an `editor` profile to access metadata.
 
         -   `None`: the UUID of the record loaded is left unchanged. If a metadata record with the same UUID is already present in the catalog, an error message is returned.
         -   `Overwrite metadata with same UUID`: any existing metadata record in the catalog having the same UUID as the loaded record will be updated.
+
+        !!! note
+
+            By default, only the XML content of the existing record will be overwritten. To completely remove the existing record including attachments and privileges, use the `Delete and replace the existing record` option.
+
+
         -   `Generate UUID for inserted metadata`: a new UUID is affected to the loaded record.
 
     -   `Apply XSLT conversion` allows to transform the record loaded using an XSLT stylesheet. A list of predefined transformations is provided. The selected transformation should be compatible with the standard of the loaded record (see [Adding XSLT conversion for import](../workflow/batchupdate-xsl.md#customizing-xslt-conversion)).

--- a/web-ui/src/main/resources/catalog/js/edit/ImportController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/ImportController.js
@@ -125,7 +125,10 @@
         autoUpload: false,
         done: uploadImportMdDone,
         fail: uploadImportMdError,
-        headers: { "X-XSRF-TOKEN": $rootScope.csrf, "Accept-Language": $scope.lang }
+        headers: {
+          "X-XSRF-TOKEN": $rootScope.csrf,
+          "Accept-Language": $scope.lang
+        }
       };
 
       var formatExceptionArray = function () {

--- a/web-ui/src/main/resources/catalog/js/edit/ImportController.js
+++ b/web-ui/src/main/resources/catalog/js/edit/ImportController.js
@@ -78,6 +78,31 @@
       };
       $scope.importing = false;
 
+      var overwriteReplaceEnabled = false;
+      function setUuidProcessingOverwrite() {
+        $scope.params.uuidProcessing = overwriteReplaceEnabled
+          ? "REMOVE_AND_REPLACE"
+          : "OVERWRITE";
+      }
+      $scope.uuidProcessingOverwriteGetSet = function (uuidProcessing) {
+        if (uuidProcessing === undefined) {
+          // is getter
+          return $scope.params.uuidProcessing === "OVERWRITE" ||
+            $scope.params.uuidProcessing === "REMOVE_AND_REPLACE"
+            ? "OVERWRITE_OR_REMOVE_AND_REPLACE"
+            : "";
+        }
+        setUuidProcessingOverwrite();
+      };
+      $scope.overwriteReplaceRecordGetSet = function (enableReplace) {
+        if (enableReplace === undefined) {
+          // is getter
+          return overwriteReplaceEnabled;
+        }
+        overwriteReplaceEnabled = enableReplace;
+        setUuidProcessingOverwrite();
+      };
+
       gnConfigService.load().then(function (c) {
         $scope.isMdWorkflowEnable = gnConfig["metadata.workflow.enable"];
         $scope.params.group = gnConfig["system.metadatacreate.preferredGroup"];

--- a/web-ui/src/main/resources/catalog/locales/en-editor.json
+++ b/web-ui/src/main/resources/catalog/locales/en-editor.json
@@ -274,6 +274,8 @@
     "overview": "Overview",
     "overviews": "Overviews",
     "overwrite": "Overwrite metadata with same UUID",
+    "overwriteReplaceRecord": "Delete and replace the existing record",
+    "overwriteReplaceRecordHint": "If checked, existing privileges and attachments on the existing record will be completely deleted.",
     "parentMd": "Parent Metadata",
     "print_layout": "Layout",
     "print_scale": "Scale",

--- a/web-ui/src/main/resources/catalog/templates/editor/import.html
+++ b/web-ui/src/main/resources/catalog/templates/editor/import.html
@@ -287,16 +287,46 @@
                     <span data-translate="">none</span>
                   </label>
                 </div>
+                <input
+                  class="hidden"
+                  type="radio"
+                  name="uuidProcessing"
+                  data-ng-model="params.uuidProcessing"
+                  value="OVERWRITE"
+                />
+                <input
+                  class="hidden"
+                  type="radio"
+                  name="uuidProcessing"
+                  data-ng-model="params.uuidProcessing"
+                  value="REMOVE_AND_REPLACE"
+                />
                 <div id="gn-import-action-list-overwrite-row" class="radio">
                   <label>
                     <input
                       id="gn-import-action-list-overwrite-radio"
                       type="radio"
-                      name="uuidProcessing"
-                      data-ng-model="params.uuidProcessing"
-                      value="OVERWRITE"
+                      form=""
+                      data-ng-model="uuidProcessingOverwriteGetSet"
+                      data-ng-model-options="{ getterSetter: true }"
+                      value="OVERWRITE_OR_REMOVE_AND_REPLACE"
                     />
                     <span data-translate="">overwrite</span>
+                  </label>
+                </div>
+                <div
+                  data-ng-if="params.uuidProcessing === 'OVERWRITE' || params.uuidProcessing === 'REMOVE_AND_REPLACE'"
+                  class="checkbox"
+                  style="margin-left: 20px"
+                >
+                  <label title="{{'overwriteReplaceRecordHint' | translate}}">
+                    <input
+                      id="gn-import-action-list-overwrite-replace-record"
+                      type="checkbox"
+                      data-ng-model="overwriteReplaceRecordGetSet"
+                      data-ng-model-options="{ getterSetter: true }"
+                    />
+                    <span data-translate="">overwriteReplaceRecord</span>
                   </label>
                 </div>
                 <div id="gn-import-action-list-generate-row" class="radio">


### PR DESCRIPTION
<!--Include a few sentences describing the overall goals for this Pull Request-->
  
<!-- Please help our volunteers reviewing this PR by completing the following items. 
Ask in a comment if you have troubles with any of them. -->

This PR adds an option in the import menu to delete and replace a record with the same UUID instead of just rewriting the XML content. This is a follow-up of https://github.com/geonetwork/core-geonetwork/pull/7178 where this option was given in the API but not in the UI.

The option only appears when "Overwrite metadata with the same UUID" is selected

<img width="707" height="158" alt="image" src="https://github.com/user-attachments/assets/df5f6073-769f-4e7b-8d19-4cd3d05cf6d3" />

<img width="1130" height="159" alt="image" src="https://github.com/user-attachments/assets/c6a20a33-1272-462a-b922-d990481c5026" />


# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

