### PR TITLE
[Backport 4.2.x] Release note updates and coordination - #9497

### DIFF
--- a/docs/manual/docs/overview/change-log/history/index.md
+++ b/docs/manual/docs/overview/change-log/history/index.md
@@ -4,13 +4,15 @@ The GeoNetwork community is not large enough to maintain many active branches of
 
 Volunteers wishing to backport security fixes to older versions of GeoNetwork are welcome to do so. Commercial support providers are welcome to do so on behalf of their customers.
 
-## Stable Release
+## Maintenance Release
 
-The stable release of GeoNetwork is recommended for production use and for new installations of GeoNetwork.
+The maintenance release of GeoNetwork provides production systems with essential updates and fixes to allow time to upgrade to the recommended stable release. 
 
-This series is under **active use** by our community, with regular improvements, documentation updates, bug reports, fixes, and releases.
+When available the maintenace series provides **time to upgrade** for our community - limited to providing essential fixes only.
 
 ### 4.2
+
+Be advised that GeoNetwork 4.2 series is nearing end-of-life. Production systems are advised to update to 4.4 above if they have not already done so.
 
 - [Version 4.2.17](../version-4.2.17.md)
 - [Version 4.2.16](../version-4.2.16.md)
@@ -30,18 +32,6 @@ This series is under **active use** by our community, with regular improvements,
 - [Version 4.2.2](../version-4.2.2.md)
 - [Version 4.2.1](../version-4.2.1.md)
 - [Version 4.2.0](../version-4.2.0.md)
-
-## Maintenance Release
-
-The maintenance release of GeoNetwork provides production systems with essential updates and fixes to allow time to upgrade to the recommended stable release. 
-
-When available the maintenace series provides **time to upgrade** for our community - limited to providing essential fixes only.
-
-### No maintenance release
-
-With the final release of 3.12.12 there is no active maintenance release being provided.
-
-Production systems are advised to update to 4.2 above if they have not already done so.
 
 ## Archived Releases
 

--- a/docs/manual/docs/overview/change-log/version-4.2.17.md
+++ b/docs/manual/docs/overview/change-log/version-4.2.17.md
@@ -2,7 +2,19 @@
 
 GeoNetwork 4.2.17 is a minor release.
 
+## Security Considerations
+
+This release includes a security fix for a vulnerability affecting previous 4.2.x versions. **All users are encouraged to update to 4.2.17 as soon as possible.**
+
+
+* [CVE-2026-63219](https://github.com/geonetwork/core-geonetwork/security/advisories/GHSA-mh22-prqr-vf42) Unauthenticated file upload via missing authorization on formatter upload endpoint 
+* [CVE-2026-55864](https://github.com/geonetwork/core-geonetwork/security/advisories/GHSA-5hx7-j24v-rffj) Unauthenticated Server-Side Request Forgery in SLD Tool 
+* [CVE-2026-58400](https://github.com/geonetwork/core-geonetwork/security/advisories/GHSA-x898-729x-cc3r) Remote Code Execution via unsafe Saxon XSLT processor configuration in formatter
+* [CVE-2026-69130](https://github.com/geonetwork/core-geonetwork/security/advisories/GHSA-jcv2-3cfh-v9h2) Map feature popup renders KML/vector description and attributes as raw HTML via innerHTML
+
 ## Migration notes
+
+Please note that GeoNetwork 4.2 is nearing end-of-life and you should plan your upgrade to GeoNetwork 4.4 at this time.
 
 ### API changes
 


### PR DESCRIPTION
Backport of 4.2.17 release notes from:

* https://github.com/geonetwork/core-geonetwork/pull/9497

This "backport" just provides the updated release notes.
