### PR TITLE
Consider switching to a maintained `nv-i18n` fork

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -557,7 +557,7 @@
       <artifactId>netcdf</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.neovisionaries</groupId>
+      <groupId>uk.co.foundationsedge</groupId>
       <artifactId>nv-i18n</artifactId>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1024,9 +1024,9 @@
         <version>${spring.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.neovisionaries</groupId>
+        <groupId>uk.co.foundationsedge</groupId>
         <artifactId>nv-i18n</artifactId>
-        <version>1.29</version>
+        <version>1.34.1</version>
       </dependency>
       <dependency>
         <groupId>org.springframework</groupId>


### PR DESCRIPTION
The original nv-i18n is no longer being maintained. Our company app relies on it, and needed newly created entries. A colleague and I have forked and published a new version of it. Due to our reliance on it we will be continuing to maintain it.

The fork is available here, and we have published updates to mvnrepository

https://github.com/foundationsedge/nv-i18n

https://central.sonatype.com/artifact/uk.co.foundationsedge/nv-i18n

Changes from `com.neovisionaries:nv-i18n:1.29` to `uk.co.foundationsedge:nv-i18n:1.34.1`

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [X] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [X] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [X] *Build documentation* provided for development instructions in `README.md` files
- [X] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

I tried to build and run tests locally before submitting but had errors doing so. I checked the classes that refer to the library: `IsoLanguagesMapper` and `XslUtil` and couldn't see anything that would cause a breaking change. I didn't see separate unit tests for either of these classes which covered the code.

