### PR TITLE
Update docs.yml to publish 4.4 as stable

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,9 +33,9 @@ jobs:
         if: ${{ github.event_name == 'pull_request' }}
         working-directory: docs/manual
         run: |
-          mike deploy --title "4.4" --alias-type=copy --update-aliases 4.4 latest
-      - name: deploy latest docs to gh-pages branch
+          mike deploy --title "4.4" --alias-type=copy --update-aliases 4.4 stable
+      - name: deploy stable docs to gh-pages branch
         if: ${{ github.event_name != 'pull_request' }}
         working-directory: docs/manual
         run: |
-          mike deploy --push --title "4.4" --alias-type=copy --update-aliases 4.4 latest
+          mike deploy --push --title "4.4" --alias-type=copy --update-aliases 4.4 stable


### PR DESCRIPTION
Update version selector so 4.4 docs are published as stable

# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [ ] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [ ] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [ ] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

