### PR TITLE
Update property exclusions in User/UserSecurity XML format

### DIFF
--- a/domain/src/main/java/org/fao/geonet/domain/GeonetEntity.java
+++ b/domain/src/main/java/org/fao/geonet/domain/GeonetEntity.java
@@ -264,7 +264,8 @@ public class GeonetEntity {
      * Subclasses can override this if there are properties that should not be called when constructing the XML representation. of this
      * entity.
      *
-     * The property should not have the get prefix.
+     * Entries must be the full getter method name, including the {@code get}/{@code is} prefix (e.g. {@code "getPassword"}),
+     * since matching is done against {@link Method#getName()}.
      */
     protected Set<String> propertiesToExcludeFromXml() {
         return Collections.emptySet();

--- a/domain/src/main/java/org/fao/geonet/domain/User.java
+++ b/domain/src/main/java/org/fao/geonet/domain/User.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2020 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2026 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -528,5 +528,16 @@ public class User extends GeonetEntity implements UserDetails {
         result = 31 * result + _security.hashCode();
         result = 31 * result + (_lastLoginDate != null ? _lastLoginDate.hashCode() : 0);
         return result;
+    }
+
+    @Override
+    protected Set<String> propertiesToExcludeFromXml() {
+        Set<String> properties = new HashSet<>(super.propertiesToExcludeFromXml());
+        properties.add("getPassword");
+        properties.add("getAuthorities");
+        properties.add("isAccountNonExpired");
+        properties.add("isAccountNonLocked");
+        properties.add("isCredentialsNonExpired");
+        return properties;
     }
 }

--- a/domain/src/main/java/org/fao/geonet/domain/User.java
+++ b/domain/src/main/java/org/fao/geonet/domain/User.java
@@ -534,6 +534,9 @@ public class User extends GeonetEntity implements UserDetails {
     protected Set<String> propertiesToExcludeFromXml() {
         Set<String> properties = new HashSet<>(super.propertiesToExcludeFromXml());
         properties.add("getPassword");
+        // getRandomPassword() is a static utility that returns a fresh random value on every
+        // call, not a user property. It is getter-shaped so it would otherwise be serialized.
+        properties.add("getRandomPassword");
         properties.add("getAuthorities");
         properties.add("isAccountNonExpired");
         properties.add("isAccountNonLocked");

--- a/domain/src/main/java/org/fao/geonet/domain/UserSecurity.java
+++ b/domain/src/main/java/org/fao/geonet/domain/UserSecurity.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2016 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2026 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -24,7 +24,6 @@
 package org.fao.geonet.domain;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import org.jdom.Element;
 
 import javax.annotation.Nonnull;
 import javax.persistence.Column;
@@ -33,7 +32,6 @@ import javax.persistence.Transient;
 import java.io.Serializable;
 import java.util.Arrays;
 import java.util.HashSet;
-import java.util.IdentityHashMap;
 import java.util.Set;
 
 /**
@@ -199,9 +197,9 @@ public class UserSecurity extends GeonetEntity implements Serializable {
     }
 
     @Override
-    protected Element asXml(IdentityHashMap<Object, Void> alreadyEncoded) {
-        final Element element = super.asXml(alreadyEncoded);
-        element.removeChild("password");
-        return element;
+    protected Set<String> propertiesToExcludeFromXml() {
+        Set<String> properties = new HashSet<>(super.propertiesToExcludeFromXml());
+        properties.add("getPassword");
+        return properties;
     }
 }

--- a/domain/src/test/java/org/fao/geonet/domain/UserXmlSanitizationTest.java
+++ b/domain/src/test/java/org/fao/geonet/domain/UserXmlSanitizationTest.java
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2001-2026 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+
+package org.fao.geonet.domain;
+
+import org.jdom.Element;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Verifies that {@link User#asXml()} never leaks the password hash or other
+ * {@link org.springframework.security.core.userdetails.UserDetails} security fields, regardless
+ * of which caller invokes it (e.g. {@link org.fao.geonet.util.XslUtil#getUserDetails}, admin
+ * user listings, feedback/download services). Unlike {@code UserTest}, this does not extend
+ * {@link org.fao.geonet.repository.AbstractSpringDataTest}, so it runs with the default,
+ * DB-less {@code mvn test} build rather than only under the {@code it} Maven profile.
+ */
+public class UserXmlSanitizationTest {
+
+    private User newUser() {
+        User user = new User().setName("name1").setUsername("username1").setId(1);
+        user.getSecurity().setPassword("secret-hash");
+        user.getSecurity().setAuthType("authtype1");
+        user.getSecurity().getSecurityNotifications().add(UserSecurityNotification.UPDATE_HASH_REQUIRED);
+        user.setProfile(Profile.Administrator);
+        return user;
+    }
+
+    @Test
+    public void asXmlDoesNotExposePasswordHash() {
+        Element xml = newUser().asXml();
+
+        assertNoElementNamed(xml, "password");
+    }
+
+    @Test
+    public void asXmlDoesNotExposeAuthoritiesOrAccountStatusFlags() {
+        Element xml = newUser().asXml();
+
+        assertNull("authorities must not be serialized to XML", xml.getChild("authorities"));
+        assertNull("accountnonexpired must not be serialized to XML", xml.getChild("accountnonexpired"));
+        assertNull("accountnonlocked must not be serialized to XML", xml.getChild("accountnonlocked"));
+        assertNull("credentialsnonexpired must not be serialized to XML", xml.getChild("credentialsnonexpired"));
+    }
+
+    @Test
+    public void asXmlStillExposesNonSensitiveSecurityFields() {
+        Element xml = newUser().asXml();
+
+        Element security = xml.getChild("security");
+        assertNotNull("the security element itself should still be present", security);
+        assertNull("password must not appear inside the security element either", security.getChild("password"));
+        assertNotNull("authtype is not sensitive and should still be available",
+            security.getChild("authtype"));
+        assertNotNull("securitynotifications is not sensitive and should still be available",
+            security.getChild("securitynotifications"));
+    }
+
+    /**
+     * Recursively asserts that no element anywhere in the tree has the given name, since a
+     * regression here (e.g. excluding the wrong key) could otherwise leave the field reachable
+     * through a different nesting level than the one a narrower assertion happens to check.
+     */
+    private void assertNoElementNamed(Element root, String name) {
+        assertFalse("found unexpected <" + name + "> in " + root.getName(), name.equals(root.getName()));
+
+        @SuppressWarnings("unchecked")
+        List<Element> children = root.getChildren();
+        for (Element child : children) {
+            assertNoElementNamed(child, name);
+        }
+    }
+}

--- a/domain/src/test/java/org/fao/geonet/domain/UserXmlSanitizationTest.java
+++ b/domain/src/test/java/org/fao/geonet/domain/UserXmlSanitizationTest.java
@@ -66,6 +66,9 @@ public class UserXmlSanitizationTest {
         assertNull("accountnonexpired must not be serialized to XML", xml.getChild("accountnonexpired"));
         assertNull("accountnonlocked must not be serialized to XML", xml.getChild("accountnonlocked"));
         assertNull("credentialsnonexpired must not be serialized to XML", xml.getChild("credentialsnonexpired"));
+        // getRandomPassword() is a static utility returning a fresh random value, not a user
+        // property, so it must not be serialized either.
+        assertNull("randompassword must not be serialized to XML", xml.getChild("randompassword"));
     }
 
     @Test


### PR DESCRIPTION
Update the properties from `User` and `UserSecurity` that are output to XML format when using the `asXml` method.

---

Claude Sonnet 5 has been used to generate the unit tests and review the changes.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [X] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation
