### PR TITLE
Add method to retrieve records for use in untrusted XSLT

### DIFF
--- a/common/src/main/java/org/fao/geonet/utils/XmlTransformer.java
+++ b/common/src/main/java/org/fao/geonet/utils/XmlTransformer.java
@@ -301,7 +301,7 @@ public class XmlTransformer {
             "{java:org.fao.geonet.util.XslUtil}getUserDetails",
             "{java:org.fao.geonet.util.XslUtil}reprojectCoords",
             "{java:org.fao.geonet.util.XslUtil}geomToBbox",
-            "{java:org.fao.geonet.util.XslUtil}getRecord",
+            "{java:org.fao.geonet.util.XslUtil}getRecordIfViewable",
             "{java:org.fao.geonet.util.XslUtil}evaluate",
             "{java:org.fao.geonet.util.XslUtil}getSiteUrl",
             "{java:org.fao.geonet.util.XslUtil}getPermalink",

--- a/core/src/main/java/org/fao/geonet/util/XslUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/XslUtil.java
@@ -55,6 +55,7 @@ import org.fao.geonet.api.records.attachments.FilesystemStoreResourceContainer;
 import org.fao.geonet.api.records.attachments.Store;
 import org.fao.geonet.constants.Geonet;
 import org.fao.geonet.domain.*;
+import org.fao.geonet.exceptions.OperationNotAllowedEx;
 import org.fao.geonet.kernel.*;
 import org.fao.geonet.kernel.datamanager.base.BaseMetadataUtils;
 import org.fao.geonet.kernel.search.CodeListTranslator;
@@ -99,6 +100,7 @@ import org.springframework.beans.factory.annotation.BeanFactoryAnnotationUtils;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ConfigurableApplicationContext;
 import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.authentication.AnonymousAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -1222,7 +1224,20 @@ public final class XslUtil {
                             uuid));
                         return null;
                     }
-                    Lib.resource.checkPrivilege(context, id, ReservedOperation.view);
+                    try {
+                        Lib.resource.checkPrivilege(context, id, ReservedOperation.view);
+                    } catch (OperationNotAllowedEx | AccessDeniedException e) {
+                        // The current user is not allowed to view this record. This is an
+                        // expected outcome (eg. a formatter referencing a record the viewer
+                        // can't see), not a failure, so log at debug and return null instead
+                        // of falling through to the error path below.
+                        if (Log.isDebugEnabled(Geonet.GEONETWORK)) {
+                            Log.debug(Geonet.GEONETWORK, String.format(
+                                "XslUtil getRecordIfViewable: record %s is not viewable by the current user.",
+                                uuid));
+                        }
+                        return null;
+                    }
                 }
 
                 Element metadata = dataManager.getMetadata(id);

--- a/core/src/main/java/org/fao/geonet/util/XslUtil.java
+++ b/core/src/main/java/org/fao/geonet/util/XslUtil.java
@@ -1176,16 +1176,55 @@ public final class XslUtil {
      * Retrieve a metadata record. Use this function only
      * to retrieve records visible for current user. This
      * does not make any security checks.
+     *
+     * This is used by internal processes (eg. indexing) which
+     * may run asynchronously with no user session bound to the
+     * current thread. Do NOT expose this function to untrusted
+     * XSLT (eg. formatters) - use {@link #getRecordIfViewable(String)}
+     * instead which enforces the view privilege for the current user.
      */
     public static Node getRecord(String uuid) {
         return getRecord(uuid, null);
     }
     public static Node getRecord(String uuid, String schema) {
+        return getRecord(uuid, schema, false);
+    }
+
+    /**
+     * Retrieve a metadata record, only if it is visible to the current user
+     * (ie. the user is granted the view operation on the record), similar to
+     * {@code ApiUtils#canViewRecord}. Returns {@code null} if the record does
+     * not exist or is not visible to the current user (or if there is no
+     * user session bound to the current thread to check against).
+     *
+     * This is the function that should be exposed to untrusted XSLT (eg.
+     * formatters) that may be used to retrieve records other than the one
+     * currently being processed.
+     */
+    public static Node getRecordIfViewable(String uuid) {
+        return getRecordIfViewable(uuid, null);
+    }
+    public static Node getRecordIfViewable(String uuid, String schema) {
+        return getRecord(uuid, schema, true);
+    }
+
+    private static Node getRecord(String uuid, String schema, boolean checkPrivilege) {
         ApplicationContext applicationContext = ApplicationContextHolder.get();
         DataManager dataManager = applicationContext.getBean(DataManager.class);
         try {
             String id = dataManager.getMetadataId(uuid);
             if (id != null) {
+                if (checkPrivilege) {
+                    ServiceContext context = ServiceContext.get();
+                    if (context == null) {
+                        Log.warning(Geonet.GEONETWORK, String.format(
+                            "XslUtil getRecordIfViewable warning: Can't retrieve record %s. No service context available to check user privileges.",
+                            uuid));
+                        return null;
+                    }
+                    Lib.resource.checkPrivilege(context, id, ReservedOperation.view);
+                }
+
                 Element metadata = dataManager.getMetadata(id);
                 String metadataSchema = dataManager.getMetadataSchema(id);
 

--- a/core/src/test/java/org/fao/geonet/util/XslUtilTest.java
+++ b/core/src/test/java/org/fao/geonet/util/XslUtilTest.java
@@ -144,6 +144,25 @@ public class XslUtilTest {
     }
 
     @Test
+    public void testGetRecordIfViewableReturnsNullWhenAuthenticatedUserNotAllowed() throws Exception {
+        DataManager dataManager = mockDataManagerWithRecord();
+        // Authenticated user without the view operation: checkPrivilege throws
+        // AccessDeniedException (rather than OperationNotAllowedEx). Both are
+        // treated as an expected "not viewable" outcome, returning null.
+        ServiceContext context = mockServiceContextGrantingOperations(Collections.emptySet());
+        when(context.getUserSession().isAuthenticated()).thenReturn(true);
+
+        try (MockedStatic<ServiceContext> serviceContextMock = mockStatic(ServiceContext.class)) {
+            serviceContextMock.when(ServiceContext::get).thenReturn(context);
+
+            org.w3c.dom.Node node = XslUtil.getRecordIfViewable(UUID);
+
+            assertNull(node);
+            verify(dataManager, never()).getMetadata(anyString());
+        }
+    }
+
+    @Test
     public void testGetRecordIfViewableReturnsNullWhenNoServiceContext() throws Exception {
         DataManager dataManager = mockDataManagerWithRecord();
 

--- a/core/src/test/java/org/fao/geonet/util/XslUtilTest.java
+++ b/core/src/test/java/org/fao/geonet/util/XslUtilTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2001-2022 Food and Agriculture Organization of the
+ * Copyright (C) 2001-2026 Food and Agriculture Organization of the
  * United Nations (FAO-UN), United Nations World Food Programme (WFP)
  * and United Nations Environment Programme (UNEP)
  *
@@ -23,13 +23,145 @@
 
 package org.fao.geonet.util;
 
+import jeeves.server.UserSession;
+import jeeves.server.context.ServiceContext;
+import org.fao.geonet.ApplicationContextHolder;
+import org.fao.geonet.domain.Operation;
+import org.fao.geonet.domain.ReservedOperation;
+import org.fao.geonet.kernel.AccessManager;
+import org.fao.geonet.kernel.DataManager;
+import org.jdom.Element;
+import org.junit.After;
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.springframework.context.ConfigurableApplicationContext;
+
+import java.util.Collections;
+import java.util.Set;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 public class XslUtilTest {
+
+    private static final String UUID = "test-uuid";
+    private static final String METADATA_ID = "42";
+
+    @After
+    public void tearDown() {
+        ApplicationContextHolder.clear();
+    }
+
+    private DataManager mockDataManagerWithRecord() throws Exception {
+        ConfigurableApplicationContext applicationContext = mock(ConfigurableApplicationContext.class);
+        DataManager dataManager = mock(DataManager.class);
+        when(applicationContext.getBean(DataManager.class)).thenReturn(dataManager);
+        when(dataManager.getMetadataId(UUID)).thenReturn(METADATA_ID);
+        when(dataManager.getMetadataSchema(METADATA_ID)).thenReturn("iso19139");
+        when(dataManager.getMetadata(METADATA_ID)).thenReturn(new Element("MD_Metadata"));
+
+        ApplicationContextHolder.set(applicationContext);
+        return dataManager;
+    }
+
+    private ServiceContext mockServiceContextGrantingOperations(Set<Operation> operations) throws Exception {
+        ServiceContext context = mock(ServiceContext.class);
+        AccessManager accessManager = mock(AccessManager.class);
+        UserSession userSession = mock(UserSession.class);
+
+        when(context.getBean(AccessManager.class)).thenReturn(accessManager);
+        when(context.getIpAddress()).thenReturn("127.0.0.1");
+        when(context.getUserSession()).thenReturn(userSession);
+        when(userSession.isAuthenticated()).thenReturn(false);
+        when(accessManager.getOperations(eq(context), anyString(), anyString())).thenReturn(operations);
+
+        return context;
+    }
+
+    private static Set<Operation> viewAllowed() {
+        return Collections.singleton(new Operation().setId(ReservedOperation.view.getId()));
+    }
+
+    @Test
+    public void testGetRecordDoesNotCheckPrivileges() throws Exception {
+        DataManager dataManager = mockDataManagerWithRecord();
+
+        // No ServiceContext at all bound to the thread (eg. async indexing) -
+        // the unchecked getRecord() must still return the record.
+        try (MockedStatic<ServiceContext> serviceContextMock = mockStatic(ServiceContext.class)) {
+            serviceContextMock.when(ServiceContext::get).thenReturn(null);
+
+            org.w3c.dom.Node node = XslUtil.getRecord(UUID);
+
+            assertNotNullRecord(node);
+        }
+    }
+
+    @Test
+    public void testGetRecordUnknownUuidReturnsNull() throws Exception {
+        mockDataManagerWithRecord();
+
+        assertNull(XslUtil.getRecord("does-not-exist"));
+        assertNull(XslUtil.getRecordIfViewable("does-not-exist"));
+    }
+
+    @Test
+    public void testGetRecordIfViewableReturnsRecordWhenViewAllowed() throws Exception {
+        DataManager dataManager = mockDataManagerWithRecord();
+        ServiceContext context = mockServiceContextGrantingOperations(viewAllowed());
+
+        try (MockedStatic<ServiceContext> serviceContextMock = mockStatic(ServiceContext.class)) {
+            serviceContextMock.when(ServiceContext::get).thenReturn(context);
+
+            org.w3c.dom.Node node = XslUtil.getRecordIfViewable(UUID);
+
+            assertNotNullRecord(node);
+        }
+    }
+
+    @Test
+    public void testGetRecordIfViewableReturnsNullWhenViewNotAllowed() throws Exception {
+        DataManager dataManager = mockDataManagerWithRecord();
+        ServiceContext context = mockServiceContextGrantingOperations(Collections.emptySet());
+
+        try (MockedStatic<ServiceContext> serviceContextMock = mockStatic(ServiceContext.class)) {
+            serviceContextMock.when(ServiceContext::get).thenReturn(context);
+
+            org.w3c.dom.Node node = XslUtil.getRecordIfViewable(UUID);
+
+            assertNull(node);
+            verify(dataManager, never()).getMetadata(anyString());
+        }
+    }
+
+    @Test
+    public void testGetRecordIfViewableReturnsNullWhenNoServiceContext() throws Exception {
+        DataManager dataManager = mockDataManagerWithRecord();
+
+        try (MockedStatic<ServiceContext> serviceContextMock = mockStatic(ServiceContext.class)) {
+            serviceContextMock.when(ServiceContext::get).thenReturn(null);
+
+            org.w3c.dom.Node node = XslUtil.getRecordIfViewable(UUID);
+
+            assertNull(node);
+            verify(dataManager, never()).getMetadata(anyString());
+        }
+    }
+
+    private static void assertNotNullRecord(org.w3c.dom.Node node) {
+        org.junit.Assert.assertNotNull(node);
+        org.w3c.dom.Document domDocument = (org.w3c.dom.Document) node;
+        assertEquals("MD_Metadata", domDocument.getDocumentElement().getTagName());
+    }
 
     @Test
     public void testHtml2text() {


### PR DESCRIPTION
In `XslUtil` keep `getRecord` for internal callers that run without a bound user session (eg. the async indexing pipeline), and add `getRecordIfViewable`, which enforces the view privilege for formatters. 

Point the untrusted-formatter allowlist at `getRecordIfViewable` instead of `getRecord`.

---

Claude Sonnet 5 has been used to review the changes to improve the code quality and generate unit tests.

# Checklist

- [X] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [X] *Pull request* provided for `main` branch, backports managed with label
- [X] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [X] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [X] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [ ] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [ ] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

