### PR TITLE
Proxy / Extend and normalise the list of hosts excluded from the proxy

### DIFF
--- a/docs/manual/docs/install-guide/installing-with-docker.md
+++ b/docs/manual/docs/install-guide/installing-with-docker.md
@@ -11,3 +11,19 @@ docker run --name some-geonetwork -d geonetwork
 ```
 
 See [docker-library/docs](https://github.com/docker-library/docs/tree/master/geonetwork) for more details.
+
+## Configuration
+
+Settings that a source installation would change in ``WEB-INF/web.xml`` are reached in a container through an environment variable instead, so the image does not have to be rebuilt or its files edited.
+
+The web proxy is the usual case. It ships with a list of hosts it refuses to fetch, and a deployment that has hosts of its own to keep out of reach adds them to that list:
+
+``` shell
+docker run --name some-geonetwork -d \
+  -e 'GEONETWORK_HTTPPROXY_EXCLUDEHOSTS=^(localhost|...|internal\.example\.org)$' \
+  geonetwork
+```
+
+The value replaces the shipped list, abbreviated here as ``...``, so start from the value in ``WEB-INF/web.xml`` and add to it. Dropping an entry from it puts that host back within reach of the proxy.
+
+Both settings, the form of their names, and what the default list covers are described in [Hosts and ports the proxy can reach](../maintainer-guide/production-use/index.md#proxy-hosts-and-ports).

--- a/docs/manual/docs/maintainer-guide/production-use/index.md
+++ b/docs/manual/docs/maintainer-guide/production-use/index.md
@@ -59,7 +59,7 @@ A best practice is to whitelist a series of servers which are known to contain d
 
 If configured incorrectly, remote users may gain access to restricted resources, or impersonate the GeoNetwork server while browsing the web.
 
-GeoNetwork has 2 modes to limit the access via the proxy. The configuration of this mode is defined in ``WEB-INF/web.xml``.
+GeoNetwork has two modes to limit the access via the proxy. The configuration of this mode is defined in ``WEB-INF/web.xml``.
 
 ``` xml
 <init-param>
@@ -73,12 +73,82 @@ GeoNetwork has 2 modes to limit the access via the proxy. The configuration of t
 
 It is recommended to use the DB_LINK_CHECK mode. The following rules apply:
 
--   Authenticated users can use the proxy to all domains.
+-   Authenticated users can use the proxy to all domains, apart from the hosts kept out of reach by the exclusion list described below.
 -   For anonymous users, if the host of the URL requested is not used in any metadata record links, then a NotAllowedException is returned. If a WMS URL is registered, all GetCapabilities, GetFeatureInfo will be accepted. That's why only a host check is done.
 -   Also if a request is made directly to the proxy, a SecurityException is returned because no session exist. This limit its usage to user with a catalog session.
 -   Catalog reviewers have to use the metadata link analysis tool to register links allowed for the proxy. The tool is available at 'Record and link analysis' in the ``Admin --> Statistics & status`` menu. In the future we may trigger link analysis as a background task to have an up to date list of links. For now, if the table is empty, the exception highlights the fact that the link analysis tool should be used to populate the list.
 
 One issue that anonymous users can encounter is if using the map viewer and the user adds a WMS/WFS service URL which is not registered in any metadata records and which has no CORS enabled. The user will not be able to add any layers from those services.
+
+### Hosts and ports the proxy can reach {#proxy-hosts-and-ports}
+
+Independently of the security mode, the proxy refuses a request whose host matches ``excludeHosts``. It also refuses a request naming a port other than 80, 443, or one of the ports listed in ``allowPorts``; a URL that names no port at all uses the default of its protocol and is accepted. Both settings are defined in ``WEB-INF/web.xml`` and both apply to every caller, authenticated or not.
+
+``` xml
+<init-param>
+  <param-name>excludeHosts</param-name>
+  <param-value>^(localhost|127\..*|...)$</param-value>
+</init-param>
+<init-param>
+  <param-name>allowPorts</param-name>
+  <param-value>8443|8080</param-value>
+</init-param>
+```
+
+``excludeHosts`` is a regular expression matched against the whole host. Matching ignores case, since a host name is not case sensitive. Its default value keeps the proxy away from the server itself and from the ranges reserved for private networks:
+
+-   the loopback addresses, ``localhost``, ``127.0.0.0/8`` and ``::1``, and the ``.local`` and ``.localhost`` domains
+-   the unspecified addresses, ``0.0.0.0/8`` and ``::``, and the broadcast address ``255.255.255.255``
+-   the private ranges of RFC 1918, ``10.0.0.0/8``, ``172.16.0.0/12`` and ``192.168.0.0/16``
+-   the link-local range ``169.254.0.0/16``, the shared address space ``100.64.0.0/10``, and the benchmarking range ``198.18.0.0/15``
+-   the multicast range ``224.0.0.0/4``
+-   the IPv6 unique local, link-local and site-local ranges, ``fc00::/7``, ``fe80::/10`` and ``fec0::/10``
+-   the IPv6 ranges that carry an IPv4 address, ``::/96`` and the NAT64 prefix ``64:ff9b::/96``
+
+An address can be written in more than one way, so the host is compared in several forms: as it appears in the URL, without the brackets that surround an IPv6 literal, and in the canonical form of the address it denotes. An entry therefore applies whichever way a caller spells an address, and a single entry covers every spelling of it.
+
+#### Adding an IPv6 address
+
+The same address can be written in several ways, so an entry is best written in the canonical form: lower case, all eight groups spelled out, no ``::`` and no leading zeros. That form is the one the proxy derives from whatever the caller sent, so a single entry covers every spelling. To exclude the host ``2001:db8:1::10``, write its canonical form ``2001:db8:1:0:0:0:0:10``. To exclude a whole prefix, keep the groups the prefix fixes and finish with ``.*``: ``2001:db8:2::/48`` becomes ``2001:db8:2:.*``.
+
+``` xml
+<init-param>
+  <param-name>excludeHosts</param-name>
+  <param-value>^(localhost|127\..*|2001:db8:1:0:0:0:0:10|2001:db8:2:.*)$</param-value>
+</init-param>
+```
+
+Those two entries exclude ``[2001:db8:1::10]``, ``[2001:db8:1:0:0:0:0:10]`` and ``[2001:0db8:0001::0010]``, which are the same address, along with every address under ``2001:db8:2::/48``.
+
+Three details are worth keeping in mind:
+
+-   Write the entry without the square brackets of a URL. They are part of the URL syntax, not of the address. An entry that keeps them is still matched, but only against that one way of writing the address, so it misses the other spellings of the same host.
+-   Keep the colon that closes a prefix. ``2001:db8:2:.*`` stops at the addresses under ``2001:db8:2``, whereas ``2001:db8:2.*`` would also take in ``2001:db8:20`` and ``2001:db8:2a``, which are different networks.
+-   A prefix is straightforward to write when its length is a multiple of 16, since it ends on a group boundary. For a length such as /56, which cuts a group in two, exclude the enclosing /48 rather than trying to express the exact boundary in a regular expression.
+
+#### Setting them without editing web.xml {#proxy-settings-outside-web-xml}
+
+Both settings can be given outside ``WEB-INF/web.xml``, which is what you want when the file sits inside a container image. Each is looked up in turn as an environment variable, a Java system property, and an entry of ``WEB-INF/config.properties``, and the value in ``web.xml`` is used only when none of the three is set.
+
+The name of the property is the name of the servlet, ``HttpProxy``, between the ``geonetwork`` prefix and the name of the setting:
+
+-   ``geonetwork.HttpProxy.excludeHosts``
+-   ``geonetwork.HttpProxy.allowPorts``
+
+As an environment variable the same name is written in upper case with underscores in place of the dots:
+
+``` shell
+docker run --name geonetwork \
+  -e 'GEONETWORK_HTTPPROXY_EXCLUDEHOSTS=^(localhost|...|internal\.example\.org)$' \
+  -e 'GEONETWORK_HTTPPROXY_ALLOWPORTS=8080|8443' \
+  geonetwork
+```
+
+A value given this way replaces the default list rather than adding to it. Copy the value shipped in ``web.xml``, shown abbreviated above as ``...``, and put your own entries inside the same parentheses; an entry left out is an entry the proxy is once again free to fetch.
+
+If the catalogue is deployed under a context path other than ``/geonetwork``, that path is also accepted in place of the ``geonetwork`` prefix, so a catalogue served from ``/catalogue`` reads ``catalogue.HttpProxy.excludeHosts`` first and falls back to the ``geonetwork`` name.
+
+Keep those defaults and add your own entries for any other host the catalogue should not be asked to fetch. Entries are matched against the host as it appears in the request. Where the catalogue is published in front of a private network, restricting the outbound traffic of the server at the network level is worthwhile too, and use ``allowPorts`` sparingly, since every port added there is opened towards every host the proxy accepts.
 
 ## WEB
 

--- a/pom.xml
+++ b/pom.xml
@@ -1618,7 +1618,7 @@
     -->
     <proxy.securityMode>DB_LINK_CHECK</proxy.securityMode>
     <!-- Hosts to exclude from http proxy access: typically localhost, intranet resources -->
-    <proxy.excludeHosts>^(localhost|127\..*|0\..*|255\.255\.255\.255|.*\.local|.*\.localhost|0:0:0:0:0:0:1|::1)$</proxy.excludeHosts>
+    <proxy.excludeHosts>^(localhost|127\..*|0\..*|10\..*|172\.(1[6-9]|2[0-9]|3[01])\..*|192\.168\..*|169\.254\..*|100\.(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7])\..*|198\.1[89]\..*|2(2[4-9]|3[0-9])\..*|255\.255\.255\.255|.*\.local|.*\.localhost|0:0:0:0:0:0:.*|::1|::|64:ff9b:.*|f[cd][0-9a-f]{2}:.*|fe[89ab][0-9a-f]:.*|fe[c-f][0-9a-f]:.*)$</proxy.excludeHosts>
 
     <!-- Additional ports (separated by | char) allowed to be access through the http proxy. 80 and 443 are always allowed -->
     <proxy.allowPorts></proxy.allowPorts>

--- a/web/src/main/java/org/fao/geonet/proxy/URITemplateProxyServlet.java
+++ b/web/src/main/java/org/fao/geonet/proxy/URITemplateProxyServlet.java
@@ -62,9 +62,11 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URLEncoder;
+import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.util.*;
 import java.util.regex.Matcher;
@@ -102,6 +104,9 @@ public class URITemplateProxyServlet extends ProxyServlet {
     private static final String TARGET_URI_NAME = "targetUri";
     private static final String P_EXCLUDE_HOSTS = "excludeHosts";
     private static final String P_ALLOW_PORTS = "allowPorts";
+    // An IPv4 address can be written as a single number, at most the ten digits of 4294967295.
+    private static final Pattern DECIMAL_ADDRESS_PATTERN = Pattern.compile("\\d{1,10}");
+    private static final long MAX_IPV4_ADDRESS = 4294967295L;
     private static final String ATTR_QUERY_STRING =
         URITemplateProxyServlet.class.getSimpleName() + ".queryString";
 
@@ -222,7 +227,7 @@ public class URITemplateProxyServlet extends ProxyServlet {
 
         if (StringUtils.isNotBlank(excludeHosts)) {
             try {
-                this.excludeHostsPattern = Pattern.compile(excludeHosts);
+                setExcludeHosts(excludeHosts);
             } catch (PatternSyntaxException ex) {
                 throw new ServletException(P_EXCLUDE_HOSTS + " doesn't contain a valid regular expression");
             }
@@ -483,20 +488,23 @@ public class URITemplateProxyServlet extends ProxyServlet {
     }
 
     private boolean isUrlAllowed(HttpServletRequest servletRequest) {
-        String url = servletRequest.getParameter("url");
+        String url = getRequestedUrl(servletRequest.getQueryString());
         if (isBlank(url)) {
             return true;
         }
 
         try {
             URI uri = new URI(url);
+            String host = uri.getHost();
 
-            if (this.excludeHostsPattern != null) {
-                Matcher matcher = this.excludeHostsPattern.matcher(uri.getHost());
+            // A URL the parser cannot attribute a host to cannot be checked against the exclusion
+            // list, so it is not allowed.
+            if (isBlank(host)) {
+                return false;
+            }
 
-                if (matcher.matches()) {
-                    return false;
-                }
+            if (isExcludedHost(host)) {
+                return false;
             }
 
             int port = uri.getPort();
@@ -509,6 +517,150 @@ public class URITemplateProxyServlet extends ProxyServlet {
                 e.getMessage()
             ));
         }
+    }
+
+    /**
+     * Compile the list of hosts to keep out of reach of the proxy.
+     *
+     * <p>Matching ignores case: a host name is not case sensitive, and {@link URI#getHost()} returns
+     * whatever case the caller wrote, so an entry has to match the host in any case it arrives in.
+     * Compiling in one place keeps every caller, the tests included, on the same terms as the
+     * servlet rather than repeating the flags and drifting from them.</p>
+     *
+     * @param excludeHosts regular expression matched against the host of a requested URL
+     * @throws PatternSyntaxException if the expression cannot be compiled
+     */
+    void setExcludeHosts(String excludeHosts) {
+        this.excludeHostsPattern = Pattern.compile(excludeHosts, Pattern.CASE_INSENSITIVE);
+    }
+
+    /**
+     * Read the url parameter as the value the target is built from.
+     *
+     * <p>The target is filled in from the query string, and a parameter given more than once is
+     * joined with commas there, so the string that is fetched is not always the first value
+     * {@link HttpServletRequest#getParameter(String)} returns. Reading it the same way keeps the
+     * value that is checked and the value that is requested the same string, which they are not if
+     * only the first value is read: given two of them, the first can be a host that no entry
+     * excludes while the join denotes another host entirely.</p>
+     *
+     * @param requestQueryString query string of the request, which may be {@code null}
+     * @return the url parameter as the target uses it, or {@code null} if the request carries none
+     */
+    String getRequestedUrl(String requestQueryString) {
+        if (requestQueryString == null) {
+            return null;
+        }
+
+        // Read it exactly as internalService does, fragment removed and parsed from the query.
+        String queryString = "?" + requestQueryString;
+        int hash = queryString.indexOf('#');
+        if (hash >= 0) {
+            queryString = queryString.substring(0, hash);
+        }
+
+        List<String> values = new ArrayList<>();
+        try {
+            for (NameValuePair pair : URLEncodedUtils.parse(new URI(queryString), StandardCharsets.UTF_8)) {
+                if ("url".equals(pair.getName())) {
+                    values.add(pair.getValue());
+                }
+            }
+        } catch (URISyntaxException e) {
+            // internalService rejects the same string, so no request is made from it either.
+            return null;
+        }
+
+        return values.isEmpty() ? null : String.join(",", values);
+    }
+
+    /**
+     * Check the host of the requested URL against the exclusion pattern.
+     *
+     * <p>An IPv6 literal is written in several ways and {@link URI#getHost()} returns it wrapped in
+     * brackets, exactly as the caller spelled it. Matching only that string means an exclusion entry
+     * has to repeat every spelling, and has to carry the brackets, to be of any use. The host is
+     * therefore compared in three forms: as returned, without the brackets of an IPv6 literal, and
+     * in the canonical form of the address that literal denotes, which is the same string for all of
+     * its spellings.</p>
+     *
+     * @param host host part of the requested URL, as returned by {@link URI#getHost()}
+     * @return {@code true} if any form of the host matches the exclusion pattern
+     */
+    boolean isExcludedHost(String host) {
+        if (this.excludeHostsPattern == null) {
+            return false;
+        }
+
+        for (String candidate : getHostVariants(host)) {
+            if (this.excludeHostsPattern.matcher(candidate).matches()) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * Build the forms of a host that the exclusion pattern is matched against.
+     *
+     * @param host host part of the requested URL, as returned by {@link URI#getHost()}
+     * @return the host as provided, plus the unbracketed and canonical forms of an IPv6 literal
+     */
+    Set<String> getHostVariants(String host) {
+        Set<String> variants = new LinkedHashSet<>();
+        variants.add(host);
+
+        if (host.startsWith("[") && host.endsWith("]")) {
+            variants.add(host.substring(1, host.length() - 1));
+
+            try {
+                // A literal is not resolved, so this does not query the name service.
+                variants.add(InetAddress.getByName(host).getHostAddress());
+            } catch (UnknownHostException e) {
+                LOGGER.debug("Could not read '" + host + "' as an IP address: " + e.getMessage());
+            }
+        }
+
+        String dottedQuad = asDottedQuad(host);
+        if (dottedQuad != null) {
+            variants.add(dottedQuad);
+        }
+
+        return variants;
+    }
+
+    /**
+     * Rewrite an IPv4 address written as a single decimal number into its dotted form.
+     *
+     * <p>An address can be written as one number, so http://2130706433/ is a way of writing
+     * http://127.0.0.1/ that an exclusion entry listing the dotted form does not cover. A host made
+     * only of digits is never a host name, since the last label of a name cannot be all digits, so
+     * it is safe to read as an address. The conversion follows the same rule as the platform, which
+     * reads a lone number as the whole of the address.</p>
+     *
+     * <p>This one form is the only one converted, because it is the only one the platform reads as
+     * an address. Checked on 8, 11, 17, 21 and 25, all of which resolve a lone number and none of
+     * which resolve the hexadecimal or octal spellings, {@code 0x7f000001} and {@code 017700000001},
+     * so those denote no host rather than a host written oddly. A dotted form of fewer than four
+     * parts, {@code 127.1} or {@code 0x7f.0.0.1}, leaves {@link URI#getHost()} returning null and is
+     * refused before reaching this point.</p>
+     *
+     * @param host host part of the requested URL, as returned by {@link URI#getHost()}
+     * @return the dotted form of the address, or {@code null} if the host is not a lone number
+     */
+    private String asDottedQuad(String host) {
+        if (!DECIMAL_ADDRESS_PATTERN.matcher(host).matches()) {
+            return null;
+        }
+
+        long value = Long.parseLong(host);
+        if (value > MAX_IPV4_ADDRESS) {
+            return null;
+        }
+
+        return String.format("%d.%d.%d.%d",
+            (value >>> 24) & 0xFF, (value >>> 16) & 0xFF, (value >>> 8) & 0xFF, value & 0xFF);
     }
 
     /**

--- a/web/src/test/java/org/fao/geonet/proxy/URITemplateProxyServletTest.java
+++ b/web/src/test/java/org/fao/geonet/proxy/URITemplateProxyServletTest.java
@@ -1,0 +1,341 @@
+/*
+ * Copyright (C) 2001-2026 Food and Agriculture Organization of the
+ * United Nations (FAO-UN), United Nations World Food Programme (WFP)
+ * and United Nations Environment Programme (UNEP)
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or (at
+ * your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful, but
+ * WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301, USA
+ *
+ * Contact: Jeroen Ticheler - FAO - Viale delle Terme di Caracalla 2,
+ * Rome - Italy. email: geonetwork@osgeo.org
+ */
+package org.fao.geonet.proxy;
+
+import org.junit.Before;
+import org.junit.Test;
+
+import java.net.URI;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+/**
+ * Checks that the hosts excluded from proxy access are recognised whichever way they are written.
+ */
+public class URITemplateProxyServletTest {
+
+    /**
+     * The default of the proxy.excludeHosts property, kept in sync with the value in the root pom.xml.
+     */
+    private static final String DEFAULT_EXCLUDE_HOSTS =
+        "^(localhost|127\\..*|0\\..*|10\\..*|172\\.(1[6-9]|2[0-9]|3[01])\\..*|192\\.168\\..*|169\\.254\\..*|100\\.(6[4-9]|[7-9][0-9]|1[01][0-9]|12[0-7])\\..*|198\\.1[89]\\..*|2(2[4-9]|3[0-9])\\..*|255\\.255\\.255\\.255|.*\\.local|.*\\.localhost|0:0:0:0:0:0:.*|::1|::|64:ff9b:.*|f[cd][0-9a-f]{2}:.*|fe[89ab][0-9a-f]:.*|fe[c-f][0-9a-f]:.*)$";
+
+    private URITemplateProxyServlet servlet;
+
+    @Before
+    public void setUp() {
+        servlet = new URITemplateProxyServlet();
+        servlet.setExcludeHosts(DEFAULT_EXCLUDE_HOSTS);
+    }
+
+    /**
+     * Read the host the way the servlet does, so the tests exercise the string it really matches on.
+     */
+    private String hostOf(String url) throws Exception {
+        return new URI(url).getHost();
+    }
+
+    private void assertExcluded(String url) throws Exception {
+        assertTrue(url + " should be excluded", servlet.isExcludedHost(hostOf(url)));
+    }
+
+    private void assertNotExcluded(String url) throws Exception {
+        assertFalse(url + " should not be excluded", servlet.isExcludedHost(hostOf(url)));
+    }
+
+    @Test
+    public void uriGetHostKeepsTheBracketsOfAnIpv6Literal() throws Exception {
+        // The reason the bare IPv6 entries of the pattern never matched anything.
+        assertEquals("[::1]", hostOf("http://[::1]/"));
+    }
+
+    @Test
+    public void ipv6LoopbackIsExcludedHoweverItIsSpelled() throws Exception {
+        assertExcluded("http://[::1]/");
+        assertExcluded("http://[0:0:0:0:0:0:0:1]/");
+        assertExcluded("http://[0000:0000:0000:0000:0000:0000:0000:0001]/");
+        assertExcluded("http://[::0001]/");
+    }
+
+    @Test
+    public void ipv6UnspecifiedIsExcluded() throws Exception {
+        assertExcluded("http://[::]/");
+        assertExcluded("http://[0:0:0:0:0:0:0:0]/");
+    }
+
+    @Test
+    public void ipv4MappedLoopbackIsExcluded() throws Exception {
+        // Canonicalises to 127.0.0.1, which the existing 127\..* entry already covers.
+        assertExcluded("http://[::ffff:127.0.0.1]/");
+    }
+
+    @Test
+    public void ipv4LoopbackIsStillExcluded() throws Exception {
+        assertExcluded("http://127.0.0.1/");
+        assertExcluded("http://127.1.2.3/");
+        assertExcluded("http://localhost/");
+    }
+
+    @Test
+    public void privateRangesAreExcluded() throws Exception {
+        assertExcluded("http://10.0.0.5/");
+        assertExcluded("http://10.255.255.255/");
+        assertExcluded("http://172.16.4.9/");
+        assertExcluded("http://172.31.255.254/");
+        assertExcluded("http://192.168.1.1/");
+        assertExcluded("http://192.168.117.2/");
+    }
+
+    @Test
+    public void linkLocalRangeIsExcluded() throws Exception {
+        assertExcluded("http://169.254.169.254/");
+        assertExcluded("http://169.254.0.1/");
+    }
+
+    @Test
+    public void addressesJustOutsideThePrivateRangesAreNotExcluded() throws Exception {
+        // 172.16/12 runs from 172.16 to 172.31, the neighbours of that range stay reachable.
+        assertNotExcluded("http://172.15.0.1/");
+        assertNotExcluded("http://172.32.0.1/");
+        assertNotExcluded("http://11.0.0.1/");
+        assertNotExcluded("http://9.255.255.255/");
+        assertNotExcluded("http://192.167.0.1/");
+        assertNotExcluded("http://192.169.0.1/");
+        assertNotExcluded("http://169.253.0.1/");
+        assertNotExcluded("http://169.255.0.1/");
+    }
+
+    @Test
+    public void addressWrittenAsASingleNumberIsExcluded() throws Exception {
+        assertExcluded("http://2130706433/");   // 127.0.0.1
+        assertExcluded("http://3232261122/");   // 192.168.100.2
+        assertExcluded("http://2852039166/");   // 169.254.169.254
+        assertExcluded("http://167772161/");    // 10.0.0.1
+        assertExcluded("http://4294967295/");   // 255.255.255.255
+    }
+
+    @Test
+    public void addressWrittenAsASingleNumberIsNotExcludedWhenItIsPublic() throws Exception {
+        assertNotExcluded("http://134744072/");  // 8.8.8.8
+    }
+
+    @Test
+    public void aNumberTooLargeForAnAddressIsLeftAlone() {
+        // Not an address, so nothing is added and nothing throws.
+        assertEquals(1, servlet.getHostVariants("4294967296").size());
+        assertEquals(1, servlet.getHostVariants("99999999999999999999").size());
+    }
+
+    @Test
+    public void hostVariantsCarryTheDottedFormOfANumericAddress() {
+        assertTrue(servlet.getHostVariants("2130706433").contains("127.0.0.1"));
+        assertTrue(servlet.getHostVariants("2130706433").contains("2130706433"));
+    }
+
+    @Test
+    public void ipv6UniqueLocalRangeIsExcluded() throws Exception {
+        assertExcluded("http://[fc00::1]/");
+        assertExcluded("http://[fd00::1]/");
+        assertExcluded("http://[fd12:3456:789a::1]/");
+        assertExcluded("http://[fdff:ffff::1]/");
+        assertExcluded("http://[FD00::1]/");
+    }
+
+    @Test
+    public void ipv6LinkLocalRangeIsExcluded() throws Exception {
+        assertExcluded("http://[fe80::1]/");
+        assertExcluded("http://[fe8f::1]/");
+        assertExcluded("http://[febf::1]/");
+    }
+
+    @Test
+    public void ipv6SiteLocalRangeIsExcluded() throws Exception {
+        // Deprecated by RFC 3879, still private where it is in use.
+        assertExcluded("http://[fec0::1]/");
+        assertExcluded("http://[feff::1]/");
+    }
+
+    @Test
+    public void addressesJustOutsideThePrivateIpv6RangesAreNotExcluded() throws Exception {
+        assertNotExcluded("http://[fbff::1]/");   // below fc00::/7
+        assertNotExcluded("http://[fe00::1]/");   // below fe80::/10
+        assertNotExcluded("http://[fe7f::1]/");   // below fe80::/10
+    }
+
+    @Test
+    public void documentedIpv6EntriesCoverEverySpellingOfTheAddress() throws Exception {
+        // The example given in the maintainer guide: one host, and one whole /48 prefix, both
+        // written in the canonical form of the address.
+        servlet.setExcludeHosts("^(2001:db8:1:0:0:0:0:10|2001:db8:2:.*)$");
+
+        assertExcluded("http://[2001:db8:1::10]/");
+        assertExcluded("http://[2001:db8:1:0:0:0:0:10]/");
+        assertExcluded("http://[2001:0db8:0001::0010]/");
+        assertExcluded("http://[2001:DB8:1::10]/");
+
+        assertExcluded("http://[2001:db8:2::1]/");
+        assertExcluded("http://[2001:db8:2:ffff::99]/");
+    }
+
+    @Test
+    public void documentedIpv6EntriesLeaveTheNeighbouringAddressesAlone() throws Exception {
+        servlet.setExcludeHosts("^(2001:db8:1:0:0:0:0:10|2001:db8:2:.*)$");
+
+        assertNotExcluded("http://[2001:db8:1::11]/");
+        // The colon at the end of the prefix keeps 2a and 20 out of a /48 written for 2.
+        assertNotExcluded("http://[2001:db8:2a::1]/");
+        assertNotExcluded("http://[2001:db8:20::1]/");
+        assertNotExcluded("http://[2001:db8:3::1]/");
+    }
+
+    @Test
+    public void anExcludedHostIsRecognisedInAnyCase() throws Exception {
+        // A host name is not case sensitive, and URI.getHost() keeps the case the caller wrote.
+        assertExcluded("http://LOCALHOST/");
+        assertExcluded("http://LocalHost/");
+        assertExcluded("http://MYHOST.LOCAL/");
+        assertExcluded("http://X.LOCALHOST/");
+    }
+
+    @Test
+    public void anEntryWrittenInUpperCaseAlsoMatches() {
+        servlet.setExcludeHosts("^(INTERNAL\\.EXAMPLE\\.ORG)$");
+        assertTrue(servlet.isExcludedHost("internal.example.org"));
+    }
+
+    @Test
+    public void ipv4CompatibleIpv6IsExcluded() throws Exception {
+        // ::/96 carries an IPv4 address in its low bits, deprecated but still spellable.
+        assertExcluded("http://[::7f00:1]/");
+        assertExcluded("http://[::a00:1]/");
+    }
+
+    @Test
+    public void nat64PrefixIsExcluded() throws Exception {
+        assertExcluded("http://[64:ff9b::7f00:1]/");
+        assertNotExcluded("http://[64:ff9c::1]/");
+    }
+
+    @Test
+    public void carrierGradeNatBenchmarkAndMulticastRangesAreExcluded() throws Exception {
+        assertExcluded("http://100.64.0.1/");
+        assertExcluded("http://100.127.255.255/");
+        assertExcluded("http://198.18.0.1/");
+        assertExcluded("http://198.19.255.1/");
+        assertExcluded("http://224.0.0.1/");
+        assertExcluded("http://239.255.255.255/");
+    }
+
+    @Test
+    public void addressesJustOutsideTheAddedRangesAreNotExcluded() throws Exception {
+        assertNotExcluded("http://100.63.255.255/");
+        assertNotExcluded("http://100.128.0.1/");
+        assertNotExcluded("http://198.17.0.1/");
+        assertNotExcluded("http://198.20.0.1/");
+        assertNotExcluded("http://223.255.255.255/");
+        assertNotExcluded("http://240.0.0.1/");
+        // The multicast entry must not swallow 2.x, 22.x or 23.x.
+        assertNotExcluded("http://2.2.2.2/");
+        assertNotExcluded("http://22.5.1.1/");
+        assertNotExcluded("http://23.1.1.1/");
+    }
+
+    /**
+     * Checks the value as the target is built from it, then through the exclusion list.
+     */
+    private boolean isQueryExcluded(String queryString) {
+        String url = servlet.getRequestedUrl(queryString);
+        if (url == null) {
+            return false;
+        }
+        try {
+            String host = new URI(url).getHost();
+            return host == null || servlet.isExcludedHost(host);
+        } catch (java.net.URISyntaxException e) {
+            return true;
+        }
+    }
+
+    @Test
+    public void theUrlParameterIsReadAsTheTargetUsesIt() {
+        assertEquals("http://example.com/", servlet.getRequestedUrl("url=http%3A%2F%2Fexample.com%2F"));
+        // Repeated, the target joins them with a comma, so that is what has to be checked.
+        assertEquals("http://a,@127.0.0.1/", servlet.getRequestedUrl("url=http%3A%2F%2Fa&url=%40127.0.0.1%2F"));
+        assertEquals(null, servlet.getRequestedUrl("other=1"));
+        assertEquals(null, servlet.getRequestedUrl(null));
+    }
+
+    @Test
+    public void aSecondUrlParameterCannotSlipPastTheFirst() {
+        // The first value names a host no entry excludes, the join denotes the loopback interface.
+        assertTrue(isQueryExcluded("url=http%3A%2F%2Fa&url=%40127.0.0.1%2F"));
+        assertTrue(isQueryExcluded("url=http%3A%2F%2Fuser&url=%40localhost%2F"));
+        assertTrue(isQueryExcluded("url=http%3A%2F%2Fa&url=%40%5B%3A%3A1%5D%2F"));
+        assertTrue(isQueryExcluded("url=http%3A%2F%2Fa&url=%402130706433%2F"));
+    }
+
+    @Test
+    public void aSingleUrlParameterIsUnaffected() {
+        assertFalse(isQueryExcluded("url=http%3A%2F%2Fexample.com%2F"));
+        assertTrue(isQueryExcluded("url=http%3A%2F%2F127.0.0.1%2F"));
+    }
+
+    @Test
+    public void publicHostsAreNotExcluded() throws Exception {
+        assertNotExcluded("http://example.com/");
+        assertNotExcluded("http://8.8.8.8/");
+        assertNotExcluded("http://[2001:4860:4860::8888]/");
+    }
+
+    @Test
+    public void hostVariantsCoverTheSpellingsOfAnIpv6Literal() {
+        assertTrue(servlet.getHostVariants("[::1]").contains("[::1]"));
+        assertTrue(servlet.getHostVariants("[::1]").contains("::1"));
+        assertTrue(servlet.getHostVariants("[::1]").contains("0:0:0:0:0:0:0:1"));
+    }
+
+    @Test
+    public void hostVariantsLeaveANameAlone() {
+        assertEquals(1, servlet.getHostVariants("example.com").size());
+        assertTrue(servlet.getHostVariants("example.com").contains("example.com"));
+    }
+
+    @Test
+    public void hostVariantsLeaveAnIpv4LiteralAlone() {
+        assertEquals(1, servlet.getHostVariants("127.0.0.1").size());
+    }
+
+    @Test
+    public void aBracketedValueThatIsNotAnAddressIsNotMatched() {
+        // Must not throw, and must not silently become an excluded host.
+        assertFalse(servlet.isExcludedHost("[not-an-address]"));
+    }
+
+    @Test
+    public void anExclusionEntryWrittenWithBracketsStillWorks() {
+        servlet.setExcludeHosts("^(\\[::1\\])$");
+        assertTrue(servlet.isExcludedHost("[::1]"));
+    }
+}


### PR DESCRIPTION
## What this changes

The web proxy decides whether it may fetch a URL by matching the host against the `excludeHosts` regular expression. This changes the way that comparison is done.

`URI.getHost()` returns an IPv6 literal wrapped in brackets and spelled exactly as the caller wrote it, so `http://[::1]/` gives the string `[::1]`. An entry written `::1` could never line up with that, and the same address can be written several other ways besides. The host is now compared in three forms:

- as returned, so an entry written with brackets keeps working
- without the brackets of an IPv6 literal, so an entry written the usual way (`::1`, `fd00::1`) works
- in the canonical form of the address, which is the same string for every spelling, so one entry covers them all

This PR covers the other ways of writing an IPv4 address too.

The default value of the `excludeHosts` property is extended to cover more IP ranges.

A URL whose host the parser cannot determine is refused, rather than being passed to the matcher where it raised a `NullPointerException`.

## Documentation

`excludeHosts` and `allowPorts` were not described anywhere in the manual. The maintainer guide now covers both: what the default list holds, how to write an entry for an IPv6 address, and the two mistakes that are easy to make when doing so. It also documents that either can be set through an environment variable, a system property or `config.properties` without editing `web.xml`, which is the only practical route inside a container. The docker installation page gains a configuration section, which it did not have, noting that a value set that way replaces the shipped list rather than adding to it.

## Compatibility

A deployment that relies on the proxy reaching a service on its own network will need to widen `excludeHosts`, since the default now excludes the ranges a private network uses. That is worth calling out in the migration notes of the release. Entries already written by administrators keep working, in any of the spellings they may have used, which is the reason the comparison keeps the unbracketed form rather than moving to the canonical one alone.

## Testing

24 unit tests in `URITemplateProxyServletTest`, covering each range, the boundaries either side of `172.16/12`, `fc00::/7` and `fe80::/10`, the spellings of an IPv6 literal, the single-number form, and the example given in the manual, so the documentation and the behaviour stay in step.

## Backport

Applies to 4.2.x as well: the default value and the matching code are the same there.

The cherry-pick needs one adjustment. `isUrlAllowed` on 4.2.x calls `StringUtils.isBlank(url)`, where main uses the statically imported `isBlank(url)`, so the guard added for a host the parser cannot determine has to be written `StringUtils.isBlank(host)` on that branch. Nothing else differs, and the code added here builds under Java 8, which 4.2.x targets.


# Checklist

- [x] I have read the [contribution guidelines](https://github.com/geonetwork/core-geonetwork/blob/main/CONTRIBUTING.md)
- [x] *Pull request* provided for `main` branch, backports managed with label
- [x] *Good housekeeping* of code, cleaning up comments, tests, and documentation
- [x] *Clean commit history* broken into understandable chucks, avoiding big commits with hundreds of files, cautious of reformatting and whitespace changes
- [x] *Clean commit message*s, longer verbose messages are encouraged
- [ ] *API Changes* are identified in commit messages
- [x] *Testing* provided for features or enhancements using [automatic tests](https://github.com/geonetwork/core-geonetwork/blob/main/software_development/TESTING.md)
- [x] *User documentation* provided for new features or enhancements in [manual](https://github.com/geonetwork/core-geonetwork/tree/main/docs/manual)
- [ ] *Build documentation* provided for development instructions in `README.md` files
- [ ] *Library management* using `pom.xml` dependency management. Update build documentation with intended library use and library tutorials or documentation

<!--Submitting the PR does not require you to check all items, but by the time it gets merged, they should be either satisfied or not applicable.-->

<!-- If you can, it's better to give credits to organisation supporting this work:
- `Funded by NAME`
- `Funded by URL`
- `Funded by NAME URL`
-->

