### PR TITLE
UI / Render typeahead suggestions as text instead of HTML

### DIFF
--- a/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
+++ b/web-ui/src/main/resources/catalog/components/thesaurus/ThesaurusDirective.js
@@ -929,11 +929,14 @@
                   templates: {
                     suggestion: function (data) {
                       var def = data.props.definitions[searchLanguage];
-                      var text = "<p>" + data.props.values[searchLanguage] + "";
+                      var suggestion = $("<p></p>").text(
+                        data.props.values[searchLanguage]
+                      );
                       if (displayDefinition && def != "") {
-                        text += " - <i>" + def + "</i>";
+                        suggestion.append(document.createTextNode(" - "));
+                        suggestion.append($("<i></i>").text(def));
                       }
-                      return text + "</p>";
+                      return suggestion;
                     }
                     // header: '<h4>' + scope.thesaurusKey + '</h4>'
                   }

--- a/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
+++ b/web-ui/src/main/resources/catalog/components/utility/UtilityDirective.js
@@ -578,14 +578,8 @@
                     limit: 100,
                     templates: {
                       suggestion: function (datum) {
-                        return (
-                          "<p>" +
-                          datum.name +
-                          " " +
-                          datum.surname +
-                          " (" +
-                          datum.profile +
-                          ")</p>"
+                        return $("<p></p>").text(
+                          datum.name + " " + datum.surname + " (" + datum.profile + ")"
                         );
                       }
                     },
@@ -895,13 +889,12 @@
                               props.push(loc[p]);
                             }
                           });
-                          return (
-                            "<div>" +
-                            loc.name +
-                            (props.length == 0
-                              ? ""
-                              : " — <em>" + props.join(", ") + "</em></div>")
-                          );
+                          var suggestion = $("<div></div>").text(loc.name);
+                          if (props.length != 0) {
+                            suggestion.append(document.createTextNode(" — "));
+                            suggestion.append($("<em></em>").text(props.join(", ")));
+                          }
+                          return suggestion;
                         }
                       }
                     }
@@ -1037,7 +1030,7 @@
                     source: allOrSearchFn,
                     templates: {
                       suggestion: function (datum) {
-                        return "<p>" + datum.name + " (" + datum.code + ")</p>";
+                        return $("<p></p>").text(datum.name + " (" + datum.code + ")");
                       }
                     }
                   }
@@ -1148,7 +1141,7 @@
                       limit: Infinity,
                       templates: {
                         suggestion: function (datum) {
-                          return "<p>" + datum.name + " (" + datum.code + ")</p>";
+                          return $("<p></p>").text(datum.name + " (" + datum.code + ")");
                         }
                       }
                     }
@@ -1469,7 +1462,7 @@
               source: source.ttAdapter(),
               templates: {
                 suggestion: function (datum) {
-                  return "<p>" + datum[displayField] + "</p>";
+                  return $("<p></p>").text(datum[displayField]);
                 }
               }
             }
@@ -1744,7 +1737,7 @@
               source: source.ttAdapter(),
               templates: {
                 suggestion: function (datum) {
-                  return "<p>" + datum.label + "</p>";
+                  return $("<p></p>").text(datum.label);
                 }
               }
             }


### PR DESCRIPTION
### What this does

The typeahead suggestion templates built their markup by concatenating field values into an HTML string, which the bundled typeahead then hands to jQuery. jQuery parses that string as HTML, so any markup contained in a field value is interpreted as DOM instead of being shown as text.

This changes the affected suggestion templates to return a DOM node and set the field values with `.text()`, so values are always rendered as literal text. Where a suggestion legitimately needs emphasis markup (the region picker's admin/country name, the thesaurus definition), the wrapper elements are still created and only the dynamic parts are set as text.

Templates updated:

- `gnUserPicker` (user picker)
- `directoryEntry` (directory entry picker)
- ISO language and code pickers
- the generic `gnTypeahead` directive
- the region / geonames picker
- the thesaurus keyword picker

### Why

Rendering suggestion values as text rather than as HTML is the correct default for a list of names and labels, and it removes the need to trust that every field reaching these widgets is markup-free. Defense in depth.

### Testing

- Suggestion highlighting (`highlight: true`) still works, since it operates on the text nodes of the returned element.
- Verified in a running GeoNetwork (4.4.12) using the application's own jQuery/typeahead/Bloodhound: suggestions render as before, highlighting works, the region and thesaurus pickers keep their `<em>`/`<i>` emphasis, and field values containing markup are shown as plain text instead of being parsed into nodes.

### Credits

Thanks to @arpitjain099 for flagging the string-concatenation pattern in the suggestion templates and for suggesting the `.text()` node approach used here.
